### PR TITLE
feat(enforcer): new sub-agent, settings, and cross-doc rules plus richer checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,10 +115,31 @@ profile:
   `## Environment & toolchain`, `## Build, test, and run`,
   `## Code style & conventions`, `## Releasing`, `## Pull requests & commits`).
 - `SkillFilesExistRule` (`skillFilesExist`) checks that every skill directory
-  under `.claude/skills` contains a `SKILL.md` file.
+  under `.claude/skills` contains a non-empty `SKILL.md` whose YAML front matter
+  declares every required key (`name`, `description` by default, overridable via
+  `requiredKeys`). The `name` must be lower-case kebab-case, at most 64
+  characters, and match the skill's directory name; the `description` must be
+  non-empty and within `maxDescriptionLength`. Setting `allowedFrontMatterKeys`
+  also reports unknown keys, catching typos such as `descripton`.
+- `SubAgentFormatRule` (`subAgentFormat`) applies the same front-matter checks to
+  every `*.md` sub-agent definition under a configured `agentsDir`; the `name`
+  must match the file name, and an optional `allowedModels` list rejects an
+  unknown `model`.
+- `SettingsJsonValidRule` (`settingsJsonValid`) checks that `.claude/settings.json`
+  exists and is valid JSON, and can assert `requiredPermissions` and
+  `forbiddenPermissions` against the `permissions.allow` list.
+- `CrossDocConsistencyRule` (`crossDocConsistency`) keeps `CLAUDE.md` and
+  `AGENTS.md` from contradicting each other: each configured `consistentPatterns`
+  regex (one capturing group) must capture the same value in both files, e.g.
+  `Java (\d+)` pins the Java version.
 
 The `claudeMdFormat` and `agentsMdFormat` rules share a `MarkdownFormatRule`
-base class that performs the file-existence, BOM, title, and section checks.
+base class that performs the file-existence, BOM, title, and section checks, and
+offer optional checks switched on from configuration: `forbiddenTokens`,
+`enforceSectionOrder`, `maxLineLength`, and `validateFileReferences` (Markdown
+links to local files must resolve on disk). Every rule supports a `severity` of
+`error` (default, fails the build) or `warn` (logs the same violations), so a new
+rule can be adopted gradually.
 
 The check is **opt-in**: the `claude-md-enforce` profile activates only when the
 `enforceClaudeMd` property is set (`-DenforceClaudeMd`). This keeps every other

--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -58,6 +58,10 @@
 			<artifactId>javax.inject</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 		</dependency>

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/ClaudeCodeEnforcerRule.java
@@ -1,0 +1,57 @@
+package io.github.adamw7.tools.enforcer;
+
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * Base for every Claude Code enforcer rule. It owns the one behaviour they all
+ * share: turning a collected list of violations into either a build failure or a
+ * build warning, depending on the configured {@link #severity}.
+ * <p>
+ * The default severity is {@code error}, which fails the build and preserves the
+ * original behaviour. Setting {@code <severity>warn</severity>} in the rule
+ * configuration downgrades the same violations to a logged warning, so a team can
+ * adopt a rule gradually before it is allowed to break the build. Severity only
+ * governs collected structural violations; a misconfigured rule (missing file or
+ * directory parameter) always fails, because that is a build-setup mistake rather
+ * than a document-quality problem.
+ */
+abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
+
+	private static final String WARN = "warn";
+
+	/** Optional override: {@code error} (default) fails the build, {@code warn} only logs. */
+	private String severity;
+
+	/**
+	 * Reports the violations as a single grouped message. Throws when severity is
+	 * {@code error} and there is at least one violation; logs a warning when
+	 * severity is {@code warn}; does nothing when there are no violations.
+	 */
+	protected final void report(String header, List<String> violations) throws EnforcerRuleException {
+		if (violations.isEmpty()) {
+			return;
+		}
+		String message = format(header, violations);
+		if (isWarn()) {
+			getLog().warn(message);
+		} else {
+			throw new EnforcerRuleException(message);
+		}
+	}
+
+	private String format(String header, List<String> violations) {
+		String separator = System.lineSeparator() + "  - ";
+		return header + separator + String.join(separator, violations);
+	}
+
+	private boolean isWarn() {
+		return WARN.equalsIgnoreCase(severity);
+	}
+
+	void setSeverity(String severity) {
+		this.severity = severity;
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/CrossDocConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/CrossDocConsistencyRule.java
@@ -1,0 +1,124 @@
+package io.github.adamw7.tools.enforcer;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * Enforcer rule that keeps two documents from contradicting each other. Because
+ * {@code CLAUDE.md} defers to {@code AGENTS.md} as the single source of truth,
+ * any fact stated in both must agree. Each configured pattern is a regular
+ * expression with one capturing group; the rule captures that group from each
+ * file and fails when the captured values differ, or when the fact appears in
+ * one file but not the other.
+ * <p>
+ * For example the pattern {@code Java (\d+)} pins the Java version: if
+ * {@code CLAUDE.md} says {@code Java 25} and {@code AGENTS.md} says
+ * {@code Java 24}, the build fails. A pattern that matches in neither file is
+ * ignored, so unrelated documents are unaffected. All mismatches are reported
+ * together.
+ */
+@Named("crossDocConsistency")
+public class CrossDocConsistencyRule extends ClaudeCodeEnforcerRule {
+
+	/** The first document to compare. Injected from the rule configuration. */
+	private File claudeMdFile;
+
+	/** The second document to compare. Injected from the rule configuration. */
+	private File agentsMdFile;
+
+	/** Regular expressions, each with one capturing group, whose captured value must agree. */
+	private List<String> consistentPatterns;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		verifyConfigured();
+		String first = readContent(claudeMdFile);
+		String second = readContent(agentsMdFile);
+		List<String> violations = new ArrayList<>();
+		for (String pattern : patterns()) {
+			collectPatternViolations(pattern, first, second, violations);
+		}
+		report("Documents are inconsistent:", violations);
+	}
+
+	private void verifyConfigured() throws EnforcerRuleException {
+		verifyConfigured(claudeMdFile, "claudeMdFile");
+		verifyConfigured(agentsMdFile, "agentsMdFile");
+	}
+
+	private void verifyConfigured(File file, String parameter) throws EnforcerRuleException {
+		if (file == null) {
+			throw new EnforcerRuleException("The " + parameter + " parameter is not configured");
+		}
+		if (!file.isFile()) {
+			throw new EnforcerRuleException(parameter + " does not exist at " + file);
+		}
+	}
+
+	private void collectPatternViolations(String pattern, String first, String second, List<String> violations) {
+		Pattern compiled = Pattern.compile(pattern);
+		Optional<String> firstValue = capture(compiled, first);
+		Optional<String> secondValue = capture(compiled, second);
+		if (firstValue.isEmpty() && secondValue.isEmpty()) {
+			return;
+		}
+		addMismatchViolation(pattern, firstValue, secondValue, violations);
+	}
+
+	private void addMismatchViolation(String pattern, Optional<String> firstValue, Optional<String> secondValue,
+			List<String> violations) {
+		if (!firstValue.equals(secondValue)) {
+			violations.add("pattern '" + pattern + "' captured " + describe(claudeMdFile, firstValue) + " but "
+					+ describe(agentsMdFile, secondValue));
+		}
+	}
+
+	private String describe(File file, Optional<String> value) {
+		return file.getName() + "=" + value.map(captured -> "'" + captured + "'").orElse("<absent>");
+	}
+
+	private Optional<String> capture(Pattern pattern, String content) {
+		Matcher matcher = pattern.matcher(content);
+		return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
+	}
+
+	private String readContent(File file) {
+		try {
+			return MarkdownText.stripByteOrderMark(Files.readString(file.toPath()));
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read " + file, e);
+		}
+	}
+
+	private List<String> patterns() {
+		return consistentPatterns != null ? consistentPatterns : List.of();
+	}
+
+	void setClaudeMdFile(File claudeMdFile) {
+		this.claudeMdFile = claudeMdFile;
+	}
+
+	void setAgentsMdFile(File agentsMdFile) {
+		this.agentsMdFile = agentsMdFile;
+	}
+
+	void setConsistentPatterns(List<String> consistentPatterns) {
+		this.consistentPatterns = consistentPatterns;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("CrossDocConsistencyRule[claudeMdFile=%s, agentsMdFile=%s]", claudeMdFile, agentsMdFile);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/FrontMatter.java
@@ -1,0 +1,103 @@
+package io.github.adamw7.tools.enforcer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The YAML front matter block at the top of a Markdown document: the lines
+ * between a leading {@code ---} delimiter and the next {@code ---} delimiter.
+ * <p>
+ * This is a deliberately small reader, not a full YAML parser. It understands
+ * the flat {@code key: value} shape that Claude Code skill and sub-agent files
+ * use, which is all the rules need. Parsing is shared here so every rule agrees
+ * on what counts as front matter, which keys it declares, and each key's value.
+ */
+final class FrontMatter {
+
+	private static final String DELIMITER = "---";
+	private static final char KEY_VALUE_SEPARATOR = ':';
+
+	private final List<String> lines;
+
+	private FrontMatter(List<String> lines) {
+		this.lines = lines;
+	}
+
+	/**
+	 * Parses the front matter at the start of {@code content}, or returns empty
+	 * when the content does not begin with a closed {@code ---} delimited block.
+	 * A byte-order mark, if any, must already be stripped by the caller.
+	 */
+	static Optional<FrontMatter> parse(String content) {
+		List<String> allLines = content.lines().toList();
+		if (!MarkdownText.firstNonBlankLine(content).equals(DELIMITER)) {
+			return Optional.empty();
+		}
+		int start = indexOfDelimiter(allLines, 0);
+		int end = indexOfDelimiter(allLines, start + 1);
+		if (end < 0) {
+			return Optional.empty();
+		}
+		return Optional.of(new FrontMatter(allLines.subList(start + 1, end)));
+	}
+
+	/** True when a {@code key:} entry is present, regardless of its value. */
+	boolean hasKey(String key) {
+		return lines.stream().anyMatch(line -> isEntryFor(line, key));
+	}
+
+	/**
+	 * The trimmed value declared for {@code key}, or empty when the key is absent.
+	 * A present key with no value yields an empty string, not an empty optional.
+	 */
+	Optional<String> value(String key) {
+		return lines.stream()
+				.filter(line -> isEntryFor(line, key))
+				.findFirst()
+				.map(line -> valueOf(line, key));
+	}
+
+	/** The declared keys, in document order, without their trailing colon. */
+	List<String> keys() {
+		List<String> keys = new ArrayList<>();
+		for (String line : lines) {
+			addKey(line, keys);
+		}
+		return keys;
+	}
+
+	private void addKey(String line, List<String> keys) {
+		String stripped = line.strip();
+		int separator = stripped.indexOf(KEY_VALUE_SEPARATOR);
+		if (isKeyLine(stripped, separator)) {
+			keys.add(stripped.substring(0, separator).strip());
+		}
+	}
+
+	/** A key line is an unindented {@code key: ...} entry, not a nested value or a comment. */
+	private boolean isKeyLine(String stripped, int separator) {
+		return separator > 0 && !stripped.startsWith("#") && !stripped.startsWith("-");
+	}
+
+	private boolean isEntryFor(String line, String key) {
+		String stripped = line.strip();
+		return stripped.equals(key + KEY_VALUE_SEPARATOR)
+				|| stripped.startsWith(key + KEY_VALUE_SEPARATOR + " ")
+				|| stripped.startsWith(key + KEY_VALUE_SEPARATOR + "\t");
+	}
+
+	private String valueOf(String line, String key) {
+		String stripped = line.strip();
+		return stripped.substring((key + KEY_VALUE_SEPARATOR).length()).strip();
+	}
+
+	private static int indexOfDelimiter(List<String> lines, int from) {
+		for (int i = from; i < lines.size(); i++) {
+			if (lines.get(i).strip().equals(DELIMITER)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/MarkdownFormatRule.java
@@ -8,8 +8,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 /**
@@ -24,16 +25,26 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
  * not satisfy {@code # CLAUDE.md}. All structural problems are collected and
  * reported together rather than one per build.
  * <p>
+ * Beyond the mandatory structure, several optional checks can be switched on
+ * from the rule configuration: a list of {@code forbiddenTokens} that must not
+ * appear outside code fences, {@code enforceSectionOrder} to require the
+ * sections in the configured order, a {@code maxLineLength} cap, and
+ * {@code validateFileReferences} to confirm that Markdown links to local files
+ * resolve to something on disk. Each is disabled by default, so existing
+ * configurations are unaffected.
+ * <p>
  * The title and required sections default to the subclass-provided values but
  * can be overridden from the rule configuration, so the rule is reusable across
  * projects without a recompile. Subclasses contribute the file, its name, the
  * defaults, and any document-specific checks.
  */
-abstract class MarkdownFormatRule extends AbstractEnforcerRule {
+abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 
 	private static final String CODE_FENCE = "```";
 	private static final String HEADING_PREFIX = "#";
 	private static final char HEADING_CHAR = '#';
+	private static final Pattern MARKDOWN_LINK = Pattern.compile("\\[[^\\]]*\\]\\(([^)]+)\\)");
+	private static final Pattern EXTERNAL_REFERENCE = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+.-]*:.*");
 
 	/** Optional override for the title heading. Falls back to the subclass default. */
 	private String titleHeading;
@@ -41,14 +52,33 @@ abstract class MarkdownFormatRule extends AbstractEnforcerRule {
 	/** Optional override for the required sections. Falls back to the subclass default. */
 	private List<String> requiredSections;
 
+	/** Optional tokens that must not appear outside fenced code blocks. */
+	private List<String> forbiddenTokens;
+
+	/** When true, the required sections must appear in the configured order. */
+	private boolean enforceSectionOrder;
+
+	/** Maximum allowed line length outside code fences. Zero (default) disables the check. */
+	private int maxLineLength;
+
+	/** When true, Markdown links to local files must resolve to an existing file. */
+	private boolean validateFileReferences;
+
+	/** Base directory for resolving relative file references. Defaults to the document's directory. */
+	private File referenceBaseDir;
+
 	@Override
 	public void execute() throws EnforcerRuleException {
 		String content = readContent();
 		List<String> violations = new ArrayList<>();
 		collectTitleViolation(content, violations);
 		collectSectionViolations(content, violations);
+		collectOrderViolations(content, violations);
+		collectForbiddenTokenViolations(content, violations);
+		collectLineLengthViolations(content, violations);
+		collectFileReferenceViolations(content, violations);
 		collectAdditionalViolations(content, violations);
-		failIfAny(violations);
+		report(documentName() + " is not well formed:", violations);
 	}
 
 	/** The file to validate. Injected from the rule configuration. */
@@ -96,6 +126,26 @@ abstract class MarkdownFormatRule extends AbstractEnforcerRule {
 		this.requiredSections = requiredSections;
 	}
 
+	void setForbiddenTokens(List<String> forbiddenTokens) {
+		this.forbiddenTokens = forbiddenTokens;
+	}
+
+	void setEnforceSectionOrder(boolean enforceSectionOrder) {
+		this.enforceSectionOrder = enforceSectionOrder;
+	}
+
+	void setMaxLineLength(int maxLineLength) {
+		this.maxLineLength = maxLineLength;
+	}
+
+	void setValidateFileReferences(boolean validateFileReferences) {
+		this.validateFileReferences = validateFileReferences;
+	}
+
+	void setReferenceBaseDir(File referenceBaseDir) {
+		this.referenceBaseDir = referenceBaseDir;
+	}
+
 	private String readContent() throws EnforcerRuleException {
 		File file = documentFile();
 		if (file == null) {
@@ -141,6 +191,124 @@ abstract class MarkdownFormatRule extends AbstractEnforcerRule {
 		} else if (!hasBody(lines, insideFence, headingIndex(lines, insideFence, section))) {
 			violations.add(documentName() + " has an empty section: " + section);
 		}
+	}
+
+	/**
+	 * When ordering is enforced, the required sections that are present must appear
+	 * in the same relative order as configured. Absent sections are already
+	 * reported by the section check, so only the present ones are compared here.
+	 */
+	private void collectOrderViolations(String content, List<String> violations) {
+		if (!enforceSectionOrder) {
+			return;
+		}
+		List<String> lines = lines(content);
+		boolean[] insideFence = fenceMask(lines);
+		Set<String> headings = headings(lines, insideFence);
+		List<String> expected = presentRequiredSections(headings);
+		List<String> actual = requiredHeadingsInOrder(lines, insideFence);
+		if (!actual.equals(expected)) {
+			violations.add(documentName() + " sections are out of order; expected " + expected + " but found " + actual);
+		}
+	}
+
+	private List<String> presentRequiredSections(Set<String> headings) {
+		return requiredSections().stream().filter(headings::contains).toList();
+	}
+
+	private List<String> requiredHeadingsInOrder(List<String> lines, boolean[] insideFence) {
+		Set<String> required = new LinkedHashSet<>(requiredSections());
+		List<String> ordered = new ArrayList<>();
+		for (int i = 0; i < lines.size(); i++) {
+			addIfRequiredHeading(lines.get(i).strip(), insideFence[i], required, ordered);
+		}
+		return ordered;
+	}
+
+	private void addIfRequiredHeading(String line, boolean insideFence, Set<String> required, List<String> ordered) {
+		if (!insideFence && required.contains(line)) {
+			ordered.add(line);
+		}
+	}
+
+	private void collectForbiddenTokenViolations(String content, List<String> violations) {
+		if (forbiddenTokens == null) {
+			return;
+		}
+		for (String token : forbiddenTokens) {
+			if (containsOutsideCodeFences(content, token)) {
+				violations.add(documentName() + " must not contain forbidden token: " + token);
+			}
+		}
+	}
+
+	private void collectLineLengthViolations(String content, List<String> violations) {
+		if (maxLineLength <= 0) {
+			return;
+		}
+		List<String> lines = lines(content);
+		boolean[] insideFence = fenceMask(lines);
+		for (int i = 0; i < lines.size(); i++) {
+			addLineLengthViolation(lines.get(i), insideFence[i], i, violations);
+		}
+	}
+
+	private void addLineLengthViolation(String line, boolean insideFence, int index, List<String> violations) {
+		if (!insideFence && line.length() > maxLineLength) {
+			violations.add(documentName() + " line " + (index + 1) + " exceeds " + maxLineLength
+					+ " characters (" + line.length() + ")");
+		}
+	}
+
+	private void collectFileReferenceViolations(String content, List<String> violations) {
+		if (!validateFileReferences) {
+			return;
+		}
+		File baseDir = referenceBaseDir();
+		List<String> lines = lines(content);
+		boolean[] insideFence = fenceMask(lines);
+		for (int i = 0; i < lines.size(); i++) {
+			collectLineReferences(lines.get(i), insideFence[i], baseDir, violations);
+		}
+	}
+
+	private void collectLineReferences(String line, boolean insideFence, File baseDir, List<String> violations) {
+		if (insideFence) {
+			return;
+		}
+		Matcher matcher = MARKDOWN_LINK.matcher(line);
+		while (matcher.find()) {
+			addReferenceViolation(matcher.group(1).strip(), baseDir, violations);
+		}
+	}
+
+	private void addReferenceViolation(String target, File baseDir, List<String> violations) {
+		String localPath = localReferencePath(target);
+		if (localPath != null && !new File(baseDir, localPath).exists()) {
+			violations.add(documentName() + " references a missing file: " + localPath);
+		}
+	}
+
+	/** The on-disk path a link points to, or null when the link is external or an anchor. */
+	private String localReferencePath(String target) {
+		if (target.isEmpty() || target.startsWith("#") || EXTERNAL_REFERENCE.matcher(target).matches()) {
+			return null;
+		}
+		String withoutAnchor = stripAfter(stripAfter(target, '#'), '?');
+		return withoutAnchor.isEmpty() ? null : withoutAnchor;
+	}
+
+	private String stripAfter(String value, char delimiter) {
+		int index = value.indexOf(delimiter);
+		return index < 0 ? value : value.substring(0, index);
+	}
+
+	private File referenceBaseDir() {
+		if (referenceBaseDir != null) {
+			return referenceBaseDir;
+		}
+		File parent = documentFile().getAbsoluteFile().getParentFile();
+		return parent != null ? parent : new File(".");
 	}
 
 	/**
@@ -216,13 +384,5 @@ abstract class MarkdownFormatRule extends AbstractEnforcerRule {
 
 	private List<String> lines(String content) {
 		return content.lines().toList();
-	}
-
-	private void failIfAny(List<String> violations) throws EnforcerRuleException {
-		if (!violations.isEmpty()) {
-			String separator = System.lineSeparator() + "  - ";
-			throw new EnforcerRuleException(
-					documentName() + " is not well formed:" + separator + String.join(separator, violations));
-		}
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/NameConvention.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/NameConvention.java
@@ -1,0 +1,45 @@
+package io.github.adamw7.tools.enforcer;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * The shared rules for a Claude Code {@code name} front matter value. A name
+ * must be lower-case kebab-case, no longer than the allowed maximum, and equal
+ * to the identifier its file or directory already uses, so the catalogue cannot
+ * drift from what is on disk. Skills and sub-agents both follow this convention,
+ * so the checks live in one place.
+ */
+final class NameConvention {
+
+	/** Lower-case alphanumerics in hyphen-separated words, e.g. {@code git-commit}. */
+	private static final Pattern KEBAB_CASE = Pattern.compile("[a-z0-9]+(-[a-z0-9]+)*");
+
+	/** The Claude Code limit for skill and sub-agent names. */
+	static final int MAX_LENGTH = 64;
+
+	private NameConvention() {
+	}
+
+	/**
+	 * Adds a violation for each way {@code name} breaks convention for the file
+	 * described by {@code where}, expecting it to equal {@code expected} (the
+	 * directory or file identifier). An empty name is reported once and the other
+	 * checks are skipped, since they would only restate the same problem.
+	 */
+	static void collect(String name, String expected, String where, List<String> violations) {
+		if (name.isBlank()) {
+			violations.add("name must not be empty in " + where);
+			return;
+		}
+		if (name.length() > MAX_LENGTH) {
+			violations.add("name '" + name + "' exceeds " + MAX_LENGTH + " characters in " + where);
+		}
+		if (!KEBAB_CASE.matcher(name).matches()) {
+			violations.add("name '" + name + "' must be lower-case kebab-case in " + where);
+		}
+		if (!name.equals(expected)) {
+			violations.add("name '" + name + "' must match '" + expected + "' in " + where);
+		}
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/SettingsJsonValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/SettingsJsonValidRule.java
@@ -1,0 +1,159 @@
+package io.github.adamw7.tools.enforcer;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Enforcer rule that fails the build when {@code .claude/settings.json} is
+ * missing, empty, or not valid JSON. Beyond that baseline it can assert policy
+ * on the {@code permissions.allow} list: {@code requiredPermissions} must all be
+ * present and {@code forbiddenPermissions} must all be absent, so a project can
+ * mandate a permission it relies on or ban an over-broad wildcard such as
+ * {@code Bash(*)}.
+ * <p>
+ * Both policy lists are optional and empty by default, so a project that only
+ * wants the JSON parsed needs no further configuration. All problems found are
+ * reported together.
+ */
+@Named("settingsJsonValid")
+public class SettingsJsonValidRule extends ClaudeCodeEnforcerRule {
+
+	private static final String PERMISSIONS_KEY = "permissions";
+	private static final String ALLOW_KEY = "allow";
+
+	/** The {@code .claude/settings.json} file to validate. Injected from the rule configuration. */
+	private File settingsFile;
+
+	/** Permission entries that must appear in {@code permissions.allow}. */
+	private List<String> requiredPermissions;
+
+	/** Permission entries that must not appear in {@code permissions.allow}. */
+	private List<String> forbiddenPermissions;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		verifyConfigured();
+		verifyFile();
+		String content = readContent();
+		List<String> violations = new ArrayList<>();
+		parseAndCollect(content, violations);
+		report("settings.json is not well formed:", violations);
+	}
+
+	private void verifyConfigured() throws EnforcerRuleException {
+		if (settingsFile == null) {
+			throw new EnforcerRuleException("The settingsFile parameter is not configured");
+		}
+	}
+
+	private void verifyFile() throws EnforcerRuleException {
+		if (!settingsFile.isFile()) {
+			throw new EnforcerRuleException("settings.json does not exist at " + settingsFile);
+		}
+	}
+
+	private String readContent() throws EnforcerRuleException {
+		String content = MarkdownText.stripByteOrderMark(readAll());
+		if (content.isBlank()) {
+			throw new EnforcerRuleException("settings.json is empty: " + settingsFile);
+		}
+		return content;
+	}
+
+	private String readAll() {
+		try {
+			return Files.readString(settingsFile.toPath());
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read settings.json at " + settingsFile, e);
+		}
+	}
+
+	private void parseAndCollect(String content, List<String> violations) {
+		JSONObject settings = parse(content, violations);
+		if (settings != null) {
+			collectPermissionViolations(settings, violations);
+		}
+	}
+
+	private JSONObject parse(String content, List<String> violations) {
+		try {
+			return new JSONObject(content);
+		} catch (JSONException e) {
+			violations.add("settings.json is not valid JSON: " + e.getMessage());
+			return null;
+		}
+	}
+
+	private void collectPermissionViolations(JSONObject settings, List<String> violations) {
+		if (requiredPermissions == null && forbiddenPermissions == null) {
+			return;
+		}
+		List<String> allow = allowList(settings);
+		collectRequiredPermissions(allow, violations);
+		collectForbiddenPermissions(allow, violations);
+	}
+
+	private List<String> allowList(JSONObject settings) {
+		JSONObject permissions = settings.optJSONObject(PERMISSIONS_KEY);
+		JSONArray allow = permissions != null ? permissions.optJSONArray(ALLOW_KEY) : null;
+		return allow != null ? toStringList(allow) : List.of();
+	}
+
+	private List<String> toStringList(JSONArray array) {
+		List<String> entries = new ArrayList<>();
+		for (int i = 0; i < array.length(); i++) {
+			entries.add(array.getString(i));
+		}
+		return entries;
+	}
+
+	private void collectRequiredPermissions(List<String> allow, List<String> violations) {
+		if (requiredPermissions == null) {
+			return;
+		}
+		for (String permission : requiredPermissions) {
+			if (!allow.contains(permission)) {
+				violations.add("settings.json is missing required permission: " + permission);
+			}
+		}
+	}
+
+	private void collectForbiddenPermissions(List<String> allow, List<String> violations) {
+		if (forbiddenPermissions == null) {
+			return;
+		}
+		for (String permission : forbiddenPermissions) {
+			if (allow.contains(permission)) {
+				violations.add("settings.json contains forbidden permission: " + permission);
+			}
+		}
+	}
+
+	void setSettingsFile(File settingsFile) {
+		this.settingsFile = settingsFile;
+	}
+
+	void setRequiredPermissions(List<String> requiredPermissions) {
+		this.requiredPermissions = requiredPermissions;
+	}
+
+	void setForbiddenPermissions(List<String> forbiddenPermissions) {
+		this.forbiddenPermissions = forbiddenPermissions;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("SettingsJsonValidRule[settingsFile=%s]", settingsFile);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/SkillFilesExistRule.java
@@ -6,29 +6,50 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.inject.Named;
 
-import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 /**
  * Enforcer rule that fails the build when any skill under the configured skills
- * directory is missing its {@code SKILL.md}, or that file is empty, or it lacks
- * a YAML front matter block with the {@code name} and {@code description} keys
- * a skill requires. Every immediate subdirectory of {@code skillsDir} is treated
- * as a skill. A skills directory with no skills is allowed; all problems found
- * are reported together.
+ * directory is malformed. Every immediate subdirectory of {@code skillsDir} is
+ * treated as a skill and must contain a non-empty {@code SKILL.md} that opens
+ * with a YAML front matter block declaring every required key.
+ * <p>
+ * The required keys default to {@code name} and {@code description} but can be
+ * overridden with {@code requiredKeys}. The {@code name} value is held to the
+ * Claude Code naming convention: lower-case kebab-case, at most
+ * {@value NameConvention#MAX_LENGTH} characters, and equal to the skill's
+ * directory name. The {@code description} must be non-empty and within
+ * {@code maxDescriptionLength}. When {@code allowedFrontMatterKeys} is
+ * configured, any key outside that set is reported, which catches typos such as
+ * {@code descripton}.
+ * <p>
+ * A skills directory with no skills is allowed; all problems found are reported
+ * together.
  */
 @Named("skillFilesExist")
-public class SkillFilesExistRule extends AbstractEnforcerRule {
+public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 
 	private static final String SKILL_FILE_NAME = "SKILL.md";
-	private static final String FRONT_MATTER_DELIMITER = "---";
-	private static final List<String> REQUIRED_KEYS = List.of("name:", "description:");
+	private static final String NAME_KEY = "name";
+	private static final String DESCRIPTION_KEY = "description";
+	private static final List<String> DEFAULT_REQUIRED_KEYS = List.of(NAME_KEY, DESCRIPTION_KEY);
+	private static final int DEFAULT_MAX_DESCRIPTION_LENGTH = 1024;
 
 	/** The {@code .claude/skills} directory to scan. Injected from the rule configuration. */
 	private File skillsDir;
+
+	/** Optional override for the required front matter keys. */
+	private List<String> requiredKeys;
+
+	/** Optional whitelist of allowed front matter keys. When set, unknown keys are reported. */
+	private List<String> allowedFrontMatterKeys;
+
+	/** Maximum allowed description length. */
+	private int maxDescriptionLength = DEFAULT_MAX_DESCRIPTION_LENGTH;
 
 	@Override
 	public void execute() throws EnforcerRuleException {
@@ -38,7 +59,7 @@ public class SkillFilesExistRule extends AbstractEnforcerRule {
 		for (File skillDirectory : listSkillDirectories()) {
 			collectSkillViolations(skillDirectory, violations);
 		}
-		failIfAny(violations);
+		report("Skill files are not well formed:", violations);
 	}
 
 	private void verifyConfigured() throws EnforcerRuleException {
@@ -63,16 +84,16 @@ public class SkillFilesExistRule extends AbstractEnforcerRule {
 		if (!skillFile.isFile()) {
 			violations.add("Missing " + SKILL_FILE_NAME + " in skill directory: " + skillDirectory);
 		} else {
-			collectContentViolations(skillFile, violations);
+			collectContentViolations(skillDirectory, skillFile, violations);
 		}
 	}
 
-	private void collectContentViolations(File skillFile, List<String> violations) {
+	private void collectContentViolations(File skillDirectory, File skillFile, List<String> violations) {
 		String content = readContent(skillFile);
 		if (content.isBlank()) {
 			violations.add(SKILL_FILE_NAME + " is empty: " + skillFile);
 		} else {
-			collectFrontMatterViolations(skillFile, content, violations);
+			collectFrontMatterViolations(skillDirectory, skillFile, content, violations);
 		}
 	}
 
@@ -84,57 +105,86 @@ public class SkillFilesExistRule extends AbstractEnforcerRule {
 		}
 	}
 
-	private void collectFrontMatterViolations(File skillFile, String content, List<String> violations) {
-		List<String> frontMatter = frontMatter(content);
-		if (frontMatter == null) {
-			violations.add(SKILL_FILE_NAME + " must start with a YAML front matter block delimited by '"
-					+ FRONT_MATTER_DELIMITER + "': " + skillFile);
+	private void collectFrontMatterViolations(File skillDirectory, File skillFile, String content,
+			List<String> violations) {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse(content);
+		if (frontMatter.isEmpty()) {
+			violations.add(SKILL_FILE_NAME + " must start with a YAML front matter block delimited by '---': "
+					+ skillFile);
 		} else {
-			collectMissingKeys(skillFile, frontMatter, violations);
+			collectFrontMatterViolations(skillDirectory, skillFile, frontMatter.get(), violations);
 		}
 	}
 
-	private List<String> frontMatter(String content) {
-		List<String> lines = content.lines().toList();
-		if (!MarkdownText.firstNonBlankLine(content).equals(FRONT_MATTER_DELIMITER)) {
-			return null;
-		}
-		int start = indexOfDelimiter(lines, 0);
-		int end = indexOfDelimiter(lines, start + 1);
-		return end < 0 ? null : lines.subList(start + 1, end);
+	private void collectFrontMatterViolations(File skillDirectory, File skillFile, FrontMatter frontMatter,
+			List<String> violations) {
+		collectMissingKeys(skillFile, frontMatter, violations);
+		collectUnknownKeys(skillFile, frontMatter, violations);
+		collectNameViolations(skillDirectory, skillFile, frontMatter, violations);
+		collectDescriptionViolations(skillFile, frontMatter, violations);
 	}
 
-	private int indexOfDelimiter(List<String> lines, int from) {
-		for (int i = from; i < lines.size(); i++) {
-			if (lines.get(i).strip().equals(FRONT_MATTER_DELIMITER)) {
-				return i;
-			}
-		}
-		return -1;
-	}
-
-	private void collectMissingKeys(File skillFile, List<String> frontMatter, List<String> violations) {
-		for (String key : REQUIRED_KEYS) {
-			if (!hasKey(frontMatter, key)) {
-				violations.add(SKILL_FILE_NAME + " front matter is missing '" + key + "' in: " + skillFile);
+	private void collectMissingKeys(File skillFile, FrontMatter frontMatter, List<String> violations) {
+		for (String key : requiredKeys()) {
+			if (!frontMatter.hasKey(key)) {
+				violations.add(SKILL_FILE_NAME + " front matter is missing '" + key + ":' in: " + skillFile);
 			}
 		}
 	}
 
-	private boolean hasKey(List<String> frontMatter, String key) {
-		return frontMatter.stream().anyMatch(line -> line.strip().startsWith(key));
+	private void collectUnknownKeys(File skillFile, FrontMatter frontMatter, List<String> violations) {
+		if (allowedFrontMatterKeys == null) {
+			return;
+		}
+		for (String key : frontMatter.keys()) {
+			addUnknownKeyViolation(skillFile, key, violations);
+		}
 	}
 
-	private void failIfAny(List<String> violations) throws EnforcerRuleException {
-		if (!violations.isEmpty()) {
-			String separator = System.lineSeparator() + "  - ";
-			throw new EnforcerRuleException("Skill files are not well formed:" + separator
-					+ String.join(separator, violations));
+	private void addUnknownKeyViolation(File skillFile, String key, List<String> violations) {
+		if (!allowedFrontMatterKeys.contains(key)) {
+			violations.add(SKILL_FILE_NAME + " front matter has unknown key '" + key + ":' in: " + skillFile);
 		}
+	}
+
+	private void collectNameViolations(File skillDirectory, File skillFile, FrontMatter frontMatter,
+			List<String> violations) {
+		frontMatter.value(NAME_KEY).ifPresent(
+				name -> NameConvention.collect(name, skillDirectory.getName(), skillFile.toString(), violations));
+	}
+
+	private void collectDescriptionViolations(File skillFile, FrontMatter frontMatter, List<String> violations) {
+		frontMatter.value(DESCRIPTION_KEY).ifPresent(
+				description -> addDescriptionViolations(skillFile, description, violations));
+	}
+
+	private void addDescriptionViolations(File skillFile, String description, List<String> violations) {
+		if (description.isBlank()) {
+			violations.add(SKILL_FILE_NAME + " description must not be empty in: " + skillFile);
+		} else if (description.length() > maxDescriptionLength) {
+			violations.add(SKILL_FILE_NAME + " description exceeds " + maxDescriptionLength
+					+ " characters in: " + skillFile);
+		}
+	}
+
+	private List<String> requiredKeys() {
+		return requiredKeys != null ? requiredKeys : DEFAULT_REQUIRED_KEYS;
 	}
 
 	void setSkillsDir(File skillsDir) {
 		this.skillsDir = skillsDir;
+	}
+
+	void setRequiredKeys(List<String> requiredKeys) {
+		this.requiredKeys = requiredKeys;
+	}
+
+	void setAllowedFrontMatterKeys(List<String> allowedFrontMatterKeys) {
+		this.allowedFrontMatterKeys = allowedFrontMatterKeys;
+	}
+
+	void setMaxDescriptionLength(int maxDescriptionLength) {
+		this.maxDescriptionLength = maxDescriptionLength;
 	}
 
 	@Override

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/SubAgentFormatRule.java
@@ -1,0 +1,162 @@
+package io.github.adamw7.tools.enforcer;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * Enforcer rule that fails the build when any sub-agent definition under the
+ * configured agents directory is malformed. Every {@code *.md} file directly in
+ * {@code agentsDir} is treated as a sub-agent and must be non-empty, open with a
+ * YAML front matter block declaring every required key, and carry a {@code name}
+ * that follows the Claude Code naming convention and matches its file name.
+ * <p>
+ * The required keys default to {@code name} and {@code description}. When
+ * {@code allowedModels} is configured and a definition declares a {@code model},
+ * that model must be one of the allowed values, so a typo such as
+ * {@code claud-opus} cannot slip through. An agents directory with no
+ * definitions is allowed; all problems found are reported together.
+ */
+@Named("subAgentFormat")
+public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
+
+	private static final String MARKDOWN_SUFFIX = ".md";
+	private static final String NAME_KEY = "name";
+	private static final String DESCRIPTION_KEY = "description";
+	private static final String MODEL_KEY = "model";
+	private static final List<String> DEFAULT_REQUIRED_KEYS = List.of(NAME_KEY, DESCRIPTION_KEY);
+
+	/** The {@code .claude/agents} directory to scan. Injected from the rule configuration. */
+	private File agentsDir;
+
+	/** Optional override for the required front matter keys. */
+	private List<String> requiredKeys;
+
+	/** Optional whitelist of model identifiers a sub-agent may declare. */
+	private List<String> allowedModels;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		verifyConfigured();
+		verifyDirectory();
+		List<String> violations = new ArrayList<>();
+		for (File definition : listDefinitions()) {
+			collectDefinitionViolations(definition, violations);
+		}
+		report("Sub-agent files are not well formed:", violations);
+	}
+
+	private void verifyConfigured() throws EnforcerRuleException {
+		if (agentsDir == null) {
+			throw new EnforcerRuleException("The agentsDir parameter is not configured");
+		}
+	}
+
+	private void verifyDirectory() throws EnforcerRuleException {
+		if (!agentsDir.isDirectory()) {
+			throw new EnforcerRuleException("Agents directory does not exist at " + agentsDir);
+		}
+	}
+
+	private File[] listDefinitions() {
+		File[] definitions = agentsDir.listFiles(this::isMarkdownFile);
+		return definitions != null ? definitions : new File[0];
+	}
+
+	private boolean isMarkdownFile(File file) {
+		return file.isFile() && file.getName().endsWith(MARKDOWN_SUFFIX);
+	}
+
+	private void collectDefinitionViolations(File definition, List<String> violations) {
+		String content = readContent(definition);
+		if (content.isBlank()) {
+			violations.add("Sub-agent definition is empty: " + definition);
+		} else {
+			collectFrontMatterViolations(definition, content, violations);
+		}
+	}
+
+	private String readContent(File definition) {
+		try {
+			return MarkdownText.stripByteOrderMark(Files.readString(definition.toPath()));
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read sub-agent definition at " + definition, e);
+		}
+	}
+
+	private void collectFrontMatterViolations(File definition, String content, List<String> violations) {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse(content);
+		if (frontMatter.isEmpty()) {
+			violations.add("Sub-agent definition must start with a YAML front matter block delimited by '---': "
+					+ definition);
+		} else {
+			collectFrontMatterViolations(definition, frontMatter.get(), violations);
+		}
+	}
+
+	private void collectFrontMatterViolations(File definition, FrontMatter frontMatter, List<String> violations) {
+		collectMissingKeys(definition, frontMatter, violations);
+		collectNameViolations(definition, frontMatter, violations);
+		collectModelViolations(definition, frontMatter, violations);
+	}
+
+	private void collectMissingKeys(File definition, FrontMatter frontMatter, List<String> violations) {
+		for (String key : requiredKeys()) {
+			if (!frontMatter.hasKey(key)) {
+				violations.add("Sub-agent front matter is missing '" + key + ":' in: " + definition);
+			}
+		}
+	}
+
+	private void collectNameViolations(File definition, FrontMatter frontMatter, List<String> violations) {
+		frontMatter.value(NAME_KEY).ifPresent(
+				name -> NameConvention.collect(name, baseName(definition), definition.toString(), violations));
+	}
+
+	private void collectModelViolations(File definition, FrontMatter frontMatter, List<String> violations) {
+		if (allowedModels == null) {
+			return;
+		}
+		frontMatter.value(MODEL_KEY).ifPresent(model -> addModelViolation(definition, model, violations));
+	}
+
+	private void addModelViolation(File definition, String model, List<String> violations) {
+		if (!allowedModels.contains(model)) {
+			violations.add("Sub-agent declares unsupported model '" + model + "' in: " + definition);
+		}
+	}
+
+	private String baseName(File definition) {
+		String name = definition.getName();
+		return name.substring(0, name.length() - MARKDOWN_SUFFIX.length());
+	}
+
+	private List<String> requiredKeys() {
+		return requiredKeys != null ? requiredKeys : DEFAULT_REQUIRED_KEYS;
+	}
+
+	void setAgentsDir(File agentsDir) {
+		this.agentsDir = agentsDir;
+	}
+
+	void setRequiredKeys(List<String> requiredKeys) {
+		this.requiredKeys = requiredKeys;
+	}
+
+	void setAllowedModels(List<String> allowedModels) {
+		this.allowedModels = allowedModels;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("SubAgentFormatRule[agentsDir=%s]", agentsDir);
+	}
+}

--- a/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,3 +1,6 @@
 io.github.adamw7.tools.enforcer.ClaudeMdFormatRule
 io.github.adamw7.tools.enforcer.AgentsMdFormatRule
 io.github.adamw7.tools.enforcer.SkillFilesExistRule
+io.github.adamw7.tools.enforcer.SubAgentFormatRule
+io.github.adamw7.tools.enforcer.SettingsJsonValidRule
+io.github.adamw7.tools.enforcer.CrossDocConsistencyRule

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/CapturingLogger.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/CapturingLogger.java
@@ -1,0 +1,84 @@
+package io.github.adamw7.tools.enforcer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+
+/**
+ * A test double for {@link EnforcerLogger} that records the warnings a rule
+ * emits, so warn-severity behaviour can be asserted without a Maven runtime.
+ */
+class CapturingLogger implements EnforcerLogger {
+
+	private final List<String> warnings = new ArrayList<>();
+
+	List<String> warnings() {
+		return warnings;
+	}
+
+	@Override
+	public void warn(CharSequence message) {
+		warnings.add(String.valueOf(message));
+	}
+
+	@Override
+	public void warn(Supplier<CharSequence> message) {
+		warnings.add(String.valueOf(message.get()));
+	}
+
+	@Override
+	public void warnOrError(CharSequence message) {
+		warnings.add(String.valueOf(message));
+	}
+
+	@Override
+	public void warnOrError(Supplier<CharSequence> message) {
+		warnings.add(String.valueOf(message.get()));
+	}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return false;
+	}
+
+	@Override
+	public void debug(CharSequence message) {
+	}
+
+	@Override
+	public void debug(Supplier<CharSequence> message) {
+	}
+
+	@Override
+	public boolean isInfoEnabled() {
+		return false;
+	}
+
+	@Override
+	public void info(CharSequence message) {
+	}
+
+	@Override
+	public void info(Supplier<CharSequence> message) {
+	}
+
+	@Override
+	public boolean isWarnEnabled() {
+		return true;
+	}
+
+	@Override
+	public boolean isErrorEnabled() {
+		return true;
+	}
+
+	@Override
+	public void error(CharSequence message) {
+	}
+
+	@Override
+	public void error(Supplier<CharSequence> message) {
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRuleTest.java
@@ -183,6 +183,110 @@ class ClaudeMdFormatRuleTest {
 		assertTrue(exception.getMessage().contains("## Maven"), exception.getMessage());
 	}
 
+	@Test
+	void failsWhenAForbiddenTokenAppears() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nTODO: finish this.\n");
+		rule.setForbiddenTokens(java.util.List.of("TODO"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("forbidden token: TODO"), exception.getMessage());
+	}
+
+	@Test
+	void ignoresAForbiddenTokenInsideACodeFence() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n```\nTODO inside code\n```\n");
+		rule.setForbiddenTokens(java.util.List.of("TODO"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void passesWhenSectionsAreInConfiguredOrder() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
+		rule.setEnforceSectionOrder(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenRequiredSectionsAppearInTheWrongOrder() throws IOException {
+		String reordered = """
+				# CLAUDE.md
+
+				See [AGENTS.md](AGENTS.md) for the full agent guide.
+
+				## Project
+				Java project built with Maven.
+
+				## Java version
+				Java 25.
+
+				## Maven
+				Versions live in the root pom.
+
+				## Principles for Java Development
+				Use SOLID Principles.
+
+				## Dependencies
+				Ask before adding a new one.
+
+				## Testing
+				Write unit tests for all new logic.
+				""";
+		ClaudeMdFormatRule rule = ruleFor(reordered);
+		rule.setEnforceSectionOrder(true);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("out of order"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenALineExceedsTheMaximumLength() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n" + "x".repeat(200) + "\n");
+		rule.setMaxLineLength(120);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("exceeds 120 characters"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAFileReferenceIsMissing() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
+		rule.setValidateFileReferences(true);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing file: AGENTS.md"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenReferencedFilesExist() throws IOException {
+		Files.writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
+		rule.setValidateFileReferences(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void ignoresExternalLinksWhenValidatingReferences() throws IOException {
+		Files.writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nSee [site](https://example.com) and [top](#project).\n");
+		rule.setValidateFileReferences(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void warnSeverityLogsInsteadOfFailing() throws IOException {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# CLAUDE.md", "# Wrong"));
+		rule.setSeverity("WARN");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("title heading")), logger.warnings().toString());
+	}
+
 	private ClaudeMdFormatRule ruleFor(String content) throws IOException {
 		Path file = tempDir.resolve("CLAUDE.md");
 		Files.writeString(file, content);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/CrossDocConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/CrossDocConsistencyRuleTest.java
@@ -1,0 +1,81 @@
+package io.github.adamw7.tools.enforcer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CrossDocConsistencyRuleTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesWhenCapturedValuesAgree() throws IOException {
+		CrossDocConsistencyRule rule = ruleFor("Java 25 is required.", "We target Java 25.");
+		rule.setConsistentPatterns(List.of("Java (\\d+)"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenCapturedValuesDiffer() throws IOException {
+		CrossDocConsistencyRule rule = ruleFor("Java 25 is required.", "We target Java 24.");
+		rule.setConsistentPatterns(List.of("Java (\\d+)"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("'25'"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("'24'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAFactAppearsInOnlyOneDocument() throws IOException {
+		CrossDocConsistencyRule rule = ruleFor("Java 25 is required.", "No version here.");
+		rule.setConsistentPatterns(List.of("Java (\\d+)"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("<absent>"), exception.getMessage());
+	}
+
+	@Test
+	void ignoresPatternsThatMatchNeitherDocument() throws IOException {
+		CrossDocConsistencyRule rule = ruleFor("Nothing relevant.", "Also nothing.");
+		rule.setConsistentPatterns(List.of("Java (\\d+)"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void passesWhenNoPatternsAreConfigured() throws IOException {
+		assertDoesNotThrow(ruleFor("a", "b")::execute);
+	}
+
+	@Test
+	void failsWhenAFileIsMissing() {
+		CrossDocConsistencyRule rule = new CrossDocConsistencyRule();
+		rule.setClaudeMdFile(tempDir.resolve("absent-claude.md").toFile());
+		rule.setAgentsMdFile(tempDir.resolve("absent-agents.md").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	private CrossDocConsistencyRule ruleFor(String claudeContent, String agentsContent) throws IOException {
+		Path claude = tempDir.resolve("CLAUDE.md");
+		Path agents = tempDir.resolve("AGENTS.md");
+		Files.writeString(claude, claudeContent);
+		Files.writeString(agents, agentsContent);
+		CrossDocConsistencyRule rule = new CrossDocConsistencyRule();
+		rule.setClaudeMdFile(claude.toFile());
+		rule.setAgentsMdFile(agents.toFile());
+		return rule;
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/FrontMatterTest.java
@@ -1,0 +1,91 @@
+package io.github.adamw7.tools.enforcer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+class FrontMatterTest {
+
+	private static final String DOCUMENT = """
+			---
+			name: git-commit
+			description: Generate commit messages.
+			model: claude-opus-4-8
+			---
+			# Body
+			""";
+
+	@Test
+	void parsesADelimitedBlock() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse(DOCUMENT);
+
+		assertTrue(frontMatter.isPresent());
+	}
+
+	@Test
+	void returnsEmptyWhenNoFrontMatter() {
+		assertTrue(FrontMatter.parse("# Just a heading").isEmpty());
+	}
+
+	@Test
+	void returnsEmptyWhenBlockIsNotClosed() {
+		assertTrue(FrontMatter.parse("---\nname: x\n# unterminated").isEmpty());
+	}
+
+	@Test
+	void detectsDeclaredKeys() {
+		FrontMatter frontMatter = FrontMatter.parse(DOCUMENT).orElseThrow();
+
+		assertTrue(frontMatter.hasKey("name"));
+		assertFalse(frontMatter.hasKey("tools"));
+	}
+
+	@Test
+	void doesNotTreatAKeyPrefixAsAMatch() {
+		FrontMatter frontMatter = FrontMatter.parse("---\nnamed: x\n---\n").orElseThrow();
+
+		assertFalse(frontMatter.hasKey("name"));
+	}
+
+	@Test
+	void readsValues() {
+		FrontMatter frontMatter = FrontMatter.parse(DOCUMENT).orElseThrow();
+
+		assertEquals(Optional.of("git-commit"), frontMatter.value("name"));
+		assertEquals(Optional.of("Generate commit messages."), frontMatter.value("description"));
+		assertEquals(Optional.empty(), frontMatter.value("tools"));
+	}
+
+	@Test
+	void treatsAValuelessKeyAsAnEmptyValue() {
+		FrontMatter frontMatter = FrontMatter.parse("---\nname:\n---\n").orElseThrow();
+
+		assertEquals(Optional.of(""), frontMatter.value("name"));
+	}
+
+	@Test
+	void listsKeysInOrder() {
+		FrontMatter frontMatter = FrontMatter.parse(DOCUMENT).orElseThrow();
+
+		assertEquals(List.of("name", "description", "model"), frontMatter.keys());
+	}
+
+	@Test
+	void ignoresCommentsAndListItemsWhenListingKeys() {
+		FrontMatter frontMatter = FrontMatter.parse("""
+				---
+				name: x
+				# a comment
+				tools:
+				  - Read
+				---
+				""").orElseThrow();
+
+		assertEquals(List.of("name", "tools"), frontMatter.keys());
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/NameConventionTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/NameConventionTest.java
@@ -1,0 +1,48 @@
+package io.github.adamw7.tools.enforcer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class NameConventionTest {
+
+	@Test
+	void acceptsAKebabCaseNameThatMatches() {
+		assertEquals(List.of(), collect("git-commit", "git-commit"));
+	}
+
+	@Test
+	void rejectsAnEmptyNameOnce() {
+		List<String> violations = collect("  ", "git-commit");
+
+		assertEquals(1, violations.size());
+		assertTrue(violations.get(0).contains("must not be empty"), violations.toString());
+	}
+
+	@Test
+	void rejectsUpperCaseAndUnderscores() {
+		assertTrue(collect("Git_Commit", "Git_Commit").stream().anyMatch(v -> v.contains("kebab-case")));
+	}
+
+	@Test
+	void rejectsANameLongerThanTheMaximum() {
+		String tooLong = "a".repeat(NameConvention.MAX_LENGTH + 1);
+
+		assertTrue(collect(tooLong, tooLong).stream().anyMatch(v -> v.contains("exceeds")));
+	}
+
+	@Test
+	void rejectsANameThatDoesNotMatchTheIdentifier() {
+		assertTrue(collect("git-commit", "commit").stream().anyMatch(v -> v.contains("must match 'commit'")));
+	}
+
+	private List<String> collect(String name, String expected) {
+		List<String> violations = new ArrayList<>();
+		NameConvention.collect(name, expected, "where", violations);
+		return violations;
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SettingsJsonValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SettingsJsonValidRuleTest.java
@@ -1,0 +1,96 @@
+package io.github.adamw7.tools.enforcer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SettingsJsonValidRuleTest {
+
+	private static final String VALID_SETTINGS = """
+			{
+			  "permissions": {
+			    "allow": [ "Bash(mvn *)", "Edit" ]
+			  }
+			}
+			""";
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesForValidJson() throws IOException {
+		assertDoesNotThrow(ruleFor(VALID_SETTINGS)::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new SettingsJsonValidRule()::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenFileIsMissing() {
+		SettingsJsonValidRule rule = new SettingsJsonValidRule();
+		rule.setSettingsFile(tempDir.resolve("absent.json").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenFileIsEmpty() throws IOException {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("   ")::execute);
+		assertTrue(exception.getMessage().contains("empty"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenJsonIsMalformed() throws IOException {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": ")::execute);
+		assertTrue(exception.getMessage().contains("not valid JSON"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenARequiredPermissionIsMissing() throws IOException {
+		SettingsJsonValidRule rule = ruleFor(VALID_SETTINGS);
+		rule.setRequiredPermissions(List.of("Bash(git *)"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing required permission: Bash(git *)"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAForbiddenPermissionIsPresent() throws IOException {
+		SettingsJsonValidRule rule = ruleFor(VALID_SETTINGS);
+		rule.setForbiddenPermissions(List.of("Edit"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("forbidden permission: Edit"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenPermissionPolicyIsSatisfied() throws IOException {
+		SettingsJsonValidRule rule = ruleFor(VALID_SETTINGS);
+		rule.setRequiredPermissions(List.of("Edit"));
+		rule.setForbiddenPermissions(List.of("Bash(*)"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	private SettingsJsonValidRule ruleFor(String content) throws IOException {
+		Path file = tempDir.resolve("settings.json");
+		Files.writeString(file, content);
+		SettingsJsonValidRule rule = new SettingsJsonValidRule();
+		rule.setSettingsFile(file.toFile());
+		return rule;
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SkillFilesExistRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SkillFilesExistRuleTest.java
@@ -102,6 +102,103 @@ class SkillFilesExistRuleTest {
 		assertTrue(exception.getMessage().contains("empty-skill"), exception.getMessage());
 	}
 
+	@Test
+	void failsWhenNameDoesNotMatchDirectory() throws IOException {
+		Path skillDir = Files.createDirectory(tempDir.resolve("git-commit"));
+		Files.writeString(skillDir.resolve("SKILL.md"), """
+				---
+				name: commit
+				description: Mismatched name.
+				---
+				""");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("must match 'git-commit'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenNameIsNotKebabCase() throws IOException {
+		Path skillDir = Files.createDirectory(tempDir.resolve("Git_Commit"));
+		Files.writeString(skillDir.resolve("SKILL.md"), """
+				---
+				name: Git_Commit
+				description: Bad casing.
+				---
+				""");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("kebab-case"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenDescriptionIsEmpty() throws IOException {
+		Path skillDir = Files.createDirectory(tempDir.resolve("git-commit"));
+		Files.writeString(skillDir.resolve("SKILL.md"), """
+				---
+				name: git-commit
+				description:
+				---
+				""");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("description must not be empty"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenDescriptionExceedsConfiguredMaximum() throws IOException {
+		createSkill("git-commit");
+		SkillFilesExistRule rule = ruleFor(tempDir);
+		rule.setMaxDescriptionLength(5);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("description exceeds 5"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAnUnknownFrontMatterKeyIsPresent() throws IOException {
+		Path skillDir = Files.createDirectory(tempDir.resolve("git-commit"));
+		Files.writeString(skillDir.resolve("SKILL.md"), """
+				---
+				name: git-commit
+				descripton: Typo in the key.
+				description: Real description.
+				---
+				""");
+		SkillFilesExistRule rule = ruleFor(tempDir);
+		rule.setAllowedFrontMatterKeys(java.util.List.of("name", "description"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("unknown key 'descripton:'"), exception.getMessage());
+	}
+
+	@Test
+	void honoursConfiguredRequiredKeys() throws IOException {
+		Path skillDir = Files.createDirectory(tempDir.resolve("git-commit"));
+		Files.writeString(skillDir.resolve("SKILL.md"), """
+				---
+				name: git-commit
+				description: A skill.
+				---
+				""");
+		SkillFilesExistRule rule = ruleFor(tempDir);
+		rule.setRequiredKeys(java.util.List.of("name", "description", "model"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing 'model:'"), exception.getMessage());
+	}
+
+	@Test
+	void warnSeverityLogsInsteadOfFailing() throws IOException {
+		Files.createDirectory(tempDir.resolve("broken-skill"));
+		SkillFilesExistRule rule = ruleFor(tempDir);
+		rule.setSeverity("warn");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("broken-skill")), logger.warnings().toString());
+	}
+
 	private void createSkill(String name) throws IOException {
 		Path skillDir = Files.createDirectory(tempDir.resolve(name));
 		Files.writeString(skillDir.resolve("SKILL.md"), """

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SubAgentFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SubAgentFormatRuleTest.java
@@ -1,0 +1,124 @@
+package io.github.adamw7.tools.enforcer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SubAgentFormatRuleTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesWhenEveryDefinitionIsWellFormed() throws IOException {
+		createAgent("reviewer", "claude-opus-4-8");
+		createAgent("planner", "claude-sonnet-4-6");
+
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
+	@Test
+	void passesWhenNoDefinitionsExist() {
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
+	@Test
+	void ignoresNonMarkdownFiles() throws IOException {
+		Files.writeString(tempDir.resolve("notes.txt"), "not an agent");
+
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new SubAgentFormatRule()::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenDirectoryIsMissing() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor(tempDir.resolve("absent"))::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenDefinitionHasNoFrontMatter() throws IOException {
+		Files.writeString(tempDir.resolve("reviewer.md"), "# Reviewer\nNo front matter.");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("front matter"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("reviewer.md"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenADescriptionIsMissing() throws IOException {
+		Files.writeString(tempDir.resolve("reviewer.md"), """
+				---
+				name: reviewer
+				---
+				# Reviewer
+				""");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("missing 'description:'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenNameDoesNotMatchFileName() throws IOException {
+		Files.writeString(tempDir.resolve("reviewer.md"), """
+				---
+				name: code-reviewer
+				description: Reviews code.
+				---
+				""");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("must match 'reviewer'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenModelIsNotAllowed() throws IOException {
+		createAgent("reviewer", "claud-opus");
+		SubAgentFormatRule rule = ruleFor(tempDir);
+		rule.setAllowedModels(List.of("claude-opus-4-8", "claude-sonnet-4-6"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("unsupported model 'claud-opus'"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenModelIsAllowed() throws IOException {
+		createAgent("reviewer", "claude-opus-4-8");
+		SubAgentFormatRule rule = ruleFor(tempDir);
+		rule.setAllowedModels(List.of("claude-opus-4-8", "claude-sonnet-4-6"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	private void createAgent(String name, String model) throws IOException {
+		Files.writeString(tempDir.resolve(name + ".md"), """
+				---
+				name: %s
+				description: A sub-agent named %s.
+				model: %s
+				---
+				# %s
+				""".formatted(name, name, model, name));
+	}
+
+	private SubAgentFormatRule ruleFor(Path agentsDir) {
+		SubAgentFormatRule rule = new SubAgentFormatRule();
+		rule.setAgentsDir(agentsDir.toFile());
+		return rule;
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,16 @@
 										<skillFilesExist>
 											<skillsDir>${project.basedir}/.claude/skills</skillsDir>
 										</skillFilesExist>
+										<settingsJsonValid>
+											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
+										</settingsJsonValid>
+										<crossDocConsistency>
+											<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
+											<agentsMdFile>${project.basedir}/AGENTS.md</agentsMdFile>
+											<consistentPatterns>
+												<consistentPattern>Java (\d+)</consistentPattern>
+											</consistentPatterns>
+										</crossDocConsistency>
 									</rules>
 								</configuration>
 							</execution>


### PR DESCRIPTION
## Summary

Extends the `claude-code-enforcer` module with three new Maven enforcer rules, richer checks on the existing rules, and a configurable severity model. All checks are opt-in/disabled by default, so existing configurations are unaffected.

### New rules
| Rule | Enforces |
|---|---|
| `subAgentFormat` | `.claude/agents/*.md` front matter (`name`/`description`), `name` matches file name + kebab-case, optional `allowedModels` |
| `settingsJsonValid` | `.claude/settings.json` is valid JSON, with optional `requiredPermissions`/`forbiddenPermissions` over `permissions.allow` |
| `crossDocConsistency` | Configured `consistentPatterns` regexes capture the same value in `CLAUDE.md` and `AGENTS.md` (e.g. `Java (\d+)`) |

### Enhancements
- **`skillFilesExist`**: `name` validated (non-empty, kebab-case, ≤64 chars, matches directory); `description` non-empty + `maxDescriptionLength`; configurable `requiredKeys`; `allowedFrontMatterKeys` flags unknown/typo'd keys.
- **`MarkdownFormatRule`** (`claudeMdFormat` + `agentsMdFormat`): `forbiddenTokens`, `enforceSectionOrder`, `maxLineLength`, `validateFileReferences`.
- **All rules**: `severity` of `error` (default, fails build) or `warn` (logs only) for gradual adoption.

### Refactoring (SOLID/clean)
- `ClaudeCodeEnforcerRule` — shared base owning the severity → throw/log decision.
- `FrontMatter` — reusable YAML front-matter reader shared by skill + sub-agent rules.
- `NameConvention` — single kebab-case/length/identity check used by both name-bearing rules.

### Wiring & deps
- Registered all six rules in the sisu `Named` file.
- Added `org.json:json` to the module pom — version already managed in the root pom, **no new dependency** introduced.
- Wired `settingsJsonValid` and `crossDocConsistency` into the root `claude-md-enforce` profile and documented all rules in `AGENTS.md`.

## Testing
- `mvn -pl claude-code-enforcer test` → **86 tests pass**.
- `mvn -pl . validate -DenforceClaudeMd` → all 5 wired rules pass against this repo.

Note: `subAgentFormat` is intentionally **not** wired into the build (no `.claude/agents` directory yet); it's ready once agents are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)