### PR TITLE
build(deps): upgrade MCP SDK from 1.1.2 to 2.0.0-M3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ buildNumber.properties
 .mvn/
 
 data/logs
+data/derby.log
 code/logs
 
 .project

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -46,7 +46,7 @@
 			<dependency>
 				<groupId>io.modelcontextprotocol.sdk</groupId>
 				<artifactId>mcp-bom</artifactId>
-				<version>1.1.2</version>
+				<version>2.0.0-M3</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
@@ -31,7 +31,7 @@ public class UniquenessTool implements Function<Map<String, Object>, CallToolRes
                         "object",
                         Map.of(
                             "file", Map.of("type", "string", "description", "filename"),
-                            "columns_row", Map.of("type", "int", "description", "number of the columns row"),
+                            "columns_row", Map.of("type", "integer", "description", "number of the columns row"),
                             "columns_name", Map.of("type", "string", "description", "name of the column to check")
                         ),
                         List.of("file", "columns_row", "columns_name"),


### PR DESCRIPTION
Update io.modelcontextprotocol.sdk:mcp-bom to the latest early access
release. Fix columns_row JSON Schema type from "int" to "integer" to
comply with JSON Schema 2020-12 validation enforced by 2.0.0-M3.

https://claude.ai/code/session_013haUpghUcvqfHH3LdQtNoD