### PR TITLE
Add enforcer rules to harden the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,19 @@
 						<configuration>
 							<rules>
 								<banDuplicatePomDependencyVersions />
+								<requireMavenVersion>
+									<version>[3.9,4.0)</version>
+								</requireMavenVersion>
+								<requireJavaVersion>
+									<version>25</version>
+								</requireJavaVersion>
+								<requireReleaseDeps>
+									<onlyWhenRelease>true</onlyWhenRelease>
+								</requireReleaseDeps>
+								<reactorModuleConvergence />
+								<requirePluginVersions>
+									<banSnapshots>false</banSnapshots>
+								</requirePluginVersions>
 							</rules>
 						</configuration>
 					</execution>


### PR DESCRIPTION
Add five maven-enforcer rules to the root pom alongside the existing
banDuplicatePomDependencyVersions:

- requireMavenVersion [3.9,4.0): matches the documented Maven 3.9.x build
- requireJavaVersion 25: fails fast on a wrong build JDK
- requireReleaseDeps (onlyWhenRelease): blocks releasing against SNAPSHOTs
- reactorModuleConvergence: keeps the multi-module parent versions aligned
- requirePluginVersions: enforces explicit plugin versions, matching the
  project rule that all plugin versions live in the root pom

dependencyConvergence and banDynamicVersions were evaluated but left out:
the former surfaces a pre-existing org.eclipse.platform transitive
conflict, and the latter is incompatible with the ${revision} SNAPSHOT
development workflow.