### PR TITLE
Use Locale.ROOT for identifier case conversions

### DIFF
--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Utils.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Utils.java
@@ -2,12 +2,13 @@ package io.github.adamw7.tools.code.gen;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import com.google.protobuf.Descriptors.FieldDescriptor;
 
 public class Utils {
-	
+
 	private Utils() {}
 
 	public static String to(FieldDescriptor fieldDescriptor, String suffix) {
@@ -15,7 +16,7 @@ public class Utils {
 	}
 
 	public static String firstToLower(String string) {
-		return (String.valueOf(string.charAt(0)).toLowerCase() + string.substring(1));
+		return (String.valueOf(string.charAt(0)).toLowerCase(Locale.ROOT) + string.substring(1));
 	}
 
 	public static String firstToUpper(String string) {
@@ -23,7 +24,7 @@ public class Utils {
 	}
 
 	private static String firstUpper(String string) {
-		return String.valueOf(string.charAt(0)).toUpperCase();
+		return String.valueOf(string.charAt(0)).toUpperCase(Locale.ROOT);
 	}
 
 	public static String toUpperCamelCase(String s) {
@@ -36,7 +37,7 @@ public class Utils {
 	}
 
 	static String toProperCase(String s) {
-		return s.substring(0, 1).toUpperCase() + s.substring(1).toLowerCase();
+		return s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1).toLowerCase(Locale.ROOT);
 	}
 	
 	public static String getNextIfc(String className, List<FieldDescriptor> fields, FieldDescriptor requiredField) {


### PR DESCRIPTION
## Summary
`Utils.firstToLower`, `firstUpper`, and `toProperCase` called `String#toUpperCase()` / `toLowerCase()` with the default locale. These helpers are used to build **Java identifiers** that are emitted into generated source. Under the Turkish locale, `'I'.toLowerCase()` yields `ı` (dotless) and `'i'.toUpperCase()` yields `İ` — either one produces an identifier the Java compiler rejects.

Pass `Locale.ROOT` to every call so the output is deterministic across locales.

## Test plan
- [ ] `mvn install` passes
- [ ] Generator output unchanged under a US/UK locale
- [ ] Spot-check: run the generator under `-Duser.language=tr -Duser.country=TR` and confirm identifiers now remain ASCII-lower/upper case
