### PR TITLE
chore(claude): allowlist read-only unzip and mvn dependency goals

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,12 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(unzip -p *)",
+      "Bash(unzip -l *)",
+      "Bash(mvn dependency:tree *)",
+      "Bash(mvn dependency:analyze *)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

Adds a `permissions.allow` block to the project `.claude/settings.json` so recurring **read-only** inspection commands stop triggering permission prompts. These patterns came from scanning recent session transcripts for the most frequent read-only Bash calls.

## Patterns added

| Pattern | Why |
|---------|-----|
| `Bash(unzip -p *)` | pipe an archive entry to stdout (read-only) |
| `Bash(unzip -l *)` | list archive contents (read-only) |
| `Bash(mvn dependency:tree *)` | dependency graph inspection (read-only) |
| `Bash(mvn dependency:analyze *)` | unused/undeclared dependency analysis (read-only) |

All four are read-only: nothing extracts to disk, mutates the repo, or runs project code. Build/test/install `mvn` invocations were deliberately **not** allowlisted (side effects + arbitrary plugin execution).

## Notes

- Only the tracked `.claude/settings.json` is changed here. The local `.claude/settings.local.json` (gitignored) had ~27 redundant one-off exact entries cleaned up separately; those are now covered either by the patterns above or by existing broad rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)