### PR TITLE
Make Key record defensively copy its array

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/Key.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/Key.java
@@ -4,6 +4,15 @@ import java.util.Arrays;
 
 public record Key(String[] values) {
 
+	public Key {
+		values = values == null ? new String[0] : values.clone();
+	}
+
+	@Override
+	public String[] values() {
+		return values.clone();
+	}
+
 	@Override
 	public String toString() {
 		return Arrays.toString(values);
@@ -11,23 +20,17 @@ public record Key(String[] values) {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + Arrays.hashCode(values);
-		return result;
+		return Arrays.hashCode(values);
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		}
+		if (!(obj instanceof Key other)) {
 			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Key other = (Key) obj;
+		}
 		return Arrays.equals(values, other.values);
 	}
-	
-	
 }


### PR DESCRIPTION
## Summary
`record Key(String[] values)` let the caller keep a reference to the array passed into the constructor, and the synthesized accessor handed back the internal reference. Because `equals`/`hashCode` are computed from that array via `Arrays.equals` / `Arrays.hashCode`, any later mutation of the caller's or returned array silently corrupts `Key` instances stored in a `Set` or used as a `Map` key.

Add a compact constructor and an accessor override that clone the array so the record is effectively immutable.

Also switch `equals` to `instanceof` pattern-matching — same behaviour, less boilerplate.

## Test plan
- [ ] `mvn -pl data test` passes (`UniquenessCheckTest` exercises `Key` indirectly)
- [ ] Add a regression test: put a `Key` in a `HashSet`, mutate the original array, verify `set.contains(key)` still returns true
