### PR TITLE
refactor(enforcer): wrap test file I/O in UncheckedIOException

### DIFF
--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/AgentsMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/AgentsMdFormatRuleTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -46,14 +47,14 @@ class AgentsMdFormatRuleTest {
 	private Path tempDir;
 
 	@Test
-	void passesForWellFormedFile() throws IOException {
+	void passesForWellFormedFile() {
 		AgentsMdFormatRule rule = ruleFor(VALID_CONTENT);
 
 		assertDoesNotThrow(rule::execute);
 	}
 
 	@Test
-	void passesWhenFileStartsWithByteOrderMark() throws IOException {
+	void passesWhenFileStartsWithByteOrderMark() {
 		AgentsMdFormatRule rule = ruleFor((char) 0xFEFF + VALID_CONTENT);
 
 		assertDoesNotThrow(rule::execute);
@@ -77,7 +78,7 @@ class AgentsMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenFileIsEmpty() throws IOException {
+	void failsWhenFileIsEmpty() {
 		AgentsMdFormatRule rule = ruleFor("   \n  ");
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
@@ -85,7 +86,7 @@ class AgentsMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenTitleHeadingIsWrong() throws IOException {
+	void failsWhenTitleHeadingIsWrong() {
 		AgentsMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# AGENTS.md", "# Something Else"));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
@@ -93,7 +94,7 @@ class AgentsMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenARequiredSectionIsMissing() throws IOException {
+	void failsWhenARequiredSectionIsMissing() {
 		AgentsMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Releasing", "## Shipping"));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
@@ -101,7 +102,7 @@ class AgentsMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenSectionHeadingAppearsOnlyInsideCodeFence() throws IOException {
+	void failsWhenSectionHeadingAppearsOnlyInsideCodeFence() {
 		AgentsMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Releasing", "```\n## Releasing\n```"));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
@@ -110,7 +111,7 @@ class AgentsMdFormatRuleTest {
 	}
 
 	@Test
-	void honoursConfiguredTitleAndSections() throws IOException {
+	void honoursConfiguredTitleAndSections() {
 		String content = """
 				# Custom Guide
 
@@ -124,11 +125,19 @@ class AgentsMdFormatRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
-	private AgentsMdFormatRule ruleFor(String content) throws IOException {
+	private AgentsMdFormatRule ruleFor(String content) {
 		Path file = tempDir.resolve("AGENTS.md");
-		Files.writeString(file, content);
+		writeString(file, content);
 		AgentsMdFormatRule rule = new AgentsMdFormatRule();
 		rule.setAgentsMdFile(file.toFile());
 		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/ClaudeMdFormatRuleTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -43,14 +44,14 @@ class ClaudeMdFormatRuleTest {
 	private Path tempDir;
 
 	@Test
-	void passesForWellFormedFile() throws IOException {
+	void passesForWellFormedFile() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
 
 		assertDoesNotThrow(rule::execute);
 	}
 
 	@Test
-	void passesWhenFileStartsWithByteOrderMark() throws IOException {
+	void passesWhenFileStartsWithByteOrderMark() {
 		ClaudeMdFormatRule rule = ruleFor((char) 0xFEFF + VALID_CONTENT);
 
 		assertDoesNotThrow(rule::execute);
@@ -74,7 +75,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenFileIsEmpty() throws IOException {
+	void failsWhenFileIsEmpty() {
 		ClaudeMdFormatRule rule = ruleFor("   \n  ");
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
@@ -82,7 +83,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenTitleHeadingIsWrong() throws IOException {
+	void failsWhenTitleHeadingIsWrong() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# CLAUDE.md", "# Something Else"));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
@@ -90,7 +91,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenAgentsReferenceIsMissing() throws IOException {
+	void failsWhenAgentsReferenceIsMissing() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("AGENTS.md", "OTHER.md"));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
@@ -98,7 +99,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenARequiredSectionIsMissing() throws IOException {
+	void failsWhenARequiredSectionIsMissing() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "## Quality"));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
@@ -106,7 +107,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenSectionHeadingAppearsOnlyInsideCodeFence() throws IOException {
+	void failsWhenSectionHeadingAppearsOnlyInsideCodeFence() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "```\n## Testing\n```"));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
@@ -115,7 +116,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenTitleIsOnlyAPartialMatch() throws IOException {
+	void failsWhenTitleIsOnlyAPartialMatch() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# CLAUDE.md", "# CLAUDE.md-extended"));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
@@ -123,7 +124,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenARequiredSectionIsEmpty() throws IOException {
+	void failsWhenARequiredSectionIsEmpty() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("Ask before adding a new one.", ""));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
@@ -131,7 +132,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void passesWhenASectionContainsOnlySubsections() throws IOException {
+	void passesWhenASectionContainsOnlySubsections() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace(
 				"## Maven\nVersions live in the root pom.",
 				"## Maven\n### Versions\nVersions live in the root pom."));
@@ -140,7 +141,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenRealSectionIsEmptyDespiteFencedDuplicate() throws IOException {
+	void failsWhenRealSectionIsEmptyDespiteFencedDuplicate() {
 		String content = """
 				# CLAUDE.md
 
@@ -175,7 +176,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void reportsEveryProblemTogether() throws IOException {
+	void reportsEveryProblemTogether() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# CLAUDE.md", "# Wrong").replace("## Maven", "## Build"));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
@@ -184,7 +185,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenAForbiddenTokenAppears() throws IOException {
+	void failsWhenAForbiddenTokenAppears() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nTODO: finish this.\n");
 		rule.setForbiddenTokens(java.util.List.of("TODO"));
 
@@ -193,7 +194,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void ignoresAForbiddenTokenInsideACodeFence() throws IOException {
+	void ignoresAForbiddenTokenInsideACodeFence() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n```\nTODO inside code\n```\n");
 		rule.setForbiddenTokens(java.util.List.of("TODO"));
 
@@ -201,7 +202,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void passesWhenSectionsAreInConfiguredOrder() throws IOException {
+	void passesWhenSectionsAreInConfiguredOrder() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
 		rule.setEnforceSectionOrder(true);
 
@@ -209,7 +210,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenRequiredSectionsAppearInTheWrongOrder() throws IOException {
+	void failsWhenRequiredSectionsAppearInTheWrongOrder() {
 		String reordered = """
 				# CLAUDE.md
 
@@ -241,7 +242,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenALineExceedsTheMaximumLength() throws IOException {
+	void failsWhenALineExceedsTheMaximumLength() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n" + "x".repeat(200) + "\n");
 		rule.setMaxLineLength(120);
 
@@ -250,7 +251,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenAFileReferenceIsMissing() throws IOException {
+	void failsWhenAFileReferenceIsMissing() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
 		rule.setValidateFileReferences(true);
 
@@ -259,8 +260,8 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void passesWhenReferencedFilesExist() throws IOException {
-		Files.writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+	void passesWhenReferencedFilesExist() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
 		rule.setValidateFileReferences(true);
 
@@ -268,8 +269,8 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void ignoresLinkTitlesWhenValidatingReferences() throws IOException {
-		Files.writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+	void ignoresLinkTitlesWhenValidatingReferences() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nSee [guide](AGENTS.md \"The agent guide\").\n");
 		rule.setValidateFileReferences(true);
 
@@ -277,8 +278,8 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void ignoresExternalLinksWhenValidatingReferences() throws IOException {
-		Files.writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+	void ignoresExternalLinksWhenValidatingReferences() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nSee [site](https://example.com) and [top](#project).\n");
 		rule.setValidateFileReferences(true);
 
@@ -286,7 +287,7 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
-	void warnSeverityLogsInsteadOfFailing() throws IOException {
+	void warnSeverityLogsInsteadOfFailing() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# CLAUDE.md", "# Wrong"));
 		rule.setSeverity("WARN");
 		CapturingLogger logger = new CapturingLogger();
@@ -296,11 +297,19 @@ class ClaudeMdFormatRuleTest {
 		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("title heading")), logger.warnings().toString());
 	}
 
-	private ClaudeMdFormatRule ruleFor(String content) throws IOException {
+	private ClaudeMdFormatRule ruleFor(String content) {
 		Path file = tempDir.resolve("CLAUDE.md");
-		Files.writeString(file, content);
+		writeString(file, content);
 		ClaudeMdFormatRule rule = new ClaudeMdFormatRule();
 		rule.setClaudeMdFile(file.toFile());
 		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/CrossDocConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/CrossDocConsistencyRuleTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -19,7 +20,7 @@ class CrossDocConsistencyRuleTest {
 	private Path tempDir;
 
 	@Test
-	void passesWhenCapturedValuesAgree() throws IOException {
+	void passesWhenCapturedValuesAgree() {
 		CrossDocConsistencyRule rule = ruleFor("Java 25 is required.", "We target Java 25.");
 		rule.setConsistentPatterns(List.of("Java (\\d+)"));
 
@@ -27,7 +28,7 @@ class CrossDocConsistencyRuleTest {
 	}
 
 	@Test
-	void failsWhenCapturedValuesDiffer() throws IOException {
+	void failsWhenCapturedValuesDiffer() {
 		CrossDocConsistencyRule rule = ruleFor("Java 25 is required.", "We target Java 24.");
 		rule.setConsistentPatterns(List.of("Java (\\d+)"));
 
@@ -37,7 +38,7 @@ class CrossDocConsistencyRuleTest {
 	}
 
 	@Test
-	void failsWhenAFactAppearsInOnlyOneDocument() throws IOException {
+	void failsWhenAFactAppearsInOnlyOneDocument() {
 		CrossDocConsistencyRule rule = ruleFor("Java 25 is required.", "No version here.");
 		rule.setConsistentPatterns(List.of("Java (\\d+)"));
 
@@ -46,7 +47,7 @@ class CrossDocConsistencyRuleTest {
 	}
 
 	@Test
-	void ignoresPatternsThatMatchNeitherDocument() throws IOException {
+	void ignoresPatternsThatMatchNeitherDocument() {
 		CrossDocConsistencyRule rule = ruleFor("Nothing relevant.", "Also nothing.");
 		rule.setConsistentPatterns(List.of("Java (\\d+)"));
 
@@ -54,12 +55,12 @@ class CrossDocConsistencyRuleTest {
 	}
 
 	@Test
-	void passesWhenNoPatternsAreConfigured() throws IOException {
+	void passesWhenNoPatternsAreConfigured() {
 		assertDoesNotThrow(ruleFor("a", "b")::execute);
 	}
 
 	@Test
-	void failsWithAClearMessageWhenAPatternHasNoCapturingGroup() throws IOException {
+	void failsWithAClearMessageWhenAPatternHasNoCapturingGroup() {
 		CrossDocConsistencyRule rule = ruleFor("Java 25.", "Java 25.");
 		rule.setConsistentPatterns(List.of("Java \\d+"));
 
@@ -77,14 +78,22 @@ class CrossDocConsistencyRuleTest {
 		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
 	}
 
-	private CrossDocConsistencyRule ruleFor(String claudeContent, String agentsContent) throws IOException {
+	private CrossDocConsistencyRule ruleFor(String claudeContent, String agentsContent) {
 		Path claude = tempDir.resolve("CLAUDE.md");
 		Path agents = tempDir.resolve("AGENTS.md");
-		Files.writeString(claude, claudeContent);
-		Files.writeString(agents, agentsContent);
+		writeString(claude, claudeContent);
+		writeString(agents, agentsContent);
 		CrossDocConsistencyRule rule = new CrossDocConsistencyRule();
 		rule.setClaudeMdFile(claude.toFile());
 		rule.setAgentsMdFile(agents.toFile());
 		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SettingsJsonValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SettingsJsonValidRuleTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -27,7 +28,7 @@ class SettingsJsonValidRuleTest {
 	private Path tempDir;
 
 	@Test
-	void passesForValidJson() throws IOException {
+	void passesForValidJson() {
 		assertDoesNotThrow(ruleFor(VALID_SETTINGS)::execute);
 	}
 
@@ -47,20 +48,20 @@ class SettingsJsonValidRuleTest {
 	}
 
 	@Test
-	void failsWhenFileIsEmpty() throws IOException {
+	void failsWhenFileIsEmpty() {
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("   ")::execute);
 		assertTrue(exception.getMessage().contains("empty"), exception.getMessage());
 	}
 
 	@Test
-	void failsWhenJsonIsMalformed() throws IOException {
+	void failsWhenJsonIsMalformed() {
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
 				ruleFor("{ \"permissions\": ")::execute);
 		assertTrue(exception.getMessage().contains("not valid JSON"), exception.getMessage());
 	}
 
 	@Test
-	void failsWhenARequiredPermissionIsMissing() throws IOException {
+	void failsWhenARequiredPermissionIsMissing() {
 		SettingsJsonValidRule rule = ruleFor(VALID_SETTINGS);
 		rule.setRequiredPermissions(List.of("Bash(git *)"));
 
@@ -69,7 +70,7 @@ class SettingsJsonValidRuleTest {
 	}
 
 	@Test
-	void failsWhenAForbiddenPermissionIsPresent() throws IOException {
+	void failsWhenAForbiddenPermissionIsPresent() {
 		SettingsJsonValidRule rule = ruleFor(VALID_SETTINGS);
 		rule.setForbiddenPermissions(List.of("Edit"));
 
@@ -78,7 +79,7 @@ class SettingsJsonValidRuleTest {
 	}
 
 	@Test
-	void passesWhenPermissionPolicyIsSatisfied() throws IOException {
+	void passesWhenPermissionPolicyIsSatisfied() {
 		SettingsJsonValidRule rule = ruleFor(VALID_SETTINGS);
 		rule.setRequiredPermissions(List.of("Edit"));
 		rule.setForbiddenPermissions(List.of("Bash(*)"));
@@ -86,11 +87,19 @@ class SettingsJsonValidRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
-	private SettingsJsonValidRule ruleFor(String content) throws IOException {
+	private SettingsJsonValidRule ruleFor(String content) {
 		Path file = tempDir.resolve("settings.json");
-		Files.writeString(file, content);
+		writeString(file, content);
 		SettingsJsonValidRule rule = new SettingsJsonValidRule();
 		rule.setSettingsFile(file.toFile());
 		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SkillFilesExistRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SkillFilesExistRuleTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -18,7 +19,7 @@ class SkillFilesExistRuleTest {
 	private Path tempDir;
 
 	@Test
-	void passesWhenEverySkillHasSkillFile() throws IOException {
+	void passesWhenEverySkillHasSkillFile() {
 		createSkill("git-commit");
 		createSkill("java-code-review");
 
@@ -47,9 +48,9 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void failsWhenASkillIsMissingItsSkillFile() throws IOException {
+	void failsWhenASkillIsMissingItsSkillFile() {
 		createSkill("git-commit");
-		Files.createDirectory(tempDir.resolve("broken-skill"));
+		createDirectory(tempDir.resolve("broken-skill"));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
 		assertTrue(exception.getMessage().contains("Missing SKILL.md"), exception.getMessage());
@@ -57,9 +58,9 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void failsWhenSkillFileIsEmpty() throws IOException {
-		Path skillDir = Files.createDirectory(tempDir.resolve("empty-skill"));
-		Files.writeString(skillDir.resolve("SKILL.md"), "   \n  ");
+	void failsWhenSkillFileIsEmpty() {
+		Path skillDir = createDirectory(tempDir.resolve("empty-skill"));
+		writeString(skillDir.resolve("SKILL.md"), "   \n  ");
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
 		assertTrue(exception.getMessage().contains("is empty"), exception.getMessage());
@@ -67,9 +68,9 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void failsWhenSkillFileHasNoFrontMatter() throws IOException {
-		Path skillDir = Files.createDirectory(tempDir.resolve("untitled-skill"));
-		Files.writeString(skillDir.resolve("SKILL.md"), "# Just a heading, no front matter.");
+	void failsWhenSkillFileHasNoFrontMatter() {
+		Path skillDir = createDirectory(tempDir.resolve("untitled-skill"));
+		writeString(skillDir.resolve("SKILL.md"), "# Just a heading, no front matter.");
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
 		assertTrue(exception.getMessage().contains("front matter"), exception.getMessage());
@@ -77,9 +78,9 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void failsWhenFrontMatterIsMissingARequiredKey() throws IOException {
-		Path skillDir = Files.createDirectory(tempDir.resolve("nameless-skill"));
-		Files.writeString(skillDir.resolve("SKILL.md"), """
+	void failsWhenFrontMatterIsMissingARequiredKey() {
+		Path skillDir = createDirectory(tempDir.resolve("nameless-skill"));
+		writeString(skillDir.resolve("SKILL.md"), """
 				---
 				description: Does a thing.
 				---
@@ -92,10 +93,10 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void reportsEverySkillProblemTogether() throws IOException {
-		Files.createDirectory(tempDir.resolve("no-file"));
-		Path empty = Files.createDirectory(tempDir.resolve("empty-skill"));
-		Files.writeString(empty.resolve("SKILL.md"), "");
+	void reportsEverySkillProblemTogether() {
+		createDirectory(tempDir.resolve("no-file"));
+		Path empty = createDirectory(tempDir.resolve("empty-skill"));
+		writeString(empty.resolve("SKILL.md"), "");
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
 		assertTrue(exception.getMessage().contains("no-file"), exception.getMessage());
@@ -103,9 +104,9 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void failsWhenNameDoesNotMatchDirectory() throws IOException {
-		Path skillDir = Files.createDirectory(tempDir.resolve("git-commit"));
-		Files.writeString(skillDir.resolve("SKILL.md"), """
+	void failsWhenNameDoesNotMatchDirectory() {
+		Path skillDir = createDirectory(tempDir.resolve("git-commit"));
+		writeString(skillDir.resolve("SKILL.md"), """
 				---
 				name: commit
 				description: Mismatched name.
@@ -117,9 +118,9 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void failsWhenNameIsNotKebabCase() throws IOException {
-		Path skillDir = Files.createDirectory(tempDir.resolve("Git_Commit"));
-		Files.writeString(skillDir.resolve("SKILL.md"), """
+	void failsWhenNameIsNotKebabCase() {
+		Path skillDir = createDirectory(tempDir.resolve("Git_Commit"));
+		writeString(skillDir.resolve("SKILL.md"), """
 				---
 				name: Git_Commit
 				description: Bad casing.
@@ -131,9 +132,9 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void failsWhenDescriptionIsEmpty() throws IOException {
-		Path skillDir = Files.createDirectory(tempDir.resolve("git-commit"));
-		Files.writeString(skillDir.resolve("SKILL.md"), """
+	void failsWhenDescriptionIsEmpty() {
+		Path skillDir = createDirectory(tempDir.resolve("git-commit"));
+		writeString(skillDir.resolve("SKILL.md"), """
 				---
 				name: git-commit
 				description:
@@ -145,7 +146,7 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void failsWhenDescriptionExceedsConfiguredMaximum() throws IOException {
+	void failsWhenDescriptionExceedsConfiguredMaximum() {
 		createSkill("git-commit");
 		SkillFilesExistRule rule = ruleFor(tempDir);
 		rule.setMaxDescriptionLength(5);
@@ -155,9 +156,9 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void failsWhenAnUnknownFrontMatterKeyIsPresent() throws IOException {
-		Path skillDir = Files.createDirectory(tempDir.resolve("git-commit"));
-		Files.writeString(skillDir.resolve("SKILL.md"), """
+	void failsWhenAnUnknownFrontMatterKeyIsPresent() {
+		Path skillDir = createDirectory(tempDir.resolve("git-commit"));
+		writeString(skillDir.resolve("SKILL.md"), """
 				---
 				name: git-commit
 				descripton: Typo in the key.
@@ -172,9 +173,9 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void honoursConfiguredRequiredKeys() throws IOException {
-		Path skillDir = Files.createDirectory(tempDir.resolve("git-commit"));
-		Files.writeString(skillDir.resolve("SKILL.md"), """
+	void honoursConfiguredRequiredKeys() {
+		Path skillDir = createDirectory(tempDir.resolve("git-commit"));
+		writeString(skillDir.resolve("SKILL.md"), """
 				---
 				name: git-commit
 				description: A skill.
@@ -188,8 +189,8 @@ class SkillFilesExistRuleTest {
 	}
 
 	@Test
-	void warnSeverityLogsInsteadOfFailing() throws IOException {
-		Files.createDirectory(tempDir.resolve("broken-skill"));
+	void warnSeverityLogsInsteadOfFailing() {
+		createDirectory(tempDir.resolve("broken-skill"));
 		SkillFilesExistRule rule = ruleFor(tempDir);
 		rule.setSeverity("warn");
 		CapturingLogger logger = new CapturingLogger();
@@ -199,9 +200,9 @@ class SkillFilesExistRuleTest {
 		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("broken-skill")), logger.warnings().toString());
 	}
 
-	private void createSkill(String name) throws IOException {
-		Path skillDir = Files.createDirectory(tempDir.resolve(name));
-		Files.writeString(skillDir.resolve("SKILL.md"), """
+	private void createSkill(String name) {
+		Path skillDir = createDirectory(tempDir.resolve(name));
+		writeString(skillDir.resolve("SKILL.md"), """
 				---
 				name: %s
 				description: A skill named %s.
@@ -214,5 +215,21 @@ class SkillFilesExistRuleTest {
 		SkillFilesExistRule rule = new SkillFilesExistRule();
 		rule.setSkillsDir(skillsDir.toFile());
 		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private static Path createDirectory(Path dir) {
+		try {
+			return Files.createDirectory(dir);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create " + dir, e);
+		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SubAgentFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/SubAgentFormatRuleTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -19,7 +20,7 @@ class SubAgentFormatRuleTest {
 	private Path tempDir;
 
 	@Test
-	void passesWhenEveryDefinitionIsWellFormed() throws IOException {
+	void passesWhenEveryDefinitionIsWellFormed() {
 		createAgent("reviewer", "claude-opus-4-8");
 		createAgent("planner", "claude-sonnet-4-6");
 
@@ -32,8 +33,8 @@ class SubAgentFormatRuleTest {
 	}
 
 	@Test
-	void ignoresNonMarkdownFiles() throws IOException {
-		Files.writeString(tempDir.resolve("notes.txt"), "not an agent");
+	void ignoresNonMarkdownFiles() {
+		writeString(tempDir.resolve("notes.txt"), "not an agent");
 
 		assertDoesNotThrow(ruleFor(tempDir)::execute);
 	}
@@ -52,8 +53,8 @@ class SubAgentFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenDefinitionHasNoFrontMatter() throws IOException {
-		Files.writeString(tempDir.resolve("reviewer.md"), "# Reviewer\nNo front matter.");
+	void failsWhenDefinitionHasNoFrontMatter() {
+		writeString(tempDir.resolve("reviewer.md"), "# Reviewer\nNo front matter.");
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
 		assertTrue(exception.getMessage().contains("front matter"), exception.getMessage());
@@ -61,8 +62,8 @@ class SubAgentFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenADescriptionIsMissing() throws IOException {
-		Files.writeString(tempDir.resolve("reviewer.md"), """
+	void failsWhenADescriptionIsMissing() {
+		writeString(tempDir.resolve("reviewer.md"), """
 				---
 				name: reviewer
 				---
@@ -74,8 +75,8 @@ class SubAgentFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenNameDoesNotMatchFileName() throws IOException {
-		Files.writeString(tempDir.resolve("reviewer.md"), """
+	void failsWhenNameDoesNotMatchFileName() {
+		writeString(tempDir.resolve("reviewer.md"), """
 				---
 				name: code-reviewer
 				description: Reviews code.
@@ -87,7 +88,7 @@ class SubAgentFormatRuleTest {
 	}
 
 	@Test
-	void failsWhenModelIsNotAllowed() throws IOException {
+	void failsWhenModelIsNotAllowed() {
 		createAgent("reviewer", "claud-opus");
 		SubAgentFormatRule rule = ruleFor(tempDir);
 		rule.setAllowedModels(List.of("claude-opus-4-8", "claude-sonnet-4-6"));
@@ -97,7 +98,7 @@ class SubAgentFormatRuleTest {
 	}
 
 	@Test
-	void passesWhenModelIsAllowed() throws IOException {
+	void passesWhenModelIsAllowed() {
 		createAgent("reviewer", "claude-opus-4-8");
 		SubAgentFormatRule rule = ruleFor(tempDir);
 		rule.setAllowedModels(List.of("claude-opus-4-8", "claude-sonnet-4-6"));
@@ -105,8 +106,8 @@ class SubAgentFormatRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
-	private void createAgent(String name, String model) throws IOException {
-		Files.writeString(tempDir.resolve(name + ".md"), """
+	private void createAgent(String name, String model) {
+		writeString(tempDir.resolve(name + ".md"), """
 				---
 				name: %s
 				description: A sub-agent named %s.
@@ -120,5 +121,13 @@ class SubAgentFormatRuleTest {
 		SubAgentFormatRule rule = new SubAgentFormatRule();
 		rule.setAgentsDir(agentsDir.toFile());
 		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
 	}
 }


### PR DESCRIPTION
Replace checked IOException propagation in the claude-code-enforcer tests
with UncheckedIOException, mirroring the production rules. File writes and
directory creation now go through private helpers that wrap IOException, so
test methods no longer declare throws IOException.