### PR TITLE
Enforce TLS 1.3+ for all HTTPS connections

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/Application.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/Application.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.data;
 
+import io.github.adamw7.tools.data.network.TlsEnforcer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Application {
 
 	public static void main(String[] args) {
+		TlsEnforcer.enforce();
 		SpringApplication.run(Application.class, args);
 	}
 

--- a/data/src/main/java/io/github/adamw7/tools/data/network/TlsEnforcer.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/network/TlsEnforcer.java
@@ -1,0 +1,14 @@
+package io.github.adamw7.tools.data.network;
+
+public class TlsEnforcer {
+
+    static final String TLS_1_3 = "TLSv1.3";
+
+    private TlsEnforcer() {}
+
+    public static void enforce() {
+        System.setProperty("jdk.tls.client.protocols", TLS_1_3);
+        System.setProperty("jdk.tls.server.protocols", TLS_1_3);
+        System.setProperty("https.protocols", TLS_1_3);
+    }
+}

--- a/data/src/main/resources/application.properties
+++ b/data/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=Application
 server.port=8081
+server.ssl.enabled-protocols=TLSv1.3
 spring.main.allow-bean-definition-overriding=true
 
 logging.level.root=INFO

--- a/data/src/test/java/io/github/adamw7/tools/data/network/TlsEnforcerTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/network/TlsEnforcerTest.java
@@ -1,0 +1,16 @@
+package io.github.adamw7.tools.data.network;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TlsEnforcerTest {
+
+    @Test
+    public void enforce_setsTls13SystemProperties() {
+        TlsEnforcer.enforce();
+        assertEquals(TlsEnforcer.TLS_1_3, System.getProperty("jdk.tls.client.protocols"));
+        assertEquals(TlsEnforcer.TLS_1_3, System.getProperty("jdk.tls.server.protocols"));
+        assertEquals(TlsEnforcer.TLS_1_3, System.getProperty("https.protocols"));
+    }
+}


### PR DESCRIPTION
Set JVM system properties (jdk.tls.client.protocols, jdk.tls.server.protocols,
https.protocols) to TLSv1.3 before the Spring context starts, and configure
the embedded server's enabled-protocols accordingly so no older TLS version
can be negotiated on any HTTPS connection.

https://claude.ai/code/session_01EDkk9PKdV3YNGB1tsv65Ud