### PR TITLE
fix: guard against null resultSet and reuse stateless formatters

### DIFF
--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/ClassContainer.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/ClassContainer.java
@@ -5,9 +5,12 @@ import io.github.adamw7.tools.code.format.UnusedImportsRemover;
 
 public record ClassContainer(String name, CharSequence code) {
 
+	private static final UnusedImportsRemover IMPORTS_REMOVER = new UnusedImportsRemover();
+	private static final Formatter FORMATTER = new Formatter();
+
 	public ClassContainer format() {
-		String withoutUnusedImports = new UnusedImportsRemover().removeUnused(codeAsString());
-		return new ClassContainer(name, new Formatter().format(withoutUnusedImports));
+		String withoutUnusedImports = IMPORTS_REMOVER.removeUnused(codeAsString());
+		return new ClassContainer(name, FORMATTER.format(withoutUnusedImports));
 	}
 
 	String codeAsString() {

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -84,7 +84,7 @@ public class IterableSQLDataSource implements IterableDataSource {
 	}
 
 	private void applyFetchSize(int batchSize) {
-		if (batchSize <= 0) {
+		if (batchSize <= 0 || resultSet == null) {
 			return;
 		}
 		try {


### PR DESCRIPTION
- IterableSQLDataSource.applyFetchSize: add null check for resultSet
  so calling nextRows() before open() silently skips the fetch-size
  hint instead of throwing a NullPointerException
- ClassContainer.format: promote UnusedImportsRemover and Formatter
  to static final fields; both are stateless so one instance per JVM
  is sufficient and avoids repeated allocation during code generation

https://claude.ai/code/session_016ggnek5oshairH2DEqU77u