### PR TITLE
refactor: dedup JSON file rules and firstNonBlankLine in enforcer

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
@@ -1,17 +1,13 @@
 package io.github.adamw7.tools.enforcer.mcp;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Named;
 
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.json.JSONException;
 import org.json.JSONObject;
 
-import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
 
 /**
  * Enforcer rule that fails the build when the project's {@code .mcp.json} is
@@ -35,7 +31,7 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * All problems found are reported together.
  */
 @Named("mcpServersValid")
-public class McpServersValidRule extends ClaudeCodeEnforcerRule {
+public class McpServersValidRule extends JsonFileRule {
 
 	private static final String MCP_SERVERS_KEY = "mcpServers";
 	private static final String TYPE_KEY = "type";
@@ -59,45 +55,33 @@ public class McpServersValidRule extends ClaudeCodeEnforcerRule {
 	private List<String> allowedTypes;
 
 	@Override
-	public void execute() throws EnforcerRuleException {
-		verifyConfigured();
-		if (!mcpFile.isFile()) {
-			return;
-		}
-		String content = readContent();
-		List<String> violations = new ArrayList<>();
-		parseAndCollect(content, violations);
-		report("mcp.json is not well formed:", violations);
+	protected File jsonFile() {
+		return mcpFile;
 	}
 
-	private void verifyConfigured() throws EnforcerRuleException {
-		if (mcpFile == null) {
-			throw new EnforcerRuleException("The mcpFile parameter is not configured");
-		}
+	@Override
+	protected String fileParameter() {
+		return "mcpFile";
 	}
 
-	private String readContent() throws EnforcerRuleException {
-		String content = MarkdownText.read(mcpFile, "mcp.json");
-		if (content.isBlank()) {
-			throw new EnforcerRuleException("mcp.json is empty: " + mcpFile);
-		}
-		return content;
+	@Override
+	protected String description() {
+		return "mcp.json";
 	}
 
-	private void parseAndCollect(String content, List<String> violations) {
-		JSONObject mcp = parse(content, violations);
-		if (mcp != null) {
-			collectServersViolations(mcp, violations);
-		}
+	@Override
+	protected String header() {
+		return "mcp.json is not well formed:";
 	}
 
-	private JSONObject parse(String content, List<String> violations) {
-		try {
-			return new JSONObject(content);
-		} catch (JSONException e) {
-			violations.add("mcp.json is not valid JSON: " + e.getMessage());
-			return null;
-		}
+	/** A project-level {@code .mcp.json} is optional in Claude Code, so an absent file is a pass. */
+	@Override
+	protected void handleMissingFile(File file) {
+	}
+
+	@Override
+	protected void collectViolations(JSONObject mcp, List<String> violations) {
+		collectServersViolations(mcp, violations);
 	}
 
 	private void collectServersViolations(JSONObject mcp, List<String> violations) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -1,0 +1,88 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * Base for enforcer rules that validate a single JSON configuration file. It
+ * owns the scaffolding every such rule repeats: the file parameter must be
+ * configured, the file must exist (unless the subclass treats absence as a
+ * pass), it must be non-empty, and it must parse as JSON. A parse failure is
+ * collected as a violation rather than thrown, so it is reported through the
+ * shared {@link #report} path alongside any structural problems.
+ * <p>
+ * Subclasses contribute the file, its parameter name, a human-readable
+ * description used in messages, the report header, and the document-specific
+ * checks against the parsed {@link JSONObject}. A misconfigured rule (missing
+ * file parameter) or a missing or empty file always fails, because that is a
+ * build-setup mistake; a rule whose file is optional overrides
+ * {@link #handleMissingFile} to pass instead.
+ */
+public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
+
+	@Override
+	public final void execute() throws EnforcerRuleException {
+		File file = jsonFile();
+		if (file == null) {
+			throw new EnforcerRuleException("The " + fileParameter() + " parameter is not configured");
+		}
+		if (!file.isFile()) {
+			handleMissingFile(file);
+			return;
+		}
+		List<String> violations = new ArrayList<>();
+		JSONObject root = parse(readContent(file), violations);
+		if (root != null) {
+			collectViolations(root, violations);
+		}
+		report(header(), violations);
+	}
+
+	/** The JSON file to validate. Injected from the rule configuration. */
+	protected abstract File jsonFile();
+
+	/** The configuration parameter name, used in the "not configured" message, e.g. {@code settingsFile}. */
+	protected abstract String fileParameter();
+
+	/** Human-readable file name used in messages, e.g. {@code settings.json}. */
+	protected abstract String description();
+
+	/** The header that prefixes the grouped violation report. */
+	protected abstract String header();
+
+	/** Document-specific checks against the parsed JSON. */
+	protected abstract void collectViolations(JSONObject root, List<String> violations);
+
+	/**
+	 * How to react when the file is absent. The default fails the build, because a
+	 * missing required file is a build-setup mistake. A rule whose file is optional
+	 * overrides this to return without reporting.
+	 */
+	protected void handleMissingFile(File file) throws EnforcerRuleException {
+		throw new EnforcerRuleException(description() + " does not exist at " + file);
+	}
+
+	private String readContent(File file) throws EnforcerRuleException {
+		String content = MarkdownText.read(file, description());
+		if (content.isBlank()) {
+			throw new EnforcerRuleException(description() + " is empty: " + file);
+		}
+		return content;
+	}
+
+	private JSONObject parse(String content, List<String> violations) {
+		try {
+			return new JSONObject(content);
+		} catch (JSONException e) {
+			violations.add(description() + " is not valid JSON: " + e.getMessage());
+			return null;
+		}
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -1,18 +1,14 @@
 package io.github.adamw7.tools.enforcer.settings;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Named;
 
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 
-import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
 
 /**
  * Enforcer rule that fails the build when the {@code hooks} section of
@@ -36,7 +32,7 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * are reported together.
  */
 @Named("hookCommandsValid")
-public class HookCommandsValidRule extends ClaudeCodeEnforcerRule {
+public class HookCommandsValidRule extends JsonFileRule {
 
 	private static final String HOOKS_KEY = "hooks";
 	private static final String TYPE_KEY = "type";
@@ -58,49 +54,28 @@ public class HookCommandsValidRule extends ClaudeCodeEnforcerRule {
 	private boolean validateScriptReferences = true;
 
 	@Override
-	public void execute() throws EnforcerRuleException {
-		verifyConfigured();
-		verifyFile();
-		String content = readContent();
-		List<String> violations = new ArrayList<>();
-		parseAndCollect(content, violations);
-		report("settings.json hooks are not well formed:", violations);
+	protected File jsonFile() {
+		return settingsFile;
 	}
 
-	private void verifyConfigured() throws EnforcerRuleException {
-		if (settingsFile == null) {
-			throw new EnforcerRuleException("The settingsFile parameter is not configured");
-		}
+	@Override
+	protected String fileParameter() {
+		return "settingsFile";
 	}
 
-	private void verifyFile() throws EnforcerRuleException {
-		if (!settingsFile.isFile()) {
-			throw new EnforcerRuleException("settings.json does not exist at " + settingsFile);
-		}
+	@Override
+	protected String description() {
+		return "settings.json";
 	}
 
-	private String readContent() throws EnforcerRuleException {
-		String content = MarkdownText.read(settingsFile, "settings.json");
-		if (content.isBlank()) {
-			throw new EnforcerRuleException("settings.json is empty: " + settingsFile);
-		}
-		return content;
+	@Override
+	protected String header() {
+		return "settings.json hooks are not well formed:";
 	}
 
-	private void parseAndCollect(String content, List<String> violations) {
-		JSONObject settings = parse(content, violations);
-		if (settings != null) {
-			collectHookViolations(settings, violations);
-		}
-	}
-
-	private JSONObject parse(String content, List<String> violations) {
-		try {
-			return new JSONObject(content);
-		} catch (JSONException e) {
-			violations.add("settings.json is not valid JSON: " + e.getMessage());
-			return null;
-		}
+	@Override
+	protected void collectViolations(JSONObject settings, List<String> violations) {
+		collectHookViolations(settings, violations);
 	}
 
 	private void collectHookViolations(JSONObject settings, List<String> violations) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
@@ -6,13 +6,10 @@ import java.util.List;
 
 import javax.inject.Named;
 
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 
-import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
 
 /**
  * Enforcer rule that fails the build when {@code .claude/settings.json} is
@@ -27,7 +24,7 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * reported together.
  */
 @Named("settingsJsonValid")
-public class SettingsJsonValidRule extends ClaudeCodeEnforcerRule {
+public class SettingsJsonValidRule extends JsonFileRule {
 
 	private static final String PERMISSIONS_KEY = "permissions";
 	private static final String ALLOW_KEY = "allow";
@@ -42,49 +39,28 @@ public class SettingsJsonValidRule extends ClaudeCodeEnforcerRule {
 	private List<String> forbiddenPermissions;
 
 	@Override
-	public void execute() throws EnforcerRuleException {
-		verifyConfigured();
-		verifyFile();
-		String content = readContent();
-		List<String> violations = new ArrayList<>();
-		parseAndCollect(content, violations);
-		report("settings.json is not well formed:", violations);
+	protected File jsonFile() {
+		return settingsFile;
 	}
 
-	private void verifyConfigured() throws EnforcerRuleException {
-		if (settingsFile == null) {
-			throw new EnforcerRuleException("The settingsFile parameter is not configured");
-		}
+	@Override
+	protected String fileParameter() {
+		return "settingsFile";
 	}
 
-	private void verifyFile() throws EnforcerRuleException {
-		if (!settingsFile.isFile()) {
-			throw new EnforcerRuleException("settings.json does not exist at " + settingsFile);
-		}
+	@Override
+	protected String description() {
+		return "settings.json";
 	}
 
-	private String readContent() throws EnforcerRuleException {
-		String content = MarkdownText.read(settingsFile, "settings.json");
-		if (content.isBlank()) {
-			throw new EnforcerRuleException("settings.json is empty: " + settingsFile);
-		}
-		return content;
+	@Override
+	protected String header() {
+		return "settings.json is not well formed:";
 	}
 
-	private void parseAndCollect(String content, List<String> violations) {
-		JSONObject settings = parse(content, violations);
-		if (settings != null) {
-			collectPermissionViolations(settings, violations);
-		}
-	}
-
-	private JSONObject parse(String content, List<String> violations) {
-		try {
-			return new JSONObject(content);
-		} catch (JSONException e) {
-			violations.add("settings.json is not valid JSON: " + e.getMessage());
-			return null;
-		}
+	@Override
+	protected void collectViolations(JSONObject settings, List<String> violations) {
+		collectPermissionViolations(settings, violations);
 	}
 
 	private void collectPermissionViolations(JSONObject settings, List<String> violations) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -54,7 +54,7 @@ public final class MarkdownDocument {
 
 	/** The first line that is not blank, stripped of surrounding whitespace, or empty if none. */
 	public String firstNonBlankLine() {
-		return lines.stream().map(String::strip).filter(line -> !line.isEmpty()).findFirst().orElse("");
+		return MarkdownText.firstNonBlankLine(lines.stream());
 	}
 
 	/** True when {@code token} appears on a line outside a fenced code block. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.util.stream.Stream;
 
 /**
  * Small helpers for reading Markdown content. Shared by the enforcer rules so
@@ -40,10 +41,11 @@ public final class MarkdownText {
 
 	/** The first line that is not blank, stripped of surrounding whitespace, or empty if none. */
 	public static String firstNonBlankLine(String content) {
-		return content.lines()
-				.map(String::strip)
-				.filter(line -> !line.isEmpty())
-				.findFirst()
-				.orElse("");
+		return firstNonBlankLine(content.lines());
+	}
+
+	/** The first line that is not blank, stripped of surrounding whitespace, or empty if none. */
+	public static String firstNonBlankLine(Stream<String> lines) {
+		return lines.map(String::strip).filter(line -> !line.isEmpty()).findFirst().orElse("");
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
@@ -1,0 +1,173 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JsonFileRuleTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void failsWhenFileIsNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new TestJsonRule()::execute);
+		assertTrue(exception.getMessage().contains("The testFile parameter is not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenFileIsMissingByDefault() {
+		TestJsonRule rule = new TestJsonRule();
+		rule.setFile(tempDir.resolve("absent.json").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("test.json does not exist at"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenAnOptionalFileIsMissing() {
+		TestJsonRule rule = new TestJsonRule();
+		rule.setOptional(true);
+		rule.setFile(tempDir.resolve("absent.json").toFile());
+
+		assertDoesNotThrow(rule::execute);
+		assertNull(rule.parsedRoot, "collectViolations must not run when the file is absent");
+	}
+
+	@Test
+	void failsWhenFileIsEmpty() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("   ")::execute);
+		assertTrue(exception.getMessage().contains("test.json is empty"), exception.getMessage());
+	}
+
+	@Test
+	void reportsMalformedJsonAsAViolationWithoutDispatchingToCollect() {
+		TestJsonRule rule = ruleFor("{ \"broken\": ");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("test.json is not valid JSON"), exception.getMessage());
+		assertNull(rule.parsedRoot, "collectViolations must not run when parsing fails");
+	}
+
+	@Test
+	void passesValidJsonAndPassesTheParsedObjectToCollect() {
+		TestJsonRule rule = ruleFor("{ \"name\": \"value\" }");
+
+		assertDoesNotThrow(rule::execute);
+		assertNotNull(rule.parsedRoot, "collectViolations must receive the parsed object");
+		assertEquals("value", rule.parsedRoot.getString("name"));
+	}
+
+	@Test
+	void reportsCollectedViolationsUnderTheHeader() {
+		TestJsonRule rule = ruleFor("{ }");
+		rule.addViolation("something is wrong");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("test.json is not well formed:"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("something is wrong"), exception.getMessage());
+	}
+
+	@Test
+	void warnSeverityDowngradesCollectedViolationsToAWarning() {
+		TestJsonRule rule = ruleFor("{ }");
+		rule.addViolation("something is wrong");
+		rule.setSeverity("warn");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertEquals(1, logger.warnings().size());
+		assertTrue(logger.warnings().get(0).contains("something is wrong"), logger.warnings().get(0));
+	}
+
+	private TestJsonRule ruleFor(String content) {
+		Path file = tempDir.resolve("test.json");
+		writeString(file, content);
+		TestJsonRule rule = new TestJsonRule();
+		rule.setFile(file.toFile());
+		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	/**
+	 * Minimal concrete rule that records what the base class hands to
+	 * {@link #collectViolations} so the shared scaffolding can be asserted in
+	 * isolation from any real document checks.
+	 */
+	private static final class TestJsonRule extends JsonFileRule {
+
+		private File file;
+		private boolean optional;
+		private final List<String> injectedViolations = new ArrayList<>();
+		private JSONObject parsedRoot;
+
+		void setFile(File file) {
+			this.file = file;
+		}
+
+		void setOptional(boolean optional) {
+			this.optional = optional;
+		}
+
+		void addViolation(String violation) {
+			injectedViolations.add(violation);
+		}
+
+		@Override
+		protected File jsonFile() {
+			return file;
+		}
+
+		@Override
+		protected String fileParameter() {
+			return "testFile";
+		}
+
+		@Override
+		protected String description() {
+			return "test.json";
+		}
+
+		@Override
+		protected String header() {
+			return "test.json is not well formed:";
+		}
+
+		@Override
+		protected void handleMissingFile(File missing) throws EnforcerRuleException {
+			if (!optional) {
+				super.handleMissingFile(missing);
+			}
+		}
+
+		@Override
+		protected void collectViolations(JSONObject root, List<String> violations) {
+			this.parsedRoot = root;
+			violations.addAll(injectedViolations);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownTextTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownTextTest.java
@@ -1,0 +1,98 @@
+package io.github.adamw7.tools.enforcer.text;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MarkdownTextTest {
+
+	private static final char BYTE_ORDER_MARK = (char) 0xFEFF;
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void firstNonBlankLineSkipsLeadingBlanksAndStrips() {
+		assertEquals("# Title", MarkdownText.firstNonBlankLine("\n   \n   # Title  \nbody"));
+	}
+
+	@Test
+	void firstNonBlankLineIsEmptyWhenAllBlank() {
+		assertEquals("", MarkdownText.firstNonBlankLine("\n   \n\t\n"));
+	}
+
+	@Test
+	void firstNonBlankLineIsEmptyForEmptyContent() {
+		assertEquals("", MarkdownText.firstNonBlankLine(""));
+	}
+
+	@Test
+	void streamOverloadMatchesTheStringOverload() {
+		String content = "\n   \n   # Title  \nbody";
+
+		assertEquals(MarkdownText.firstNonBlankLine(content),
+				MarkdownText.firstNonBlankLine(content.lines()));
+	}
+
+	@Test
+	void streamOverloadStripsAndPicksTheFirstContentLine() {
+		assertEquals("# Title", MarkdownText.firstNonBlankLine(Stream.of("", "   ", "  # Title  ", "body")));
+	}
+
+	@Test
+	void streamOverloadIsEmptyWhenNoContentLine() {
+		assertEquals("", MarkdownText.firstNonBlankLine(Stream.of("", "   ", "\t")));
+	}
+
+	@Test
+	void stripByteOrderMarkRemovesALeadingMark() {
+		assertEquals("# Title", MarkdownText.stripByteOrderMark(BYTE_ORDER_MARK + "# Title"));
+	}
+
+	@Test
+	void stripByteOrderMarkLeavesContentWithoutAMarkUnchanged() {
+		String content = "# Title";
+
+		assertSame(content, MarkdownText.stripByteOrderMark(content));
+	}
+
+	@Test
+	void stripByteOrderMarkHandlesEmptyContent() {
+		assertEquals("", MarkdownText.stripByteOrderMark(""));
+	}
+
+	@Test
+	void readReturnsFileContentWithTheByteOrderMarkStripped() {
+		Path file = tempDir.resolve("doc.md");
+		writeString(file, BYTE_ORDER_MARK + "# Title\nbody");
+
+		assertEquals("# Title\nbody", MarkdownText.read(file.toFile(), "doc.md"));
+	}
+
+	@Test
+	void readWrapsAReadFailureWithTheDescription() {
+		Path missing = tempDir.resolve("absent.md");
+
+		UncheckedIOException exception = assertThrows(UncheckedIOException.class,
+				() -> MarkdownText.read(missing.toFile(), "absent.md"));
+		assertTrue(exception.getMessage().contains("absent.md"), exception.getMessage());
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}


### PR DESCRIPTION
Extract a shared JsonFileRule base class holding the configure/exist/
read/parse scaffolding that SettingsJsonValidRule, HookCommandsValidRule
and McpServersValidRule each repeated. Rules where the file is optional
(mcp.json) override handleMissingFile to pass instead of failing.

Collapse the duplicated firstNonBlankLine stream pipeline: MarkdownDocument
now delegates to a Stream-based MarkdownText.firstNonBlankLine overload.

No behaviour change; all 131 tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NUZgFDSiAkbxJYaBkQyYyX