### PR TITLE
Move file read out of ClassContainer constructor

### DIFF
--- a/code/context/src/main/java/io/github/adamw7/context/ClassContainer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/ClassContainer.java
@@ -6,34 +6,28 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class ClassContainer {
-	
-	private final Path originalPath;
-	private final String className; 
+
+	private final String className;
 	private final String originalCode;
 
-	public ClassContainer(Path path, String className) {
-		this.originalPath = path;
+	public ClassContainer(String className, String originalCode) {
 		this.className = className;
-		originalCode = readCode();
+		this.originalCode = originalCode;
 	}
-	
 
-	private String readCode() {
-        try {
-            return Files.readString(originalPath);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
+	public static ClassContainer load(Path path, String className) {
+		try {
+			return new ClassContainer(className, Files.readString(path));
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
 
 	public String originalCode() {
 		return originalCode;
 	}
 
-
 	public String className() {
 		return className;
 	}
-
 }

--- a/code/context/src/test/java/io/github/adamw7/context/FinderTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/FinderTest.java
@@ -29,7 +29,7 @@ public class FinderTest {
 	private static ClassContainer createContainer(String location) {
 		File file = new File(location);
 		Path path = Path.of(file.getAbsolutePath());
-		return new ClassContainer(path, path.getFileName().toString());
+		return ClassContainer.load(path, path.getFileName().toString());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
`ClassContainer` read the file in its constructor, which:

- made plain construction fail with `UncheckedIOException` on any I/O error,
- coupled what is otherwise a simple data carrier to the filesystem,
- prevented using `ClassContainer` for in-memory sources (e.g. tests, strings generated at runtime).

This PR makes the primary constructor take `(className, originalCode)` directly and adds a `ClassContainer.load(Path, String)` static factory for the disk-backed case. The only existing caller (`FinderTest`) is updated.

**Breaking change**: the old two-arg `(Path, String)` constructor is replaced. Anyone consuming this module must switch to `ClassContainer.load(...)`.

## Test plan
- [ ] `mvn -pl code/context test` passes
- [ ] Confirm no other callers exist in the workspace (`grep -R "new ClassContainer("` under `code/context`)
