### PR TITLE
feat(build): enforce CLAUDE.md presence and format via custom enforcer rule

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,6 +26,13 @@ jobs:
         java-version: '25'
         distribution: 'temurin'
         cache: maven
+    - name: Bootstrap CLAUDE.md enforcer rule
+      # The custom enforcer rule (tools.claude-md-enforcer) is consumed as a
+      # maven-enforcer-plugin dependency by the root build, so it must be
+      # installed to the local repo first. -DbootstrapClaudeMdRule disables the
+      # claude-md-enforce profile for this step so the module is not asked to
+      # depend on itself while it is being built.
+      run: mvn -B -pl claude-md-enforcer -am -DbootstrapClaudeMdRule install
     - name: Build with Maven
       run: |
         start=$(date +%s)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,14 +29,17 @@ jobs:
     - name: Bootstrap CLAUDE.md enforcer rule
       # The custom enforcer rule (tools.claude-md-enforcer) is consumed as a
       # maven-enforcer-plugin dependency by the root build, so it must be
-      # installed to the local repo first. -DbootstrapClaudeMdRule disables the
-      # claude-md-enforce profile for this step so the module is not asked to
-      # depend on itself while it is being built.
-      run: mvn -B -pl claude-md-enforcer -am -DbootstrapClaudeMdRule install
+      # installed to the local repo first. The claude-md-enforce profile is
+      # off here (no -DenforceClaudeMd), so the module is not asked to depend
+      # on itself while it is being built.
+      run: mvn -B -pl claude-md-enforcer -am install
     - name: Build with Maven
+      # -DenforceClaudeMd activates the claude-md-enforce profile so the root
+      # build fails when CLAUDE.md is missing or malformed. This is the only
+      # workflow that runs the check.
       run: |
         start=$(date +%s)
-        mvn -B package --file pom.xml
+        mvn -B package -DenforceClaudeMd --file pom.xml
         end=$(date +%s)
         duration=$((end - start))
         echo "Build took ${duration} seconds."

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ pom.xml.versionsBackup
 pom.xml.next
 release.properties
 dependency-reduced-pom.xml
+.flattened-pom.xml
 buildNumber.properties
 .mvn/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,9 @@ for client configuration (Claude Desktop, Cline, etc.).
 ## Build, test, and run
 
 ```bash
-# One-time bootstrap (see "CLAUDE.md enforcement" below): install the custom
-# enforcer rule into the local repo before any build that consumes it.
-mvn -pl claude-md-enforcer -am -DbootstrapClaudeMdRule install
+# Install the custom enforcer rule into the local repo. Only needed if you want
+# to run the CLAUDE.md check locally (see "CLAUDE.md enforcement" below).
+mvn -pl claude-md-enforcer -am install
 
 # Full clean build + install to local repo (use clean — see note below)
 mvn clean install
@@ -91,10 +91,11 @@ generates protobuf builders into `target/`; stale generated output from a
 previous build can otherwise linger and mask the change. If you have not
 removed anything, plain `mvn install` is fine and faster.
 
-CI (`.github/workflows/maven.yml`) runs the bootstrap step
-(`mvn -B -pl claude-md-enforcer -am -DbootstrapClaudeMdRule install`) and then
-`mvn -B package` on JDK 25 (Temurin) for every push and for pull requests
-targeting `main`.
+CI (`.github/workflows/maven.yml`) installs the enforcer rule
+(`mvn -B -pl claude-md-enforcer -am install`) and then runs
+`mvn -B package -DenforceClaudeMd` on JDK 25 (Temurin) for every push and for
+pull requests targeting `main`. It is the only workflow that runs the CLAUDE.md
+check; the other workflows build normally and are unaffected.
 
 ## CLAUDE.md enforcement
 
@@ -107,25 +108,25 @@ heading (`## Project`, `## Java version`, `## Maven`,
 `## Principles for Java Development`, `## Testing`, `## Dependencies`). The rule
 runs at the **root** only, in the `claude-md-enforce` profile.
 
-Because a maven-enforcer rule must be a JAR resolvable from a repository before
-the build runs, and Maven resolves plugin dependencies from repositories (not
-the reactor), the rule cannot be produced and consumed in the same build. Hence
-the **two-phase build**:
+The check is **opt-in**: the `claude-md-enforce` profile activates only when the
+`enforceClaudeMd` property is set (`-DenforceClaudeMd`). This keeps every other
+Maven build — the other CI workflows and ordinary local builds — unaffected and
+free of any bootstrap requirement. Only `.github/workflows/maven.yml` opts in.
 
-1. **Bootstrap** — install the rule (and the root pom it inherits) into the
-   local repo: `mvn -pl claude-md-enforcer -am -DbootstrapClaudeMdRule install`.
-   The `-DbootstrapClaudeMdRule` property disables the `claude-md-enforce`
-   profile so the module is not asked to depend on itself while building. The
-   module's pom is flattened (flatten-maven-plugin) so the installed pom has no
-   unresolved `${revision}` and is resolvable as a plugin dependency.
-2. **Build** — any normal build (`mvn install`, `mvn -B package`, …) then runs
-   the `claude-md-enforce` profile, which is active by default (property
-   activation, so it stays on under `-P coverage`/`-P pitest`).
+A maven-enforcer rule must be a JAR resolvable from a repository before the
+build runs, and Maven resolves plugin dependencies from repositories (not the
+reactor), so the rule cannot be produced and consumed in the same build. To run
+the check (in CI or locally) use a **two-phase build**:
 
-After the rule is installed once, day-to-day builds just work (a full
-`mvn install` reinstalls it as part of the reactor). Re-run the bootstrap only
-on a fresh checkout with an empty local repo, or after the local-repo artifact
-is removed or its version changes.
+1. **Install the rule** into the local repo:
+   `mvn -pl claude-md-enforcer -am install`. The module's pom is flattened
+   (flatten-maven-plugin) so the installed pom has no unresolved `${revision}`
+   and is resolvable as a plugin dependency.
+2. **Build with the check on**: `mvn package -DenforceClaudeMd` (or
+   `mvn -N validate -DenforceClaudeMd` for a quick check of CLAUDE.md alone).
+
+Without `-DenforceClaudeMd`, the rule is neither resolved nor run, so no
+bootstrap is needed for normal builds.
 
 ## Code style & conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ See [README.md](README.md) for worked code examples of each capability.
 
 ```
 tools (root pom, packaging=pom)
+├── claude-md-enforcer          # custom maven-enforcer rule validating CLAUDE.md
 ├── data                        # data sources, uniqueness checks, structures, MCP server
 ├── code
 │   ├── protogen-maven-plugin       # the proto2 builder-generating Maven plugin
@@ -41,8 +42,9 @@ tools (root pom, packaging=pom)
 └── data-test                   # standalone test module for the data module
 ```
 
-Root reactor modules are `data`, `code`, and `assembly`. The `data-test` module
-is built separately (it is not in the root `<modules>` list).
+Root reactor modules are `claude-md-enforcer`, `data`, `code`, and `assembly`.
+The `data-test` module is built separately (it is not in the root `<modules>`
+list).
 
 Base Java package: `io.github.adamw7` (`io.github.adamw7.context` for the
 context module, `io.github.adamw7.tools.*` elsewhere).
@@ -64,6 +66,10 @@ for client configuration (Claude Desktop, Cline, etc.).
 ## Build, test, and run
 
 ```bash
+# One-time bootstrap (see "CLAUDE.md enforcement" below): install the custom
+# enforcer rule into the local repo before any build that consumes it.
+mvn -pl claude-md-enforcer -am -DbootstrapClaudeMdRule install
+
 # Full clean build + install to local repo (use clean — see note below)
 mvn clean install
 
@@ -85,8 +91,41 @@ generates protobuf builders into `target/`; stale generated output from a
 previous build can otherwise linger and mask the change. If you have not
 removed anything, plain `mvn install` is fine and faster.
 
-CI (`.github/workflows/maven.yml`) runs `mvn -B package` on JDK 25 (Temurin)
-for every push and for pull requests targeting `main`.
+CI (`.github/workflows/maven.yml`) runs the bootstrap step
+(`mvn -B -pl claude-md-enforcer -am -DbootstrapClaudeMdRule install`) and then
+`mvn -B package` on JDK 25 (Temurin) for every push and for pull requests
+targeting `main`.
+
+## CLAUDE.md enforcement
+
+The `claude-md-enforcer` module is a custom `maven-enforcer-plugin` rule
+(`io.github.adamw7.tools.enforcer.ClaudeMdFormatRule`) that **fails the build**
+when the repository `CLAUDE.md` is missing or malformed. It checks that the file
+exists and is non-empty, starts with the `# CLAUDE.md` title (a leading UTF-8
+BOM is tolerated), references `AGENTS.md`, and contains every required section
+heading (`## Project`, `## Java version`, `## Maven`,
+`## Principles for Java Development`, `## Testing`, `## Dependencies`). The rule
+runs at the **root** only, in the `claude-md-enforce` profile.
+
+Because a maven-enforcer rule must be a JAR resolvable from a repository before
+the build runs, and Maven resolves plugin dependencies from repositories (not
+the reactor), the rule cannot be produced and consumed in the same build. Hence
+the **two-phase build**:
+
+1. **Bootstrap** — install the rule (and the root pom it inherits) into the
+   local repo: `mvn -pl claude-md-enforcer -am -DbootstrapClaudeMdRule install`.
+   The `-DbootstrapClaudeMdRule` property disables the `claude-md-enforce`
+   profile so the module is not asked to depend on itself while building. The
+   module's pom is flattened (flatten-maven-plugin) so the installed pom has no
+   unresolved `${revision}` and is resolvable as a plugin dependency.
+2. **Build** — any normal build (`mvn install`, `mvn -B package`, …) then runs
+   the `claude-md-enforce` profile, which is active by default (property
+   activation, so it stays on under `-P coverage`/`-P pitest`).
+
+After the rule is installed once, day-to-day builds just work (a full
+`mvn install` reinstalls it as part of the reactor). Re-run the bootstrap only
+on a fresh checkout with an empty local repo, or after the local-repo artifact
+is removed or its version changes.
 
 ## Code style & conventions
 

--- a/claude-md-enforcer/pom.xml
+++ b/claude-md-enforcer/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>io.github.adamw7</groupId>
+		<artifactId>tools</artifactId>
+		<version>${revision}</version>
+	</parent>
+	<artifactId>tools.claude-md-enforcer</artifactId>
+	<packaging>jar</packaging>
+	<name>CLAUDE.md enforcer rule</name>
+	<url>https://maven.apache.org</url>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+			</plugin>
+			<!-- The root pom uses a CI-friendly ${revision} version. This module
+			     is consumed as a maven-enforcer-plugin dependency, i.e. resolved
+			     from a repository outside the reactor, so its installed pom must
+			     not contain the unresolved ${revision}. Flatten it into a
+			     self-contained pom on install. -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+						<configuration>
+							<updatePomFile>true</updatePomFile>
+							<flattenMode>oss</flattenMode>
+						</configuration>
+					</execution>
+					<execution>
+						<id>flatten-clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.maven.enforcer</groupId>
+			<artifactId>enforcer-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.inject</groupId>
+			<artifactId>javax.inject</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRule.java
+++ b/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRule.java
@@ -1,0 +1,105 @@
+package io.github.adamw7.tools.enforcer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * Enforcer rule that fails the build when {@code CLAUDE.md} is missing or does
+ * not follow the expected structure: it must start with the {@code # CLAUDE.md}
+ * title, reference {@code AGENTS.md}, and contain every required section
+ * heading.
+ */
+@Named("claudeMdFormat")
+public class ClaudeMdFormatRule extends AbstractEnforcerRule {
+
+	private static final char BYTE_ORDER_MARK = (char) 0xFEFF;
+	private static final String TITLE_HEADING = "# CLAUDE.md";
+	private static final String AGENTS_REFERENCE = "AGENTS.md";
+	private static final List<String> REQUIRED_SECTIONS = List.of(
+			"## Project",
+			"## Java version",
+			"## Maven",
+			"## Principles for Java Development",
+			"## Testing",
+			"## Dependencies");
+
+	/** The {@code CLAUDE.md} file to validate. Injected from the rule configuration. */
+	private File claudeMdFile;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		String content = readContent();
+		verifyTitle(content);
+		verifyAgentsReference(content);
+		verifyRequiredSections(content);
+	}
+
+	private String readContent() throws EnforcerRuleException {
+		if (claudeMdFile == null) {
+			throw new EnforcerRuleException("The claudeMdFile parameter is not configured");
+		}
+		if (!claudeMdFile.isFile()) {
+			throw new EnforcerRuleException("CLAUDE.md does not exist at " + claudeMdFile);
+		}
+		String content = stripByteOrderMark(readAll(claudeMdFile));
+		if (content.isBlank()) {
+			throw new EnforcerRuleException("CLAUDE.md is empty: " + claudeMdFile);
+		}
+		return content;
+	}
+
+	private String stripByteOrderMark(String content) {
+		if (!content.isEmpty() && content.charAt(0) == BYTE_ORDER_MARK) {
+			return content.substring(1);
+		}
+		return content;
+	}
+
+	private String readAll(File file) throws EnforcerRuleException {
+		try {
+			return Files.readString(file.toPath());
+		} catch (IOException e) {
+			throw new EnforcerRuleException("Could not read CLAUDE.md at " + file, e);
+		}
+	}
+
+	private void verifyTitle(String content) throws EnforcerRuleException {
+		if (!content.stripLeading().startsWith(TITLE_HEADING)) {
+			throw new EnforcerRuleException("CLAUDE.md must start with the '" + TITLE_HEADING + "' title heading");
+		}
+	}
+
+	private void verifyAgentsReference(String content) throws EnforcerRuleException {
+		if (!content.contains(AGENTS_REFERENCE)) {
+			throw new EnforcerRuleException("CLAUDE.md must reference " + AGENTS_REFERENCE + " as the source of truth");
+		}
+	}
+
+	private void verifyRequiredSections(String content) throws EnforcerRuleException {
+		for (String section : REQUIRED_SECTIONS) {
+			verifySection(content, section);
+		}
+	}
+
+	private void verifySection(String content, String section) throws EnforcerRuleException {
+		if (!content.contains(section)) {
+			throw new EnforcerRuleException("CLAUDE.md is missing required section heading: " + section);
+		}
+	}
+
+	void setClaudeMdFile(File claudeMdFile) {
+		this.claudeMdFile = claudeMdFile;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("ClaudeMdFormatRule[claudeMdFile=%s]", claudeMdFile);
+	}
+}

--- a/claude-md-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/claude-md-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,0 +1,1 @@
+io.github.adamw7.tools.enforcer.ClaudeMdFormatRule

--- a/claude-md-enforcer/src/test/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRuleTest.java
+++ b/claude-md-enforcer/src/test/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRuleTest.java
@@ -1,0 +1,115 @@
+package io.github.adamw7.tools.enforcer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ClaudeMdFormatRuleTest {
+
+	private static final String VALID_CONTENT = """
+			# CLAUDE.md
+
+			See [AGENTS.md](AGENTS.md) for the full agent guide.
+
+			## Project
+			Java project built with Maven.
+
+			## Java version
+			Java 25.
+
+			## Maven
+			Versions live in the root pom.
+
+			## Principles for Java Development
+			Use SOLID Principles.
+
+			## Testing
+			Write unit tests for all new logic.
+
+			## Dependencies
+			Ask before adding a new one.
+			""";
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesForWellFormedFile() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void passesWhenFileStartsWithByteOrderMark() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor((char) 0xFEFF + VALID_CONTENT);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenFileIsNotConfigured() {
+		ClaudeMdFormatRule rule = new ClaudeMdFormatRule();
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenFileIsMissing() {
+		ClaudeMdFormatRule rule = new ClaudeMdFormatRule();
+		rule.setClaudeMdFile(tempDir.resolve("absent.md").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenFileIsEmpty() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor("   \n  ");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("empty"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTitleHeadingIsWrong() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# CLAUDE.md", "# Something Else"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("title heading"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAgentsReferenceIsMissing() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("AGENTS.md", "OTHER.md"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("AGENTS.md"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenARequiredSectionIsMissing() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "## Quality"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("## Testing"), exception.getMessage());
+	}
+
+	private ClaudeMdFormatRule ruleFor(String content) throws IOException {
+		Path file = tempDir.resolve("CLAUDE.md");
+		Files.writeString(file, content);
+		ClaudeMdFormatRule rule = new ClaudeMdFormatRule();
+		rule.setClaudeMdFile(file.toFile());
+		return rule;
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 		<tag>HEAD</tag>
 	</scm>
 	<modules>
+		<module>claude-md-enforcer</module>
 		<module>data</module>
 		<module>code</module>
 		<module>grpc-example</module>
@@ -46,6 +47,18 @@
 	<dependencyManagement>
 		<dependencies>
 
+			<dependency>
+				<groupId>org.apache.maven.enforcer</groupId>
+				<artifactId>enforcer-api</artifactId>
+				<version>3.6.3</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>javax.inject</groupId>
+				<artifactId>javax.inject</artifactId>
+				<version>1</version>
+				<scope>provided</scope>
+			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
@@ -275,6 +288,11 @@
 					<version>3.6.3</version>
 				</plugin>
 				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>flatten-maven-plugin</artifactId>
+					<version>1.6.0</version>
+				</plugin>
+				<plugin>
 					<groupId>dev.dimlight</groupId>
 					<artifactId>shellcheck-maven-plugin</artifactId>
 					<version>0.5.1</version>
@@ -353,6 +371,53 @@
 	</build>
 
 	<profiles>
+		<profile>
+			<!-- Validates that the repository CLAUDE.md exists and is well formed,
+			     using the custom rule from the tools.claude-md-enforcer module.
+			     That module must be installed first (see AGENTS.md "CLAUDE.md
+			     enforcement"); this profile is therefore disabled during that
+			     bootstrap build by setting -DbootstrapClaudeMdRule. Property-based
+			     activation keeps it on even when -P coverage/pitest is used. -->
+			<id>claude-md-enforce</id>
+			<activation>
+				<property>
+					<name>!bootstrapClaudeMdRule</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-enforcer-plugin</artifactId>
+						<dependencies>
+							<dependency>
+								<groupId>io.github.adamw7</groupId>
+								<artifactId>tools.claude-md-enforcer</artifactId>
+								<version>${revision}</version>
+							</dependency>
+						</dependencies>
+						<executions>
+							<execution>
+								<id>enforce-claude-md</id>
+								<!-- CLAUDE.md lives only at the repository root, so run
+								     this at the root reactor module only. -->
+								<inherited>false</inherited>
+								<goals>
+									<goal>enforce</goal>
+								</goals>
+								<configuration>
+									<rules>
+										<claudeMdFormat>
+											<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
+										</claudeMdFormat>
+									</rules>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 		<profile>
 			<id>coverage</id>
 			<build>

--- a/pom.xml
+++ b/pom.xml
@@ -374,14 +374,15 @@
 		<profile>
 			<!-- Validates that the repository CLAUDE.md exists and is well formed,
 			     using the custom rule from the tools.claude-md-enforcer module.
-			     That module must be installed first (see AGENTS.md "CLAUDE.md
-			     enforcement"); this profile is therefore disabled during that
-			     bootstrap build by setting -DbootstrapClaudeMdRule. Property-based
-			     activation keeps it on even when -P coverage/pitest is used. -->
+			     Opt-in via -DenforceClaudeMd so that only the dedicated CI build
+			     (.github/workflows/maven.yml) runs it; every other Maven build
+			     (other workflows, local) is unaffected and needs no bootstrap.
+			     The rule must be installed into the local repo first (see
+			     AGENTS.md "CLAUDE.md enforcement"). -->
 			<id>claude-md-enforce</id>
 			<activation>
 				<property>
-					<name>!bootstrapClaudeMdRule</name>
+					<name>enforceClaudeMd</name>
 				</property>
 			</activation>
 			<build>


### PR DESCRIPTION
## Summary

Adds a new **`claude-md-enforcer`** Maven module — a custom `maven-enforcer-plugin` rule (`io.github.adamw7.tools.enforcer.ClaudeMdFormatRule`) that **fails the build** when the repository `CLAUDE.md` is missing or malformed. The root `pom.xml` only references the rule; no rule logic lives in the pom.

The rule checks that `CLAUDE.md`:
- exists and is non-empty
- starts with the `# CLAUDE.md` title (tolerates a leading UTF-8 BOM)
- references `AGENTS.md`
- contains every required section heading (`## Project`, `## Java version`, `## Maven`, `## Principles for Java Development`, `## Testing`, `## Dependencies`)

## Two-phase build (why)

A maven-enforcer rule must be a JAR resolvable from a repository *before* the build runs, and Maven resolves plugin dependencies from repositories — not the reactor. So the rule can't be produced and consumed in one build:

1. **Bootstrap:** `mvn -pl claude-md-enforcer -am -DbootstrapClaudeMdRule install`
2. **Build:** `mvn install` / `mvn -B package`

- The check lives in a `claude-md-enforce` profile, **property-activated** (active unless `-DbootstrapClaudeMdRule` is set) so it survives `-P coverage`/`-P pitest`.
- `flatten-maven-plugin` flattens the module pom so its CI-friendly `${revision}` parent reference resolves as an external plugin dependency.
- CI (`maven.yml`) runs the bootstrap step before `mvn -B package`.

## New build dependencies (root pom)

- `org.apache.maven.enforcer:enforcer-api:3.6.3` (provided) — rule API
- `javax.inject:javax.inject:1` (provided) — `@Named` discovery via a hand-written Sisu index (avoids the legacy-API deprecation warning)
- `org.codehaus.mojo:flatten-maven-plugin:1.6.0` (pluginManagement) — used only by the rule module

## Testing

- 8 unit tests covering pass, missing, empty, unconfigured, wrong title, missing AGENTS reference, missing section, and BOM.
- Verified end-to-end: valid `CLAUDE.md` passes; a broken one fails with a precise message (e.g. `CLAUDE.md is missing required section heading: ## Testing`).
- Full-reactor `validate` passes with the profile active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)