### PR TITLE
Fix documentation example and stop swallowing close errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,10 @@ All maven plugin versions are defined only in root pom.xml in plugin management.
 
 ## Principles for Java Development
 Use SOLID Principles for all code.
-Use clean code. No continue or break instructions. Short methods. Meaningul parameter names.
+Use clean code. No continue or break instructions. Short methods. Meaningful parameter names.
 
 ## Testing
 Write unit tests for all new logic. Focus on behavior, edge cases, and error paths.
 
 ## Dependencies
-Use the existing maven depdendencies. Always ask before adding a new one.
+Use the existing maven dependencies. Always ask before adding a new one.

--- a/README.md
+++ b/README.md
@@ -44,17 +44,22 @@ Solution:
 <plugin>
 	<groupId>io.github.adamw7</groupId>
 	<artifactId>protogen-maven-plugin</artifactId>
+	<version>1.5.0</version>
 	<configuration>
 		<generatedSourcesDir>${project.basedir}/target/generated-sources/</generatedSourcesDir>
+		<pkgs>
+			<param>io.github.adamw7.tools.code.protos</param>
+		</pkgs>
+		<outputpackage>io.github.adamw7.tools.code.builders</outputpackage>
 	</configuration>
-		<executions>
-			<execution>
-				<phase>generate-sources</phase>
-				<goals>
-					<goal>code-generator</goal>
-				<goals>
-			</execution>
-		</executions>
+	<executions>
+		<execution>
+			<phase>generate-sources</phase>
+			<goals>
+				<goal>code-generator</goal>
+			</goals>
+		</execution>
+	</executions>
 </plugin>
 ```
 that generates builders detecting missing required fields in compile time (some methods are excluded for simplicity of the example):
@@ -177,7 +182,7 @@ in memory check:
 ```java
 		AbstractUniqueness check = new InMemoryUniquenessCheck();
 		check.setDataSource(new InMemorySQLDataSource(connection, query));
-		Result result = check.exec("COLUM1", "COLUMN2", "COLUMN3");
+		Result result = check.exec("COLUMN1", "COLUMN2", "COLUMN3");
 		log.info(result.isUnique());
 		Set<Result> betterOptions = result.getBetterOptions();
 		for (Result betterOption : betterOptions) {

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
@@ -6,10 +6,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 
 public abstract class AbstractUniqueness implements Uniqueness {
-	
+
+	private static final Logger log = LogManager.getLogger(AbstractUniqueness.class);
+
 	protected IterableDataSource dataSource;
 
 	protected void checkIfCandidatesExistIn(String[] keyCandidates, String[] allColumns) {
@@ -85,7 +90,9 @@ public abstract class AbstractUniqueness implements Uniqueness {
 	protected void close(IterableDataSource dataSource) {
 		try {
 			dataSource.close();
-		} catch (Exception ignored) {}
+		} catch (Exception e) {
+			log.warn("Failed to close data source: {}", dataSource, e);
+		}
 	}
 	
 	protected abstract Set<Result> findPotentiallySmallerSetOfCandidates(String[] keyCandidates);


### PR DESCRIPTION
## Summary

A focused review pass over the project and its `.claude` files surfaced a few concrete, low-risk improvements. This PR fixes a misleading documentation example, a couple of typos, and one code-quality issue flagged by the project's own `java-code-review` skill.

## Changes

### Documentation
- **`README.md`** – The `protogen-maven-plugin` usage example had a broken `<goals>` closing tag (it read `<goals>` instead of `</goals>`), so copying it produced invalid XML. Fixed the tag and completed the snippet with the two other **required** Mojo parameters (`<pkgs>`, `<outputpackage>`) and a `<version>`, so it is now copy-paste usable. Verified the parameter names/structure against the actual configuration in `protogen-maven-plugin-test`.
- **`README.md`** – Fixed a column-name typo in the uniqueness example (`COLUM1` → `COLUMN1`).
- **`CLAUDE.md`** – Fixed two typos: `Meaningul` → `Meaningful`, `depdendencies` → `dependencies`.

### Code quality
- **`AbstractUniqueness.close()`** – Previously `catch (Exception ignored) {}` silently swallowed any failure to close a data source. The project's bundled `java-code-review` skill explicitly flags empty catch blocks, so this now logs a warning (with the offending data source and stack trace) via the log4j logger already used throughout the module.

## Verification
- Built the affected module with Java 25: `mvn -pl data -am install -DskipTests` → success.
- Ran the uniqueness test suite: `mvn -pl data test -Dtest='*Uniqueness*'` → passing.

https://claude.ai/code/session_011n2f4XUhM59hrFQCSqy1sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011n2f4XUhM59hrFQCSqy1sQ)_