### PR TITLE
build(deps): upgrade MCP SDK from 2.0.0-M3 to 2.0.0-RC1

### DIFF
--- a/data/pom.xml
+++ b/data/pom.xml
@@ -70,7 +70,7 @@
 			<dependency>
 				<groupId>io.modelcontextprotocol.sdk</groupId>
 				<artifactId>mcp-bom</artifactId>
-				<version>2.0.0-M3</version>
+				<version>2.0.0-RC1</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
Update io.modelcontextprotocol.sdk BOM from 2.0.0-M3 to 2.0.0-RC1.
No API breaking changes; RC1 includes bug fixes and minor enhancements.