### PR TITLE
feat(mcp): add legacy HTTP+SSE transport to both MCP servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Maven project. The notable capabilities are:
   that scans a whole Java project into a tree of folders, files and
   dependencies, to assemble context for gen-AI agents working with Java code. An
   **MCP server** (in the `io.github.adamw7.context.mcp` package) exposes the
-  project-tree and context-finder tools over stdio or streamable HTTP.
+  project-tree and context-finder tools over stdio, streamable HTTP or HTTP+SSE.
 - **Data** (`data`) — data sources (CSV, GZip, JDBC; in-memory and iterative
   loading), a uniqueness-checking tool (finds whether a subset of columns can
   serve as a key, and searches for a smaller key), data structures (an
@@ -52,8 +52,10 @@ Base Java package: `io.github.adamw7` (`io.github.adamw7.context` for the
 context module, `io.github.adamw7.tools.*` elsewhere).
 
 The repository ships two MCP servers, each a Spring Boot app whose entry point
-is `Main.java` and which supports stdio (default) or streamable HTTP
-(`--transport.mode=streamable-http`):
+is `Main.java` and which supports stdio (default), streamable HTTP
+(`--transport.mode=streamable-http`, served at `/mcp`), or the legacy HTTP+SSE
+transport (`--transport.mode=sse`, event stream at `/sse`, messages at
+`/mcp/message`):
 
 - The uniqueness-checker server in
   `data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/`; see its

--- a/README.md
+++ b/README.md
@@ -331,7 +331,10 @@ It contains:
 - MCP server
   - Model Context Protocol server exposing uniqueness checking as a tool for AI assistants
   - Compatible with Claude Desktop, Cline, and other MCP clients
-  - Transport: stdio over JSON-RPC (Spring Boot, no HTTP server started)
+  - Transports (select with `--transport.mode`):
+    - `stdio` (default) — JSON-RPC over stdin/stdout (Spring Boot, no HTTP server started)
+    - `streamable-http` — the modern HTTP transport served at `/mcp`
+    - `sse` — the legacy HTTP+SSE transport for older clients: the event stream is served at `/sse` and JSON-RPC messages are POSTed to `/mcp/message`
   - Build: `mvn clean install` produces `data/target/tools.data-<version>.jar`
   - Run: `java -jar data/target/tools.data-<version>.jar --transport.mode=stdio`
   - See [MCP Usage Documentation](data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md) for client configuration (Claude Desktop, Cline) and usage examples

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -32,8 +32,10 @@ The implementation lives in a package separate from the core finders:
 
 The server uses:
 
-- **Transport**: stdio (default) or streamable HTTP
-  (`--transport.mode=streamable-http`), which serves the MCP endpoint at `/mcp`.
+- **Transport**: stdio (default), streamable HTTP
+  (`--transport.mode=streamable-http`), which serves the MCP endpoint at `/mcp`,
+  or the legacy HTTP+SSE transport (`--transport.mode=sse`), which serves the
+  event stream at `/sse` and accepts JSON-RPC messages at `/mcp/message`.
 - **MCP SDK**: `io.modelcontextprotocol.sdk` v2.0.0
 - **Framework**: Spring Boot
 - **Protocol**: Model Context Protocol (MCP)
@@ -139,6 +141,18 @@ java -jar code/context/target/tools.code.context-2.2.0-SNAPSHOT.jar --transport.
 The MCP endpoint is then served at `http://localhost:8082/mcp` (the port is
 configurable through `server.port`).
 
+### HTTP+SSE (legacy)
+
+```bash
+java -jar code/context/target/tools.code.context-2.2.0-SNAPSHOT.jar --transport.mode=sse
+```
+
+This is the legacy HTTP+SSE transport (MCP protocol revision 2024-11-05),
+kept for clients that predate streamable HTTP. The server opens the event
+stream at `http://localhost:8082/sse` and accepts JSON-RPC messages POSTed to
+`http://localhost:8082/mcp/message`. Prefer `streamable-http` for new clients;
+this transport is deprecated in the current MCP specification.
+
 ### HTTPS (TLS 1.3)
 
 To serve the streamable HTTP transport over HTTPS, point the standard Spring
@@ -172,10 +186,11 @@ The tools read source files from disk, so access is constrained by design:
   context.allowed-roots=/home/me/projects:/srv/code
   ```
 
-- **Loopback binding.** The streamable HTTP transport binds to `127.0.0.1` by
-  default (`server.address`). The `/mcp` endpoint has **no authentication**, so
-  it must not be exposed on a routable interface. Change `server.address` only
-  after putting authentication in front of it.
+- **Loopback binding.** The HTTP transports (streamable HTTP and HTTP+SSE) bind
+  to `127.0.0.1` by default (`server.address`). The `/mcp`, `/sse` and
+  `/mcp/message` endpoints have **no authentication**, so they must not be
+  exposed on a routable interface. Change `server.address` only after putting
+  authentication in front of them.
 
 - **Bounded depth.** The `depth` argument is capped at `10` to bound the cost of
   transitive dependency resolution.
@@ -206,6 +221,19 @@ The tools read source files from disk, so access is constrained by design:
     "context-engineering": {
       "type": "http",
       "url": "http://localhost:8082/mcp"
+    }
+  }
+}
+```
+
+### HTTP+SSE client (legacy)
+
+```json
+{
+  "mcpServers": {
+    "context-engineering": {
+      "type": "sse",
+      "url": "http://localhost:8082/sse"
     }
   }
 }

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/McpConfiguration.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/McpConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
 import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
@@ -25,12 +26,19 @@ import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 
 /**
  * Wires the context-engineering MCP server. The server exposes the project-tree,
- * context-finder and token-estimate tools over either stdio (the default) or a streamable HTTP
- * transport selected with {@code --transport.mode=streamable-http}; the latter
- * registers the {@code /mcp} servlet so MCP clients can connect over HTTP.
+ * context-finder and token-estimate tools over one of three transports, selected
+ * with {@code --transport.mode}: stdio (the default), a streamable HTTP transport
+ * ({@code streamable-http}) registered at {@code /mcp}, or the legacy HTTP+SSE
+ * transport ({@code sse}) registered at {@code /sse} (the event stream) and
+ * {@code /mcp/message} (the JSON-RPC POST endpoint) for clients that predate
+ * streamable HTTP.
  */
 @Configuration
 public class McpConfiguration {
+
+	static final String SSE_ENDPOINT = "/sse";
+
+	static final String SSE_MESSAGE_ENDPOINT = "/mcp/message";
 
 	private static final Logger log = LogManager.getLogger(McpConfiguration.class.getName());
 
@@ -65,6 +73,27 @@ public class McpConfiguration {
 			HttpServletStreamableServerTransportProvider transport) {
 		ServletRegistrationBean<HttpServletStreamableServerTransportProvider> registration =
 				new ServletRegistrationBean<>(transport, "/mcp");
+		registration.setAsyncSupported(true);
+		return registration;
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "sse")
+	public HttpServletSseServerTransportProvider sseServerTransport() {
+		log.info("Creating HttpServletSseServerTransport");
+		return HttpServletSseServerTransportProvider.builder()
+				.jsonMapper(new JacksonMcpJsonMapper(objectMapper()))
+				.sseEndpoint(SSE_ENDPOINT)
+				.messageEndpoint(SSE_MESSAGE_ENDPOINT)
+				.build();
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "sse")
+	public ServletRegistrationBean<HttpServletSseServerTransportProvider> sseServletRegistration(
+			HttpServletSseServerTransportProvider transport) {
+		ServletRegistrationBean<HttpServletSseServerTransportProvider> registration =
+				new ServletRegistrationBean<>(transport, SSE_ENDPOINT, SSE_MESSAGE_ENDPOINT);
 		registration.setAsyncSupported(true);
 		return registration;
 	}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/MainTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/MainTest.java
@@ -83,4 +83,14 @@ public class MainTest {
 		// application type must not be forced to "none" here.
 		assertNull(System.getProperty(WEB_APPLICATION_TYPE));
 	}
+
+	@Test
+	public void configureRuntimeKeepsWebApplicationForSseMode() {
+		Main.configureRuntime(new String[] { "--transport.mode=sse" });
+
+		// The SSE transport exposes the /sse and /mcp/message servlets, so it
+		// likewise needs a web server and must not be forced to "none".
+		assertEquals("sse", System.getProperty(TRANSPORT_MODE));
+		assertNull(System.getProperty(WEB_APPLICATION_TYPE));
+	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpConfigurationTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpConfigurationTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.context.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.OutputStream;
 import java.io.PipedInputStream;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
 import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 
@@ -59,6 +61,35 @@ public class McpConfigurationTest {
 		HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
 		McpSyncServer server = config.mcpSyncServerStreamable(transport);
 		assertFalse(server.getServerCapabilities().tools() == null);
+		server.close();
+	}
+
+	@Test
+	public void sseTransportIsNotNull() {
+		McpConfiguration config = new McpConfiguration();
+		assertNotNull(config.sseServerTransport());
+	}
+
+	@Test
+	public void sseServletRegistrationIsNotNull() {
+		McpConfiguration config = new McpConfiguration();
+		HttpServletSseServerTransportProvider transport = config.sseServerTransport();
+		assertNotNull(config.sseServletRegistration(transport));
+	}
+
+	@Test
+	public void sseServletRegistrationServesBothEndpoints() {
+		McpConfiguration config = new McpConfiguration();
+		HttpServletSseServerTransportProvider transport = config.sseServerTransport();
+		assertTrue(config.sseServletRegistration(transport).getUrlMappings()
+				.containsAll(java.util.List.of("/sse", "/mcp/message")));
+	}
+
+	@Test
+	public void mcpSyncServerWiresSseTransport() {
+		McpConfiguration config = new McpConfiguration();
+		McpSyncServer server = config.mcpSyncServer(config.sseServerTransport());
+		assertNotNull(server.getServerCapabilities().tools());
 		server.close();
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpSseIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpSseIT.java
@@ -1,0 +1,96 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+
+@SpringBootTest(
+		classes = Main.class,
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = {
+				"transport.mode=sse",
+				"spring.main.banner-mode=off",
+				"context.allowed-roots=${java.io.tmpdir}" })
+public class McpSseIT {
+
+	@LocalServerPort
+	private int port;
+
+	@TempDir
+	Path projectRoot;
+
+	private McpSyncClient client;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		Files.writeString(projectRoot.resolve("A.java"), "public class A {}");
+		Files.writeString(projectRoot.resolve("B.java"), "public class B { A a; }");
+		HttpClientSseClientTransport transport = HttpClientSseClientTransport
+				.builder("http://localhost:" + port)
+				.sseEndpoint("/sse")
+				.build();
+		client = McpClient.sync(transport)
+				.clientInfo(McpSchema.Implementation.builder("integration-test-client", "1.0").build())
+				.build();
+		client.initialize();
+	}
+
+	@AfterEach
+	void tearDown() {
+		client.close();
+	}
+
+	@Test
+	void listsAllContextTools() {
+		McpSchema.ListToolsResult tools = client.listTools();
+
+		assertTrue(tools.tools().stream().anyMatch(tool -> tool.name().equals("project_tree")));
+		assertTrue(tools.tools().stream().anyMatch(tool -> tool.name().equals("find_context")));
+		assertTrue(tools.tools().stream().anyMatch(tool -> tool.name().equals("estimate_tokens")));
+	}
+
+	@Test
+	void projectTreeToolReturnsTheScannedTree() {
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("project_tree")
+				.arguments(Map.of("path", projectRoot.toString()))
+				.build();
+
+		McpSchema.CallToolResult result = client.callTool(request);
+
+		assertFalse(result.isError());
+		String tree = ((McpSchema.TextContent) result.content().getFirst()).text();
+		assertTrue(tree.contains("A.java"));
+		assertTrue(tree.contains("B.java"));
+	}
+
+	@Test
+	void findContextToolReturnsDependencies() {
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("find_context")
+				.arguments(Map.of("path", projectRoot.toString(), "class_name", "B"))
+				.build();
+
+		McpSchema.CallToolResult result = client.callTool(request);
+
+		assertFalse(result.isError());
+		String dependencies = ((McpSchema.TextContent) result.content().getFirst()).text();
+		assertEquals("A.java", new JSONArray(dependencies).getString(0));
+	}
+}

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
@@ -15,7 +15,7 @@ The implementation consists of three main components:
 3. **UniquenessTool.java** - Implements the uniqueness checking tool
 
 The server uses:
-- **Transport**: stdio (default) or streamable-http (`--transport.mode=streamable-http`)
+- **Transport**: stdio (default), streamable-http (`--transport.mode=streamable-http`, served at `/mcp`), or the legacy HTTP+SSE transport (`--transport.mode=sse`, event stream at `/sse`, JSON-RPC messages POSTed to `/mcp/message`)
 - **MCP SDK**: io.modelcontextprotocol.sdk v2.0.0-RC1
 - **Framework**: Spring Boot
 - **Protocol**: Model Context Protocol (MCP)

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfiguration.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
 import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
@@ -22,6 +23,10 @@ import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 
 @Configuration
 public class McpConfiguration {
+
+	static final String SSE_ENDPOINT = "/sse";
+
+	static final String SSE_MESSAGE_ENDPOINT = "/mcp/message";
 
 	private static final Logger log = LogManager.getLogger(McpConfiguration.class.getName());
 
@@ -53,6 +58,27 @@ public class McpConfiguration {
 			HttpServletStreamableServerTransportProvider transport) {
 		ServletRegistrationBean<HttpServletStreamableServerTransportProvider> registration =
 				new ServletRegistrationBean<>(transport, "/mcp");
+		registration.setAsyncSupported(true);
+		return registration;
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "sse")
+	public HttpServletSseServerTransportProvider sseServerTransport() {
+		log.info("Creating HttpServletSseServerTransport");
+		return HttpServletSseServerTransportProvider.builder()
+				.jsonMapper(new JacksonMcpJsonMapper(objectMapper()))
+				.sseEndpoint(SSE_ENDPOINT)
+				.messageEndpoint(SSE_MESSAGE_ENDPOINT)
+				.build();
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "sse")
+	public ServletRegistrationBean<HttpServletSseServerTransportProvider> sseServletRegistration(
+			HttpServletSseServerTransportProvider transport) {
+		ServletRegistrationBean<HttpServletSseServerTransportProvider> registration =
+				new ServletRegistrationBean<>(transport, SSE_ENDPOINT, SSE_MESSAGE_ENDPOINT);
 		registration.setAsyncSupported(true);
 		return registration;
 	}

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/MainTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/MainTest.java
@@ -88,4 +88,14 @@ public class MainTest {
 		// application type must not be forced to "none" here.
 		assertNull(System.getProperty(WEB_APPLICATION_TYPE));
 	}
+
+	@Test
+	public void configureRuntimeKeepsWebApplicationForSseMode() {
+		Main.configureRuntime(new String[] { "--transport.mode=sse" });
+
+		// The SSE transport exposes the /sse and /mcp/message servlets, so it
+		// likewise needs a web server and must not be forced to "none".
+		assertEquals("sse", System.getProperty(TRANSPORT_MODE));
+		assertNull(System.getProperty(WEB_APPLICATION_TYPE));
+	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.data.uniqueness.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.OutputStream;
 import java.io.PipedInputStream;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
 import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 
@@ -58,6 +60,35 @@ public class McpConfigurationTest {
         McpConfiguration config = new McpConfiguration();
         HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
         McpSyncServer server = config.mcpSyncServerStreamable(transport);
+        assertNotNull(server.getServerCapabilities().tools());
+        server.close();
+    }
+
+    @Test
+    public void sseTransportIsNotNull() {
+        McpConfiguration config = new McpConfiguration();
+        assertNotNull(config.sseServerTransport());
+    }
+
+    @Test
+    public void sseServletRegistrationIsNotNull() {
+        McpConfiguration config = new McpConfiguration();
+        HttpServletSseServerTransportProvider transport = config.sseServerTransport();
+        assertNotNull(config.sseServletRegistration(transport));
+    }
+
+    @Test
+    public void sseServletRegistrationServesBothEndpoints() {
+        McpConfiguration config = new McpConfiguration();
+        HttpServletSseServerTransportProvider transport = config.sseServerTransport();
+        assertTrue(config.sseServletRegistration(transport).getUrlMappings()
+                .containsAll(java.util.List.of("/sse", "/mcp/message")));
+    }
+
+    @Test
+    public void mcpSyncServerWiresSseTransport() {
+        McpConfiguration config = new McpConfiguration();
+        McpSyncServer server = config.mcpSyncServer(config.sseServerTransport());
         assertNotNull(server.getServerCapabilities().tools());
         server.close();
     }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpSseIT.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpSseIT.java
@@ -1,0 +1,73 @@
+package io.github.adamw7.tools.data.uniqueness.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import io.github.adamw7.tools.data.Utils;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+
+@SpringBootTest(
+		classes = Main.class,
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = { "transport.mode=sse", "spring.main.banner-mode=off" })
+public class McpSseIT {
+
+	@LocalServerPort
+	private int port;
+
+	private McpSyncClient client;
+
+	@BeforeEach
+	void setUp() {
+		HttpClientSseClientTransport transport = HttpClientSseClientTransport
+				.builder("http://localhost:" + port)
+				.sseEndpoint("/sse")
+				.build();
+		client = McpClient.sync(transport)
+				.clientInfo(McpSchema.Implementation.builder("integration-test-client", "1.0").build())
+				.build();
+		client.initialize();
+	}
+
+	@AfterEach
+	void tearDown() {
+		client.close();
+	}
+
+	@Test
+	void nonUniqueColumnReturnsFalse() {
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("uniqueness_check")
+				.arguments(Map.of("file", Utils.getHouseholdFile(), "columns_row", 1, "columns_name", "year1"))
+				.build();
+
+		McpSchema.CallToolResult result = client.callTool(request);
+
+		assertFalse(result.isError());
+		McpSchema.TextContent content = (McpSchema.TextContent) result.content().getFirst();
+		assertEquals("false", content.text());
+	}
+
+	@Test
+	void uniqueColumnReturnsTrue() {
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("uniqueness_check")
+				.arguments(Map.of("file", Utils.getHouseholdFile(), "columns_row", 1, "columns_name", "income"))
+				.build();
+
+		McpSchema.CallToolResult result = client.callTool(request);
+
+		assertFalse(result.isError());
+		McpSchema.TextContent content = (McpSchema.TextContent) result.content().getFirst();
+		assertEquals("true", content.text());
+	}
+}


### PR DESCRIPTION
Add a third transport mode, selectable with --transport.mode=sse, to the
context-engineering and uniqueness-checker MCP servers. The SSE provider
(HttpServletSseServerTransportProvider) implements McpServerTransportProvider,
so the existing mcpSyncServer bean wires it automatically; the provider is
registered as a servlet on the event-stream endpoint (/sse) and the JSON-RPC
message endpoint (/mcp/message). No Main changes are needed since only stdio
forces a non-web application.

Covered by new McpConfigurationTest cases, MainTest web-server assertions, and
McpSseIT integration tests in both modules. Docs updated in README, AGENTS,
and both MCP_USAGE guides.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KZ3f4qxvVsTL8QDn3jQqJ5