### PR TITLE
test(context): add tests and strengthen asserts in context engineering

### DIFF
--- a/code/context/src/test/java/io/github/adamw7/context/ClassContainerTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/ClassContainerTest.java
@@ -1,0 +1,84 @@
+package io.github.adamw7.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class ClassContainerTest {
+
+	@TempDir
+	Path projectRoot;
+
+	@Test
+	void exposesClassNameAndOriginalCode() {
+		ClassContainer container = new ClassContainer("A.java", "public class A {}");
+
+		assertEquals("A.java", container.className());
+		assertEquals("public class A {}", container.originalCode());
+	}
+
+	@Test
+	void loadReadsTheFileContentVerbatim() throws IOException {
+		Path path = projectRoot.resolve("A.java");
+		Files.writeString(path, "public class A {}");
+
+		ClassContainer container = ClassContainer.load(path, "A.java");
+
+		assertEquals("A.java", container.className());
+		assertEquals("public class A {}", container.originalCode());
+	}
+
+	@Test
+	void loadWrapsMissingFileInUncheckedIOException() {
+		Path missing = projectRoot.resolve("Missing.java");
+
+		assertThrows(java.io.UncheckedIOException.class, () -> ClassContainer.load(missing, "Missing.java"));
+	}
+
+	@Test
+	void equalContainersShareSameNameAndCode() {
+		ClassContainer one = new ClassContainer("A.java", "public class A {}");
+		ClassContainer copy = new ClassContainer("A.java", "public class A {}");
+
+		assertEquals(one, copy);
+		assertEquals(one.hashCode(), copy.hashCode());
+	}
+
+	@Test
+	void equalsIsReflexive() {
+		ClassContainer container = new ClassContainer("A.java", "public class A {}");
+
+		assertEquals(container, container);
+	}
+
+	@Test
+	void differsWhenClassNameDiffers() {
+		ClassContainer a = new ClassContainer("A.java", "public class A {}");
+		ClassContainer b = new ClassContainer("B.java", "public class A {}");
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	void differsWhenOriginalCodeDiffers() {
+		ClassContainer a = new ClassContainer("A.java", "public class A {}");
+		ClassContainer other = new ClassContainer("A.java", "public class A { int x; }");
+
+		assertNotEquals(a, other);
+	}
+
+	@Test
+	void isNotEqualToNullOrUnrelatedType() {
+		ClassContainer container = new ClassContainer("A.java", "public class A {}");
+
+		assertNotEquals(container, null);
+		assertNotEquals(container, "A.java");
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/JavaFinderTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/JavaFinderTest.java
@@ -48,7 +48,40 @@ public class JavaFinderTest {
 
 		Set<ClassContainer> dependencies = new Finder(containers(a, b)).find(b, 1);
 
+		assertEquals(1, dependencies.size());
 		assertEquals(names("A.java"), classNames(dependencies));
+	}
+
+	@Test
+	void findsAllDistinctDirectDependencies() throws IOException {
+		ClassContainer a = writeJava("A", "public class A {}");
+		ClassContainer c = writeJava("C", "public class C {}");
+		ClassContainer b = writeJava("B", "public class B { A a; C c; A again; }");
+
+		Set<ClassContainer> dependencies = new Finder(containers(a, b, c)).find(b, 1);
+
+		assertEquals(2, dependencies.size());
+		assertEquals(names("A.java", "C.java"), classNames(dependencies));
+	}
+
+	@Test
+	void reportsSharedDependencyOnlyOnceInDiamondGraph() throws IOException {
+		ClassContainer a = writeJava("A", "public class A {}");
+		ClassContainer b = writeJava("B", "public class B { A a; }");
+		ClassContainer c = writeJava("C", "public class C { A a; }");
+		ClassContainer d = writeJava("D", "public class D { B b; C c; }");
+
+		Set<ClassContainer> dependencies = new Finder(containers(a, b, c, d)).find(d, 3);
+
+		assertEquals(3, dependencies.size());
+		assertEquals(names("A.java", "B.java", "C.java"), classNames(dependencies));
+	}
+
+	@Test
+	void ignoresReferencesWithoutAMatchingSourceFile() throws IOException {
+		ClassContainer b = writeJava("B", "public class B { Unknown u; }");
+
+		assertTrue(new Finder(containers(b)).find(b, 1).isEmpty());
 	}
 
 	@Test
@@ -81,6 +114,7 @@ public class JavaFinderTest {
 
 		Set<ClassContainer> dependencies = new Finder(containers(a, b)).find(a, 10);
 
+		assertEquals(1, dependencies.size());
 		assertEquals(names("B.java"), classNames(dependencies));
 	}
 
@@ -98,6 +132,32 @@ public class JavaFinderTest {
 		ClassContainer b = writeJava("B", "public class B { String s = \"A\"; }");
 
 		assertTrue(new Finder(containers(a, b)).find(b, 1).isEmpty());
+	}
+
+	@Test
+	void ignoresClassNamesInCharacterLiterals() throws IOException {
+		ClassContainer a = writeJava("A", "public class A {}");
+		ClassContainer b = writeJava("B", "public class B { char c = 'A'; }");
+
+		assertTrue(new Finder(containers(a, b)).find(b, 1).isEmpty());
+	}
+
+	@Test
+	void ignoresClassNamesInMultiLineBlockComments() throws IOException {
+		ClassContainer a = writeJava("A", "public class A {}");
+		ClassContainer b = writeJava("B", "public class B {\n/*\n A spanning\n several A lines\n*/\n}");
+
+		assertTrue(new Finder(containers(a, b)).find(b, 1).isEmpty());
+	}
+
+	@Test
+	void findsDependencyMentionedOnlyOutsideCommentsAndLiterals() throws IOException {
+		ClassContainer a = writeJava("A", "public class A {}");
+		ClassContainer b = writeJava("B", "public class B { /* not A */ String s = \"A\"; A real; }");
+
+		Set<ClassContainer> dependencies = new Finder(containers(a, b)).find(b, 1);
+
+		assertEquals(names("A.java"), classNames(dependencies));
 	}
 
 	private ClassContainer writeJava(String className, String body) throws IOException {

--- a/code/context/src/test/java/io/github/adamw7/context/KotlinFinderTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/KotlinFinderTest.java
@@ -40,6 +40,42 @@ public class KotlinFinderTest {
 		assertTrue(classes.isEmpty());
 	}
 
+	@Test
+	void ignoresClassNamesInTripleQuotedStrings() throws IOException {
+		ClassContainer a = writeKotlin("A", "class A");
+		ClassContainer b = writeKotlin("B", "class B { val s = \"\"\"uses A here\"\"\" }");
+		Set<ClassContainer> allContainers = new HashSet<>(Set.of(a, b));
+
+		Set<ClassContainer> classes = new Finder(allContainers, Language.KOTLIN).find(b, 1);
+
+		assertTrue(classes.isEmpty());
+	}
+
+	@Test
+	void ignoresClassNamesInComments() throws IOException {
+		ClassContainer a = writeKotlin("A", "class A");
+		ClassContainer b = writeKotlin("B", "class B { /* uses A */ }");
+		Set<ClassContainer> allContainers = new HashSet<>(Set.of(a, b));
+
+		Set<ClassContainer> classes = new Finder(allContainers, Language.KOTLIN).find(b, 1);
+
+		assertTrue(classes.isEmpty());
+	}
+
+	@Test
+	void resolvesTransitiveKotlinDependencies() throws IOException {
+		ClassContainer a = writeKotlin("A", "class A");
+		ClassContainer b = writeKotlin("B", "class B { val a: A = A() }");
+		ClassContainer c = writeKotlin("C", "class C { val b: B = B() }");
+		Set<ClassContainer> allContainers = new HashSet<>(Set.of(a, b, c));
+
+		Set<ClassContainer> classes = new Finder(allContainers, Language.KOTLIN).find(c, 2);
+
+		assertEquals(2, classes.size());
+		assertTrue(contains(classes, "A.kt"));
+		assertTrue(contains(classes, "B.kt"));
+	}
+
 	private ClassContainer writeKotlin(String className, String body) throws IOException {
 		Path path = projectRoot.resolve(className + ".kt");
 		Files.writeString(path, body);

--- a/code/context/src/test/java/io/github/adamw7/context/tree/JavaProjectTreeBuilderTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/tree/JavaProjectTreeBuilderTest.java
@@ -39,8 +39,37 @@ public class JavaProjectTreeBuilderTest {
 		ProjectTreeNode pkgNode = onlyChild(new ProjectTreeBuilder(1).build(projectRoot));
 
 		ProjectTreeNode b = child(pkgNode, "B.java");
+		assertFalse(b.isDirectory());
 		assertEquals(1, b.dependencies().size());
 		assertTrue(b.dependencies().contains("A.java"));
+	}
+
+	@Test
+	void transitiveDependenciesAppearAtDepthTwo() throws IOException {
+		Path pkg = createPackage("pkg");
+		writeJava(pkg, "A", "public class A {}");
+		writeJava(pkg, "B", "public class B { A a; }");
+		writeJava(pkg, "C", "public class C { B b; }");
+
+		ProjectTreeNode pkgNode = onlyChild(new ProjectTreeBuilder(2).build(projectRoot));
+
+		ProjectTreeNode c = child(pkgNode, "C.java");
+		assertEquals(2, c.dependencies().size());
+		assertTrue(c.dependencies().contains("A.java"));
+		assertTrue(c.dependencies().contains("B.java"));
+	}
+
+	@Test
+	void dependenciesAreListedInSortedOrder() throws IOException {
+		Path pkg = createPackage("pkg");
+		writeJava(pkg, "A", "public class A {}");
+		writeJava(pkg, "C", "public class C {}");
+		writeJava(pkg, "B", "public class B { C c; A a; }");
+
+		ProjectTreeNode pkgNode = onlyChild(new ProjectTreeBuilder(1).build(projectRoot));
+
+		ProjectTreeNode b = child(pkgNode, "B.java");
+		assertEquals(java.util.List.of("A.java", "C.java"), java.util.List.copyOf(b.dependencies()));
 	}
 
 	@Test

--- a/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreePrinterTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreePrinterTest.java
@@ -1,5 +1,7 @@
 package io.github.adamw7.context.tree;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -22,6 +24,34 @@ public class ProjectTreePrinterTest {
 		assertTrue(output.contains("[dir] project"));
 		assertTrue(output.contains("[file] B.java"));
 		assertTrue(output.contains("-> A.java"));
+		assertTrue(output.indexOf("[file] B.java") < output.indexOf("-> A.java"),
+				"a file must be printed before its dependencies");
+	}
+
+	@Test
+	void printsEachDependencyOnItsOwnIndentedLine() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/B.java"));
+		file.addDependency("A.java");
+		file.addDependency("C.java");
+		root.addChild(file);
+
+		String output = printer.print(root);
+
+		assertTrue(output.contains("    -> A.java"));
+		assertTrue(output.contains("    -> C.java"));
+		assertEquals(4, output.split(System.lineSeparator()).length);
+	}
+
+	@Test
+	void fileWithoutDependenciesHasNoArrow() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		root.addChild(ProjectTreeNode.file(Path.of("project/A.java")));
+
+		String output = printer.print(root);
+
+		assertTrue(output.contains("[file] A.java"));
+		assertFalse(output.contains("->"));
 	}
 
 	@Test


### PR DESCRIPTION
Expand coverage for the context-engineering module from 21 to 42 tests:

- JavaFinderTest: multiple distinct dependencies, diamond-graph
  de-duplication, unresolved references, character literals,
  multi-line block comments, and a mixed comment/literal/code case;
  add size asserts to existing cases.
- KotlinFinderTest: triple-quoted strings, comments, and transitive
  dependency resolution.
- ClassContainerTest (new): accessors, load(), UncheckedIOException
  wrapping, and equals/hashCode contract.
- JavaProjectTreeBuilderTest: transitive depth-two dependencies and
  sorted dependency ordering.
- ProjectTreePrinterTest: per-line indented dependencies and files
  without dependencies.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0142wu1epmc5C2xco7XyzU4t