### PR TITLE
feat(protogen): support messages carrying custom options

### DIFF
--- a/code/protogen-maven-plugin-test/src/main/proto/customoption.proto
+++ b/code/protogen-maven-plugin-test/src/main/proto/customoption.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package test;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.code.test";
+
+import "foo.proto";
+
+// Exercises a message that carries a custom (extension-based) option as well
+// as a field-level custom option. Options are descriptor metadata rather than
+// fields, so the generated staged builder must build the message normally and
+// leave the options intact on the produced type.
+message MyMessage {
+  option (foo.my_option) = "Hello world!";
+
+  required int32 id = 1;
+  optional string name = 2 [(foo.my_field_option) = "field option value"];
+}

--- a/code/protogen-maven-plugin-test/src/main/proto/foo.proto
+++ b/code/protogen-maven-plugin-test/src/main/proto/foo.proto
@@ -1,0 +1,20 @@
+syntax = "proto2";
+
+package foo;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.code.foo";
+
+import "google/protobuf/descriptor.proto";
+
+// Declares custom options by extending the well-known descriptor option
+// messages. A custom option is just an extension field on these option
+// messages, so exercising them proves the builder generator copes with
+// messages and fields that carry such options.
+extend google.protobuf.MessageOptions {
+  optional string my_option = 50001;
+}
+
+extend google.protobuf.FieldOptions {
+  optional string my_field_option = 50002;
+}

--- a/code/protogen-maven-plugin-test/src/test/java/io/github/adamw7/tools/code/usecase/GeneretedCodeTest.java
+++ b/code/protogen-maven-plugin-test/src/test/java/io/github/adamw7/tools/code/usecase/GeneretedCodeTest.java
@@ -15,6 +15,7 @@ import org.output.generated.ComputerOptionalIfc;
 import org.output.generated.GroupBuilder;
 import org.output.generated.GroupingBuilder;
 import org.output.generated.MeasurementBuilder;
+import org.output.generated.MyMessageBuilder;
 import org.output.generated.OneOptionalFieldOnlyBuilder;
 import org.output.generated.ServerBuilder;
 import org.output.generated.UserBuilder;
@@ -22,12 +23,14 @@ import org.output.generated.WheelBuilder;
 
 import com.google.protobuf.ByteString;
 
+import io.github.adamw7.tools.code.foo.Foo;
 import io.github.adamw7.tools.code.test.Account;
 import io.github.adamw7.tools.code.test.Car;
 import io.github.adamw7.tools.code.test.Computer;
 import io.github.adamw7.tools.code.test.Extension;
 import io.github.adamw7.tools.code.test.Grouping;
 import io.github.adamw7.tools.code.test.Measurement;
+import io.github.adamw7.tools.code.test.MyMessage;
 import io.github.adamw7.tools.code.test.Server;
 import io.github.adamw7.tools.code.test.Wheel;
 
@@ -137,6 +140,22 @@ public class GeneretedCodeTest {
 				.setExtension(Extension.note, "vip").build();
 		assertEquals(7, extended.getExtension(Extension.priority));
 		assertEquals("vip", extended.getExtension(Extension.note));
+	}
+
+	@Test
+	public void customOptionsArePreservedOnBuiltMessage() {
+		MyMessageBuilder builder = new MyMessageBuilder();
+		MyMessage message = builder.setId(11).setName("widget").build();
+		assertNotNull(message);
+		assertEquals(11, message.getId());
+		assertEquals("widget", message.getName());
+
+		String messageOption = MyMessage.getDescriptor().getOptions().getExtension(Foo.myOption);
+		assertEquals("Hello world!", messageOption);
+
+		String fieldOption = MyMessage.getDescriptor().findFieldByName("name").getOptions()
+				.getExtension(Foo.myFieldOption);
+		assertEquals("field option value", fieldOption);
 	}
 
 	@Test

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Clazz.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Clazz.java
@@ -90,8 +90,8 @@ public class Clazz implements Generator {
 	private StringBuilder generateFields() {
 		StringBuilder builder = new StringBuilder("private final ");
 		builder.append(info.name()).append(".Builder ");
-		
-		builder.append(info.name().toLowerCase()).append("Builder = ");
+
+		builder.append(Utils.firstToLower(builderClassName)).append(" = ");
 		builder.append(info.name()).append(".newBuilder();");
 		return builder;
 	}


### PR DESCRIPTION
Custom (extension-based) proto options are descriptor metadata, not fields, so the staged builder generator should build such messages normally and leave the options intact.

While adding coverage for a message named like the documented example (MyMessage), the required-field builder failed to compile: the main builder field was declared from name().toLowerCase() (mymessageBuilder) but every method body referenced firstToLower(builderClassName) (myMessageBuilder). The two only matched for single-capital message names. Generate the field name with the same helper so camelCase message names compile.

Add foo.proto declaring message- and field-level custom options, customoption.proto using them on MyMessage, and a test asserting the generated builder builds the message and preserves both options.