### PR TITLE
Reuse package+imports header in Clazz

### DIFF
--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Clazz.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Clazz.java
@@ -12,12 +12,13 @@ public class Clazz implements Generator {
 	private final Implementations implementations;
 	private final Methods methods;
 	private final ClassInfo info;
-	 
+	private final String header;
+
 	public Clazz(ClassInfo info, TypeMappings typeMappings) {
 		this.info = info;
 		builderClassName = info.name() + "Builder";
-		String header = generatePackage() + generateImports();
-		
+		this.header = generatePackage() + generateImports();
+
 		this.interfaces = new Interfaces(info, typeMappings, header);
 		this.implementations = new Implementations(info, typeMappings, header);
 		this.methods = new Methods(typeMappings, info.name());
@@ -25,16 +26,15 @@ public class Clazz implements Generator {
 
 	@Override
 	public List<ClassContainer> generate() {
-		List<ClassContainer> requiredInterfaces = interfaces.generateRequired();	
+		List<ClassContainer> requiredInterfaces = interfaces.generateRequired();
 		ClassContainer optionalInterface = interfaces.generateOptional();
 		List<ClassContainer> requiredImpls = implementations.generateRequired();
 		ClassContainer optionalImpl = implementations.generateOptional();
-		
-		StringBuilder full = new StringBuilder();		
-		full.append(generatePackage()).append(generateImports());
+
+		StringBuilder full = new StringBuilder(header);
 		full.append(generateHeader()).append(handleMethodsInMainClass());
 		full.append(generateFooter());
-		
+
 		return createClassesList(requiredInterfaces, optionalInterface, requiredImpls, optionalImpl, full);
 	}
 


### PR DESCRIPTION
## Summary
`Clazz` computed `generatePackage() + generateImports()` twice: once in the constructor (to hand to `Interfaces`/`Implementations`) and again at the top of `generate()`. The two values are computed from the same inputs with no state change between them, so the second call is dead work — and if they ever diverged, we'd silently emit different imports in the main class than in the sibling interfaces/impls.

Store the header once on the instance and reuse it.

## Test plan
- [ ] `mvn install` passes
- [ ] Generated output byte-for-byte identical (regression tests under `protogen-maven-plugin-test`)
