### PR TITLE
feat(enforcer): validate AGENTS.md structure and skill files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,14 +99,26 @@ check; the other workflows build normally and are unaffected.
 
 ## CLAUDE.md enforcement
 
-The `claude-md-enforcer` module is a custom `maven-enforcer-plugin` rule
-(`io.github.adamw7.tools.enforcer.ClaudeMdFormatRule`) that **fails the build**
-when the repository `CLAUDE.md` is missing or malformed. It checks that the file
-exists and is non-empty, starts with the `# CLAUDE.md` title (a leading UTF-8
-BOM is tolerated), references `AGENTS.md`, and contains every required section
-heading (`## Project`, `## Java version`, `## Maven`,
-`## Principles for Java Development`, `## Testing`, `## Dependencies`). The rule
-runs at the **root** only, in the `claude-md-enforce` profile.
+The `claude-md-enforcer` module is a set of custom `maven-enforcer-plugin` rules
+that **fail the build** when the repository's agent files are missing or
+malformed. The rules run at the **root** only, in the `claude-md-enforce`
+profile:
+
+- `ClaudeMdFormatRule` (`claudeMdFormat`) checks that `CLAUDE.md` exists and is
+  non-empty, starts with the `# CLAUDE.md` title (a leading UTF-8 BOM is
+  tolerated), references `AGENTS.md`, and contains every required section
+  heading (`## Project`, `## Java version`, `## Maven`,
+  `## Principles for Java Development`, `## Testing`, `## Dependencies`).
+- `AgentsMdFormatRule` (`agentsMdFormat`) applies the same structural checks to
+  `AGENTS.md`: it must start with the `# AGENTS.md` title and contain every
+  required section heading (`## Project overview`, `## Module layout`,
+  `## Environment & toolchain`, `## Build, test, and run`,
+  `## Code style & conventions`, `## Releasing`, `## Pull requests & commits`).
+- `SkillFilesExistRule` (`skillFilesExist`) checks that every skill directory
+  under `.claude/skills` contains a `SKILL.md` file.
+
+The `claudeMdFormat` and `agentsMdFormat` rules share a `MarkdownFormatRule`
+base class that performs the file-existence, BOM, title, and section checks.
 
 The check is **opt-in**: the `claude-md-enforce` profile activates only when the
 `enforceClaudeMd` property is set (`-DenforceClaudeMd`). This keeps every other

--- a/README.md
+++ b/README.md
@@ -302,6 +302,35 @@ Notes:
 in memory checks are using in memory sources that load all the data once and run multiple recursive checks to find better options.
 Iterative (no memory) checks are keeping only one row at the time so they require very tiny heap size but for the recursive checks need to read the source many times. 
 
+## Agent file enforcement
+
+The `claude-md-enforcer` module is a set of custom
+[`maven-enforcer-plugin`](https://maven.apache.org/enforcer/maven-enforcer-plugin/)
+rules that **fail the build** when the repository's agent files are missing or
+malformed, keeping `CLAUDE.md`, `AGENTS.md`, and the skills under
+`.claude/skills` consistent and in their expected shape:
+
+- **`claudeMdFormat`** (`ClaudeMdFormatRule`) — checks that `CLAUDE.md` exists
+  and is non-empty, starts with the `# CLAUDE.md` title (a leading UTF-8 BOM is
+  tolerated), references `AGENTS.md`, and contains every required section
+  heading.
+- **`agentsMdFormat`** (`AgentsMdFormatRule`) — applies the same structural
+  checks to `AGENTS.md`: it must start with the `# AGENTS.md` title and contain
+  every required section heading.
+- **`skillFilesExist`** (`SkillFilesExistRule`) — checks that every skill
+  directory under `.claude/skills` contains a `SKILL.md` file.
+
+The `claudeMdFormat` and `agentsMdFormat` rules share a `MarkdownFormatRule`
+base class that performs the file-existence, BOM, title, and section checks.
+
+The rules are wired into the root `pom.xml` and run at the repository root only.
+The check is **opt-in** via the `enforceClaudeMd` property, so ordinary builds
+are unaffected:
+```
+mvn -pl claude-md-enforcer -am install   # install the rule jar once
+mvn package -DenforceClaudeMd            # build with the checks enabled
+```
+
 # Building
 ```
 mvn clean install

--- a/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/AgentsMdFormatRule.java
+++ b/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/AgentsMdFormatRule.java
@@ -1,0 +1,60 @@
+package io.github.adamw7.tools.enforcer;
+
+import java.io.File;
+import java.util.List;
+
+import javax.inject.Named;
+
+/**
+ * Enforcer rule that fails the build when {@code AGENTS.md} is missing or does
+ * not follow the expected structure: it must start with the {@code # AGENTS.md}
+ * title and contain every required section heading. {@code CLAUDE.md} defers to
+ * {@code AGENTS.md} as the single source of truth, so this rule keeps that
+ * source intact.
+ */
+@Named("agentsMdFormat")
+public class AgentsMdFormatRule extends MarkdownFormatRule {
+
+	private static final String DOCUMENT_NAME = "AGENTS.md";
+	private static final String TITLE_HEADING = "# AGENTS.md";
+	private static final List<String> REQUIRED_SECTIONS = List.of(
+			"## Project overview",
+			"## Module layout",
+			"## Environment & toolchain",
+			"## Build, test, and run",
+			"## Code style & conventions",
+			"## Releasing",
+			"## Pull requests & commits");
+
+	/** The {@code AGENTS.md} file to validate. Injected from the rule configuration. */
+	private File agentsMdFile;
+
+	@Override
+	protected File documentFile() {
+		return agentsMdFile;
+	}
+
+	@Override
+	protected String documentName() {
+		return DOCUMENT_NAME;
+	}
+
+	@Override
+	protected String titleHeading() {
+		return TITLE_HEADING;
+	}
+
+	@Override
+	protected List<String> requiredSections() {
+		return REQUIRED_SECTIONS;
+	}
+
+	void setAgentsMdFile(File agentsMdFile) {
+		this.agentsMdFile = agentsMdFile;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("AgentsMdFormatRule[agentsMdFile=%s]", agentsMdFile);
+	}
+}

--- a/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRule.java
+++ b/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRule.java
@@ -1,13 +1,10 @@
 package io.github.adamw7.tools.enforcer;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
 
 import javax.inject.Named;
 
-import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 /**
@@ -17,9 +14,9 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
  * heading.
  */
 @Named("claudeMdFormat")
-public class ClaudeMdFormatRule extends AbstractEnforcerRule {
+public class ClaudeMdFormatRule extends MarkdownFormatRule {
 
-	private static final char BYTE_ORDER_MARK = (char) 0xFEFF;
+	private static final String DOCUMENT_NAME = "CLAUDE.md";
 	private static final String TITLE_HEADING = "# CLAUDE.md";
 	private static final String AGENTS_REFERENCE = "AGENTS.md";
 	private static final List<String> REQUIRED_SECTIONS = List.of(
@@ -34,63 +31,29 @@ public class ClaudeMdFormatRule extends AbstractEnforcerRule {
 	private File claudeMdFile;
 
 	@Override
-	public void execute() throws EnforcerRuleException {
-		String content = readContent();
-		verifyTitle(content);
-		verifyAgentsReference(content);
-		verifyRequiredSections(content);
+	protected File documentFile() {
+		return claudeMdFile;
 	}
 
-	private String readContent() throws EnforcerRuleException {
-		if (claudeMdFile == null) {
-			throw new EnforcerRuleException("The claudeMdFile parameter is not configured");
-		}
-		if (!claudeMdFile.isFile()) {
-			throw new EnforcerRuleException("CLAUDE.md does not exist at " + claudeMdFile);
-		}
-		String content = stripByteOrderMark(readAll(claudeMdFile));
-		if (content.isBlank()) {
-			throw new EnforcerRuleException("CLAUDE.md is empty: " + claudeMdFile);
-		}
-		return content;
+	@Override
+	protected String documentName() {
+		return DOCUMENT_NAME;
 	}
 
-	private String stripByteOrderMark(String content) {
-		if (!content.isEmpty() && content.charAt(0) == BYTE_ORDER_MARK) {
-			return content.substring(1);
-		}
-		return content;
+	@Override
+	protected String titleHeading() {
+		return TITLE_HEADING;
 	}
 
-	private String readAll(File file) throws EnforcerRuleException {
-		try {
-			return Files.readString(file.toPath());
-		} catch (IOException e) {
-			throw new EnforcerRuleException("Could not read CLAUDE.md at " + file, e);
-		}
+	@Override
+	protected List<String> requiredSections() {
+		return REQUIRED_SECTIONS;
 	}
 
-	private void verifyTitle(String content) throws EnforcerRuleException {
-		if (!content.stripLeading().startsWith(TITLE_HEADING)) {
-			throw new EnforcerRuleException("CLAUDE.md must start with the '" + TITLE_HEADING + "' title heading");
-		}
-	}
-
-	private void verifyAgentsReference(String content) throws EnforcerRuleException {
+	@Override
+	protected void verifyAdditional(String content) throws EnforcerRuleException {
 		if (!content.contains(AGENTS_REFERENCE)) {
 			throw new EnforcerRuleException("CLAUDE.md must reference " + AGENTS_REFERENCE + " as the source of truth");
-		}
-	}
-
-	private void verifyRequiredSections(String content) throws EnforcerRuleException {
-		for (String section : REQUIRED_SECTIONS) {
-			verifySection(content, section);
-		}
-	}
-
-	private void verifySection(String content, String section) throws EnforcerRuleException {
-		if (!content.contains(section)) {
-			throw new EnforcerRuleException("CLAUDE.md is missing required section heading: " + section);
 		}
 	}
 

--- a/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/MarkdownFormatRule.java
+++ b/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/MarkdownFormatRule.java
@@ -1,0 +1,94 @@
+package io.github.adamw7.tools.enforcer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * Base for enforcer rules that validate a Markdown document follows an expected
+ * structure: it must exist, be non-empty, start with a required title heading
+ * (a leading UTF-8 BOM is tolerated), and contain every required section
+ * heading. Subclasses contribute the file, its name, the title, the required
+ * sections, and any document-specific checks.
+ */
+abstract class MarkdownFormatRule extends AbstractEnforcerRule {
+
+	private static final char BYTE_ORDER_MARK = (char) 0xFEFF;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		String content = readContent();
+		verifyTitle(content);
+		verifyRequiredSections(content);
+		verifyAdditional(content);
+	}
+
+	/** The file to validate. Injected from the rule configuration. */
+	protected abstract File documentFile();
+
+	/** Human-readable file name used in messages, e.g. {@code CLAUDE.md}. */
+	protected abstract String documentName();
+
+	/** The title heading the document must start with, e.g. {@code # CLAUDE.md}. */
+	protected abstract String titleHeading();
+
+	/** The section headings the document must contain. */
+	protected abstract List<String> requiredSections();
+
+	/** Hook for document-specific checks. The default implementation does nothing. */
+	protected void verifyAdditional(String content) throws EnforcerRuleException {
+	}
+
+	private String readContent() throws EnforcerRuleException {
+		File file = documentFile();
+		if (file == null) {
+			throw new EnforcerRuleException("The " + documentName() + " file parameter is not configured");
+		}
+		if (!file.isFile()) {
+			throw new EnforcerRuleException(documentName() + " does not exist at " + file);
+		}
+		String content = stripByteOrderMark(readAll(file));
+		if (content.isBlank()) {
+			throw new EnforcerRuleException(documentName() + " is empty: " + file);
+		}
+		return content;
+	}
+
+	private String stripByteOrderMark(String content) {
+		if (!content.isEmpty() && content.charAt(0) == BYTE_ORDER_MARK) {
+			return content.substring(1);
+		}
+		return content;
+	}
+
+	private String readAll(File file) throws EnforcerRuleException {
+		try {
+			return Files.readString(file.toPath());
+		} catch (IOException e) {
+			throw new EnforcerRuleException("Could not read " + documentName() + " at " + file, e);
+		}
+	}
+
+	private void verifyTitle(String content) throws EnforcerRuleException {
+		if (!content.stripLeading().startsWith(titleHeading())) {
+			throw new EnforcerRuleException(
+					documentName() + " must start with the '" + titleHeading() + "' title heading");
+		}
+	}
+
+	private void verifyRequiredSections(String content) throws EnforcerRuleException {
+		for (String section : requiredSections()) {
+			verifySection(content, section);
+		}
+	}
+
+	private void verifySection(String content, String section) throws EnforcerRuleException {
+		if (!content.contains(section)) {
+			throw new EnforcerRuleException(documentName() + " is missing required section heading: " + section);
+		}
+	}
+}

--- a/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/SkillFilesExistRule.java
+++ b/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/SkillFilesExistRule.java
@@ -1,0 +1,72 @@
+package io.github.adamw7.tools.enforcer;
+
+import java.io.File;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * Enforcer rule that fails the build when any skill under the configured skills
+ * directory is missing its {@code SKILL.md}. Every immediate subdirectory of
+ * {@code skillsDir} is treated as a skill and must contain a {@code SKILL.md}
+ * file.
+ */
+@Named("skillFilesExist")
+public class SkillFilesExistRule extends AbstractEnforcerRule {
+
+	private static final String SKILL_FILE_NAME = "SKILL.md";
+
+	/** The {@code .claude/skills} directory to scan. Injected from the rule configuration. */
+	private File skillsDir;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		verifyConfigured();
+		verifyDirectory();
+		verifySkillFiles(listSkillDirectories());
+	}
+
+	private void verifyConfigured() throws EnforcerRuleException {
+		if (skillsDir == null) {
+			throw new EnforcerRuleException("The skillsDir parameter is not configured");
+		}
+	}
+
+	private void verifyDirectory() throws EnforcerRuleException {
+		if (!skillsDir.isDirectory()) {
+			throw new EnforcerRuleException("Skills directory does not exist at " + skillsDir);
+		}
+	}
+
+	private File[] listSkillDirectories() throws EnforcerRuleException {
+		File[] skillDirectories = skillsDir.listFiles(File::isDirectory);
+		if (skillDirectories == null || skillDirectories.length == 0) {
+			throw new EnforcerRuleException("No skill directories found in " + skillsDir);
+		}
+		return skillDirectories;
+	}
+
+	private void verifySkillFiles(File[] skillDirectories) throws EnforcerRuleException {
+		for (File skillDirectory : skillDirectories) {
+			verifySkillFile(skillDirectory);
+		}
+	}
+
+	private void verifySkillFile(File skillDirectory) throws EnforcerRuleException {
+		File skillFile = new File(skillDirectory, SKILL_FILE_NAME);
+		if (!skillFile.isFile()) {
+			throw new EnforcerRuleException("Missing " + SKILL_FILE_NAME + " in skill directory: " + skillDirectory);
+		}
+	}
+
+	void setSkillsDir(File skillsDir) {
+		this.skillsDir = skillsDir;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("SkillFilesExistRule[skillsDir=%s]", skillsDir);
+	}
+}

--- a/claude-md-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/claude-md-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,1 +1,3 @@
 io.github.adamw7.tools.enforcer.ClaudeMdFormatRule
+io.github.adamw7.tools.enforcer.AgentsMdFormatRule
+io.github.adamw7.tools.enforcer.SkillFilesExistRule

--- a/claude-md-enforcer/src/test/java/io/github/adamw7/tools/enforcer/AgentsMdFormatRuleTest.java
+++ b/claude-md-enforcer/src/test/java/io/github/adamw7/tools/enforcer/AgentsMdFormatRuleTest.java
@@ -1,0 +1,110 @@
+package io.github.adamw7.tools.enforcer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AgentsMdFormatRuleTest {
+
+	private static final String VALID_CONTENT = """
+			# AGENTS.md
+
+			Guidance for AI coding agents working in this repository.
+
+			## Project overview
+			A library of Java tooling.
+
+			## Module layout
+			A multi-module Maven project.
+
+			## Environment & toolchain
+			Java 25 and Maven 3.9.x.
+
+			## Build, test, and run
+			Build from the repository root.
+
+			## Code style & conventions
+			SOLID principles and clean code.
+
+			## Releasing
+			Bump the revision property.
+
+			## Pull requests & commits
+			Use conventional commit messages.
+			""";
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesForWellFormedFile() throws IOException {
+		AgentsMdFormatRule rule = ruleFor(VALID_CONTENT);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void passesWhenFileStartsWithByteOrderMark() throws IOException {
+		AgentsMdFormatRule rule = ruleFor((char) 0xFEFF + VALID_CONTENT);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenFileIsNotConfigured() {
+		AgentsMdFormatRule rule = new AgentsMdFormatRule();
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenFileIsMissing() {
+		AgentsMdFormatRule rule = new AgentsMdFormatRule();
+		rule.setAgentsMdFile(tempDir.resolve("absent.md").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenFileIsEmpty() throws IOException {
+		AgentsMdFormatRule rule = ruleFor("   \n  ");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("empty"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTitleHeadingIsWrong() throws IOException {
+		AgentsMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# AGENTS.md", "# Something Else"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("title heading"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenARequiredSectionIsMissing() throws IOException {
+		AgentsMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Releasing", "## Shipping"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("## Releasing"), exception.getMessage());
+	}
+
+	private AgentsMdFormatRule ruleFor(String content) throws IOException {
+		Path file = tempDir.resolve("AGENTS.md");
+		Files.writeString(file, content);
+		AgentsMdFormatRule rule = new AgentsMdFormatRule();
+		rule.setAgentsMdFile(file.toFile());
+		return rule;
+	}
+}

--- a/claude-md-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SkillFilesExistRuleTest.java
+++ b/claude-md-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SkillFilesExistRuleTest.java
@@ -1,0 +1,72 @@
+package io.github.adamw7.tools.enforcer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SkillFilesExistRuleTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesWhenEverySkillHasSkillFile() throws IOException {
+		createSkill("git-commit");
+		createSkill("java-code-review");
+
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
+	@Test
+	void failsWhenFileIsNotConfigured() {
+		SkillFilesExistRule rule = new SkillFilesExistRule();
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenDirectoryIsMissing() {
+		SkillFilesExistRule rule = ruleFor(tempDir.resolve("absent"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenNoSkillDirectoriesExist() {
+		SkillFilesExistRule rule = ruleFor(tempDir);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("No skill directories"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenASkillIsMissingItsSkillFile() throws IOException {
+		createSkill("git-commit");
+		Files.createDirectory(tempDir.resolve("broken-skill"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("Missing SKILL.md"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("broken-skill"), exception.getMessage());
+	}
+
+	private void createSkill(String name) throws IOException {
+		Path skillDir = Files.createDirectory(tempDir.resolve(name));
+		Files.writeString(skillDir.resolve("SKILL.md"), "# " + name);
+	}
+
+	private SkillFilesExistRule ruleFor(Path skillsDir) {
+		SkillFilesExistRule rule = new SkillFilesExistRule();
+		rule.setSkillsDir(skillsDir.toFile());
+		return rule;
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,12 @@
 										<claudeMdFormat>
 											<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
 										</claudeMdFormat>
+										<agentsMdFormat>
+											<agentsMdFile>${project.basedir}/AGENTS.md</agentsMdFile>
+										</agentsMdFormat>
+										<skillFilesExist>
+											<skillsDir>${project.basedir}/.claude/skills</skillsDir>
+										</skillFilesExist>
 									</rules>
 								</configuration>
 							</execution>


### PR DESCRIPTION
## Summary

Extends the `claude-md-enforcer` module beyond `CLAUDE.md` to also validate the other agent files in the repo.

- **`AgentsMdFormatRule`** (`agentsMdFormat`) — requires `AGENTS.md` to exist, be non-empty, start with the `# AGENTS.md` title (leading UTF-8 BOM tolerated), and contain every required section heading (`## Project overview`, `## Module layout`, `## Environment & toolchain`, `## Build, test, and run`, `## Code style & conventions`, `## Releasing`, `## Pull requests & commits`).
- **`SkillFilesExistRule`** (`skillFilesExist`) — requires every skill directory under `.claude/skills` to contain a `SKILL.md`.
- Extracted a shared **`MarkdownFormatRule`** base class for the file/BOM/title/section checks. `ClaudeMdFormatRule` now extends it and keeps its `AGENTS.md`-reference check via a `verifyAdditional` hook — existing behavior unchanged.

Both new rules are registered in the Sisu index and wired into the root `pom.xml` enforcer execution (`enforce-claude-md`), alongside the existing `claudeMdFormat`. AGENTS.md's enforcement section documents all three rules.

## Testing

- `mvn -pl claude-md-enforcer -am test` — all unit tests pass (added `AgentsMdFormatRuleTest` and `SkillFilesExistRuleTest` covering happy path, BOM, not-configured, missing, empty, wrong title, and missing section / missing `SKILL.md`).
- End-to-end: ran the actual `enforce-claude-md` execution with `-DenforceClaudeMd` against the real `CLAUDE.md`, `AGENTS.md`, and `.claude/skills` → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)