### PR TITLE
feat(mcp): add streamable HTTP transport support

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/Main.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/Main.java
@@ -7,10 +7,23 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Main {
 
     public static void main(String[] args) {
-        System.setProperty("transport.mode", "stdio");
-        System.setProperty("spring.main.web-application-type", "none");
+        String transportMode = resolveTransportMode(args);
+        System.setProperty("transport.mode", transportMode);
+        if ("stdio".equals(transportMode)) {
+            System.setProperty("spring.main.web-application-type", "none");
+        }
         System.setProperty("banner-mode", "off");
         SpringApplication.run(Main.class, args);
+    }
+
+    private static String resolveTransportMode(String[] args) {
+        String prefix = "--transport.mode=";
+        for (String arg : args) {
+            if (arg.startsWith(prefix)) {
+                return arg.substring(prefix.length());
+            }
+        }
+        return "stdio";
     }
 
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfiguration.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfiguration.java
@@ -1,60 +1,92 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
-import io.modelcontextprotocol.server.McpSyncServerExchange;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
-
-import java.util.function.BiFunction;
+import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 
 @Configuration
 public class McpConfiguration {
 
-	private final static Logger log = LogManager.getLogger(McpConfiguration.class.getName());
+	private static final Logger log = LogManager.getLogger(McpConfiguration.class.getName());
 
 	@Bean
 	public ObjectMapper objectMapper() {
 		return new ObjectMapper();
 	}
 
-    @Bean
-    @ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stdio", matchIfMissing = true)
-    public StdioServerTransportProvider stdioServerTransport() {
-        log.info("Creating StdioServerTransport");
-        return new StdioServerTransportProvider(new JacksonMcpJsonMapper(objectMapper()));
-    }
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stdio", matchIfMissing = true)
+	public StdioServerTransportProvider stdioServerTransport() {
+		log.info("Creating StdioServerTransport");
+		return new StdioServerTransportProvider(new JacksonMcpJsonMapper(objectMapper()));
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
+	public HttpServletStreamableServerTransportProvider streamableServerTransport() {
+		log.info("Creating HttpServletStreamableServerTransport");
+		return HttpServletStreamableServerTransportProvider.builder()
+				.jsonMapper(new JacksonMcpJsonMapper(objectMapper()))
+				.mcpEndpoint("/mcp")
+				.build();
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
+	public ServletRegistrationBean<HttpServletStreamableServerTransportProvider> streamableServletRegistration(
+			HttpServletStreamableServerTransportProvider transport) {
+		ServletRegistrationBean<HttpServletStreamableServerTransportProvider> registration =
+				new ServletRegistrationBean<>(transport, "/mcp");
+		registration.setAsyncSupported(true);
+		return registration;
+	}
 
 	@Bean(destroyMethod = "close")
+	@ConditionalOnBean(McpServerTransportProvider.class)
 	public McpSyncServer mcpSyncServer(McpServerTransportProvider transport) {
 		log.info("Initializing McpSyncServer with transport: {}", transport);
-
-		McpSyncServer syncServer = McpServer.sync(transport).serverInfo("custom-server", "0.0.1").capabilities(
-				McpSchema.ServerCapabilities.builder().tools(true).resources(false, false).prompts(false).build())
+		McpSyncServer syncServer = McpServer.sync(transport)
+				.serverInfo("custom-server", "0.0.1")
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).resources(false, false).prompts(false).build())
 				.build();
-
-		UniquenessTool uniquenessTool = new UniquenessTool();
-
-        SyncToolSpecification.Builder tool = SyncToolSpecification.builder().tool(uniquenessTool.getToolDefinition());
-        tool.callHandler(new BiFunction<McpSyncServerExchange, McpSchema.CallToolRequest, McpSchema.CallToolResult>() {
-            @Override
-            public McpSchema.CallToolResult apply(McpSyncServerExchange mcpSyncServerExchange, McpSchema.CallToolRequest callToolRequest) {
-                return uniquenessTool.apply(callToolRequest.arguments());
-            }
-        });
-        syncServer.addTool(tool.build());
-
+		registerTools(syncServer);
 		return syncServer;
+	}
+
+	@Bean(destroyMethod = "close")
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
+	public McpSyncServer mcpSyncServerStreamable(McpStreamableServerTransportProvider transport) {
+		log.info("Initializing McpSyncServer with streamable transport: {}", transport);
+		McpSyncServer syncServer = McpServer.sync(transport)
+				.serverInfo("custom-server", "0.0.1")
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).resources(false, false).prompts(false).build())
+				.build();
+		registerTools(syncServer);
+		return syncServer;
+	}
+
+	private void registerTools(McpSyncServer server) {
+		UniquenessTool uniquenessTool = new UniquenessTool();
+		SyncToolSpecification toolSpec = SyncToolSpecification.builder()
+				.tool(uniquenessTool.getToolDefinition())
+				.callHandler((exchange, request) -> uniquenessTool.apply(request.arguments()))
+				.build();
+		server.addTool(toolSpec);
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
@@ -1,12 +1,14 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 
 public class McpConfigurationTest {
@@ -24,5 +26,27 @@ public class McpConfigurationTest {
     public void stdioTransportIsNotNull() {
         McpConfiguration config = new McpConfiguration();
         assertFalse(config.stdioServerTransport() == null);
+    }
+
+    @Test
+    public void streamableTransportIsNotNull() {
+        McpConfiguration config = new McpConfiguration();
+        assertNotNull(config.streamableServerTransport());
+    }
+
+    @Test
+    public void streamableServletRegistrationIsNotNull() {
+        McpConfiguration config = new McpConfiguration();
+        HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
+        assertNotNull(config.streamableServletRegistration(transport));
+    }
+
+    @Test
+    public void mcpSyncServerStreamableHasTools() {
+        McpConfiguration config = new McpConfiguration();
+        HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
+        McpSyncServer server = config.mcpSyncServerStreamable(transport);
+        assertNotNull(server.getServerCapabilities().tools());
+        server.close();
     }
 }


### PR DESCRIPTION
## Summary

- Adds `HttpServletStreamableServerTransportProvider` as an alternative to stdio for MCP transport, activated via `--transport.mode=streamable-http`
- Extracts `resolveTransportMode` in `Main` to parse the transport mode from CLI args, defaulting to `stdio`; the `web-application-type=none` property is now only set for stdio mode
- Refactors `McpConfiguration`: extracts `registerTools` helper, replaces anonymous `BiFunction` with a lambda, and fixes `final static` → `static final` field modifier order

## Test plan

- [ ] `McpConfigurationTest.streamableTransportIsNotNull` — verifies `HttpServletStreamableServerTransportProvider` bean is created
- [ ] `McpConfigurationTest.streamableServletRegistrationIsNotNull` — verifies servlet registration bean is non-null
- [ ] `McpConfigurationTest.mcpSyncServerStreamableHasTools` — verifies streamable server has tools capability registered
- [ ] Existing stdio tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)