### PR TITLE
feat(context): build project tree of folders, files and dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,9 @@ Maven project. The notable capabilities are:
   **compile time** instead of runtime (shift-left). Supports proto2 only,
   because proto3 has no concept of required fields.
 - **Context engineering** (`code/context`) — a fast, regex-based finder that
-  builds the tree of classes used by a given class, to assemble context for
-  gen-AI agents working with Java code.
+  builds the tree of classes used by a given class, plus a `ProjectTreeBuilder`
+  that scans a whole Java project into a tree of folders, files and
+  dependencies, to assemble context for gen-AI agents working with Java code.
 - **Data** (`data`) — data sources (CSV, GZip, JDBC; in-memory and iterative
   loading), a uniqueness-checking tool (finds whether a subset of columns can
   serve as a key, and searches for a smaller key), data structures (an

--- a/README.md
+++ b/README.md
@@ -194,6 +194,28 @@ where ClassContiner contains the path of the class and its sources.
 The depth param tells the finder how deep we want to go in the tree of usages of the class.
 Of course when the depth is growing the tree grows very fast.
 
+To go from a single class to a whole project, `ProjectTreeBuilder` walks a Java
+project directory and produces a tree of its folders, files and dependencies:
+
+```java
+ProjectTreeNode root = new ProjectTreeBuilder(/* depth */ 1).build(Path.of("my-project"));
+System.out.println(new ProjectTreePrinter().print(root));
+```
+
+Every folder becomes a directory node, every file becomes a file node, and each
+`.java` file lists the project classes it depends on (resolved with the same
+regex-based `Context`). `ProjectTreePrinter` renders the tree as indented text,
+for example:
+
+```
+[dir] pkg
+  [file] A.java
+  [file] B.java
+    -> A.java
+```
+
+ready to be handed to a gen-AI agent as context.
+
 ## Data
 It contains:
 - data sources

--- a/README.md
+++ b/README.md
@@ -194,18 +194,35 @@ where ClassContiner contains the path of the class and its sources.
 The depth param tells the finder how deep we want to go in the tree of usages of the class.
 Of course when the depth is growing the tree grows very fast.
 
-To go from a single class to a whole project, `ProjectTreeBuilder` walks a Java
-project directory and produces a tree of its folders, files and dependencies:
+### Project tree
+
+A single class is rarely enough context — an agent usually needs to see how a
+whole project is laid out and how its files relate. `ProjectTreeBuilder` walks a
+Java project directory and produces a tree of its **folders, files and
+dependencies** in one structure:
 
 ```java
 ProjectTreeNode root = new ProjectTreeBuilder(/* depth */ 1).build(Path.of("my-project"));
 System.out.println(new ProjectTreePrinter().print(root));
 ```
 
-Every folder becomes a directory node, every file becomes a file node, and each
-`.java` file lists the project classes it depends on (resolved with the same
-regex-based `Context`). `ProjectTreePrinter` renders the tree as indented text,
-for example:
+The building blocks are:
+
+- **`ProjectTreeNode`** — a node in the tree. Each node is either a *directory*
+  (mirroring a project folder and holding child nodes) or a *file*. File nodes
+  additionally carry the set of project classes they depend on, so folders,
+  files and dependencies are all described by the same tree.
+- **`ProjectTreeBuilder`** — scans the project directory recursively. Every
+  folder becomes a directory node and every file a file node (directories are
+  listed before files, then alphabetically). For each `.java` file it resolves
+  the project classes it uses with the same regex-based `Context`, skipping the
+  file's own class. `depth` controls how deep the usage search goes, exactly as
+  in the `Context` interface above.
+- **`ContextFactory`** — decouples the builder from the concrete dependency
+  finder (defaulting to `Finder`), so a different resolution strategy can be
+  plugged in without changing the builder.
+- **`ProjectTreePrinter`** — renders the tree as indented text, with each file's
+  dependencies listed beneath it:
 
 ```
 [dir] pkg
@@ -214,7 +231,8 @@ for example:
     -> A.java
 ```
 
-ready to be handed to a gen-AI agent as context.
+The result is a compact, human- and LLM-readable view of the project, ready to
+be handed to a gen-AI agent as context.
 
 ## Data
 It contains:

--- a/code/context/src/main/java/io/github/adamw7/context/ContextFactory.java
+++ b/code/context/src/main/java/io/github/adamw7/context/ContextFactory.java
@@ -1,0 +1,13 @@
+package io.github.adamw7.context;
+
+import java.util.Set;
+
+/**
+ * Creates a {@link Context} over a set of containers. Decoupling the
+ * {@link ProjectTreeBuilder} from a concrete {@link Context} keeps the builder
+ * open for extension (e.g. a different dependency finder) without modification.
+ */
+@FunctionalInterface
+public interface ContextFactory {
+	Context create(Set<ClassContainer> allContainers);
+}

--- a/code/context/src/main/java/io/github/adamw7/context/ProjectTreeBuilder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/ProjectTreeBuilder.java
@@ -1,0 +1,105 @@
+package io.github.adamw7.context;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Builds a {@link ProjectTreeNode} tree from a Java project on disk. The tree
+ * mirrors the project's folders and files; every {@code .java} file is enriched
+ * with the classes it depends on, resolved by a {@link Context} over all the
+ * project's sources. The result is a ready-to-serialise context for gen-AI
+ * agents working with Java code.
+ */
+public class ProjectTreeBuilder {
+
+	private static final String JAVA_EXTENSION = ".java";
+
+	private final ContextFactory contextFactory;
+	private final int depth;
+
+	public ProjectTreeBuilder(int depth) {
+		this(Finder::new, depth);
+	}
+
+	public ProjectTreeBuilder(ContextFactory contextFactory, int depth) {
+		this.contextFactory = contextFactory;
+		this.depth = depth;
+	}
+
+	public ProjectTreeNode build(Path root) {
+		Map<Path, ClassContainer> containersByPath = loadContainers(root);
+		Context context = contextFactory.create(new HashSet<>(containersByPath.values()));
+		return buildNode(root, context, containersByPath);
+	}
+
+	private Map<Path, ClassContainer> loadContainers(Path root) {
+		try (Stream<Path> paths = Files.walk(root)) {
+			return paths.filter(this::isJavaFile)
+					.collect(Collectors.toMap(path -> path, this::toContainer));
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	private boolean isJavaFile(Path path) {
+		return Files.isRegularFile(path) && path.getFileName().toString().endsWith(JAVA_EXTENSION);
+	}
+
+	private ClassContainer toContainer(Path path) {
+		return ClassContainer.load(path, path.getFileName().toString());
+	}
+
+	private ProjectTreeNode buildNode(Path path, Context context, Map<Path, ClassContainer> containers) {
+		if (Files.isDirectory(path)) {
+			return buildDirectory(path, context, containers);
+		}
+		return buildFile(path, context, containers);
+	}
+
+	private ProjectTreeNode buildDirectory(Path path, Context context, Map<Path, ClassContainer> containers) {
+		ProjectTreeNode node = ProjectTreeNode.directory(path);
+		listChildren(path).forEach(child -> node.addChild(buildNode(child, context, containers)));
+		return node;
+	}
+
+	private ProjectTreeNode buildFile(Path path, Context context, Map<Path, ClassContainer> containers) {
+		ProjectTreeNode node = ProjectTreeNode.file(path);
+		addDependencies(node, path, context, containers);
+		return node;
+	}
+
+	private void addDependencies(ProjectTreeNode node, Path path, Context context,
+			Map<Path, ClassContainer> containers) {
+		ClassContainer container = containers.get(path);
+		if (container == null) {
+			return;
+		}
+		context.find(container, depth).stream()
+				.map(ClassContainer::className)
+				.filter(dependency -> !dependency.equals(container.className()))
+				.sorted()
+				.forEach(node::addDependency);
+	}
+
+	private List<Path> listChildren(Path directory) {
+		try (Stream<Path> entries = Files.list(directory)) {
+			return entries.sorted(childOrdering()).toList();
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	private Comparator<Path> childOrdering() {
+		return Comparator.comparing((Path path) -> Files.isDirectory(path) ? 0 : 1)
+				.thenComparing(path -> path.getFileName().toString());
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/ProjectTreeNode.java
+++ b/code/context/src/main/java/io/github/adamw7/context/ProjectTreeNode.java
@@ -1,0 +1,77 @@
+package io.github.adamw7.context;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A node in the tree of a Java project. A node is either a {@link Type#DIRECTORY}
+ * (a project folder holding child nodes) or a {@link Type#FILE} (a source or
+ * resource file). File nodes additionally carry the set of classes they depend
+ * on, so the tree describes folders, files and dependencies at once.
+ */
+public class ProjectTreeNode {
+
+	public enum Type {
+		DIRECTORY, FILE
+	}
+
+	private final String name;
+	private final Path path;
+	private final Type type;
+	private final List<ProjectTreeNode> children = new ArrayList<>();
+	private final Set<String> dependencies = new LinkedHashSet<>();
+
+	public ProjectTreeNode(String name, Path path, Type type) {
+		this.name = name;
+		this.path = path;
+		this.type = type;
+	}
+
+	public static ProjectTreeNode directory(Path path) {
+		return new ProjectTreeNode(nameOf(path), path, Type.DIRECTORY);
+	}
+
+	public static ProjectTreeNode file(Path path) {
+		return new ProjectTreeNode(nameOf(path), path, Type.FILE);
+	}
+
+	private static String nameOf(Path path) {
+		Path fileName = path.getFileName();
+		return fileName == null ? path.toString() : fileName.toString();
+	}
+
+	public void addChild(ProjectTreeNode child) {
+		children.add(child);
+	}
+
+	public void addDependency(String dependency) {
+		dependencies.add(dependency);
+	}
+
+	public boolean isDirectory() {
+		return type == Type.DIRECTORY;
+	}
+
+	public String name() {
+		return name;
+	}
+
+	public Path path() {
+		return path;
+	}
+
+	public Type type() {
+		return type;
+	}
+
+	public List<ProjectTreeNode> children() {
+		return children;
+	}
+
+	public Set<String> dependencies() {
+		return dependencies;
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/ProjectTreePrinter.java
+++ b/code/context/src/main/java/io/github/adamw7/context/ProjectTreePrinter.java
@@ -1,0 +1,36 @@
+package io.github.adamw7.context;
+
+/**
+ * Renders a {@link ProjectTreeNode} tree as indented text. Directories and
+ * files are listed hierarchically and each file's dependencies are printed
+ * beneath it, giving a compact, human- and LLM-readable view of the project.
+ */
+public class ProjectTreePrinter {
+
+	private static final String INDENT = "  ";
+	private static final String DIRECTORY_MARKER = "[dir] ";
+	private static final String FILE_MARKER = "[file] ";
+	private static final String DEPENDENCY_MARKER = "-> ";
+
+	public String print(ProjectTreeNode root) {
+		StringBuilder builder = new StringBuilder();
+		append(builder, root, "");
+		return builder.toString();
+	}
+
+	private void append(StringBuilder builder, ProjectTreeNode node, String indent) {
+		builder.append(indent).append(marker(node)).append(node.name()).append(System.lineSeparator());
+		appendDependencies(builder, node, indent + INDENT);
+		node.children().forEach(child -> append(builder, child, indent + INDENT));
+	}
+
+	private void appendDependencies(StringBuilder builder, ProjectTreeNode node, String indent) {
+		node.dependencies().forEach(dependency ->
+				builder.append(indent).append(DEPENDENCY_MARKER).append(dependency)
+						.append(System.lineSeparator()));
+	}
+
+	private String marker(ProjectTreeNode node) {
+		return node.isDirectory() ? DIRECTORY_MARKER : FILE_MARKER;
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/ProjectTreeBuilderTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/ProjectTreeBuilderTest.java
@@ -1,0 +1,89 @@
+package io.github.adamw7.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class ProjectTreeBuilderTest {
+
+	@TempDir
+	Path projectRoot;
+
+	@Test
+	void buildsFoldersFilesAndDependencies() throws IOException {
+		Path pkg = createPackage("pkg");
+		writeJava(pkg, "A", "public class A {}");
+		writeJava(pkg, "B", "public class B { A a; }");
+
+		ProjectTreeNode root = new ProjectTreeBuilder(1).build(projectRoot);
+
+		assertTrue(root.isDirectory());
+		ProjectTreeNode pkgNode = onlyChild(root);
+		assertEquals("pkg", pkgNode.name());
+		assertEquals(2, pkgNode.children().size());
+	}
+
+	@Test
+	void fileDependsOnUsedClass() throws IOException {
+		Path pkg = createPackage("pkg");
+		writeJava(pkg, "A", "public class A {}");
+		writeJava(pkg, "B", "public class B { A a; }");
+
+		ProjectTreeNode pkgNode = onlyChild(new ProjectTreeBuilder(1).build(projectRoot));
+
+		ProjectTreeNode b = child(pkgNode, "B.java");
+		assertEquals(1, b.dependencies().size());
+		assertTrue(b.dependencies().contains("A.java"));
+	}
+
+	@Test
+	void selfReferenceIsNotADependency() throws IOException {
+		Path pkg = createPackage("pkg");
+		writeJava(pkg, "A", "public class A {}");
+
+		ProjectTreeNode pkgNode = onlyChild(new ProjectTreeBuilder(1).build(projectRoot));
+
+		ProjectTreeNode a = child(pkgNode, "A.java");
+		assertTrue(a.dependencies().isEmpty());
+		assertFalse(a.isDirectory());
+	}
+
+	@Test
+	void directoriesAreListedBeforeFiles() throws IOException {
+		writeJava(projectRoot, "Root", "public class Root {}");
+		createPackage("sub");
+
+		ProjectTreeNode root = new ProjectTreeBuilder(1).build(projectRoot);
+
+		assertEquals(2, root.children().size());
+		assertTrue(root.children().get(0).isDirectory());
+		assertFalse(root.children().get(1).isDirectory());
+	}
+
+	private Path createPackage(String name) throws IOException {
+		return Files.createDirectories(projectRoot.resolve(name));
+	}
+
+	private void writeJava(Path directory, String className, String body) throws IOException {
+		Files.writeString(directory.resolve(className + ".java"), body);
+	}
+
+	private ProjectTreeNode onlyChild(ProjectTreeNode node) {
+		assertEquals(1, node.children().size());
+		return node.children().get(0);
+	}
+
+	private ProjectTreeNode child(ProjectTreeNode parent, String name) {
+		return parent.children().stream()
+				.filter(node -> node.name().equals(name))
+				.findFirst()
+				.orElseThrow();
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/ProjectTreePrinterTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/ProjectTreePrinterTest.java
@@ -1,0 +1,37 @@
+package io.github.adamw7.context;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class ProjectTreePrinterTest {
+
+	private final ProjectTreePrinter printer = new ProjectTreePrinter();
+
+	@Test
+	void rendersDirectoriesFilesAndDependencies() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/B.java"));
+		file.addDependency("A.java");
+		root.addChild(file);
+
+		String output = printer.print(root);
+
+		assertTrue(output.contains("[dir] project"));
+		assertTrue(output.contains("[file] B.java"));
+		assertTrue(output.contains("-> A.java"));
+	}
+
+	@Test
+	void nestsChildrenWithIndentation() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode pkg = ProjectTreeNode.directory(Path.of("project/pkg"));
+		root.addChild(pkg);
+
+		String output = printer.print(root);
+
+		assertTrue(output.contains("  [dir] pkg"));
+	}
+}


### PR DESCRIPTION
Add ProjectTreeBuilder that scans a Java project directory into a
ProjectTreeNode tree mirroring its folders and files, with each .java
file enriched with the project classes it depends on (resolved via the
existing regex-based Context). ProjectTreePrinter renders the tree as
indented text for use as gen-AI agent context. Dependency resolution is
decoupled through a ContextFactory (DIP), defaulting to Finder.

Covered by tests for tree structure, dependency detection, self-reference
exclusion, ordering, and rendering.

https://claude.ai/code/session_01PSEnpBDcjUp883xZuGagh2