### PR TITLE
refactor(data): extract shared base for in-memory map data sources

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryMapDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryMapDataSource.java
@@ -1,0 +1,92 @@
+package io.github.adamw7.tools.data.source.file;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
+
+/**
+ * Base class for in-memory data sources that flatten a document into a map of
+ * {@code key -> value} pairs and then emit each entry as a {@code {key, value}} row.
+ *
+ * <p>Subclasses only need to parse the document into {@link #fieldsMap}; the
+ * row-iteration lifecycle (open/next/hasMoreData/reset/iterator) is shared here.</p>
+ */
+public abstract class AbstractInMemoryMapDataSource extends AbstractFileSource implements InMemoryDataSource {
+
+	protected final Map<String, String> fieldsMap = new HashMap<>();
+	private Iterator<String> mapIterator;
+
+	protected AbstractInMemoryMapDataSource(InputStream inputStream) {
+		super(inputStream);
+		scanner = createScanner(inputStream);
+		parse();
+	}
+
+	protected AbstractInMemoryMapDataSource(String filePath) {
+		super(filePath);
+		parse();
+	}
+
+	/** Parses the open {@link #scanner} into {@link #fieldsMap}. */
+	protected abstract void parse();
+
+	@Override
+	public void open() {
+		if (opened) {
+			throw new IllegalStateException("DataSource is already open");
+		}
+		mapIterator = fieldsMap.keySet().iterator();
+		opened = true;
+	}
+
+	@Override
+	public String[] nextRow() {
+		checkIfOpen();
+		if (mapIterator.hasNext()) {
+			String key = mapIterator.next();
+			String value = fieldsMap.get(key);
+			return new String[] { key, value };
+		}
+		return null;
+	}
+
+	@Override
+	public boolean hasMoreData() {
+		checkIfOpen();
+		return mapIterator.hasNext();
+	}
+
+	@Override
+	public void reset() {
+		checkIfOpen();
+		mapIterator = fieldsMap.keySet().iterator();
+	}
+
+	public Iterator<String[]> iterator() {
+		return new Iterator<>() {
+			@Override
+			public boolean hasNext() {
+				return hasMoreData();
+			}
+
+			@Override
+			public String[] next() {
+				return nextRow();
+			}
+		};
+	}
+
+	@Override
+	public String[] getColumnNames() {
+		return fieldsMap.keySet().toArray(new String[] {});
+	}
+
+	@Override
+	public List<String[]> readAll() {
+		return super.readAll();
+	}
+}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
@@ -1,33 +1,23 @@
 package io.github.adamw7.tools.data.source.file;
 
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
-
-public class InMemoryJSONDataSource extends AbstractFileSource implements InMemoryDataSource {
-	private final Map<String, String> fieldsMap = new HashMap<>();
-	private Iterator<String> mapIterator;
+public class InMemoryJSONDataSource extends AbstractInMemoryMapDataSource {
 
 	public InMemoryJSONDataSource(InputStream inputStream) {
 		super(inputStream);
-		scanner = createScanner(inputStream);
-		parse();
-	}
-	
-	public InMemoryJSONDataSource(String filePath) {
-		super(filePath);
-		parse();
 	}
 
-	private void parse() {
+	public InMemoryJSONDataSource(String filePath) {
+		super(filePath);
+	}
+
+	@Override
+	protected void parse() {
 		StringBuilder jsonContent = new StringBuilder();
 		while (scanner.hasNextLine()) {
 			jsonContent.append(scanner.nextLine());
@@ -73,61 +63,5 @@ public class InMemoryJSONDataSource extends AbstractFileSource implements InMemo
 				fieldsMap.put(key, String.valueOf(value));
 			}
 		}
-	}
-
-	@Override
-	public void open() {
-		if (opened) {
-			throw new IllegalStateException("DataSource is already open");
-		}
-		mapIterator = fieldsMap.keySet().iterator();
-		opened = true;
-	}
-
-	@Override
-	public String[] nextRow() {
-		checkIfOpen();
-		if (mapIterator.hasNext()) {
-			String key = mapIterator.next();
-			String value = fieldsMap.get(key);
-			return new String[] { key, value };
-		}
-		return null;
-	}
-
-	@Override
-	public boolean hasMoreData() {
-		checkIfOpen();
-		return mapIterator.hasNext();
-	}
-
-	@Override
-	public void reset() {
-		checkIfOpen();
-		mapIterator = fieldsMap.keySet().iterator();
-	}
-
-	public Iterator<String[]> iterator() {
-		return new Iterator<>() {
-			@Override
-			public boolean hasNext() {
-				return hasMoreData();
-			}
-
-			@Override
-			public String[] next() {
-				return nextRow();
-			}
-		};
-	}
-
-	@Override
-	public String[] getColumnNames() {
-		return fieldsMap.keySet().toArray(new String[] {});
-	}
-
-	@Override
-	public List<String[]> readAll() {
-		return super.readAll();
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryTOONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryTOONDataSource.java
@@ -2,14 +2,9 @@ package io.github.adamw7.tools.data.source.file;
 
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
-
-import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
 
 /**
  * Data source for TOON (Token-Oriented Object Notation) format files.
@@ -21,23 +16,18 @@ import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
  * - Tabular arrays (key[N]{field1,field2}: row1,row2...)
  * - Nested objects via indentation
  */
-public class InMemoryTOONDataSource extends AbstractFileSource implements InMemoryDataSource {
-
-	private final Map<String, String> fieldsMap = new HashMap<>();
-	private Iterator<String> mapIterator;
+public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 
 	public InMemoryTOONDataSource(InputStream inputStream) {
 		super(inputStream);
-		scanner = createScanner(inputStream);
-		parse();
 	}
 
 	public InMemoryTOONDataSource(String filePath) {
 		super(filePath);
-		parse();
 	}
 
-	private void parse() {
+	@Override
+	protected void parse() {
 		List<String> lines = new ArrayList<>();
 		while (scanner.hasNextLine()) {
 			lines.add(scanner.nextLine());
@@ -275,61 +265,5 @@ public class InMemoryTOONDataSource extends AbstractFileSource implements InMemo
 
 		fieldsMap.put(fullKey, ToonSyntax.unquote(value));
 		return index + 1;
-	}
-
-	@Override
-	public void open() {
-		if (opened) {
-			throw new IllegalStateException("DataSource is already open");
-		}
-		mapIterator = fieldsMap.keySet().iterator();
-		opened = true;
-	}
-
-	@Override
-	public String[] nextRow() {
-		checkIfOpen();
-		if (mapIterator.hasNext()) {
-			String key = mapIterator.next();
-			String value = fieldsMap.get(key);
-			return new String[] { key, value };
-		}
-		return null;
-	}
-
-	@Override
-	public boolean hasMoreData() {
-		checkIfOpen();
-		return mapIterator.hasNext();
-	}
-
-	@Override
-	public void reset() {
-		checkIfOpen();
-		mapIterator = fieldsMap.keySet().iterator();
-	}
-
-	public Iterator<String[]> iterator() {
-		return new Iterator<>() {
-			@Override
-			public boolean hasNext() {
-				return hasMoreData();
-			}
-
-			@Override
-			public String[] next() {
-				return nextRow();
-			}
-		};
-	}
-
-	@Override
-	public String[] getColumnNames() {
-		return fieldsMap.keySet().toArray(new String[] {});
-	}
-
-	@Override
-	public List<String[]> readAll() {
-		return super.readAll();
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryYAMLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryYAMLDataSource.java
@@ -1,32 +1,24 @@
 package io.github.adamw7.tools.data.source.file;
 
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
-import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
-
-public class InMemoryYAMLDataSource extends AbstractFileSource implements InMemoryDataSource {
-	private final Map<String, String> fieldsMap = new HashMap<>();
-	private Iterator<String> mapIterator;
+public class InMemoryYAMLDataSource extends AbstractInMemoryMapDataSource {
 
 	public InMemoryYAMLDataSource(InputStream inputStream) {
 		super(inputStream);
-		scanner = createScanner(inputStream);
-		parse();
 	}
 
 	public InMemoryYAMLDataSource(String filePath) {
 		super(filePath);
-		parse();
 	}
 
-	private void parse() {
+	@Override
+	protected void parse() {
 		StringBuilder yamlContent = new StringBuilder();
 		while (scanner.hasNextLine()) {
 			yamlContent.append(scanner.nextLine()).append("\n");
@@ -77,61 +69,5 @@ public class InMemoryYAMLDataSource extends AbstractFileSource implements InMemo
 				fieldsMap.put(key, String.valueOf(value));
 			}
 		}
-	}
-
-	@Override
-	public void open() {
-		if (opened) {
-			throw new IllegalStateException("DataSource is already open");
-		}
-		mapIterator = fieldsMap.keySet().iterator();
-		opened = true;
-	}
-
-	@Override
-	public String[] nextRow() {
-		checkIfOpen();
-		if (mapIterator.hasNext()) {
-			String key = mapIterator.next();
-			String value = fieldsMap.get(key);
-			return new String[] { key, value };
-		}
-		return null;
-	}
-
-	@Override
-	public boolean hasMoreData() {
-		checkIfOpen();
-		return mapIterator.hasNext();
-	}
-
-	@Override
-	public void reset() {
-		checkIfOpen();
-		mapIterator = fieldsMap.keySet().iterator();
-	}
-
-	public Iterator<String[]> iterator() {
-		return new Iterator<>() {
-			@Override
-			public boolean hasNext() {
-				return hasMoreData();
-			}
-
-			@Override
-			public String[] next() {
-				return nextRow();
-			}
-		};
-	}
-
-	@Override
-	public String[] getColumnNames() {
-		return fieldsMap.keySet().toArray(new String[] {});
-	}
-
-	@Override
-	public List<String[]> readAll() {
-		return super.readAll();
 	}
 }


### PR DESCRIPTION
InMemoryJSONDataSource, InMemoryYAMLDataSource and InMemoryTOONDataSource
each repeated the same ~60-line row-iteration block verbatim (fieldsMap and
mapIterator state plus open/nextRow/hasMoreData/reset/iterator/getColumnNames/
readAll). Pull that boilerplate into a new AbstractInMemoryMapDataSource so
each subclass only implements its format-specific parse() into fieldsMap.

No behavior change; the moved method bodies are identical.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DdfQp5ZCEKJuRPWUgXJnHC