### PR TITLE
test(context): rename FinderTest to JavaFinderTest

### DIFF
--- a/code/context/src/test/java/io/github/adamw7/context/JavaFinderTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/JavaFinderTest.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class FinderTest {
+public class JavaFinderTest {
 
 	@TempDir
 	Path projectRoot;

--- a/code/context/src/test/java/io/github/adamw7/context/tree/JavaProjectTreeBuilderTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/tree/JavaProjectTreeBuilderTest.java
@@ -11,7 +11,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class ProjectTreeBuilderTest {
+public class JavaProjectTreeBuilderTest {
 
 	@TempDir
 	Path projectRoot;


### PR DESCRIPTION
## Summary
- Renames `FinderTest` to `JavaFinderTest` (file and class).

The test writes only `.java` sources and exercises Java-specific dependency resolution. The Kotlin equivalent is already named `KotlinFinderTest`, so this rename makes the language split explicit and consistent.

## Test plan
- Pure rename of an existing test class; no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)