### PR TITLE
Add commandFormat and hookCommandsValid enforcer rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,9 +125,23 @@ profile:
   every `*.md` sub-agent definition under a configured `agentsDir`; the `name`
   must match the file name, and an optional `allowedModels` list rejects an
   unknown `model`.
+- `CommandFormatRule` (`commandFormat`) treats every `*.md` file under a
+  configured `commandsDir` (e.g. `.claude/commands`) as a custom slash command:
+  it must be non-empty and its file name must be lower-case kebab-case (the
+  command's name comes from the file name). Front matter is optional, but a
+  present `description` must be non-empty, a present `model` must be in an
+  optional `allowedModels` list, and `allowedFrontMatterKeys` reports unknown
+  keys.
 - `SettingsJsonValidRule` (`settingsJsonValid`) checks that `.claude/settings.json`
   exists and is valid JSON, and can assert `requiredPermissions` and
   `forbiddenPermissions` against the `permissions.allow` list.
+- `HookCommandsValidRule` (`hookCommandsValid`) validates the `hooks` section of
+  `.claude/settings.json`: every event maps to an array of groups, each group
+  carries a `hooks` array, and every hook declares a non-blank `type` (a
+  `command` hook also a non-blank `command`). A `$CLAUDE_PROJECT_DIR`-rooted
+  script command is resolved against `projectDir` and must exist on disk. An
+  optional `allowedEvents` list rejects mistyped events and
+  `validateScriptReferences` toggles the script-existence check.
 - `CrossDocConsistencyRule` (`crossDocConsistency`) keeps `CLAUDE.md` and
   `AGENTS.md` from contradicting each other: each configured `consistentPatterns`
   regex (one capturing group) must capture the same value in both files, e.g.

--- a/README.md
+++ b/README.md
@@ -331,11 +331,27 @@ consistent and in their expected shape:
   YAML front matter block declaring every required key, and carry a `name` that
   follows the naming convention and matches its file name. An optional
   `allowedModels` whitelist rejects a mistyped `model` such as `claud-opus`.
+- **`commandFormat`** (`CommandFormatRule`) — treats every `*.md` file in the
+  configured commands directory (e.g. `.claude/commands`) as a custom slash
+  command: it must be non-empty and carry a file name that follows the Claude
+  Code naming convention, because the command's name comes from its file name.
+  Front matter is optional, but when present a `description` must be non-empty, a
+  `model` must be one of `allowedModels` when that whitelist is configured, and
+  an optional `allowedFrontMatterKeys` whitelist catches typos such as
+  `argument-hnt`.
 - **`settingsJsonValid`** (`SettingsJsonValidRule`) — checks that
   `.claude/settings.json` exists, is non-empty, and parses as JSON. It can also
   assert policy on `permissions.allow`: `requiredPermissions` must all be
   present and `forbiddenPermissions` must all be absent, so a project can mandate
   a permission it relies on or ban an over-broad wildcard such as `Bash(*)`.
+- **`hookCommandsValid`** (`HookCommandsValidRule`) — validates the `hooks`
+  section of `.claude/settings.json`: every event must map to an array of groups,
+  each group must carry a `hooks` array, and every hook must declare a non-blank
+  `type` (a `command` hook also a non-blank `command`). A command that points at
+  a project-local script through `$CLAUDE_PROJECT_DIR` is resolved against
+  `projectDir` and must exist on disk, so a renamed or missing hook script is
+  caught. An optional `allowedEvents` whitelist rejects a mistyped event such as
+  `SessionSart`, and `validateScriptReferences` can switch the script check off.
 - **`crossDocConsistency`** (`CrossDocConsistencyRule`) — keeps `CLAUDE.md` and
   `AGENTS.md` from contradicting each other. Each configured `consistentPattern`
   is a regular expression with one capturing group; the captured value must

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -1,0 +1,162 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.FrontMatter;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.enforcer.text.NameConvention;
+
+/**
+ * Enforcer rule that fails the build when any custom slash command under the
+ * configured commands directory is malformed. Every {@code *.md} file directly
+ * in {@code commandsDir} is treated as a slash command: it must be non-empty and
+ * carry a file name that follows the Claude Code naming convention, because the
+ * command's name is taken from its file name rather than from front matter.
+ * <p>
+ * Front matter is optional for a command. When a command does open with a YAML
+ * front matter block, the optional checks apply: a present {@code description}
+ * must be non-empty; a present {@code model} must be one of {@code allowedModels}
+ * when that whitelist is configured; and when {@code allowedFrontMatterKeys} is
+ * configured, any key outside that set is reported, which catches typos such as
+ * {@code argument-hnt}.
+ * <p>
+ * A commands directory with no commands is allowed; all problems found are
+ * reported together.
+ */
+@Named("commandFormat")
+public class CommandFormatRule extends ClaudeCodeEnforcerRule {
+
+	private static final String MARKDOWN_SUFFIX = ".md";
+	private static final String DESCRIPTION_KEY = "description";
+	private static final String MODEL_KEY = "model";
+
+	/** The {@code .claude/commands} directory to scan. Injected from the rule configuration. */
+	private File commandsDir;
+
+	/** Optional whitelist of allowed front matter keys. When set, unknown keys are reported. */
+	private List<String> allowedFrontMatterKeys;
+
+	/** Optional whitelist of model identifiers a command may declare. */
+	private List<String> allowedModels;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		verifyConfigured();
+		verifyDirectory();
+		List<String> violations = new ArrayList<>();
+		for (File command : listCommands()) {
+			collectCommandViolations(command, violations);
+		}
+		report("Command files are not well formed:", violations);
+	}
+
+	private void verifyConfigured() throws EnforcerRuleException {
+		if (commandsDir == null) {
+			throw new EnforcerRuleException("The commandsDir parameter is not configured");
+		}
+	}
+
+	private void verifyDirectory() throws EnforcerRuleException {
+		if (!commandsDir.isDirectory()) {
+			throw new EnforcerRuleException("Commands directory does not exist at " + commandsDir);
+		}
+	}
+
+	private File[] listCommands() {
+		File[] commands = commandsDir.listFiles(this::isMarkdownFile);
+		return commands != null ? commands : new File[0];
+	}
+
+	private boolean isMarkdownFile(File file) {
+		return file.isFile() && file.getName().endsWith(MARKDOWN_SUFFIX);
+	}
+
+	private void collectCommandViolations(File command, List<String> violations) {
+		String content = MarkdownText.read(command, "command definition");
+		if (content.isBlank()) {
+			violations.add("Command definition is empty: " + command);
+		} else {
+			collectNonEmptyViolations(command, content, violations);
+		}
+	}
+
+	private void collectNonEmptyViolations(File command, String content, List<String> violations) {
+		String baseName = baseName(command);
+		NameConvention.collect(baseName, baseName, command.toString(), violations);
+		FrontMatter.parse(content)
+				.ifPresent(frontMatter -> collectFrontMatterViolations(command, frontMatter, violations));
+	}
+
+	private void collectFrontMatterViolations(File command, FrontMatter frontMatter, List<String> violations) {
+		collectUnknownKeys(command, frontMatter, violations);
+		collectDescriptionViolations(command, frontMatter, violations);
+		collectModelViolations(command, frontMatter, violations);
+	}
+
+	private void collectUnknownKeys(File command, FrontMatter frontMatter, List<String> violations) {
+		if (allowedFrontMatterKeys == null) {
+			return;
+		}
+		for (String key : frontMatter.keys()) {
+			addUnknownKeyViolation(command, key, violations);
+		}
+	}
+
+	private void addUnknownKeyViolation(File command, String key, List<String> violations) {
+		if (!allowedFrontMatterKeys.contains(key)) {
+			violations.add("Command front matter has unknown key '" + key + ":' in: " + command);
+		}
+	}
+
+	private void collectDescriptionViolations(File command, FrontMatter frontMatter, List<String> violations) {
+		frontMatter.value(DESCRIPTION_KEY).ifPresent(description -> addDescriptionViolation(command, description, violations));
+	}
+
+	private void addDescriptionViolation(File command, String description, List<String> violations) {
+		if (description.isBlank()) {
+			violations.add("Command description must not be empty in: " + command);
+		}
+	}
+
+	private void collectModelViolations(File command, FrontMatter frontMatter, List<String> violations) {
+		if (allowedModels == null) {
+			return;
+		}
+		frontMatter.value(MODEL_KEY).ifPresent(model -> addModelViolation(command, model, violations));
+	}
+
+	private void addModelViolation(File command, String model, List<String> violations) {
+		if (!allowedModels.contains(model)) {
+			violations.add("Command declares unsupported model '" + model + "' in: " + command);
+		}
+	}
+
+	private String baseName(File command) {
+		String name = command.getName();
+		return name.substring(0, name.length() - MARKDOWN_SUFFIX.length());
+	}
+
+	void setCommandsDir(File commandsDir) {
+		this.commandsDir = commandsDir;
+	}
+
+	void setAllowedFrontMatterKeys(List<String> allowedFrontMatterKeys) {
+		this.allowedFrontMatterKeys = allowedFrontMatterKeys;
+	}
+
+	void setAllowedModels(List<String> allowedModels) {
+		this.allowedModels = allowedModels;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("CommandFormatRule[commandsDir=%s]", commandsDir);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -1,0 +1,247 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * Enforcer rule that fails the build when the {@code hooks} section of
+ * {@code .claude/settings.json} is malformed. The file must exist, be non-empty,
+ * and parse as JSON. When a {@code hooks} object is present, every event must map
+ * to an array of groups, every group must carry a {@code hooks} array, and every
+ * hook in it must declare a non-blank {@code type}; a {@code command} hook must
+ * also declare a non-blank {@code command}.
+ * <p>
+ * A command that points at a project-local script through the
+ * {@code $CLAUDE_PROJECT_DIR} variable is resolved against {@code projectDir}
+ * (the parent of the settings file's directory by default) and must exist on
+ * disk, so a renamed or missing hook script such as
+ * {@code $CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh} is caught. This
+ * check is on by default and can be switched off with
+ * {@code validateScriptReferences}. When {@code allowedEvents} is configured, any
+ * event name outside that set is reported, which catches a mistyped
+ * {@code SessionSart}.
+ * <p>
+ * A settings file without a {@code hooks} object is allowed; all problems found
+ * are reported together.
+ */
+@Named("hookCommandsValid")
+public class HookCommandsValidRule extends ClaudeCodeEnforcerRule {
+
+	private static final String HOOKS_KEY = "hooks";
+	private static final String TYPE_KEY = "type";
+	private static final String COMMAND_KEY = "command";
+	private static final String COMMAND_TYPE = "command";
+	private static final String PROJECT_DIR_BRACED = "${CLAUDE_PROJECT_DIR}";
+	private static final String PROJECT_DIR_PLAIN = "$CLAUDE_PROJECT_DIR";
+
+	/** The {@code .claude/settings.json} file to validate. Injected from the rule configuration. */
+	private File settingsFile;
+
+	/** Base directory that {@code $CLAUDE_PROJECT_DIR} resolves to. Defaults to the settings file's grandparent. */
+	private File projectDir;
+
+	/** Optional whitelist of hook event names. When set, unknown events are reported. */
+	private List<String> allowedEvents;
+
+	/** When true (default), a {@code $CLAUDE_PROJECT_DIR} script reference must resolve to an existing file. */
+	private boolean validateScriptReferences = true;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		verifyConfigured();
+		verifyFile();
+		String content = readContent();
+		List<String> violations = new ArrayList<>();
+		parseAndCollect(content, violations);
+		report("settings.json hooks are not well formed:", violations);
+	}
+
+	private void verifyConfigured() throws EnforcerRuleException {
+		if (settingsFile == null) {
+			throw new EnforcerRuleException("The settingsFile parameter is not configured");
+		}
+	}
+
+	private void verifyFile() throws EnforcerRuleException {
+		if (!settingsFile.isFile()) {
+			throw new EnforcerRuleException("settings.json does not exist at " + settingsFile);
+		}
+	}
+
+	private String readContent() throws EnforcerRuleException {
+		String content = MarkdownText.read(settingsFile, "settings.json");
+		if (content.isBlank()) {
+			throw new EnforcerRuleException("settings.json is empty: " + settingsFile);
+		}
+		return content;
+	}
+
+	private void parseAndCollect(String content, List<String> violations) {
+		JSONObject settings = parse(content, violations);
+		if (settings != null) {
+			collectHookViolations(settings, violations);
+		}
+	}
+
+	private JSONObject parse(String content, List<String> violations) {
+		try {
+			return new JSONObject(content);
+		} catch (JSONException e) {
+			violations.add("settings.json is not valid JSON: " + e.getMessage());
+			return null;
+		}
+	}
+
+	private void collectHookViolations(JSONObject settings, List<String> violations) {
+		JSONObject hooks = settings.optJSONObject(HOOKS_KEY);
+		if (hooks == null) {
+			return;
+		}
+		for (String event : hooks.keySet()) {
+			collectEventViolations(event, hooks, violations);
+		}
+	}
+
+	private void collectEventViolations(String event, JSONObject hooks, List<String> violations) {
+		addEventNameViolation(event, violations);
+		JSONArray groups = hooks.optJSONArray(event);
+		if (groups == null) {
+			violations.add("hook event '" + event + "' must be a JSON array");
+		} else {
+			collectGroupsViolations(event, groups, violations);
+		}
+	}
+
+	private void addEventNameViolation(String event, List<String> violations) {
+		if (allowedEvents != null && !allowedEvents.contains(event)) {
+			violations.add("hook event '" + event + "' is not an allowed event");
+		}
+	}
+
+	private void collectGroupsViolations(String event, JSONArray groups, List<String> violations) {
+		for (int i = 0; i < groups.length(); i++) {
+			collectGroupViolations(event, groups.optJSONObject(i), violations);
+		}
+	}
+
+	private void collectGroupViolations(String event, JSONObject group, List<String> violations) {
+		if (group == null) {
+			violations.add("hook event '" + event + "' has an entry that is not a JSON object");
+		} else {
+			collectEntriesViolations(event, group, violations);
+		}
+	}
+
+	private void collectEntriesViolations(String event, JSONObject group, List<String> violations) {
+		JSONArray entries = group.optJSONArray(HOOKS_KEY);
+		if (entries == null) {
+			violations.add("hook event '" + event + "' entry is missing a 'hooks' array");
+		} else {
+			collectEntriesViolations(event, entries, violations);
+		}
+	}
+
+	private void collectEntriesViolations(String event, JSONArray entries, List<String> violations) {
+		for (int i = 0; i < entries.length(); i++) {
+			collectEntryViolations(event, entries.optJSONObject(i), violations);
+		}
+	}
+
+	private void collectEntryViolations(String event, JSONObject entry, List<String> violations) {
+		if (entry == null) {
+			violations.add("hook event '" + event + "' has a hook that is not a JSON object");
+		} else {
+			collectTypedEntryViolations(event, entry, violations);
+		}
+	}
+
+	private void collectTypedEntryViolations(String event, JSONObject entry, List<String> violations) {
+		String type = entry.optString(TYPE_KEY, "").strip();
+		if (type.isBlank()) {
+			violations.add("hook event '" + event + "' has a hook missing 'type'");
+		} else if (type.equals(COMMAND_TYPE)) {
+			collectCommandViolations(event, entry, violations);
+		}
+	}
+
+	private void collectCommandViolations(String event, JSONObject entry, List<String> violations) {
+		String command = entry.optString(COMMAND_KEY, "").strip();
+		if (command.isBlank()) {
+			violations.add("hook event '" + event + "' has a command hook with an empty 'command'");
+		} else {
+			addScriptReferenceViolation(event, command, violations);
+		}
+	}
+
+	private void addScriptReferenceViolation(String event, String command, List<String> violations) {
+		if (!validateScriptReferences) {
+			return;
+		}
+		String script = localScriptPath(command);
+		if (script != null && !new File(script).isFile()) {
+			violations.add("hook event '" + event + "' references a missing script: " + script);
+		}
+	}
+
+	/** The resolved on-disk path of a {@code $CLAUDE_PROJECT_DIR}-rooted token, or null when none is referenced. */
+	private String localScriptPath(String command) {
+		for (String token : command.split("\\s+")) {
+			String expanded = expand(token);
+			if (expanded != null) {
+				return expanded;
+			}
+		}
+		return null;
+	}
+
+	private String expand(String token) {
+		if (token.contains(PROJECT_DIR_BRACED)) {
+			return token.replace(PROJECT_DIR_BRACED, projectDir().getPath());
+		}
+		if (token.contains(PROJECT_DIR_PLAIN)) {
+			return token.replace(PROJECT_DIR_PLAIN, projectDir().getPath());
+		}
+		return null;
+	}
+
+	private File projectDir() {
+		if (projectDir != null) {
+			return projectDir;
+		}
+		File claudeDir = settingsFile.getAbsoluteFile().getParentFile();
+		File root = claudeDir != null ? claudeDir.getParentFile() : null;
+		return root != null ? root : new File(".");
+	}
+
+	void setSettingsFile(File settingsFile) {
+		this.settingsFile = settingsFile;
+	}
+
+	void setProjectDir(File projectDir) {
+		this.projectDir = projectDir;
+	}
+
+	void setAllowedEvents(List<String> allowedEvents) {
+		this.allowedEvents = allowedEvents;
+	}
+
+	void setValidateScriptReferences(boolean validateScriptReferences) {
+		this.validateScriptReferences = validateScriptReferences;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("HookCommandsValidRule[settingsFile=%s]", settingsFile);
+	}
+}

--- a/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -4,3 +4,5 @@ io.github.adamw7.tools.enforcer.definition.SkillFilesExistRule
 io.github.adamw7.tools.enforcer.definition.SubAgentFormatRule
 io.github.adamw7.tools.enforcer.settings.SettingsJsonValidRule
 io.github.adamw7.tools.enforcer.doc.CrossDocConsistencyRule
+io.github.adamw7.tools.enforcer.definition.CommandFormatRule
+io.github.adamw7.tools.enforcer.settings.HookCommandsValidRule

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
@@ -1,0 +1,147 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+
+class CommandFormatRuleTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesWhenEveryCommandIsWellFormed() {
+		writeString(tempDir.resolve("review.md"), """
+				---
+				description: Reviews the pending changes.
+				model: claude-opus-4-8
+				---
+				Review the diff.
+				""");
+		writeString(tempDir.resolve("plain.md"), "Just a body, no front matter.");
+
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
+	@Test
+	void passesWhenNoCommandsExist() {
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
+	@Test
+	void ignoresNonMarkdownFiles() {
+		writeString(tempDir.resolve("notes.txt"), "not a command");
+
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new CommandFormatRule()::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenDirectoryIsMissing() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor(tempDir.resolve("absent"))::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenCommandIsEmpty() {
+		writeString(tempDir.resolve("blank.md"), "   ");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("is empty"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenFileNameIsNotKebabCase() {
+		writeString(tempDir.resolve("ReviewPR.md"), "Review the pull request.");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("must be lower-case kebab-case"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenDescriptionIsEmpty() {
+		writeString(tempDir.resolve("review.md"), """
+				---
+				description:
+				---
+				Review the diff.
+				""");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("description must not be empty"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenModelIsNotAllowed() {
+		writeString(tempDir.resolve("review.md"), """
+				---
+				model: claud-opus
+				---
+				Review the diff.
+				""");
+		CommandFormatRule rule = ruleFor(tempDir);
+		rule.setAllowedModels(List.of("claude-opus-4-8", "claude-sonnet-4-6"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("unsupported model 'claud-opus'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenFrontMatterHasUnknownKey() {
+		writeString(tempDir.resolve("review.md"), """
+				---
+				descripton: Reviews the diff.
+				---
+				Review the diff.
+				""");
+		CommandFormatRule rule = ruleFor(tempDir);
+		rule.setAllowedFrontMatterKeys(List.of("description", "argument-hint", "allowed-tools", "model"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("unknown key 'descripton:'"), exception.getMessage());
+	}
+
+	@Test
+	void warnSeverityLogsInsteadOfFailing() {
+		writeString(tempDir.resolve("blank.md"), "   ");
+		CommandFormatRule rule = ruleFor(tempDir);
+		rule.setSeverity("warn");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("blank.md")), logger.warnings().toString());
+	}
+
+	private CommandFormatRule ruleFor(Path commandsDir) {
+		CommandFormatRule rule = new CommandFormatRule();
+		rule.setCommandsDir(commandsDir.toFile());
+		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -1,0 +1,153 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+
+class HookCommandsValidRuleTest {
+
+	private static final String NO_HOOKS = """
+			{ "permissions": { "allow": [ "Edit" ] } }
+			""";
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesWhenNoHooksDeclared() {
+		assertDoesNotThrow(ruleFor(NO_HOOKS)::execute);
+	}
+
+	@Test
+	void passesWhenHookScriptExists() {
+		writeString(tempDir.resolve("session-start.sh"), "#!/bin/sh\necho hi\n");
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("$CLAUDE_PROJECT_DIR/session-start.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new HookCommandsValidRule()::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenFileIsMissing() {
+		HookCommandsValidRule rule = new HookCommandsValidRule();
+		rule.setSettingsFile(tempDir.resolve("absent.json").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenJsonIsMalformed() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("{ \"hooks\": ")::execute);
+		assertTrue(exception.getMessage().contains("not valid JSON"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenHookScriptIsMissing() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("$CLAUDE_PROJECT_DIR/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("references a missing script"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenCommandIsEmpty() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor(hooksReferencing(""))::execute);
+		assertTrue(exception.getMessage().contains("empty 'command'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenHookTypeIsMissing() {
+		String content = """
+				{ "hooks": { "SessionStart": [ { "hooks": [ { "command": "echo hi" } ] } ] } }
+				""";
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(content)::execute);
+		assertTrue(exception.getMessage().contains("missing 'type'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenGroupIsMissingHooksArray() {
+		String content = """
+				{ "hooks": { "SessionStart": [ { "matcher": "*" } ] } }
+				""";
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(content)::execute);
+		assertTrue(exception.getMessage().contains("missing a 'hooks' array"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenEventIsNotAllowed() {
+		writeString(tempDir.resolve("session-start.sh"), "#!/bin/sh\n");
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("$CLAUDE_PROJECT_DIR/session-start.sh"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setAllowedEvents(List.of("PreToolUse", "PostToolUse"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("is not an allowed event"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenScriptReferenceValidationIsDisabled() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("$CLAUDE_PROJECT_DIR/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setValidateScriptReferences(false);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void warnSeverityLogsInsteadOfFailing() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("$CLAUDE_PROJECT_DIR/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setSeverity("warn");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("gone.sh")), logger.warnings().toString());
+	}
+
+	private String hooksReferencing(String command) {
+		return """
+				{ "hooks": { "SessionStart": [ { "hooks": [ { "type": "command", "command": "%s" } ] } ] } }
+				""".formatted(command);
+	}
+
+	private HookCommandsValidRule ruleFor(String content) {
+		Path file = tempDir.resolve("settings.json");
+		writeString(file, content);
+		HookCommandsValidRule rule = new HookCommandsValidRule();
+		rule.setSettingsFile(file.toFile());
+		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -420,6 +420,10 @@
 										<settingsJsonValid>
 											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
 										</settingsJsonValid>
+										<hookCommandsValid>
+											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
+											<projectDir>${project.basedir}</projectDir>
+										</hookCommandsValid>
 										<crossDocConsistency>
 											<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
 											<agentsMdFile>${project.basedir}/AGENTS.md</agentsMdFile>


### PR DESCRIPTION
Add two custom maven-enforcer rules to the claude-code-enforcer module:

- commandFormat (CommandFormatRule): validates custom slash command
  definitions under a configured commands directory. Each *.md file must be
  non-empty with a kebab-case file name (the command name); optional front
  matter is checked for a non-empty description, an allowed model, and
  whitelisted keys.
- hookCommandsValid (HookCommandsValidRule): validates the hooks section of
  .claude/settings.json structurally and verifies that
  $CLAUDE_PROJECT_DIR-rooted hook scripts exist on disk, with an optional
  allowedEvents whitelist and a toggle for the script-existence check.

Both rules are registered for sisu discovery and covered by unit tests.
hookCommandsValid is wired into the root enforcement profile to validate the
repository's own SessionStart hook. Docs updated in README.md and AGENTS.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DGy1uoCzu7gvAYRVBQncTi