### PR TITLE
feat(protogen): strip unused imports from generated code

### DIFF
--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/ImportRemoverIfc.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/ImportRemoverIfc.java
@@ -1,0 +1,6 @@
+package io.github.adamw7.tools.code.format;
+
+public interface ImportRemoverIfc {
+
+	String removeUnused(String code);
+}

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/ReferencedNamesVisitor.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/ReferencedNamesVisitor.java
@@ -1,0 +1,33 @@
+package io.github.adamw7.tools.code.format;
+
+import java.util.Set;
+
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
+import org.eclipse.jdt.core.dom.SimpleName;
+
+class ReferencedNamesVisitor extends ASTVisitor {
+
+	private final Set<String> referencedNames;
+
+	ReferencedNamesVisitor(Set<String> referencedNames) {
+		this.referencedNames = referencedNames;
+	}
+
+	@Override
+	public boolean visit(ImportDeclaration importDeclaration) {
+		return false;
+	}
+
+	@Override
+	public boolean visit(PackageDeclaration packageDeclaration) {
+		return false;
+	}
+
+	@Override
+	public boolean visit(SimpleName simpleName) {
+		referencedNames.add(simpleName.getIdentifier());
+		return true;
+	}
+}

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/UnusedImportsRemover.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/UnusedImportsRemover.java
@@ -1,0 +1,83 @@
+package io.github.adamw7.tools.code.format;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.text.edits.TextEdit;
+
+public class UnusedImportsRemover implements ImportRemoverIfc {
+
+	@Override
+	public String removeUnused(String code) {
+		CompilationUnit unit = parse(code);
+		Set<String> referencedNames = collectReferencedNames(unit);
+		return rewriteWithoutUnusedImports(code, unit, referencedNames);
+	}
+
+	private CompilationUnit parse(String code) {
+		ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setSource(code.toCharArray());
+		return (CompilationUnit) parser.createAST(null);
+	}
+
+	private Set<String> collectReferencedNames(CompilationUnit unit) {
+		Set<String> referencedNames = new HashSet<>();
+		unit.accept(new ReferencedNamesVisitor(referencedNames));
+		return referencedNames;
+	}
+
+	private String rewriteWithoutUnusedImports(String code, CompilationUnit unit, Set<String> referencedNames) {
+		ASTRewrite rewrite = ASTRewrite.create(unit.getAST());
+		for (ImportDeclaration importDeclaration : imports(unit)) {
+			removeIfUnused(rewrite, importDeclaration, referencedNames);
+		}
+		return applyRewrite(code, rewrite);
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<ImportDeclaration> imports(CompilationUnit unit) {
+		return unit.imports();
+	}
+
+	private void removeIfUnused(ASTRewrite rewrite, ImportDeclaration importDeclaration, Set<String> referencedNames) {
+		if (isUnused(importDeclaration, referencedNames)) {
+			rewrite.remove(importDeclaration, null);
+		}
+	}
+
+	private boolean isUnused(ImportDeclaration importDeclaration, Set<String> referencedNames) {
+		return !importDeclaration.isOnDemand() && !referencedNames.contains(importedName(importDeclaration));
+	}
+
+	private String importedName(ImportDeclaration importDeclaration) {
+		Name name = importDeclaration.getName();
+		if (name instanceof QualifiedName qualifiedName) {
+			return qualifiedName.getName().getIdentifier();
+		}
+		return ((SimpleName) name).getIdentifier();
+	}
+
+	private String applyRewrite(String code, ASTRewrite rewrite) {
+		IDocument document = new Document(code);
+		try {
+			TextEdit edits = rewrite.rewriteAST(document, null);
+			edits.apply(document);
+		} catch (BadLocationException e) {
+			throw new FormatException(e);
+		}
+		return document.get();
+	}
+}

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/ClassContainer.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/ClassContainer.java
@@ -1,11 +1,13 @@
 package io.github.adamw7.tools.code.gen;
 
 import io.github.adamw7.tools.code.format.Formatter;
+import io.github.adamw7.tools.code.format.UnusedImportsRemover;
 
 public record ClassContainer(String name, CharSequence code) {
-	
+
 	public ClassContainer format() {
-		return new ClassContainer(name, new Formatter().format(codeAsString()));
+		String withoutUnusedImports = new UnusedImportsRemover().removeUnused(codeAsString());
+		return new ClassContainer(name, new Formatter().format(withoutUnusedImports));
 	}
 
 	String codeAsString() {

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/format/UnusedImportsRemoverTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/format/UnusedImportsRemoverTest.java
@@ -1,0 +1,116 @@
+package io.github.adamw7.tools.code.format;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class UnusedImportsRemoverTest {
+
+	private final ImportRemoverIfc remover = new UnusedImportsRemover();
+
+	@Test
+	public void removesSingleUnusedImport() {
+		String code = """
+				package com.example;
+
+				import java.util.List;
+				import java.util.Map;
+
+				public class Sample {
+					private List<String> values;
+				}
+				""";
+
+		String result = remover.removeUnused(code);
+
+		assertTrue(result.contains("import java.util.List;"));
+		assertFalse(result.contains("import java.util.Map;"));
+	}
+
+	@Test
+	public void keepsImportUsedOnlyAsNestedTypeQualifier() {
+		String code = """
+				package com.example;
+
+				import com.example.protos.Person;
+
+				public class Sample {
+					private Person.Builder builder;
+				}
+				""";
+
+		String result = remover.removeUnused(code);
+
+		assertTrue(result.contains("import com.example.protos.Person;"));
+	}
+
+	@Test
+	public void keepsWildcardImports() {
+		String code = """
+				package com.example;
+
+				import com.example.protos.*;
+
+				public class Sample {
+				}
+				""";
+
+		String result = remover.removeUnused(code);
+
+		assertTrue(result.contains("import com.example.protos.*;"));
+	}
+
+	@Test
+	public void removesAllImportsWhenNoneReferenced() {
+		String code = """
+				package com.example;
+
+				import java.util.List;
+				import java.util.Map;
+
+				public class Sample {
+				}
+				""";
+
+		String result = remover.removeUnused(code);
+
+		assertFalse(result.contains("import java.util.List;"));
+		assertFalse(result.contains("import java.util.Map;"));
+	}
+
+	@Test
+	public void keepsAllImportsWhenAllReferenced() {
+		String code = """
+				package com.example;
+
+				import java.util.List;
+				import java.util.Map;
+
+				public class Sample {
+					private List<String> values;
+					private Map<String, String> mappings;
+				}
+				""";
+
+		String result = remover.removeUnused(code);
+
+		assertTrue(result.contains("import java.util.List;"));
+		assertTrue(result.contains("import java.util.Map;"));
+	}
+
+	@Test
+	public void returnsCodeUnchangedWhenNoImports() {
+		String code = """
+				package com.example;
+
+				public class Sample {
+				}
+				""";
+
+		String result = remover.removeUnused(code);
+
+		assertTrue(result.contains("public class Sample"));
+		assertFalse(result.contains("import"));
+	}
+}


### PR DESCRIPTION
The proto-maven-plugin emits a fixed set of imports for every generated
builder, so classes that do not reference all of them end up with unused
imports. Add an import-removal layer to the generation pipeline.

UnusedImportsRemover parses the generated source with the Eclipse JDT AST
(already a dependency), collects every referenced simple name, and uses
ASTRewrite to drop single-type imports that are never referenced. Wildcard
(on-demand) imports are always kept. The remover runs in
ClassContainer.format() before the existing formatter.

https://claude.ai/code/session_01AS19UV95tEpqAMoTNQDTQ1