### PR TITLE
refactor(enforcer): extract MarkdownDocument and share file reading

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -1,9 +1,6 @@
 package io.github.adamw7.tools.enforcer.definition;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -94,19 +91,11 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private void collectContentViolations(File skillDirectory, File skillFile, List<String> violations) {
-		String content = readContent(skillFile);
+		String content = MarkdownText.read(skillFile, SKILL_FILE_NAME);
 		if (content.isBlank()) {
 			violations.add(SKILL_FILE_NAME + " is empty: " + skillFile);
 		} else {
 			collectFrontMatterViolations(skillDirectory, skillFile, content, violations);
-		}
-	}
-
-	private String readContent(File skillFile) {
-		try {
-			return MarkdownText.stripByteOrderMark(Files.readString(skillFile.toPath()));
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read " + SKILL_FILE_NAME + " at " + skillFile, e);
 		}
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -1,9 +1,6 @@
 package io.github.adamw7.tools.enforcer.definition;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -81,19 +78,11 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private void collectDefinitionViolations(File definition, List<String> violations) {
-		String content = readContent(definition);
+		String content = MarkdownText.read(definition, "sub-agent definition");
 		if (content.isBlank()) {
 			violations.add("Sub-agent definition is empty: " + definition);
 		} else {
 			collectFrontMatterViolations(definition, content, violations);
-		}
-	}
-
-	private String readContent(File definition) {
-		try {
-			return MarkdownText.stripByteOrderMark(Files.readString(definition.toPath()));
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read sub-agent definition at " + definition, e);
 		}
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.inject.Named;
 
 import io.github.adamw7.tools.enforcer.rule.MarkdownFormatRule;
+import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
 
 /**
  * Enforcer rule that fails the build when {@code CLAUDE.md} is missing or does
@@ -51,8 +52,8 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 	}
 
 	@Override
-	protected void collectAdditionalViolations(String content, List<String> violations) {
-		if (!containsOutsideCodeFences(content, AGENTS_REFERENCE)) {
+	protected void collectAdditionalViolations(MarkdownDocument document, List<String> violations) {
+		if (!document.containsOutsideFences(AGENTS_REFERENCE)) {
 			violations.add("CLAUDE.md must reference " + AGENTS_REFERENCE + " as the source of truth");
 		}
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRule.java
@@ -1,9 +1,6 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -47,8 +44,8 @@ public class CrossDocConsistencyRule extends ClaudeCodeEnforcerRule {
 	public void execute() throws EnforcerRuleException {
 		verifyConfigured();
 		verifyPatterns();
-		String first = readContent(claudeMdFile);
-		String second = readContent(agentsMdFile);
+		String first = MarkdownText.read(claudeMdFile, claudeMdFile.getName());
+		String second = MarkdownText.read(agentsMdFile, agentsMdFile.getName());
 		List<String> violations = new ArrayList<>();
 		for (String pattern : patterns()) {
 			collectPatternViolations(pattern, first, second, violations);
@@ -110,14 +107,6 @@ public class CrossDocConsistencyRule extends ClaudeCodeEnforcerRule {
 	private Optional<String> capture(Pattern pattern, String content) {
 		Matcher matcher = pattern.matcher(content);
 		return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
-	}
-
-	private String readContent(File file) {
-		try {
-			return MarkdownText.stripByteOrderMark(Files.readString(file.toPath()));
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read " + file, e);
-		}
 	}
 
 	private List<String> patterns() {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -1,11 +1,7 @@
 package io.github.adamw7.tools.enforcer.rule;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -13,6 +9,7 @@ import java.util.regex.Pattern;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
+import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
 /**
@@ -42,9 +39,6 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  */
 public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 
-	private static final String CODE_FENCE = "```";
-	private static final String HEADING_PREFIX = "#";
-	private static final char HEADING_CHAR = '#';
 	private static final Pattern MARKDOWN_LINK = Pattern.compile("\\[[^\\]]*\\]\\(([^)]+)\\)");
 	private static final Pattern EXTERNAL_REFERENCE = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+.-]*:.*");
 
@@ -71,15 +65,15 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 
 	@Override
 	public void execute() throws EnforcerRuleException {
-		String content = readContent();
+		MarkdownDocument document = readDocument();
 		List<String> violations = new ArrayList<>();
-		collectTitleViolation(content, violations);
-		collectSectionViolations(content, violations);
-		collectOrderViolations(content, violations);
-		collectForbiddenTokenViolations(content, violations);
-		collectLineLengthViolations(content, violations);
-		collectFileReferenceViolations(content, violations);
-		collectAdditionalViolations(content, violations);
+		collectTitleViolation(document, violations);
+		collectSectionViolations(document, violations);
+		collectOrderViolations(document, violations);
+		collectForbiddenTokenViolations(document, violations);
+		collectLineLengthViolations(document, violations);
+		collectFileReferenceViolations(document, violations);
+		collectAdditionalViolations(document, violations);
 		report(documentName() + " is not well formed:", violations);
 	}
 
@@ -96,20 +90,7 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	protected abstract List<String> defaultRequiredSections();
 
 	/** Hook for document-specific checks. The default implementation does nothing. */
-	protected void collectAdditionalViolations(String content, List<String> violations) {
-	}
-
-	/** True when {@code token} appears on a line outside a fenced code block. */
-	protected final boolean containsOutsideCodeFences(String content, String token) {
-		boolean insideCodeFence = false;
-		for (String line : lines(content)) {
-			if (line.strip().startsWith(CODE_FENCE)) {
-				insideCodeFence = !insideCodeFence;
-			} else if (!insideCodeFence && line.contains(token)) {
-				return true;
-			}
-		}
-		return false;
+	protected void collectAdditionalViolations(MarkdownDocument document, List<String> violations) {
 	}
 
 	final String titleHeading() {
@@ -148,7 +129,7 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 		this.referenceBaseDir = referenceBaseDir;
 	}
 
-	private String readContent() throws EnforcerRuleException {
+	private MarkdownDocument readDocument() throws EnforcerRuleException {
 		File file = documentFile();
 		if (file == null) {
 			throw new EnforcerRuleException("The " + documentName() + " file parameter is not configured");
@@ -156,41 +137,29 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 		if (!file.isFile()) {
 			throw new EnforcerRuleException(documentName() + " does not exist at " + file);
 		}
-		String content = MarkdownText.stripByteOrderMark(readAll(file));
+		String content = MarkdownText.read(file, documentName());
 		if (content.isBlank()) {
 			throw new EnforcerRuleException(documentName() + " is empty: " + file);
 		}
-		return content;
+		return MarkdownDocument.parse(content);
 	}
 
-	private String readAll(File file) {
-		try {
-			return Files.readString(file.toPath());
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read " + documentName() + " at " + file, e);
-		}
-	}
-
-	private void collectTitleViolation(String content, List<String> violations) {
-		if (!MarkdownText.firstNonBlankLine(content).equals(titleHeading())) {
+	private void collectTitleViolation(MarkdownDocument document, List<String> violations) {
+		if (!document.firstNonBlankLine().equals(titleHeading())) {
 			violations.add(documentName() + " must start with the '" + titleHeading() + "' title heading");
 		}
 	}
 
-	private void collectSectionViolations(String content, List<String> violations) {
-		List<String> lines = lines(content);
-		boolean[] insideFence = fenceMask(lines);
-		Set<String> headings = headings(lines, insideFence);
+	private void collectSectionViolations(MarkdownDocument document, List<String> violations) {
 		for (String section : requiredSections()) {
-			addSectionViolation(lines, insideFence, headings, section, violations);
+			addSectionViolation(document, section, violations);
 		}
 	}
 
-	private void addSectionViolation(List<String> lines, boolean[] insideFence, Set<String> headings,
-			String section, List<String> violations) {
-		if (!headings.contains(section)) {
+	private void addSectionViolation(MarkdownDocument document, String section, List<String> violations) {
+		if (!document.hasHeading(section)) {
 			violations.add(documentName() + " is missing required section heading: " + section);
-		} else if (!hasBody(lines, insideFence, headingIndex(lines, insideFence, section))) {
+		} else if (!document.hasBody(section)) {
 			violations.add(documentName() + " has an empty section: " + section);
 		}
 	}
@@ -200,58 +169,39 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	 * in the same relative order as configured. Absent sections are already
 	 * reported by the section check, so only the present ones are compared here.
 	 */
-	private void collectOrderViolations(String content, List<String> violations) {
+	private void collectOrderViolations(MarkdownDocument document, List<String> violations) {
 		if (!enforceSectionOrder) {
 			return;
 		}
-		List<String> lines = lines(content);
-		boolean[] insideFence = fenceMask(lines);
-		Set<String> headings = headings(lines, insideFence);
-		List<String> expected = presentRequiredSections(headings);
-		List<String> actual = requiredHeadingsInOrder(lines, insideFence);
+		List<String> expected = presentRequiredSections(document);
+		List<String> actual = document.headingsInOrder(requiredSections());
 		if (!actual.equals(expected)) {
 			violations.add(documentName() + " sections are out of order; expected " + expected + " but found " + actual);
 		}
 	}
 
-	private List<String> presentRequiredSections(Set<String> headings) {
+	private List<String> presentRequiredSections(MarkdownDocument document) {
+		Set<String> headings = document.headings();
 		return requiredSections().stream().filter(headings::contains).toList();
 	}
 
-	private List<String> requiredHeadingsInOrder(List<String> lines, boolean[] insideFence) {
-		Set<String> required = new LinkedHashSet<>(requiredSections());
-		List<String> ordered = new ArrayList<>();
-		for (int i = 0; i < lines.size(); i++) {
-			addIfRequiredHeading(lines.get(i).strip(), insideFence[i], required, ordered);
-		}
-		return ordered;
-	}
-
-	private void addIfRequiredHeading(String line, boolean insideFence, Set<String> required, List<String> ordered) {
-		if (!insideFence && required.contains(line)) {
-			ordered.add(line);
-		}
-	}
-
-	private void collectForbiddenTokenViolations(String content, List<String> violations) {
+	private void collectForbiddenTokenViolations(MarkdownDocument document, List<String> violations) {
 		if (forbiddenTokens == null) {
 			return;
 		}
 		for (String token : forbiddenTokens) {
-			if (containsOutsideCodeFences(content, token)) {
+			if (document.containsOutsideFences(token)) {
 				violations.add(documentName() + " must not contain forbidden token: " + token);
 			}
 		}
 	}
 
-	private void collectLineLengthViolations(String content, List<String> violations) {
+	private void collectLineLengthViolations(MarkdownDocument document, List<String> violations) {
 		if (maxLineLength <= 0) {
 			return;
 		}
-		List<String> lines = lines(content);
-		boolean[] insideFence = fenceMask(lines);
-		for (int i = 0; i < lines.size(); i++) {
-			addLineLengthViolation(lines.get(i), insideFence[i], i, violations);
+		for (int i = 0; i < document.lineCount(); i++) {
+			addLineLengthViolation(document.line(i), document.isInsideFence(i), i, violations);
 		}
 	}
 
@@ -262,15 +212,13 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 		}
 	}
 
-	private void collectFileReferenceViolations(String content, List<String> violations) {
+	private void collectFileReferenceViolations(MarkdownDocument document, List<String> violations) {
 		if (!validateFileReferences) {
 			return;
 		}
 		File baseDir = referenceBaseDir();
-		List<String> lines = lines(content);
-		boolean[] insideFence = fenceMask(lines);
-		for (int i = 0; i < lines.size(); i++) {
-			collectLineReferences(lines.get(i), insideFence[i], baseDir, violations);
+		for (int i = 0; i < document.lineCount(); i++) {
+			collectLineReferences(document.line(i), document.isInsideFence(i), baseDir, violations);
 		}
 	}
 
@@ -324,80 +272,5 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 		}
 		File parent = documentFile().getAbsoluteFile().getParentFile();
 		return parent != null ? parent : new File(".");
-	}
-
-	/**
-	 * Marks every line that belongs to a fenced code block, including the opening
-	 * and closing {@code ```} delimiters, so heading detection and body detection
-	 * agree on what is code and what is document structure.
-	 */
-	private boolean[] fenceMask(List<String> lines) {
-		boolean[] mask = new boolean[lines.size()];
-		boolean insideCodeFence = false;
-		for (int i = 0; i < lines.size(); i++) {
-			boolean isFenceDelimiter = lines.get(i).strip().startsWith(CODE_FENCE);
-			mask[i] = insideCodeFence || isFenceDelimiter;
-			insideCodeFence = isFenceDelimiter != insideCodeFence;
-		}
-		return mask;
-	}
-
-	private Set<String> headings(List<String> lines, boolean[] insideFence) {
-		Set<String> headings = new LinkedHashSet<>();
-		for (int i = 0; i < lines.size(); i++) {
-			String trimmed = lines.get(i).strip();
-			if (!insideFence[i] && isHeading(trimmed)) {
-				headings.add(trimmed);
-			}
-		}
-		return headings;
-	}
-
-	private int headingIndex(List<String> lines, boolean[] insideFence, String section) {
-		for (int i = 0; i < lines.size(); i++) {
-			if (!insideFence[i] && lines.get(i).strip().equals(section)) {
-				return i;
-			}
-		}
-		return -1;
-	}
-
-	/**
-	 * A section has a body when it is followed, before the next heading at its own
-	 * level or shallower, by any prose, a code block, or a deeper sub-heading. A
-	 * deeper heading is content that belongs to the section; a sibling or parent
-	 * heading ends it.
-	 */
-	private boolean hasBody(List<String> lines, boolean[] insideFence, int headingIndex) {
-		int sectionLevel = headingLevel(lines.get(headingIndex).strip());
-		for (int i = headingIndex + 1; i < lines.size(); i++) {
-			String line = lines.get(i).strip();
-			if (insideFence[i]) {
-				return true;
-			}
-			if (isHeading(line)) {
-				return headingLevel(line) > sectionLevel;
-			}
-			if (!line.isEmpty()) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private boolean isHeading(String line) {
-		return line.startsWith(HEADING_PREFIX);
-	}
-
-	private int headingLevel(String heading) {
-		int level = 0;
-		while (level < heading.length() && heading.charAt(level) == HEADING_CHAR) {
-			level++;
-		}
-		return level;
-	}
-
-	private List<String> lines(String content) {
-		return content.lines().toList();
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
@@ -1,9 +1,6 @@
 package io.github.adamw7.tools.enforcer.settings;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,19 +64,11 @@ public class SettingsJsonValidRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private String readContent() throws EnforcerRuleException {
-		String content = MarkdownText.stripByteOrderMark(readAll());
+		String content = MarkdownText.read(settingsFile, "settings.json");
 		if (content.isBlank()) {
 			throw new EnforcerRuleException("settings.json is empty: " + settingsFile);
 		}
 		return content;
-	}
-
-	private String readAll() {
-		try {
-			return Files.readString(settingsFile.toPath());
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read settings.json at " + settingsFile, e);
-		}
 	}
 
 	private void parseAndCollect(String content, List<String> violations) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -1,0 +1,160 @@
+package io.github.adamw7.tools.enforcer.text;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A parsed Markdown document: its lines plus a mask marking which lines belong
+ * to a fenced code block. Parsing the fence mask once, at construction, lets the
+ * structural checks share it instead of each rebuilding it.
+ * <p>
+ * Headings are recognised on whole lines outside fenced code blocks, so a
+ * heading mentioned inside a {@code ```} fence or in prose is not treated as
+ * document structure. The fence mask includes the opening and closing
+ * {@code ```} delimiters themselves, so heading detection and body detection
+ * agree on what is code and what is structure.
+ */
+public final class MarkdownDocument {
+
+	private static final String CODE_FENCE = "```";
+	private static final String HEADING_PREFIX = "#";
+	private static final char HEADING_CHAR = '#';
+
+	private final List<String> lines;
+	private final boolean[] insideFence;
+
+	private MarkdownDocument(List<String> lines, boolean[] insideFence) {
+		this.lines = lines;
+		this.insideFence = insideFence;
+	}
+
+	/** Parses {@code content} into lines and a fenced-code-block mask. */
+	public static MarkdownDocument parse(String content) {
+		List<String> lines = content.lines().toList();
+		return new MarkdownDocument(lines, fenceMask(lines));
+	}
+
+	public int lineCount() {
+		return lines.size();
+	}
+
+	/** The raw line at {@code index}, without trimming. */
+	public String line(int index) {
+		return lines.get(index);
+	}
+
+	/** True when the line at {@code index} is part of a fenced code block. */
+	public boolean isInsideFence(int index) {
+		return insideFence[index];
+	}
+
+	/** The first line that is not blank, stripped of surrounding whitespace, or empty if none. */
+	public String firstNonBlankLine() {
+		return lines.stream().map(String::strip).filter(line -> !line.isEmpty()).findFirst().orElse("");
+	}
+
+	/** True when {@code token} appears on a line outside a fenced code block. */
+	public boolean containsOutsideFences(String token) {
+		for (int i = 0; i < lines.size(); i++) {
+			if (!insideFence[i] && lines.get(i).contains(token)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** The heading lines outside fenced code blocks, in document order. */
+	public Set<String> headings() {
+		Set<String> headings = new LinkedHashSet<>();
+		for (int i = 0; i < lines.size(); i++) {
+			String trimmed = lines.get(i).strip();
+			if (!insideFence[i] && isHeading(trimmed)) {
+				headings.add(trimmed);
+			}
+		}
+		return headings;
+	}
+
+	/** True when {@code heading} appears as a real heading outside code fences. */
+	public boolean hasHeading(String heading) {
+		return headings().contains(heading);
+	}
+
+	/**
+	 * True when {@code heading} is present and is followed, before the next heading
+	 * at its own level or shallower, by any prose, a code block, or a deeper
+	 * sub-heading. A deeper heading is content that belongs to the section; a
+	 * sibling or parent heading ends it.
+	 */
+	public boolean hasBody(String heading) {
+		int index = headingIndex(heading);
+		return index >= 0 && hasBodyAt(index);
+	}
+
+	/** The headings from {@code wanted} that are present, in the order they appear in the document. */
+	public List<String> headingsInOrder(List<String> wanted) {
+		Set<String> required = new LinkedHashSet<>(wanted);
+		List<String> ordered = new ArrayList<>();
+		for (int i = 0; i < lines.size(); i++) {
+			addIfRequiredHeading(lines.get(i).strip(), insideFence[i], required, ordered);
+		}
+		return ordered;
+	}
+
+	private void addIfRequiredHeading(String line, boolean lineInsideFence, Set<String> required, List<String> ordered) {
+		if (!lineInsideFence && required.contains(line)) {
+			ordered.add(line);
+		}
+	}
+
+	private int headingIndex(String section) {
+		for (int i = 0; i < lines.size(); i++) {
+			if (!insideFence[i] && lines.get(i).strip().equals(section)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private boolean hasBodyAt(int headingIndex) {
+		int sectionLevel = headingLevel(lines.get(headingIndex).strip());
+		for (int i = headingIndex + 1; i < lines.size(); i++) {
+			String line = lines.get(i).strip();
+			if (insideFence[i]) {
+				return true;
+			}
+			if (isHeading(line)) {
+				return headingLevel(line) > sectionLevel;
+			}
+			if (!line.isEmpty()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isHeading(String line) {
+		return line.startsWith(HEADING_PREFIX);
+	}
+
+	private static int headingLevel(String heading) {
+		int level = 0;
+		while (level < heading.length() && heading.charAt(level) == HEADING_CHAR) {
+			level++;
+		}
+		return level;
+	}
+
+	private static boolean[] fenceMask(List<String> lines) {
+		boolean[] mask = new boolean[lines.size()];
+		boolean insideCodeFence = false;
+		for (int i = 0; i < lines.size(); i++) {
+			boolean isFenceDelimiter = lines.get(i).strip().startsWith(CODE_FENCE);
+			mask[i] = insideCodeFence || isFenceDelimiter;
+			insideCodeFence = isFenceDelimiter != insideCodeFence;
+		}
+		return mask;
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
@@ -1,15 +1,33 @@
 package io.github.adamw7.tools.enforcer.text;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+
 /**
  * Small helpers for reading Markdown content. Shared by the enforcer rules so
- * byte-order-mark stripping and first-line detection behave identically
- * everywhere.
+ * file reading, byte-order-mark stripping and first-line detection behave
+ * identically everywhere.
  */
 public final class MarkdownText {
 
 	private static final char BYTE_ORDER_MARK = (char) 0xFEFF;
 
 	private MarkdownText() {
+	}
+
+	/**
+	 * Reads {@code file} as a UTF-8 document with any leading byte-order mark
+	 * removed. An {@link IOException} is wrapped in an {@link UncheckedIOException}
+	 * describing the document, so every rule reports a read failure the same way.
+	 */
+	public static String read(File file, String description) {
+		try {
+			return stripByteOrderMark(Files.readString(file.toPath()));
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read " + description + " at " + file, e);
+		}
 	}
 
 	/** Removes a single leading UTF-8 byte-order mark, if present. */


### PR DESCRIPTION
## Summary

A SOLID-driven cleanup of the recently repackaged enforcer module (follow-up to #251). Two findings, no behaviour change.

**SRP + recomputation — `MarkdownFormatRule` was doing too much.** It owned six independent structural checks and re-derived the line list and fenced-code-block mask in four separate methods. The structural parsing now lives in a new `text/MarkdownDocument` value type that computes the fence mask once at `parse(...)` and exposes `headings`, `hasHeading`, `hasBody`, `headingsInOrder`, `containsOutsideFences`, and `firstNonBlankLine`. `MarkdownFormatRule` drops from ~400 to ~250 lines and now reads as *which* checks to run. The `collectAdditionalViolations` hook takes a `MarkdownDocument` instead of the raw content string.

**DRY/SRP — duplicated file reading.** Five rules each re-implemented read-file + strip-BOM + wrap-`IOException`. Added `MarkdownText.read(File, description)` and removed the five private copies.

The strategy-list refactor for the six optional checks was deliberately left out: it fights Maven's reflective setter injection without a clear payoff. The `MarkdownDocument` extraction captures the real wins (single parse, smaller class, clean model).

## Testing

`mvn -pl claude-code-enforcer -am test` — all 88 tests pass. Messages are unchanged except `CrossDocConsistencyRule`'s read-error text, which gained the document name for consistency; no test asserts on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)