### PR TITLE
Close scanner unconditionally in CSVDataSource.reset

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
@@ -100,8 +100,8 @@ public class CSVDataSource extends AbstractFileSource {
 
 	@Override
 	public void reset() {
+		closeScanner();
 		try {
-			close();
 			scanner = createScanner();
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
@@ -109,6 +109,12 @@ public class CSVDataSource extends AbstractFileSource {
 		columns = null;
 		hasMoreData = true;
 		open();
+	}
+
+	private void closeScanner() {
+		if (scanner != null) {
+			scanner.close();
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
## Summary
`CSVDataSource#reset` called `close()` and then overwrote `scanner` with a freshly-built one. But `AbstractFileSource#close` is guarded by the `opened` flag — and `CSVDataSource#open` never sets that flag to `true`. So the old `Scanner` (and its wrapped `FileInputStream`) was never closed, and every `reset()` call leaked a stream.

If `createScanner()` subsequently threw, we hit the same leak path with nothing recoverable.

Fix `reset()` to close the current scanner directly before replacing it, so the underlying stream is released independently of the `opened` bookkeeping.

There's a separate latent issue — `CSVDataSource#open` not setting `opened = true` means the regular `close()` path also fails to close — but that's out of scope here and worth a follow-up.

## Test plan
- [ ] `mvn -pl data test` passes (`CSVDataSourceTest`)
- [ ] Add a regression test that calls `reset()` multiple times on a file-backed source and asserts no file-handle leak (`lsof` / `ProcHandle` or just verify via `FileChannel#isOpen` pre-replacement)
