### PR TITLE
test: strengthen assertions for top PIT mutation-testing findings

### DIFF
--- a/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
@@ -289,6 +289,13 @@ public class MapTest {
 	}
 	
 	@Test
+	public void zeroSizeIsRejected() {
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> new OpenAddressingMap<>(0), "Expected constructor method to throw, but it didn't");
+
+		assertEquals("Wrong size: 0", thrown.getMessage());
+	}
+
+	@Test
 	public void nullKey() {
 		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> new OpenAddressingMap<>(2).put(null, null), "Expected put method to throw, but it didn't");
 
@@ -299,5 +306,12 @@ public class MapTest {
 	@MethodSource("allImplementations")
 	public void empty(Map<Integer, String> map) {
 		assertTrue(map.isEmpty());
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void notEmptyAfterPut(Map<Integer, String> map) {
+		map.put(1, "A");
+		assertFalse(map.isEmpty());
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/KeyTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/KeyTest.java
@@ -58,6 +58,14 @@ public class KeyTest {
 	}
 
 	@Test
+	public void distinctKeysHaveDistinctHashCodes() {
+		Key first = new Key(new String[] { "x", "y" });
+		Key second = new Key(new String[] { "x", "z" });
+
+		assertNotEquals(first.hashCode(), second.hashCode());
+	}
+
+	@Test
 	public void toStringRendersValues() {
 		Key key = new Key(new String[] { "a", "b" });
 

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/ResultTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/ResultTest.java
@@ -70,4 +70,90 @@ public class ResultTest {
 		assertTrue(first.equals(sameRowDifferentOrder));
 		assertFalse(first.equals(differentRow));
 	}
+
+	@Test
+	public void equalToItself() {
+		Result result = new Result(true, new String[] { "year1" });
+
+		assertTrue(result.equals(result));
+	}
+
+	@Test
+	public void notEqualToNull() {
+		Result result = new Result(true, new String[] { "year1" });
+
+		assertFalse(result.equals(null));
+	}
+
+	@Test
+	public void notEqualToDifferentType() {
+		Result result = new Result(true, new String[] { "year1" });
+
+		assertFalse(result.equals("year1"));
+	}
+
+	@Test
+	public void differentUniquenessIsNotEqual() {
+		Result unique = new Result(true, new String[] { "year1" });
+		Result notUnique = new Result(false, new String[] { "year1" });
+
+		assertNotEquals(unique, notUnique);
+	}
+
+	@Test
+	public void differentBetterOptionsAreNotEqual() {
+		Set<Result> options = new HashSet<>();
+		options.add(new Result(true, new String[] { "year1" }));
+		Result withOptions = new Result(true, new String[] { "income" }, null, options);
+		Result withoutOptions = new Result(true, new String[] { "income" });
+
+		assertNotEquals(withOptions, withoutOptions);
+	}
+
+	@Test
+	public void differentColumnsHaveDifferentHashCodes() {
+		Result first = new Result(true, new String[] { "year1", "hlpi_name" });
+		Result second = new Result(true, new String[] { "year1", "income" });
+
+		assertNotEquals(first.hashCode(), second.hashCode());
+	}
+
+	@Test
+	public void unequalResultsHaveDifferentHashCodes() {
+		Result unique = new Result(true, new String[] { "year1" });
+		Result notUnique = new Result(false, new String[] { "year1" });
+
+		assertNotEquals(unique.hashCode(), notUnique.hashCode());
+	}
+
+	@Test
+	public void nullColumnsEqualOnlyOtherNullColumns() {
+		Result firstNull = new Result(true, null);
+		Result secondNull = new Result(true, null);
+		Result withColumns = new Result(true, new String[] { "year1" });
+
+		assertEquals(firstNull, secondNull);
+		assertNotEquals(firstNull, withColumns);
+		assertNotEquals(withColumns, firstNull);
+	}
+
+	@Test
+	public void nullColumnsContributeZeroToHashCode() {
+		Result firstNull = new Result(true, null);
+		Result secondNull = new Result(true, null);
+
+		assertEquals(firstNull.hashCode(), secondNull.hashCode());
+	}
+
+	@Test
+	public void toStringRendersAllFields() {
+		Result result = new Result(true, new String[] { "year1" }, new String[] { "2020" });
+
+		String text = result.toString();
+
+		assertTrue(text.contains("unique=true"), text);
+		assertTrue(text.contains("year1"), text);
+		assertTrue(text.contains("2020"), text);
+		assertTrue(text.contains("betterOptions="), text);
+	}
 }


### PR DESCRIPTION
Ran PIT mutation testing on the data module (633 mutations, 78% killed)
and added behavioral assertions targeting the surviving mutants in the
top findings:

- Result: cover reflexive/null/different-type equals, null-columns
  equality, distinct-column and unequal-result hash codes, and toString.
- Key: assert distinct keys yield distinct hash codes.
- OpenAddressingMap: reject zero size and verify a populated map is not
  empty.

Remaining survivors are equivalent arithmetic mutants in hashCode/hashing
internals that are only killable via brittle implementation-coupled
characterization.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0114t3ApfF66GND3kktCVgEG