### PR TITLE
fix(protogen-maven-plugin): harden code generation and test cleanup

### DIFF
--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Code.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Code.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,6 +20,8 @@ import org.apache.logging.log4j.Logger;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.GeneratedMessage;
+
+import io.github.adamw7.tools.code.MojoException;
 
 public class Code {
 
@@ -36,7 +39,7 @@ public class Code {
 
 	private void createPkg(String pkg) {
 		String directory = generatedSourcesDir + File.separator + pkg;
-		Path dir = replace(directory);
+		Path dir = pkgToPath(directory);
 
 		try {
 			deleteRecursively(dir);
@@ -65,7 +68,7 @@ public class Code {
 		}
 	}
 
-	private Path replace(String pkg) {
+	private Path pkgToPath(String pkg) {
 		return Paths.get(pkg.replaceAll("\\.", "/"));
 	}
 
@@ -74,18 +77,18 @@ public class Code {
 		for (Class<? extends GeneratedMessage> c : allMessages) {
 			try {
 				List<ClassContainer> classes = genBuilder(c);
-				for (ClassContainer container : classes) {					
-					write(container.format());					
+				for (ClassContainer container : classes) {
+					write(container.format());
 				}
 			} catch (NoSuchMethodException | SecurityException | IllegalAccessException | InvocationTargetException e) {
-				log.error(e);
+				throw new MojoException(e);
 			}
 		}
 	}
 
 	private void write(ClassContainer container) {
-		String fileName = generatedSourcesDir + replace(outputPkg + File.separator + container.name()) + ".java";
-		try (FileWriter myWriter = new FileWriter(fileName)) {
+		String fileName = generatedSourcesDir + pkgToPath(outputPkg + File.separator + container.name()) + ".java";
+		try (FileWriter myWriter = new FileWriter(fileName, StandardCharsets.UTF_8)) {
 			log.info("Writing {}", fileName);
 			myWriter.write(container.codeAsString());
 		} catch (IOException e) {
@@ -96,7 +99,7 @@ public class Code {
 	private List<ClassContainer> genBuilder(Class<? extends GeneratedMessage> c)
 			throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
 		Method getDescriptorMethod = c.getDeclaredMethod("getDescriptor");
-		Object object = getDescriptorMethod.invoke(this);
+		Object object = getDescriptorMethod.invoke(null);
 		if (object == null) {
 			throw new IllegalStateException("getDescriptor method return null");
 		}

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/MojoTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/MojoTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -134,9 +135,22 @@ public class MojoTest {
 	}
 
 	@AfterEach
-	public void cleanUp() {
-		File dir = new File(GENERATED_SOURCES);
-		dir.delete();
+	public void cleanUp() throws IOException {
+		deleteRecursively(Path.of(GENERATED_SOURCES));
+	}
+
+	private void deleteRecursively(Path path) throws IOException {
+		if (Files.notExists(path)) {
+			return;
+		}
+		if (Files.isDirectory(path)) {
+			try (var children = Files.newDirectoryStream(path)) {
+				for (Path child : children) {
+					deleteRecursively(child);
+				}
+			}
+		}
+		Files.delete(path);
 	}
 
 }


### PR DESCRIPTION
- Throw MojoException instead of silently logging when reflection
  fails in genBuilders(), so the Maven build fails fast on errors
- Use invoke(null) for static getDescriptor() method call
- Write generated files with explicit UTF-8 charset
- Rename replace() to pkgToPath() for clarity
- Fix MojoTest.cleanUp() to recursively delete the generated
  sources directory instead of silently failing on non-empty dirs

https://claude.ai/code/session_019L87fM9BMDueVXLcEZ4zpf