### PR TITLE
Add missing Linux equivalents for all Windows scripts

### DIFF
--- a/scripts/linux/generate-maven-update-reports.sh
+++ b/scripts/linux/generate-maven-update-reports.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mvn versions:plugin-updates-aggregate-report &
+mvn versions:dependency-updates-aggregate-report &

--- a/scripts/linux/install-jdk-25.sh
+++ b/scripts/linux/install-jdk-25.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Downloads and installs Eclipse Temurin JDK 25 on Linux.
+# Usage: ./install-jdk-25.sh [install-dir]
+# Example: ./install-jdk-25.sh /opt/jdk-25
+
+set -euo pipefail
+
+INSTALL_DIR="${1:-/opt/eclipse-adoptium/jdk-25}"
+JDK_VERSION=25
+ADOPTIUM_API="https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ga/linux/x64/jdk/hotspot/normal/eclipse"
+TEMP_DIR="/tmp/jdk25-install"
+ARCHIVE_PATH="${TEMP_DIR}/jdk-25-linux-x64.tar.gz"
+
+step()    { echo -e "\n[*] $1"; }
+success() { echo "[+] $1"; }
+failure() { echo "[-] $1" >&2; }
+
+test_jdk_already_installed() {
+    if ! command -v java &>/dev/null; then
+        return 1
+    fi
+    if java -version 2>&1 | grep -q '"25'; then
+        success "JDK 25 is already installed: $(java -version 2>&1 | head -1)"
+        return 0
+    fi
+    return 1
+}
+
+download_from_adoptium() {
+    step "Resolving download URL from Adoptium API..."
+    local resolved_url
+    resolved_url=$(curl -Ls -o /dev/null -w '%{url_effective}' "$ADOPTIUM_API")
+    echo "    URL: $resolved_url"
+
+    step "Downloading JDK 25 archive..."
+    mkdir -p "$TEMP_DIR"
+    curl -L --progress-bar -o "$ARCHIVE_PATH" "$resolved_url"
+
+    local size_mb
+    size_mb=$(du -m "$ARCHIVE_PATH" | cut -f1)
+    success "Downloaded ${size_mb} MB -> $ARCHIVE_PATH"
+}
+
+install_jdk() {
+    step "Installing JDK 25..."
+    mkdir -p "$INSTALL_DIR"
+    tar -xzf "$ARCHIVE_PATH" -C "$INSTALL_DIR" --strip-components=1
+    success "JDK 25 installed to: $INSTALL_DIR"
+}
+
+set_java_home() {
+    step "Setting JAVA_HOME and updating PATH..."
+    local profile_script="/etc/profile.d/jdk25.sh"
+
+    sudo tee "$profile_script" > /dev/null <<EOF
+export JAVA_HOME="${INSTALL_DIR}"
+export PATH="\${JAVA_HOME}/bin:\${PATH}"
+EOF
+
+    export JAVA_HOME="$INSTALL_DIR"
+    export PATH="${JAVA_HOME}/bin:${PATH}"
+
+    success "JAVA_HOME = $INSTALL_DIR"
+    success "Profile script written to $profile_script"
+}
+
+test_installation() {
+    step "Verifying installation..."
+    local java_exe="${INSTALL_DIR}/bin/java"
+    if [ ! -x "$java_exe" ]; then
+        failure "java binary not found at: $java_exe"
+        exit 1
+    fi
+    success "java -version output:"
+    "$java_exe" -version 2>&1 | sed 's/^/    /'
+}
+
+remove_temp_files() {
+    if [ -d "$TEMP_DIR" ]; then
+        rm -rf "$TEMP_DIR"
+        success "Cleaned up temporary files"
+    fi
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+echo -e "\nJDK 25 Installer for Linux"
+echo "==========================\n"
+
+if test_jdk_already_installed; then
+    echo -e "\nJDK 25 is already present. Nothing to do."
+    exit 0
+fi
+
+cleanup_on_failure() {
+    failure "Installation failed: $1"
+    remove_temp_files
+    exit 1
+}
+
+trap 'cleanup_on_failure "unexpected error"' ERR
+
+download_from_adoptium
+install_jdk
+set_java_home
+test_installation
+remove_temp_files
+
+echo -e "\nJDK 25 installed successfully."
+echo "Run 'source /etc/profile.d/jdk25.sh' or open a new terminal for PATH changes to take effect."

--- a/scripts/linux/update-git-client.sh
+++ b/scripts/linux/update-git-client.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+if command -v apt-get &>/dev/null; then
+    sudo apt-get update && sudo apt-get install --only-upgrade git
+elif command -v dnf &>/dev/null; then
+    sudo dnf upgrade git
+elif command -v yum &>/dev/null; then
+    sudo yum update git
+elif command -v pacman &>/dev/null; then
+    sudo pacman -Syu git
+else
+    echo "Unsupported package manager" >&2
+    exit 1
+fi

--- a/scripts/linux/update-git-repos-async.sh
+++ b/scripts/linux/update-git-repos-async.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+for dir in "$SCRIPT_DIR"/*/; do
+    if [ -d "$dir/.git" ]; then
+        (cd "$dir" && git pull) &
+    fi
+done


### PR DESCRIPTION
Create Linux scripts to match the existing Windows batch/PowerShell scripts:
- generate-maven-update-reports.sh: runs Maven plugin/dependency update reports in background
- install-jdk-25.sh: downloads and installs Eclipse Temurin JDK 25 from Adoptium
- update-git-client.sh: updates git via the system package manager (apt/dnf/yum/pacman)
- update-git-repos-async.sh: pulls all git repos under the script directory asynchronously

https://claude.ai/code/session_01GSRr2ZiBKR8xgTPKZbaK6Y