### PR TITLE
docs: sync AGENTS.md and MCP_USAGE.md with current code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ tools (root pom, packaging=pom)
 │   ├── protogen-maven-plugin       # the proto2 builder-generating Maven plugin
 │   ├── protogen-maven-plugin-test  # integration tests / use cases for the plugin
 │   └── context                     # regex-based class-usage context finder
+├── grpc-example                # end-to-end gRPC example with compile-time-safe builders
 ├── assembly                    # builds an executable jar-with-dependencies
 │                               #   (mainClass: io.github.adamw7.tools.data.SampleApp)
 └── data-test                   # standalone test module for the data module

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
@@ -15,8 +15,8 @@ The implementation consists of three main components:
 3. **UniquenessTool.java** - Implements the uniqueness checking tool
 
 The server uses:
-- **Transport**: stdio (standard input/output)
-- **MCP SDK**: io.modelcontextprotocol.sdk v0.12.1
+- **Transport**: stdio (default) or streamable-http (`--transport.mode=streamable-http`)
+- **MCP SDK**: io.modelcontextprotocol.sdk v2.0.0-RC1
 - **Framework**: Spring Boot
 - **Protocol**: Model Context Protocol (MCP)
 
@@ -70,7 +70,7 @@ Add the following to your Claude Desktop configuration file:
       "command": "java",
       "args": [
         "-jar",
-        "/absolute/path/to/tools/data/target/tools.data-1.4.0-SNAPSHOT.jar"
+        "/absolute/path/to/tools/data/target/tools.data-2.0.0-SNAPSHOT.jar"
       ]
     }
   }
@@ -90,7 +90,7 @@ In VS Code settings (settings.json):
       "command": "java",
       "args": [
         "-jar",
-        "/absolute/path/to/tools/data/target/tools.data-1.4.0-SNAPSHOT.jar"
+        "/absolute/path/to/tools/data/target/tools.data-2.0.0-SNAPSHOT.jar"
       ]
     }
   }
@@ -104,7 +104,7 @@ For any MCP client that supports stdio transport:
 ```json
 {
   "command": "java",
-  "args": ["-jar", "/path/to/tools.data-1.4.0-SNAPSHOT.jar"],
+  "args": ["-jar", "/path/to/tools.data-2.0.0-SNAPSHOT.jar"],
   "transport": "stdio"
 }
 ```
@@ -234,7 +234,7 @@ mvn test
 To enable debug logging, modify the Log4j2 configuration or set system properties:
 
 ```bash
-java -Dlog4j.configurationFile=log4j2-debug.xml -jar tools.data-1.4.0-SNAPSHOT.jar
+java -Dlog4j.configurationFile=log4j2-debug.xml -jar tools.data-2.0.0-SNAPSHOT.jar
 ```
 
 ## Extending the Server


### PR DESCRIPTION
## Summary

- Add `grpc-example` to the module layout tree in `AGENTS.md` — it has been a root reactor module since #204 but was missing from the diagram
- Update MCP SDK version in `MCP_USAGE.md`: `v0.12.1` → `v2.0.0-RC1` (bumped in #196)
- Update JAR filename references: `1.4.0-SNAPSHOT` → `2.0.0-SNAPSHOT` (current `revision` in root pom.xml)
- Document `streamable-http` as a second supported transport mode (already implemented in `McpConfiguration.java`)

## Test plan

- [ ] Verify module layout in `AGENTS.md` matches root `pom.xml` `<modules>` block
- [ ] Verify MCP SDK version matches `data/pom.xml` `mcp-bom` version
- [ ] Verify JAR version matches `revision` property in root `pom.xml`
- [ ] Verify `streamable-http` transport is wired in `McpConfiguration.java`

🤖 Generated with [Claude Code](https://claude.com/claude-code)