### PR TITLE
test: add unit tests for KeyFinder and ProjectTreeNode

### DIFF
--- a/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeNodeTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeNodeTest.java
@@ -1,0 +1,104 @@
+package io.github.adamw7.context.tree;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.context.tree.ProjectTreeNode.Type;
+
+public class ProjectTreeNodeTest {
+
+	@Test
+	public void directoryFactoryUsesLastPathSegmentAsName() {
+		ProjectTreeNode node = ProjectTreeNode.directory(Path.of("src", "main", "java"));
+
+		assertEquals("java", node.name());
+		assertTrue(node.isDirectory());
+	}
+
+	@Test
+	public void fileFactoryUsesFileNameAsName() {
+		ProjectTreeNode node = ProjectTreeNode.file(Path.of("src", "Main.java"));
+
+		assertEquals("Main.java", node.name());
+		assertFalse(node.isDirectory());
+	}
+
+	@Test
+	public void rootPathWithoutFileNameFallsBackToFullPath() {
+		Path root = Path.of("/");
+
+		ProjectTreeNode node = ProjectTreeNode.directory(root);
+
+		assertEquals(root.toString(), node.name());
+	}
+
+	@Test
+	public void newNodeHasNoChildren() {
+		ProjectTreeNode node = new ProjectTreeNode("root", Type.DIRECTORY);
+
+		assertTrue(node.children().isEmpty());
+	}
+
+	@Test
+	public void addChildAppendsInInsertionOrder() {
+		ProjectTreeNode root = new ProjectTreeNode("root", Type.DIRECTORY);
+		ProjectTreeNode first = new ProjectTreeNode("a", Type.FILE);
+		ProjectTreeNode second = new ProjectTreeNode("b", Type.FILE);
+
+		root.addChild(first);
+		root.addChild(second);
+
+		assertEquals(List.of(first, second), root.children());
+	}
+
+	@Test
+	public void newNodeHasNoDependencies() {
+		ProjectTreeNode node = new ProjectTreeNode("Main.java", Type.FILE);
+
+		assertTrue(node.dependencies().isEmpty());
+	}
+
+	@Test
+	public void addDependencyStoresTheDependency() {
+		ProjectTreeNode node = new ProjectTreeNode("Main.java", Type.FILE);
+
+		node.addDependency("com.example.Foo");
+
+		assertTrue(node.dependencies().contains("com.example.Foo"));
+	}
+
+	@Test
+	public void duplicateDependenciesAreDeduplicated() {
+		ProjectTreeNode node = new ProjectTreeNode("Main.java", Type.FILE);
+
+		node.addDependency("com.example.Foo");
+		node.addDependency("com.example.Foo");
+
+		assertEquals(1, node.dependencies().size());
+	}
+
+	@Test
+	public void dependenciesPreserveInsertionOrder() {
+		ProjectTreeNode node = new ProjectTreeNode("Main.java", Type.FILE);
+
+		node.addDependency("com.example.C");
+		node.addDependency("com.example.A");
+		node.addDependency("com.example.B");
+
+		assertEquals(List.of("com.example.C", "com.example.A", "com.example.B"),
+				List.copyOf(node.dependencies()));
+	}
+
+	@Test
+	public void fileNodeIsNotADirectory() {
+		ProjectTreeNode node = new ProjectTreeNode("Main.java", Type.FILE);
+
+		assertFalse(node.isDirectory());
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/KeyFinderTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/KeyFinderTest.java
@@ -1,0 +1,86 @@
+package io.github.adamw7.tools.data.uniqueness;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class KeyFinderTest {
+
+	@Test
+	public void nullRowIsNeverFound() {
+		KeyFinder finder = new KeyFinder(new Integer[] { 0 });
+
+		assertFalse(finder.found(null));
+	}
+
+	@Test
+	public void firstRowIsNotADuplicate() {
+		KeyFinder finder = new KeyFinder(new Integer[] { 0 });
+
+		assertFalse(finder.found(new String[] { "a", "b" }));
+	}
+
+	@Test
+	public void repeatedRowIsADuplicate() {
+		KeyFinder finder = new KeyFinder(new Integer[] { 0 });
+
+		finder.found(new String[] { "a", "b" });
+
+		assertTrue(finder.found(new String[] { "a", "b" }));
+	}
+
+	@Test
+	public void onlyConfiguredColumnsFormTheKey() {
+		KeyFinder finder = new KeyFinder(new Integer[] { 0 });
+
+		finder.found(new String[] { "a", "b" });
+
+		assertTrue(finder.found(new String[] { "a", "different" }));
+	}
+
+	@Test
+	public void differenceInUncheckedColumnDoesNotCollideOnCheckedColumn() {
+		KeyFinder finder = new KeyFinder(new Integer[] { 1 });
+
+		finder.found(new String[] { "a", "b" });
+
+		assertFalse(finder.found(new String[] { "a", "c" }));
+	}
+
+	@Test
+	public void multiColumnKeyMatchesOnAllConfiguredColumns() {
+		KeyFinder finder = new KeyFinder(new Integer[] { 0, 2 });
+
+		finder.found(new String[] { "a", "b", "c" });
+
+		assertTrue(finder.found(new String[] { "a", "ignored", "c" }));
+	}
+
+	@Test
+	public void multiColumnKeyDiffersWhenAnyConfiguredColumnDiffers() {
+		KeyFinder finder = new KeyFinder(new Integer[] { 0, 2 });
+
+		finder.found(new String[] { "a", "b", "c" });
+
+		assertFalse(finder.found(new String[] { "a", "b", "different" }));
+	}
+
+	@Test
+	public void distinctRowsAreNotDuplicates() {
+		KeyFinder finder = new KeyFinder(new Integer[] { 0 });
+
+		assertFalse(finder.found(new String[] { "a" }));
+		assertFalse(finder.found(new String[] { "b" }));
+		assertFalse(finder.found(new String[] { "c" }));
+	}
+
+	@Test
+	public void keyProjectsConfiguredColumnsInOrder() {
+		KeyFinder finder = new KeyFinder(new Integer[] { 2, 0 });
+
+		Key key = finder.key(new String[] { "x", "y", "z" }, new Integer[] { 2, 0 });
+
+		assertTrue(key.equals(new Key(new String[] { "z", "x" })));
+	}
+}


### PR DESCRIPTION
Cover two previously untested classes with real logic:
- KeyFinder: null rows, duplicate detection, configured-index
  projection, and multi-column keys
- ProjectTreeNode: directory/file factories, the null-fileName
  fallback in nameOf, child ordering, and dependency dedup/order

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tb8qjR3GJWakSjKJQ6V5ju