### PR TITLE
build(pom): add requireNoRepositories and bannedDependencies enforcers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,13 @@
 								<requirePluginVersions>
 									<banSnapshots>false</banSnapshots>
 								</requirePluginVersions>
+								<requireNoRepositories />
+								<bannedDependencies>
+									<excludes>
+										<exclude>log4j:log4j</exclude>
+										<exclude>commons-collections:commons-collections:(,3.2.2)</exclude>
+									</excludes>
+								</bannedDependencies>
 							</rules>
 						</configuration>
 					</execution>


### PR DESCRIPTION
Prevent child POMs from declaring repositories (security hygiene)
and ban known-vulnerable artifacts: pre-2.x log4j and
commons-collections < 3.2.2 (deserialization CVEs).