### PR TITLE
build(shellcheck): add shellcheck-maven-plugin to lint shell scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,7 @@
 			<plugin>
 				<groupId>dev.dimlight</groupId>
 				<artifactId>shellcheck-maven-plugin</artifactId>
+				<inherited>false</inherited>
 				<executions>
 					<execution>
 						<id>shellcheck</id>
@@ -256,9 +257,11 @@
 							<goal>check</goal>
 						</goals>
 						<configuration>
-							<sourceLocations>
-								<sourceLocation>${project.basedir}/scripts</sourceLocation>
-							</sourceLocations>
+							<sourceDirs>
+								<sourceDir>
+									<directory>${project.basedir}/scripts</directory>
+								</sourceDir>
+							</sourceDirs>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -238,9 +238,31 @@
 					<artifactId>maven-enforcer-plugin</artifactId>
 					<version>3.6.3</version>
 				</plugin>
+				<plugin>
+					<groupId>dev.dimlight</groupId>
+					<artifactId>shellcheck-maven-plugin</artifactId>
+					<version>0.5.1</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
+			<plugin>
+				<groupId>dev.dimlight</groupId>
+				<artifactId>shellcheck-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shellcheck</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<sourceLocations>
+								<sourceLocation>${project.basedir}/scripts</sourceLocation>
+							</sourceLocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/scripts/linux/install-jdk-25.sh
+++ b/scripts/linux/install-jdk-25.sh
@@ -85,7 +85,7 @@ remove_temp_files() {
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 echo -e "\nJDK 25 Installer for Linux"
-echo "==========================\n"
+printf "==========================\n\n"
 
 if test_jdk_already_installed; then
     echo -e "\nJDK 25 is already present. Nothing to do."


### PR DESCRIPTION
Configure dev.dimlight:shellcheck-maven-plugin:0.5.1 to check all
.sh files under scripts/ on every build. Version is pinned in
pluginManagement; the active execution lives in the root build/plugins.