### PR TITLE
build: suppress protobuf sun.misc.Unsafe (JEP 498) deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ pom.xml.next
 release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
-.mvn/
+.mvn/*
+!.mvn/jvm.config
 
 logs/
 data/derby.log

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--sun-misc-unsafe-memory-access=allow

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,10 @@
 		<java.version>25</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<protobuf.version>4.33.4</protobuf.version>
-		<argLine/>
+		<!-- Suppress the JDK 24+ (JEP 498) "terminally deprecated sun.misc.Unsafe"
+		     warning emitted by com.google.protobuf.UnsafeUtil when forked test
+		     JVMs exercise protobuf generated messages. -->
+		<argLine>--sun-misc-unsafe-memory-access=allow</argLine>
 	</properties>
 	<licenses>
 		<license>


### PR DESCRIPTION
protobuf-java's UnsafeUtil calls terminally deprecated sun.misc.Unsafe
memory-access methods (e.g. arrayBaseOffset), which emit a JEP 498
warning on JDK 24+. The warning appears both in forked test JVMs that
exercise generated protobuf messages and in the Maven JVM during the
code-generator goal, which loads GeneratedMessage subclasses in-process.

Pass --sun-misc-unsafe-memory-access=allow:
- via the argLine property (surefire reads it by default; @{argLine}
  chains and the jacoco coverage profile preserve it)
- via .mvn/jvm.config for the Maven process itself

https://claude.ai/code/session_01Xxv7wFBnRgfmi3PgdTvyYG