### PR TITLE
fix(context): harden MCP server file access and HTTP exposure

### DIFF
--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
-import org.springframework.stereotype.Component;
 
 import io.github.adamw7.context.ClassContainer;
 import io.github.adamw7.context.Finder;
@@ -26,12 +25,18 @@ import io.modelcontextprotocol.spec.McpSchema.Tool;
  * reported as an error result rather than an exception so the agent gets a clear,
  * actionable message.
  */
-@Component
 public class ContextFinderTool implements ContextTool {
 
 	private static final Logger log = LogManager.getLogger(ContextFinderTool.class.getName());
 
 	private static final int DEFAULT_DEPTH = 1;
+	private static final int MAX_DEPTH = 10;
+
+	private final PathPolicy pathPolicy;
+
+	public ContextFinderTool(PathPolicy pathPolicy) {
+		this.pathPolicy = pathPolicy;
+	}
 
 	private final Tool toolDefinition = Tool.builder("find_context",
 			Map.of(
@@ -57,9 +62,9 @@ public class ContextFinderTool implements ContextTool {
 	@Override
 	public CallToolResult apply(Map<String, Object> arguments) {
 		log.info("Calling MCP find_context tool for {}", arguments);
-		Path root = Path.of(ToolArguments.requiredString(arguments, "path"));
+		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
 		Language language = ToolArguments.optionalLanguage(arguments, "language", Language.JAVA);
-		int depth = ToolArguments.optionalInt(arguments, "depth", DEFAULT_DEPTH);
+		int depth = ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH);
 		Set<ClassContainer> containers = Set.copyOf(new ProjectSources(language).load(root).values());
 
 		ClassContainer target = findTarget(containers, arguments, language);

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -126,6 +126,30 @@ server.ssl.key-store-type=PKCS12
 negotiated even if they are requested. The endpoint is then served at
 `https://localhost:8082/mcp`.
 
+## Security
+
+The tools read source files from disk, so access is constrained by design:
+
+- **Allowed roots.** Every `path` argument is resolved to its real location
+  (symlinks followed, `..` collapsed) and must fall within a configured allowed
+  root, otherwise the call is rejected. Configure the roots with
+  `context.allowed-roots` (a `File.pathSeparator`-separated list of absolute
+  paths). When left blank, the server's working directory is the single allowed
+  root. This prevents a client from steering the scanners at arbitrary files
+  such as `/etc` or a user's home directory.
+
+  ```properties
+  context.allowed-roots=/home/me/projects:/srv/code
+  ```
+
+- **Loopback binding.** The streamable HTTP transport binds to `127.0.0.1` by
+  default (`server.address`). The `/mcp` endpoint has **no authentication**, so
+  it must not be exposed on a routable interface. Change `server.address` only
+  after putting authentication in front of it.
+
+- **Bounded depth.** The `depth` argument is capped at `10` to bound the cost of
+  transitive dependency resolution.
+
 ## Configuring MCP Clients
 
 ### Claude Desktop (stdio)

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/McpConfiguration.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/McpConfiguration.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
@@ -32,6 +33,9 @@ import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 public class McpConfiguration {
 
 	private static final Logger log = LogManager.getLogger(McpConfiguration.class.getName());
+
+	@Value("${context.allowed-roots:}")
+	private String allowedRoots;
 
 	@Bean
 	public ObjectMapper objectMapper() {
@@ -92,7 +96,9 @@ public class McpConfiguration {
 	}
 
 	private void registerTools(McpSyncServer server) {
-		List<ContextTool> tools = List.of(new ProjectTreeTool(), new ContextFinderTool());
+		PathPolicy pathPolicy = new PathPolicy(allowedRoots);
+		log.info("Confining MCP file access to allowed roots: {}", pathPolicy.allowedRoots());
+		List<ContextTool> tools = List.of(new ProjectTreeTool(pathPolicy), new ContextFinderTool(pathPolicy));
 		tools.forEach(tool -> server.addTool(specificationFor(tool)));
 	}
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/PathPolicy.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/PathPolicy.java
@@ -1,0 +1,63 @@
+package io.github.adamw7.context.mcp;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Confines the file-system access of the MCP tools to a set of allowed root
+ * directories. Every caller-supplied path is resolved to its real location
+ * (following symlinks and collapsing {@code ..}) and must lie within one of the
+ * configured roots, so a malicious or confused client cannot steer the project
+ * scanners at arbitrary files such as {@code /etc} or a user's home directory.
+ * Roots are configured through {@code context.allowed-roots} as a
+ * {@link File#pathSeparator}-separated list; when none are configured the
+ * server's working directory becomes the single allowed root.
+ */
+final class PathPolicy {
+
+	private final List<Path> allowedRoots;
+
+	PathPolicy(String configuredRoots) {
+		this.allowedRoots = resolveRoots(configuredRoots);
+	}
+
+	List<Path> allowedRoots() {
+		return allowedRoots;
+	}
+
+	Path resolve(String requestedPath) {
+		Path candidate = realPath(Path.of(requestedPath));
+		if (isWithinAllowedRoot(candidate)) {
+			return candidate;
+		}
+		throw new SecurityException("Access denied: path is outside the allowed roots: " + requestedPath);
+	}
+
+	private boolean isWithinAllowedRoot(Path candidate) {
+		return allowedRoots.stream().anyMatch(candidate::startsWith);
+	}
+
+	private List<Path> resolveRoots(String configuredRoots) {
+		if (configuredRoots == null || configuredRoots.isBlank()) {
+			return List.of(realPath(Path.of(System.getProperty("user.dir"))));
+		}
+		return Arrays.stream(configuredRoots.split(File.pathSeparator))
+				.map(String::trim)
+				.filter(root -> !root.isEmpty())
+				.map(Path::of)
+				.map(this::realPath)
+				.toList();
+	}
+
+	private Path realPath(Path path) {
+		try {
+			return path.toRealPath();
+		} catch (IOException e) {
+			throw new UncheckedIOException("Path does not exist or is not accessible: " + path, e);
+		}
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.stereotype.Component;
 
 import io.github.adamw7.context.Language;
 import io.github.adamw7.context.tree.ProjectTreeBuilder;
@@ -26,13 +25,19 @@ import io.modelcontextprotocol.spec.McpSchema.Tool;
  * caller; JSON is the default as it is the most convenient for programmatic
  * consumers.
  */
-@Component
 public class ProjectTreeTool implements ContextTool {
 
 	private static final Logger log = LogManager.getLogger(ProjectTreeTool.class.getName());
 
 	private static final int DEFAULT_DEPTH = 1;
+	private static final int MAX_DEPTH = 10;
 	private static final String DEFAULT_FORMAT = "json";
+
+	private final PathPolicy pathPolicy;
+
+	public ProjectTreeTool(PathPolicy pathPolicy) {
+		this.pathPolicy = pathPolicy;
+	}
 
 	private final Tool toolDefinition = Tool.builder("project_tree",
 			Map.of(
@@ -63,9 +68,9 @@ public class ProjectTreeTool implements ContextTool {
 	}
 
 	private String buildTree(Map<String, Object> arguments) {
-		Path root = Path.of(ToolArguments.requiredString(arguments, "path"));
+		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
 		Language language = ToolArguments.optionalLanguage(arguments, "language", Language.JAVA);
-		int depth = ToolArguments.optionalInt(arguments, "depth", DEFAULT_DEPTH);
+		int depth = ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH);
 		ProjectTreeNode tree = new ProjectTreeBuilder(language, depth).build(root);
 		return serializerFor(ToolArguments.optionalString(arguments, "format", DEFAULT_FORMAT)).serialize(tree);
 	}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ToolArguments.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ToolArguments.java
@@ -33,6 +33,15 @@ final class ToolArguments {
 		return value == null ? defaultValue : Integer.parseInt(String.valueOf(value).trim());
 	}
 
+	static int optionalBoundedInt(Map<String, Object> arguments, String key, int defaultValue, int min, int max) {
+		int value = optionalInt(arguments, key, defaultValue);
+		if (value < min || value > max) {
+			throw new IllegalArgumentException(
+					"Argument " + key + " must be between " + min + " and " + max + " but was " + value);
+		}
+		return value;
+	}
+
 	static Language optionalLanguage(Map<String, Object> arguments, String key, Language defaultLanguage) {
 		Object value = arguments.get(key);
 		return value == null ? defaultLanguage : Language.fromName(String.valueOf(value));

--- a/code/context/src/main/resources/application.properties
+++ b/code/context/src/main/resources/application.properties
@@ -1,6 +1,16 @@
 spring.application.name=context-engineering-mcp
 server.port=8082
+# Bind the streamable HTTP transport to the loopback interface only. The MCP
+# endpoint has no authentication, so it must not be reachable from the network.
+# Override deliberately (and add authentication) before exposing it more widely.
+server.address=127.0.0.1
 spring.main.allow-bean-definition-overriding=true
+
+# Confine the project scanners to these directories (File.pathSeparator-separated
+# list of absolute paths). Any requested path is resolved to its real location
+# and rejected if it falls outside them, preventing arbitrary file-system reads.
+# When left blank the server's working directory is the single allowed root.
+# context.allowed-roots=/home/me/projects
 
 # Streamable HTTP is served over plain HTTP by default. To serve it over HTTPS,
 # point server.ssl.* at a key store and set server.ssl.enabled=true; the

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ContextFinderToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ContextFinderToolTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.json.JSONArray;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -24,7 +25,15 @@ public class ContextFinderToolTest {
 	@TempDir
 	Path projectRoot;
 
-	private final ContextFinderTool tool = new ContextFinderTool();
+	@TempDir
+	Path outsideRoot;
+
+	private ContextFinderTool tool;
+
+	@BeforeEach
+	void setUp() {
+		tool = new ContextFinderTool(new PathPolicy(projectRoot.toString()));
+	}
 
 	@Test
 	void toolDefinitionExposesName() {
@@ -97,6 +106,21 @@ public class ContextFinderToolTest {
 	void missingClassNameIsRejected() {
 		Map<String, Object> arguments = new HashMap<>();
 		arguments.put("path", projectRoot.toString());
+		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
+	}
+
+	@Test
+	void pathOutsideTheAllowedRootIsRejected() {
+		Map<String, Object> arguments = arguments("B");
+		arguments.put("path", outsideRoot.toString());
+		assertThrows(SecurityException.class, () -> tool.apply(arguments));
+	}
+
+	@Test
+	void excessiveDepthIsRejected() throws IOException {
+		writeJava("A", "public class A {}");
+		Map<String, Object> arguments = arguments("A");
+		arguments.put("depth", 99);
 		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
 	}
 

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpIT.java
@@ -25,7 +25,10 @@ import io.modelcontextprotocol.spec.McpSchema;
 @SpringBootTest(
 		classes = Main.class,
 		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-		properties = { "transport.mode=streamable-http", "spring.main.banner-mode=off" })
+		properties = {
+				"transport.mode=streamable-http",
+				"spring.main.banner-mode=off",
+				"context.allowed-roots=${java.io.tmpdir}" })
 public class McpStreamableHttpIT {
 
 	@LocalServerPort

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/PathPolicyTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/PathPolicyTest.java
@@ -1,0 +1,77 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class PathPolicyTest {
+
+	@TempDir
+	Path allowedRoot;
+
+	@TempDir
+	Path otherRoot;
+
+	@Test
+	void resolvesAPathInsideAnAllowedRoot() throws IOException {
+		Path nested = Files.createDirectory(allowedRoot.resolve("module"));
+
+		Path resolved = new PathPolicy(allowedRoot.toString()).resolve(nested.toString());
+
+		assertEquals(nested.toRealPath(), resolved);
+	}
+
+	@Test
+	void resolvesTheAllowedRootItself() throws IOException {
+		Path resolved = new PathPolicy(allowedRoot.toString()).resolve(allowedRoot.toString());
+
+		assertEquals(allowedRoot.toRealPath(), resolved);
+	}
+
+	@Test
+	void rejectsAPathOutsideEveryAllowedRoot() {
+		PathPolicy policy = new PathPolicy(allowedRoot.toString());
+
+		assertThrows(SecurityException.class, () -> policy.resolve(otherRoot.toString()));
+	}
+
+	@Test
+	void rejectsTraversalThatEscapesTheAllowedRoot() {
+		PathPolicy policy = new PathPolicy(allowedRoot.toString());
+		String escaping = allowedRoot.resolve("..").toString();
+
+		assertThrows(SecurityException.class, () -> policy.resolve(escaping));
+	}
+
+	@Test
+	void rejectsAPathThatDoesNotExist() {
+		PathPolicy policy = new PathPolicy(allowedRoot.toString());
+		String missing = allowedRoot.resolve("does-not-exist").toString();
+
+		assertThrows(UncheckedIOException.class, () -> policy.resolve(missing));
+	}
+
+	@Test
+	void defaultsToTheWorkingDirectoryWhenNoRootsAreConfigured() throws IOException {
+		Path workingDir = Path.of(System.getProperty("user.dir")).toRealPath();
+
+		Path resolved = new PathPolicy("").resolve(workingDir.toString());
+
+		assertEquals(workingDir, resolved);
+	}
+
+	@Test
+	void supportsSeveralAllowedRoots() throws IOException {
+		String roots = allowedRoot + java.io.File.pathSeparator + otherRoot;
+		PathPolicy policy = new PathPolicy(roots);
+
+		assertEquals(otherRoot.toRealPath(), policy.resolve(otherRoot.toString()));
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -24,7 +25,15 @@ public class ProjectTreeToolTest {
 	@TempDir
 	Path projectRoot;
 
-	private final ProjectTreeTool tool = new ProjectTreeTool();
+	@TempDir
+	Path outsideRoot;
+
+	private ProjectTreeTool tool;
+
+	@BeforeEach
+	void setUp() {
+		tool = new ProjectTreeTool(new PathPolicy(projectRoot.toString()));
+	}
 
 	@Test
 	void toolDefinitionExposesName() {
@@ -95,6 +104,21 @@ public class ProjectTreeToolTest {
 	@Test
 	void missingPathIsRejected() {
 		assertThrows(IllegalArgumentException.class, () -> tool.apply(new HashMap<>()));
+	}
+
+	@Test
+	void pathOutsideTheAllowedRootIsRejected() {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("path", outsideRoot.toString());
+		assertThrows(SecurityException.class, () -> tool.apply(arguments));
+	}
+
+	@Test
+	void excessiveDepthIsRejected() throws IOException {
+		writeJava("A", "public class A {}");
+		Map<String, Object> arguments = arguments();
+		arguments.put("depth", 99);
+		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
 	}
 
 	private Map<String, Object> arguments() {

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ToolArgumentsTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ToolArgumentsTest.java
@@ -49,6 +49,29 @@ public class ToolArgumentsTest {
 	}
 
 	@Test
+	void optionalBoundedIntAcceptsValuesWithinRange() {
+		assertEquals(5, ToolArguments.optionalBoundedInt(Map.of("depth", 5), "depth", 1, 0, 10));
+	}
+
+	@Test
+	void optionalBoundedIntFallsBackToDefaultWhenMissing() {
+		assertEquals(1, ToolArguments.optionalBoundedInt(Map.of(), "depth", 1, 0, 10));
+	}
+
+	@Test
+	void optionalBoundedIntRejectsValuesAboveTheMaximum() {
+		IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+				() -> ToolArguments.optionalBoundedInt(Map.of("depth", 11), "depth", 1, 0, 10));
+		assertEquals("Argument depth must be between 0 and 10 but was 11", error.getMessage());
+	}
+
+	@Test
+	void optionalBoundedIntRejectsNegativeValues() {
+		assertThrows(IllegalArgumentException.class,
+				() -> ToolArguments.optionalBoundedInt(Map.of("depth", -1), "depth", 1, 0, 10));
+	}
+
+	@Test
 	void optionalLanguageFallsBackToDefault() {
 		assertEquals(Language.JAVA, ToolArguments.optionalLanguage(Map.of(), "language", Language.JAVA));
 	}


### PR DESCRIPTION
Address the three highest-priority security findings in the
context-engineering MCP server:

- Path confinement: new PathPolicy resolves every caller-supplied path to
  its real location and rejects anything outside the configured
  context.allowed-roots (defaulting to the working directory), preventing
  arbitrary file-system reads via project_tree / find_context.
- Loopback binding: the streamable HTTP transport now binds to 127.0.0.1
  by default, since the /mcp endpoint has no authentication.
- Bounded depth: the depth argument is capped (0..10) to bound the cost of
  transitive dependency resolution.

Add unit tests for the policy, the bounded-int parsing, and tool-level
rejection of out-of-policy paths and excessive depth.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JSkoQ1k9js1uyFBKHtstNm