### PR TITLE
feat(mcp): add streamable HTTP transport support

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,22 @@
+name: MCP Integration Tests
+
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  integration-tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up JDK 25
+      uses: actions/setup-java@v5
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: maven
+    - name: Run MCP streamable HTTP integration tests
+      run: mvn -B verify -P integration-tests --file pom.xml

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,9 +1,8 @@
 name: MCP Integration Tests
 
 on:
-  push:
-  pull_request:
-    branches: [ "main" ]
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   integration-tests:

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -41,6 +41,30 @@
             </plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>integration-tests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<executions>
+							<execution>
+								<goals>
+									<goal>integration-test</goal>
+									<goal>verify</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<argLine>--add-reads datamodule=ALL-UNNAMED</argLine>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -99,10 +99,11 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 			if (wrapper == null) {
 				array[hash] = new Wrapper<>(key, value);
 				size++;
-				return value;
+				return null;
 			} else if (wrapper.key.equals(key)) {
-				array[hash] = new Wrapper<>(key, value); // overwrite
-				return value;
+				V previous = wrapper.value;
+				array[hash] = new Wrapper<>(key, value);
+				return previous;
 			} // removed are skipped
 		}
 		resize();

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
@@ -23,10 +23,11 @@ public class NoMemoryUniquenessCheck extends AbstractUniqueness {
 		while (dataSource.hasMoreData()) {
 			String[] row = dataSource.nextRow();
 			if (finder.found(row)) {
+				close(dataSource);
 				return new Result(false, keyCandidates, row);
 			}
 		}
-		
+
 		Result result = handleSuccessfulCheck(keyCandidates);
 		close(dataSource);
 		return result;

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/Main.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/Main.java
@@ -7,10 +7,23 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Main {
 
     public static void main(String[] args) {
-        System.setProperty("transport.mode", "stdio");
-        System.setProperty("spring.main.web-application-type", "none");
+        String transportMode = resolveTransportMode(args);
+        System.setProperty("transport.mode", transportMode);
+        if ("stdio".equals(transportMode)) {
+            System.setProperty("spring.main.web-application-type", "none");
+        }
         System.setProperty("banner-mode", "off");
         SpringApplication.run(Main.class, args);
+    }
+
+    private static String resolveTransportMode(String[] args) {
+        String prefix = "--transport.mode=";
+        for (String arg : args) {
+            if (arg.startsWith(prefix)) {
+                return arg.substring(prefix.length());
+            }
+        }
+        return "stdio";
     }
 
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfiguration.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfiguration.java
@@ -1,60 +1,92 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
-import io.modelcontextprotocol.server.McpSyncServerExchange;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
-
-import java.util.function.BiFunction;
+import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 
 @Configuration
 public class McpConfiguration {
 
-	private final static Logger log = LogManager.getLogger(McpConfiguration.class.getName());
+	private static final Logger log = LogManager.getLogger(McpConfiguration.class.getName());
 
 	@Bean
 	public ObjectMapper objectMapper() {
 		return new ObjectMapper();
 	}
 
-    @Bean
-    @ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stdio", matchIfMissing = true)
-    public StdioServerTransportProvider stdioServerTransport() {
-        log.info("Creating StdioServerTransport");
-        return new StdioServerTransportProvider(new JacksonMcpJsonMapper(objectMapper()));
-    }
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stdio", matchIfMissing = true)
+	public StdioServerTransportProvider stdioServerTransport() {
+		log.info("Creating StdioServerTransport");
+		return new StdioServerTransportProvider(new JacksonMcpJsonMapper(objectMapper()));
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
+	public HttpServletStreamableServerTransportProvider streamableServerTransport() {
+		log.info("Creating HttpServletStreamableServerTransport");
+		return HttpServletStreamableServerTransportProvider.builder()
+				.jsonMapper(new JacksonMcpJsonMapper(objectMapper()))
+				.mcpEndpoint("/mcp")
+				.build();
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
+	public ServletRegistrationBean<HttpServletStreamableServerTransportProvider> streamableServletRegistration(
+			HttpServletStreamableServerTransportProvider transport) {
+		ServletRegistrationBean<HttpServletStreamableServerTransportProvider> registration =
+				new ServletRegistrationBean<>(transport, "/mcp");
+		registration.setAsyncSupported(true);
+		return registration;
+	}
 
 	@Bean(destroyMethod = "close")
+	@ConditionalOnBean(McpServerTransportProvider.class)
 	public McpSyncServer mcpSyncServer(McpServerTransportProvider transport) {
 		log.info("Initializing McpSyncServer with transport: {}", transport);
-
-		McpSyncServer syncServer = McpServer.sync(transport).serverInfo("custom-server", "0.0.1").capabilities(
-				McpSchema.ServerCapabilities.builder().tools(true).resources(false, false).prompts(false).build())
+		McpSyncServer syncServer = McpServer.sync(transport)
+				.serverInfo("custom-server", "0.0.1")
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).resources(false, false).prompts(false).build())
 				.build();
-
-		UniquenessTool uniquenessTool = new UniquenessTool();
-
-        SyncToolSpecification.Builder tool = SyncToolSpecification.builder().tool(uniquenessTool.getToolDefinition());
-        tool.callHandler(new BiFunction<McpSyncServerExchange, McpSchema.CallToolRequest, McpSchema.CallToolResult>() {
-            @Override
-            public McpSchema.CallToolResult apply(McpSyncServerExchange mcpSyncServerExchange, McpSchema.CallToolRequest callToolRequest) {
-                return uniquenessTool.apply(callToolRequest.arguments());
-            }
-        });
-        syncServer.addTool(tool.build());
-
+		registerTools(syncServer);
 		return syncServer;
+	}
+
+	@Bean(destroyMethod = "close")
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
+	public McpSyncServer mcpSyncServerStreamable(McpStreamableServerTransportProvider transport) {
+		log.info("Initializing McpSyncServer with streamable transport: {}", transport);
+		McpSyncServer syncServer = McpServer.sync(transport)
+				.serverInfo("custom-server", "0.0.1")
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).resources(false, false).prompts(false).build())
+				.build();
+		registerTools(syncServer);
+		return syncServer;
+	}
+
+	private void registerTools(McpSyncServer server) {
+		UniquenessTool uniquenessTool = new UniquenessTool();
+		SyncToolSpecification toolSpec = SyncToolSpecification.builder()
+				.tool(uniquenessTool.getToolDefinition())
+				.callHandler((exchange, request) -> uniquenessTool.apply(request.arguments()))
+				.build();
+		server.addTool(toolSpec);
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
@@ -71,6 +71,19 @@ public class MapTest {
 
 	@ParameterizedTest
 	@MethodSource("allImplementations")
+	public void putNewKeyReturnsNull(Map<Integer, String> map) {
+		assertNull(map.put(1, "A"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void putExistingKeyReturnsPreviousValue(Map<Integer, String> map) {
+		map.put(1, "A");
+		assertEquals("A", map.put(1, "B"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
 	public void values(Map<Integer, String> map) {
 		int size = 50;
 		for (int i = 0; i < size; ++i) {

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/UniquenessCheckTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/UniquenessCheckTest.java
@@ -137,6 +137,64 @@ public class UniquenessCheckTest extends DBTest {
 	}
 
 	@Test
+	public void notUniquePathClosesDataSource() throws Exception {
+		ClosingSpyDataSource source = new ClosingSpyDataSource(
+				Utils.createDataSource(Utils.getHouseholdFile(), COLUMNS_ROW));
+		NoMemoryUniquenessCheck uniqueness = new NoMemoryUniquenessCheck();
+		uniqueness.setDataSource(source);
+
+		Result result = uniqueness.exec(NOT_UNIQUE_COLUMNS);
+
+		assertFalse(result.isUnique());
+		assertTrue(source.isClosed(), "Data source must be closed when a duplicate is found");
+	}
+
+	private static final class ClosingSpyDataSource implements IterableDataSource {
+
+		private final IterableDataSource delegate;
+		private boolean closed = false;
+
+		ClosingSpyDataSource(IterableDataSource delegate) {
+			this.delegate = delegate;
+		}
+
+		boolean isClosed() {
+			return closed;
+		}
+
+		@Override
+		public void close() throws java.io.IOException {
+			closed = true;
+			delegate.close();
+		}
+
+		@Override
+		public String[] getColumnNames() {
+			return delegate.getColumnNames();
+		}
+
+		@Override
+		public void open() {
+			delegate.open();
+		}
+
+		@Override
+		public String[] nextRow() {
+			return delegate.nextRow();
+		}
+
+		@Override
+		public boolean hasMoreData() {
+			return delegate.hasMoreData();
+		}
+
+		@Override
+		public void reset() {
+			delegate.reset();
+		}
+	}
+
+	@Test
 	public void negativeInMemorySourceVsNoMemoryCheck() {
 		AbstractUniqueness uniqueness = new InMemoryUniquenessCheck();
 		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> uniqueness.setDataSource(new IterableSQLDataSource(connection, query)), "Expected setDataSource method to throw, but it didn't");

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
@@ -1,12 +1,14 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 
 public class McpConfigurationTest {
@@ -24,5 +26,27 @@ public class McpConfigurationTest {
     public void stdioTransportIsNotNull() {
         McpConfiguration config = new McpConfiguration();
         assertFalse(config.stdioServerTransport() == null);
+    }
+
+    @Test
+    public void streamableTransportIsNotNull() {
+        McpConfiguration config = new McpConfiguration();
+        assertNotNull(config.streamableServerTransport());
+    }
+
+    @Test
+    public void streamableServletRegistrationIsNotNull() {
+        McpConfiguration config = new McpConfiguration();
+        HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
+        assertNotNull(config.streamableServletRegistration(transport));
+    }
+
+    @Test
+    public void mcpSyncServerStreamableHasTools() {
+        McpConfiguration config = new McpConfiguration();
+        HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
+        McpSyncServer server = config.mcpSyncServerStreamable(transport);
+        assertNotNull(server.getServerCapabilities().tools());
+        server.close();
     }
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpStreamableHttpIT.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpStreamableHttpIT.java
@@ -1,0 +1,72 @@
+package io.github.adamw7.tools.data.uniqueness.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import io.github.adamw7.tools.data.Utils;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+
+@SpringBootTest(
+		classes = Main.class,
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = { "transport.mode=streamable-http", "spring.main.banner-mode=off" })
+public class McpStreamableHttpIT {
+
+	@LocalServerPort
+	private int port;
+
+	private McpSyncClient client;
+
+	@BeforeEach
+	void setUp() {
+		HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
+				.builder("http://localhost:" + port)
+				.build();
+		client = McpClient.sync(transport)
+				.clientInfo(McpSchema.Implementation.builder("integration-test-client", "1.0").build())
+				.build();
+		client.initialize();
+	}
+
+	@AfterEach
+	void tearDown() {
+		client.close();
+	}
+
+	@Test
+	void nonUniqueColumnReturnsFalse() {
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("uniqueness_check")
+				.arguments(Map.of("file", Utils.getHouseholdFile(), "columns_row", 1, "columns_name", "year1"))
+				.build();
+
+		McpSchema.CallToolResult result = client.callTool(request);
+
+		assertFalse(result.isError());
+		McpSchema.TextContent content = (McpSchema.TextContent) result.content().getFirst();
+		assertEquals("false", content.text());
+	}
+
+	@Test
+	void uniqueColumnReturnsTrue() {
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("uniqueness_check")
+				.arguments(Map.of("file", Utils.getHouseholdFile(), "columns_row", 1, "columns_name", "income"))
+				.build();
+
+		McpSchema.CallToolResult result = client.callTool(request);
+
+		assertFalse(result.isError());
+		McpSchema.TextContent content = (McpSchema.TextContent) result.content().getFirst();
+		assertEquals("true", content.text());
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,11 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-failsafe-plugin</artifactId>
+					<version>3.5.6</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-plugin-plugin</artifactId>
 					<version>3.15.2</version>
 				</plugin>


### PR DESCRIPTION
## Summary

- Add streamable HTTP transport support for MCP
- Add nightly CI workflow for integration tests with separate job for streamable HTTP
- Fix `OpenAddressingMap.put` to return the previous value (or null) per the `Map` contract
- Fix `NoMemoryUniquenessCheck` to close the data source when a duplicate is found

## Test plan

- [ ] `mvn test` passes locally
- [ ] Integration test `McpStreamableHttpIT` covers the new transport end-to-end
- [ ] `MapTest` — new parameterized tests `putNewKeyReturnsNull` and `putExistingKeyReturnsPreviousValue` verify the `put` contract across all implementations
- [ ] Nightly CI workflow runs integration tests at midnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)