### PR TITLE
test(protogen-maven-plugin-test): add proto files for new builder cases

### DIFF
--- a/code/protogen-maven-plugin-test/src/main/proto/measurement.proto
+++ b/code/protogen-maven-plugin-test/src/main/proto/measurement.proto
@@ -1,0 +1,26 @@
+syntax = "proto2";
+
+package test;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.code.test";
+
+// Exercises the optional-only builder path across the full range of scalar
+// type mappings together with a nested enum field.
+message Measurement {
+  optional int64 count = 1;
+  optional double ratio = 2;
+  optional float weight = 3;
+  optional bool enabled = 4;
+  optional bytes payload = 5;
+  optional uint32 small = 6;
+  optional uint64 big = 7;
+  optional sint32 delta = 8;
+
+  enum Unit {
+    METRIC = 0;
+    IMPERIAL = 1;
+  }
+
+  optional Unit unit = 9;
+}

--- a/code/protogen-maven-plugin-test/src/main/proto/server.proto
+++ b/code/protogen-maven-plugin-test/src/main/proto/server.proto
@@ -1,0 +1,15 @@
+syntax = "proto2";
+
+package test;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.code.test";
+
+// Exercises the staged builder with more than two required fields of mixed
+// scalar types followed by an optional field.
+message Server {
+  required string host = 1;
+  required int32 port = 2;
+  required bool secure = 3;
+  optional string description = 4;
+}

--- a/code/protogen-maven-plugin-test/src/main/proto/vehicle.proto
+++ b/code/protogen-maven-plugin-test/src/main/proto/vehicle.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+
+package test;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.code.test";
+
+// Exercises a required field whose type is another generated message, so the
+// builder of one message composes the output of another builder.
+message Wheel {
+  required int32 size = 1;
+}
+
+message Car {
+  required Wheel wheel = 1;
+  optional string model = 2;
+}

--- a/code/protogen-maven-plugin-test/src/test/java/io/github/adamw7/tools/code/usecase/GeneretedCodeTest.java
+++ b/code/protogen-maven-plugin-test/src/test/java/io/github/adamw7/tools/code/usecase/GeneretedCodeTest.java
@@ -7,15 +7,25 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.output.generated.CarBuilder;
 import org.output.generated.ComputerBuilder;
 import org.output.generated.ComputerOptionalIfc;
 import org.output.generated.GroupBuilder;
 import org.output.generated.GroupingBuilder;
+import org.output.generated.MeasurementBuilder;
 import org.output.generated.OneOptionalFieldOnlyBuilder;
+import org.output.generated.ServerBuilder;
 import org.output.generated.UserBuilder;
+import org.output.generated.WheelBuilder;
 
+import com.google.protobuf.ByteString;
+
+import io.github.adamw7.tools.code.test.Car;
 import io.github.adamw7.tools.code.test.Computer;
 import io.github.adamw7.tools.code.test.Grouping;
+import io.github.adamw7.tools.code.test.Measurement;
+import io.github.adamw7.tools.code.test.Server;
+import io.github.adamw7.tools.code.test.Wheel;
 
 public class GeneretedCodeTest {
 
@@ -57,5 +67,59 @@ public class GeneretedCodeTest {
 		assertNotNull(grouping);
 		assertTrue(grouping.getGroup().getActive());
 	}
-	
+
+	@Test
+	public void multipleRequiredFields() {
+		ServerBuilder builder = new ServerBuilder();
+		Server server = builder.setHost("localhost").setPort(8080).setSecure(true).setDescription("primary").build();
+		assertNotNull(server);
+		assertEquals("localhost", server.getHost());
+		assertEquals(8080, server.getPort());
+		assertTrue(server.getSecure());
+		assertEquals("primary", server.getDescription());
+		assertTrue(builder.hasHost());
+	}
+
+	@Test
+	public void requiredFieldsWithoutOptional() {
+		Wheel wheel = new WheelBuilder().setSize(15).build();
+		assertNotNull(wheel);
+		assertEquals(15, wheel.getSize());
+	}
+
+	@Test
+	public void messageTypedRequiredField() {
+		Wheel wheel = new WheelBuilder().setSize(17).build();
+		Car car = new CarBuilder().setWheel(wheel).setModel("Sedan").build();
+		assertNotNull(car);
+		assertEquals(17, car.getWheel().getSize());
+		assertEquals("Sedan", car.getModel());
+	}
+
+	@Test
+	public void scalarTypeMappings() {
+		MeasurementBuilder builder = new MeasurementBuilder();
+		Measurement measurement = builder.setCount(42L).setRatio(1.5).setWeight(2.5f).setEnabled(true)
+				.setPayload(ByteString.copyFromUtf8("data")).setSmall(7).setBig(99L).setDelta(-3)
+				.setUnit(Measurement.Unit.METRIC).build();
+		assertNotNull(measurement);
+		assertEquals(42L, measurement.getCount());
+		assertEquals(1.5, measurement.getRatio());
+		assertEquals(2.5f, measurement.getWeight());
+		assertTrue(measurement.getEnabled());
+		assertEquals("data", measurement.getPayload().toStringUtf8());
+		assertEquals(7, measurement.getSmall());
+		assertEquals(99L, measurement.getBig());
+		assertEquals(-3, measurement.getDelta());
+		assertEquals(Measurement.Unit.METRIC, measurement.getUnit());
+	}
+
+	@Test
+	public void clearOptionalFieldReturnsBuilder() {
+		MeasurementBuilder builder = new MeasurementBuilder();
+		builder.setEnabled(true);
+		assertTrue(builder.hasEnabled());
+		assertFalse(builder.clearEnabled().build().getEnabled());
+	}
+
 }


### PR DESCRIPTION
Add server.proto, vehicle.proto and measurement.proto to exercise generated
builder scenarios not previously covered: a staged builder with more than two
required fields, a required field typed as another generated message, and the
optional-only path across the full range of scalar type mappings plus a nested
enum. Cover each with assertions in GeneretedCodeTest.

https://claude.ai/code/session_01UtK8f3b3gXVELwby9GTb6F