### PR TITLE
fix(protogen): handle proto2 messages with extension ranges

### DIFF
--- a/code/protogen-maven-plugin-test/src/main/proto/extension.proto
+++ b/code/protogen-maven-plugin-test/src/main/proto/extension.proto
@@ -1,0 +1,21 @@
+syntax = "proto2";
+
+package test;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.code.test";
+
+// Exercises a message that declares extension ranges. Such a message is
+// generated as a subclass of the abstract GeneratedMessage.ExtendableMessage,
+// which the builder generator must handle without choking on that abstract
+// base type.
+message Account {
+  required string owner = 1;
+  optional string label = 2;
+  extensions 100 to 200;
+}
+
+extend Account {
+  optional int32 priority = 100;
+  optional string note = 101;
+}

--- a/code/protogen-maven-plugin-test/src/test/java/io/github/adamw7/tools/code/usecase/GeneretedCodeTest.java
+++ b/code/protogen-maven-plugin-test/src/test/java/io/github/adamw7/tools/code/usecase/GeneretedCodeTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.output.generated.AccountBuilder;
+import org.output.generated.AccountOptionalIfc;
 import org.output.generated.CarBuilder;
 import org.output.generated.ComputerBuilder;
 import org.output.generated.ComputerOptionalIfc;
@@ -20,8 +22,10 @@ import org.output.generated.WheelBuilder;
 
 import com.google.protobuf.ByteString;
 
+import io.github.adamw7.tools.code.test.Account;
 import io.github.adamw7.tools.code.test.Car;
 import io.github.adamw7.tools.code.test.Computer;
+import io.github.adamw7.tools.code.test.Extension;
 import io.github.adamw7.tools.code.test.Grouping;
 import io.github.adamw7.tools.code.test.Measurement;
 import io.github.adamw7.tools.code.test.Server;
@@ -112,6 +116,27 @@ public class GeneretedCodeTest {
 		assertEquals(99L, measurement.getBig());
 		assertEquals(-3, measurement.getDelta());
 		assertEquals(Measurement.Unit.METRIC, measurement.getUnit());
+	}
+
+	@Test
+	public void extendableMessageBuilds() {
+		AccountBuilder builder = new AccountBuilder();
+		AccountOptionalIfc optional = builder.setOwner("alice");
+		assertNotNull(optional);
+		Account account = optional.setLabel("primary").build();
+		assertNotNull(account);
+		assertEquals("alice", account.getOwner());
+		assertEquals("primary", account.getLabel());
+		assertTrue(builder.hasOwner());
+	}
+
+	@Test
+	public void extensionsRemainSettableOnBuiltMessage() {
+		Account account = new AccountBuilder().setOwner("bob").build();
+		Account extended = account.toBuilder().setExtension(Extension.priority, 7)
+				.setExtension(Extension.note, "vip").build();
+		assertEquals(7, extended.getExtension(Extension.priority));
+		assertEquals("vip", extended.getExtension(Extension.note));
 	}
 
 	@Test

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/MessagesFinder.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/MessagesFinder.java
@@ -1,6 +1,8 @@
 package io.github.adamw7.tools.code;
 
+import java.lang.reflect.Modifier;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -10,22 +12,31 @@ import org.reflections.util.ConfigurationBuilder;
 import com.google.protobuf.GeneratedMessage;
 
 public class MessagesFinder {
-	
+
 	private final static Logger log = LogManager.getLogger(MessagesFinder.class.getName());
 	private final String[] pkg;
 
 	public MessagesFinder(String... pkg) {
 		this.pkg = pkg;
 	}
-	
+
 	public Set<Class<? extends GeneratedMessage>> execute() {
 		Reflections reflections = new Reflections(new ConfigurationBuilder().forPackages(pkg));
 		Set<Class<? extends GeneratedMessage>> classes = reflections.getSubTypesOf(GeneratedMessage.class);
+		Set<Class<? extends GeneratedMessage>> messages = onlyConcreteMessages(classes);
 		log.info("Found these proto classes:");
-		for (Class<? extends GeneratedMessage> cl : classes) {
+		for (Class<? extends GeneratedMessage> cl : messages) {
 			log.info(cl);
 		}
-		return classes;
+		return messages;
+	}
+
+	private Set<Class<? extends GeneratedMessage>> onlyConcreteMessages(Set<Class<? extends GeneratedMessage>> classes) {
+		return classes.stream().filter(this::isConcrete).collect(Collectors.toSet());
+	}
+
+	private boolean isConcrete(Class<? extends GeneratedMessage> clazz) {
+		return !Modifier.isAbstract(clazz.getModifiers());
 	}
 
 }

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/MessagesFinderTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/MessagesFinderTest.java
@@ -1,13 +1,16 @@
 package io.github.adamw7.tools.code;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Modifier;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
 import com.google.protobuf.GeneratedMessage;
 
+import io.github.adamw7.tools.code.protos.Account;
 import io.github.adamw7.tools.code.protos.Person;
 
 public class MessagesFinderTest {
@@ -16,5 +19,19 @@ public class MessagesFinderTest {
 	public void happyPath() {
 		Set<Class<? extends GeneratedMessage>> allMessages = new MessagesFinder("io.github.adamw7.tools.code.protos").execute();
 		assertTrue(allMessages.contains(Person.class));
+	}
+
+	@Test
+	public void findsExtendableMessage() {
+		Set<Class<? extends GeneratedMessage>> allMessages = new MessagesFinder("io.github.adamw7.tools.code.protos").execute();
+		assertTrue(allMessages.contains(Account.class));
+	}
+
+	@Test
+	public void skipsAbstractFrameworkClasses() {
+		Set<Class<? extends GeneratedMessage>> allMessages = new MessagesFinder("io.github.adamw7.tools.code.protos").execute();
+		for (Class<? extends GeneratedMessage> message : allMessages) {
+			assertFalse(Modifier.isAbstract(message.getModifiers()), message + " should be concrete");
+		}
 	}
 }

--- a/code/protogen-maven-plugin/src/test/proto/extension.proto
+++ b/code/protogen-maven-plugin/src/test/proto/extension.proto
@@ -1,0 +1,20 @@
+syntax = "proto2";
+
+package tutorial;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.code.protos";
+
+// A message that declares extension ranges. protoc generates it as a subclass
+// of the abstract GeneratedMessage.ExtendableMessage, which the message finder
+// must not mistake for a concrete generated message.
+message Account {
+  required string owner = 1;
+  optional string label = 2;
+  extensions 100 to 200;
+}
+
+extend Account {
+  optional int32 priority = 100;
+  optional string note = 101;
+}


### PR DESCRIPTION
Messages that declare `extensions` ranges are generated by protoc as
subclasses of the abstract `GeneratedMessage.ExtendableMessage`. Reflections
returns that abstract base as an intermediate subtype of `GeneratedMessage`,
and the generator then crashed invoking `getDescriptor()` on it
(NoSuchMethodException).

Filter the discovered classes to concrete messages in `MessagesFinder` so the
abstract framework base is skipped. Extension fields are always optional or
repeated in proto2, so the generated builder covers the message's own fields
while extensions remain settable through the standard protobuf API.

Add an `extension.proto` to both the plugin unit tests and the integration
test module, with coverage for finding extendable messages, skipping abstract
bases, building an extendable message, and setting extensions on the result.

https://claude.ai/code/session_01CXC5BFvQoR2JWdWttPcbPq