### PR TITLE
build(deps): upgrade MCP Java SDK from 2.0.0-RC1 to 2.0.0

### DIFF
--- a/data/pom.xml
+++ b/data/pom.xml
@@ -71,7 +71,7 @@
 			<dependency>
 				<groupId>io.modelcontextprotocol.sdk</groupId>
 				<artifactId>mcp-bom</artifactId>
-				<version>2.0.0-RC1</version>
+				<version>2.0.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
Update io.modelcontextprotocol.sdk:mcp-bom to the first stable
GA release of the 2.x line.

https://claude.ai/code/session_01PzvDoCM7CqYnqo8y3g6ftC