### PR TITLE
Add country support to gRPC greeting and enable server/client execution

### DIFF
--- a/grpc-example/README.md
+++ b/grpc-example/README.md
@@ -39,3 +39,20 @@ example server, client, and test live under `src/test/java`.
 ```bash
 mvn -pl grpc-example -am test
 ```
+
+## Run
+
+The server and client live under `src/test/java`, so `exec:java` is configured
+with `classpathScope=test`. Build the module first so the generated builders are
+on the classpath, then start the server (the default `mainClass`):
+
+```bash
+mvn -pl grpc-example -am test-compile
+mvn -pl grpc-example exec:java
+```
+
+In another terminal, drive it with the client, overriding the main class:
+
+```bash
+mvn -pl grpc-example exec:java -Dexec.mainClass=io.github.adamw7.tools.grpc.GreeterClient -Dexec.args=Smith
+```

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -66,6 +66,14 @@
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<configuration>
+					<mainClass>io.github.adamw7.tools.grpc.GreeterServer</mainClass>
+					<classpathScope>test</classpathScope>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
 				<executions>
 					<execution>

--- a/grpc-example/src/test/java/io/github/adamw7/tools/grpc/GreeterExampleTest.java
+++ b/grpc-example/src/test/java/io/github/adamw7/tools/grpc/GreeterExampleTest.java
@@ -71,6 +71,15 @@ public class GreeterExampleTest {
 		Person person = new PersonBuilder().setName("Smith").setTitle("Dr.").setAddress(address).build();
 		HelloRequest request = new HelloRequestBuilder().setPerson(person).build();
 		HelloReply reply = stub.sayHello(request);
-		assertEquals("Hello, Dr. Smith from London!", reply.getMessage());
+		assertEquals("Hello, Dr. Smith from London, UK!", reply.getMessage());
+	}
+
+	@Test
+	public void greetsWithCityOnlyAddress() {
+		Address address = new AddressBuilder().setCity("London").build();
+		Person person = new PersonBuilder().setName("Smith").setAddress(address).build();
+		HelloRequest request = new HelloRequestBuilder().setPerson(person).build();
+		HelloReply reply = stub.sayHello(request);
+		assertEquals("Hello, Smith from London!", reply.getMessage());
 	}
 }

--- a/grpc-example/src/test/java/io/github/adamw7/tools/grpc/GreeterServiceImpl.java
+++ b/grpc-example/src/test/java/io/github/adamw7/tools/grpc/GreeterServiceImpl.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.grpc;
 
 import io.github.adamw7.tools.grpc.builders.HelloReplyBuilder;
+import io.github.adamw7.tools.grpc.proto.Address;
 import io.github.adamw7.tools.grpc.proto.GreeterGrpc;
 import io.github.adamw7.tools.grpc.proto.HelloReply;
 import io.github.adamw7.tools.grpc.proto.HelloRequest;
@@ -31,6 +32,10 @@ public class GreeterServiceImpl extends GreeterGrpc.GreeterImplBase {
 	}
 
 	private String locationSuffix(Person person) {
-		return person.hasAddress() ? " from " + person.getAddress().getCity() : "";
+		return person.hasAddress() ? " from " + place(person.getAddress()) : "";
+	}
+
+	private String place(Address address) {
+		return address.hasCountry() ? address.getCity() + ", " + address.getCountry() : address.getCity();
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,11 @@
 					<version>3.6.1</version>
 				</plugin>
 				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>exec-maven-plugin</artifactId>
+					<version>3.5.0</version>
+				</plugin>
+				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>
 					<version>3.6.3</version>


### PR DESCRIPTION
## Summary
Enhanced the gRPC example to support country information in addresses and added Maven configuration to easily run the server and client applications.

## Key Changes
- **Address formatting**: Updated `GreeterServiceImpl` to include country in the location suffix when available (e.g., "London, UK" instead of just "London")
- **New test case**: Added `greetsWithCityOnlyAddress()` test to verify backward compatibility when country is not specified
- **Updated existing test**: Modified `greetsWithNestedAddress()` assertion to expect the new format with country included
- **Maven exec plugin**: Configured `exec-maven-plugin` in the grpc-example module to run the server by default and support client execution via mainClass override
- **Documentation**: Added "Run" section to README with instructions for starting the server and client

## Implementation Details
- The `place()` helper method in `GreeterServiceImpl` conditionally includes the country in the formatted address string
- The exec plugin is configured with `classpathScope=test` to access test-scoped classes (server and client implementations)
- Plugin version (3.5.0) is defined in the root pom.xml plugin management section per project conventions

https://claude.ai/code/session_01H7MVDkRHhMQ67bMyEt4koN