### PR TITLE
test: stop SwitchTest from targeting an external server

### DIFF
--- a/data/src/test/java/io/github/adamw7/tools/data/network/SwitchTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/network/SwitchTest.java
@@ -31,7 +31,10 @@ public class SwitchTest {
 	}
 
 	private void connectToInternet() throws Exception {
-		URL url = new URI("https://www.google.com").toURL();
+		// RFC 5737 TEST-NET-1: a reserved, non-routable address. The Switch is
+		// expected to block the connection before it is ever attempted, so this
+		// test must never reach a real external server even if the block fails.
+		URL url = new URI("http://192.0.2.1").toURL();
         
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         


### PR DESCRIPTION
happyPath connected to https://www.google.com to verify the network
Switch blocks outbound traffic. The Switch is meant to block before the
connection leaves the machine, but if the block ever fails to engage the
test would silently reach a real external host.

Point the test at 192.0.2.1 (RFC 5737 TEST-NET-1, reserved and
non-routable) so the unit test can never contact an external server while
keeping the assertion behaviour unchanged.