### PR TITLE
fix: migrate SQL data sources from Statement to PreparedStatement (CW…

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/InMemorySQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/InMemorySQLDataSource.java
@@ -3,9 +3,9 @@ package io.github.adamw7.tools.data.source.db;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,11 +22,16 @@ public class InMemorySQLDataSource extends IterableSQLDataSource implements InMe
 	public InMemorySQLDataSource(Connection connection, String query) {
 		super(connection, query);
 	}
+
+	public InMemorySQLDataSource(Connection connection, String query, Object... params) {
+		super(connection, query, params);
+	}
 	
 	@Override
 	public List<String[]> readAll() {
-		try (Statement statement = connection.createStatement()) {
-			ResultSet resultSet = statement.executeQuery(query);
+		try (PreparedStatement preparedStatement = connection.prepareStatement(query)) {
+			bindParameters(preparedStatement, params);
+			ResultSet resultSet = preparedStatement.executeQuery();
 			List<String[]> allData = new ArrayList<>();
 			while (resultSet.next()) {
 				allData.add(getNextFrom(resultSet));

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -3,10 +3,10 @@ package io.github.adamw7.tools.data.source.db;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Statement;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -21,10 +21,16 @@ public class IterableSQLDataSource implements IterableDataSource {
 	protected boolean hasMoreData = true;
 	protected final String query;
 	protected final Connection connection;
+	protected final Object[] params;
 
 	public IterableSQLDataSource(Connection connection, String query) {
+		this(connection, query, new Object[0]);
+	}
+
+	public IterableSQLDataSource(Connection connection, String query, Object... params) {
 		this.connection = connection;
 		this.query = query;
+		this.params = params;
 	}
 
 	@Override
@@ -53,9 +59,10 @@ public class IterableSQLDataSource implements IterableDataSource {
 	@Override
 	public void open() {
 		try {
-			Statement statement = connection.createStatement();
-			log.info("Executing query: {}", query);
-			resultSet = statement.executeQuery(query);
+			PreparedStatement preparedStatement = connection.prepareStatement(query);
+			bindParameters(preparedStatement, params);
+			log.debug("Executing query: {}", query);
+			resultSet = preparedStatement.executeQuery();
 		} catch (SQLException e) {
 			throw new UncheckedIOException(new IOException(e));
 		}
@@ -103,6 +110,12 @@ public class IterableSQLDataSource implements IterableDataSource {
 			columns[i] = meta.getColumnName(i + 1);
 		}
 		return columns;
+	}
+
+	protected static void bindParameters(PreparedStatement ps, Object[] params) throws SQLException {
+		for (int i = 0; i < params.length; i++) {
+			ps.setObject(i + 1, params[i]);
+		}
 	}
 
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/source/db/SQLDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/db/SQLDataSourceTest.java
@@ -76,4 +76,27 @@ public class SQLDataSourceTest extends DBTest {
 
 		assertTrue(thrown.getMessage().contains("NON_EXISTING_TABLE"));
 	}
+
+	static Stream<Arguments> parameterizedSources() {
+		String query = "SELECT * FROM PEOPLE WHERE ID = ?";
+		IterableSQLDataSource iterableSource = new IterableSQLDataSource(connection, query, "1");
+		InMemorySQLDataSource inMemorySource = new InMemorySQLDataSource(connection, query, "1");
+		return Stream.of(of(Utils.named(iterableSource)), of(Utils.named(inMemorySource)));
+	}
+
+	@ParameterizedTest
+	@MethodSource("parameterizedSources")
+	public void happyPathWithParams(IterableSQLDataSource source) {
+		source.open();
+
+		assertEquals("ID", source.getColumnNames()[0]);
+		assertEquals("NAME", source.getColumnNames()[1]);
+		assertEquals("SURNAME", source.getColumnNames()[2]);
+
+		String[] row = source.nextRow();
+		assertEquals("1", row[0]);
+		assertEquals("Adam", row[1]);
+		assertEquals("W", row[2]);
+		Utils.close(source);
+	}
 }


### PR DESCRIPTION
…E-89)

- Replace Statement.executeQuery(query) with PreparedStatement in both IterableSQLDataSource and InMemorySQLDataSource to prevent SQL injection
- Add new constructors accepting Object... params for parameterized queries
- Preserve backward-compatible (Connection, String) constructors
- Add bindParameters() helper for setting PreparedStatement parameters
- Downgrade query logging from INFO to DEBUG to avoid leaking sensitive data
- Add happyPathWithParams test validating parameterized query execution