### PR TITLE
fix(context): correct depth-bounded dependency traversal in Finder

### DIFF
--- a/code/context/src/main/java/io/github/adamw7/context/ClassContainer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/ClassContainer.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 
 public class ClassContainer {
 
@@ -29,5 +30,21 @@ public class ClassContainer {
 
 	public String className() {
 		return className;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (this == other) {
+			return true;
+		}
+		if (!(other instanceof ClassContainer container)) {
+			return false;
+		}
+		return className.equals(container.className) && originalCode.equals(container.originalCode);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(className, originalCode);
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/Finder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/Finder.java
@@ -3,13 +3,41 @@ package io.github.adamw7.context;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Resolves the classes a source file depends on by scanning its text for class
+ * references. Traversal is a breadth-first expansion of the dependency graph
+ * bounded by {@code depth}: every visited class is recorded once, so cycles
+ * terminate and no node is expanded twice. The root itself is never reported as
+ * one of its own dependencies.
+ *
+ * <p>Resolution is by simple file name (a referenced {@code Foo} resolves to a
+ * {@code Foo} source file of the configured {@link Language}). Comments, string
+ * and character literals are stripped before matching so that class names
+ * mentioned there are not reported as dependencies. Two source files sharing the
+ * same simple name in different packages still cannot be told apart — that needs
+ * package-aware resolution, which this name-based finder does not attempt.
+ */
 public class Finder implements Context {
+
 	private static final Logger log = LogManager.getLogger(Finder.class.getName());
+
+	private static final Pattern CLASS_REFERENCE =
+			Pattern.compile("\\b[A-Z][A-Za-z0-9_]*(\\.[A-Z][A-Za-z0-9_]*)*\\b");
+
+	private static final Pattern COMMENTS_AND_LITERALS = Pattern.compile(
+			"\"\"\".*?\"\"\""              // Kotlin triple-quoted string
+			+ "|//[^\\n]*"                 // line comment
+			+ "|/\\*.*?\\*/"               // block comment
+			+ "|\"(?:\\\\.|[^\"\\\\])*\""  // string literal
+			+ "|'(?:\\\\.|[^'\\\\])*'",    // character literal
+			Pattern.DOTALL);
+
 	private final Set<ClassContainer> allContainers;
 	private final Language language;
 
@@ -24,35 +52,66 @@ public class Finder implements Context {
 
 	@Override
 	public Set<ClassContainer> find(ClassContainer root, int depth) {
-		Set<ClassContainer> classes = findAllUsedClasses(root, depth);
-		for (int i = depth - 1; i > 0; i--) {
-			for (ClassContainer clazz : classes) {
-				classes.addAll(find(clazz, i));
-			}
-		}
-		return classes;
+		requirePositiveDepth(depth);
+		Set<ClassContainer> dependencies = new LinkedHashSet<>();
+		Set<ClassContainer> visited = new HashSet<>();
+		visited.add(root);
+		expand(root, depth, dependencies, visited);
+		return dependencies;
 	}
 
-	private Set<ClassContainer> findAllUsedClasses(ClassContainer root, int depth) {
+	private void requirePositiveDepth(int depth) {
 		if (depth <= 0) {
 			throw new IllegalArgumentException("Depth must be positive and received: " + depth);
 		}
-		Pattern pattern = Pattern.compile("\\b[A-Z][A-Za-z0-9_]*(\\.[A-Z][A-Za-z0-9_]*)*\\b");
-		return findByRegEx(root, pattern);
 	}
 
-	private Set<ClassContainer> findByRegEx(ClassContainer root, Pattern pattern) {
-		Set<ClassContainer> classes = ConcurrentHashMap.newKeySet();
-		Matcher matcher = pattern.matcher(root.originalCode());
-		while (matcher.find()) {
-			String className = matcher.group();
-			ClassContainer container = findContainer(className);
-			if (container != null) {
-				log.info("Found {} used in {}", container.className(), root.className());
-				classes.add(container);				
+	private void expand(ClassContainer root, int depth, Set<ClassContainer> dependencies,
+			Set<ClassContainer> visited) {
+		Set<ClassContainer> frontier = Set.of(root);
+		for (int level = 0; level < depth && !frontier.isEmpty(); level++) {
+			frontier = nextLevel(frontier, dependencies, visited);
+		}
+	}
+
+	private Set<ClassContainer> nextLevel(Set<ClassContainer> frontier,
+			Set<ClassContainer> dependencies, Set<ClassContainer> visited) {
+		Set<ClassContainer> next = new LinkedHashSet<>();
+		for (ClassContainer current : frontier) {
+			addNewDependencies(current, dependencies, visited, next);
+		}
+		return next;
+	}
+
+	private void addNewDependencies(ClassContainer current, Set<ClassContainer> dependencies,
+			Set<ClassContainer> visited, Set<ClassContainer> next) {
+		for (ClassContainer dependency : findDirectDependencies(current)) {
+			if (visited.add(dependency)) {
+				dependencies.add(dependency);
+				next.add(dependency);
 			}
 		}
-		return classes;
+	}
+
+	private Set<ClassContainer> findDirectDependencies(ClassContainer source) {
+		Set<ClassContainer> dependencies = new LinkedHashSet<>();
+		Matcher matcher = CLASS_REFERENCE.matcher(stripCommentsAndLiterals(source.originalCode()));
+		while (matcher.find()) {
+			addResolved(matcher.group(), source, dependencies);
+		}
+		return dependencies;
+	}
+
+	private void addResolved(String className, ClassContainer source, Set<ClassContainer> dependencies) {
+		ClassContainer container = findContainer(className);
+		if (container != null) {
+			log.info("Found {} used in {}", container.className(), source.className());
+			dependencies.add(container);
+		}
+	}
+
+	private String stripCommentsAndLiterals(String code) {
+		return COMMENTS_AND_LITERALS.matcher(code).replaceAll(" ");
 	}
 
 	private ClassContainer findContainer(String className) {

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeBuilder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeBuilder.java
@@ -99,7 +99,6 @@ public class ProjectTreeBuilder {
 		}
 		context.find(container, depth).stream()
 				.map(ClassContainer::className)
-				.filter(dependency -> !dependency.equals(container.className()))
 				.sorted()
 				.forEach(node::addDependency);
 	}

--- a/code/context/src/test/java/io/github/adamw7/context/FinderTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/FinderTest.java
@@ -1,73 +1,124 @@
 package io.github.adamw7.context;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class FinderTest {
-	protected final static Set<ClassContainer> allContainers = new HashSet<>();
-	protected final	 static String currentDir = new File(System.getProperty("user.dir")).getParentFile().getParent() 
-			+ "/data/src/main/java/io/github/adamw7/tools/data/source/file/";
 
-	@BeforeAll
-	public static void prepareSources() {
-		allContainers.add(createContainer(currentDir + toFileName("AbstractFileSource")));
-		allContainers.add(createContainer(currentDir + toFileName("CSVDataSource")));
+	@TempDir
+	Path projectRoot;
+
+	@Test
+	void rejectsNonPositiveDepth() throws IOException {
+		ClassContainer a = writeJava("A", "public class A {}");
+		Finder finder = new Finder(containers(a));
+
+		assertThrows(IllegalArgumentException.class, () -> finder.find(a, 0));
+		assertThrows(IllegalArgumentException.class, () -> finder.find(a, -1));
 	}
 
-	private static String toFileName(String clazz) {
-		return clazz + ".java";
+	@Test
+	void leafHasNoDependencies() throws IOException {
+		ClassContainer a = writeJava("A", "public class A {}");
+
+		assertTrue(new Finder(containers(a)).find(a, 1).isEmpty());
 	}
 
-	private static ClassContainer createContainer(String location) {
-		File file = new File(location);
-		Path path = Path.of(file.getAbsolutePath());
+	@Test
+	void rootIsNeverItsOwnDependency() throws IOException {
+		ClassContainer a = writeJava("A", "public class A { A self; }");
+
+		assertTrue(new Finder(containers(a)).find(a, 1).isEmpty());
+	}
+
+	@Test
+	void findsDirectDependencyAtDepthOne() throws IOException {
+		ClassContainer a = writeJava("A", "public class A {}");
+		ClassContainer b = writeJava("B", "public class B { A a; }");
+
+		Set<ClassContainer> dependencies = new Finder(containers(a, b)).find(b, 1);
+
+		assertEquals(names("A.java"), classNames(dependencies));
+	}
+
+	@Test
+	void stopsAtTheRequestedDepth() throws IOException {
+		ClassContainer a = writeJava("A", "public class A {}");
+		ClassContainer b = writeJava("B", "public class B { A a; }");
+		ClassContainer c = writeJava("C", "public class C { B b; }");
+		Set<ClassContainer> all = containers(a, b, c);
+
+		assertEquals(names("B.java"), classNames(new Finder(all).find(c, 1)));
+		assertEquals(names("A.java", "B.java"), classNames(new Finder(all).find(c, 2)));
+	}
+
+	@Test
+	void doesNotWalkPastDepthInLongerChain() throws IOException {
+		ClassContainer a = writeJava("A", "public class A {}");
+		ClassContainer b = writeJava("B", "public class B { A a; }");
+		ClassContainer c = writeJava("C", "public class C { B b; }");
+		ClassContainer d = writeJava("D", "public class D { C c; }");
+
+		Set<ClassContainer> dependencies = new Finder(containers(a, b, c, d)).find(d, 2);
+
+		assertEquals(names("B.java", "C.java"), classNames(dependencies));
+	}
+
+	@Test
+	void terminatesOnCycles() throws IOException {
+		ClassContainer a = writeJava("A", "public class A { B b; }");
+		ClassContainer b = writeJava("B", "public class B { A a; }");
+
+		Set<ClassContainer> dependencies = new Finder(containers(a, b)).find(a, 10);
+
+		assertEquals(names("B.java"), classNames(dependencies));
+	}
+
+	@Test
+	void ignoresClassNamesInComments() throws IOException {
+		ClassContainer a = writeJava("A", "public class A {}");
+		ClassContainer b = writeJava("B", "public class B { /* uses A */ // also A\n }");
+
+		assertTrue(new Finder(containers(a, b)).find(b, 1).isEmpty());
+	}
+
+	@Test
+	void ignoresClassNamesInStringLiterals() throws IOException {
+		ClassContainer a = writeJava("A", "public class A {}");
+		ClassContainer b = writeJava("B", "public class B { String s = \"A\"; }");
+
+		assertTrue(new Finder(containers(a, b)).find(b, 1).isEmpty());
+	}
+
+	private ClassContainer writeJava(String className, String body) throws IOException {
+		Path path = projectRoot.resolve(className + ".java");
+		Files.writeString(path, body);
 		return ClassContainer.load(path, path.getFileName().toString());
 	}
 
-	@Test
-	void levelOne() {
-		ClassContainer root = createContainer(currentDir + toFileName("AbstractFileSource"));
-		Set<ClassContainer> classes = new Finder(allContainers).find(root, 1);
-
-		require(classes, toFileName("AbstractFileSource"));
+	private Set<ClassContainer> containers(ClassContainer... containers) {
+		return new HashSet<>(Set.of(containers));
 	}
 
-	private void require(Set<ClassContainer> classes, String... fileNames) {
-		assertEquals(classes.size(), fileNames.length);
-		Set<String> found = lookForFileNames(classes, fileNames);
-		for (String fileName : fileNames) {
-			assertTrue(found.contains(fileName));
+	private Set<String> classNames(Set<ClassContainer> containers) {
+		Set<String> names = new HashSet<>();
+		for (ClassContainer container : containers) {
+			names.add(container.className());
 		}
+		return names;
 	}
 
-	private Set<String> lookForFileNames(Set<ClassContainer> classes, String... fileNames) {
-		Set<String> found = new HashSet<>();
-
-		for (ClassContainer clazz : classes) {
-			for (String fileName : fileNames) {
-				if (clazz.className().equals(fileName)) {
-					found.add(fileName);
-				}
-			}
-		}
-		return found;
-	}
-	
-	@Test
-	void levelTwo() {
-		ClassContainer root = createContainer(currentDir + toFileName("CSVDataSource"));
-		
-		Set<ClassContainer> classes = new Finder(allContainers).find(root, 2);
-
-		require(classes, toFileName("AbstractFileSource"),
-				toFileName("CSVDataSource"));
+	private Set<String> names(String... names) {
+		return new HashSet<>(Set.of(names));
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/KotlinFinderTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/KotlinFinderTest.java
@@ -25,9 +25,8 @@ public class KotlinFinderTest {
 
 		Set<ClassContainer> classes = new Finder(allContainers, Language.KOTLIN).find(b, 1);
 
-		assertEquals(2, classes.size());
+		assertEquals(1, classes.size());
 		assertTrue(contains(classes, "A.kt"));
-		assertTrue(contains(classes, "B.kt"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Fixes all five bugs documented for the `code/context` module. The core change reworks `Finder` to resolve dependencies via a deterministic breadth-first expansion bounded by `depth`.

## Fixes

- **Non-deterministic depth limit** — `find()` no longer mutates the set it iterates. Each BFS level builds a fresh frontier, so depth-bounded queries return the same result every time.
- **Over-traversal / no `visited` / no memoization** — `expand()` loops exactly `depth` times over the frontier, with a `visited` set (seeded with the root) so cycles (`A→B→A`) terminate and each class is expanded at most once. Replaces the exponential nested-loop recursion.
- **Ignored `depth` parameter** — all depth handling now lives in `find()`/`expand()`; direct-dependency resolution no longer takes a meaningless `depth` argument.
- **False positives from comments/strings** — comments, string/char literals, and Kotlin triple-quoted strings are stripped before matching, so class names mentioned there are not reported as dependencies. Added `equals`/`hashCode` to `ClassContainer` so duplicate containers collapse. (The simple-name collision across packages remains a documented limitation of the name-based model.)
- **Coincidental tests / layer disagreement** — `Finder` now never returns the root as its own dependency, and the redundant root filter in `ProjectTreeBuilder` is removed so both layers agree. `FinderTest` is rewritten with self-contained sources that pin down depth cutoffs, cycle termination, comment/literal exclusion, and root exclusion; `KotlinFinderTest` is updated (it relied on the old self-inclusion behaviour).

## Testing

`mvn -pl code/context -am test` — 21 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)