### PR TITLE
build: upgrade JaCoCo to 0.8.13 for Java 25 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.8.12</version>
+					<version>0.8.13</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
JaCoCo 0.8.12 fails to instrument and analyze Java 25 class files
(major version 69), breaking the Coverage workflow with
"Unsupported class file major version 69". 0.8.13 adds support
for Java 25 class files.