### PR TITLE
perf(data): stop OpenAddressingMap probing at first empty slot

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -59,12 +59,25 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 
 	@Override
 	public V get(Object key) {
+		Wrapper<K, V> wrapper = find(key);
+		return wrapper == null ? null : wrapper.value;
+	}
+
+	/**
+	 * Probes the double-hashing sequence for {@code key} and returns its live
+	 * wrapper, or {@code null} when the key is absent. An empty (never-used) slot
+	 * ends the search: {@link #put} always fills the first such slot, so the key
+	 * cannot lie beyond it. Tombstones ({@code removed}) are skipped rather than
+	 * treated as terminal, because live entries may sit past them.
+	 */
+	private Wrapper<K, V> find(Object key) {
 		for (int i = 0; i < array.length; ++i) {
-			int hash = hash(key, i);
-			Wrapper<K, V> wrapper = array[hash];
-			
+			Wrapper<K, V> wrapper = array[hash(key, i)];
+			if (wrapper == null) {
+				return null;
+			}
 			if (valid(wrapper) && wrapper.key.equals(key)) {
-				return wrapper.value;
+				return wrapper;
 			}
 		}
 		return null;
@@ -127,17 +140,13 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 
 	@Override
 	public V remove(Object key) {
-		for (int i = 0; i < array.length; ++i) {
-			int hash = hash(key, i);
-			Wrapper<K, V> wrapper = array[hash];
-			
-			if (valid(wrapper) && wrapper.key.equals(key)) {
-				wrapper.removed = true;
-				size--;
-				return wrapper.value;
-			}
+		Wrapper<K, V> wrapper = find(key);
+		if (wrapper == null) {
+			return null;
 		}
-		return null;
+		wrapper.removed = true;
+		size--;
+		return wrapper.value;
 	}
 
 	@Override

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
@@ -265,6 +265,39 @@ public class MapTest {
 	}
 	
 	@ParameterizedTest
+	@MethodSource("conflictingHashImplementations")
+	public void liveEntriesFoundPastTombstoneInProbeChain(Map<ConflictingKey, String> map) {
+		ConflictingKey first = new ConflictingKey(1, "1");
+		ConflictingKey middle = new ConflictingKey(2, "2");
+		ConflictingKey last = new ConflictingKey(3, "3");
+		map.put(first, "A");
+		map.put(middle, "B");
+		map.put(last, "C");
+
+		assertEquals("B", map.remove(middle));
+
+		assertNull(map.get(middle));
+		assertEquals("A", map.get(first));
+		assertEquals("C", map.get(last));
+		assertEquals(2, map.size());
+	}
+
+	@ParameterizedTest
+	@MethodSource("conflictingHashImplementations")
+	public void missingKeyInProbeChainWithTombstoneReturnsNull(Map<ConflictingKey, String> map) {
+		ConflictingKey present = new ConflictingKey(1, "1");
+		ConflictingKey removed = new ConflictingKey(2, "2");
+		map.put(present, "A");
+		map.put(removed, "B");
+		map.remove(removed);
+
+		assertNull(map.get(new ConflictingKey(99, "99")));
+		assertNull(map.remove(new ConflictingKey(99, "99")));
+		assertEquals(1, map.size());
+		assertEquals("A", map.get(present));
+	}
+
+	@ParameterizedTest
 	@MethodSource("allImplementations")
 	public void multipleClear(Map<Integer, String> map) {
 		final int size = OpenAddressingMap.DEFAULT_SIZE * 5; // forcing resize


### PR DESCRIPTION
get() and remove() scanned the entire backing array on every call,
making each lookup O(capacity) — defeating the average-case O(1) the
open-addressing scheme exists to provide, with misses always paying the
full cost. Extract a shared find() helper that follows the same
double-hashing probe sequence as put() but stops at the first empty
(never-used) slot: put() always fills that slot, so the key cannot lie
beyond it. Tombstones are still skipped, since live entries may sit past
them, preserving correctness after removals.

Add regression tests over a colliding-hash key (single probe chain) that
verify live entries past a tombstone are still found and that a miss in a
chain containing a tombstone returns null, cross-checked against HashMap.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VacQuBiEDGNGeJ35ufV3oQ