### PR TITLE
docs: document JSON/YAML/TOON sources, GZIP, MCP build/run, and gRPC source layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ The service implementation uses the generated builder:
 HelloReply reply = new HelloReplyBuilder().setMessage(greetingFor(request)).build();
 ```
 
+> **Note:** All example code (`GreeterServiceImpl`, `GreeterServer`, `GreeterClient`) lives under `src/test/java` because the protogen-generated builders are written to `target/generated-test-sources`. Run the example with `mvn -pl grpc-example -am test`.
+
 See the [grpc-example module](grpc-example/README.md) for full details and how to run the example.
 
 ## Context engineering
@@ -197,7 +199,12 @@ It contains:
 - data sources
   - support relational data loading
   - in memory and iterative loading
-  - CSV, GZip, JDBC support
+  - CSV, JDBC support
+  - JSON (`InMemoryJSONDataSource`, `IterableJSONDataSource`) — nested objects are flattened with dotted-path keys (e.g. `people[0].address.city`)
+  - YAML (`InMemoryYAMLDataSource`, `IterableYAMLDataSource`) — same flattening convention; no document-size limit
+  - TOON (`InMemoryTOONDataSource`, `IterableTOONDataSource`) — a compact, LLM-friendly format that minimises tokens; supports key-value pairs, primitive arrays, tabular arrays, and nested objects
+  - All file-based sources accept either a file path or an `InputStream`
+  - GZIP decompression — any file-based source transparently decompresses `.gz` files; no extra configuration needed
 - uniqueness checks tool
   - for a given set of data and subset of columns you can ask if these columns are unique (can be used as a key)
   - the tool also tries to find a better (smaller) answer
@@ -207,7 +214,10 @@ It contains:
 - MCP server
   - Model Context Protocol server exposing uniqueness checking as a tool for AI assistants
   - Compatible with Claude Desktop, Cline, and other MCP clients
-  - See [MCP Usage Documentation](data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md) for configuration and usage
+  - Transport: stdio over JSON-RPC (Spring Boot, no HTTP server started)
+  - Build: `mvn clean install` produces `data/target/tools.data-<version>.jar`
+  - Run: `java -jar data/target/tools.data-<version>.jar --transport.mode=stdio`
+  - See [MCP Usage Documentation](data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md) for client configuration (Claude Desktop, Cline) and usage examples
   
 Examples:
 


### PR DESCRIPTION
- Expand data sources section with JSON, YAML, and TOON variants (class
  names, constructor signatures, flattening behaviour)
- Note that all file-based sources transparently decompress .gz files
- Add MCP server build and run instructions (Spring Boot stdio jar)
- Clarify that gRPC example code lives in src/test/java and builders are
  generated into target/generated-test-sources

https://claude.ai/code/session_01MZqr8171htdZxtgR64uNj8