### PR TITLE
fix(enforcer): correct fence, front-matter, and hook-script edge cases

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -189,7 +189,7 @@ public class HookCommandsValidRule extends ClaudeCodeEnforcerRule {
 			return;
 		}
 		String script = localScriptPath(command);
-		if (script != null && !new File(script).isFile()) {
+		if (script != null && !new File(script).exists()) {
 			violations.add("hook event '" + event + "' references a missing script: " + script);
 		}
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -62,22 +62,29 @@ public final class FrontMatter {
 	public List<String> keys() {
 		List<String> keys = new ArrayList<>();
 		for (String line : lines) {
-			addKey(line, keys);
+			entryKey(line).ifPresent(keys::add);
 		}
 		return keys;
 	}
 
-	private void addKey(String line, List<String> keys) {
+	/**
+	 * The key a line declares, or empty when the line is not a {@code key:} entry.
+	 * This shares its definition with {@link #hasKey} and {@link #value}, so the
+	 * three never disagree about whether a line declares a key: a bare {@code key:}
+	 * or a {@code key: value} (or {@code key:\tvalue}) counts, while {@code key:value}
+	 * without a separating space, comments, and list items do not.
+	 */
+	private Optional<String> entryKey(String line) {
 		String stripped = line.strip();
-		int separator = stripped.indexOf(KEY_VALUE_SEPARATOR);
-		if (isKeyLine(stripped, separator)) {
-			keys.add(stripped.substring(0, separator).strip());
+		if (stripped.startsWith("#") || stripped.startsWith("-")) {
+			return Optional.empty();
 		}
-	}
-
-	/** A key line is an unindented {@code key: ...} entry, not a nested value or a comment. */
-	private boolean isKeyLine(String stripped, int separator) {
-		return separator > 0 && !stripped.startsWith("#") && !stripped.startsWith("-");
+		int separator = stripped.indexOf(KEY_VALUE_SEPARATOR);
+		if (separator <= 0) {
+			return Optional.empty();
+		}
+		String key = stripped.substring(0, separator);
+		return isEntryFor(line, key) ? Optional.of(key) : Optional.empty();
 	}
 
 	private boolean isEntryFor(String line, String key) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -11,14 +11,16 @@ import java.util.Set;
  * structural checks share it instead of each rebuilding it.
  * <p>
  * Headings are recognised on whole lines outside fenced code blocks, so a
- * heading mentioned inside a {@code ```} fence or in prose is not treated as
- * document structure. The fence mask includes the opening and closing
- * {@code ```} delimiters themselves, so heading detection and body detection
- * agree on what is code and what is structure.
+ * heading mentioned inside a {@code ```} or {@code ~~~} fence or in prose is not
+ * treated as document structure. The fence mask includes the opening and closing
+ * delimiters themselves, so heading detection and body detection agree on what is
+ * code and what is structure. A fence opened with one delimiter is only closed by
+ * the same delimiter, so a {@code ~~~} line inside a {@code ```} block stays code.
  */
 public final class MarkdownDocument {
 
-	private static final String CODE_FENCE = "```";
+	private static final String BACKTICK_FENCE = "```";
+	private static final String TILDE_FENCE = "~~~";
 	private static final String HEADING_PREFIX = "#";
 	private static final char HEADING_CHAR = '#';
 
@@ -149,12 +151,40 @@ public final class MarkdownDocument {
 
 	private static boolean[] fenceMask(List<String> lines) {
 		boolean[] mask = new boolean[lines.size()];
-		boolean insideCodeFence = false;
+		String openMarker = null;
 		for (int i = 0; i < lines.size(); i++) {
-			boolean isFenceDelimiter = lines.get(i).strip().startsWith(CODE_FENCE);
-			mask[i] = insideCodeFence || isFenceDelimiter;
-			insideCodeFence = isFenceDelimiter != insideCodeFence;
+			openMarker = applyFence(lines.get(i).strip(), openMarker, mask, i);
 		}
 		return mask;
+	}
+
+	/**
+	 * Marks line {@code index} as code or structure and returns the fence marker
+	 * still open afterwards. A fence is only closed by the marker it was opened
+	 * with, so a {@code ~~~} line inside a {@code ```} block, or the reverse, stays
+	 * content rather than ending the block.
+	 */
+	private static String applyFence(String line, String openMarker, boolean[] mask, int index) {
+		String marker = fenceMarker(line);
+		if (openMarker == null) {
+			mask[index] = marker != null;
+			return marker;
+		}
+		mask[index] = true;
+		return closesFence(marker, openMarker) ? null : openMarker;
+	}
+
+	private static boolean closesFence(String marker, String openMarker) {
+		return marker != null && marker.charAt(0) == openMarker.charAt(0);
+	}
+
+	private static String fenceMarker(String line) {
+		if (line.startsWith(BACKTICK_FENCE)) {
+			return BACKTICK_FENCE;
+		}
+		if (line.startsWith(TILDE_FENCE)) {
+			return TILDE_FENCE;
+		}
+		return null;
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -204,6 +204,34 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
+	void ignoresAForbiddenTokenInsideATildeFence() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n~~~\nTODO inside code\n~~~\n");
+		rule.setForbiddenTokens(java.util.List.of("TODO"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenSectionHeadingAppearsOnlyInsideTildeFence() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "~~~\n## Testing\n~~~"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing required section heading: ## Testing"),
+				exception.getMessage());
+	}
+
+	@Test
+	void treatsABacktickLineInsideATildeFenceAsCode() {
+		// The ``` does not close the ~~~ block, so the ## Testing heading between the
+		// two backtick lines stays code and the required section is reported missing.
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "~~~\n```\n## Testing\n```\n~~~"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing required section heading: ## Testing"),
+				exception.getMessage());
+	}
+
+	@Test
 	void passesWhenSectionsAreInConfiguredOrder() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
 		rule.setEnforceSectionOrder(true);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -40,6 +40,17 @@ class HookCommandsValidRuleTest {
 	}
 
 	@Test
+	void passesWhenCommandOnlyChangesIntoProjectDir() {
+		writeString(tempDir.resolve("run.sh"), "#!/bin/sh\necho hi\n");
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("cd $CLAUDE_PROJECT_DIR && bash run.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		// $CLAUDE_PROJECT_DIR here resolves to the project directory itself, which
+		// exists, so it must not be reported as a missing script.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
 	void failsWhenNotConfigured() {
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new HookCommandsValidRule()::execute);
 		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -76,6 +76,17 @@ class FrontMatterTest {
 	}
 
 	@Test
+	void keysAgreeWithHasKeyWhenColonHasNoSeparatingSpace() {
+		FrontMatter frontMatter = FrontMatter.parse("---\nname:git-commit\n---\n").orElseThrow();
+
+		// A YAML mapping needs a space after the colon, so "name:git-commit" declares
+		// no key. keys(), hasKey() and value() must all agree on that.
+		assertEquals(List.of(), frontMatter.keys());
+		assertFalse(frontMatter.hasKey("name"));
+		assertEquals(Optional.empty(), frontMatter.value("name"));
+	}
+
+	@Test
 	void ignoresCommentsAndListItemsWhenListingKeys() {
 		FrontMatter frontMatter = FrontMatter.parse("""
 				---


### PR DESCRIPTION
Fix three bugs in claude-code-enforcer found by edge-case review, each
covered by a regression test that fails without the fix:

- MarkdownDocument only recognised ``` fences, so headings and forbidden
  tokens inside a ~~~ code block were treated as document structure. Fence
  detection now handles both ``` and ~~~, and a fence is only closed by the
  marker it was opened with (a ~~~ line inside a ``` block stays code).
- FrontMatter.keys() and hasKey()/value() disagreed about what a key line
  is: keys() accepted "key:value" (no space) and "key :" while the others
  required a space, so the same line was both a present and a missing key.
  Both paths now share one definition.
- HookCommandsValidRule reported a "missing script" when a command only
  cd'd into the project dir (e.g. "cd $CLAUDE_PROJECT_DIR && bash run.sh"),
  because the expanded token resolved to the existing directory. The check
  now treats any existing path (file or directory) as present.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JuJexZt2yftiKxHK8MFFx5