### PR TITLE
feat(context): MCP server for project tree and context finders (streamable HTTP, TLS 1.3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,9 @@ Maven project. The notable capabilities are:
 - **Context engineering** (`code/context`) — a fast, regex-based finder that
   builds the tree of classes used by a given class, plus a `ProjectTreeBuilder`
   that scans a whole Java project into a tree of folders, files and
-  dependencies, to assemble context for gen-AI agents working with Java code.
+  dependencies, to assemble context for gen-AI agents working with Java code. An
+  **MCP server** (in the `io.github.adamw7.context.mcp` package) exposes the
+  project-tree and context-finder tools over stdio or streamable HTTP.
 - **Data** (`data`) — data sources (CSV, GZip, JDBC; in-memory and iterative
   loading), a uniqueness-checking tool (finds whether a subset of columns can
   serve as a key, and searches for a smaller key), data structures (an
@@ -49,11 +51,17 @@ list).
 Base Java package: `io.github.adamw7` (`io.github.adamw7.context` for the
 context module, `io.github.adamw7.tools.*` elsewhere).
 
-The MCP server lives in
-`data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/`. Its entry
-point is `Main.java`; see
-[MCP_USAGE.md](data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md)
-for client configuration (Claude Desktop, Cline, etc.).
+The repository ships two MCP servers, each a Spring Boot app whose entry point
+is `Main.java` and which supports stdio (default) or streamable HTTP
+(`--transport.mode=streamable-http`):
+
+- The uniqueness-checker server in
+  `data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/`; see its
+  [MCP_USAGE.md](data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md).
+- The context-engineering server in
+  `code/context/src/main/java/io/github/adamw7/context/mcp/`, exposing the
+  `project_tree` and `find_context` tools; see its
+  [MCP_USAGE.md](code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md).
 
 ## Environment & toolchain
 

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -17,13 +17,74 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<mainClass>io.github.adamw7.context.mcp.Main</mainClass>
+					<executable>true</executable>
+					<layout>JAR</layout>
+					<jvmArguments>-Djdk.tls.client.protocols=TLSv1.3</jvmArguments>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>integration-tests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<executions>
+							<execution>
+								<goals>
+									<goal>integration-test</goal>
+									<goal>verify</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.modelcontextprotocol.sdk</groupId>
+				<artifactId>mcp-bom</artifactId>
+				<version>2.0.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp-json-jackson2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/code/context/src/main/java/io/github/adamw7/context/Language.java
+++ b/code/context/src/main/java/io/github/adamw7/context/Language.java
@@ -1,5 +1,7 @@
 package io.github.adamw7.context;
 
+import java.util.Locale;
+
 /**
  * A programming language supported by the context finder. Each language is
  * identified by the file extension of its source files, which is how the
@@ -16,6 +18,17 @@ public enum Language {
 
 	Language(String extension) {
 		this.extension = extension;
+	}
+
+	/**
+	 * Resolves a language from its case-insensitive name (e.g. {@code "java"} or
+	 * {@code "kotlin"}), so callers such as the MCP tools can accept the language
+	 * as a plain string argument.
+	 *
+	 * @throws IllegalArgumentException if no language matches the given name
+	 */
+	public static Language fromName(String name) {
+		return valueOf(name.trim().toUpperCase(Locale.ROOT));
 	}
 
 	public String extension() {

--- a/code/context/src/main/java/io/github/adamw7/context/ProjectSources.java
+++ b/code/context/src/main/java/io/github/adamw7/context/ProjectSources.java
@@ -1,0 +1,43 @@
+package io.github.adamw7.context;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Loads the source files of a Java or Kotlin project from disk into
+ * {@link ClassContainer}s, keyed by their {@link Path}. A source file is any
+ * regular file whose name ends with the configured {@link Language}'s extension.
+ * Centralising the rules for recognising and reading sources here keeps the
+ * {@link io.github.adamw7.context.tree.ProjectTreeBuilder} and the MCP tools that
+ * expose the finders from each re-implementing the same project walk.
+ */
+public class ProjectSources {
+
+	private final Language language;
+
+	public ProjectSources(Language language) {
+		this.language = language;
+	}
+
+	public Map<Path, ClassContainer> load(Path root) {
+		try (Stream<Path> paths = Files.walk(root)) {
+			return paths.filter(this::isSourceFile)
+					.collect(Collectors.toMap(path -> path, this::toContainer));
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	private boolean isSourceFile(Path path) {
+		return Files.isRegularFile(path) && path.getFileName().toString().endsWith(language.extension());
+	}
+
+	private ClassContainer toContainer(Path path) {
+		return ClassContainer.load(path, path.getFileName().toString());
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
@@ -1,0 +1,108 @@
+package io.github.adamw7.context.mcp;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONArray;
+import org.springframework.stereotype.Component;
+
+import io.github.adamw7.context.ClassContainer;
+import io.github.adamw7.context.Finder;
+import io.github.adamw7.context.Language;
+import io.github.adamw7.context.ProjectSources;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+
+/**
+ * MCP tool that resolves the classes a single source file depends on. It loads
+ * every source of a Java or Kotlin project, locates the requested class by its
+ * simple name, and runs the regex-based {@link Finder} to a bounded depth. The
+ * dependency class names are returned as a JSON array. An unknown class is
+ * reported as an error result rather than an exception so the agent gets a clear,
+ * actionable message.
+ */
+@Component
+public class ContextFinderTool implements ContextTool {
+
+	private static final Logger log = LogManager.getLogger(ContextFinderTool.class.getName());
+
+	private static final int DEFAULT_DEPTH = 1;
+
+	private final Tool toolDefinition = Tool.builder("find_context",
+			Map.of(
+					"type", "object",
+					"properties", Map.of(
+							"path", Map.of("type", "string",
+									"description", "absolute path to the project root directory"),
+							"class_name", Map.of("type", "string",
+									"description", "simple name of the class to inspect, e.g. Foo or Foo.java"),
+							"language", Map.of("type", "string",
+									"description", "source language: java (default) or kotlin"),
+							"depth", Map.of("type", "integer",
+									"description", "how many levels of transitive dependencies to resolve (default 1)")),
+					"required", List.of("path", "class_name")))
+			.description("Find the classes a given class depends on, within a Java or Kotlin project")
+			.build();
+
+	@Override
+	public Tool getToolDefinition() {
+		return toolDefinition;
+	}
+
+	@Override
+	public CallToolResult apply(Map<String, Object> arguments) {
+		log.info("Calling MCP find_context tool for {}", arguments);
+		Path root = Path.of(ToolArguments.requiredString(arguments, "path"));
+		Language language = ToolArguments.optionalLanguage(arguments, "language", Language.JAVA);
+		int depth = ToolArguments.optionalInt(arguments, "depth", DEFAULT_DEPTH);
+		Set<ClassContainer> containers = Set.copyOf(new ProjectSources(language).load(root).values());
+
+		ClassContainer target = findTarget(containers, arguments, language);
+		if (target == null) {
+			return error("Class not found: " + ToolArguments.requiredString(arguments, "class_name"));
+		}
+		return success(dependenciesOf(containers, target, language, depth));
+	}
+
+	private ClassContainer findTarget(Set<ClassContainer> containers, Map<String, Object> arguments, Language language) {
+		String fileName = fileNameOf(ToolArguments.requiredString(arguments, "class_name"), language);
+		return containers.stream()
+				.filter(container -> container.className().equals(fileName))
+				.findFirst()
+				.orElse(null);
+	}
+
+	private String fileNameOf(String className, Language language) {
+		if (className.endsWith(language.extension())) {
+			return className;
+		}
+		return className + language.extension();
+	}
+
+	private String dependenciesOf(Set<ClassContainer> containers, ClassContainer target, Language language, int depth) {
+		List<String> dependencies = new Finder(containers, language).find(target, depth).stream()
+				.map(ClassContainer::className)
+				.sorted()
+				.toList();
+		return new JSONArray(dependencies).toString();
+	}
+
+	private CallToolResult success(String dependenciesJson) {
+		return CallToolResult.builder()
+				.content(List.of(TextContent.builder(dependenciesJson).build()))
+				.isError(false)
+				.build();
+	}
+
+	private CallToolResult error(String message) {
+		return CallToolResult.builder()
+				.content(List.of(TextContent.builder(message).build()))
+				.isError(true)
+				.build();
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ContextTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ContextTool.java
@@ -1,0 +1,19 @@
+package io.github.adamw7.context.mcp;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+
+/**
+ * A tool the context-engineering MCP server exposes. Each tool carries its own
+ * {@link Tool} definition (name and input schema) and maps a call's arguments to
+ * a {@link CallToolResult}. Depending on this abstraction lets
+ * {@link McpConfiguration} register any number of tools without knowing their
+ * concrete types.
+ */
+public interface ContextTool extends Function<Map<String, Object>, CallToolResult> {
+
+	Tool getToolDefinition();
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -109,6 +109,23 @@ java -jar code/context/target/tools.code.context-2.2.0-SNAPSHOT.jar --transport.
 The MCP endpoint is then served at `http://localhost:8082/mcp` (the port is
 configurable through `server.port`).
 
+### HTTPS (TLS 1.3)
+
+To serve the streamable HTTP transport over HTTPS, point the standard Spring
+Boot SSL properties at a key store and enable SSL:
+
+```properties
+server.ssl.enabled=true
+server.ssl.key-store=classpath:keystore.p12
+server.ssl.key-store-password=changeit
+server.ssl.key-store-type=PKCS12
+```
+
+`TlsConfiguration` then pins the embedded connector to **TLS 1.3** — it forces
+`server.ssl.enabled-protocols` to `TLSv1.3`, so older protocols can never be
+negotiated even if they are requested. The endpoint is then served at
+`https://localhost:8082/mcp`.
+
 ## Configuring MCP Clients
 
 ### Claude Desktop (stdio)

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -1,0 +1,155 @@
+# MCP Server for Context Engineering
+
+This package contains a Model Context Protocol (MCP) server that exposes the
+context-engineering capabilities of the `code/context` module — the project-tree
+scanner and the class-usage context finder — to MCP clients such as Claude
+Desktop, Cline, or any other MCP-compatible client.
+
+## Overview
+
+The server exposes two tools:
+
+- **`project_tree`** — scans a Java or Kotlin project into a tree of folders,
+  files and the classes each file depends on, then serialises it as JSON
+  (default), Markdown or plain text.
+- **`find_context`** — resolves the classes a single source file depends on,
+  bounded by a configurable depth, and returns them as a JSON array.
+
+## Architecture
+
+The implementation lives in a package separate from the core finders:
+
+1. **Main.java** — Spring Boot entry point that selects the transport.
+2. **McpConfiguration.java** — Spring configuration that wires the transports and
+   registers the tools.
+3. **ContextTool.java** — the abstraction every tool implements.
+4. **ProjectTreeTool.java** / **ContextFinderTool.java** — the two tools.
+5. **ToolArguments.java** — shared parsing of the call arguments.
+
+The server uses:
+
+- **Transport**: stdio (default) or streamable HTTP
+  (`--transport.mode=streamable-http`), which serves the MCP endpoint at `/mcp`.
+- **MCP SDK**: `io.modelcontextprotocol.sdk` v2.0.0
+- **Framework**: Spring Boot
+- **Protocol**: Model Context Protocol (MCP)
+
+## Building the Server
+
+From the root of the repository:
+
+```bash
+mvn clean install
+```
+
+This creates an executable JAR in `code/context/target/tools.code.context-{version}.jar`.
+
+## Tool Specifications
+
+### project_tree
+
+Scans a project into a tree of folders, files and class dependencies.
+
+**Parameters:**
+
+- `path` (string, required): absolute path to the project root directory
+- `language` (string, optional): `java` (default) or `kotlin`
+- `depth` (integer, optional): levels of transitive dependencies to resolve (default `1`)
+- `format` (string, optional): `json` (default), `markdown` or `text`
+
+**Example:**
+
+```json
+{
+  "path": "/path/to/project",
+  "language": "java",
+  "depth": 2,
+  "format": "json"
+}
+```
+
+### find_context
+
+Finds the classes a given class depends on, within a project.
+
+**Parameters:**
+
+- `path` (string, required): absolute path to the project root directory
+- `class_name` (string, required): simple name of the class to inspect, e.g. `Foo` or `Foo.java`
+- `language` (string, optional): `java` (default) or `kotlin`
+- `depth` (integer, optional): levels of transitive dependencies to resolve (default `1`)
+
+**Returns:** a JSON array of dependency class names, e.g. `["A.java","B.java"]`.
+An unknown class is reported as an error result.
+
+**Example:**
+
+```json
+{
+  "path": "/path/to/project",
+  "class_name": "B",
+  "depth": 1
+}
+```
+
+## Running the Server
+
+### stdio (default)
+
+```bash
+java -jar code/context/target/tools.code.context-2.2.0-SNAPSHOT.jar
+```
+
+### streamable HTTP
+
+```bash
+java -jar code/context/target/tools.code.context-2.2.0-SNAPSHOT.jar --transport.mode=streamable-http
+```
+
+The MCP endpoint is then served at `http://localhost:8082/mcp` (the port is
+configurable through `server.port`).
+
+## Configuring MCP Clients
+
+### Claude Desktop (stdio)
+
+```json
+{
+  "mcpServers": {
+    "context-engineering": {
+      "command": "java",
+      "args": [
+        "-jar",
+        "/absolute/path/to/tools/code/context/target/tools.code.context-2.2.0-SNAPSHOT.jar"
+      ]
+    }
+  }
+}
+```
+
+### Streamable HTTP client
+
+```json
+{
+  "mcpServers": {
+    "context-engineering": {
+      "type": "http",
+      "url": "http://localhost:8082/mcp"
+    }
+  }
+}
+```
+
+## Server Capabilities
+
+The server advertises:
+
+- **Tools**: true (`project_tree`, `find_context`)
+- **Resources**: false
+- **Prompts**: false
+
+## Related Documentation
+
+- [Model Context Protocol Specification](https://modelcontextprotocol.io/)
+- [MCP Java SDK Documentation](https://github.com/modelcontextprotocol/java-sdk)
+- [Data module MCP server](../../../../../../../../../../data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md)

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/Main.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/Main.java
@@ -1,0 +1,38 @@
+package io.github.adamw7.context.mcp;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Entry point of the context-engineering MCP server. It selects the transport
+ * from {@code --transport.mode} (defaulting to stdio) before starting Spring so
+ * that stdio mode runs without a web server and never prints a banner that would
+ * corrupt the stdio JSON-RPC channel.
+ */
+@SpringBootApplication
+public class Main {
+
+	public static void main(String[] args) {
+		configureRuntime(args);
+		SpringApplication.run(Main.class, args);
+	}
+
+	static void configureRuntime(String[] args) {
+		String transportMode = resolveTransportMode(args);
+		System.setProperty("transport.mode", transportMode);
+		if ("stdio".equals(transportMode)) {
+			System.setProperty("spring.main.web-application-type", "none");
+		}
+		System.setProperty("spring.main.banner-mode", "off");
+	}
+
+	static String resolveTransportMode(String[] args) {
+		String prefix = "--transport.mode=";
+		for (String arg : args) {
+			if (arg.startsWith(prefix)) {
+				return arg.substring(prefix.length());
+			}
+		}
+		return "stdio";
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/McpConfiguration.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/McpConfiguration.java
@@ -1,0 +1,105 @@
+package io.github.adamw7.context.mcp;
+
+import java.util.List;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
+import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
+
+/**
+ * Wires the context-engineering MCP server. The server exposes the project-tree
+ * and context-finder tools over either stdio (the default) or a streamable HTTP
+ * transport selected with {@code --transport.mode=streamable-http}; the latter
+ * registers the {@code /mcp} servlet so MCP clients can connect over HTTP.
+ */
+@Configuration
+public class McpConfiguration {
+
+	private static final Logger log = LogManager.getLogger(McpConfiguration.class.getName());
+
+	@Bean
+	public ObjectMapper objectMapper() {
+		return new ObjectMapper();
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stdio", matchIfMissing = true)
+	public StdioServerTransportProvider stdioServerTransport() {
+		log.info("Creating StdioServerTransport");
+		return new StdioServerTransportProvider(new JacksonMcpJsonMapper(objectMapper()));
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
+	public HttpServletStreamableServerTransportProvider streamableServerTransport() {
+		log.info("Creating HttpServletStreamableServerTransport");
+		return HttpServletStreamableServerTransportProvider.builder()
+				.jsonMapper(new JacksonMcpJsonMapper(objectMapper()))
+				.mcpEndpoint("/mcp")
+				.build();
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
+	public ServletRegistrationBean<HttpServletStreamableServerTransportProvider> streamableServletRegistration(
+			HttpServletStreamableServerTransportProvider transport) {
+		ServletRegistrationBean<HttpServletStreamableServerTransportProvider> registration =
+				new ServletRegistrationBean<>(transport, "/mcp");
+		registration.setAsyncSupported(true);
+		return registration;
+	}
+
+	@Bean(destroyMethod = "close")
+	@ConditionalOnBean(McpServerTransportProvider.class)
+	public McpSyncServer mcpSyncServer(McpServerTransportProvider transport) {
+		log.info("Initializing McpSyncServer with transport: {}", transport);
+		McpSyncServer syncServer = McpServer.sync(transport)
+				.serverInfo("context-engineering-server", "0.0.1")
+				.capabilities(McpSchema.ServerCapabilities.builder()
+						.tools(true).resources(false, false).prompts(false).build())
+				.build();
+		registerTools(syncServer);
+		return syncServer;
+	}
+
+	@Bean(destroyMethod = "close")
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
+	public McpSyncServer mcpSyncServerStreamable(McpStreamableServerTransportProvider transport) {
+		log.info("Initializing McpSyncServer with streamable transport: {}", transport);
+		McpSyncServer syncServer = McpServer.sync(transport)
+				.serverInfo("context-engineering-server", "0.0.1")
+				.capabilities(McpSchema.ServerCapabilities.builder()
+						.tools(true).resources(false, false).prompts(false).build())
+				.build();
+		registerTools(syncServer);
+		return syncServer;
+	}
+
+	private void registerTools(McpSyncServer server) {
+		List<ContextTool> tools = List.of(new ProjectTreeTool(), new ContextFinderTool());
+		tools.forEach(tool -> server.addTool(specificationFor(tool)));
+	}
+
+	private SyncToolSpecification specificationFor(ContextTool tool) {
+		return SyncToolSpecification.builder()
+				.tool(tool.getToolDefinition())
+				.callHandler((exchange, request) -> tool.apply(request.arguments()))
+				.build();
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
@@ -1,0 +1,80 @@
+package io.github.adamw7.context.mcp;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Component;
+
+import io.github.adamw7.context.Language;
+import io.github.adamw7.context.tree.ProjectTreeBuilder;
+import io.github.adamw7.context.tree.ProjectTreeJsonSerializer;
+import io.github.adamw7.context.tree.ProjectTreeMarkdownSerializer;
+import io.github.adamw7.context.tree.ProjectTreeNode;
+import io.github.adamw7.context.tree.ProjectTreePrinter;
+import io.github.adamw7.context.tree.ProjectTreeSerializer;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+
+/**
+ * MCP tool that scans a Java or Kotlin project into a tree of folders, files and
+ * the classes each file depends on, then serialises it for a gen-AI agent. The
+ * output format ({@code json}, {@code markdown} or {@code text}) is chosen by the
+ * caller; JSON is the default as it is the most convenient for programmatic
+ * consumers.
+ */
+@Component
+public class ProjectTreeTool implements ContextTool {
+
+	private static final Logger log = LogManager.getLogger(ProjectTreeTool.class.getName());
+
+	private static final int DEFAULT_DEPTH = 1;
+	private static final String DEFAULT_FORMAT = "json";
+
+	private final Tool toolDefinition = Tool.builder("project_tree",
+			Map.of(
+					"type", "object",
+					"properties", Map.of(
+							"path", Map.of("type", "string",
+									"description", "absolute path to the project root directory"),
+							"language", Map.of("type", "string",
+									"description", "source language: java (default) or kotlin"),
+							"depth", Map.of("type", "integer",
+									"description", "how many levels of transitive dependencies to resolve (default 1)"),
+							"format", Map.of("type", "string",
+									"description", "output format: json (default), markdown or text")),
+					"required", List.of("path")))
+			.description("Scan a Java or Kotlin project into a tree of folders, files and class dependencies")
+			.build();
+
+	@Override
+	public Tool getToolDefinition() {
+		return toolDefinition;
+	}
+
+	@Override
+	public CallToolResult apply(Map<String, Object> arguments) {
+		log.info("Calling MCP project_tree tool for {}", arguments);
+		String rendered = buildTree(arguments);
+		return CallToolResult.builder().content(List.of(TextContent.builder(rendered).build())).isError(false).build();
+	}
+
+	private String buildTree(Map<String, Object> arguments) {
+		Path root = Path.of(ToolArguments.requiredString(arguments, "path"));
+		Language language = ToolArguments.optionalLanguage(arguments, "language", Language.JAVA);
+		int depth = ToolArguments.optionalInt(arguments, "depth", DEFAULT_DEPTH);
+		ProjectTreeNode tree = new ProjectTreeBuilder(language, depth).build(root);
+		return serializerFor(ToolArguments.optionalString(arguments, "format", DEFAULT_FORMAT)).serialize(tree);
+	}
+
+	private ProjectTreeSerializer serializerFor(String format) {
+		return switch (format.trim().toLowerCase(java.util.Locale.ROOT)) {
+			case "markdown" -> new ProjectTreeMarkdownSerializer();
+			case "text" -> new ProjectTreePrinter();
+			default -> new ProjectTreeJsonSerializer();
+		};
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/TlsConfiguration.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/TlsConfiguration.java
@@ -1,0 +1,37 @@
+package io.github.adamw7.context.mcp;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.boot.web.server.Ssl;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Pins the embedded server's HTTPS to TLS 1.3. When the streamable HTTP
+ * transport is served over HTTPS (SSL enabled through {@code server.ssl.*}), this
+ * customiser forces the only enabled protocol to {@code TLSv1.3}, regardless of
+ * what the configuration requested, so older, weaker protocols can never be
+ * negotiated. Plain HTTP and disabled SSL are left untouched — there is no TLS to
+ * constrain in those cases.
+ */
+@Configuration
+public class TlsConfiguration {
+
+	static final String TLS_1_3 = "TLSv1.3";
+
+	private static final Logger log = LogManager.getLogger(TlsConfiguration.class.getName());
+
+	@Bean
+	public WebServerFactoryCustomizer<TomcatServletWebServerFactory> enforceTls13() {
+		return factory -> pinToTls13(factory.getSsl());
+	}
+
+	private void pinToTls13(Ssl ssl) {
+		if (ssl != null && ssl.isEnabled()) {
+			log.info("Pinning HTTPS to {}", TLS_1_3);
+			ssl.setEnabledProtocols(new String[] { TLS_1_3 });
+		}
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ToolArguments.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ToolArguments.java
@@ -1,0 +1,40 @@
+package io.github.adamw7.context.mcp;
+
+import java.util.Map;
+
+import io.github.adamw7.context.Language;
+
+/**
+ * Reads typed values out of the loosely-typed {@code Map<String, Object>} the MCP
+ * runtime hands a tool. Keeping the parsing here lets every tool share the same
+ * rules for required arguments, defaults, and language resolution rather than
+ * repeating the conversions.
+ */
+final class ToolArguments {
+
+	private ToolArguments() {
+	}
+
+	static String requiredString(Map<String, Object> arguments, String key) {
+		Object value = arguments.get(key);
+		if (value == null) {
+			throw new IllegalArgumentException("Missing required argument: " + key);
+		}
+		return String.valueOf(value);
+	}
+
+	static String optionalString(Map<String, Object> arguments, String key, String defaultValue) {
+		Object value = arguments.get(key);
+		return value == null ? defaultValue : String.valueOf(value);
+	}
+
+	static int optionalInt(Map<String, Object> arguments, String key, int defaultValue) {
+		Object value = arguments.get(key);
+		return value == null ? defaultValue : Integer.parseInt(String.valueOf(value).trim());
+	}
+
+	static Language optionalLanguage(Map<String, Object> arguments, String key, Language defaultLanguage) {
+		Object value = arguments.get(key);
+		return value == null ? defaultLanguage : Language.fromName(String.valueOf(value));
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeBuilder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeBuilder.java
@@ -5,6 +5,7 @@ import io.github.adamw7.context.Context;
 import io.github.adamw7.context.ContextFactory;
 import io.github.adamw7.context.Finder;
 import io.github.adamw7.context.Language;
+import io.github.adamw7.context.ProjectSources;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -14,7 +15,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -56,20 +56,7 @@ public class ProjectTreeBuilder {
 	}
 
 	private Map<Path, ClassContainer> loadContainers(Path root) {
-		try (Stream<Path> paths = Files.walk(root)) {
-			return paths.filter(this::isSourceFile)
-					.collect(Collectors.toMap(path -> path, this::toContainer));
-		} catch (IOException e) {
-			throw new UncheckedIOException(e);
-		}
-	}
-
-	private boolean isSourceFile(Path path) {
-		return Files.isRegularFile(path) && path.getFileName().toString().endsWith(language.extension());
-	}
-
-	private ClassContainer toContainer(Path path) {
-		return ClassContainer.load(path, path.getFileName().toString());
+		return new ProjectSources(language).load(root);
 	}
 
 	private ProjectTreeNode buildNode(Path path, Context context, Map<Path, ClassContainer> containers) {

--- a/code/context/src/main/resources/application.properties
+++ b/code/context/src/main/resources/application.properties
@@ -2,6 +2,14 @@ spring.application.name=context-engineering-mcp
 server.port=8082
 spring.main.allow-bean-definition-overriding=true
 
+# Streamable HTTP is served over plain HTTP by default. To serve it over HTTPS,
+# point server.ssl.* at a key store and set server.ssl.enabled=true; the
+# TlsConfiguration customiser then pins the connector to TLS 1.3 automatically.
+# server.ssl.enabled=true
+# server.ssl.key-store=classpath:keystore.p12
+# server.ssl.key-store-password=changeit
+# server.ssl.key-store-type=PKCS12
+
 logging.level.root=INFO
 logging.level.org.springframework.boot.autoconfigure=ERROR
 logging.level.io.modelcontextprotocol=INFO

--- a/code/context/src/main/resources/application.properties
+++ b/code/context/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+spring.application.name=context-engineering-mcp
+server.port=8082
+spring.main.allow-bean-definition-overriding=true
+
+logging.level.root=INFO
+logging.level.org.springframework.boot.autoconfigure=ERROR
+logging.level.io.modelcontextprotocol=INFO
+logging.level.io.github.adamw7.context=INFO

--- a/code/context/src/main/resources/log4j2.properties
+++ b/code/context/src/main/resources/log4j2.properties
@@ -1,0 +1,35 @@
+# Set to debug or trace if log4j initialization is failing
+status = info
+
+# Name of the configuration
+name = Log4jConfig
+
+property.basePath = logs
+
+# RollingFileAppender name, pattern, path and rollover policy
+appender.rolling.type = RollingFile
+appender.rolling.name = fileLogger
+appender.rolling.fileName= ${basePath}/context-mcp.log
+appender.rolling.filePattern= ${basePath}/context-mcp_%d{yyyyMMdd}.log.gz
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %level [%t] [%l] - %msg%n
+appender.rolling.policies.type = Policies
+
+# RollingFileAppender rotation policy
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size = 10MB
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.time.modulate = true
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.delete.type = Delete
+appender.rolling.strategy.delete.basePath = ${basePath}
+appender.rolling.strategy.delete.maxDepth = 10
+appender.rolling.strategy.delete.ifLastModified.type = IfLastModified
+
+# Delete all files older than 30 days
+appender.rolling.strategy.delete.ifLastModified.age = 30d
+
+# Configure root logger
+rootLogger.level = info
+rootLogger.appenderRef.rolling.ref = fileLogger

--- a/code/context/src/test/java/io/github/adamw7/context/LanguageTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/LanguageTest.java
@@ -1,0 +1,25 @@
+package io.github.adamw7.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class LanguageTest {
+
+	@Test
+	void resolvesJavaIgnoringCase() {
+		assertEquals(Language.JAVA, Language.fromName("java"));
+		assertEquals(Language.JAVA, Language.fromName("JAVA"));
+	}
+
+	@Test
+	void resolvesKotlinIgnoringSurroundingWhitespace() {
+		assertEquals(Language.KOTLIN, Language.fromName("  Kotlin  "));
+	}
+
+	@Test
+	void rejectsUnknownLanguage() {
+		assertThrows(IllegalArgumentException.class, () -> Language.fromName("scala"));
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/ProjectSourcesTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/ProjectSourcesTest.java
@@ -1,0 +1,65 @@
+package io.github.adamw7.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class ProjectSourcesTest {
+
+	@TempDir
+	Path projectRoot;
+
+	@Test
+	void loadsOnlySourceFilesOfTheConfiguredLanguage() throws IOException {
+		writeFile("A.java", "public class A {}");
+		writeFile("B.java", "public class B {}");
+		writeFile("notes.txt", "ignore me");
+		writeFile("Script.kt", "class Script");
+
+		Set<String> names = classNames(new ProjectSources(Language.JAVA).load(projectRoot));
+
+		assertEquals(Set.of("A.java", "B.java"), names);
+	}
+
+	@Test
+	void recognisesKotlinSources() throws IOException {
+		writeFile("A.java", "public class A {}");
+		writeFile("Script.kt", "class Script");
+
+		Set<String> names = classNames(new ProjectSources(Language.KOTLIN).load(projectRoot));
+
+		assertEquals(Set.of("Script.kt"), names);
+	}
+
+	@Test
+	void readsTheOriginalSourceIntoEachContainer() throws IOException {
+		writeFile("A.java", "public class A { int x; }");
+
+		Map<Path, ClassContainer> containers = new ProjectSources(Language.JAVA).load(projectRoot);
+
+		ClassContainer container = containers.get(projectRoot.resolve("A.java"));
+		assertTrue(container.originalCode().contains("int x;"));
+	}
+
+	@Test
+	void emptyProjectYieldsNoSources() {
+		assertTrue(new ProjectSources(Language.JAVA).load(projectRoot).isEmpty());
+	}
+
+	private void writeFile(String name, String content) throws IOException {
+		Files.writeString(projectRoot.resolve(name), content);
+	}
+
+	private Set<String> classNames(Map<Path, ClassContainer> containers) {
+		return containers.values().stream().map(ClassContainer::className).collect(Collectors.toSet());
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ContextFinderToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ContextFinderToolTest.java
@@ -1,0 +1,121 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+
+public class ContextFinderToolTest {
+
+	@TempDir
+	Path projectRoot;
+
+	private final ContextFinderTool tool = new ContextFinderTool();
+
+	@Test
+	void toolDefinitionExposesName() {
+		assertEquals("find_context", tool.getToolDefinition().name());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void toolDefinitionRequiresPathAndClassName() {
+		List<String> required = (List<String>) tool.getToolDefinition().inputSchema().get("required");
+		assertTrue(required.contains("path"));
+		assertTrue(required.contains("class_name"));
+	}
+
+	@Test
+	void findsDirectDependencies() throws IOException {
+		writeJava("A", "public class A {}");
+		writeJava("B", "public class B { A a; }");
+
+		List<Object> dependencies = dependencies(tool.apply(arguments("B")));
+
+		assertEquals(List.of("A.java"), dependencies);
+	}
+
+	@Test
+	void acceptsAClassNameWithExtension() throws IOException {
+		writeJava("A", "public class A {}");
+		writeJava("B", "public class B { A a; }");
+
+		List<Object> dependencies = dependencies(tool.apply(arguments("B.java")));
+
+		assertEquals(List.of("A.java"), dependencies);
+	}
+
+	@Test
+	void resolvesTransitiveDependenciesAtTheGivenDepth() throws IOException {
+		writeJava("A", "public class A {}");
+		writeJava("B", "public class B { A a; }");
+		writeJava("C", "public class C { B b; }");
+
+		Map<String, Object> arguments = arguments("C");
+		arguments.put("depth", 2);
+
+		List<Object> dependencies = dependencies(tool.apply(arguments));
+
+		assertEquals(List.of("A.java", "B.java"), dependencies);
+	}
+
+	@Test
+	void unknownClassYieldsAnErrorResult() throws IOException {
+		writeJava("A", "public class A {}");
+
+		CallToolResult result = tool.apply(arguments("Missing"));
+
+		assertTrue(result.isError());
+		assertTrue(text(result).contains("Class not found: Missing"));
+	}
+
+	@Test
+	void aClassWithoutDependenciesReturnsAnEmptyArray() throws IOException {
+		writeJava("A", "public class A {}");
+
+		CallToolResult result = tool.apply(arguments("A"));
+
+		assertFalse(result.isError());
+		assertTrue(dependencies(result).isEmpty());
+	}
+
+	@Test
+	void missingClassNameIsRejected() {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("path", projectRoot.toString());
+		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
+	}
+
+	private Map<String, Object> arguments(String className) {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("path", projectRoot.toString());
+		arguments.put("class_name", className);
+		return arguments;
+	}
+
+	private void writeJava(String className, String body) throws IOException {
+		Files.writeString(projectRoot.resolve(className + ".java"), body);
+	}
+
+	private List<Object> dependencies(CallToolResult result) {
+		return new JSONArray(text(result)).toList();
+	}
+
+	private String text(CallToolResult result) {
+		return ((TextContent) result.content().getFirst()).text();
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/MainTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/MainTest.java
@@ -1,0 +1,86 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MainTest {
+
+	private static final String TRANSPORT_MODE = "transport.mode";
+	private static final String WEB_APPLICATION_TYPE = "spring.main.web-application-type";
+	private static final String BANNER_MODE = "spring.main.banner-mode";
+
+	@BeforeEach
+	@AfterEach
+	public void clearRuntimeProperties() {
+		System.clearProperty(TRANSPORT_MODE);
+		System.clearProperty(WEB_APPLICATION_TYPE);
+		System.clearProperty(BANNER_MODE);
+	}
+
+	@Test
+	public void defaultsToStdioWhenNoArguments() {
+		assertEquals("stdio", Main.resolveTransportMode(new String[] {}));
+	}
+
+	@Test
+	public void defaultsToStdioWhenPrefixAbsent() {
+		assertEquals("stdio", Main.resolveTransportMode(new String[] { "--server.port=8080", "--other" }));
+	}
+
+	@Test
+	public void readsExplicitTransportMode() {
+		assertEquals("streamable-http", Main.resolveTransportMode(new String[] { "--transport.mode=streamable-http" }));
+	}
+
+	@Test
+	public void findsTransportModeAmongOtherArguments() {
+		String[] args = { "--server.port=8080", "--transport.mode=streamable-http" };
+		assertEquals("streamable-http", Main.resolveTransportMode(args));
+	}
+
+	@Test
+	public void supportsEmptyTransportModeValue() {
+		assertEquals("", Main.resolveTransportMode(new String[] { "--transport.mode=" }));
+	}
+
+	@Test
+	public void configureRuntimeDisablesBanner() {
+		Main.configureRuntime(new String[] {});
+
+		assertEquals("off", System.getProperty(BANNER_MODE));
+	}
+
+	@Test
+	public void configureRuntimePropagatesTransportMode() {
+		Main.configureRuntime(new String[] { "--transport.mode=streamable-http" });
+
+		assertEquals("streamable-http", System.getProperty(TRANSPORT_MODE));
+	}
+
+	@Test
+	public void configureRuntimeDefaultsTransportModeToStdio() {
+		Main.configureRuntime(new String[] {});
+
+		assertEquals("stdio", System.getProperty(TRANSPORT_MODE));
+	}
+
+	@Test
+	public void configureRuntimeForcesNonWebApplicationInStdioMode() {
+		Main.configureRuntime(new String[] {});
+
+		assertEquals("none", System.getProperty(WEB_APPLICATION_TYPE));
+	}
+
+	@Test
+	public void configureRuntimeKeepsWebApplicationForStreamableHttpMode() {
+		Main.configureRuntime(new String[] { "--transport.mode=streamable-http" });
+
+		// A web server is required to expose the /mcp servlet, so the web
+		// application type must not be forced to "none" here.
+		assertNull(System.getProperty(WEB_APPLICATION_TYPE));
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpConfigurationTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpConfigurationTest.java
@@ -1,0 +1,64 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
+import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
+
+public class McpConfigurationTest {
+
+	@Test
+	public void happyPath() throws Exception {
+		McpConfiguration config = new McpConfiguration();
+		assertNotNull(config.objectMapper());
+		// Drive the stdio server from a controllable pipe instead of System.in. The
+		// reader thread is non-daemon and cannot be interrupted while blocked on a
+		// read, so closing the pipe is the only way to let it terminate and avoid
+		// leaking it into the forked test JVM.
+		PipedInputStream input = new PipedInputStream();
+		PipedOutputStream inputWriter = new PipedOutputStream(input);
+		McpSyncServer server = config.mcpSyncServer(new StdioServerTransportProvider(
+				new JacksonMcpJsonMapper(new ObjectMapper()), input, OutputStream.nullOutputStream()));
+		assertNotNull(server.getServerCapabilities().tools());
+		server.close();
+		inputWriter.close();
+	}
+
+	@Test
+	public void stdioTransportIsNotNull() {
+		McpConfiguration config = new McpConfiguration();
+		assertNotNull(config.stdioServerTransport());
+	}
+
+	@Test
+	public void streamableTransportIsNotNull() {
+		McpConfiguration config = new McpConfiguration();
+		assertNotNull(config.streamableServerTransport());
+	}
+
+	@Test
+	public void streamableServletRegistrationIsNotNull() {
+		McpConfiguration config = new McpConfiguration();
+		HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
+		assertNotNull(config.streamableServletRegistration(transport));
+	}
+
+	@Test
+	public void mcpSyncServerStreamableHasTools() {
+		McpConfiguration config = new McpConfiguration();
+		HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
+		McpSyncServer server = config.mcpSyncServerStreamable(transport);
+		assertFalse(server.getServerCapabilities().tools() == null);
+		server.close();
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpIT.java
@@ -1,0 +1,91 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+
+@SpringBootTest(
+		classes = Main.class,
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = { "transport.mode=streamable-http", "spring.main.banner-mode=off" })
+public class McpStreamableHttpIT {
+
+	@LocalServerPort
+	private int port;
+
+	@TempDir
+	Path projectRoot;
+
+	private McpSyncClient client;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		Files.writeString(projectRoot.resolve("A.java"), "public class A {}");
+		Files.writeString(projectRoot.resolve("B.java"), "public class B { A a; }");
+		HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
+				.builder("http://localhost:" + port)
+				.build();
+		client = McpClient.sync(transport)
+				.clientInfo(McpSchema.Implementation.builder("integration-test-client", "1.0").build())
+				.build();
+		client.initialize();
+	}
+
+	@AfterEach
+	void tearDown() {
+		client.close();
+	}
+
+	@Test
+	void listsBothContextTools() {
+		McpSchema.ListToolsResult tools = client.listTools();
+
+		assertTrue(tools.tools().stream().anyMatch(tool -> tool.name().equals("project_tree")));
+		assertTrue(tools.tools().stream().anyMatch(tool -> tool.name().equals("find_context")));
+	}
+
+	@Test
+	void projectTreeToolReturnsTheScannedTree() {
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("project_tree")
+				.arguments(Map.of("path", projectRoot.toString()))
+				.build();
+
+		McpSchema.CallToolResult result = client.callTool(request);
+
+		assertFalse(result.isError());
+		String tree = ((McpSchema.TextContent) result.content().getFirst()).text();
+		assertTrue(tree.contains("A.java"));
+		assertTrue(tree.contains("B.java"));
+	}
+
+	@Test
+	void findContextToolReturnsDependencies() {
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("find_context")
+				.arguments(Map.of("path", projectRoot.toString(), "class_name", "B"))
+				.build();
+
+		McpSchema.CallToolResult result = client.callTool(request);
+
+		assertFalse(result.isError());
+		String dependencies = ((McpSchema.TextContent) result.content().getFirst()).text();
+		assertEquals("A.java", new JSONArray(dependencies).getString(0));
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
@@ -1,0 +1,113 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+
+public class ProjectTreeToolTest {
+
+	@TempDir
+	Path projectRoot;
+
+	private final ProjectTreeTool tool = new ProjectTreeTool();
+
+	@Test
+	void toolDefinitionExposesName() {
+		assertEquals("project_tree", tool.getToolDefinition().name());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void toolDefinitionRequiresPath() {
+		List<String> required = (List<String>) tool.getToolDefinition().inputSchema().get("required");
+		assertTrue(required.contains("path"));
+	}
+
+	@Test
+	void buildsJsonTreeByDefault() throws IOException {
+		writeJava("A", "public class A {}");
+		writeJava("B", "public class B { A a; }");
+
+		JSONObject tree = new JSONObject(text(tool.apply(arguments())));
+
+		assertEquals(projectRoot.getFileName().toString(), tree.getString("name"));
+		assertEquals("directory", tree.getString("type"));
+		assertEquals(2, tree.getJSONArray("children").length());
+	}
+
+	@Test
+	void honoursTheMarkdownFormat() throws IOException {
+		writeJava("A", "public class A {}");
+
+		Map<String, Object> arguments = arguments();
+		arguments.put("format", "markdown");
+
+		String rendered = text(tool.apply(arguments));
+		assertTrue(rendered.contains("- `A.java`"));
+	}
+
+	@Test
+	void honoursTheTextFormat() throws IOException {
+		writeJava("A", "public class A {}");
+
+		Map<String, Object> arguments = arguments();
+		arguments.put("format", "text");
+
+		String rendered = text(tool.apply(arguments));
+		assertTrue(rendered.contains("[file] A.java"));
+	}
+
+	@Test
+	void resolvesTransitiveDependenciesAtTheRequestedDepth() throws IOException {
+		writeJava("A", "public class A {}");
+		writeJava("B", "public class B { A a; }");
+		writeJava("C", "public class C { B b; }");
+
+		Map<String, Object> arguments = arguments();
+		arguments.put("depth", 2);
+
+		String rendered = text(tool.apply(arguments));
+		assertTrue(rendered.contains("A.java"));
+		assertTrue(rendered.contains("B.java"));
+	}
+
+	@Test
+	void resultIsNotAnError() throws IOException {
+		writeJava("A", "public class A {}");
+		assertFalse(tool.apply(arguments()).isError());
+	}
+
+	@Test
+	void missingPathIsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> tool.apply(new HashMap<>()));
+	}
+
+	private Map<String, Object> arguments() {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("path", projectRoot.toString());
+		return arguments;
+	}
+
+	private void writeJava(String className, String body) throws IOException {
+		Files.writeString(projectRoot.resolve(className + ".java"), body);
+	}
+
+	private String text(CallToolResult result) {
+		return ((TextContent) result.content().getFirst()).text();
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/TlsConfigurationTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/TlsConfigurationTest.java
@@ -1,0 +1,61 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.server.Ssl;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+
+public class TlsConfigurationTest {
+
+	private final TlsConfiguration config = new TlsConfiguration();
+
+	@Test
+	void pinsEnabledHttpsToTls13() {
+		TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory();
+		factory.setSsl(enabledSsl(new String[] { "TLSv1.2", "TLSv1.3" }));
+
+		config.enforceTls13().customize(factory);
+
+		assertArrayEquals(new String[] { TlsConfiguration.TLS_1_3 }, factory.getSsl().getEnabledProtocols());
+	}
+
+	@Test
+	void pinsHttpsEvenWhenNoProtocolWasRequested() {
+		TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory();
+		factory.setSsl(enabledSsl(null));
+
+		config.enforceTls13().customize(factory);
+
+		assertArrayEquals(new String[] { TlsConfiguration.TLS_1_3 }, factory.getSsl().getEnabledProtocols());
+	}
+
+	@Test
+	void leavesPlainHttpUntouched() {
+		TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory();
+
+		config.enforceTls13().customize(factory);
+
+		assertNull(factory.getSsl());
+	}
+
+	@Test
+	void leavesDisabledSslUntouched() {
+		TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory();
+		Ssl ssl = enabledSsl(new String[] { "TLSv1.2" });
+		ssl.setEnabled(false);
+		factory.setSsl(ssl);
+
+		config.enforceTls13().customize(factory);
+
+		assertArrayEquals(new String[] { "TLSv1.2" }, factory.getSsl().getEnabledProtocols());
+	}
+
+	private Ssl enabledSsl(String[] protocols) {
+		Ssl ssl = new Ssl();
+		ssl.setEnabled(true);
+		ssl.setEnabledProtocols(protocols);
+		return ssl;
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ToolArgumentsTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ToolArgumentsTest.java
@@ -1,0 +1,61 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.context.Language;
+
+public class ToolArgumentsTest {
+
+	@Test
+	void requiredStringReturnsTheValue() {
+		assertEquals("foo", ToolArguments.requiredString(Map.of("path", "foo"), "path"));
+	}
+
+	@Test
+	void requiredStringFailsWhenMissing() {
+		IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+				() -> ToolArguments.requiredString(Map.of(), "path"));
+		assertEquals("Missing required argument: path", error.getMessage());
+	}
+
+	@Test
+	void optionalStringFallsBackToDefault() {
+		assertEquals("json", ToolArguments.optionalString(Map.of(), "format", "json"));
+	}
+
+	@Test
+	void optionalStringPrefersTheGivenValue() {
+		assertEquals("markdown", ToolArguments.optionalString(Map.of("format", "markdown"), "format", "json"));
+	}
+
+	@Test
+	void optionalIntFallsBackToDefault() {
+		assertEquals(1, ToolArguments.optionalInt(Map.of(), "depth", 1));
+	}
+
+	@Test
+	void optionalIntParsesNumericStrings() {
+		assertEquals(3, ToolArguments.optionalInt(Map.of("depth", "3"), "depth", 1));
+	}
+
+	@Test
+	void optionalIntParsesIntegers() {
+		assertEquals(2, ToolArguments.optionalInt(Map.of("depth", 2), "depth", 1));
+	}
+
+	@Test
+	void optionalLanguageFallsBackToDefault() {
+		assertEquals(Language.JAVA, ToolArguments.optionalLanguage(Map.of(), "language", Language.JAVA));
+	}
+
+	@Test
+	void optionalLanguageResolvesTheGivenName() {
+		assertEquals(Language.KOTLIN, ToolArguments.optionalLanguage(Map.of("language", "kotlin"), "language",
+				Language.JAVA));
+	}
+}


### PR DESCRIPTION
## Summary

Adds an MCP server that exposes the context-engineering capabilities of the `code/context` module to MCP clients (Claude Desktop, Cline, etc.). It lives in a new package `io.github.adamw7.context.mcp` within the same module, mirroring the existing data-module MCP server, and supports **stdio** (default) and **streamable HTTP** (`--transport.mode=streamable-http`, served at `/mcp`). HTTPS is pinned to **TLS 1.3**.

## Tools

- **`project_tree`** — scans a Java/Kotlin project into a tree of folders, files and class dependencies; output as `json` (default), `markdown` or `text`. Params: `path` (required), `language`, `depth`, `format`.
- **`find_context`** — resolves the classes a given class depends on, to a configurable depth, returned as a JSON array; an unknown class yields an error result. Params: `path` (required), `class_name` (required), `language`, `depth`.

## Implementation

- `Main` (Spring Boot entry point, transport selection), `McpConfiguration` (transports + tool registration), `ContextTool` (shared abstraction), `ProjectTreeTool`, `ContextFinderTool`, `ToolArguments` (argument parsing).
- `TlsConfiguration` — a `WebServerFactoryCustomizer` that forces the embedded server's enabled SSL protocols to `TLSv1.3` whenever HTTPS is enabled, so weaker protocols can never be negotiated. Plain HTTP / disabled SSL are left untouched.
- Refactor: extracted a reusable `ProjectSources` loader (now used by both `ProjectTreeBuilder` and the finder tool) and added `Language.fromName` for string-based language selection.
- Build: imports the MCP SDK (`mcp-bom` 2.0.0) and Spring Boot web, configures `spring-boot-maven-plugin` for an executable jar, and adds an `integration-tests` profile.

## Testing

- 113 unit tests pass, covering both tools, argument parsing, the loader, language parsing, TLS enforcement (enabled / disabled / plain-HTTP), config and main.
- A streamable-HTTP end-to-end integration test (`McpStreamableHttpIT`, under the `integration-tests` profile) drives a real MCP client against the running server and exercises both tools.
- CLAUDE.md / AGENTS.md enforcer rules pass; docs updated (`MCP_USAGE.md`, `AGENTS.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0129NXQ1ezrLrXSRfSwsuC4m)_