### PR TITLE
test(mcp): expand MCP tool and configuration test coverage

### DIFF
--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
@@ -19,4 +19,10 @@ public class McpConfigurationTest {
         assertFalse(server.getServerCapabilities().tools() == null);
         server.close();
     }
+
+    @Test
+    public void stdioTransportIsNotNull() {
+        McpConfiguration config = new McpConfiguration();
+        assertFalse(config.stdioServerTransport() == null);
+    }
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessToolTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessToolTest.java
@@ -2,14 +2,18 @@ package io.github.adamw7.tools.data.uniqueness.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.UncheckedIOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import io.github.adamw7.tools.data.Utils;
+import io.github.adamw7.tools.data.uniqueness.ColumnNotFoundException;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.Content;
@@ -30,5 +34,54 @@ public class UniquenessToolTest {
         assertTrue(content instanceof McpSchema.TextContent);
         McpSchema.TextContent textContent = (McpSchema.TextContent) content;
         assertTrue("false".equals(textContent.text()));
+	}
+
+	@Test
+	public void uniqueColumn() {
+		UniquenessTool tool = new UniquenessTool();
+		Map<String, Object> input = new HashMap<>();
+		input.put("file", Utils.getHouseholdFile());
+		input.put("columns_row", "1");
+		input.put("columns_name", "income");
+		CallToolResult result = tool.apply(input);
+		assertFalse(result.isError());
+		McpSchema.TextContent textContent = (McpSchema.TextContent) result.content().getFirst();
+		assertTrue("true".equals(textContent.text()));
+	}
+
+	@Test
+	public void missingFile() {
+		UniquenessTool tool = new UniquenessTool();
+		Map<String, Object> input = new HashMap<>();
+		input.put("file", "nonExistentFile.csv");
+		input.put("columns_row", "1");
+		input.put("columns_name", "income");
+		assertThrows(UncheckedIOException.class, () -> tool.apply(input));
+	}
+
+	@Test
+	public void invalidColumn() {
+		UniquenessTool tool = new UniquenessTool();
+		Map<String, Object> input = new HashMap<>();
+		input.put("file", Utils.getHouseholdFile());
+		input.put("columns_row", "1");
+		input.put("columns_name", "nonExistingColumn");
+		assertThrows(ColumnNotFoundException.class, () -> tool.apply(input));
+	}
+
+	@Test
+	public void toolDefinitionName() {
+		UniquenessTool tool = new UniquenessTool();
+		assertTrue("uniqueness_check".equals(tool.getToolDefinition().name()));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void toolDefinitionRequiredFields() {
+		UniquenessTool tool = new UniquenessTool();
+		List<String> required = (List<String>) tool.getToolDefinition().inputSchema().get("required");
+		assertTrue(required.contains("file"));
+		assertTrue(required.contains("columns_row"));
+		assertTrue(required.contains("columns_name"));
 	}
 }


### PR DESCRIPTION
Add tests for UniquenessTool covering unique column result, missing
file exception, invalid column exception, tool definition name, and
required schema fields. Add stdioTransportIsNotNull test to
McpConfigurationTest.