### PR TITLE
build(shellcheck): force LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must always use LF, even when checked out on Windows.
+# shellcheck (SC1017) rejects literal carriage returns, so CRLF breaks the build.
+*.sh text eol=lf


### PR DESCRIPTION
## Problem

Running `mvn clean install` on Windows fails in the `shellcheck` plugin goal with a cryptic `Input length = 1` error.

Root cause: with `core.autocrlf=true`, the scripts under `scripts/` are checked out with **CRLF** line endings on Windows. shellcheck then reports `SC1017` (literal carriage return) on every line, and the failing output (which echoes a comment line containing UTF-8 box-drawing characters) trips a strict-UTF-8 decode in the plugin, surfacing as `Input length = 1`.

Linux CI is unaffected because the working tree there keeps LF.

## Fix

Add a `.gitattributes` that pins `*.sh` to `text eol=lf`, so the working tree always uses LF regardless of platform. shellcheck now passes and `mvn install` is green on Windows.

## Verification

- `shellcheck scripts/linux/*.sh` → exit 0
- shell scripts now check out as `w/lf` on Windows (`git ls-files --eol`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)