### PR TITLE
feat(enforcer): add uniqueNames rule for command/agent/skill names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,13 @@ profile:
   `http` server needs a `url`). An explicit `type` outside `allowedTypes`
   (`stdio`, `sse`, `http` by default) is rejected, and `requiredServers` /
   `forbiddenServers` assert which servers must or must not be declared.
+- `UniqueNamesRule` (`uniqueNames`) gathers the names of every command,
+  sub-agent, and skill from the configured `commandsDir`, `agentsDir`, and
+  `skillsDir` (file name for commands and sub-agents, directory name for skills)
+  and fails when a name is used more than once, naming every source that uses it.
+  At least one directory must be configured, any configured directory must
+  exist, and uniqueness is checked across all of them at once, so a command that
+  clashes with a skill is caught just like two clashing commands.
 - `CrossDocConsistencyRule` (`crossDocConsistency`) keeps `CLAUDE.md` and
   `AGENTS.md` from contradicting each other: each configured `consistentPatterns`
   regex (one capturing group) must capture the same value in both files, e.g.

--- a/README.md
+++ b/README.md
@@ -362,6 +362,14 @@ consistent and in their expected shape:
   catching a mistyped `htttp`. `requiredServers` must all be present and
   `forbiddenServers` must all be absent, so a project can mandate an MCP server
   it relies on or ban one it does not want committed.
+- **`uniqueNames`** (`UniqueNamesRule`) — gathers the names of every command,
+  sub-agent, and skill from the configured `commandsDir`, `agentsDir`, and
+  `skillsDir` (a command's and a sub-agent's name is its `*.md` file name, a
+  skill's name is its directory name) and fails when one name is used more than
+  once, naming every file or directory that uses it. At least one directory must
+  be configured, and any directory that is configured must exist. Uniqueness is
+  checked across all configured directories at once, so a command that clashes
+  with a skill is caught just like two commands that clash.
 - **`crossDocConsistency`** (`CrossDocConsistencyRule`) — keeps `CLAUDE.md` and
   `AGENTS.md` from contradicting each other. Each configured `consistentPattern`
   is a regular expression with one capturing group; the captured value must

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRule.java
@@ -1,0 +1,147 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+
+/**
+ * Enforcer rule that fails the build when two Claude Code definitions claim the
+ * same name. A command's name is its {@code *.md} file name, a sub-agent's name
+ * is its {@code *.md} file name, and a skill's name is its directory name, so a
+ * command and a sub-agent both called {@code review}, or two skills called
+ * {@code commit}, are a real source of confusion. The rule gathers the names
+ * from every configured directory and reports each name that is used more than
+ * once, naming every file or directory that uses it.
+ * <p>
+ * The three directories are independent: {@code commandsDir}, {@code agentsDir}
+ * and {@code skillsDir} are each optional, and at least one must be configured.
+ * A directory that is configured must exist, because that is a build-setup
+ * mistake rather than a naming problem. Uniqueness is checked across every
+ * configured directory at once, so a clash between a command and a skill is
+ * caught just like a clash between two commands. All clashes found are reported
+ * together.
+ */
+@Named("uniqueNames")
+public class UniqueNamesRule extends ClaudeCodeEnforcerRule {
+
+	private static final String MARKDOWN_SUFFIX = ".md";
+
+	/** The {@code .claude/commands} directory to scan. Injected from the rule configuration. */
+	private File commandsDir;
+
+	/** The {@code .claude/agents} directory to scan. Injected from the rule configuration. */
+	private File agentsDir;
+
+	/** The {@code .claude/skills} directory to scan. Injected from the rule configuration. */
+	private File skillsDir;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		verifyConfigured();
+		Map<String, List<String>> sourcesByName = new LinkedHashMap<>();
+		collectMarkdownNames(commandsDir, "Commands", sourcesByName);
+		collectMarkdownNames(agentsDir, "Agents", sourcesByName);
+		collectSkillNames(skillsDir, sourcesByName);
+		report("Claude Code names must be unique:", duplicates(sourcesByName));
+	}
+
+	private void verifyConfigured() throws EnforcerRuleException {
+		if (commandsDir == null && agentsDir == null && skillsDir == null) {
+			throw new EnforcerRuleException(
+					"At least one of commandsDir, agentsDir or skillsDir must be configured");
+		}
+	}
+
+	private void collectMarkdownNames(File directory, String label, Map<String, List<String>> sourcesByName)
+			throws EnforcerRuleException {
+		if (directory == null) {
+			return;
+		}
+		verifyDirectory(directory, label);
+		for (File markdown : listMarkdownFiles(directory)) {
+			record(baseName(markdown), markdown.toString(), sourcesByName);
+		}
+	}
+
+	private void collectSkillNames(File directory, Map<String, List<String>> sourcesByName)
+			throws EnforcerRuleException {
+		if (directory == null) {
+			return;
+		}
+		verifyDirectory(directory, "Skills");
+		for (File skill : listSubdirectories(directory)) {
+			record(skill.getName(), skill.toString(), sourcesByName);
+		}
+	}
+
+	private void verifyDirectory(File directory, String label) throws EnforcerRuleException {
+		if (!directory.isDirectory()) {
+			throw new EnforcerRuleException(label + " directory does not exist at " + directory);
+		}
+	}
+
+	private void record(String name, String source, Map<String, List<String>> sourcesByName) {
+		sourcesByName.computeIfAbsent(name, key -> new ArrayList<>()).add(source);
+	}
+
+	private List<String> duplicates(Map<String, List<String>> sourcesByName) {
+		List<String> violations = new ArrayList<>();
+		for (Map.Entry<String, List<String>> entry : sourcesByName.entrySet()) {
+			addDuplicateViolation(entry, violations);
+		}
+		return violations;
+	}
+
+	private void addDuplicateViolation(Map.Entry<String, List<String>> entry, List<String> violations) {
+		List<String> sources = entry.getValue();
+		if (sources.size() > 1) {
+			violations.add("name '" + entry.getKey() + "' is used by " + sources.size()
+					+ " definitions: " + String.join(", ", sources));
+		}
+	}
+
+	private File[] listMarkdownFiles(File directory) {
+		File[] files = directory.listFiles(this::isMarkdownFile);
+		return files != null ? files : new File[0];
+	}
+
+	private File[] listSubdirectories(File directory) {
+		File[] directories = directory.listFiles(File::isDirectory);
+		return directories != null ? directories : new File[0];
+	}
+
+	private boolean isMarkdownFile(File file) {
+		return file.isFile() && file.getName().endsWith(MARKDOWN_SUFFIX);
+	}
+
+	private String baseName(File markdown) {
+		String name = markdown.getName();
+		return name.substring(0, name.length() - MARKDOWN_SUFFIX.length());
+	}
+
+	void setCommandsDir(File commandsDir) {
+		this.commandsDir = commandsDir;
+	}
+
+	void setAgentsDir(File agentsDir) {
+		this.agentsDir = agentsDir;
+	}
+
+	void setSkillsDir(File skillsDir) {
+		this.skillsDir = skillsDir;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("UniqueNamesRule[commandsDir=%s, agentsDir=%s, skillsDir=%s]",
+				commandsDir, agentsDir, skillsDir);
+	}
+}

--- a/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -7,3 +7,4 @@ io.github.adamw7.tools.enforcer.doc.CrossDocConsistencyRule
 io.github.adamw7.tools.enforcer.definition.CommandFormatRule
 io.github.adamw7.tools.enforcer.settings.HookCommandsValidRule
 io.github.adamw7.tools.enforcer.mcp.McpServersValidRule
+io.github.adamw7.tools.enforcer.definition.UniqueNamesRule

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRuleTest.java
@@ -1,0 +1,171 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+
+class UniqueNamesRuleTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesWhenEveryNameIsUnique() {
+		Path commands = createDir("commands");
+		Path agents = createDir("agents");
+		Path skills = createDir("skills");
+		writeMarkdown(commands.resolve("commit.md"));
+		writeMarkdown(agents.resolve("reviewer.md"));
+		createSkill(skills, "planner");
+
+		assertDoesNotThrow(ruleFor(commands, agents, skills)::execute);
+	}
+
+	@Test
+	void passesWhenNoDefinitionsExist() {
+		Path commands = createDir("commands");
+		Path agents = createDir("agents");
+		Path skills = createDir("skills");
+
+		assertDoesNotThrow(ruleFor(commands, agents, skills)::execute);
+	}
+
+	@Test
+	void passesWhenOnlyOneDirectoryIsConfigured() {
+		Path skills = createDir("skills");
+		createSkill(skills, "commit");
+		createSkill(skills, "review");
+
+		UniqueNamesRule rule = new UniqueNamesRule();
+		rule.setSkillsDir(skills.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void ignoresNonMarkdownFiles() {
+		Path commands = createDir("commands");
+		writeString(commands.resolve("notes.txt"), "not a command");
+
+		UniqueNamesRule rule = new UniqueNamesRule();
+		rule.setCommandsDir(commands.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new UniqueNamesRule()::execute);
+		assertTrue(exception.getMessage().contains("must be configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenConfiguredDirectoryIsMissing() {
+		UniqueNamesRule rule = new UniqueNamesRule();
+		rule.setCommandsDir(tempDir.resolve("absent").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenACommandAndASubAgentShareAName() {
+		Path commands = createDir("commands");
+		Path agents = createDir("agents");
+		writeMarkdown(commands.resolve("review.md"));
+		writeMarkdown(agents.resolve("review.md"));
+
+		UniqueNamesRule rule = new UniqueNamesRule();
+		rule.setCommandsDir(commands.toFile());
+		rule.setAgentsDir(agents.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("name 'review'"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("2 definitions"), exception.getMessage());
+		assertTrue(exception.getMessage().contains(commands.resolve("review.md").toString()), exception.getMessage());
+		assertTrue(exception.getMessage().contains(agents.resolve("review.md").toString()), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenASubAgentAndASkillShareAName() {
+		Path agents = createDir("agents");
+		Path skills = createDir("skills");
+		writeMarkdown(agents.resolve("commit.md"));
+		createSkill(skills, "commit");
+
+		UniqueNamesRule rule = new UniqueNamesRule();
+		rule.setAgentsDir(agents.toFile());
+		rule.setSkillsDir(skills.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("name 'commit'"), exception.getMessage());
+	}
+
+	@Test
+	void downgradesClashToAWarningWhenSeverityIsWarn() {
+		Path commands = createDir("commands");
+		Path agents = createDir("agents");
+		writeMarkdown(commands.resolve("review.md"));
+		writeMarkdown(agents.resolve("review.md"));
+
+		UniqueNamesRule rule = new UniqueNamesRule();
+		rule.setCommandsDir(commands.toFile());
+		rule.setAgentsDir(agents.toFile());
+		rule.setSeverity("warn");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("name 'review'")),
+				logger.warnings().toString());
+	}
+
+	private UniqueNamesRule ruleFor(Path commandsDir, Path agentsDir, Path skillsDir) {
+		UniqueNamesRule rule = new UniqueNamesRule();
+		rule.setCommandsDir(commandsDir.toFile());
+		rule.setAgentsDir(agentsDir.toFile());
+		rule.setSkillsDir(skillsDir.toFile());
+		return rule;
+	}
+
+	private Path createDir(String name) {
+		try {
+			return Files.createDirectories(tempDir.resolve(name));
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create " + name, e);
+		}
+	}
+
+	private void createSkill(Path skillsDir, String name) {
+		Path skill = skillsDir.resolve(name);
+		try {
+			Files.createDirectories(skill);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create skill " + name, e);
+		}
+		writeString(skill.resolve("SKILL.md"), "# " + name);
+	}
+
+	private void writeMarkdown(Path file) {
+		writeString(file, "# " + file.getFileName());
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,9 @@
 										<skillFilesExist>
 											<skillsDir>${project.basedir}/.claude/skills</skillsDir>
 										</skillFilesExist>
+										<uniqueNames>
+											<skillsDir>${project.basedir}/.claude/skills</skillsDir>
+										</uniqueNames>
 										<settingsJsonValid>
 											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
 										</settingsJsonValid>


### PR DESCRIPTION
Add a UniqueNamesRule that gathers the names of every command, sub-agent,
and skill from the configured commandsDir, agentsDir, and skillsDir and
fails the build when one name is used more than once, naming every source
that uses it. Names come from the *.md file name for commands and
sub-agents and from the directory name for skills. At least one directory
must be configured, any configured directory must exist, and uniqueness is
checked across all configured directories at once so a command that clashes
with a skill is caught just like two clashing commands.

Register the rule in the Sisu index, wire it into the root enforcer profile
against .claude/skills, and document it in README.md and AGENTS.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HBrusxu6oofFeTzDuRB42X