### PR TITLE
Resolve map entry type directly from the field

### DIFF
--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/TypeMappings.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/TypeMappings.java
@@ -105,22 +105,13 @@ public class TypeMappings {
 	}
 
 	private String handleMap(FieldDescriptor field) {
-		List<Descriptor> descriptors = field.getContainingType().getNestedTypes();
-		for (Descriptor descriptor : descriptors) {
-			if (belongsTo(field, descriptor)) {
-				FieldDescriptor keyDesc = descriptor.findFieldByName("key");
-				FieldDescriptor valueDesc = descriptor.findFieldByName("value");
-				
-				String key = wrapIfNeeded(get(keyDesc));		
-				String value = wrapIfNeeded(get(valueDesc));
-				return name(Map.class) + "<" + key + "," + value + ">";		
-			}
-		}
-		throw new IllegalStateException("Have not found types for map: " + field.getFullName());
-	}
+		Descriptor entry = field.getMessageType();
+		FieldDescriptor keyDesc = entry.findFieldByName("key");
+		FieldDescriptor valueDesc = entry.findFieldByName("value");
 
-	private boolean belongsTo(FieldDescriptor field, Descriptor descriptor) {
-		return descriptor.getFullName().toLowerCase().contains(field.getJsonName().toLowerCase());
+		String key = wrapIfNeeded(get(keyDesc));
+		String value = wrapIfNeeded(get(valueDesc));
+		return name(Map.class) + "<" + key + "," + value + ">";
 	}
 
 	private String wrapIfNeeded(String type) {


### PR DESCRIPTION
## Summary
`TypeMappings#handleMap` iterated the containing message's nested types and picked the first one whose lower-cased full name *contained* the field's lower-cased JSON name. That substring match is fragile — for a map field `foo` next to a sibling message `FooBar`, iteration order decides which descriptor wins, and nothing in the protobuf spec guarantees that order.

The protobuf API already exposes the synthetic map-entry descriptor directly via `FieldDescriptor#getMessageType()` for map fields, so use it and drop both the loop and the `belongsTo` helper.

## Test plan
- [ ] `mvn install` passes
- [ ] Existing codegen tests cover maps (verify no regression in generated output for message types containing `map<K,V>` fields)
- [ ] Add a regression test with a message that has both a map field and a sibling nested message whose name is a superstring of the map's JSON name
