### PR TITLE
refactor(enforcer): divide rules into cohesive packages

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.definition;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,6 +11,11 @@ import java.util.Optional;
 import javax.inject.Named;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.FrontMatter;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.enforcer.text.NameConvention;
 
 /**
  * Enforcer rule that fails the build when any skill under the configured skills

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.definition;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,6 +11,11 @@ import java.util.Optional;
 import javax.inject.Named;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.FrontMatter;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.enforcer.text.NameConvention;
 
 /**
  * Enforcer rule that fails the build when any sub-agent definition under the

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRule.java
@@ -1,9 +1,11 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.doc;
 
 import java.io.File;
 import java.util.List;
 
 import javax.inject.Named;
+
+import io.github.adamw7.tools.enforcer.rule.MarkdownFormatRule;
 
 /**
  * Enforcer rule that fails the build when {@code AGENTS.md} is missing or does

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
@@ -1,9 +1,11 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.doc;
 
 import java.io.File;
 import java.util.List;
 
 import javax.inject.Named;
+
+import io.github.adamw7.tools.enforcer.rule.MarkdownFormatRule;
 
 /**
  * Enforcer rule that fails the build when {@code CLAUDE.md} is missing or does

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRule.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.doc;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,6 +13,9 @@ import java.util.regex.Pattern;
 import javax.inject.Named;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
 /**
  * Enforcer rule that keeps two documents from contradicting each other. Because

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.rule;
 
 import java.util.List;
 
@@ -18,7 +18,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
  * directory parameter) always fails, because that is a build-setup mistake rather
  * than a document-quality problem.
  */
-abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
+public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 
 	private static final String WARN = "warn";
 
@@ -51,7 +51,7 @@ abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 		return WARN.equalsIgnoreCase(severity);
 	}
 
-	void setSeverity(String severity) {
+	public void setSeverity(String severity) {
 		this.severity = severity;
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.rule;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,6 +12,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
 /**
  * Base for enforcer rules that validate a Markdown document follows an expected
@@ -38,7 +40,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
  * projects without a recompile. Subclasses contribute the file, its name, the
  * defaults, and any document-specific checks.
  */
-abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
+public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 
 	private static final String CODE_FENCE = "```";
 	private static final String HEADING_PREFIX = "#";
@@ -118,31 +120,31 @@ abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 		return requiredSections != null ? requiredSections : defaultRequiredSections();
 	}
 
-	void setTitleHeading(String titleHeading) {
+	public void setTitleHeading(String titleHeading) {
 		this.titleHeading = titleHeading;
 	}
 
-	void setRequiredSections(List<String> requiredSections) {
+	public void setRequiredSections(List<String> requiredSections) {
 		this.requiredSections = requiredSections;
 	}
 
-	void setForbiddenTokens(List<String> forbiddenTokens) {
+	public void setForbiddenTokens(List<String> forbiddenTokens) {
 		this.forbiddenTokens = forbiddenTokens;
 	}
 
-	void setEnforceSectionOrder(boolean enforceSectionOrder) {
+	public void setEnforceSectionOrder(boolean enforceSectionOrder) {
 		this.enforceSectionOrder = enforceSectionOrder;
 	}
 
-	void setMaxLineLength(int maxLineLength) {
+	public void setMaxLineLength(int maxLineLength) {
 		this.maxLineLength = maxLineLength;
 	}
 
-	void setValidateFileReferences(boolean validateFileReferences) {
+	public void setValidateFileReferences(boolean validateFileReferences) {
 		this.validateFileReferences = validateFileReferences;
 	}
 
-	void setReferenceBaseDir(File referenceBaseDir) {
+	public void setReferenceBaseDir(File referenceBaseDir) {
 		this.referenceBaseDir = referenceBaseDir;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.settings;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,6 +13,9 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
 /**
  * Enforcer rule that fails the build when {@code .claude/settings.json} is

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.text;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,7 +13,7 @@ import java.util.Optional;
  * use, which is all the rules need. Parsing is shared here so every rule agrees
  * on what counts as front matter, which keys it declares, and each key's value.
  */
-final class FrontMatter {
+public final class FrontMatter {
 
 	private static final String DELIMITER = "---";
 	private static final char KEY_VALUE_SEPARATOR = ':';
@@ -29,7 +29,7 @@ final class FrontMatter {
 	 * when the content does not begin with a closed {@code ---} delimited block.
 	 * A byte-order mark, if any, must already be stripped by the caller.
 	 */
-	static Optional<FrontMatter> parse(String content) {
+	public static Optional<FrontMatter> parse(String content) {
 		List<String> allLines = content.lines().toList();
 		if (!MarkdownText.firstNonBlankLine(content).equals(DELIMITER)) {
 			return Optional.empty();
@@ -43,7 +43,7 @@ final class FrontMatter {
 	}
 
 	/** True when a {@code key:} entry is present, regardless of its value. */
-	boolean hasKey(String key) {
+	public boolean hasKey(String key) {
 		return lines.stream().anyMatch(line -> isEntryFor(line, key));
 	}
 
@@ -51,7 +51,7 @@ final class FrontMatter {
 	 * The trimmed value declared for {@code key}, or empty when the key is absent.
 	 * A present key with no value yields an empty string, not an empty optional.
 	 */
-	Optional<String> value(String key) {
+	public Optional<String> value(String key) {
 		return lines.stream()
 				.filter(line -> isEntryFor(line, key))
 				.findFirst()
@@ -59,7 +59,7 @@ final class FrontMatter {
 	}
 
 	/** The declared keys, in document order, without their trailing colon. */
-	List<String> keys() {
+	public List<String> keys() {
 		List<String> keys = new ArrayList<>();
 		for (String line : lines) {
 			addKey(line, keys);

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
@@ -1,11 +1,11 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.text;
 
 /**
  * Small helpers for reading Markdown content. Shared by the enforcer rules so
  * byte-order-mark stripping and first-line detection behave identically
  * everywhere.
  */
-final class MarkdownText {
+public final class MarkdownText {
 
 	private static final char BYTE_ORDER_MARK = (char) 0xFEFF;
 
@@ -13,7 +13,7 @@ final class MarkdownText {
 	}
 
 	/** Removes a single leading UTF-8 byte-order mark, if present. */
-	static String stripByteOrderMark(String content) {
+	public static String stripByteOrderMark(String content) {
 		if (!content.isEmpty() && content.charAt(0) == BYTE_ORDER_MARK) {
 			return content.substring(1);
 		}
@@ -21,7 +21,7 @@ final class MarkdownText {
 	}
 
 	/** The first line that is not blank, stripped of surrounding whitespace, or empty if none. */
-	static String firstNonBlankLine(String content) {
+	public static String firstNonBlankLine(String content) {
 		return content.lines()
 				.map(String::strip)
 				.filter(line -> !line.isEmpty())

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/NameConvention.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/NameConvention.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.text;
 
 import java.util.List;
 import java.util.regex.Pattern;
@@ -10,13 +10,13 @@ import java.util.regex.Pattern;
  * drift from what is on disk. Skills and sub-agents both follow this convention,
  * so the checks live in one place.
  */
-final class NameConvention {
+public final class NameConvention {
 
 	/** Lower-case alphanumerics in hyphen-separated words, e.g. {@code git-commit}. */
 	private static final Pattern KEBAB_CASE = Pattern.compile("[a-z0-9]+(-[a-z0-9]+)*");
 
 	/** The Claude Code limit for skill and sub-agent names. */
-	static final int MAX_LENGTH = 64;
+	public static final int MAX_LENGTH = 64;
 
 	private NameConvention() {
 	}
@@ -27,7 +27,7 @@ final class NameConvention {
 	 * directory or file identifier). An empty name is reported once and the other
 	 * checks are skipped, since they would only restate the same problem.
 	 */
-	static void collect(String name, String expected, String where, List<String> violations) {
+	public static void collect(String name, String expected, String where, List<String> violations) {
 		if (name.isBlank()) {
 			violations.add("name must not be empty in " + where);
 			return;

--- a/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,6 +1,6 @@
-io.github.adamw7.tools.enforcer.ClaudeMdFormatRule
-io.github.adamw7.tools.enforcer.AgentsMdFormatRule
-io.github.adamw7.tools.enforcer.SkillFilesExistRule
-io.github.adamw7.tools.enforcer.SubAgentFormatRule
-io.github.adamw7.tools.enforcer.SettingsJsonValidRule
-io.github.adamw7.tools.enforcer.CrossDocConsistencyRule
+io.github.adamw7.tools.enforcer.doc.ClaudeMdFormatRule
+io.github.adamw7.tools.enforcer.doc.AgentsMdFormatRule
+io.github.adamw7.tools.enforcer.definition.SkillFilesExistRule
+io.github.adamw7.tools.enforcer.definition.SubAgentFormatRule
+io.github.adamw7.tools.enforcer.settings.SettingsJsonValidRule
+io.github.adamw7.tools.enforcer.doc.CrossDocConsistencyRule

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.definition;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,6 +12,8 @@ import java.nio.file.Path;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
 
 class SkillFilesExistRuleTest {
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.definition;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRuleTest.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.doc;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.doc;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -13,6 +13,8 @@ import java.nio.file.Path;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
 
 class ClaudeMdFormatRuleTest {
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.doc;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/CapturingLogger.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/CapturingLogger.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.rule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,11 +10,11 @@ import org.apache.maven.enforcer.rule.api.EnforcerLogger;
  * A test double for {@link EnforcerLogger} that records the warnings a rule
  * emits, so warn-severity behaviour can be asserted without a Maven runtime.
  */
-class CapturingLogger implements EnforcerLogger {
+public class CapturingLogger implements EnforcerLogger {
 
 	private final List<String> warnings = new ArrayList<>();
 
-	List<String> warnings() {
+	public List<String> warnings() {
 		return warnings;
 	}
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRuleTest.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.settings;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.text;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/NameConventionTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/NameConventionTest.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer;
+package io.github.adamw7.tools.enforcer.text;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
Split the single io.github.adamw7.tools.enforcer package into focused
sub-packages by responsibility:

- rule: framework base classes (ClaudeCodeEnforcerRule, MarkdownFormatRule)
- text: parsing helpers (MarkdownText, FrontMatter, NameConvention)
- doc: document-structure rules (ClaudeMd/AgentsMd/CrossDoc)
- settings: SettingsJsonValidRule
- definition: skill and sub-agent rules

Widened visibility of the shared base classes and helpers to public so
they can be reused across packages, and updated the Sisu component index
with the new fully-qualified rule names so the enforcer still discovers
them. Tests moved alongside their classes; all 88 pass.

https://claude.ai/code/session_01BVu2CR6mUT1fcr2HDzyFz9