### PR TITLE
refactor: simplify collection, stream, and control-flow idioms

### DIFF
--- a/code/context/src/main/java/io/github/adamw7/context/Finder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/Finder.java
@@ -50,11 +50,9 @@ public class Finder implements Context {
 	}
 
 	private ClassContainer findContainer(String className) {
-		for (ClassContainer container : allContainers) {
-			if (container.className().equals(className + ".java")) {
-				return container;
-			}
-		}
-		return null;
+		return allContainers.stream()
+				.filter(container -> container.className().equals(className + ".java"))
+				.findAny()
+				.orElse(null);
 	}
 }

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/TypeMappings.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/TypeMappings.java
@@ -115,12 +115,7 @@ public class TypeMappings {
 	}
 
 	private String wrapIfNeeded(String type) {
-		String value = primitiveToObjectMap.get(type);
-		if (value == null) {
-			return type;
-		} else {
-			return value;
-		}
+		return primitiveToObjectMap.getOrDefault(type, type);
 	}
 
 	private String handleEnum(FieldDescriptor field) {

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -65,11 +65,7 @@ public class IterableSQLDataSource implements IterableDataSource {
 	public String[] nextRow() {
 		try {
 			hasMoreData = resultSet.next();
-			if (hasMoreData) {
-				return getNextFrom(resultSet);
-			} else {
-				return null;
-			}
+			return hasMoreData ? getNextFrom(resultSet) : null;
 		} catch (SQLException e) {
 			throw new UncheckedIOException(new IOException(e));
 		}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryTOONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryTOONDataSource.java
@@ -65,13 +65,9 @@ public class InMemoryTOONDataSource extends AbstractFileSource implements InMemo
 			return index + 1;
 		}
 
-		Optional<Integer> arrayResult = tryParseArrayHeader(lines, index, trimmed);
-		if (arrayResult.isPresent()) {
-			return arrayResult.get();
-		}
-
-		Optional<Integer> kvResult = tryParseKeyValue(lines, index, trimmed);
-        return kvResult.orElseGet(() -> index + 1);
+		return tryParseArrayHeader(lines, index, trimmed)
+				.or(() -> tryParseKeyValue(lines, index, trimmed))
+				.orElseGet(() -> index + 1);
     }
 
 	private Optional<Integer> tryParseArrayHeader(List<String> lines, int index, String trimmed) {

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -1,11 +1,11 @@
 package io.github.adamw7.tools.data.structure;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.github.adamw7.tools.data.structure.internal.Primes;
 import io.github.adamw7.tools.data.structure.internal.Wrapper;
@@ -160,43 +160,25 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 
 	@Override
 	public Set<K> keySet() {
-		Set<K> keys = new HashSet<>();
-		for (int i = 0; i < array.length; ++i) {
-			Wrapper<K, V> wrapper = array[i];
-			if (valid(wrapper)) {
-				keys.add(wrapper.key);
-			}
-		}
-		return keys;
+		return validWrappers().map(wrapper -> wrapper.key).collect(Collectors.toSet());
 	}
 
 	@Override
 	public Collection<V> values() {
-		List<V> values = new ArrayList<>();
-		for (int i = 0; i < array.length; ++i) {
-			Wrapper<K, V> wrapper = array[i];
-			if (valid(wrapper)) {
-				values.add(wrapper.value);
-			}
-		}
-		return values;
-	}
-
-	private boolean valid(Wrapper<K, V> wrapper) {
-		return wrapper != null && !wrapper.removed;
+		return validWrappers().map(wrapper -> wrapper.value).collect(Collectors.toList());
 	}
 
 	@Override
 	public Set<Entry<K, V>> entrySet() {
-		Set<Entry<K, V>> entrySet = new HashSet<>(size);
-		for (int i = 0; i < array.length; ++i) {
-			Wrapper<K, V> wrapper = array[i];
-			if (valid(wrapper)) {
-				entrySet.add(wrapper);
-			}
-		}
-		
-		return entrySet;
+		return validWrappers().<Entry<K, V>>map(wrapper -> wrapper).collect(Collectors.toSet());
+	}
+
+	private Stream<Wrapper<K, V>> validWrappers() {
+		return Arrays.stream(array).filter(this::valid);
+	}
+
+	private boolean valid(Wrapper<K, V> wrapper) {
+		return wrapper != null && !wrapper.removed;
 	}
 
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
@@ -28,11 +28,9 @@ public abstract class AbstractUniqueness implements Uniqueness {
 	}
 	
 	protected String[] toLower(String[] items) {
-		String[] arrayToLower = new String[items.length];
-		for (int i = 0; i < items.length; ++i) {
-			arrayToLower[i] = items[i] == null ? null : items[i].toLowerCase();
-		}
-		return arrayToLower;
+		return Arrays.stream(items)
+				.map(item -> item == null ? null : item.toLowerCase())
+				.toArray(String[]::new);
 	}
 
 	protected Integer[] getIndiciesOf(String[] keyCandidates, String[] allColumns) {
@@ -68,10 +66,8 @@ public abstract class AbstractUniqueness implements Uniqueness {
 	private void handleDuplicates(String[] keyCandidates) {
 		Set<String> set = new HashSet<>();
 		for (String candidate : keyCandidates) {
-			if (set.contains(candidate)) {
+			if (!set.add(candidate)) {
 				throw new IllegalArgumentException("Duplicate in input: " + candidate);
-			} else {
-				set.add(candidate);
 			}
 		}
 	}

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/KeyFinder.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/KeyFinder.java
@@ -1,8 +1,7 @@
 package io.github.adamw7.tools.data.uniqueness;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class KeyFinder {
@@ -15,25 +14,15 @@ public class KeyFinder {
 	}
 
 	public boolean found(String[] row) {
-		if (row != null) {
-			Key key = key(row, indices);
-			if (set.contains(key)) {
-				return true;
-			} else {
-				set.add(key);
-			}
+		if (row == null) {
+			return false;
 		}
-		return false;
+		return !set.add(key(row, indices));
 	}
-	
+
 	protected Key key(String[] row, Integer[] indices) {
-		List<String> values = new ArrayList<>(indices.length);
-
-		for (Integer index : indices) {
-			values.add(row[index]);
-		}
-
-		return new Key(values.toArray(new String[indices.length]));
+		String[] values = Arrays.stream(indices).map(index -> row[index]).toArray(String[]::new);
+		return new Key(values);
 	}
 
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
@@ -73,11 +73,7 @@ public class UniquenessTool implements Function<Map<String, Object>, CallToolRes
 	}
 	
 	private static void print(Result result, String column) {
-		if (result.isUnique()) {
-            log.info("{} is unique", column);
-		} else {
-            log.info("{} is NOT unique", column);
-		}
+		log.info("{} is {}", column, result.isUnique() ? "unique" : "NOT unique");
 	}
 
 }


### PR DESCRIPTION
- OpenAddressingMap: extract validWrappers() stream helper, removing
  triplicated loops in keySet/values/entrySet
- AbstractUniqueness: toLower via stream; handleDuplicates via Set.add
  return value
- KeyFinder: found() via Set.add return value; key() via stream
- IterableSQLDataSource: ternary in nextRow
- TypeMappings: wrapIfNeeded via Map.getOrDefault
- Finder: findContainer via stream findAny
- InMemoryTOONDataSource: chain Optional.or instead of nested checks
- UniquenessTool: collapse print branches into one log statement