### PR TITLE
fix(mcp): stop stdout corruption and file-handle leak in MCP server

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
@@ -58,6 +58,7 @@ public class CSVDataSource extends AbstractFileSource {
 	@Override
 	public void open() {
 		log.info("Opening: {}", fileName);
+		opened = true;
 		if (columnsExist() && !columnsAreLoaded()) {
 			loadColumns();
 		}

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/Main.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/Main.java
@@ -7,16 +7,20 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Main {
 
     public static void main(String[] args) {
+        configureRuntime(args);
+        SpringApplication.run(Main.class, args);
+    }
+
+    static void configureRuntime(String[] args) {
         String transportMode = resolveTransportMode(args);
         System.setProperty("transport.mode", transportMode);
         if ("stdio".equals(transportMode)) {
             System.setProperty("spring.main.web-application-type", "none");
         }
         System.setProperty("spring.main.banner-mode", "off");
-        SpringApplication.run(Main.class, args);
     }
 
-    private static String resolveTransportMode(String[] args) {
+    static String resolveTransportMode(String[] args) {
         String prefix = "--transport.mode=";
         for (String arg : args) {
             if (arg.startsWith(prefix)) {

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/Main.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/Main.java
@@ -12,7 +12,7 @@ public class Main {
         if ("stdio".equals(transportMode)) {
             System.setProperty("spring.main.web-application-type", "none");
         }
-        System.setProperty("banner-mode", "off");
+        System.setProperty("spring.main.banner-mode", "off");
         SpringApplication.run(Main.class, args);
     }
 

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
@@ -55,17 +55,14 @@ public class UniquenessTool implements Function<Map<String, Object>, CallToolRes
 		String fileName = String.valueOf(arguments.get("file"));
 		String columnName = String.valueOf(arguments.get("columns_name"));
 		int columnsRow = Integer.parseInt(String.valueOf(arguments.get("columns_row")));
-		try {
-			InMemoryDataSource source = new InMemoryCSVDataSource(fileName, columnsRow);
+		try (InMemoryDataSource source = new InMemoryCSVDataSource(fileName, columnsRow)) {
 			AbstractUniqueness check = new InMemoryUniquenessCheck();
-			
-			source.readAll();
-			
+
 			check.setDataSource(source);
 			Result result = check.exec(columnName);
-			print(result, columnName);		
+			print(result, columnName);
 			return String.valueOf(result.isUnique());
-		} catch (FileNotFoundException e) {
+		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}
 	}

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/CSVDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/CSVDataSourceTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.data.source.file;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.of;
@@ -136,6 +137,45 @@ public class CSVDataSourceTest {
 		// Once the scanner is genuinely closed, any further read attempt fails fast
 		// instead of silently keeping the file handle open.
 		assertThrows(IllegalStateException.class, source::nextRow);
+	}
+
+	@Test
+	public void closeReleasesUnderlyingScannerWithoutColumns() throws IOException {
+		InMemoryCSVDataSource source = Utils.createInMemoryDataSource(Utils.getFileName("addresses.csv"));
+		source.open();
+		source.close();
+		assertThrows(IllegalStateException.class, source::nextRow);
+	}
+
+	@Test
+	public void closeIsIdempotent() throws IOException {
+		InMemoryCSVDataSource source = Utils.createInMemoryDataSource(Utils.getHouseholdFile(), COLUMNS_ROW);
+		source.open();
+		source.close();
+		// A second close must be a harmless no-op now that the source is flagged closed.
+		assertDoesNotThrow(source::close);
+	}
+
+	@Test
+	public void closeBeforeOpenDoesNotThrow() throws IOException {
+		InMemoryCSVDataSource source = Utils.createInMemoryDataSource(Utils.getHouseholdFile(), COLUMNS_ROW);
+		// The source was never opened, so close must not attempt to touch the scanner.
+		assertDoesNotThrow(source::close);
+	}
+
+	@Test
+	public void resetReopensSourceAfterClose() {
+		InMemoryCSVDataSource source = Utils.createInMemoryDataSource(Utils.getHouseholdFile(), COLUMNS_ROW);
+		int firstPass = source.readAll().size();
+		source.reset();
+		int secondPass = source.readAll().size();
+		Utils.close(source);
+		// reset() closes the exhausted scanner and opens a fresh one, so the same
+		// rows are produced again instead of an empty (or leaked) read.
+		assertEquals(70, firstPass);
+		assertEquals(firstPass, secondPass);
+		assertEquals(15, source.getColumnNames().length);
+		assertEquals("hlpi_name", source.getColumnNames()[0]);
 	}
 
 	@Test

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/CSVDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/CSVDataSourceTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.data.source.file;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 import java.io.FileInputStream;
@@ -125,6 +126,16 @@ public class CSVDataSourceTest {
 		}
 		Utils.close(source);
 		assertEquals(70, i);
+	}
+
+	@Test
+	public void closeReleasesUnderlyingScanner() throws IOException {
+		InMemoryCSVDataSource source = Utils.createInMemoryDataSource(Utils.getHouseholdFile(), COLUMNS_ROW);
+		source.open();
+		source.close();
+		// Once the scanner is genuinely closed, any further read attempt fails fast
+		// instead of silently keeping the file handle open.
+		assertThrows(IllegalStateException.class, source::nextRow);
 	}
 
 	@Test

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/MainTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/MainTest.java
@@ -1,42 +1,91 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.lang.reflect.Method;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class MainTest {
 
-	private String resolveTransportMode(String[] args) throws Exception {
-		Method method = Main.class.getDeclaredMethod("resolveTransportMode", String[].class);
-		method.setAccessible(true);
-		return (String) method.invoke(null, (Object) args);
+	private static final String TRANSPORT_MODE = "transport.mode";
+	private static final String WEB_APPLICATION_TYPE = "spring.main.web-application-type";
+	private static final String BANNER_MODE = "spring.main.banner-mode";
+
+	@BeforeEach
+	@AfterEach
+	public void clearRuntimeProperties() {
+		System.clearProperty(TRANSPORT_MODE);
+		System.clearProperty(WEB_APPLICATION_TYPE);
+		System.clearProperty(BANNER_MODE);
+		System.clearProperty("banner-mode");
 	}
 
 	@Test
-	public void defaultsToStdioWhenNoArguments() throws Exception {
-		assertEquals("stdio", resolveTransportMode(new String[] {}));
+	public void defaultsToStdioWhenNoArguments() {
+		assertEquals("stdio", Main.resolveTransportMode(new String[] {}));
 	}
 
 	@Test
-	public void defaultsToStdioWhenPrefixAbsent() throws Exception {
-		assertEquals("stdio", resolveTransportMode(new String[] { "--server.port=8080", "--other" }));
+	public void defaultsToStdioWhenPrefixAbsent() {
+		assertEquals("stdio", Main.resolveTransportMode(new String[] { "--server.port=8080", "--other" }));
 	}
 
 	@Test
-	public void readsExplicitTransportMode() throws Exception {
-		assertEquals("sse", resolveTransportMode(new String[] { "--transport.mode=sse" }));
+	public void readsExplicitTransportMode() {
+		assertEquals("sse", Main.resolveTransportMode(new String[] { "--transport.mode=sse" }));
 	}
 
 	@Test
-	public void findsTransportModeAmongOtherArguments() throws Exception {
+	public void findsTransportModeAmongOtherArguments() {
 		String[] args = { "--server.port=8080", "--transport.mode=streamable-http" };
-		assertEquals("streamable-http", resolveTransportMode(args));
+		assertEquals("streamable-http", Main.resolveTransportMode(args));
 	}
 
 	@Test
-	public void supportsEmptyTransportModeValue() throws Exception {
-		assertEquals("", resolveTransportMode(new String[] { "--transport.mode=" }));
+	public void supportsEmptyTransportModeValue() {
+		assertEquals("", Main.resolveTransportMode(new String[] { "--transport.mode=" }));
+	}
+
+	@Test
+	public void configureRuntimeDisablesBannerWithTheSpringProperty() {
+		Main.configureRuntime(new String[] {});
+
+		// The banner must be disabled through the property Spring actually reads;
+		// the bare "banner-mode" key has no effect and would leave the banner on
+		// stdout, corrupting the stdio JSON-RPC channel.
+		assertEquals("off", System.getProperty(BANNER_MODE));
+		assertNull(System.getProperty("banner-mode"));
+	}
+
+	@Test
+	public void configureRuntimePropagatesTransportMode() {
+		Main.configureRuntime(new String[] { "--transport.mode=streamable-http" });
+
+		assertEquals("streamable-http", System.getProperty(TRANSPORT_MODE));
+	}
+
+	@Test
+	public void configureRuntimeDefaultsTransportModeToStdio() {
+		Main.configureRuntime(new String[] {});
+
+		assertEquals("stdio", System.getProperty(TRANSPORT_MODE));
+	}
+
+	@Test
+	public void configureRuntimeForcesNonWebApplicationInStdioMode() {
+		Main.configureRuntime(new String[] {});
+
+		assertEquals("none", System.getProperty(WEB_APPLICATION_TYPE));
+	}
+
+	@Test
+	public void configureRuntimeKeepsWebApplicationForStreamableHttpMode() {
+		Main.configureRuntime(new String[] { "--transport.mode=streamable-http" });
+
+		// A web server is required to expose the /mcp servlet, so the web
+		// application type must not be forced to "none" here.
+		assertNull(System.getProperty(WEB_APPLICATION_TYPE));
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessToolTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessToolTest.java
@@ -1,14 +1,21 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +37,7 @@ public class UniquenessToolTest {
 		input.put("columns_name", "year1");
 		CallToolResult result = tool.apply(input);
         assertFalse(result.isError());
+        assertEquals(1, result.content().size());
         Content content = result.content().getFirst();
         assertTrue(content instanceof McpSchema.TextContent);
         McpSchema.TextContent textContent = (McpSchema.TextContent) content;
@@ -83,5 +91,63 @@ public class UniquenessToolTest {
 		assertTrue(required.contains("file"));
 		assertTrue(required.contains("columns_row"));
 		assertTrue(required.contains("columns_name"));
+	}
+
+	@Test
+	public void repeatedInvocationsDoNotLeakFileHandles() throws Exception {
+		Path fdDir = Paths.get("/proc/self/fd");
+		assumeTrue(Files.isDirectory(fdDir), "file-descriptor probing is only available on Linux");
+
+		UniquenessTool tool = new UniquenessTool();
+		warmUp(tool);
+
+		long before = openFileDescriptors(fdDir);
+		for (int i = 0; i < 60; i++) {
+			invokeSuccess(tool);
+			invokeMissingColumn(tool);
+			invokeMissingFile(tool);
+		}
+		long after = openFileDescriptors(fdDir);
+
+		// Every success and every failure path must close its data source. Before the
+		// fix each call leaked at least one descriptor, so 180 calls would balloon the
+		// count well past this small allowance for unrelated JVM activity.
+		assertTrue(after - before <= 15, "leaked file descriptors: before=" + before + " after=" + after);
+	}
+
+	private void warmUp(UniquenessTool tool) {
+		invokeSuccess(tool);
+		invokeMissingColumn(tool);
+		invokeMissingFile(tool);
+	}
+
+	private void invokeSuccess(UniquenessTool tool) {
+		Map<String, Object> input = new HashMap<>();
+		input.put("file", Utils.getHouseholdFile());
+		input.put("columns_row", "1");
+		input.put("columns_name", "income");
+		tool.apply(input);
+	}
+
+	private void invokeMissingColumn(UniquenessTool tool) {
+		Map<String, Object> input = new HashMap<>();
+		input.put("file", Utils.getHouseholdFile());
+		input.put("columns_row", "1");
+		input.put("columns_name", "nonExistingColumn");
+		assertThrows(ColumnNotFoundException.class, () -> tool.apply(input));
+	}
+
+	private void invokeMissingFile(UniquenessTool tool) {
+		Map<String, Object> input = new HashMap<>();
+		input.put("file", "nonExistentFile.csv");
+		input.put("columns_row", "1");
+		input.put("columns_name", "income");
+		assertThrows(UncheckedIOException.class, () -> tool.apply(input));
+	}
+
+	private long openFileDescriptors(Path fdDir) throws IOException {
+		try (Stream<Path> descriptors = Files.list(fdDir)) {
+			return descriptors.count();
+		}
 	}
 }


### PR DESCRIPTION
Three related bugs in the uniqueness MCP server:

- Main used System property "banner-mode" to disable the Spring Boot
  banner, but the correct key is "spring.main.banner-mode", so the banner
  was still printed to stdout. In stdio transport mode stdout is the
  JSON-RPC channel, so the banner corrupted the MCP protocol stream
  (logging is deliberately routed to a file to keep stdout clean).

- CSVDataSource.open() never set the inherited "opened" flag, unlike every
  sibling source, so AbstractFileSource.close() was a silent no-op and the
  underlying FileInputStream/Scanner was never released (also leaked on
  every reset()).

- UniquenessTool never closed its data source, and exec() only closes on
  the success path, so a failing lookup (e.g. unknown column) leaked the
  handle. Wrapped the source in try-with-resources.

Added a CSVDataSource test asserting close() actually closes the scanner.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E95zkgqwM2g6qh14n3r4NX