### PR TITLE
docs: fix stale plugin version and add License section to README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,7 +225,7 @@ These are hard requirements for any code you add or modify:
 To release version `X`:
 
 1. Change the `revision` property in the root `pom.xml` to `X` (it is currently
-   a `-SNAPSHOT`, e.g. `1.6.0-SNAPSHOT`).
+   a `-SNAPSHOT`, e.g. `2.2.0-SNAPSHOT`).
 2. Commit and push.
 3. Confirm all builds pass.
 4. Release and mark as latest in GitHub.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Solution:
 <plugin>
 	<groupId>io.github.adamw7</groupId>
 	<artifactId>protogen-maven-plugin</artifactId>
-	<version>1.5.0</version>
+	<!-- Use the latest release: https://github.com/adamw7/tools/releases/latest -->
+	<version>2.1.0</version>
 	<configuration>
 		<generatedSourcesDir>${project.basedir}/target/generated-sources/</generatedSourcesDir>
 		<pkgs>
@@ -508,3 +509,7 @@ In order to release a new version - X you need to:
 2. Commit and push
 3. Check if all builds pass
 4. Release and mark as latest in GitHub
+
+# License
+
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
- Bump protogen-maven-plugin example from 1.5.0 to the latest release 2.1.0
  and link to the releases page so it does not go stale
- Correct the AGENTS.md release snapshot example to 2.2.0-SNAPSHOT
- Add a License section to README referencing the MIT LICENSE file

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NDUXWEA5VTrTxFQgP6hLgX