### PR TITLE
Make Finder traversal depth-bounded and predictable

### DIFF
--- a/code/context/src/main/java/io/github/adamw7/context/Finder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/Finder.java
@@ -3,13 +3,17 @@ package io.github.adamw7.context;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Finder implements Context {
+
 	private static final Logger log = LogManager.getLogger(Finder.class.getName());
+	private static final Pattern CLASS_NAME_PATTERN =
+			Pattern.compile("\\b[A-Z][A-Za-z0-9_]*(\\.[A-Z][A-Za-z0-9_]*)*\\b");
+
 	private final Set<ClassContainer> allContainers;
 
 	public Finder(Set<ClassContainer> allContainers) {
@@ -18,35 +22,42 @@ public class Finder implements Context {
 
 	@Override
 	public Set<ClassContainer> find(ClassContainer root, int depth) {
-		Set<ClassContainer> classes = findAllUsedClasses(root, depth);
-		for (int i = depth - 1; i > 0; i--) {
-			for (ClassContainer clazz : classes) {
-				classes.addAll(find(clazz, i));
-			}
-		}
-		return classes;
-	}
-
-	private Set<ClassContainer> findAllUsedClasses(ClassContainer root, int depth) {
 		if (depth <= 0) {
 			throw new IllegalArgumentException("Depth must be positive and received: " + depth);
 		}
-		Pattern pattern = Pattern.compile("\\b[A-Z][A-Za-z0-9_]*(\\.[A-Z][A-Za-z0-9_]*)*\\b");
-		return findByRegEx(root, pattern);
+		Set<ClassContainer> visited = new HashSet<>();
+		visited.add(root);
+		Set<ClassContainer> frontier = new HashSet<>();
+		frontier.add(root);
+		for (int level = 0; level < depth && !frontier.isEmpty(); level++) {
+			frontier = expand(frontier, visited);
+		}
+		return visited;
 	}
 
-	private Set<ClassContainer> findByRegEx(ClassContainer root, Pattern pattern) {
-		Set<ClassContainer> classes = ConcurrentHashMap.newKeySet();
-		Matcher matcher = pattern.matcher(root.originalCode());
-		while (matcher.find()) {
-			String className = matcher.group();
-			ClassContainer container = findContainer(className);
-			if (container != null) {
-				log.info("Found {} used in {}", container.className(), root.className());
-				classes.add(container);				
+	private Set<ClassContainer> expand(Set<ClassContainer> frontier, Set<ClassContainer> visited) {
+		Set<ClassContainer> next = new HashSet<>();
+		for (ClassContainer current : frontier) {
+			for (ClassContainer referenced : referencesIn(current)) {
+				if (visited.add(referenced)) {
+					next.add(referenced);
+				}
 			}
 		}
-		return classes;
+		return next;
+	}
+
+	private Set<ClassContainer> referencesIn(ClassContainer source) {
+		Set<ClassContainer> references = new HashSet<>();
+		Matcher matcher = CLASS_NAME_PATTERN.matcher(source.originalCode());
+		while (matcher.find()) {
+			ClassContainer container = findContainer(matcher.group());
+			if (container != null) {
+				log.info("Found {} used in {}", container.className(), source.className());
+				references.add(container);
+			}
+		}
+		return references;
 	}
 
 	private ClassContainer findContainer(String className) {


### PR DESCRIPTION
## Summary
`Finder#find` mixed recursion with an outer loop in a way where neither the recursion nor the `depth` parameter actually bounded traversal:

- `findAllUsedClasses` only validated `depth > 0` and then scanned `root` regardless of depth.
- The outer loop re-iterated the result set while mutating it through `classes.addAll(find(clazz, i))` and passed a new `depth` that again only served as a `> 0` guard.

The existing tests happened to pass because the transitive graph in the fixture converges in one hop. On any larger graph the behaviour was effectively "walk everything" with redundant re-scans.

This PR rewrites `find` as an explicit BFS:

- `depth` is now the number of hops from `root`.
- One `visited` set avoids revisiting.
- Each level only expands the newly-discovered frontier — no concurrent mutation of the iteration source.
- The compiled `Pattern` is hoisted to a `static final` constant.

Existing `FinderTest` cases produce the same result set (hand-traced `levelOne` and `levelTwo`).

## Test plan
- [ ] `mvn -pl code/context test` passes
- [ ] Add a regression test with a chain `A -> B -> C -> D` and verify `find(A, 2)` returns `{A, B, C}` (not `{A, B, C, D}`)
