### PR TITLE
fix(file-data-sources): NPE on InMemoryJSON InputStream ctor and CSV scanner leak

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.data.source.file;
 
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,9 +46,6 @@ public class CSVDataSource extends AbstractFileSource {
 
 	public CSVDataSource(String fileName, String delimiter, int columnsRow) throws FileNotFoundException {
 		super(fileName);
-		this.inputStream = new FileInputStream(fileName);
-		this.fileName = fileName;
-		scanner = createScanner(inputStream);
 		this.delimiter = delimiter;
 		this.columnsRow = columnsRow;
 		regex = delimiter + REGEX_SUFFIX;

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
@@ -19,6 +19,7 @@ public class InMemoryJSONDataSource extends AbstractFileSource implements InMemo
 
 	public InMemoryJSONDataSource(InputStream inputStream) {
 		super(inputStream);
+		scanner = createScanner(inputStream);
 		parse();
 	}
 	

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/JSONDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/JSONDataSourceTest.java
@@ -5,9 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -49,5 +52,21 @@ public class JSONDataSourceTest {
         assertEquals(10, rowCount);
         source.close();
     }
+
+	@Test
+	public void readsFromInputStream() throws IOException {
+		try (InputStream stream = new FileInputStream(Utils.getFileName("test.json"))) {
+			InMemoryJSONDataSource source = new InMemoryJSONDataSource(stream);
+			source.open();
+			assertEquals(10, source.getColumnNames().length);
+			int rowCount = 0;
+			while (source.hasMoreData()) {
+				assertNotNull(source.nextRow());
+				rowCount++;
+			}
+			assertEquals(10, rowCount);
+			source.close();
+		}
+	}
 }
 


### PR DESCRIPTION
InMemoryJSONDataSource(InputStream) never created a Scanner before
parse(), so reading from a stream threw NullPointerException. The YAML
and TOON in-memory sources already do this; JSON was missing the call.

CSVDataSource(String, String, int) called super(fileName), which already
opens a Scanner over a FileInputStream, then opened a second
FileInputStream and Scanner. The first Scanner/stream leaked, the file
was opened twice, and the validated path was overwritten with the raw
one (bypassing PathValidator canonicalization). Rely on the stream
opened by the parent instead.

Add a regression test reading InMemoryJSONDataSource from an InputStream.