### PR TITLE
Fix InMemoryJSONDataSource inserting non-leaf entries into fieldsMap

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
@@ -36,19 +36,8 @@ public class InMemoryJSONDataSource extends AbstractFileSource implements InMemo
 	}
 
 	private void parseJSON(String jsonString) throws JSONException {
-		JSONObject jsonArray = new JSONObject(jsonString);
-		extractFieldNames(jsonArray);
-		flattenJSON(jsonArray);
-	}
-
-	private void extractFieldNames(JSONObject jsonObject) throws JSONException {
-		for (String key : jsonObject.keySet()) {
-			Object value = jsonObject.get(key);
-			fieldsMap.put(key, String.valueOf(value));
-			if (value instanceof JSONObject jsonObjectValue) {
-				extractFieldNames(jsonObjectValue);
-			}
-		}
+		JSONObject jsonObject = new JSONObject(jsonString);
+		flattenJSON(jsonObject);
 	}
 
 	private void flattenJSON(JSONArray jsonArray) throws JSONException {

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/JSONDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/JSONDataSourceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,8 +29,11 @@ public class JSONDataSourceTest {
     public void testGetColumnNames(InMemoryJSONDataSource source) throws IOException {
 		source.open();
         String[] columnNames = source.getColumnNames();
-        assertEquals(10, columnNames.length);
-        assertArrayEquals(new String[]{"cars", "fruits", "year", "city", "name", "model", "state", "people", "age", "manufacturer"}, columnNames);
+        assertEquals(7, columnNames.length);
+        String[] expected = {"year", "city", "name", "model", "state", "age", "manufacturer"};
+        Arrays.sort(expected);
+        Arrays.sort(columnNames);
+        assertArrayEquals(expected, columnNames);
         source.close();
     }
 
@@ -46,7 +50,7 @@ public class JSONDataSourceTest {
             assertNotNull(row[0]);
             assertNotNull(row[1]);
         }
-        assertEquals(10, rowCount);
+        assertEquals(7, rowCount);
         source.close();
     }
 }


### PR DESCRIPTION
extractFieldNames() was writing parent keys whose values are nested
JSONObjects as their toString() representation alongside the leaf values
that flattenJSON() correctly produced. Remove extractFieldNames entirely
since flattenJSON(JSONObject) already handles full traversal and writes
only leaf entries.

https://claude.ai/code/session_018xkmGFH24xvDYykZoKmR8S