### PR TITLE
refactor(context): dedup finders/MCP tools and wire package-aware resolution

### DIFF
--- a/code/context/src/main/java/io/github/adamw7/context/AbstractFinder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/AbstractFinder.java
@@ -1,0 +1,84 @@
+package io.github.adamw7.context;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Shared skeleton for the regex-based {@link Context} finders. It owns the
+ * depth-bounded, breadth-first traversal of the dependency graph: starting from
+ * the root, each level's direct dependencies become the next level's frontier,
+ * every class is visited once so cycles terminate, and the root is never reported
+ * as one of its own dependencies. Subclasses supply only
+ * {@link #findDirectDependencies(ClassContainer)} — how a single source file's
+ * class references resolve to concrete containers — which is the one concern in
+ * which name-based and package-aware resolution differ.
+ */
+public abstract class AbstractFinder implements Context {
+
+	protected static final Pattern CLASS_REFERENCE =
+			Pattern.compile("\\b[A-Z][A-Za-z0-9_]*(\\.[A-Z][A-Za-z0-9_]*)*\\b");
+
+	private static final Pattern COMMENTS_AND_LITERALS = Pattern.compile(
+			"\"\"\".*?\"\"\""              // triple-quoted string (Kotlin/Scala)
+			+ "|//[^\\n]*"                 // line comment
+			+ "|/\\*.*?\\*/"               // block comment
+			+ "|\"(?:\\\\.|[^\"\\\\])*\""  // string literal
+			+ "|'(?:\\\\.|[^'\\\\])*'",    // character literal
+			Pattern.DOTALL);
+
+	@Override
+	public Set<ClassContainer> find(ClassContainer root, int depth) {
+		requirePositiveDepth(depth);
+		Set<ClassContainer> dependencies = new LinkedHashSet<>();
+		Set<ClassContainer> visited = new HashSet<>();
+		visited.add(root);
+		expand(root, depth, dependencies, visited);
+		return dependencies;
+	}
+
+	private void requirePositiveDepth(int depth) {
+		if (depth <= 0) {
+			throw new IllegalArgumentException("Depth must be positive and received: " + depth);
+		}
+	}
+
+	private void expand(ClassContainer root, int depth, Set<ClassContainer> dependencies,
+			Set<ClassContainer> visited) {
+		Set<ClassContainer> frontier = Set.of(root);
+		for (int level = 0; level < depth && !frontier.isEmpty(); level++) {
+			frontier = nextLevel(frontier, dependencies, visited);
+		}
+	}
+
+	private Set<ClassContainer> nextLevel(Set<ClassContainer> frontier,
+			Set<ClassContainer> dependencies, Set<ClassContainer> visited) {
+		Set<ClassContainer> next = new LinkedHashSet<>();
+		for (ClassContainer current : frontier) {
+			addNewDependencies(current, dependencies, visited, next);
+		}
+		return next;
+	}
+
+	private void addNewDependencies(ClassContainer current, Set<ClassContainer> dependencies,
+			Set<ClassContainer> visited, Set<ClassContainer> next) {
+		for (ClassContainer dependency : findDirectDependencies(current)) {
+			if (visited.add(dependency)) {
+				dependencies.add(dependency);
+				next.add(dependency);
+			}
+		}
+	}
+
+	/**
+	 * Resolves the classes directly referenced by {@code source}. The traversal
+	 * that turns these into a depth-bounded transitive closure is handled by this
+	 * base class.
+	 */
+	protected abstract Set<ClassContainer> findDirectDependencies(ClassContainer source);
+
+	protected String stripCommentsAndLiterals(String code) {
+		return COMMENTS_AND_LITERALS.matcher(code).replaceAll(" ");
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/BudgetedContext.java
+++ b/code/context/src/main/java/io/github/adamw7/context/BudgetedContext.java
@@ -47,16 +47,16 @@ public class BudgetedContext implements Context {
 		return withinBudget;
 	}
 
-	private void fill(Iterator<ClassContainer> candidates, int remaining, Set<ClassContainer> accepted) {
-		if (!candidates.hasNext()) {
-			return;
+	private void fill(Iterator<ClassContainer> candidates, int budget, Set<ClassContainer> accepted) {
+		int remaining = budget;
+		while (candidates.hasNext()) {
+			ClassContainer candidate = candidates.next();
+			int cost = estimator.estimate(candidate.originalCode());
+			if (cost > remaining) {
+				return;
+			}
+			accepted.add(candidate);
+			remaining -= cost;
 		}
-		ClassContainer candidate = candidates.next();
-		int cost = estimator.estimate(candidate.originalCode());
-		if (cost > remaining) {
-			return;
-		}
-		accepted.add(candidate);
-		fill(candidates, remaining - cost, accepted);
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/Finder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/Finder.java
@@ -3,20 +3,17 @@ package io.github.adamw7.context;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
  * Resolves the classes a source file depends on by scanning its text for class
- * references. Traversal is a breadth-first expansion of the dependency graph
- * bounded by {@code depth}: every visited class is recorded once, so cycles
- * terminate and no node is expanded twice. The root itself is never reported as
- * one of its own dependencies.
+ * references. The depth-bounded, breadth-first traversal of the dependency graph
+ * is inherited from {@link AbstractFinder}; this class supplies only the direct
+ * resolution step.
  *
  * <p>Resolution is by simple file name (a referenced {@code Foo} resolves to a
  * {@code Foo} source file of the configured {@link Language}). The containers are
@@ -25,23 +22,12 @@ import java.util.stream.Collectors;
  * character literals are stripped before matching so that class names mentioned
  * there are not reported as dependencies. Two source files sharing the same
  * simple name in different packages still cannot be told apart — that needs
- * package-aware resolution, which this name-based finder does not attempt; the
- * first one encountered while indexing wins.
+ * package-aware resolution, which this name-based finder does not attempt (see
+ * {@link PackageAwareFinder}); the first one encountered while indexing wins.
  */
-public class Finder implements Context {
+public class Finder extends AbstractFinder {
 
 	private static final Logger log = LogManager.getLogger(Finder.class.getName());
-
-	private static final Pattern CLASS_REFERENCE =
-			Pattern.compile("\\b[A-Z][A-Za-z0-9_]*(\\.[A-Z][A-Za-z0-9_]*)*\\b");
-
-	private static final Pattern COMMENTS_AND_LITERALS = Pattern.compile(
-			"\"\"\".*?\"\"\""              // Kotlin triple-quoted string
-			+ "|//[^\\n]*"                 // line comment
-			+ "|/\\*.*?\\*/"               // block comment
-			+ "|\"(?:\\\\.|[^\"\\\\])*\""  // string literal
-			+ "|'(?:\\\\.|[^'\\\\])*'",    // character literal
-			Pattern.DOTALL);
 
 	private final Map<String, ClassContainer> containersByName;
 	private final Language language;
@@ -63,49 +49,7 @@ public class Finder implements Context {
 	}
 
 	@Override
-	public Set<ClassContainer> find(ClassContainer root, int depth) {
-		requirePositiveDepth(depth);
-		Set<ClassContainer> dependencies = new LinkedHashSet<>();
-		Set<ClassContainer> visited = new HashSet<>();
-		visited.add(root);
-		expand(root, depth, dependencies, visited);
-		return dependencies;
-	}
-
-	private void requirePositiveDepth(int depth) {
-		if (depth <= 0) {
-			throw new IllegalArgumentException("Depth must be positive and received: " + depth);
-		}
-	}
-
-	private void expand(ClassContainer root, int depth, Set<ClassContainer> dependencies,
-			Set<ClassContainer> visited) {
-		Set<ClassContainer> frontier = Set.of(root);
-		for (int level = 0; level < depth && !frontier.isEmpty(); level++) {
-			frontier = nextLevel(frontier, dependencies, visited);
-		}
-	}
-
-	private Set<ClassContainer> nextLevel(Set<ClassContainer> frontier,
-			Set<ClassContainer> dependencies, Set<ClassContainer> visited) {
-		Set<ClassContainer> next = new LinkedHashSet<>();
-		for (ClassContainer current : frontier) {
-			addNewDependencies(current, dependencies, visited, next);
-		}
-		return next;
-	}
-
-	private void addNewDependencies(ClassContainer current, Set<ClassContainer> dependencies,
-			Set<ClassContainer> visited, Set<ClassContainer> next) {
-		for (ClassContainer dependency : findDirectDependencies(current)) {
-			if (visited.add(dependency)) {
-				dependencies.add(dependency);
-				next.add(dependency);
-			}
-		}
-	}
-
-	private Set<ClassContainer> findDirectDependencies(ClassContainer source) {
+	protected Set<ClassContainer> findDirectDependencies(ClassContainer source) {
 		Set<ClassContainer> dependencies = new LinkedHashSet<>();
 		Matcher matcher = CLASS_REFERENCE.matcher(stripCommentsAndLiterals(source.originalCode()));
 		while (matcher.find()) {
@@ -120,10 +64,6 @@ public class Finder implements Context {
 			log.info("Found {} used in {}", container.className(), source.className());
 			dependencies.add(container);
 		}
-	}
-
-	private String stripCommentsAndLiterals(String code) {
-		return COMMENTS_AND_LITERALS.matcher(code).replaceAll(" ");
 	}
 
 	private ClassContainer findContainer(String className) {

--- a/code/context/src/main/java/io/github/adamw7/context/PackageAwareFinder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/PackageAwareFinder.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -25,27 +24,17 @@ import java.util.stream.Collectors;
  * the whole project, that sole candidate. An ambiguous reference with no import to
  * disambiguate it is left unresolved rather than guessed.
  *
- * <p>Like {@link Finder}, traversal is a depth-bounded breadth-first expansion in
- * which every class is visited once, so cycles terminate and the root is never
- * reported as its own dependency. Comments and string or character literals are
- * stripped before matching. The package/import grammar this relies on
- * ({@code package a.b;} and {@code import a.b.C;}) is shared by Java, Kotlin and
- * Scala, so it serves every {@link Language} the finder supports.
+ * <p>Like {@link Finder}, traversal is the depth-bounded breadth-first expansion
+ * provided by {@link AbstractFinder} in which every class is visited once, so
+ * cycles terminate and the root is never reported as its own dependency. Comments
+ * and string or character literals are stripped before matching. The
+ * package/import grammar this relies on ({@code package a.b;} and
+ * {@code import a.b.C;}) is shared by Java, Kotlin and Scala, so it serves every
+ * {@link Language} the finder supports.
  */
-public class PackageAwareFinder implements Context {
+public class PackageAwareFinder extends AbstractFinder {
 
 	private static final Logger log = LogManager.getLogger(PackageAwareFinder.class.getName());
-
-	private static final Pattern CLASS_REFERENCE =
-			Pattern.compile("\\b[A-Z][A-Za-z0-9_]*(\\.[A-Z][A-Za-z0-9_]*)*\\b");
-
-	private static final Pattern COMMENTS_AND_LITERALS = Pattern.compile(
-			"\"\"\".*?\"\"\""              // triple-quoted string
-			+ "|//[^\\n]*"                 // line comment
-			+ "|/\\*.*?\\*/"               // block comment
-			+ "|\"(?:\\\\.|[^\"\\\\])*\""  // string literal
-			+ "|'(?:\\\\.|[^'\\\\])*'",    // character literal
-			Pattern.DOTALL);
 
 	private static final Pattern PACKAGE = Pattern.compile("(?m)^\\s*package\\s+([\\w.]+)");
 
@@ -77,7 +66,7 @@ public class PackageAwareFinder implements Context {
 	}
 
 	private String fullyQualifiedName(ClassContainer container) {
-		return qualify(packageOf(container.originalCode()), simpleName(container));
+		return qualify(packageOf(stripCommentsAndLiterals(container.originalCode())), simpleName(container));
 	}
 
 	private String simpleName(ClassContainer container) {
@@ -86,49 +75,7 @@ public class PackageAwareFinder implements Context {
 	}
 
 	@Override
-	public Set<ClassContainer> find(ClassContainer root, int depth) {
-		requirePositiveDepth(depth);
-		Set<ClassContainer> dependencies = new LinkedHashSet<>();
-		Set<ClassContainer> visited = new HashSet<>();
-		visited.add(root);
-		expand(root, depth, dependencies, visited);
-		return dependencies;
-	}
-
-	private void requirePositiveDepth(int depth) {
-		if (depth <= 0) {
-			throw new IllegalArgumentException("Depth must be positive and received: " + depth);
-		}
-	}
-
-	private void expand(ClassContainer root, int depth, Set<ClassContainer> dependencies,
-			Set<ClassContainer> visited) {
-		Set<ClassContainer> frontier = Set.of(root);
-		for (int level = 0; level < depth && !frontier.isEmpty(); level++) {
-			frontier = nextLevel(frontier, dependencies, visited);
-		}
-	}
-
-	private Set<ClassContainer> nextLevel(Set<ClassContainer> frontier,
-			Set<ClassContainer> dependencies, Set<ClassContainer> visited) {
-		Set<ClassContainer> next = new LinkedHashSet<>();
-		for (ClassContainer current : frontier) {
-			addNewDependencies(current, dependencies, visited, next);
-		}
-		return next;
-	}
-
-	private void addNewDependencies(ClassContainer current, Set<ClassContainer> dependencies,
-			Set<ClassContainer> visited, Set<ClassContainer> next) {
-		for (ClassContainer dependency : findDirectDependencies(current)) {
-			if (visited.add(dependency)) {
-				dependencies.add(dependency);
-				next.add(dependency);
-			}
-		}
-	}
-
-	private Set<ClassContainer> findDirectDependencies(ClassContainer source) {
+	protected Set<ClassContainer> findDirectDependencies(ClassContainer source) {
 		String code = stripCommentsAndLiterals(source.originalCode());
 		ResolutionScope scope = scopeOf(code);
 		Set<ClassContainer> dependencies = new LinkedHashSet<>();
@@ -191,17 +138,18 @@ public class PackageAwareFinder implements Context {
 		return packageName.isEmpty() ? simpleName : packageName + "." + simpleName;
 	}
 
-	private ResolutionScope scopeOf(String code) {
-		return new ResolutionScope(packageOf(code), explicitImports(code), wildcardPackages(code));
+	private ResolutionScope scopeOf(String strippedCode) {
+		return new ResolutionScope(packageOf(strippedCode), explicitImports(strippedCode),
+				wildcardPackages(strippedCode));
 	}
 
-	private String packageOf(String code) {
-		Matcher matcher = PACKAGE.matcher(stripCommentsAndLiterals(code));
+	private String packageOf(String strippedCode) {
+		Matcher matcher = PACKAGE.matcher(strippedCode);
 		return matcher.find() ? matcher.group(1) : "";
 	}
 
-	private Map<String, String> explicitImports(String code) {
-		Matcher matcher = IMPORT.matcher(code);
+	private Map<String, String> explicitImports(String strippedCode) {
+		Matcher matcher = IMPORT.matcher(strippedCode);
 		Map<String, String> imports = new HashMap<>();
 		while (matcher.find()) {
 			recordExplicitImport(matcher.group(1), imports);
@@ -215,8 +163,8 @@ public class PackageAwareFinder implements Context {
 		}
 	}
 
-	private List<String> wildcardPackages(String code) {
-		Matcher matcher = IMPORT.matcher(code);
+	private List<String> wildcardPackages(String strippedCode) {
+		Matcher matcher = IMPORT.matcher(strippedCode);
 		List<String> packages = new ArrayList<>();
 		while (matcher.find()) {
 			recordWildcard(matcher.group(1), packages);
@@ -233,10 +181,6 @@ public class PackageAwareFinder implements Context {
 	private String lastSegment(String dotted) {
 		int dot = dotted.lastIndexOf('.');
 		return dot < 0 ? dotted : dotted.substring(dot + 1);
-	}
-
-	private String stripCommentsAndLiterals(String code) {
-		return COMMENTS_AND_LITERALS.matcher(code).replaceAll(" ");
 	}
 
 	/**

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractClassContextTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractClassContextTool.java
@@ -1,0 +1,87 @@
+package io.github.adamw7.context.mcp;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.context.ClassContainer;
+import io.github.adamw7.context.Language;
+import io.github.adamw7.context.ProjectSources;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+
+/**
+ * Shared skeleton for the MCP tools that operate on a single class within a
+ * project. They all confine and resolve the project path, load every source of
+ * the requested {@link Language}, and locate the target class by its simple name;
+ * they differ only in what they compute from that class, which subclasses supply
+ * through {@link #result}. Keeping the common steps here removes the duplication
+ * between {@link ContextFinderTool} and {@link EstimateTokensTool} and keeps their
+ * argument handling, class lookup and result envelopes identical.
+ */
+abstract class AbstractClassContextTool implements ContextTool {
+
+	protected static final int DEFAULT_DEPTH = 1;
+	protected static final int MAX_DEPTH = 10;
+
+	private final Logger log = LogManager.getLogger(getClass());
+
+	protected final PathPolicy pathPolicy;
+
+	protected AbstractClassContextTool(PathPolicy pathPolicy) {
+		this.pathPolicy = pathPolicy;
+	}
+
+	@Override
+	public CallToolResult apply(Map<String, Object> arguments) {
+		log.info("Calling MCP {} tool for {}", getToolDefinition().name(), arguments);
+		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
+		Language language = ToolArguments.optionalLanguage(arguments, "language", Language.JAVA);
+		int depth = ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH);
+		Set<ClassContainer> containers = Set.copyOf(new ProjectSources(language).load(root).values());
+
+		ClassContainer target = findTarget(containers, arguments, language);
+		if (target == null) {
+			return error("Class not found: " + ToolArguments.requiredString(arguments, "class_name"));
+		}
+		return success(result(containers, target, language, depth));
+	}
+
+	/** Computes the tool's textual result from the located class within its project. */
+	protected abstract String result(Set<ClassContainer> containers, ClassContainer target,
+			Language language, int depth);
+
+	private ClassContainer findTarget(Set<ClassContainer> containers, Map<String, Object> arguments,
+			Language language) {
+		String fileName = fileNameOf(ToolArguments.requiredString(arguments, "class_name"), language);
+		return containers.stream()
+				.filter(container -> container.className().equals(fileName))
+				.findFirst()
+				.orElse(null);
+	}
+
+	private String fileNameOf(String className, Language language) {
+		if (className.endsWith(language.extension())) {
+			return className;
+		}
+		return className + language.extension();
+	}
+
+	private CallToolResult success(String text) {
+		return CallToolResult.builder()
+				.content(List.of(TextContent.builder(text).build()))
+				.isError(false)
+				.build();
+	}
+
+	private CallToolResult error(String message) {
+		return CallToolResult.builder()
+				.content(List.of(TextContent.builder(message).build()))
+				.isError(true)
+				.build();
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
@@ -1,41 +1,29 @@
 package io.github.adamw7.context.mcp;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 
 import io.github.adamw7.context.ClassContainer;
-import io.github.adamw7.context.Finder;
 import io.github.adamw7.context.Language;
-import io.github.adamw7.context.ProjectSources;
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.github.adamw7.context.PackageAwareFinder;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 
 /**
  * MCP tool that resolves the classes a single source file depends on. It loads
- * every source of a Java or Kotlin project, locates the requested class by its
- * simple name, and runs the regex-based {@link Finder} to a bounded depth. The
- * dependency class names are returned as a JSON array. An unknown class is
- * reported as an error result rather than an exception so the agent gets a clear,
- * actionable message.
+ * every source of a Java, Kotlin or Scala project, locates the requested class by
+ * its simple name, and runs the package-aware {@link PackageAwareFinder} to a
+ * bounded depth so that classes sharing a simple name in different packages are
+ * told apart. The dependency class names are returned as a JSON array. An unknown
+ * class is reported as an error result rather than an exception so the agent gets
+ * a clear, actionable message.
  */
-public class ContextFinderTool implements ContextTool {
-
-	private static final Logger log = LogManager.getLogger(ContextFinderTool.class.getName());
-
-	private static final int DEFAULT_DEPTH = 1;
-	private static final int MAX_DEPTH = 10;
-
-	private final PathPolicy pathPolicy;
+public class ContextFinderTool extends AbstractClassContextTool {
 
 	public ContextFinderTool(PathPolicy pathPolicy) {
-		this.pathPolicy = pathPolicy;
+		super(pathPolicy);
 	}
 
 	private final Tool toolDefinition = Tool.builder("find_context",
@@ -47,11 +35,11 @@ public class ContextFinderTool implements ContextTool {
 							"class_name", Map.of("type", "string",
 									"description", "simple name of the class to inspect, e.g. Foo or Foo.java"),
 							"language", Map.of("type", "string",
-									"description", "source language: java (default) or kotlin"),
+									"description", "source language: java (default), kotlin or scala"),
 							"depth", Map.of("type", "integer",
 									"description", "how many levels of transitive dependencies to resolve (default 1)")),
 					"required", List.of("path", "class_name")))
-			.description("Find the classes a given class depends on, within a Java or Kotlin project")
+			.description("Find the classes a given class depends on, within a Java, Kotlin or Scala project")
 			.build();
 
 	@Override
@@ -60,54 +48,11 @@ public class ContextFinderTool implements ContextTool {
 	}
 
 	@Override
-	public CallToolResult apply(Map<String, Object> arguments) {
-		log.info("Calling MCP find_context tool for {}", arguments);
-		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
-		Language language = ToolArguments.optionalLanguage(arguments, "language", Language.JAVA);
-		int depth = ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH);
-		Set<ClassContainer> containers = Set.copyOf(new ProjectSources(language).load(root).values());
-
-		ClassContainer target = findTarget(containers, arguments, language);
-		if (target == null) {
-			return error("Class not found: " + ToolArguments.requiredString(arguments, "class_name"));
-		}
-		return success(dependenciesOf(containers, target, language, depth));
-	}
-
-	private ClassContainer findTarget(Set<ClassContainer> containers, Map<String, Object> arguments, Language language) {
-		String fileName = fileNameOf(ToolArguments.requiredString(arguments, "class_name"), language);
-		return containers.stream()
-				.filter(container -> container.className().equals(fileName))
-				.findFirst()
-				.orElse(null);
-	}
-
-	private String fileNameOf(String className, Language language) {
-		if (className.endsWith(language.extension())) {
-			return className;
-		}
-		return className + language.extension();
-	}
-
-	private String dependenciesOf(Set<ClassContainer> containers, ClassContainer target, Language language, int depth) {
-		List<String> dependencies = new Finder(containers, language).find(target, depth).stream()
+	protected String result(Set<ClassContainer> containers, ClassContainer target, Language language, int depth) {
+		List<String> dependencies = new PackageAwareFinder(containers, language).find(target, depth).stream()
 				.map(ClassContainer::className)
 				.sorted()
 				.toList();
 		return new JSONArray(dependencies).toString();
-	}
-
-	private CallToolResult success(String dependenciesJson) {
-		return CallToolResult.builder()
-				.content(List.of(TextContent.builder(dependenciesJson).build()))
-				.isError(false)
-				.build();
-	}
-
-	private CallToolResult error(String message) {
-		return CallToolResult.builder()
-				.content(List.of(TextContent.builder(message).build()))
-				.isError(true)
-				.build();
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/EstimateTokensTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/EstimateTokensTool.java
@@ -1,24 +1,18 @@
 package io.github.adamw7.context.mcp;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import io.github.adamw7.context.ClassContainer;
-import io.github.adamw7.context.Finder;
-import io.github.adamw7.context.HeuristicTokenEstimator;
 import io.github.adamw7.context.Language;
-import io.github.adamw7.context.ProjectSources;
+import io.github.adamw7.context.PackageAwareFinder;
+import io.github.adamw7.context.SubwordTokenEstimator;
 import io.github.adamw7.context.TokenEstimator;
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 
 /**
@@ -29,22 +23,16 @@ import io.modelcontextprotocol.spec.McpSchema.Tool;
  * is reported as an error result rather than an exception so the agent gets a
  * clear, actionable message.
  */
-public class EstimateTokensTool implements ContextTool {
+public class EstimateTokensTool extends AbstractClassContextTool {
 
-	private static final Logger log = LogManager.getLogger(EstimateTokensTool.class.getName());
-
-	private static final int DEFAULT_DEPTH = 1;
-	private static final int MAX_DEPTH = 10;
-
-	private final PathPolicy pathPolicy;
 	private final TokenEstimator estimator;
 
 	public EstimateTokensTool(PathPolicy pathPolicy) {
-		this(pathPolicy, new HeuristicTokenEstimator());
+		this(pathPolicy, new SubwordTokenEstimator());
 	}
 
 	public EstimateTokensTool(PathPolicy pathPolicy, TokenEstimator estimator) {
-		this.pathPolicy = pathPolicy;
+		super(pathPolicy);
 		this.estimator = estimator;
 	}
 
@@ -57,7 +45,7 @@ public class EstimateTokensTool implements ContextTool {
 							"class_name", Map.of("type", "string",
 									"description", "simple name of the class to inspect, e.g. Foo or Foo.java"),
 							"language", Map.of("type", "string",
-									"description", "source language: java (default) or kotlin"),
+									"description", "source language: java (default), kotlin or scala"),
 							"depth", Map.of("type", "integer",
 									"description", "how many levels of transitive dependencies to include (default 1)")),
 					"required", List.of("path", "class_name")))
@@ -70,36 +58,7 @@ public class EstimateTokensTool implements ContextTool {
 	}
 
 	@Override
-	public CallToolResult apply(Map<String, Object> arguments) {
-		log.info("Calling MCP estimate_tokens tool for {}", arguments);
-		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
-		Language language = ToolArguments.optionalLanguage(arguments, "language", Language.JAVA);
-		int depth = ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH);
-		Set<ClassContainer> containers = Set.copyOf(new ProjectSources(language).load(root).values());
-
-		ClassContainer target = findTarget(containers, arguments, language);
-		if (target == null) {
-			return error("Class not found: " + ToolArguments.requiredString(arguments, "class_name"));
-		}
-		return success(estimate(containers, target, language, depth));
-	}
-
-	private ClassContainer findTarget(Set<ClassContainer> containers, Map<String, Object> arguments, Language language) {
-		String fileName = fileNameOf(ToolArguments.requiredString(arguments, "class_name"), language);
-		return containers.stream()
-				.filter(container -> container.className().equals(fileName))
-				.findFirst()
-				.orElse(null);
-	}
-
-	private String fileNameOf(String className, Language language) {
-		if (className.endsWith(language.extension())) {
-			return className;
-		}
-		return className + language.extension();
-	}
-
-	private String estimate(Set<ClassContainer> containers, ClassContainer target, Language language, int depth) {
+	protected String result(Set<ClassContainer> containers, ClassContainer target, Language language, int depth) {
 		List<ClassContainer> context = assembleContext(containers, target, language, depth);
 		JSONArray classes = new JSONArray();
 		int total = 0;
@@ -115,7 +74,7 @@ public class EstimateTokensTool implements ContextTool {
 			Language language, int depth) {
 		List<ClassContainer> context = new ArrayList<>();
 		context.add(target);
-		context.addAll(new Finder(containers, language).find(target, depth));
+		context.addAll(new PackageAwareFinder(containers, language).find(target, depth));
 		return context;
 	}
 
@@ -131,19 +90,5 @@ public class EstimateTokensTool implements ContextTool {
 		report.put("total", total);
 		report.put("classes", classes);
 		return report;
-	}
-
-	private CallToolResult success(String reportJson) {
-		return CallToolResult.builder()
-				.content(List.of(TextContent.builder(reportJson).build()))
-				.isError(false)
-				.build();
-	}
-
-	private CallToolResult error(String message) {
-		return CallToolResult.builder()
-				.content(List.of(TextContent.builder(message).build()))
-				.isError(true)
-				.build();
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
@@ -20,8 +20,9 @@ import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 
 /**
- * MCP tool that scans a Java or Kotlin project into a tree of folders, files and
- * the classes each file depends on, then serialises it for a gen-AI agent. The
+ * MCP tool that scans a Java, Kotlin or Scala project into a tree of folders,
+ * files and the classes each file depends on, then serialises it for a gen-AI
+ * agent. The
  * output format ({@code json}, {@code markdown} or {@code text}) is chosen by the
  * caller; JSON is the default as it is the most convenient for programmatic
  * consumers.
@@ -47,13 +48,13 @@ public class ProjectTreeTool implements ContextTool {
 							"path", Map.of("type", "string",
 									"description", "absolute path to the project root directory"),
 							"language", Map.of("type", "string",
-									"description", "source language: java (default) or kotlin"),
+									"description", "source language: java (default), kotlin or scala"),
 							"depth", Map.of("type", "integer",
 									"description", "how many levels of transitive dependencies to resolve (default 1)"),
 							"format", Map.of("type", "string",
 									"description", "output format: json (default), markdown, text or dot")),
 					"required", List.of("path")))
-			.description("Scan a Java or Kotlin project into a tree of folders, files and class dependencies")
+			.description("Scan a Java, Kotlin or Scala project into a tree of folders, files and class dependencies")
 			.build();
 
 	@Override

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/EstimateTokensToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/EstimateTokensToolTest.java
@@ -107,14 +107,14 @@ public class EstimateTokensToolTest {
 	}
 
 	@Test
-	void defaultsToTheHeuristicEstimatorWhenNoneIsGiven() throws IOException {
-		writeJava("A", "abcd");
+	void defaultsToTheSubwordEstimatorWhenNoneIsGiven() throws IOException {
+		writeJava("A", "a.b");
 		EstimateTokensTool defaultTool = new EstimateTokensTool(new PathPolicy(projectRoot.toString()));
 
 		JSONObject report = report(defaultTool.apply(arguments("A")));
 
 		assertFalse(report.getJSONArray("classes").isEmpty());
-		assertEquals(1, report.getInt("total"));
+		assertEquals(3, report.getInt("total"));
 	}
 
 	@Test


### PR DESCRIPTION
Address the review of the last three days of changes:

- Extract AbstractFinder for the shared depth-bounded BFS traversal, regex
  patterns and comment/literal stripping that Finder and PackageAwareFinder
  duplicated; each now supplies only its direct-resolution step.
- Extract AbstractClassContextTool for the path-confinement, source loading
  and class lookup shared by find_context and estimate_tokens.
- Wire the more precise PackageAwareFinder into both MCP tools so classes
  sharing a simple name across packages are told apart, and default
  estimate_tokens to SubwordTokenEstimator, which tracks real tokenizers more
  closely on source code.
- Document Scala support in the project_tree, find_context and estimate_tokens
  tool schemas and Javadoc.
- Make BudgetedContext.fill iterative to avoid stack growth on large graphs.
- Drop a redundant second comment/literal strip in PackageAwareFinder indexing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016isYFmorheUkE24CRHm6hM