### PR TITLE
fix(enforcer): harden CLAUDE.md/AGENTS.md/skill validation

### DIFF
--- a/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/AgentsMdFormatRule.java
+++ b/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/AgentsMdFormatRule.java
@@ -40,12 +40,12 @@ public class AgentsMdFormatRule extends MarkdownFormatRule {
 	}
 
 	@Override
-	protected String titleHeading() {
+	protected String defaultTitleHeading() {
 		return TITLE_HEADING;
 	}
 
 	@Override
-	protected List<String> requiredSections() {
+	protected List<String> defaultRequiredSections() {
 		return REQUIRED_SECTIONS;
 	}
 

--- a/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRule.java
+++ b/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRule.java
@@ -5,8 +5,6 @@ import java.util.List;
 
 import javax.inject.Named;
 
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-
 /**
  * Enforcer rule that fails the build when {@code CLAUDE.md} is missing or does
  * not follow the expected structure: it must start with the {@code # CLAUDE.md}
@@ -41,19 +39,19 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 	}
 
 	@Override
-	protected String titleHeading() {
+	protected String defaultTitleHeading() {
 		return TITLE_HEADING;
 	}
 
 	@Override
-	protected List<String> requiredSections() {
+	protected List<String> defaultRequiredSections() {
 		return REQUIRED_SECTIONS;
 	}
 
 	@Override
-	protected void verifyAdditional(String content) throws EnforcerRuleException {
-		if (!content.contains(AGENTS_REFERENCE)) {
-			throw new EnforcerRuleException("CLAUDE.md must reference " + AGENTS_REFERENCE + " as the source of truth");
+	protected void collectAdditionalViolations(String content, List<String> violations) {
+		if (!containsOutsideCodeFences(content, AGENTS_REFERENCE)) {
+			violations.add("CLAUDE.md must reference " + AGENTS_REFERENCE + " as the source of truth");
 		}
 	}
 

--- a/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/MarkdownFormatRule.java
+++ b/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/MarkdownFormatRule.java
@@ -3,7 +3,10 @@ package io.github.adamw7.tools.enforcer;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -12,19 +15,38 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
  * Base for enforcer rules that validate a Markdown document follows an expected
  * structure: it must exist, be non-empty, start with a required title heading
  * (a leading UTF-8 BOM is tolerated), and contain every required section
- * heading. Subclasses contribute the file, its name, the title, the required
- * sections, and any document-specific checks.
+ * heading as a real, non-empty heading.
+ * <p>
+ * Headings are matched on whole lines outside fenced code blocks, so a heading
+ * mentioned inside a {@code ```} fence or in prose does not satisfy a
+ * requirement, and a partial match such as {@code # CLAUDE.md-extended} does
+ * not satisfy {@code # CLAUDE.md}. All structural problems are collected and
+ * reported together rather than one per build.
+ * <p>
+ * The title and required sections default to the subclass-provided values but
+ * can be overridden from the rule configuration, so the rule is reusable across
+ * projects without a recompile. Subclasses contribute the file, its name, the
+ * defaults, and any document-specific checks.
  */
 abstract class MarkdownFormatRule extends AbstractEnforcerRule {
 
-	private static final char BYTE_ORDER_MARK = (char) 0xFEFF;
+	private static final String CODE_FENCE = "```";
+	private static final String HEADING_PREFIX = "#";
+
+	/** Optional override for the title heading. Falls back to the subclass default. */
+	private String titleHeading;
+
+	/** Optional override for the required sections. Falls back to the subclass default. */
+	private List<String> requiredSections;
 
 	@Override
 	public void execute() throws EnforcerRuleException {
 		String content = readContent();
-		verifyTitle(content);
-		verifyRequiredSections(content);
-		verifyAdditional(content);
+		List<String> violations = new ArrayList<>();
+		collectTitleViolation(content, violations);
+		collectSectionViolations(content, violations);
+		collectAdditionalViolations(content, violations);
+		failIfAny(violations);
 	}
 
 	/** The file to validate. Injected from the rule configuration. */
@@ -33,14 +55,43 @@ abstract class MarkdownFormatRule extends AbstractEnforcerRule {
 	/** Human-readable file name used in messages, e.g. {@code CLAUDE.md}. */
 	protected abstract String documentName();
 
-	/** The title heading the document must start with, e.g. {@code # CLAUDE.md}. */
-	protected abstract String titleHeading();
+	/** The default title heading the document must start with, e.g. {@code # CLAUDE.md}. */
+	protected abstract String defaultTitleHeading();
 
-	/** The section headings the document must contain. */
-	protected abstract List<String> requiredSections();
+	/** The default section headings the document must contain. */
+	protected abstract List<String> defaultRequiredSections();
 
 	/** Hook for document-specific checks. The default implementation does nothing. */
-	protected void verifyAdditional(String content) throws EnforcerRuleException {
+	protected void collectAdditionalViolations(String content, List<String> violations) {
+	}
+
+	/** True when {@code token} appears on a line outside a fenced code block. */
+	protected final boolean containsOutsideCodeFences(String content, String token) {
+		boolean insideCodeFence = false;
+		for (String line : lines(content)) {
+			if (line.strip().startsWith(CODE_FENCE)) {
+				insideCodeFence = !insideCodeFence;
+			} else if (!insideCodeFence && line.contains(token)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	final String titleHeading() {
+		return titleHeading != null ? titleHeading : defaultTitleHeading();
+	}
+
+	final List<String> requiredSections() {
+		return requiredSections != null ? requiredSections : defaultRequiredSections();
+	}
+
+	void setTitleHeading(String titleHeading) {
+		this.titleHeading = titleHeading;
+	}
+
+	void setRequiredSections(List<String> requiredSections) {
+		this.requiredSections = requiredSections;
 	}
 
 	private String readContent() throws EnforcerRuleException {
@@ -51,16 +102,9 @@ abstract class MarkdownFormatRule extends AbstractEnforcerRule {
 		if (!file.isFile()) {
 			throw new EnforcerRuleException(documentName() + " does not exist at " + file);
 		}
-		String content = stripByteOrderMark(readAll(file));
+		String content = MarkdownText.stripByteOrderMark(readAll(file));
 		if (content.isBlank()) {
 			throw new EnforcerRuleException(documentName() + " is empty: " + file);
-		}
-		return content;
-	}
-
-	private String stripByteOrderMark(String content) {
-		if (!content.isEmpty() && content.charAt(0) == BYTE_ORDER_MARK) {
-			return content.substring(1);
 		}
 		return content;
 	}
@@ -73,22 +117,87 @@ abstract class MarkdownFormatRule extends AbstractEnforcerRule {
 		}
 	}
 
-	private void verifyTitle(String content) throws EnforcerRuleException {
-		if (!content.stripLeading().startsWith(titleHeading())) {
-			throw new EnforcerRuleException(
-					documentName() + " must start with the '" + titleHeading() + "' title heading");
+	private void collectTitleViolation(String content, List<String> violations) {
+		if (!MarkdownText.firstNonBlankLine(content).equals(titleHeading())) {
+			violations.add(documentName() + " must start with the '" + titleHeading() + "' title heading");
 		}
 	}
 
-	private void verifyRequiredSections(String content) throws EnforcerRuleException {
+	private void collectSectionViolations(String content, List<String> violations) {
+		Set<String> headings = headings(content);
+		List<String> lines = lines(content);
 		for (String section : requiredSections()) {
-			verifySection(content, section);
+			addSectionViolation(lines, headings, section, violations);
 		}
 	}
 
-	private void verifySection(String content, String section) throws EnforcerRuleException {
-		if (!content.contains(section)) {
-			throw new EnforcerRuleException(documentName() + " is missing required section heading: " + section);
+	private void addSectionViolation(List<String> lines, Set<String> headings, String section,
+			List<String> violations) {
+		if (!headings.contains(section)) {
+			violations.add(documentName() + " is missing required section heading: " + section);
+		} else if (!hasBody(lines, headingIndex(lines, section))) {
+			violations.add(documentName() + " has an empty section: " + section);
+		}
+	}
+
+	private Set<String> headings(String content) {
+		Set<String> headings = new LinkedHashSet<>();
+		boolean insideCodeFence = false;
+		for (String line : lines(content)) {
+			insideCodeFence = collectHeading(line, insideCodeFence, headings);
+		}
+		return headings;
+	}
+
+	private boolean collectHeading(String line, boolean insideCodeFence, Set<String> headings) {
+		String trimmed = line.strip();
+		if (trimmed.startsWith(CODE_FENCE)) {
+			return !insideCodeFence;
+		}
+		if (!insideCodeFence && isHeading(trimmed)) {
+			headings.add(trimmed);
+		}
+		return insideCodeFence;
+	}
+
+	private int headingIndex(List<String> lines, String section) {
+		for (int i = 0; i < lines.size(); i++) {
+			if (lines.get(i).strip().equals(section)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private boolean hasBody(List<String> lines, int headingIndex) {
+		for (int i = headingIndex + 1; i < lines.size(); i++) {
+			String line = lines.get(i).strip();
+			if (line.startsWith(CODE_FENCE)) {
+				return true;
+			}
+			if (isHeading(line)) {
+				return false;
+			}
+			if (!line.isEmpty()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean isHeading(String line) {
+		return line.startsWith(HEADING_PREFIX);
+	}
+
+	private List<String> lines(String content) {
+		return content.lines().toList();
+	}
+
+	private void failIfAny(List<String> violations) throws EnforcerRuleException {
+		if (!violations.isEmpty()) {
+			String separator = System.lineSeparator() + "  - ";
+			throw new EnforcerRuleException(
+					documentName() + " is not well formed:" + separator + String.join(separator, violations));
 		}
 	}
 }

--- a/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/MarkdownText.java
+++ b/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/MarkdownText.java
@@ -1,0 +1,31 @@
+package io.github.adamw7.tools.enforcer;
+
+/**
+ * Small helpers for reading Markdown content. Shared by the enforcer rules so
+ * byte-order-mark stripping and first-line detection behave identically
+ * everywhere.
+ */
+final class MarkdownText {
+
+	private static final char BYTE_ORDER_MARK = (char) 0xFEFF;
+
+	private MarkdownText() {
+	}
+
+	/** Removes a single leading UTF-8 byte-order mark, if present. */
+	static String stripByteOrderMark(String content) {
+		if (!content.isEmpty() && content.charAt(0) == BYTE_ORDER_MARK) {
+			return content.substring(1);
+		}
+		return content;
+	}
+
+	/** The first line that is not blank, stripped of surrounding whitespace, or empty if none. */
+	static String firstNonBlankLine(String content) {
+		return content.lines()
+				.map(String::strip)
+				.filter(line -> !line.isEmpty())
+				.findFirst()
+				.orElse("");
+	}
+}

--- a/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/SkillFilesExistRule.java
+++ b/claude-md-enforcer/src/main/java/io/github/adamw7/tools/enforcer/SkillFilesExistRule.java
@@ -1,6 +1,10 @@
 package io.github.adamw7.tools.enforcer;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.inject.Named;
 
@@ -9,14 +13,18 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 /**
  * Enforcer rule that fails the build when any skill under the configured skills
- * directory is missing its {@code SKILL.md}. Every immediate subdirectory of
- * {@code skillsDir} is treated as a skill and must contain a {@code SKILL.md}
- * file.
+ * directory is missing its {@code SKILL.md}, or that file is empty, or it lacks
+ * a YAML front matter block with the {@code name} and {@code description} keys
+ * a skill requires. Every immediate subdirectory of {@code skillsDir} is treated
+ * as a skill. A skills directory with no skills is allowed; all problems found
+ * are reported together.
  */
 @Named("skillFilesExist")
 public class SkillFilesExistRule extends AbstractEnforcerRule {
 
 	private static final String SKILL_FILE_NAME = "SKILL.md";
+	private static final String FRONT_MATTER_DELIMITER = "---";
+	private static final List<String> REQUIRED_KEYS = List.of("name:", "description:");
 
 	/** The {@code .claude/skills} directory to scan. Injected from the rule configuration. */
 	private File skillsDir;
@@ -25,7 +33,11 @@ public class SkillFilesExistRule extends AbstractEnforcerRule {
 	public void execute() throws EnforcerRuleException {
 		verifyConfigured();
 		verifyDirectory();
-		verifySkillFiles(listSkillDirectories());
+		List<String> violations = new ArrayList<>();
+		for (File skillDirectory : listSkillDirectories()) {
+			collectSkillViolations(skillDirectory, violations);
+		}
+		failIfAny(violations);
 	}
 
 	private void verifyConfigured() throws EnforcerRuleException {
@@ -40,24 +52,87 @@ public class SkillFilesExistRule extends AbstractEnforcerRule {
 		}
 	}
 
-	private File[] listSkillDirectories() throws EnforcerRuleException {
+	private File[] listSkillDirectories() {
 		File[] skillDirectories = skillsDir.listFiles(File::isDirectory);
-		if (skillDirectories == null || skillDirectories.length == 0) {
-			throw new EnforcerRuleException("No skill directories found in " + skillsDir);
-		}
-		return skillDirectories;
+		return skillDirectories != null ? skillDirectories : new File[0];
 	}
 
-	private void verifySkillFiles(File[] skillDirectories) throws EnforcerRuleException {
-		for (File skillDirectory : skillDirectories) {
-			verifySkillFile(skillDirectory);
-		}
-	}
-
-	private void verifySkillFile(File skillDirectory) throws EnforcerRuleException {
+	private void collectSkillViolations(File skillDirectory, List<String> violations) {
 		File skillFile = new File(skillDirectory, SKILL_FILE_NAME);
 		if (!skillFile.isFile()) {
-			throw new EnforcerRuleException("Missing " + SKILL_FILE_NAME + " in skill directory: " + skillDirectory);
+			violations.add("Missing " + SKILL_FILE_NAME + " in skill directory: " + skillDirectory);
+		} else {
+			collectContentViolations(skillFile, violations);
+		}
+	}
+
+	private void collectContentViolations(File skillFile, List<String> violations) {
+		String content = readContent(skillFile, violations);
+		if (content == null) {
+			return;
+		}
+		if (content.isBlank()) {
+			violations.add(SKILL_FILE_NAME + " is empty: " + skillFile);
+		} else {
+			collectFrontMatterViolations(skillFile, content, violations);
+		}
+	}
+
+	private String readContent(File skillFile, List<String> violations) {
+		try {
+			return MarkdownText.stripByteOrderMark(Files.readString(skillFile.toPath()));
+		} catch (IOException e) {
+			violations.add("Could not read " + SKILL_FILE_NAME + " at " + skillFile + ": " + e.getMessage());
+			return null;
+		}
+	}
+
+	private void collectFrontMatterViolations(File skillFile, String content, List<String> violations) {
+		List<String> frontMatter = frontMatter(content);
+		if (frontMatter == null) {
+			violations.add(SKILL_FILE_NAME + " must start with a YAML front matter block delimited by '"
+					+ FRONT_MATTER_DELIMITER + "': " + skillFile);
+		} else {
+			collectMissingKeys(skillFile, frontMatter, violations);
+		}
+	}
+
+	private List<String> frontMatter(String content) {
+		List<String> lines = content.lines().toList();
+		if (!MarkdownText.firstNonBlankLine(content).equals(FRONT_MATTER_DELIMITER)) {
+			return null;
+		}
+		int start = indexOfDelimiter(lines, 0);
+		int end = indexOfDelimiter(lines, start + 1);
+		return end < 0 ? null : lines.subList(start + 1, end);
+	}
+
+	private int indexOfDelimiter(List<String> lines, int from) {
+		for (int i = from; i < lines.size(); i++) {
+			if (lines.get(i).strip().equals(FRONT_MATTER_DELIMITER)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private void collectMissingKeys(File skillFile, List<String> frontMatter, List<String> violations) {
+		for (String key : REQUIRED_KEYS) {
+			if (!hasKey(frontMatter, key)) {
+				violations.add(SKILL_FILE_NAME + " front matter is missing '" + key + "' in: " + skillFile);
+			}
+		}
+	}
+
+	private boolean hasKey(List<String> frontMatter, String key) {
+		return frontMatter.stream().anyMatch(line -> line.strip().startsWith(key));
+	}
+
+	private void failIfAny(List<String> violations) throws EnforcerRuleException {
+		if (!violations.isEmpty()) {
+			String separator = System.lineSeparator() + "  - ";
+			throw new EnforcerRuleException("Skill files are not well formed:" + separator
+					+ String.join(separator, violations));
 		}
 	}
 

--- a/claude-md-enforcer/src/test/java/io/github/adamw7/tools/enforcer/AgentsMdFormatRuleTest.java
+++ b/claude-md-enforcer/src/test/java/io/github/adamw7/tools/enforcer/AgentsMdFormatRuleTest.java
@@ -100,6 +100,30 @@ class AgentsMdFormatRuleTest {
 		assertTrue(exception.getMessage().contains("## Releasing"), exception.getMessage());
 	}
 
+	@Test
+	void failsWhenSectionHeadingAppearsOnlyInsideCodeFence() throws IOException {
+		AgentsMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Releasing", "```\n## Releasing\n```"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing required section heading: ## Releasing"),
+				exception.getMessage());
+	}
+
+	@Test
+	void honoursConfiguredTitleAndSections() throws IOException {
+		String content = """
+				# Custom Guide
+
+				## Only Section
+				Some content.
+				""";
+		AgentsMdFormatRule rule = ruleFor(content);
+		rule.setTitleHeading("# Custom Guide");
+		rule.setRequiredSections(java.util.List.of("## Only Section"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
 	private AgentsMdFormatRule ruleFor(String content) throws IOException {
 		Path file = tempDir.resolve("AGENTS.md");
 		Files.writeString(file, content);

--- a/claude-md-enforcer/src/test/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRuleTest.java
+++ b/claude-md-enforcer/src/test/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRuleTest.java
@@ -105,6 +105,40 @@ class ClaudeMdFormatRuleTest {
 		assertTrue(exception.getMessage().contains("## Testing"), exception.getMessage());
 	}
 
+	@Test
+	void failsWhenSectionHeadingAppearsOnlyInsideCodeFence() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "```\n## Testing\n```"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing required section heading: ## Testing"),
+				exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTitleIsOnlyAPartialMatch() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# CLAUDE.md", "# CLAUDE.md-extended"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("title heading"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenARequiredSectionIsEmpty() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("Ask before adding a new one.", ""));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("empty section: ## Dependencies"), exception.getMessage());
+	}
+
+	@Test
+	void reportsEveryProblemTogether() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# CLAUDE.md", "# Wrong").replace("## Maven", "## Build"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("title heading"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("## Maven"), exception.getMessage());
+	}
+
 	private ClaudeMdFormatRule ruleFor(String content) throws IOException {
 		Path file = tempDir.resolve("CLAUDE.md");
 		Files.writeString(file, content);

--- a/claude-md-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SkillFilesExistRuleTest.java
+++ b/claude-md-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SkillFilesExistRuleTest.java
@@ -42,11 +42,8 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void failsWhenNoSkillDirectoriesExist() {
-		SkillFilesExistRule rule = ruleFor(tempDir);
-
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("No skill directories"), exception.getMessage());
+	void passesWhenNoSkillDirectoriesExist() {
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
 	}
 
 	@Test
@@ -59,9 +56,61 @@ class SkillFilesExistRuleTest {
 		assertTrue(exception.getMessage().contains("broken-skill"), exception.getMessage());
 	}
 
+	@Test
+	void failsWhenSkillFileIsEmpty() throws IOException {
+		Path skillDir = Files.createDirectory(tempDir.resolve("empty-skill"));
+		Files.writeString(skillDir.resolve("SKILL.md"), "   \n  ");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("is empty"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("empty-skill"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenSkillFileHasNoFrontMatter() throws IOException {
+		Path skillDir = Files.createDirectory(tempDir.resolve("untitled-skill"));
+		Files.writeString(skillDir.resolve("SKILL.md"), "# Just a heading, no front matter.");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("front matter"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("untitled-skill"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenFrontMatterIsMissingARequiredKey() throws IOException {
+		Path skillDir = Files.createDirectory(tempDir.resolve("nameless-skill"));
+		Files.writeString(skillDir.resolve("SKILL.md"), """
+				---
+				description: Does a thing.
+				---
+				# Body
+				""");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("name:"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("nameless-skill"), exception.getMessage());
+	}
+
+	@Test
+	void reportsEverySkillProblemTogether() throws IOException {
+		Files.createDirectory(tempDir.resolve("no-file"));
+		Path empty = Files.createDirectory(tempDir.resolve("empty-skill"));
+		Files.writeString(empty.resolve("SKILL.md"), "");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("no-file"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("empty-skill"), exception.getMessage());
+	}
+
 	private void createSkill(String name) throws IOException {
 		Path skillDir = Files.createDirectory(tempDir.resolve(name));
-		Files.writeString(skillDir.resolve("SKILL.md"), "# " + name);
+		Files.writeString(skillDir.resolve("SKILL.md"), """
+				---
+				name: %s
+				description: A skill named %s.
+				---
+				# %s
+				""".formatted(name, name, name));
 	}
 
 	private SkillFilesExistRule ruleFor(Path skillsDir) {


### PR DESCRIPTION
## Summary
Hardens the custom Maven enforcer rules so they validate document *structure* and *content* properly instead of relying on loose substring checks.

### `MarkdownFormatRule` (CLAUDE.md / AGENTS.md)
- **Line-anchored, fence-aware heading matching** — replaces `content.contains(section)`. A required heading buried in a ``` code block or in prose no longer counts.
- **Exact title match** — `# CLAUDE.md-extended` no longer satisfies `# CLAUDE.md`.
- **Aggregated reporting** — all structural problems are collected and reported together rather than one per build run. (Missing/empty/unreadable file still fails fast.)
- **Empty-section detection** — a required heading with no body before the next heading is flagged.
- **Configurable (Open/Closed)** — `titleHeading`/`requiredSections` are now optional injectable fields with subclass defaults, so the rule is reusable without recompiling.

### `SkillFilesExistRule`
- Validates `SKILL.md` **content**: non-empty + YAML front matter with `name:` and `description:` keys, not just file existence.
- An empty skills directory is now treated as valid (vacuously) instead of hard-failing.
- Violations aggregated across all skills.

### Shared
- Extracted `MarkdownText` (BOM stripping, first-non-blank-line) to remove duplication.

## Testing
- Unit tests expanded 18 → 30, including regressions that prove the old substring bug is gone (code-fence-only heading, partial title, empty section, multi-problem aggregation) and skill front-matter cases.
- Verified the **real** repo `CLAUDE.md`, `AGENTS.md`, and `.claude/skills` pass the stricter rules via a temporary integration test (since removed).

> Note: full `mvn install` could not run locally because the root module's `shellcheck-maven-plugin` fails on this Windows environment (`Input length = 1`), unrelated to these changes. CI runs the enforcer profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)