### PR TITLE
fix(uniqueness): ignore column order when comparing results

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/Result.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/Result.java
@@ -40,7 +40,7 @@ public class Result {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + Arrays.hashCode(columns);
+		result = prime * result + columnsHashCode();
 		result = prime * result + Arrays.hashCode(row);
 		result = prime * result + Objects.hash(betterOptions, unique);
 		return result;
@@ -55,8 +55,23 @@ public class Result {
 		if (getClass() != obj.getClass())
 			return false;
 		Result other = (Result) obj;
-		return Objects.equals(betterOptions, other.betterOptions) && Arrays.equals(columns, other.columns)
+		return Objects.equals(betterOptions, other.betterOptions) && sameColumns(other.columns)
 				&& Arrays.equals(row, other.row) && unique == other.unique;
+	}
+
+	private int columnsHashCode() {
+		return columns == null ? 0 : asSet(columns).hashCode();
+	}
+
+	private boolean sameColumns(String[] otherColumns) {
+		if (columns == null || otherColumns == null) {
+			return columns == otherColumns;
+		}
+		return asSet(columns).equals(asSet(otherColumns));
+	}
+
+	private static Set<String> asSet(String[] values) {
+		return new HashSet<>(Arrays.asList(values));
 	}
 	
 	@Override

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/ResultTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/ResultTest.java
@@ -1,0 +1,73 @@
+package io.github.adamw7.tools.data.uniqueness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class ResultTest {
+
+	@Test
+	public void equalsIgnoresColumnOrder() {
+		Result first = new Result(true, new String[] { "year1", "hlpi_name" });
+		Result second = new Result(true, new String[] { "hlpi_name", "year1" });
+
+		assertEquals(first, second);
+		assertEquals(second, first);
+	}
+
+	@Test
+	public void hashCodeIgnoresColumnOrder() {
+		Result first = new Result(true, new String[] { "year1", "hlpi_name", "income" });
+		Result second = new Result(true, new String[] { "income", "year1", "hlpi_name" });
+
+		assertEquals(first.hashCode(), second.hashCode());
+	}
+
+	@Test
+	public void differentColumnOrderResultsCollapseInSet() {
+		Set<Result> set = new HashSet<>();
+		set.add(new Result(true, new String[] { "year1", "hlpi_name" }));
+		set.add(new Result(true, new String[] { "hlpi_name", "year1" }));
+
+		assertEquals(1, set.size());
+	}
+
+	@Test
+	public void differentColumnsAreNotEqual() {
+		Result first = new Result(true, new String[] { "year1", "hlpi_name" });
+		Result second = new Result(true, new String[] { "year1", "income" });
+
+		assertNotEquals(first, second);
+	}
+
+	@Test
+	public void nestedBetterOptionsIgnoreColumnOrder() {
+		Set<Result> firstOptions = new HashSet<>();
+		firstOptions.add(new Result(true, new String[] { "year1", "hlpi_name" }));
+		Result first = new Result(true, new String[] { "income", "year1" }, null, firstOptions);
+
+		Set<Result> secondOptions = new HashSet<>();
+		secondOptions.add(new Result(true, new String[] { "hlpi_name", "year1" }));
+		Result second = new Result(true, new String[] { "year1", "income" }, null, secondOptions);
+
+		assertEquals(first, second);
+		assertEquals(first.hashCode(), second.hashCode());
+	}
+
+	@Test
+	public void orderIsIgnoredButRowStillMatters() {
+		Result first = new Result(false, new String[] { "year1", "hlpi_name" }, new String[] { "2020", "a" });
+		Result sameRowDifferentOrder = new Result(false, new String[] { "hlpi_name", "year1" },
+				new String[] { "2020", "a" });
+		Result differentRow = new Result(false, new String[] { "hlpi_name", "year1" }, new String[] { "2021", "a" });
+
+		assertTrue(first.equals(sameRowDifferentOrder));
+		assertFalse(first.equals(differentRow));
+	}
+}


### PR DESCRIPTION
Result equality and hashCode used order-sensitive Arrays.equals/Arrays.hashCode
on the columns array, so the same set of key candidates in a different order
was treated as a distinct result. Because candidate subsets are built from a
HashSet, the column order is effectively non-deterministic, making betterOptions
membership and equality unreliable. Compare columns as a set so order is ignored.