### PR TITLE
build(coverage): add JaCoCo unit test coverage reporting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+name: Coverage
+
+on:
+  schedule:
+    - cron: '0 0 * * 6'
+
+jobs:
+  coverage:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up JDK 25
+      uses: actions/setup-java@v5
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: maven
+    - name: Run tests with JaCoCo
+      run: mvn -B verify -Pcoverage --file pom.xml
+    - name: Upload coverage reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: jacoco-reports
+        path: '**/target/site/jacoco/'
+        retention-days: 30

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -27,7 +27,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<argLine>--add-reads datamodule=ALL-UNNAMED</argLine>
+					<argLine>@{argLine} --add-reads datamodule=ALL-UNNAMED</argLine>
 				</configuration>
 			</plugin>
 	        <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,11 @@
 					<artifactId>shellcheck-maven-plugin</artifactId>
 					<version>0.5.1</version>
 				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>0.8.12</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -280,6 +285,25 @@
 								<banDuplicatePomDependencyVersions />
 							</rules>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 		<java.version>25</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<protobuf.version>4.33.4</protobuf.version>
+		<argLine/>
 	</properties>
 	<licenses>
 		<license>

--- a/pom.xml
+++ b/pom.xml
@@ -288,27 +288,37 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>report</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>coverage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>prepare-agent</id>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>report</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>report</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<distributionManagement>
 		<repository>


### PR DESCRIPTION
Configure jacoco-maven-plugin 0.8.12 in root POM with prepare-agent
and report executions bound to the verify phase.

Fix data module surefire argLine to use @{argLine} placeholder so
JaCoCo's agent argument is preserved alongside the module-system flag.

https://claude.ai/code/session_01RjbpDiz37wXQ8fNoYq6JZd