### PR TITLE
test: add unit tests for under-covered classes (P0-P2)

### DIFF
--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/gen/ClassInfoTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/gen/ClassInfoTest.java
@@ -1,0 +1,93 @@
+package io.github.adamw7.tools.code.gen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.protobuf.Descriptors.FieldDescriptor;
+
+import io.github.adamw7.tools.code.protos.Foo;
+import io.github.adamw7.tools.code.protos.Person;
+
+public class ClassInfoTest {
+
+	private final ClassInfo personInfo = new ClassInfo(Person.getDescriptor(), "in.pkg", "out.pkg");
+
+	private List<String> names(List<FieldDescriptor> fields) {
+		return fields.stream().map(FieldDescriptor::getName).toList();
+	}
+
+	@Test
+	public void exposesMessageName() {
+		assertEquals("Person", personInfo.name());
+	}
+
+	@Test
+	public void exposesFullName() {
+		assertEquals("Person", personInfo.fullName());
+	}
+
+	@Test
+	public void retainsInputAndOutputPackages() {
+		assertEquals("in.pkg", personInfo.getInputPkg());
+		assertEquals("out.pkg", personInfo.getOutputPkg());
+	}
+
+	@Test
+	public void collectsRequiredFields() {
+		List<String> required = names(personInfo.required());
+		assertEquals(2, required.size());
+		assertTrue(required.contains("id"));
+		assertTrue(required.contains("department"));
+	}
+
+	@Test
+	public void collectsOptionalFields() {
+		List<String> optional = names(personInfo.optional());
+		assertTrue(optional.contains("name"));
+		assertTrue(optional.contains("email"));
+		assertFalse(optional.contains("id"));
+	}
+
+	@Test
+	public void collectsMapFields() {
+		List<String> maps = names(personInfo.map());
+		assertEquals(List.of("mapping"), maps);
+	}
+
+	@Test
+	public void collectsRepeatedFieldsExcludingMaps() {
+		List<String> repeated = names(personInfo.repeated());
+		assertEquals(3, repeated.size());
+		assertTrue(repeated.contains("ids"));
+		assertTrue(repeated.contains("classifications"));
+		assertTrue(repeated.contains("friends"));
+	}
+
+	@Test
+	public void collectsGroupFields() {
+		assertEquals(1, personInfo.getGroupFields().size());
+	}
+
+	@Test
+	public void nonOptionalUnionsRequiredMapAndRepeated() {
+		assertEquals(6, personInfo.nonOptional().size());
+	}
+
+	@Test
+	public void personHasNoPureComplexFields() {
+		assertTrue(personInfo.getPureComplexFields().isEmpty());
+	}
+
+	@Test
+	public void detectsSingularMessageAsPureComplexField() {
+		ClassInfo bazInfo = new ClassInfo(Foo.Baz.getDescriptor(), "in.pkg", "out.pkg");
+
+		List<String> pureComplex = names(bazInfo.getPureComplexFields());
+		assertEquals(List.of("a"), pureComplex);
+	}
+}

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/gen/TypeMappingsTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/gen/TypeMappingsTest.java
@@ -1,0 +1,88 @@
+package io.github.adamw7.tools.code.gen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.GeneratedMessage;
+
+import io.github.adamw7.tools.code.protos.City;
+import io.github.adamw7.tools.code.protos.Person;
+
+public class TypeMappingsTest {
+
+	private TypeMappings typeMappings;
+
+	@BeforeEach
+	public void setUp() {
+		Set<Class<? extends GeneratedMessage>> messages = new HashSet<>();
+		messages.add(Person.class);
+		typeMappings = new TypeMappings(messages);
+	}
+
+	private String mapFor(Descriptor descriptor, String fieldName) {
+		FieldDescriptor field = descriptor.findFieldByName(fieldName);
+		return typeMappings.get(field);
+	}
+
+	@Test
+	public void mapsStringScalar() {
+		assertEquals("String", mapFor(Person.getDescriptor(), "name"));
+	}
+
+	@Test
+	public void mapsIntScalar() {
+		assertEquals("int", mapFor(Person.getDescriptor(), "id"));
+	}
+
+	@Test
+	public void mapsLongScalar() {
+		assertEquals("long", mapFor(Person.getDescriptor(), "salary"));
+	}
+
+	@Test
+	public void mapsFloatScalar() {
+		assertEquals("float", mapFor(Person.getDescriptor(), "factor"));
+	}
+
+	@Test
+	public void mapsBooleanScalar() {
+		assertEquals("boolean", mapFor(Person.getDescriptor(), "active"));
+	}
+
+	@Test
+	public void mapsDoubleScalar() {
+		assertEquals("double", mapFor(Person.getDescriptor(), "percent"));
+	}
+
+	@Test
+	public void mapsBytesToByteString() {
+		assertEquals("com.google.protobuf.ByteString", mapFor(City.getDescriptor(), "description"));
+	}
+
+	@Test
+	public void mapsRepeatedScalarToListOfWrapperType() {
+		assertEquals("java.util.List<Integer>", mapFor(Person.getDescriptor(), "ids"));
+	}
+
+	@Test
+	public void mapsRepeatedMessageToListOfMessage() {
+		assertEquals("java.util.List<Person>", mapFor(Person.getDescriptor(), "friends"));
+	}
+
+	@Test
+	public void mapsMapFieldWrappingPrimitiveValue() {
+		assertEquals("java.util.Map<String,Integer>", mapFor(Person.getDescriptor(), "mapping"));
+	}
+
+	@Test
+	public void mapsEnumToNestedEnumName() {
+		assertEquals("Person.CLASSIFICATION", mapFor(Person.getDescriptor(), "classification"));
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/SampleAppTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/SampleAppTest.java
@@ -1,0 +1,39 @@
+package io.github.adamw7.tools.data;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.UncheckedIOException;
+
+import org.junit.jupiter.api.Test;
+
+public class SampleAppTest {
+
+	@Test
+	public void rejectsNullArguments() {
+		assertThrows(IllegalArgumentException.class, () -> SampleApp.main(null));
+	}
+
+	@Test
+	public void rejectsTooFewArguments() {
+		assertThrows(IllegalArgumentException.class, () -> SampleApp.main(new String[] { "onlyFile.csv" }));
+	}
+
+	@Test
+	public void wrapsMissingFileInUncheckedIOException() {
+		String[] args = { "doesNotExist.csv", "year1" };
+		assertThrows(UncheckedIOException.class, () -> SampleApp.main(args));
+	}
+
+	@Test
+	public void runsForNonUniqueColumn() {
+		String[] args = { Utils.getHouseholdFile(), "year1" };
+		assertDoesNotThrow(() -> SampleApp.main(args));
+	}
+
+	@Test
+	public void runsForUniqueColumn() {
+		String[] args = { Utils.getHouseholdFile(), "income" };
+		assertDoesNotThrow(() -> SampleApp.main(args));
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/PathValidatorTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/PathValidatorTest.java
@@ -1,0 +1,98 @@
+package io.github.adamw7.tools.data.source.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class PathValidatorTest {
+
+	@AfterEach
+	public void resetBaseDir() {
+		PathValidator.clearAllowedBaseDir();
+	}
+
+	@Test
+	public void rejectsNullPath() {
+		assertThrows(IllegalArgumentException.class, () -> PathValidator.validate(null));
+	}
+
+	@Test
+	public void rejectsEmptyPath() {
+		assertThrows(IllegalArgumentException.class, () -> PathValidator.validate(""));
+	}
+
+	@Test
+	public void rejectsBlankPath() {
+		assertThrows(IllegalArgumentException.class, () -> PathValidator.validate("   "));
+	}
+
+	@Test
+	public void rejectsLeadingTraversal() {
+		assertThrows(SecurityException.class, () -> PathValidator.validate("../etc/passwd"));
+	}
+
+	@Test
+	public void rejectsEmbeddedTraversal() {
+		assertThrows(SecurityException.class, () -> PathValidator.validate("/data/uploads/../secret"));
+	}
+
+	@Test
+	public void rejectsBareDotDot() {
+		assertThrows(SecurityException.class, () -> PathValidator.validate(".."));
+	}
+
+	@Test
+	public void rejectsBackslashTraversal() {
+		assertThrows(SecurityException.class, () -> PathValidator.validate("..\\windows\\system32"));
+	}
+
+	@Test
+	public void returnsCanonicalisedAbsolutePathWhenNoBaseDir() {
+		String validated = PathValidator.validate("report.csv");
+		Path expected = Path.of("report.csv").toAbsolutePath().normalize();
+		assertEquals(expected.toString(), validated);
+	}
+
+	@Test
+	public void setBaseDirRejectsNull() {
+		assertThrows(IllegalArgumentException.class, () -> PathValidator.setAllowedBaseDir(null));
+	}
+
+	@Test
+	public void allowsPathInsideBaseDir(@TempDir Path baseDir) throws IOException {
+		PathValidator.setAllowedBaseDir(baseDir);
+
+		Path inside = baseDir.toRealPath().resolve("report.csv");
+		String validated = PathValidator.validate(inside.toString());
+
+		assertEquals(inside.toAbsolutePath().normalize().toString(), validated);
+	}
+
+	@Test
+	public void deniesPathOutsideBaseDir(@TempDir Path tempDir) throws IOException {
+		Path baseDir = Files.createDirectory(tempDir.resolve("base"));
+		PathValidator.setAllowedBaseDir(baseDir);
+
+		Path outside = tempDir.resolve("outside.csv");
+		assertThrows(SecurityException.class, () -> PathValidator.validate(outside.toString()));
+	}
+
+	@Test
+	public void clearingBaseDirLiftsRestriction(@TempDir Path tempDir) throws IOException {
+		Path baseDir = Files.createDirectory(tempDir.resolve("base"));
+		PathValidator.setAllowedBaseDir(baseDir);
+		PathValidator.clearAllowedBaseDir();
+
+		Path outside = tempDir.resolve("outside.csv");
+		String validated = PathValidator.validate(outside.toString());
+		assertTrue(validated.endsWith("outside.csv"));
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/ToonSyntaxTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/ToonSyntaxTest.java
@@ -1,0 +1,123 @@
+package io.github.adamw7.tools.data.source.file;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Matcher;
+
+import org.junit.jupiter.api.Test;
+
+public class ToonSyntaxTest {
+
+	@Test
+	public void noIndentation() {
+		assertEquals(0, ToonSyntax.indentationOf("name: value"));
+	}
+
+	@Test
+	public void countsLeadingSpaces() {
+		assertEquals(2, ToonSyntax.indentationOf("  name: value"));
+	}
+
+	@Test
+	public void tabsCountAsTwo() {
+		assertEquals(4, ToonSyntax.indentationOf("\t\tname"));
+	}
+
+	@Test
+	public void mixesSpacesAndTabs() {
+		assertEquals(3, ToonSyntax.indentationOf(" \tname"));
+	}
+
+	@Test
+	public void stopsCountingAtFirstNonWhitespace() {
+		assertEquals(2, ToonSyntax.indentationOf("  a  b"));
+	}
+
+	@Test
+	public void splitsPlainValues() {
+		assertArrayEquals(new String[] { "a", "b", "c" }, ToonSyntax.splitRow("a,b,c"));
+	}
+
+	@Test
+	public void keepsCommaInsideQuotes() {
+		assertArrayEquals(new String[] { "\"a,b\"", "c" }, ToonSyntax.splitRow("\"a,b\",c"));
+	}
+
+	@Test
+	public void escapedQuoteDoesNotToggleQuoting() {
+		assertArrayEquals(new String[] { "\"a\\\"b\"", "c" }, ToonSyntax.splitRow("\"a\\\"b\",c"));
+	}
+
+	@Test
+	public void leadingCommaProducesEmptyValue() {
+		assertArrayEquals(new String[] { "", "a" }, ToonSyntax.splitRow(",a"));
+	}
+
+	@Test
+	public void trailingCommaDropsTrailingEmptyValue() {
+		assertArrayEquals(new String[] { "a" }, ToonSyntax.splitRow("a,"));
+	}
+
+	@Test
+	public void splitEmptyRowYieldsNoValues() {
+		assertEquals(0, ToonSyntax.splitRow("").length);
+	}
+
+	@Test
+	public void unquoteReturnsNullForNull() {
+		assertNull(ToonSyntax.unquote(null));
+	}
+
+	@Test
+	public void unquoteReturnsEmptyForEmpty() {
+		assertEquals("", ToonSyntax.unquote(""));
+	}
+
+	@Test
+	public void unquoteTrimsUnquotedValue() {
+		assertEquals("abc", ToonSyntax.unquote("  abc  "));
+	}
+
+	@Test
+	public void unquoteStripsSurroundingQuotes() {
+		assertEquals("abc", ToonSyntax.unquote("\"abc\""));
+	}
+
+	@Test
+	public void unquoteTrimsBeforeStrippingQuotes() {
+		assertEquals("abc", ToonSyntax.unquote("  \"abc\"  "));
+	}
+
+	@Test
+	public void singleQuoteIsNotTreatedAsQuoted() {
+		assertEquals("\"", ToonSyntax.unquote("\""));
+	}
+
+	@Test
+	public void unquoteResolvesEscapeSequences() {
+		assertEquals("a\tb", ToonSyntax.unquote("\"a\\tb\""));
+		assertEquals("a\"b", ToonSyntax.unquote("\"a\\\"b\""));
+		assertEquals("a\\b", ToonSyntax.unquote("\"a\\\\b\""));
+		assertEquals("line\nbreak", ToonSyntax.unquote("\"line\\nbreak\""));
+	}
+
+	@Test
+	public void keyValuePatternMatchesDottedKeys() {
+		Matcher matcher = ToonSyntax.KEY_VALUE_PATTERN.matcher("user.name: Alice");
+		assertTrue(matcher.matches());
+		assertEquals("user.name", matcher.group(1));
+		assertEquals("Alice", matcher.group(2));
+	}
+
+	@Test
+	public void arrayHeaderPatternCapturesSizeAndFields() {
+		Matcher matcher = ToonSyntax.ARRAY_HEADER_PATTERN.matcher("rows[2]{id,name}: ");
+		assertTrue(matcher.matches());
+		assertEquals("rows", matcher.group(1));
+		assertEquals("2", matcher.group(2));
+		assertEquals("id,name", matcher.group(4));
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/KeyTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/KeyTest.java
@@ -1,0 +1,84 @@
+package io.github.adamw7.tools.data.uniqueness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class KeyTest {
+
+	@Test
+	public void equalForSameContent() {
+		Key first = new Key(new String[] { "a", "b" });
+		Key second = new Key(new String[] { "a", "b" });
+
+		assertEquals(first, second);
+	}
+
+	@Test
+	public void equalToItself() {
+		Key key = new Key(new String[] { "a", "b" });
+
+		assertTrue(key.equals(key));
+	}
+
+	@Test
+	public void notEqualToNull() {
+		Key key = new Key(new String[] { "a" });
+
+		assertFalse(key.equals(null));
+	}
+
+	@Test
+	public void notEqualToDifferentType() {
+		Key key = new Key(new String[] { "a" });
+
+		assertFalse(key.equals("a"));
+	}
+
+	@Test
+	public void notEqualForDifferentContent() {
+		Key first = new Key(new String[] { "a", "b" });
+		Key second = new Key(new String[] { "a", "c" });
+
+		assertNotEquals(first, second);
+	}
+
+	@Test
+	public void equalKeysShareHashCode() {
+		Key first = new Key(new String[] { "x", "y" });
+		Key second = new Key(new String[] { "x", "y" });
+
+		assertEquals(first.hashCode(), second.hashCode());
+	}
+
+	@Test
+	public void toStringRendersValues() {
+		Key key = new Key(new String[] { "a", "b" });
+
+		assertEquals("[a, b]", key.toString());
+	}
+
+	@Test
+	public void equalKeysCollapseInSet() {
+		Set<Key> set = new HashSet<>();
+		set.add(new Key(new String[] { "a", "b" }));
+		set.add(new Key(new String[] { "a", "b" }));
+
+		assertEquals(1, set.size());
+	}
+
+	@Test
+	public void distinctKeysStayApartInSet() {
+		Set<Key> set = new HashSet<>();
+		set.add(new Key(new String[] { "a", "b" }));
+		set.add(new Key(new String[] { "a", "c" }));
+
+		assertEquals(2, set.size());
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/MainTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/MainTest.java
@@ -1,0 +1,42 @@
+package io.github.adamw7.tools.data.uniqueness.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+public class MainTest {
+
+	private String resolveTransportMode(String[] args) throws Exception {
+		Method method = Main.class.getDeclaredMethod("resolveTransportMode", String[].class);
+		method.setAccessible(true);
+		return (String) method.invoke(null, (Object) args);
+	}
+
+	@Test
+	public void defaultsToStdioWhenNoArguments() throws Exception {
+		assertEquals("stdio", resolveTransportMode(new String[] {}));
+	}
+
+	@Test
+	public void defaultsToStdioWhenPrefixAbsent() throws Exception {
+		assertEquals("stdio", resolveTransportMode(new String[] { "--server.port=8080", "--other" }));
+	}
+
+	@Test
+	public void readsExplicitTransportMode() throws Exception {
+		assertEquals("sse", resolveTransportMode(new String[] { "--transport.mode=sse" }));
+	}
+
+	@Test
+	public void findsTransportModeAmongOtherArguments() throws Exception {
+		String[] args = { "--server.port=8080", "--transport.mode=streamable-http" };
+		assertEquals("streamable-http", resolveTransportMode(args));
+	}
+
+	@Test
+	public void supportsEmptyTransportModeValue() throws Exception {
+		assertEquals("", resolveTransportMode(new String[] { "--transport.mode=" }));
+	}
+}


### PR DESCRIPTION
Adds focused unit tests for the highest-risk gaps found in the coverage
analysis:

- PathValidatorTest: path-traversal defence (null/empty/blank input,
  leading/embedded/bare/backslash traversal, base-dir allow/deny, clear).
- KeyTest: custom equals/hashCode/toString invariants that back the
  uniqueness HashSet dedup (reflexive, null, different type/content,
  set collapse).
- MainTest: MCP transport-mode resolution (stdio default, explicit value,
  among other args, empty value).
- SampleAppTest: CLI arg validation, missing-file wrapping, unique and
  non-unique runs.
- ToonSyntaxTest: indentation, quote-aware row splitting, unquoting and
  escape handling, plus the line patterns.
- TypeMappingsTest: proto-to-Java type mapping for scalars, bytes,
  repeated, map, enum and message fields.
- ClassInfoTest: field categorisation (required/optional/map/repeated/
  group), non-optional union and pure-complex detection.

https://claude.ai/code/session_0159kf8wB6rwb8hzgf4BKQEa