### PR TITLE
feat(enforcer): add mcpServersValid rule for .mcp.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,13 @@ profile:
   script command is resolved against `projectDir` and must exist on disk. An
   optional `allowedEvents` list rejects mistyped events and
   `validateScriptReferences` toggles the script-existence check.
+- `McpServersValidRule` (`mcpServersValid`) validates the project's `.mcp.json`.
+  The file is optional, so an absent one passes; when present it must be
+  non-empty valid JSON, and every entry under `mcpServers` must be a JSON object
+  with a well-formed transport (a `stdio` server needs a `command`; an `sse` or
+  `http` server needs a `url`). An explicit `type` outside `allowedTypes`
+  (`stdio`, `sse`, `http` by default) is rejected, and `requiredServers` /
+  `forbiddenServers` assert which servers must or must not be declared.
 - `CrossDocConsistencyRule` (`crossDocConsistency`) keeps `CLAUDE.md` and
   `AGENTS.md` from contradicting each other: each configured `consistentPatterns`
   regex (one capturing group) must capture the same value in both files, e.g.

--- a/README.md
+++ b/README.md
@@ -352,6 +352,16 @@ consistent and in their expected shape:
   `projectDir` and must exist on disk, so a renamed or missing hook script is
   caught. An optional `allowedEvents` whitelist rejects a mistyped event such as
   `SessionSart`, and `validateScriptReferences` can switch the script check off.
+- **`mcpServersValid`** (`McpServersValidRule`) — validates the project's
+  `.mcp.json`. A project-level MCP file is optional, so an absent file passes;
+  when present it must be non-empty and parse as JSON, and every entry under
+  `mcpServers` must be a JSON object with a well-formed transport. A `stdio`
+  server (the default when no `type` is declared) needs a non-blank `command`;
+  an `sse` or `http` server needs a non-blank `url`. An explicit `type` outside
+  the `allowedTypes` whitelist (`stdio`, `sse`, `http` by default) is reported,
+  catching a mistyped `htttp`. `requiredServers` must all be present and
+  `forbiddenServers` must all be absent, so a project can mandate an MCP server
+  it relies on or ban one it does not want committed.
 - **`crossDocConsistency`** (`CrossDocConsistencyRule`) — keeps `CLAUDE.md` and
   `AGENTS.md` from contradicting each other. Each configured `consistentPattern`
   is a regular expression with one capturing group; the captured value must

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
@@ -1,0 +1,215 @@
+package io.github.adamw7.tools.enforcer.mcp;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * Enforcer rule that fails the build when the project's {@code .mcp.json} is
+ * missing, empty, or not valid JSON. Beyond that baseline it validates the shape
+ * of every entry under the {@code mcpServers} object: each server must be a JSON
+ * object whose transport is well formed. A {@code stdio} server (the default when
+ * no {@code type} is declared) must carry a non-blank {@code command}; an
+ * {@code sse} or {@code http} server must carry a non-blank {@code url}. An
+ * explicit {@code type} outside the allowed set is reported, which catches a
+ * mistyped {@code htttp}.
+ * <p>
+ * A project-level {@code .mcp.json} is optional in Claude Code, so an absent file
+ * is treated as a pass; the rule only fails when the file is present and
+ * malformed. The rule can also assert policy on the configured servers:
+ * {@code requiredServers}
+ * must all be present and {@code forbiddenServers} must all be absent, so a project
+ * can mandate an MCP server it relies on or ban one it does not want committed. The
+ * {@code allowedTypes} whitelist defaults to {@code stdio}, {@code sse}, and
+ * {@code http} and can be overridden.
+ * <p>
+ * All problems found are reported together.
+ */
+@Named("mcpServersValid")
+public class McpServersValidRule extends ClaudeCodeEnforcerRule {
+
+	private static final String MCP_SERVERS_KEY = "mcpServers";
+	private static final String TYPE_KEY = "type";
+	private static final String COMMAND_KEY = "command";
+	private static final String URL_KEY = "url";
+	private static final String STDIO_TYPE = "stdio";
+	private static final String SSE_TYPE = "sse";
+	private static final String HTTP_TYPE = "http";
+	private static final List<String> DEFAULT_ALLOWED_TYPES = List.of(STDIO_TYPE, SSE_TYPE, HTTP_TYPE);
+
+	/** The {@code .mcp.json} file to validate. Injected from the rule configuration. */
+	private File mcpFile;
+
+	/** Server names that must appear under {@code mcpServers}. */
+	private List<String> requiredServers;
+
+	/** Server names that must not appear under {@code mcpServers}. */
+	private List<String> forbiddenServers;
+
+	/** Optional override for the allowed transport types. */
+	private List<String> allowedTypes;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		verifyConfigured();
+		if (!mcpFile.isFile()) {
+			return;
+		}
+		String content = readContent();
+		List<String> violations = new ArrayList<>();
+		parseAndCollect(content, violations);
+		report("mcp.json is not well formed:", violations);
+	}
+
+	private void verifyConfigured() throws EnforcerRuleException {
+		if (mcpFile == null) {
+			throw new EnforcerRuleException("The mcpFile parameter is not configured");
+		}
+	}
+
+	private String readContent() throws EnforcerRuleException {
+		String content = MarkdownText.read(mcpFile, "mcp.json");
+		if (content.isBlank()) {
+			throw new EnforcerRuleException("mcp.json is empty: " + mcpFile);
+		}
+		return content;
+	}
+
+	private void parseAndCollect(String content, List<String> violations) {
+		JSONObject mcp = parse(content, violations);
+		if (mcp != null) {
+			collectServersViolations(mcp, violations);
+		}
+	}
+
+	private JSONObject parse(String content, List<String> violations) {
+		try {
+			return new JSONObject(content);
+		} catch (JSONException e) {
+			violations.add("mcp.json is not valid JSON: " + e.getMessage());
+			return null;
+		}
+	}
+
+	private void collectServersViolations(JSONObject mcp, List<String> violations) {
+		JSONObject servers = mcp.optJSONObject(MCP_SERVERS_KEY);
+		if (servers == null) {
+			violations.add("mcp.json is missing the 'mcpServers' object");
+		} else {
+			collectKnownServersViolations(servers, violations);
+		}
+	}
+
+	private void collectKnownServersViolations(JSONObject servers, List<String> violations) {
+		for (String name : servers.keySet()) {
+			collectServerViolations(name, servers.optJSONObject(name), violations);
+		}
+		collectRequiredServers(servers, violations);
+		collectForbiddenServers(servers, violations);
+	}
+
+	private void collectServerViolations(String name, JSONObject server, List<String> violations) {
+		if (server == null) {
+			violations.add("mcp.json server '" + name + "' must be a JSON object");
+		} else {
+			collectTransportViolations(name, server, violations);
+		}
+	}
+
+	private void collectTransportViolations(String name, JSONObject server, List<String> violations) {
+		String type = server.optString(TYPE_KEY, "").strip();
+		if (type.isBlank()) {
+			collectInferredTransportViolations(name, server, violations);
+		} else {
+			collectExplicitTransportViolations(name, server, type, violations);
+		}
+	}
+
+	private void collectInferredTransportViolations(String name, JSONObject server, List<String> violations) {
+		if (server.has(COMMAND_KEY)) {
+			collectCommandViolation(name, server, violations);
+		} else {
+			violations.add("mcp.json server '" + name
+					+ "' must declare a 'command' (stdio) or a 'type' with a 'url' (sse/http)");
+		}
+	}
+
+	private void collectExplicitTransportViolations(String name, JSONObject server, String type,
+			List<String> violations) {
+		if (!allowedTypes().contains(type)) {
+			violations.add("mcp.json server '" + name + "' has an unsupported type: " + type);
+		} else if (type.equals(STDIO_TYPE)) {
+			collectCommandViolation(name, server, violations);
+		} else {
+			collectUrlViolation(name, type, server, violations);
+		}
+	}
+
+	private void collectCommandViolation(String name, JSONObject server, List<String> violations) {
+		if (server.optString(COMMAND_KEY, "").isBlank()) {
+			violations.add("mcp.json server '" + name + "' (stdio) is missing a 'command'");
+		}
+	}
+
+	private void collectUrlViolation(String name, String type, JSONObject server, List<String> violations) {
+		if (server.optString(URL_KEY, "").isBlank()) {
+			violations.add("mcp.json server '" + name + "' (" + type + ") is missing a 'url'");
+		}
+	}
+
+	private void collectRequiredServers(JSONObject servers, List<String> violations) {
+		if (requiredServers == null) {
+			return;
+		}
+		for (String name : requiredServers) {
+			if (!servers.has(name)) {
+				violations.add("mcp.json is missing required server: " + name);
+			}
+		}
+	}
+
+	private void collectForbiddenServers(JSONObject servers, List<String> violations) {
+		if (forbiddenServers == null) {
+			return;
+		}
+		for (String name : forbiddenServers) {
+			if (servers.has(name)) {
+				violations.add("mcp.json contains forbidden server: " + name);
+			}
+		}
+	}
+
+	private List<String> allowedTypes() {
+		return allowedTypes != null ? allowedTypes : DEFAULT_ALLOWED_TYPES;
+	}
+
+	void setMcpFile(File mcpFile) {
+		this.mcpFile = mcpFile;
+	}
+
+	void setRequiredServers(List<String> requiredServers) {
+		this.requiredServers = requiredServers;
+	}
+
+	void setForbiddenServers(List<String> forbiddenServers) {
+		this.forbiddenServers = forbiddenServers;
+	}
+
+	void setAllowedTypes(List<String> allowedTypes) {
+		this.allowedTypes = allowedTypes;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("McpServersValidRule[mcpFile=%s]", mcpFile);
+	}
+}

--- a/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -6,3 +6,4 @@ io.github.adamw7.tools.enforcer.settings.SettingsJsonValidRule
 io.github.adamw7.tools.enforcer.doc.CrossDocConsistencyRule
 io.github.adamw7.tools.enforcer.definition.CommandFormatRule
 io.github.adamw7.tools.enforcer.settings.HookCommandsValidRule
+io.github.adamw7.tools.enforcer.mcp.McpServersValidRule

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRuleTest.java
@@ -1,0 +1,169 @@
+package io.github.adamw7.tools.enforcer.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+
+class McpServersValidRuleTest {
+
+	private static final String VALID_MCP = """
+			{
+			  "mcpServers": {
+			    "filesystem": {
+			      "command": "npx",
+			      "args": [ "-y", "@modelcontextprotocol/server-filesystem" ]
+			    },
+			    "remote": {
+			      "type": "sse",
+			      "url": "https://example.com/sse"
+			    }
+			  }
+			}
+			""";
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesForValidConfiguration() {
+		assertDoesNotThrow(ruleFor(VALID_MCP)::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new McpServersValidRule()::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenFileIsAbsentBecauseMcpJsonIsOptional() {
+		McpServersValidRule rule = new McpServersValidRule();
+		rule.setMcpFile(tempDir.resolve("absent.json").toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenFileIsEmpty() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("   ")::execute);
+		assertTrue(exception.getMessage().contains("empty"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenJsonIsMalformed() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": ")::execute);
+		assertTrue(exception.getMessage().contains("not valid JSON"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenMcpServersObjectIsMissing() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("{ }")::execute);
+		assertTrue(exception.getMessage().contains("missing the 'mcpServers' object"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenServerIsNotAnObject() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"broken\": \"npx\" } }")::execute);
+		assertTrue(exception.getMessage().contains("server 'broken' must be a JSON object"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenStdioServerHasNoCommand() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"local\": { \"type\": \"stdio\" } } }")::execute);
+		assertTrue(exception.getMessage().contains("server 'local' (stdio) is missing a 'command'"),
+				exception.getMessage());
+	}
+
+	@Test
+	void failsWhenRemoteServerHasNoUrl() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"remote\": { \"type\": \"http\" } } }")::execute);
+		assertTrue(exception.getMessage().contains("server 'remote' (http) is missing a 'url'"),
+				exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTransportCannotBeInferred() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"mystery\": { } } }")::execute);
+		assertTrue(exception.getMessage().contains("must declare a 'command' (stdio) or a 'type' with a 'url'"),
+				exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTypeIsUnsupported() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"odd\": { \"type\": \"htttp\", \"url\": \"https://x\" } } }")::execute);
+		assertTrue(exception.getMessage().contains("server 'odd' has an unsupported type: htttp"),
+				exception.getMessage());
+	}
+
+	@Test
+	void failsWhenARequiredServerIsMissing() {
+		McpServersValidRule rule = ruleFor(VALID_MCP);
+		rule.setRequiredServers(List.of("github"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing required server: github"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAForbiddenServerIsPresent() {
+		McpServersValidRule rule = ruleFor(VALID_MCP);
+		rule.setForbiddenServers(List.of("remote"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("forbidden server: remote"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenServerPolicyIsSatisfied() {
+		McpServersValidRule rule = ruleFor(VALID_MCP);
+		rule.setRequiredServers(List.of("filesystem"));
+		rule.setForbiddenServers(List.of("github"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void warnsInsteadOfFailingWhenSeverityIsWarn() {
+		McpServersValidRule rule = ruleFor("{ \"mcpServers\": { \"mystery\": { } } }");
+		rule.setSeverity("warn");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("mystery")), logger.warnings().toString());
+	}
+
+	private McpServersValidRule ruleFor(String content) {
+		Path file = tempDir.resolve(".mcp.json");
+		writeString(file, content);
+		McpServersValidRule rule = new McpServersValidRule();
+		rule.setMcpFile(file.toFile());
+		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -424,6 +424,9 @@
 											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
 											<projectDir>${project.basedir}</projectDir>
 										</hookCommandsValid>
+										<mcpServersValid>
+											<mcpFile>${project.basedir}/.mcp.json</mcpFile>
+										</mcpServersValid>
 										<crossDocConsistency>
 											<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
 											<agentsMdFile>${project.basedir}/AGENTS.md</agentsMdFile>


### PR DESCRIPTION
Validate the project's optional .mcp.json: an absent file passes, while a
present file must be non-empty valid JSON whose mcpServers entries each carry
a well-formed transport (stdio needs command; sse/http need url). An explicit
type outside allowedTypes is rejected, and requiredServers/forbiddenServers
assert which MCP servers must or must not be declared.

Wire the rule into the root enforcer profile and document it in README and
AGENTS.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TDmBQd9s1ttPhQAucZo7Uk