### PR TITLE
build(coverage): fail build if instruction coverage drops below 80%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,27 @@
 									<goal>report</goal>
 								</goals>
 							</execution>
+							<execution>
+								<id>check</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>check</goal>
+								</goals>
+								<configuration>
+									<rules>
+										<rule>
+											<element>BUNDLE</element>
+											<limits>
+												<limit>
+													<counter>INSTRUCTION</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>0.80</minimum>
+												</limit>
+											</limits>
+										</rule>
+									</rules>
+								</configuration>
+							</execution>
 						</executions>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
Add JaCoCo check execution to the coverage profile that enforces
a minimum 80% instruction coverage ratio at the BUNDLE level.
The build will fail when the threshold is not met.