### PR TITLE
feat(context): add Scala, package-aware finder, DOT output, subword token estimator and estimate_tokens MCP tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ is `Main.java` and which supports stdio (default) or streamable HTTP
   [MCP_USAGE.md](data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md).
 - The context-engineering server in
   `code/context/src/main/java/io/github/adamw7/context/mcp/`, exposing the
-  `project_tree` and `find_context` tools; see its
+  `project_tree`, `find_context` and `estimate_tokens` tools; see its
   [MCP_USAGE.md](code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md).
 
 ## Environment & toolchain

--- a/code/context/src/main/java/io/github/adamw7/context/Language.java
+++ b/code/context/src/main/java/io/github/adamw7/context/Language.java
@@ -12,7 +12,8 @@ import java.util.Locale;
 public enum Language {
 
 	JAVA(".java"),
-	KOTLIN(".kt");
+	KOTLIN(".kt"),
+	SCALA(".scala");
 
 	private final String extension;
 

--- a/code/context/src/main/java/io/github/adamw7/context/PackageAwareFinder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/PackageAwareFinder.java
@@ -1,0 +1,250 @@
+package io.github.adamw7.context;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link Context} that resolves dependencies using each source's {@code package}
+ * declaration and {@code import} statements, so two classes that share a simple
+ * name in different packages can be told apart — the gap the name-based
+ * {@link Finder} explicitly leaves open. A referenced {@code Foo} resolves, in
+ * order of preference, to: an explicitly imported {@code a.b.Foo}; a {@code Foo}
+ * in the referencing file's own package; a {@code Foo} reachable through a
+ * wildcard import {@code a.b.*}; or, only when exactly one {@code Foo} exists in
+ * the whole project, that sole candidate. An ambiguous reference with no import to
+ * disambiguate it is left unresolved rather than guessed.
+ *
+ * <p>Like {@link Finder}, traversal is a depth-bounded breadth-first expansion in
+ * which every class is visited once, so cycles terminate and the root is never
+ * reported as its own dependency. Comments and string or character literals are
+ * stripped before matching. The package/import grammar this relies on
+ * ({@code package a.b;} and {@code import a.b.C;}) is shared by Java, Kotlin and
+ * Scala, so it serves every {@link Language} the finder supports.
+ */
+public class PackageAwareFinder implements Context {
+
+	private static final Logger log = LogManager.getLogger(PackageAwareFinder.class.getName());
+
+	private static final Pattern CLASS_REFERENCE =
+			Pattern.compile("\\b[A-Z][A-Za-z0-9_]*(\\.[A-Z][A-Za-z0-9_]*)*\\b");
+
+	private static final Pattern COMMENTS_AND_LITERALS = Pattern.compile(
+			"\"\"\".*?\"\"\""              // triple-quoted string
+			+ "|//[^\\n]*"                 // line comment
+			+ "|/\\*.*?\\*/"               // block comment
+			+ "|\"(?:\\\\.|[^\"\\\\])*\""  // string literal
+			+ "|'(?:\\\\.|[^'\\\\])*'",    // character literal
+			Pattern.DOTALL);
+
+	private static final Pattern PACKAGE = Pattern.compile("(?m)^\\s*package\\s+([\\w.]+)");
+
+	private static final Pattern IMPORT = Pattern.compile("(?m)^\\s*import\\s+(\\w+(?:\\.\\w+)*(?:\\.\\*)?)");
+
+	private final Language language;
+	private final Map<String, ClassContainer> containersByFqn;
+	private final Map<String, List<ClassContainer>> containersBySimpleName;
+
+	public PackageAwareFinder(Set<ClassContainer> allContainers) {
+		this(allContainers, Language.JAVA);
+	}
+
+	public PackageAwareFinder(Set<ClassContainer> allContainers, Language language) {
+		this.language = language;
+		this.containersByFqn = indexByFqn(allContainers);
+		this.containersBySimpleName = indexBySimpleName(allContainers);
+	}
+
+	private Map<String, ClassContainer> indexByFqn(Set<ClassContainer> allContainers) {
+		return allContainers.stream().collect(Collectors.toMap(
+				this::fullyQualifiedName,
+				container -> container,
+				(first, second) -> first));
+	}
+
+	private Map<String, List<ClassContainer>> indexBySimpleName(Set<ClassContainer> allContainers) {
+		return allContainers.stream().collect(Collectors.groupingBy(this::simpleName));
+	}
+
+	private String fullyQualifiedName(ClassContainer container) {
+		return qualify(packageOf(container.originalCode()), simpleName(container));
+	}
+
+	private String simpleName(ClassContainer container) {
+		String fileName = container.className();
+		return fileName.substring(0, fileName.length() - language.extension().length());
+	}
+
+	@Override
+	public Set<ClassContainer> find(ClassContainer root, int depth) {
+		requirePositiveDepth(depth);
+		Set<ClassContainer> dependencies = new LinkedHashSet<>();
+		Set<ClassContainer> visited = new HashSet<>();
+		visited.add(root);
+		expand(root, depth, dependencies, visited);
+		return dependencies;
+	}
+
+	private void requirePositiveDepth(int depth) {
+		if (depth <= 0) {
+			throw new IllegalArgumentException("Depth must be positive and received: " + depth);
+		}
+	}
+
+	private void expand(ClassContainer root, int depth, Set<ClassContainer> dependencies,
+			Set<ClassContainer> visited) {
+		Set<ClassContainer> frontier = Set.of(root);
+		for (int level = 0; level < depth && !frontier.isEmpty(); level++) {
+			frontier = nextLevel(frontier, dependencies, visited);
+		}
+	}
+
+	private Set<ClassContainer> nextLevel(Set<ClassContainer> frontier,
+			Set<ClassContainer> dependencies, Set<ClassContainer> visited) {
+		Set<ClassContainer> next = new LinkedHashSet<>();
+		for (ClassContainer current : frontier) {
+			addNewDependencies(current, dependencies, visited, next);
+		}
+		return next;
+	}
+
+	private void addNewDependencies(ClassContainer current, Set<ClassContainer> dependencies,
+			Set<ClassContainer> visited, Set<ClassContainer> next) {
+		for (ClassContainer dependency : findDirectDependencies(current)) {
+			if (visited.add(dependency)) {
+				dependencies.add(dependency);
+				next.add(dependency);
+			}
+		}
+	}
+
+	private Set<ClassContainer> findDirectDependencies(ClassContainer source) {
+		String code = stripCommentsAndLiterals(source.originalCode());
+		ResolutionScope scope = scopeOf(code);
+		Set<ClassContainer> dependencies = new LinkedHashSet<>();
+		Matcher matcher = CLASS_REFERENCE.matcher(code);
+		while (matcher.find()) {
+			addResolved(matcher.group(), scope, source, dependencies);
+		}
+		return dependencies;
+	}
+
+	private void addResolved(String reference, ResolutionScope scope, ClassContainer source,
+			Set<ClassContainer> dependencies) {
+		ClassContainer container = resolve(outerSimpleName(reference), scope);
+		if (container != null) {
+			log.info("Resolved {} used in {}", container.className(), source.className());
+			dependencies.add(container);
+		}
+	}
+
+	private String outerSimpleName(String reference) {
+		int dot = reference.indexOf('.');
+		return dot < 0 ? reference : reference.substring(0, dot);
+	}
+
+	private ClassContainer resolve(String simpleName, ResolutionScope scope) {
+		ClassContainer imported = resolveImported(simpleName, scope);
+		if (imported != null) {
+			return imported;
+		}
+		ClassContainer samePackage = containersByFqn.get(qualify(scope.packageName(), simpleName));
+		if (samePackage != null) {
+			return samePackage;
+		}
+		ClassContainer wildcard = resolveWildcard(simpleName, scope);
+		if (wildcard != null) {
+			return wildcard;
+		}
+		return resolveUniqueSimpleName(simpleName);
+	}
+
+	private ClassContainer resolveImported(String simpleName, ResolutionScope scope) {
+		String fqn = scope.explicitImports().get(simpleName);
+		return fqn == null ? null : containersByFqn.get(fqn);
+	}
+
+	private ClassContainer resolveWildcard(String simpleName, ResolutionScope scope) {
+		return scope.wildcardPackages().stream()
+				.map(packageName -> containersByFqn.get(qualify(packageName, simpleName)))
+				.filter(container -> container != null)
+				.findFirst()
+				.orElse(null);
+	}
+
+	private ClassContainer resolveUniqueSimpleName(String simpleName) {
+		List<ClassContainer> candidates = containersBySimpleName.getOrDefault(simpleName, List.of());
+		return candidates.size() == 1 ? candidates.getFirst() : null;
+	}
+
+	private String qualify(String packageName, String simpleName) {
+		return packageName.isEmpty() ? simpleName : packageName + "." + simpleName;
+	}
+
+	private ResolutionScope scopeOf(String code) {
+		return new ResolutionScope(packageOf(code), explicitImports(code), wildcardPackages(code));
+	}
+
+	private String packageOf(String code) {
+		Matcher matcher = PACKAGE.matcher(stripCommentsAndLiterals(code));
+		return matcher.find() ? matcher.group(1) : "";
+	}
+
+	private Map<String, String> explicitImports(String code) {
+		Matcher matcher = IMPORT.matcher(code);
+		Map<String, String> imports = new HashMap<>();
+		while (matcher.find()) {
+			recordExplicitImport(matcher.group(1), imports);
+		}
+		return imports;
+	}
+
+	private void recordExplicitImport(String imported, Map<String, String> imports) {
+		if (!imported.endsWith(".*")) {
+			imports.put(lastSegment(imported), imported);
+		}
+	}
+
+	private List<String> wildcardPackages(String code) {
+		Matcher matcher = IMPORT.matcher(code);
+		List<String> packages = new ArrayList<>();
+		while (matcher.find()) {
+			recordWildcard(matcher.group(1), packages);
+		}
+		return packages;
+	}
+
+	private void recordWildcard(String imported, List<String> packages) {
+		if (imported.endsWith(".*")) {
+			packages.add(imported.substring(0, imported.length() - 2));
+		}
+	}
+
+	private String lastSegment(String dotted) {
+		int dot = dotted.lastIndexOf('.');
+		return dot < 0 ? dotted : dotted.substring(dot + 1);
+	}
+
+	private String stripCommentsAndLiterals(String code) {
+		return COMMENTS_AND_LITERALS.matcher(code).replaceAll(" ");
+	}
+
+	/**
+	 * The package, explicit imports (simple name to fully-qualified name) and
+	 * wildcard-imported packages of a single source file, computed once and reused
+	 * to resolve every class reference within that file.
+	 */
+	private record ResolutionScope(String packageName, Map<String, String> explicitImports,
+			List<String> wildcardPackages) {
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/SubwordTokenEstimator.java
+++ b/code/context/src/main/java/io/github/adamw7/context/SubwordTokenEstimator.java
@@ -1,0 +1,73 @@
+package io.github.adamw7.context;
+
+/**
+ * A dependency-free {@link TokenEstimator} that approximates token count by
+ * respecting word and symbol boundaries rather than dividing the whole text by a
+ * fixed character count. Byte-pair encoders rarely merge across whitespace or
+ * punctuation, so this estimator splits the text into runs: each maximal run of
+ * letters, digits and underscores costs {@code ceil(length / charactersPerToken)}
+ * tokens (at least one), every other non-whitespace character (punctuation or a
+ * symbol) costs one token, and whitespace costs nothing. This tracks a real
+ * tokenizer more closely than {@link HeuristicTokenEstimator} on
+ * punctuation-dense source code, while staying fast and tokenizer-free.
+ */
+public class SubwordTokenEstimator implements TokenEstimator {
+
+	public static final int DEFAULT_CHARACTERS_PER_TOKEN = 4;
+
+	private final int charactersPerToken;
+
+	public SubwordTokenEstimator() {
+		this(DEFAULT_CHARACTERS_PER_TOKEN);
+	}
+
+	public SubwordTokenEstimator(int charactersPerToken) {
+		requirePositive(charactersPerToken);
+		this.charactersPerToken = charactersPerToken;
+	}
+
+	private void requirePositive(int charactersPerToken) {
+		if (charactersPerToken <= 0) {
+			throw new IllegalArgumentException(
+					"charactersPerToken must be positive and received: " + charactersPerToken);
+		}
+	}
+
+	@Override
+	public int estimate(String text) {
+		if (text == null || text.isEmpty()) {
+			return 0;
+		}
+		return countTokens(text);
+	}
+
+	private int countTokens(String text) {
+		int total = 0;
+		int wordLength = 0;
+		for (int index = 0; index < text.length(); index++) {
+			char character = text.charAt(index);
+			if (isWordCharacter(character)) {
+				wordLength++;
+			} else {
+				total += wordTokens(wordLength) + symbolTokens(character);
+				wordLength = 0;
+			}
+		}
+		return total + wordTokens(wordLength);
+	}
+
+	private boolean isWordCharacter(char character) {
+		return Character.isLetterOrDigit(character) || character == '_';
+	}
+
+	private int wordTokens(int wordLength) {
+		if (wordLength == 0) {
+			return 0;
+		}
+		return (wordLength + charactersPerToken - 1) / charactersPerToken;
+	}
+
+	private int symbolTokens(char character) {
+		return Character.isWhitespace(character) ? 0 : 1;
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/EstimateTokensTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/EstimateTokensTool.java
@@ -1,0 +1,149 @@
+package io.github.adamw7.context.mcp;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import io.github.adamw7.context.ClassContainer;
+import io.github.adamw7.context.Finder;
+import io.github.adamw7.context.HeuristicTokenEstimator;
+import io.github.adamw7.context.Language;
+import io.github.adamw7.context.ProjectSources;
+import io.github.adamw7.context.TokenEstimator;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+
+/**
+ * MCP tool that estimates the LLM token cost of the context assembled for a
+ * class: the class itself plus the classes it depends on, to a bounded depth. It
+ * reports a per-class token breakdown and the total, letting an agent decide
+ * whether the context fits a model's budget before sending it. An unknown class
+ * is reported as an error result rather than an exception so the agent gets a
+ * clear, actionable message.
+ */
+public class EstimateTokensTool implements ContextTool {
+
+	private static final Logger log = LogManager.getLogger(EstimateTokensTool.class.getName());
+
+	private static final int DEFAULT_DEPTH = 1;
+	private static final int MAX_DEPTH = 10;
+
+	private final PathPolicy pathPolicy;
+	private final TokenEstimator estimator;
+
+	public EstimateTokensTool(PathPolicy pathPolicy) {
+		this(pathPolicy, new HeuristicTokenEstimator());
+	}
+
+	public EstimateTokensTool(PathPolicy pathPolicy, TokenEstimator estimator) {
+		this.pathPolicy = pathPolicy;
+		this.estimator = estimator;
+	}
+
+	private final Tool toolDefinition = Tool.builder("estimate_tokens",
+			Map.of(
+					"type", "object",
+					"properties", Map.of(
+							"path", Map.of("type", "string",
+									"description", "absolute path to the project root directory"),
+							"class_name", Map.of("type", "string",
+									"description", "simple name of the class to inspect, e.g. Foo or Foo.java"),
+							"language", Map.of("type", "string",
+									"description", "source language: java (default) or kotlin"),
+							"depth", Map.of("type", "integer",
+									"description", "how many levels of transitive dependencies to include (default 1)")),
+					"required", List.of("path", "class_name")))
+			.description("Estimate the LLM token cost of the context assembled for a class and its dependencies")
+			.build();
+
+	@Override
+	public Tool getToolDefinition() {
+		return toolDefinition;
+	}
+
+	@Override
+	public CallToolResult apply(Map<String, Object> arguments) {
+		log.info("Calling MCP estimate_tokens tool for {}", arguments);
+		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
+		Language language = ToolArguments.optionalLanguage(arguments, "language", Language.JAVA);
+		int depth = ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH);
+		Set<ClassContainer> containers = Set.copyOf(new ProjectSources(language).load(root).values());
+
+		ClassContainer target = findTarget(containers, arguments, language);
+		if (target == null) {
+			return error("Class not found: " + ToolArguments.requiredString(arguments, "class_name"));
+		}
+		return success(estimate(containers, target, language, depth));
+	}
+
+	private ClassContainer findTarget(Set<ClassContainer> containers, Map<String, Object> arguments, Language language) {
+		String fileName = fileNameOf(ToolArguments.requiredString(arguments, "class_name"), language);
+		return containers.stream()
+				.filter(container -> container.className().equals(fileName))
+				.findFirst()
+				.orElse(null);
+	}
+
+	private String fileNameOf(String className, Language language) {
+		if (className.endsWith(language.extension())) {
+			return className;
+		}
+		return className + language.extension();
+	}
+
+	private String estimate(Set<ClassContainer> containers, ClassContainer target, Language language, int depth) {
+		List<ClassContainer> context = assembleContext(containers, target, language, depth);
+		JSONArray classes = new JSONArray();
+		int total = 0;
+		for (ClassContainer container : context) {
+			int tokens = estimator.estimate(container.originalCode());
+			total += tokens;
+			classes.put(classEntry(container, tokens));
+		}
+		return report(total, classes).toString();
+	}
+
+	private List<ClassContainer> assembleContext(Set<ClassContainer> containers, ClassContainer target,
+			Language language, int depth) {
+		List<ClassContainer> context = new ArrayList<>();
+		context.add(target);
+		context.addAll(new Finder(containers, language).find(target, depth));
+		return context;
+	}
+
+	private JSONObject classEntry(ClassContainer container, int tokens) {
+		JSONObject entry = new JSONObject();
+		entry.put("class", container.className());
+		entry.put("tokens", tokens);
+		return entry;
+	}
+
+	private JSONObject report(int total, JSONArray classes) {
+		JSONObject report = new JSONObject();
+		report.put("total", total);
+		report.put("classes", classes);
+		return report;
+	}
+
+	private CallToolResult success(String reportJson) {
+		return CallToolResult.builder()
+				.content(List.of(TextContent.builder(reportJson).build()))
+				.isError(false)
+				.build();
+	}
+
+	private CallToolResult error(String message) {
+		return CallToolResult.builder()
+				.content(List.of(TextContent.builder(message).build()))
+				.isError(true)
+				.build();
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -7,13 +7,16 @@ Desktop, Cline, or any other MCP-compatible client.
 
 ## Overview
 
-The server exposes two tools:
+The server exposes three tools:
 
-- **`project_tree`** — scans a Java or Kotlin project into a tree of folders,
-  files and the classes each file depends on, then serialises it as JSON
-  (default), Markdown or plain text.
+- **`project_tree`** — scans a Java, Kotlin or Scala project into a tree of
+  folders, files and the classes each file depends on, then serialises it as JSON
+  (default), Markdown, plain text or Graphviz DOT.
 - **`find_context`** — resolves the classes a single source file depends on,
   bounded by a configurable depth, and returns them as a JSON array.
+- **`estimate_tokens`** — estimates the LLM token cost of the context assembled
+  for a class (the class itself plus its dependencies), returning a per-class
+  breakdown and the total.
 
 ## Architecture
 
@@ -23,7 +26,8 @@ The implementation lives in a package separate from the core finders:
 2. **McpConfiguration.java** — Spring configuration that wires the transports and
    registers the tools.
 3. **ContextTool.java** — the abstraction every tool implements.
-4. **ProjectTreeTool.java** / **ContextFinderTool.java** — the two tools.
+4. **ProjectTreeTool.java** / **ContextFinderTool.java** / **EstimateTokensTool.java**
+   — the three tools.
 5. **ToolArguments.java** — shared parsing of the call arguments.
 
 The server uses:
@@ -53,9 +57,9 @@ Scans a project into a tree of folders, files and class dependencies.
 **Parameters:**
 
 - `path` (string, required): absolute path to the project root directory
-- `language` (string, optional): `java` (default) or `kotlin`
+- `language` (string, optional): `java` (default), `kotlin` or `scala`
 - `depth` (integer, optional): levels of transitive dependencies to resolve (default `1`)
-- `format` (string, optional): `json` (default), `markdown` or `text`
+- `format` (string, optional): `json` (default), `markdown`, `text` or `dot`
 
 **Example:**
 
@@ -76,11 +80,37 @@ Finds the classes a given class depends on, within a project.
 
 - `path` (string, required): absolute path to the project root directory
 - `class_name` (string, required): simple name of the class to inspect, e.g. `Foo` or `Foo.java`
-- `language` (string, optional): `java` (default) or `kotlin`
+- `language` (string, optional): `java` (default), `kotlin` or `scala`
 - `depth` (integer, optional): levels of transitive dependencies to resolve (default `1`)
 
 **Returns:** a JSON array of dependency class names, e.g. `["A.java","B.java"]`.
 An unknown class is reported as an error result.
+
+**Example:**
+
+```json
+{
+  "path": "/path/to/project",
+  "class_name": "B",
+  "depth": 1
+}
+```
+
+### estimate_tokens
+
+Estimates the LLM token cost of the context assembled for a class and its
+dependencies, to a bounded depth.
+
+**Parameters:**
+
+- `path` (string, required): absolute path to the project root directory
+- `class_name` (string, required): simple name of the class to inspect, e.g. `Foo` or `Foo.java`
+- `language` (string, optional): `java` (default), `kotlin` or `scala`
+- `depth` (integer, optional): levels of transitive dependencies to include (default `1`)
+
+**Returns:** a JSON object with the `total` token estimate and a `classes` array of
+`{ "class": ..., "tokens": ... }` entries, the target class first. An unknown
+class is reported as an error result.
 
 **Example:**
 
@@ -185,7 +215,7 @@ The tools read source files from disk, so access is constrained by design:
 
 The server advertises:
 
-- **Tools**: true (`project_tree`, `find_context`)
+- **Tools**: true (`project_tree`, `find_context`, `estimate_tokens`)
 - **Resources**: false
 - **Prompts**: false
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/McpConfiguration.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/McpConfiguration.java
@@ -24,8 +24,8 @@ import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 
 /**
- * Wires the context-engineering MCP server. The server exposes the project-tree
- * and context-finder tools over either stdio (the default) or a streamable HTTP
+ * Wires the context-engineering MCP server. The server exposes the project-tree,
+ * context-finder and token-estimate tools over either stdio (the default) or a streamable HTTP
  * transport selected with {@code --transport.mode=streamable-http}; the latter
  * registers the {@code /mcp} servlet so MCP clients can connect over HTTP.
  */
@@ -98,7 +98,8 @@ public class McpConfiguration {
 	private void registerTools(McpSyncServer server) {
 		PathPolicy pathPolicy = new PathPolicy(allowedRoots);
 		log.info("Confining MCP file access to allowed roots: {}", pathPolicy.allowedRoots());
-		List<ContextTool> tools = List.of(new ProjectTreeTool(pathPolicy), new ContextFinderTool(pathPolicy));
+		List<ContextTool> tools = List.of(new ProjectTreeTool(pathPolicy), new ContextFinderTool(pathPolicy),
+				new EstimateTokensTool(pathPolicy));
 		tools.forEach(tool -> server.addTool(specificationFor(tool)));
 	}
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.context.Language;
 import io.github.adamw7.context.tree.ProjectTreeBuilder;
+import io.github.adamw7.context.tree.ProjectTreeDotSerializer;
 import io.github.adamw7.context.tree.ProjectTreeJsonSerializer;
 import io.github.adamw7.context.tree.ProjectTreeMarkdownSerializer;
 import io.github.adamw7.context.tree.ProjectTreeNode;
@@ -50,7 +51,7 @@ public class ProjectTreeTool implements ContextTool {
 							"depth", Map.of("type", "integer",
 									"description", "how many levels of transitive dependencies to resolve (default 1)"),
 							"format", Map.of("type", "string",
-									"description", "output format: json (default), markdown or text")),
+									"description", "output format: json (default), markdown, text or dot")),
 					"required", List.of("path")))
 			.description("Scan a Java or Kotlin project into a tree of folders, files and class dependencies")
 			.build();
@@ -79,6 +80,7 @@ public class ProjectTreeTool implements ContextTool {
 		return switch (format.trim().toLowerCase(java.util.Locale.ROOT)) {
 			case "markdown" -> new ProjectTreeMarkdownSerializer();
 			case "text" -> new ProjectTreePrinter();
+			case "dot" -> new ProjectTreeDotSerializer();
 			default -> new ProjectTreeJsonSerializer();
 		};
 	}

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeDotSerializer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeDotSerializer.java
@@ -1,0 +1,45 @@
+package io.github.adamw7.context.tree;
+
+/**
+ * Renders the dependency graph of a {@link ProjectTreeNode} tree as a Graphviz
+ * <a href="https://graphviz.org/doc/info/lang.html">DOT</a> digraph: every file
+ * becomes a node and every dependency it carries becomes a directed edge from the
+ * file to the depended-on class. Directories contribute structure but are not
+ * drawn, so the result is a focused, render-ready view of how the project's
+ * classes depend on one another — complementary to the tree-shaped text, Markdown
+ * and JSON serializers.
+ */
+public class ProjectTreeDotSerializer implements ProjectTreeSerializer {
+
+	private static final String INDENT = "  ";
+
+	@Override
+	public String serialize(ProjectTreeNode root) {
+		StringBuilder builder = new StringBuilder();
+		builder.append("digraph project {").append(System.lineSeparator());
+		appendEdges(builder, root);
+		builder.append("}").append(System.lineSeparator());
+		return builder.toString();
+	}
+
+	private void appendEdges(StringBuilder builder, ProjectTreeNode node) {
+		appendNodeEdges(builder, node);
+		node.children().forEach(child -> appendEdges(builder, child));
+	}
+
+	private void appendNodeEdges(StringBuilder builder, ProjectTreeNode node) {
+		if (node.isDirectory()) {
+			return;
+		}
+		node.dependencies().forEach(dependency -> appendEdge(builder, node.name(), dependency));
+	}
+
+	private void appendEdge(StringBuilder builder, String from, String to) {
+		builder.append(INDENT).append(quote(from)).append(" -> ").append(quote(to)).append(";")
+				.append(System.lineSeparator());
+	}
+
+	private String quote(String label) {
+		return "\"" + label.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/LanguageTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/LanguageTest.java
@@ -19,7 +19,20 @@ public class LanguageTest {
 	}
 
 	@Test
+	void resolvesScalaIgnoringCase() {
+		assertEquals(Language.SCALA, Language.fromName("scala"));
+		assertEquals(Language.SCALA, Language.fromName("SCALA"));
+	}
+
+	@Test
+	void exposesTheSourceExtensionOfEachLanguage() {
+		assertEquals(".java", Language.JAVA.extension());
+		assertEquals(".kt", Language.KOTLIN.extension());
+		assertEquals(".scala", Language.SCALA.extension());
+	}
+
+	@Test
 	void rejectsUnknownLanguage() {
-		assertThrows(IllegalArgumentException.class, () -> Language.fromName("scala"));
+		assertThrows(IllegalArgumentException.class, () -> Language.fromName("rust"));
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/LanguageTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/LanguageTest.java
@@ -32,7 +32,22 @@ public class LanguageTest {
 	}
 
 	@Test
+	void resolvesScalaIgnoringSurroundingWhitespace() {
+		assertEquals(Language.SCALA, Language.fromName("  scala  "));
+	}
+
+	@Test
+	void supportsExactlyThreeLanguages() {
+		assertEquals(3, Language.values().length);
+	}
+
+	@Test
 	void rejectsUnknownLanguage() {
 		assertThrows(IllegalArgumentException.class, () -> Language.fromName("rust"));
+	}
+
+	@Test
+	void rejectsABlankName() {
+		assertThrows(IllegalArgumentException.class, () -> Language.fromName(""));
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/PackageAwareFinderTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/PackageAwareFinderTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -135,6 +136,98 @@ public class PackageAwareFinderTest {
 				new PackageAwareFinder(containers(foo, user), Language.SCALA).find(user, 1);
 
 		assertEquals(Set.of(foo), dependencies);
+	}
+
+	@Test
+	void defaultConstructorResolvesJavaSources() {
+		ClassContainer a = new ClassContainer("A.java", "package p;\npublic class A {}");
+		ClassContainer b = new ClassContainer("B.java", "package p;\npublic class B { A a; }");
+
+		assertEquals(Set.of(a), new PackageAwareFinder(containers(a, b)).find(b, 1));
+	}
+
+	@Test
+	void resolvesWithinTheDefaultPackageWhenNoPackageIsDeclared() {
+		ClassContainer a = new ClassContainer("A.java", "public class A {}");
+		ClassContainer b = new ClassContainer("B.java", "public class B { A a; }");
+
+		assertEquals(Set.of(a), new PackageAwareFinder(containers(a, b)).find(b, 1));
+	}
+
+	@Test
+	void explicitImportTakesPrecedenceOverASamePackageClassOfTheSameName() {
+		ClassContainer user = new ClassContainer("User.java",
+				"package a;\nimport b.Foo;\npublic class User { Foo f; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(fooInA, fooInB, user)).find(user, 1);
+
+		assertEquals(Set.of(fooInB), dependencies);
+		assertFalse(dependencies.contains(fooInA));
+	}
+
+	@Test
+	void anImportPointingAtAMissingClassFallsBackToTheSamePackage() {
+		ClassContainer user = new ClassContainer("User.java",
+				"package a;\nimport x.Foo;\npublic class User { Foo f; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(fooInA, fooInB, user)).find(user, 1);
+
+		assertEquals(Set.of(fooInA), dependencies);
+	}
+
+	@Test
+	void resolvesTheOuterTypeOfAQualifiedReference() {
+		ClassContainer map = new ClassContainer("Map.java", "package p;\npublic class Map {}");
+		ClassContainer user = new ClassContainer("User.java", "package p;\npublic class User { Map.Entry e; }");
+
+		assertEquals(Set.of(map), new PackageAwareFinder(containers(map, user)).find(user, 1));
+	}
+
+	@Test
+	void resolvesAcrossSeveralWildcardImports() {
+		ClassContainer foo = new ClassContainer("Foo.java", "package a;\npublic class Foo {}");
+		ClassContainer bar = new ClassContainer("Bar.java", "package b;\npublic class Bar {}");
+		ClassContainer user = new ClassContainer("User.java",
+				"package x;\nimport a.*;\nimport b.*;\npublic class User { Foo f; Bar b; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(foo, bar, user)).find(user, 1);
+
+		assertEquals(2, dependencies.size());
+		assertTrue(dependencies.contains(foo));
+		assertTrue(dependencies.contains(bar));
+	}
+
+	@Test
+	void resolvesKotlinSourcesByTheirPackage() {
+		ClassContainer foo = new ClassContainer("Foo.kt", "package a\nclass Foo");
+		ClassContainer user = new ClassContainer("User.kt",
+				"package x\nimport a.Foo\nclass User { val f: Foo? = null }");
+
+		Set<ClassContainer> dependencies =
+				new PackageAwareFinder(containers(foo, user), Language.KOTLIN).find(user, 1);
+
+		assertEquals(Set.of(foo), dependencies);
+	}
+
+	@Test
+	void aLeafClassHasNoDependencies() {
+		ClassContainer a = new ClassContainer("A.java", "package p;\npublic class A {}");
+
+		assertTrue(new PackageAwareFinder(containers(a)).find(a, 1).isEmpty());
+	}
+
+	@Test
+	void preservesBreadthFirstOrderOfDependencies() {
+		ClassContainer leaf = new ClassContainer("Leaf.java", "package a;\npublic class Leaf {}");
+		ClassContainer mid = new ClassContainer("Mid.java", "package a;\npublic class Mid { Leaf leaf; }");
+		ClassContainer top = new ClassContainer("Top.java",
+				"package x;\nimport a.Mid;\npublic class Top { Mid mid; }");
+
+		List<String> order = new PackageAwareFinder(containers(leaf, mid, top)).find(top, 2).stream()
+				.map(ClassContainer::className)
+				.toList();
+
+		assertEquals(List.of("Mid.java", "Leaf.java"), order);
 	}
 
 	private Set<ClassContainer> containers(ClassContainer... containers) {

--- a/code/context/src/test/java/io/github/adamw7/context/PackageAwareFinderTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/PackageAwareFinderTest.java
@@ -1,0 +1,143 @@
+package io.github.adamw7.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class PackageAwareFinderTest {
+
+	private final ClassContainer fooInA = new ClassContainer("Foo.java", "package a;\npublic class Foo {}");
+	private final ClassContainer fooInB = new ClassContainer("Foo.java", "package b;\npublic class Foo { int x; }");
+
+	@Test
+	void rejectsNonPositiveDepth() {
+		ClassContainer user = new ClassContainer("User.java", "package x;\npublic class User {}");
+		PackageAwareFinder finder = new PackageAwareFinder(containers(user));
+
+		assertThrows(IllegalArgumentException.class, () -> finder.find(user, 0));
+		assertThrows(IllegalArgumentException.class, () -> finder.find(user, -1));
+	}
+
+	@Test
+	void resolvesByExplicitImportWhenSimpleNameIsAmbiguous() {
+		ClassContainer user = new ClassContainer("User.java",
+				"package x;\nimport a.Foo;\npublic class User { Foo f; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(fooInA, fooInB, user)).find(user, 1);
+
+		assertTrue(dependencies.contains(fooInA));
+		assertFalse(dependencies.contains(fooInB));
+		assertEquals(1, dependencies.size());
+	}
+
+	@Test
+	void prefersTheClassInTheReferencingFilesOwnPackage() {
+		ClassContainer user = new ClassContainer("User.java", "package a;\npublic class User { Foo f; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(fooInA, fooInB, user)).find(user, 1);
+
+		assertTrue(dependencies.contains(fooInA));
+		assertFalse(dependencies.contains(fooInB));
+	}
+
+	@Test
+	void resolvesThroughAWildcardImport() {
+		ClassContainer user = new ClassContainer("User.java",
+				"package x;\nimport b.*;\npublic class User { Foo f; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(fooInA, fooInB, user)).find(user, 1);
+
+		assertTrue(dependencies.contains(fooInB));
+		assertFalse(dependencies.contains(fooInA));
+	}
+
+	@Test
+	void leavesAnAmbiguousReferenceUnresolved() {
+		ClassContainer user = new ClassContainer("User.java", "package x;\npublic class User { Foo f; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(fooInA, fooInB, user)).find(user, 1);
+
+		assertTrue(dependencies.isEmpty());
+	}
+
+	@Test
+	void fallsBackToTheSoleCandidateWhenTheSimpleNameIsUnique() {
+		ClassContainer user = new ClassContainer("User.java", "package x;\npublic class User { Foo f; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(fooInA, user)).find(user, 1);
+
+		assertEquals(Set.of(fooInA), dependencies);
+	}
+
+	@Test
+	void resolvesTransitiveDependenciesAcrossPackages() {
+		ClassContainer leaf = new ClassContainer("Leaf.java", "package a;\npublic class Leaf {}");
+		ClassContainer mid = new ClassContainer("Mid.java", "package a;\npublic class Mid { Leaf leaf; }");
+		ClassContainer top = new ClassContainer("Top.java",
+				"package x;\nimport a.Mid;\npublic class Top { Mid mid; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(leaf, mid, top)).find(top, 2);
+
+		assertEquals(Set.of(mid, leaf), dependencies);
+	}
+
+	@Test
+	void stopsAtTheRequestedDepth() {
+		ClassContainer leaf = new ClassContainer("Leaf.java", "package a;\npublic class Leaf {}");
+		ClassContainer mid = new ClassContainer("Mid.java", "package a;\npublic class Mid { Leaf leaf; }");
+		ClassContainer top = new ClassContainer("Top.java",
+				"package x;\nimport a.Mid;\npublic class Top { Mid mid; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(leaf, mid, top)).find(top, 1);
+
+		assertEquals(Set.of(mid), dependencies);
+	}
+
+	@Test
+	void terminatesOnCycles() {
+		ClassContainer a = new ClassContainer("A.java", "package p;\nimport p.B;\npublic class A { B b; }");
+		ClassContainer b = new ClassContainer("B.java", "package p;\nimport p.A;\npublic class B { A a; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(a, b)).find(a, 10);
+
+		assertEquals(Set.of(b), dependencies);
+	}
+
+	@Test
+	void rootIsNeverItsOwnDependency() {
+		ClassContainer a = new ClassContainer("A.java", "package p;\npublic class A { A self; }");
+
+		assertTrue(new PackageAwareFinder(containers(a)).find(a, 1).isEmpty());
+	}
+
+	@Test
+	void ignoresClassNamesInCommentsAndLiterals() {
+		ClassContainer foo = new ClassContainer("Foo.java", "package a;\npublic class Foo {}");
+		ClassContainer user = new ClassContainer("User.java",
+				"package a;\npublic class User { /* Foo */ String s = \"Foo\"; }");
+
+		assertTrue(new PackageAwareFinder(containers(foo, user)).find(user, 1).isEmpty());
+	}
+
+	@Test
+	void resolvesScalaSourcesByTheirPackage() {
+		ClassContainer foo = new ClassContainer("Foo.scala", "package a\nclass Foo");
+		ClassContainer user = new ClassContainer("User.scala",
+				"package x\nimport a.Foo\nclass User { val f: Foo = null }");
+
+		Set<ClassContainer> dependencies =
+				new PackageAwareFinder(containers(foo, user), Language.SCALA).find(user, 1);
+
+		assertEquals(Set.of(foo), dependencies);
+	}
+
+	private Set<ClassContainer> containers(ClassContainer... containers) {
+		return new HashSet<>(Set.of(containers));
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/SubwordTokenEstimatorTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/SubwordTokenEstimatorTest.java
@@ -1,0 +1,60 @@
+package io.github.adamw7.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class SubwordTokenEstimatorTest {
+
+	private final SubwordTokenEstimator estimator = new SubwordTokenEstimator();
+
+	@Test
+	void emptyTextCostsNoTokens() {
+		assertEquals(0, estimator.estimate(""));
+	}
+
+	@Test
+	void nullTextCostsNoTokens() {
+		assertEquals(0, estimator.estimate(null));
+	}
+
+	@Test
+	void aShortWordCostsAtLeastOneToken() {
+		assertEquals(1, estimator.estimate("a"));
+		assertEquals(1, estimator.estimate("abcd"));
+		assertEquals(2, estimator.estimate("abcde"));
+	}
+
+	@Test
+	void whitespaceSeparatesWordsButCostsNothing() {
+		assertEquals(3, estimator.estimate("a b c"));
+		assertEquals(3, estimator.estimate("a  b\tc\n"));
+	}
+
+	@Test
+	void eachPunctuationCharacterCostsOneToken() {
+		assertEquals(3, estimator.estimate("a.b"));
+		assertEquals(4, estimator.estimate("foo(bar)"));
+	}
+
+	@Test
+	void honoursACustomCharactersPerToken() {
+		SubwordTokenEstimator twoCharsPerToken = new SubwordTokenEstimator(2);
+
+		assertEquals(3, twoCharsPerToken.estimate("abcde"));
+	}
+
+	@Test
+	void countsPunctuationDenseCodeMoreThanAPlainCharacterDivision() {
+		String code = "a=b+c;";
+
+		assertEquals(6, estimator.estimate(code));
+	}
+
+	@Test
+	void rejectsNonPositiveCharactersPerToken() {
+		assertThrows(IllegalArgumentException.class, () -> new SubwordTokenEstimator(0));
+		assertThrows(IllegalArgumentException.class, () -> new SubwordTokenEstimator(-1));
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/SubwordTokenEstimatorTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/SubwordTokenEstimatorTest.java
@@ -53,6 +53,45 @@ public class SubwordTokenEstimatorTest {
 	}
 
 	@Test
+	void underscoresAndDigitsArePartOfAWord() {
+		assertEquals(2, estimator.estimate("foo_bar"));
+		assertEquals(2, estimator.estimate("abc123"));
+	}
+
+	@Test
+	void leadingAndTrailingPunctuationEachCostOneToken() {
+		assertEquals(3, estimator.estimate("(a)"));
+		assertEquals(2, estimator.estimate(".a"));
+	}
+
+	@Test
+	void aRunOfSymbolsCostsOneTokenPerSymbol() {
+		assertEquals(4, estimator.estimate("+-*/"));
+	}
+
+	@Test
+	void unicodeLettersCountAsWordCharacters() {
+		assertEquals(1, estimator.estimate("café"));
+	}
+
+	@Test
+	void aCustomCharactersPerTokenSplitsLongWords() {
+		SubwordTokenEstimator threeCharsPerToken = new SubwordTokenEstimator(3);
+
+		assertEquals(3, threeCharsPerToken.estimate("abcdefg"));
+	}
+
+	@Test
+	void exposesTheDefaultCharactersPerTokenConstant() {
+		assertEquals(4, SubwordTokenEstimator.DEFAULT_CHARACTERS_PER_TOKEN);
+	}
+
+	@Test
+	void countsAMixedWordAndSymbolSequence() {
+		assertEquals(4, estimator.estimate("foo = bar;"));
+	}
+
+	@Test
 	void rejectsNonPositiveCharactersPerToken() {
 		assertThrows(IllegalArgumentException.class, () -> new SubwordTokenEstimator(0));
 		assertThrows(IllegalArgumentException.class, () -> new SubwordTokenEstimator(-1));

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/EstimateTokensToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/EstimateTokensToolTest.java
@@ -1,0 +1,142 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.context.TokenEstimator;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+
+public class EstimateTokensToolTest {
+
+	@TempDir
+	Path projectRoot;
+
+	@TempDir
+	Path outsideRoot;
+
+	private EstimateTokensTool tool;
+
+	@BeforeEach
+	void setUp() {
+		tool = new EstimateTokensTool(new PathPolicy(projectRoot.toString()), oneTokenPerCharacter());
+	}
+
+	@Test
+	void toolDefinitionExposesName() {
+		assertEquals("estimate_tokens", tool.getToolDefinition().name());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void toolDefinitionRequiresPathAndClassName() {
+		List<String> required = (List<String>) tool.getToolDefinition().inputSchema().get("required");
+		assertTrue(required.contains("path"));
+		assertTrue(required.contains("class_name"));
+	}
+
+	@Test
+	void reportsTheTargetAndItsDependenciesWithATotal() throws IOException {
+		writeJava("A", "AA");
+		writeJava("B", "A");
+
+		JSONObject report = report(tool.apply(arguments("B")));
+
+		assertEquals(3, report.getInt("total"));
+		assertEquals(2, report.getJSONArray("classes").length());
+		assertEquals("B.java", report.getJSONArray("classes").getJSONObject(0).getString("class"));
+		assertEquals(1, report.getJSONArray("classes").getJSONObject(0).getInt("tokens"));
+		assertEquals("A.java", report.getJSONArray("classes").getJSONObject(1).getString("class"));
+		assertEquals(2, report.getJSONArray("classes").getJSONObject(1).getInt("tokens"));
+	}
+
+	@Test
+	void aClassWithoutDependenciesReportsOnlyItself() throws IOException {
+		writeJava("A", "AAAA");
+
+		JSONObject report = report(tool.apply(arguments("A")));
+
+		assertEquals(4, report.getInt("total"));
+		assertEquals(1, report.getJSONArray("classes").length());
+	}
+
+	@Test
+	void unknownClassYieldsAnErrorResult() throws IOException {
+		writeJava("A", "A");
+
+		CallToolResult result = tool.apply(arguments("Missing"));
+
+		assertTrue(result.isError());
+		assertTrue(text(result).contains("Class not found: Missing"));
+	}
+
+	@Test
+	void missingClassNameIsRejected() {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("path", projectRoot.toString());
+		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
+	}
+
+	@Test
+	void pathOutsideTheAllowedRootIsRejected() {
+		Map<String, Object> arguments = arguments("A");
+		arguments.put("path", outsideRoot.toString());
+		assertThrows(SecurityException.class, () -> tool.apply(arguments));
+	}
+
+	@Test
+	void excessiveDepthIsRejected() throws IOException {
+		writeJava("A", "A");
+		Map<String, Object> arguments = arguments("A");
+		arguments.put("depth", 99);
+		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
+	}
+
+	@Test
+	void defaultsToTheHeuristicEstimatorWhenNoneIsGiven() throws IOException {
+		writeJava("A", "abcd");
+		EstimateTokensTool defaultTool = new EstimateTokensTool(new PathPolicy(projectRoot.toString()));
+
+		JSONObject report = report(defaultTool.apply(arguments("A")));
+
+		assertFalse(report.getJSONArray("classes").isEmpty());
+		assertEquals(1, report.getInt("total"));
+	}
+
+	private TokenEstimator oneTokenPerCharacter() {
+		return text -> text == null ? 0 : text.length();
+	}
+
+	private Map<String, Object> arguments(String className) {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("path", projectRoot.toString());
+		arguments.put("class_name", className);
+		return arguments;
+	}
+
+	private void writeJava(String className, String body) throws IOException {
+		Files.writeString(projectRoot.resolve(className + ".java"), body);
+	}
+
+	private JSONObject report(CallToolResult result) {
+		return new JSONObject(text(result));
+	}
+
+	private String text(CallToolResult result) {
+		return ((TextContent) result.content().getFirst()).text();
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/EstimateTokensToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/EstimateTokensToolTest.java
@@ -117,6 +117,51 @@ public class EstimateTokensToolTest {
 		assertEquals(1, report.getInt("total"));
 	}
 
+	@Test
+	void includesTransitiveDependenciesAtTheRequestedDepth() throws IOException {
+		writeJava("A", "AAAA");
+		writeJava("B", "A");
+		writeJava("C", "B");
+
+		Map<String, Object> arguments = arguments("C");
+		arguments.put("depth", 2);
+
+		JSONObject report = report(tool.apply(arguments));
+
+		assertEquals(6, report.getInt("total"));
+		assertEquals(3, report.getJSONArray("classes").length());
+		assertEquals("C.java", report.getJSONArray("classes").getJSONObject(0).getString("class"));
+		assertEquals("B.java", report.getJSONArray("classes").getJSONObject(1).getString("class"));
+		assertEquals("A.java", report.getJSONArray("classes").getJSONObject(2).getString("class"));
+	}
+
+	@Test
+	void boundsTheBreakdownToTheGivenDepth() throws IOException {
+		writeJava("A", "AAAA");
+		writeJava("B", "A");
+		writeJava("C", "B");
+
+		JSONObject report = report(tool.apply(arguments("C")));
+
+		assertEquals(2, report.getJSONArray("classes").length());
+		assertEquals(2, report.getInt("total"));
+	}
+
+	@Test
+	void estimatesKotlinSourcesWhenRequested() throws IOException {
+		Files.writeString(projectRoot.resolve("Foo.kt"), "FF");
+		Files.writeString(projectRoot.resolve("Bar.kt"), "Foo");
+
+		Map<String, Object> arguments = arguments("Bar");
+		arguments.put("language", "kotlin");
+
+		JSONObject report = report(tool.apply(arguments));
+
+		assertEquals(5, report.getInt("total"));
+		assertEquals("Bar.kt", report.getJSONArray("classes").getJSONObject(0).getString("class"));
+		assertEquals("Foo.kt", report.getJSONArray("classes").getJSONObject(1).getString("class"));
+	}
+
 	private TokenEstimator oneTokenPerCharacter() {
 		return text -> text == null ? 0 : text.length();
 	}

--- a/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeDotSerializerTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeDotSerializerTest.java
@@ -68,4 +68,68 @@ public class ProjectTreeDotSerializerTest {
 
 		assertTrue(dot.contains("\\\""));
 	}
+
+	@Test
+	void escapesBackslashesInNames() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/B.java"));
+		file.addDependency("a\\b");
+		root.addChild(file);
+
+		String dot = serializer.serialize(root);
+
+		assertTrue(dot.contains("\"B.java\" -> \"a\\\\b\";"));
+	}
+
+	@Test
+	void emitsNoEdgesForAFileWithoutDependencies() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		root.addChild(ProjectTreeNode.file(Path.of("project/A.java")));
+
+		String dot = serializer.serialize(root);
+
+		assertFalse(dot.contains("->"));
+	}
+
+	@Test
+	void preservesDependencyInsertionOrder() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/B.java"));
+		file.addDependency("A.java");
+		file.addDependency("C.java");
+		root.addChild(file);
+
+		String dot = serializer.serialize(root);
+
+		assertTrue(dot.indexOf("-> \"A.java\"") < dot.indexOf("-> \"C.java\""));
+	}
+
+	@Test
+	void emitsEdgesForEveryFileInTheTree() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode first = ProjectTreeNode.file(Path.of("project/B.java"));
+		first.addDependency("A.java");
+		ProjectTreeNode second = ProjectTreeNode.file(Path.of("project/D.java"));
+		second.addDependency("C.java");
+		root.addChild(first);
+		root.addChild(second);
+
+		String dot = serializer.serialize(root);
+
+		assertTrue(dot.contains("\"B.java\" -> \"A.java\";"));
+		assertTrue(dot.contains("\"D.java\" -> \"C.java\";"));
+	}
+
+	@Test
+	void everyLineIsTerminatedAndTheGraphIsClosed() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/B.java"));
+		file.addDependency("A.java");
+		root.addChild(file);
+
+		String dot = serializer.serialize(root);
+
+		assertTrue(dot.contains(";" + System.lineSeparator()));
+		assertTrue(dot.trim().endsWith("}"));
+	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeDotSerializerTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeDotSerializerTest.java
@@ -1,0 +1,71 @@
+package io.github.adamw7.context.tree;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class ProjectTreeDotSerializerTest {
+
+	private final ProjectTreeDotSerializer serializer = new ProjectTreeDotSerializer();
+
+	@Test
+	void opensAndClosesADigraph() {
+		String dot = serializer.serialize(ProjectTreeNode.directory(Path.of("project")));
+
+		assertTrue(dot.startsWith("digraph project {"));
+		assertTrue(dot.trim().endsWith("}"));
+	}
+
+	@Test
+	void emitsAnEdgeFromAFileToEachDependency() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/B.java"));
+		file.addDependency("A.java");
+		file.addDependency("C.java");
+		root.addChild(file);
+
+		String dot = serializer.serialize(root);
+
+		assertTrue(dot.contains("\"B.java\" -> \"A.java\";"));
+		assertTrue(dot.contains("\"B.java\" -> \"C.java\";"));
+	}
+
+	@Test
+	void doesNotDrawDirectoriesAsNodes() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		root.addChild(ProjectTreeNode.directory(Path.of("project/pkg")));
+
+		String dot = serializer.serialize(root);
+
+		assertFalse(dot.contains("->"));
+	}
+
+	@Test
+	void recursesIntoNestedDirectories() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode pkg = ProjectTreeNode.directory(Path.of("project/pkg"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/pkg/B.java"));
+		file.addDependency("A.java");
+		pkg.addChild(file);
+		root.addChild(pkg);
+
+		String dot = serializer.serialize(root);
+
+		assertTrue(dot.contains("\"B.java\" -> \"A.java\";"));
+	}
+
+	@Test
+	void escapesQuotesAndBackslashesInNames() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/B.java"));
+		file.addDependency("Wei\"rd");
+		root.addChild(file);
+
+		String dot = serializer.serialize(root);
+
+		assertTrue(dot.contains("\\\""));
+	}
+}


### PR DESCRIPTION
Extend the context-engineering module through its existing seams without
modifying current behaviour:

- Language: add SCALA(".scala") so the finders, project scanner and MCP
  tools recognise Scala sources.
- PackageAwareFinder: a Context that disambiguates classes sharing a simple
  name across packages using each source's package and import statements,
  closing the gap the name-based Finder leaves open.
- ProjectTreeDotSerializer: a ProjectTreeSerializer that renders the
  dependency graph as Graphviz DOT; wired into project_tree as format "dot".
- SubwordTokenEstimator: a TokenEstimator that respects word and symbol
  boundaries for a closer estimate on punctuation-dense code.
- EstimateTokensTool: a new MCP tool (estimate_tokens) reporting the token
  cost of a class plus its dependencies, registered alongside the existing
  tools.

Unit tests cover every new class and the docs (MCP_USAGE.md, AGENTS.md) are
updated. All 164 context-module tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Kothi1KcF33KCjyRqm91f