### PR TITLE
feat(context): add output serializers and token-budget-aware context

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,46 @@ The building blocks are:
 The result is a compact, human- and LLM-readable view of the project, ready to
 be handed to a gen-AI agent as context.
 
+### Output formats
+
+The tree can be rendered in several formats behind a single
+`ProjectTreeSerializer` interface, so a consumer depends on the abstraction
+rather than a concrete format and new formats can be added without touching the
+tree:
+
+```java
+ProjectTreeSerializer serializer = new ProjectTreeMarkdownSerializer(); // or JSON / printer
+String rendered = serializer.serialize(root);
+```
+
+- **`ProjectTreePrinter`** — indented plain text (shown above).
+- **`ProjectTreeMarkdownSerializer`** — a nested Markdown bullet list, with each
+  file's dependencies as indented child bullets. Well suited to documents and
+  chat-based agents.
+- **`ProjectTreeJsonSerializer`** — structured JSON (`name`, `type`,
+  `dependencies`, `children`) for programmatic consumers; `serializePretty`
+  produces indented JSON.
+
+### Token-budget-aware context
+
+A model's context window is finite, so `BudgetedContext` wraps any `Context` and
+trims its result to fit a token budget. Because `Finder` returns dependencies in
+breadth-first order (closest first), the decorator keeps that priority order and
+accepts containers until the next one would exceed the budget:
+
+```java
+TokenEstimator estimator = new HeuristicTokenEstimator(); // ~chars/4, no tokenizer dependency
+Context budgeted = new BudgetedContext(new Finder(allContainers), estimator, /* token budget */ 8000);
+Set<ClassContainer> used = budgeted.find(root, depth);
+```
+
+- **`TokenEstimator`** — abstracts how a piece of text is costed in tokens.
+- **`HeuristicTokenEstimator`** — a fast, dependency-free estimate from character
+  count (configurable characters-per-token, default `4`), rounded up so any
+  non-empty text costs at least one token.
+- **`BudgetedContext`** — a `Context` decorator that returns the highest-priority
+  prefix of the dependency graph that fits the budget.
+
 ## Data
 It contains:
 - data sources

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -22,6 +22,10 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 		</dependency>

--- a/code/context/src/main/java/io/github/adamw7/context/BudgetedContext.java
+++ b/code/context/src/main/java/io/github/adamw7/context/BudgetedContext.java
@@ -1,0 +1,62 @@
+package io.github.adamw7.context;
+
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * A {@link Context} decorator that trims a delegate's result to fit a token
+ * budget. The delegate (for example a {@link Finder}) yields its dependencies in
+ * breadth-first order — closest dependencies first — so this decorator keeps that
+ * order and accepts containers until the next one would push the estimated token
+ * total past the {@code budget}. The first container that does not fit stops the
+ * assembly, preserving the highest-priority prefix of the dependency graph.
+ */
+public class BudgetedContext implements Context {
+
+	private final Context delegate;
+	private final TokenEstimator estimator;
+	private final int budget;
+
+	public BudgetedContext(Context delegate, TokenEstimator estimator, int budget) {
+		requireNonNull(delegate, "delegate");
+		requireNonNull(estimator, "estimator");
+		requirePositiveBudget(budget);
+		this.delegate = delegate;
+		this.estimator = estimator;
+		this.budget = budget;
+	}
+
+	private void requireNonNull(Object value, String name) {
+		if (value == null) {
+			throw new IllegalArgumentException(name + " must not be null");
+		}
+	}
+
+	private void requirePositiveBudget(int budget) {
+		if (budget <= 0) {
+			throw new IllegalArgumentException("budget must be positive and received: " + budget);
+		}
+	}
+
+	@Override
+	public Set<ClassContainer> find(ClassContainer root, int depth) {
+		Set<ClassContainer> all = delegate.find(root, depth);
+		Set<ClassContainer> withinBudget = new LinkedHashSet<>();
+		fill(all.iterator(), budget, withinBudget);
+		return withinBudget;
+	}
+
+	private void fill(Iterator<ClassContainer> candidates, int remaining, Set<ClassContainer> accepted) {
+		if (!candidates.hasNext()) {
+			return;
+		}
+		ClassContainer candidate = candidates.next();
+		int cost = estimator.estimate(candidate.originalCode());
+		if (cost > remaining) {
+			return;
+		}
+		accepted.add(candidate);
+		fill(candidates, remaining - cost, accepted);
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/HeuristicTokenEstimator.java
+++ b/code/context/src/main/java/io/github/adamw7/context/HeuristicTokenEstimator.java
@@ -1,0 +1,44 @@
+package io.github.adamw7.context;
+
+/**
+ * A fast, dependency-free {@link TokenEstimator} that approximates token count
+ * from character count. Most byte-pair encoders average a few characters per
+ * token, so dividing the length by a fixed {@code charactersPerToken} (default
+ * {@value #DEFAULT_CHARACTERS_PER_TOKEN}) gives a cheap upper-ish estimate
+ * without a tokenizer dependency. The estimate is rounded up so that any
+ * non-empty text costs at least one token.
+ */
+public class HeuristicTokenEstimator implements TokenEstimator {
+
+	public static final int DEFAULT_CHARACTERS_PER_TOKEN = 4;
+
+	private final int charactersPerToken;
+
+	public HeuristicTokenEstimator() {
+		this(DEFAULT_CHARACTERS_PER_TOKEN);
+	}
+
+	public HeuristicTokenEstimator(int charactersPerToken) {
+		requirePositive(charactersPerToken);
+		this.charactersPerToken = charactersPerToken;
+	}
+
+	private void requirePositive(int charactersPerToken) {
+		if (charactersPerToken <= 0) {
+			throw new IllegalArgumentException(
+					"charactersPerToken must be positive and received: " + charactersPerToken);
+		}
+	}
+
+	@Override
+	public int estimate(String text) {
+		if (text == null || text.isEmpty()) {
+			return 0;
+		}
+		return ceilDivision(text.length(), charactersPerToken);
+	}
+
+	private int ceilDivision(int dividend, int divisor) {
+		return (dividend + divisor - 1) / divisor;
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/TokenEstimator.java
+++ b/code/context/src/main/java/io/github/adamw7/context/TokenEstimator.java
@@ -1,0 +1,12 @@
+package io.github.adamw7.context;
+
+/**
+ * Estimates how many LLM tokens a piece of text is worth. Implementations trade
+ * accuracy for speed; the estimate lets a budget-aware {@link Context} decide how
+ * much source code fits within a model's context window.
+ */
+@FunctionalInterface
+public interface TokenEstimator {
+
+	int estimate(String text);
+}

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeJsonSerializer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeJsonSerializer.java
@@ -1,0 +1,41 @@
+package io.github.adamw7.context.tree;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Renders a {@link ProjectTreeNode} tree as JSON. Each node becomes an object
+ * with its {@code name}, {@code type} ({@code directory} or {@code file}), the
+ * {@code dependencies} it carries, and its {@code children}. The structured
+ * output is convenient for programmatic consumers such as an MCP tool that hands
+ * the context to a gen-AI agent.
+ */
+public class ProjectTreeJsonSerializer implements ProjectTreeSerializer {
+
+	private static final String DIRECTORY_TYPE = "directory";
+	private static final String FILE_TYPE = "file";
+
+	@Override
+	public String serialize(ProjectTreeNode root) {
+		return toJson(root).toString();
+	}
+
+	public String serializePretty(ProjectTreeNode root, int indentFactor) {
+		return toJson(root).toString(indentFactor);
+	}
+
+	private JSONObject toJson(ProjectTreeNode node) {
+		JSONObject object = new JSONObject();
+		object.put("name", node.name());
+		object.put("type", node.isDirectory() ? DIRECTORY_TYPE : FILE_TYPE);
+		object.put("dependencies", new JSONArray(node.dependencies()));
+		object.put("children", childrenOf(node));
+		return object;
+	}
+
+	private JSONArray childrenOf(ProjectTreeNode node) {
+		JSONArray children = new JSONArray();
+		node.children().forEach(child -> children.put(toJson(child)));
+		return children;
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeMarkdownSerializer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeMarkdownSerializer.java
@@ -1,0 +1,41 @@
+package io.github.adamw7.context.tree;
+
+/**
+ * Renders a {@link ProjectTreeNode} tree as a nested Markdown bullet list.
+ * Directories and files become list items; each file's dependencies are listed
+ * as indented child bullets. The result is a compact, Markdown-aware view well
+ * suited to documents and chat-based gen-AI agents.
+ */
+public class ProjectTreeMarkdownSerializer implements ProjectTreeSerializer {
+
+	private static final String INDENT = "  ";
+	private static final String BULLET = "- ";
+	private static final String DIRECTORY_MARKER = "**";
+	private static final String DEPENDENCY_MARKER = "depends on: ";
+
+	@Override
+	public String serialize(ProjectTreeNode root) {
+		StringBuilder builder = new StringBuilder();
+		append(builder, root, "");
+		return builder.toString();
+	}
+
+	private void append(StringBuilder builder, ProjectTreeNode node, String indent) {
+		builder.append(indent).append(BULLET).append(label(node)).append(System.lineSeparator());
+		appendDependencies(builder, node, indent + INDENT);
+		node.children().forEach(child -> append(builder, child, indent + INDENT));
+	}
+
+	private void appendDependencies(StringBuilder builder, ProjectTreeNode node, String indent) {
+		node.dependencies().forEach(dependency ->
+				builder.append(indent).append(BULLET).append(DEPENDENCY_MARKER).append('`')
+						.append(dependency).append('`').append(System.lineSeparator()));
+	}
+
+	private String label(ProjectTreeNode node) {
+		if (node.isDirectory()) {
+			return DIRECTORY_MARKER + node.name() + DIRECTORY_MARKER;
+		}
+		return "`" + node.name() + "`";
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreePrinter.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreePrinter.java
@@ -5,12 +5,17 @@ package io.github.adamw7.context.tree;
  * files are listed hierarchically and each file's dependencies are printed
  * beneath it, giving a compact, human- and LLM-readable view of the project.
  */
-public class ProjectTreePrinter {
+public class ProjectTreePrinter implements ProjectTreeSerializer {
 
 	private static final String INDENT = "  ";
 	private static final String DIRECTORY_MARKER = "[dir] ";
 	private static final String FILE_MARKER = "[file] ";
 	private static final String DEPENDENCY_MARKER = "-> ";
+
+	@Override
+	public String serialize(ProjectTreeNode root) {
+		return print(root);
+	}
 
 	public String print(ProjectTreeNode root) {
 		StringBuilder builder = new StringBuilder();

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeSerializer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeSerializer.java
@@ -1,0 +1,13 @@
+package io.github.adamw7.context.tree;
+
+/**
+ * Renders a {@link ProjectTreeNode} tree into a textual representation. Concrete
+ * serializers choose the format (indented text, Markdown, JSON, ...). Keeping
+ * serialization behind this interface lets new formats be added without changing
+ * the tree or its existing renderers, and lets callers (such as an MCP tool)
+ * depend on the abstraction rather than a concrete format.
+ */
+public interface ProjectTreeSerializer {
+
+	String serialize(ProjectTreeNode root);
+}

--- a/code/context/src/test/java/io/github/adamw7/context/BudgetedContextTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/BudgetedContextTest.java
@@ -1,0 +1,92 @@
+package io.github.adamw7.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class BudgetedContextTest {
+
+	private final TokenEstimator oneTokenPerCharacter = text -> text.length();
+
+	@Test
+	void keepsContainersWhileTheyFitTheBudget() {
+		Context delegate = orderedDelegate(container("A", "xx"), container("B", "xx"), container("C", "xx"));
+		BudgetedContext budgeted = new BudgetedContext(delegate, oneTokenPerCharacter, 4);
+
+		Set<ClassContainer> result = budgeted.find(any(), 1);
+
+		assertEquals(names("A", "B"), classNames(result));
+	}
+
+	@Test
+	void stopsAtTheFirstContainerThatDoesNotFit() {
+		Context delegate = orderedDelegate(container("A", "x"), container("B", "xxxxx"), container("C", "x"));
+		BudgetedContext budgeted = new BudgetedContext(delegate, oneTokenPerCharacter, 3);
+
+		Set<ClassContainer> result = budgeted.find(any(), 1);
+
+		assertEquals(names("A"), classNames(result),
+				"a later small container must not jump ahead of an earlier oversized one");
+	}
+
+	@Test
+	void preservesTheDelegateOrder() {
+		Context delegate = orderedDelegate(container("A", "x"), container("B", "x"), container("C", "x"));
+		BudgetedContext budgeted = new BudgetedContext(delegate, oneTokenPerCharacter, 100);
+
+		List<String> ordered = new ArrayList<>();
+		budgeted.find(any(), 1).forEach(container -> ordered.add(container.className()));
+
+		assertEquals(List.of("A", "B", "C"), ordered);
+	}
+
+	@Test
+	void returnsEmptyWhenEvenTheFirstContainerExceedsTheBudget() {
+		Context delegate = orderedDelegate(container("A", "xxxxx"));
+		BudgetedContext budgeted = new BudgetedContext(delegate, oneTokenPerCharacter, 2);
+
+		assertTrue(budgeted.find(any(), 1).isEmpty());
+	}
+
+	@Test
+	void rejectsNullDelegateNullEstimatorAndNonPositiveBudget() {
+		Context delegate = orderedDelegate();
+
+		assertThrows(IllegalArgumentException.class,
+				() -> new BudgetedContext(null, oneTokenPerCharacter, 1));
+		assertThrows(IllegalArgumentException.class,
+				() -> new BudgetedContext(delegate, null, 1));
+		assertThrows(IllegalArgumentException.class,
+				() -> new BudgetedContext(delegate, oneTokenPerCharacter, 0));
+	}
+
+	private Context orderedDelegate(ClassContainer... containers) {
+		Set<ClassContainer> ordered = new LinkedHashSet<>(List.of(containers));
+		return (root, depth) -> ordered;
+	}
+
+	private ClassContainer container(String name, String code) {
+		return new ClassContainer(name, code);
+	}
+
+	private ClassContainer any() {
+		return new ClassContainer("Root", "");
+	}
+
+	private Set<String> classNames(Set<ClassContainer> containers) {
+		Set<String> names = new LinkedHashSet<>();
+		containers.forEach(container -> names.add(container.className()));
+		return names;
+	}
+
+	private Set<String> names(String... names) {
+		return new LinkedHashSet<>(List.of(names));
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/HeuristicTokenEstimatorTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/HeuristicTokenEstimatorTest.java
@@ -1,0 +1,41 @@
+package io.github.adamw7.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class HeuristicTokenEstimatorTest {
+
+	private final HeuristicTokenEstimator estimator = new HeuristicTokenEstimator();
+
+	@Test
+	void emptyTextCostsNoTokens() {
+		assertEquals(0, estimator.estimate(""));
+	}
+
+	@Test
+	void nullTextCostsNoTokens() {
+		assertEquals(0, estimator.estimate(null));
+	}
+
+	@Test
+	void roundsUpSoAnyNonEmptyTextCostsAtLeastOneToken() {
+		assertEquals(1, estimator.estimate("a"));
+		assertEquals(1, estimator.estimate("abcd"));
+		assertEquals(2, estimator.estimate("abcde"));
+	}
+
+	@Test
+	void honoursACustomCharactersPerToken() {
+		HeuristicTokenEstimator twoCharsPerToken = new HeuristicTokenEstimator(2);
+
+		assertEquals(3, twoCharsPerToken.estimate("abcde"));
+	}
+
+	@Test
+	void rejectsNonPositiveCharactersPerToken() {
+		assertThrows(IllegalArgumentException.class, () -> new HeuristicTokenEstimator(0));
+		assertThrows(IllegalArgumentException.class, () -> new HeuristicTokenEstimator(-1));
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeJsonSerializerTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeJsonSerializerTest.java
@@ -1,0 +1,78 @@
+package io.github.adamw7.context.tree;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+public class ProjectTreeJsonSerializerTest {
+
+	private final ProjectTreeJsonSerializer serializer = new ProjectTreeJsonSerializer();
+
+	@Test
+	void serializesNameAndTypeForADirectory() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+
+		JSONObject json = new JSONObject(serializer.serialize(root));
+
+		assertEquals("project", json.getString("name"));
+		assertEquals("directory", json.getString("type"));
+	}
+
+	@Test
+	void serializesFilesAsTypeFile() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		root.addChild(ProjectTreeNode.file(Path.of("project/A.java")));
+
+		JSONObject json = new JSONObject(serializer.serialize(root));
+		JSONObject child = json.getJSONArray("children").getJSONObject(0);
+
+		assertEquals("file", child.getString("type"));
+		assertEquals("A.java", child.getString("name"));
+	}
+
+	@Test
+	void serializesDependenciesAsAnArray() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/B.java"));
+		file.addDependency("A.java");
+		file.addDependency("C.java");
+		root.addChild(file);
+
+		JSONObject json = new JSONObject(serializer.serialize(root));
+		JSONArray dependencies = json.getJSONArray("children").getJSONObject(0).getJSONArray("dependencies");
+
+		assertEquals(2, dependencies.length());
+		assertTrue(dependencies.toList().contains("A.java"));
+		assertTrue(dependencies.toList().contains("C.java"));
+	}
+
+	@Test
+	void nestsChildrenRecursively() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode pkg = ProjectTreeNode.directory(Path.of("project/pkg"));
+		pkg.addChild(ProjectTreeNode.file(Path.of("project/pkg/A.java")));
+		root.addChild(pkg);
+
+		JSONObject json = new JSONObject(serializer.serialize(root));
+		JSONObject pkgJson = json.getJSONArray("children").getJSONObject(0);
+
+		assertEquals("pkg", pkgJson.getString("name"));
+		assertEquals("A.java", pkgJson.getJSONArray("children").getJSONObject(0).getString("name"));
+	}
+
+	@Test
+	void prettyOutputIsParseableAndEquivalent() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		root.addChild(ProjectTreeNode.file(Path.of("project/A.java")));
+
+		JSONObject pretty = new JSONObject(serializer.serializePretty(root, 2));
+
+		assertEquals("project", pretty.getString("name"));
+		assertEquals(1, pretty.getJSONArray("children").length());
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeMarkdownSerializerTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeMarkdownSerializerTest.java
@@ -1,0 +1,55 @@
+package io.github.adamw7.context.tree;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class ProjectTreeMarkdownSerializerTest {
+
+	private final ProjectTreeMarkdownSerializer serializer = new ProjectTreeMarkdownSerializer();
+
+	@Test
+	void rendersDirectoriesAsBoldBullets() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+
+		String output = serializer.serialize(root);
+
+		assertTrue(output.contains("- **project**"));
+	}
+
+	@Test
+	void rendersFilesAsCodeSpannedBullets() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		root.addChild(ProjectTreeNode.file(Path.of("project/A.java")));
+
+		String output = serializer.serialize(root);
+
+		assertTrue(output.contains("- `A.java`"));
+	}
+
+	@Test
+	void rendersDependenciesAsIndentedChildBullets() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/B.java"));
+		file.addDependency("A.java");
+		root.addChild(file);
+
+		String output = serializer.serialize(root);
+
+		assertTrue(output.contains("- depends on: `A.java`"));
+		assertTrue(output.indexOf("`B.java`") < output.indexOf("depends on: `A.java`"),
+				"a file must be rendered before its dependencies");
+	}
+
+	@Test
+	void nestsChildrenWithDeeperIndentation() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		root.addChild(ProjectTreeNode.directory(Path.of("project/pkg")));
+
+		String output = serializer.serialize(root);
+
+		assertTrue(output.contains("  - **pkg**"));
+	}
+}


### PR DESCRIPTION
Extend the context-engineering module with two capabilities for assembling
context for gen-AI agents:

- Output formats behind a new ProjectTreeSerializer interface: Markdown
  (ProjectTreeMarkdownSerializer) and JSON (ProjectTreeJsonSerializer), with
  ProjectTreePrinter now implementing the same interface. Adds the managed
  org.json dependency to the module.
- Token-budget-aware assembly: TokenEstimator + HeuristicTokenEstimator
  (chars/4, no tokenizer dependency) and a BudgetedContext decorator that
  trims a Context's breadth-first result to the highest-priority prefix that
  fits a token budget.

Adds unit tests for all new logic and documents the features in the README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P9Kp7aLw2PuPYoJTjquBCb