### PR TITLE
refactor: simplify TypeMappings by removing duplicated type resolution

### DIFF
--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/TypeMappings.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/TypeMappings.java
@@ -67,37 +67,28 @@ public class TypeMappings {
 	}
 
 	public String get(FieldDescriptor field) {
-		String key = field.getType().getJavaType().name();
-		
-		if (field.isRepeated() && !field.isMapField()) {
-			return handleRepeated(field);
-		} else if (key.equals(ENUM)) {
-			return handleEnum(field);
-		} else if (key.equals(MESSAGE) && field.isMapField()) {
+		if (field.isMapField()) {
 			return handleMap(field);
-		} else if (key.equals(MESSAGE)) { 
+		} else if (field.isRepeated()) {
+			return name(List.class) + "<" + wrapIfNeeded(scalarType(field)) + ">";
+		} else {
+			return scalarType(field);
+		}
+	}
+
+	private String scalarType(FieldDescriptor field) {
+		String key = field.getType().getJavaType().name();
+		if (key.equals(ENUM)) {
+			return handleEnum(field);
+		} else if (key.equals(MESSAGE)) {
 			return handleMessage(field);
 		} else {
 			String type = mappings.get(key);
 			if (type == null) {
 				throw new IllegalArgumentException("Could not find type mapping for key: " + key);
-			} else {
-				return type;
 			}
-		}		
-	}
-
-	private String handleRepeated(FieldDescriptor field) {
-		String innerType = field.getType().getJavaType().name();
-		if (innerType.equals(ENUM)) {
-			innerType = handleEnum(field);
-		} else if (innerType.equals(MESSAGE)) { 
-			innerType = handleMessage(field);
-		} else {
-			innerType = wrapIfNeeded(mappings.get(innerType));			
+			return type;
 		}
-
-		return name(List.class) + "<" + innerType + ">";
 	}
 
 	private String handleMessage(FieldDescriptor field) {


### PR DESCRIPTION
Extract scalar type resolution into a single scalarType helper so that
both the scalar and repeated branches share the same ENUM/MESSAGE/mapping
logic. This removes handleRepeated and the duplicated branching it
contained, and lets the dispatch in get() key off field shape
(map/repeated/scalar) rather than mixing it with java-type checks.

https://claude.ai/code/session_012XaA5f4Li7V3uHskt76nPD