### PR TITLE
fix(enforcer): handle link titles and patterns without capturing groups

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/CrossDocConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/CrossDocConsistencyRule.java
@@ -43,6 +43,7 @@ public class CrossDocConsistencyRule extends ClaudeCodeEnforcerRule {
 	@Override
 	public void execute() throws EnforcerRuleException {
 		verifyConfigured();
+		verifyPatterns();
 		String first = readContent(claudeMdFile);
 		String second = readContent(agentsMdFile);
 		List<String> violations = new ArrayList<>();
@@ -63,6 +64,21 @@ public class CrossDocConsistencyRule extends ClaudeCodeEnforcerRule {
 		}
 		if (!file.isFile()) {
 			throw new EnforcerRuleException(parameter + " does not exist at " + file);
+		}
+	}
+
+	/**
+	 * Each configured pattern must declare a capturing group, since the rule
+	 * compares {@code group(1)} from each document. A pattern without one is a
+	 * build-setup mistake, so it fails with a clear message instead of letting an
+	 * opaque {@link IndexOutOfBoundsException} escape at match time.
+	 */
+	private void verifyPatterns() throws EnforcerRuleException {
+		for (String pattern : patterns()) {
+			if (Pattern.compile(pattern).matcher("").groupCount() < 1) {
+				throw new EnforcerRuleException(
+						"consistentPattern '" + pattern + "' must declare a capturing group");
+			}
 		}
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/MarkdownFormatRule.java
@@ -278,8 +278,21 @@ abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 		}
 		Matcher matcher = MARKDOWN_LINK.matcher(line);
 		while (matcher.find()) {
-			addReferenceViolation(matcher.group(1).strip(), baseDir, violations);
+			addReferenceViolation(linkDestination(matcher.group(1)), baseDir, violations);
 		}
+	}
+
+	/**
+	 * The destination part of a Markdown link target, dropping the optional title
+	 * and any {@code <...>} wrapping, so {@code [t](file.md "Title")} resolves to
+	 * {@code file.md} rather than the whole {@code file.md "Title"} string.
+	 */
+	private String linkDestination(String rawTarget) {
+		String target = rawTarget.strip();
+		if (target.startsWith("<") && target.contains(">")) {
+			return target.substring(1, target.indexOf('>')).strip();
+		}
+		return target.split("\\s", 2)[0].strip();
 	}
 
 	private void addReferenceViolation(String target, File baseDir, List<String> violations) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRuleTest.java
@@ -268,6 +268,15 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
+	void ignoresLinkTitlesWhenValidatingReferences() throws IOException {
+		Files.writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nSee [guide](AGENTS.md \"The agent guide\").\n");
+		rule.setValidateFileReferences(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
 	void ignoresExternalLinksWhenValidatingReferences() throws IOException {
 		Files.writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nSee [site](https://example.com) and [top](#project).\n");

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/CrossDocConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/CrossDocConsistencyRuleTest.java
@@ -59,6 +59,15 @@ class CrossDocConsistencyRuleTest {
 	}
 
 	@Test
+	void failsWithAClearMessageWhenAPatternHasNoCapturingGroup() throws IOException {
+		CrossDocConsistencyRule rule = ruleFor("Java 25.", "Java 25.");
+		rule.setConsistentPatterns(List.of("Java \\d+"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("must declare a capturing group"), exception.getMessage());
+	}
+
+	@Test
 	void failsWhenAFileIsMissing() {
 		CrossDocConsistencyRule rule = new CrossDocConsistencyRule();
 		rule.setClaudeMdFile(tempDir.resolve("absent-claude.md").toFile());


### PR DESCRIPTION
## Summary

Fixes two bugs in the `claude-code-enforcer` rules, each with a regression test.

### Bug 1 — Link titles cause false "missing file" violations
`MarkdownFormatRule` (`validateFileReferences`)

The link regex captured everything inside a Markdown link's parentheses, so a valid titled link such as `[guide](AGENTS.md "The guide")` produced the destination `AGENTS.md "The guide"` and was reported as a missing file even though `AGENTS.md` exists. Added `linkDestination(...)` to strip the optional title and `<...>` wrapping down to the real destination.

### Bug 2 — Pattern without a capturing group crashes opaquely
`CrossDocConsistencyRule`

The rule compares `group(1)` of each configured pattern. A pattern written without a capturing group (e.g. `Java \d+`) that matched threw a raw `IndexOutOfBoundsException: No group 1` instead of the clean, documented "misconfiguration always fails" error. Added `verifyPatterns()` to validate up front and fail with `consistentPattern '...' must declare a capturing group`.

## Testing
- `mvn test -pl claude-code-enforcer -am` — 88 tests pass (was 86; +2 new).
- New tests `ignoresLinkTitlesWhenValidatingReferences` and `failsWithAClearMessageWhenAPatternHasNoCapturingGroup` both fail without the corresponding fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)