### PR TITLE
fix(IterableSQLDataSource): use column index instead of name in getNextFrom

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -88,10 +88,10 @@ public class IterableSQLDataSource implements IterableDataSource {
 	}
 
 	protected static String[] getNextFrom(ResultSet resultSet) throws SQLException {
-		String[] columns = getColumnsFrom(resultSet);
-		String[] row = new String[columns.length];
-		for (int i = 0; i < columns.length; ++i) {
-			row[i] = resultSet.getString(columns[i]);
+		int columnCount = resultSet.getMetaData().getColumnCount();
+		String[] row = new String[columnCount];
+		for (int i = 0; i < columnCount; ++i) {
+			row[i] = resultSet.getString(i + 1);
 		}
 		return row;
 	}

--- a/data/src/test/java/io/github/adamw7/tools/data/source/db/SQLDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/db/SQLDataSourceTest.java
@@ -60,12 +60,19 @@ public class SQLDataSourceTest extends DBTest {
 	public void happyPathMultiTable(IterableSQLDataSource source) {
 		source.open();
 
-		assertEquals("ID", source.getColumnNames()[0]);
-		assertEquals("VALUE", source.getColumnNames()[1]);
+		String[] columnNames = source.getColumnNames();
+		assertEquals("ID", columnNames[0]);
+		assertEquals("VALUE", columnNames[1]);
+		assertEquals("ID", columnNames[2]);
+		assertEquals("NAME", columnNames[3]);
+		assertEquals("SURNAME", columnNames[4]);
 
 		String[] row = source.nextRow();
 		assertEquals("1", row[0]);
 		assertEquals("1000", row[1]);
+		assertEquals("1", row[2]);
+		assertEquals("Adam", row[3]);
+		assertEquals("W", row[4]);
 		Utils.close(source);
 	}
 


### PR DESCRIPTION
## Summary

- `getNextFrom` was calling `resultSet.getString(columnName)`, which returns the first matching column when a query produces duplicate column names (e.g. `SELECT * FROM a JOIN b ON a.id = b.id` yields two `id` columns). This silently produces wrong row data for the second and subsequent duplicate-named columns.
- Fixed by switching to `resultSet.getString(i + 1)` (1-based positional index), which always retrieves the correct column regardless of name duplication.
- Extended `happyPathMultiTable` test to assert all 5 columns from the `SALARY INNER JOIN PEOPLE` result, including both duplicate `ID` columns at positions 0 and 2.

Fixes issue #9 from issues.md.

## Test plan

- [ ] `SQLDataSourceTest#happyPathMultiTable` now verifies all 5 join columns, including both `ID` values
- [ ] All existing `SQLDataSourceTest` cases (6 total) pass with `mvn test -pl data -Dtest=SQLDataSourceTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)