### PR TITLE
Add Claude Code session-start hook and settings

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install Java 25 if not already present
+if ! find /usr/lib/jvm -maxdepth 1 -name "java-25-openjdk*" -type d | grep -q .; then
+  apt-get update -q
+  apt-get install -y -q openjdk-25-jdk
+fi
+
+JAVA_HOME_25=$(find /usr/lib/jvm -maxdepth 1 -name "java-25-openjdk*" -type d | head -1)
+
+echo "export JAVA_HOME=${JAVA_HOME_25}" >> "$CLAUDE_ENV_FILE"
+echo "export PATH=${JAVA_HOME_25}/bin:\$PATH" >> "$CLAUDE_ENV_FILE"
+
+export JAVA_HOME="${JAVA_HOME_25}"
+export PATH="${JAVA_HOME_25}/bin:$PATH"
+
+# Pre-download all Maven dependencies to local repo for faster builds
+cd "${CLAUDE_PROJECT_DIR}"
+mvn dependency:go-offline -q

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Installs Java 25 and pre-downloads Maven dependencies on session start
so tests and linters work correctly in remote Claude Code sessions.

https://claude.ai/code/session_017WeWuEDp8Aybq94v2xXpmi