### PR TITLE
build(pitest): add Sunday-scheduled mutation testing workflow

### DIFF
--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -1,0 +1,29 @@
+name: Mutation Testing
+
+on:
+  schedule:
+    # Sundays at 00:00 UTC
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  pitest:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up JDK 25
+      uses: actions/setup-java@v5
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: maven
+    - name: Run PIT mutation testing
+      run: mvn -B test -Ppitest --file pom.xml
+    - name: Upload mutation testing reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: pitest-reports
+        path: '**/target/pit-reports/'
+        retention-days: 30

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,18 @@
 					<artifactId>jacoco-maven-plugin</artifactId>
 					<version>0.8.15</version>
 				</plugin>
+				<plugin>
+					<groupId>org.pitest</groupId>
+					<artifactId>pitest-maven</artifactId>
+					<version>1.25.4</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.pitest</groupId>
+							<artifactId>pitest-junit5-plugin</artifactId>
+							<version>1.2.3</version>
+						</dependency>
+					</dependencies>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -377,6 +389,37 @@
 										</rule>
 									</rules>
 								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>pitest</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.pitest</groupId>
+						<artifactId>pitest-maven</artifactId>
+						<configuration>
+							<outputFormats>
+								<outputFormat>HTML</outputFormat>
+								<outputFormat>XML</outputFormat>
+							</outputFormats>
+							<timestampedReports>false</timestampedReports>
+							<failWhenNoMutations>false</failWhenNoMutations>
+							<excludedTestClasses>
+								<excludedTestClass>*IT</excludedTestClass>
+							</excludedTestClasses>
+						</configuration>
+						<executions>
+							<execution>
+								<id>pitest-mutation-coverage</id>
+								<phase>test</phase>
+								<goals>
+									<goal>mutationCoverage</goal>
+								</goals>
 							</execution>
 						</executions>
 					</plugin>


### PR DESCRIPTION
Add a PIT mutation testing setup that runs weekly on Sundays and is kept out of the normal build.

- Add pitest-maven 1.25.4 with pitest-junit5-plugin 1.2.3 to root pluginManagement (1.25.4 ships ASM 9.9, required for Java 25 bytecode; older releases fail with "Unsupported class file major version 69").
- Add a "pitest" profile binding mutationCoverage to the test phase, emitting HTML + XML reports. The profile is inactive by default, so "mvn install" never triggers mutation analysis. Integration tests (*IT) are excluded since they fail under PIT isolated runner.
- Add .github/workflows/pitest.yml running on cron "0 0 * * 0" (Sundays 00:00 UTC) plus workflow_dispatch, uploading pit-reports as an artifact.