### PR TITLE
refactor: simplify MCP server beans and OpenAddressingMap resize

### DIFF
--- a/code/context/src/main/java/io/github/adamw7/context/mcp/McpConfiguration.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/McpConfiguration.java
@@ -102,20 +102,18 @@ public class McpConfiguration {
 	@ConditionalOnBean(McpServerTransportProvider.class)
 	public McpSyncServer mcpSyncServer(McpServerTransportProvider transport) {
 		log.info("Initializing McpSyncServer with transport: {}", transport);
-		McpSyncServer syncServer = McpServer.sync(transport)
-				.serverInfo("context-engineering-server", "0.0.1")
-				.capabilities(McpSchema.ServerCapabilities.builder()
-						.tools(true).resources(false, false).prompts(false).build())
-				.build();
-		registerTools(syncServer);
-		return syncServer;
+		return buildServer(McpServer.sync(transport));
 	}
 
 	@Bean(destroyMethod = "close")
 	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
 	public McpSyncServer mcpSyncServerStreamable(McpStreamableServerTransportProvider transport) {
 		log.info("Initializing McpSyncServer with streamable transport: {}", transport);
-		McpSyncServer syncServer = McpServer.sync(transport)
+		return buildServer(McpServer.sync(transport));
+	}
+
+	private McpSyncServer buildServer(McpServer.SyncSpecification<?> spec) {
+		McpSyncServer syncServer = spec
 				.serverInfo("context-engineering-server", "0.0.1")
 				.capabilities(McpSchema.ServerCapabilities.builder()
 						.tools(true).resources(false, false).prompts(false).build())

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -130,12 +130,14 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 	}
 
 	private void resize() {
-		size = newSize();
-		OpenAddressingMap<K, V> newMap = new OpenAddressingMap<>(size);
-		newMap.putAll(this);
-		clear();
-		putAll(newMap);
-		newMap.clear();
+		Wrapper<K, V>[] old = array;
+		initArray(newSize());
+		size = 0;
+		for (Wrapper<K, V> wrapper : old) {
+			if (valid(wrapper)) {
+				put(wrapper.key, wrapper.value);
+			}
+		}
 	}
 
 	@Override

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfiguration.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfiguration.java
@@ -87,19 +87,18 @@ public class McpConfiguration {
 	@ConditionalOnBean(McpServerTransportProvider.class)
 	public McpSyncServer mcpSyncServer(McpServerTransportProvider transport) {
 		log.info("Initializing McpSyncServer with transport: {}", transport);
-		McpSyncServer syncServer = McpServer.sync(transport)
-				.serverInfo("custom-server", "0.0.1")
-				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).resources(false, false).prompts(false).build())
-				.build();
-		registerTools(syncServer);
-		return syncServer;
+		return buildServer(McpServer.sync(transport));
 	}
 
 	@Bean(destroyMethod = "close")
 	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
 	public McpSyncServer mcpSyncServerStreamable(McpStreamableServerTransportProvider transport) {
 		log.info("Initializing McpSyncServer with streamable transport: {}", transport);
-		McpSyncServer syncServer = McpServer.sync(transport)
+		return buildServer(McpServer.sync(transport));
+	}
+
+	private McpSyncServer buildServer(McpServer.SyncSpecification<?> spec) {
+		McpSyncServer syncServer = spec
 				.serverInfo("custom-server", "0.0.1")
 				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).resources(false, false).prompts(false).build())
 				.build();


### PR DESCRIPTION
Extract a shared buildServer helper in both McpConfiguration classes so the
two transport beans no longer duplicate the serverInfo/capabilities/build
chain. Each bean still calls the correct McpServer.sync overload; the helper
factors against the common SyncSpecification base.

Rewrite OpenAddressingMap.resize as a direct rehash instead of round-tripping
through a temporary map. This removes the reuse of the size field as a
capacity carrier and the dependency on clear()'s capacity heuristic.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WyPxRiejJBzmTfSghZTHzD