### PR TITLE
refactor: replace org.json with Jackson across modules

### DIFF
--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -58,8 +58,8 @@
 			<artifactId>javax.inject</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
@@ -5,9 +5,10 @@ import java.util.List;
 
 import javax.inject.Named;
 
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
+import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 
 /**
  * Enforcer rule that fails the build when the project's {@code .mcp.json} is
@@ -80,12 +81,12 @@ public class McpServersValidRule extends JsonFileRule {
 	}
 
 	@Override
-	protected void collectViolations(JSONObject mcp, List<String> violations) {
+	protected void collectViolations(JsonNode mcp, List<String> violations) {
 		collectServersViolations(mcp, violations);
 	}
 
-	private void collectServersViolations(JSONObject mcp, List<String> violations) {
-		JSONObject servers = mcp.optJSONObject(MCP_SERVERS_KEY);
+	private void collectServersViolations(JsonNode mcp, List<String> violations) {
+		JsonNode servers = JsonNodes.objectAt(mcp, MCP_SERVERS_KEY);
 		if (servers == null) {
 			violations.add("mcp.json is missing the 'mcpServers' object");
 		} else {
@@ -93,15 +94,15 @@ public class McpServersValidRule extends JsonFileRule {
 		}
 	}
 
-	private void collectKnownServersViolations(JSONObject servers, List<String> violations) {
-		for (String name : servers.keySet()) {
-			collectServerViolations(name, servers.optJSONObject(name), violations);
+	private void collectKnownServersViolations(JsonNode servers, List<String> violations) {
+		for (String name : JsonNodes.fieldNames(servers)) {
+			collectServerViolations(name, JsonNodes.objectAt(servers, name), violations);
 		}
 		collectRequiredServers(servers, violations);
 		collectForbiddenServers(servers, violations);
 	}
 
-	private void collectServerViolations(String name, JSONObject server, List<String> violations) {
+	private void collectServerViolations(String name, JsonNode server, List<String> violations) {
 		if (server == null) {
 			violations.add("mcp.json server '" + name + "' must be a JSON object");
 		} else {
@@ -109,8 +110,8 @@ public class McpServersValidRule extends JsonFileRule {
 		}
 	}
 
-	private void collectTransportViolations(String name, JSONObject server, List<String> violations) {
-		String type = server.optString(TYPE_KEY, "").strip();
+	private void collectTransportViolations(String name, JsonNode server, List<String> violations) {
+		String type = JsonNodes.textAt(server, TYPE_KEY, "").strip();
 		if (type.isBlank()) {
 			collectInferredTransportViolations(name, server, violations);
 		} else {
@@ -118,7 +119,7 @@ public class McpServersValidRule extends JsonFileRule {
 		}
 	}
 
-	private void collectInferredTransportViolations(String name, JSONObject server, List<String> violations) {
+	private void collectInferredTransportViolations(String name, JsonNode server, List<String> violations) {
 		if (server.has(COMMAND_KEY)) {
 			collectCommandViolation(name, server, violations);
 		} else {
@@ -127,7 +128,7 @@ public class McpServersValidRule extends JsonFileRule {
 		}
 	}
 
-	private void collectExplicitTransportViolations(String name, JSONObject server, String type,
+	private void collectExplicitTransportViolations(String name, JsonNode server, String type,
 			List<String> violations) {
 		if (!allowedTypes().contains(type)) {
 			violations.add("mcp.json server '" + name + "' has an unsupported type: " + type);
@@ -138,19 +139,19 @@ public class McpServersValidRule extends JsonFileRule {
 		}
 	}
 
-	private void collectCommandViolation(String name, JSONObject server, List<String> violations) {
-		if (server.optString(COMMAND_KEY, "").isBlank()) {
+	private void collectCommandViolation(String name, JsonNode server, List<String> violations) {
+		if (JsonNodes.textAt(server, COMMAND_KEY, "").isBlank()) {
 			violations.add("mcp.json server '" + name + "' (stdio) is missing a 'command'");
 		}
 	}
 
-	private void collectUrlViolation(String name, String type, JSONObject server, List<String> violations) {
-		if (server.optString(URL_KEY, "").isBlank()) {
+	private void collectUrlViolation(String name, String type, JsonNode server, List<String> violations) {
+		if (JsonNodes.textAt(server, URL_KEY, "").isBlank()) {
 			violations.add("mcp.json server '" + name + "' (" + type + ") is missing a 'url'");
 		}
 	}
 
-	private void collectRequiredServers(JSONObject servers, List<String> violations) {
+	private void collectRequiredServers(JsonNode servers, List<String> violations) {
 		if (requiredServers == null) {
 			return;
 		}
@@ -161,7 +162,7 @@ public class McpServersValidRule extends JsonFileRule {
 		}
 	}
 
-	private void collectForbiddenServers(JSONObject servers, List<String> violations) {
+	private void collectForbiddenServers(JsonNode servers, List<String> violations) {
 		if (forbiddenServers == null) {
 			return;
 		}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -5,8 +5,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.json.JSONException;
-import org.json.JSONObject;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
@@ -20,12 +22,14 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * <p>
  * Subclasses contribute the file, its parameter name, a human-readable
  * description used in messages, the report header, and the document-specific
- * checks against the parsed {@link JSONObject}. A misconfigured rule (missing
+ * checks against the parsed {@link JsonNode}. A misconfigured rule (missing
  * file parameter) or a missing or empty file always fails, because that is a
  * build-setup mistake; a rule whose file is optional overrides
  * {@link #handleMissingFile} to pass instead.
  */
 public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	@Override
 	public final void execute() throws EnforcerRuleException {
@@ -38,7 +42,7 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 			return;
 		}
 		List<String> violations = new ArrayList<>();
-		JSONObject root = parse(readContent(file), violations);
+		JsonNode root = parse(readContent(file), violations);
 		if (root != null) {
 			collectViolations(root, violations);
 		}
@@ -58,7 +62,7 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 	protected abstract String header();
 
 	/** Document-specific checks against the parsed JSON. */
-	protected abstract void collectViolations(JSONObject root, List<String> violations);
+	protected abstract void collectViolations(JsonNode root, List<String> violations);
 
 	/**
 	 * How to react when the file is absent. The default fails the build, because a
@@ -77,11 +81,16 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 		return content;
 	}
 
-	private JSONObject parse(String content, List<String> violations) {
+	private JsonNode parse(String content, List<String> violations) {
 		try {
-			return new JSONObject(content);
-		} catch (JSONException e) {
-			violations.add(description() + " is not valid JSON: " + e.getMessage());
+			JsonNode root = MAPPER.readTree(content);
+			if (root == null || !root.isObject()) {
+				violations.add(description() + " is not valid JSON: expected a JSON object");
+				return null;
+			}
+			return root;
+		} catch (JsonProcessingException e) {
+			violations.add(description() + " is not valid JSON: " + e.getOriginalMessage());
 			return null;
 		}
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonNodes.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonNodes.java
@@ -1,0 +1,52 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Null-safe accessors over Jackson {@link JsonNode} that mirror the optional
+ * lookups the JSON enforcer rules rely on. They keep the rule logic free of
+ * repeated null and type checks: a lookup that does not resolve to the expected
+ * node type yields {@code null} (or a supplied default) rather than throwing.
+ */
+public final class JsonNodes {
+
+	private JsonNodes() {
+	}
+
+	/** The child object at {@code key}, or null when it is absent or not an object. */
+	public static JsonNode objectAt(JsonNode node, String key) {
+		JsonNode child = node.get(key);
+		return child != null && child.isObject() ? child : null;
+	}
+
+	/** The child array at {@code key}, or null when it is absent or not an array. */
+	public static JsonNode arrayAt(JsonNode node, String key) {
+		JsonNode child = node.get(key);
+		return child != null && child.isArray() ? child : null;
+	}
+
+	/** The array element at {@code index}, or null when it is not an object. */
+	public static JsonNode objectAt(JsonNode array, int index) {
+		JsonNode element = array.get(index);
+		return element != null && element.isObject() ? element : null;
+	}
+
+	/** The text at {@code key}, or {@code defaultValue} when it is absent or null. */
+	public static String textAt(JsonNode node, String key, String defaultValue) {
+		JsonNode child = node.get(key);
+		return child != null && !child.isNull() ? child.asText() : defaultValue;
+	}
+
+	/** The field names of an object node, preserving document order. */
+	public static List<String> fieldNames(JsonNode node) {
+		List<String> names = new ArrayList<>();
+		for (Map.Entry<String, JsonNode> field : node.properties()) {
+			names.add(field.getKey());
+		}
+		return names;
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -5,10 +5,10 @@ import java.util.List;
 
 import javax.inject.Named;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
+import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 
 /**
  * Enforcer rule that fails the build when the {@code hooks} section of
@@ -74,23 +74,23 @@ public class HookCommandsValidRule extends JsonFileRule {
 	}
 
 	@Override
-	protected void collectViolations(JSONObject settings, List<String> violations) {
+	protected void collectViolations(JsonNode settings, List<String> violations) {
 		collectHookViolations(settings, violations);
 	}
 
-	private void collectHookViolations(JSONObject settings, List<String> violations) {
-		JSONObject hooks = settings.optJSONObject(HOOKS_KEY);
+	private void collectHookViolations(JsonNode settings, List<String> violations) {
+		JsonNode hooks = JsonNodes.objectAt(settings, HOOKS_KEY);
 		if (hooks == null) {
 			return;
 		}
-		for (String event : hooks.keySet()) {
+		for (String event : JsonNodes.fieldNames(hooks)) {
 			collectEventViolations(event, hooks, violations);
 		}
 	}
 
-	private void collectEventViolations(String event, JSONObject hooks, List<String> violations) {
+	private void collectEventViolations(String event, JsonNode hooks, List<String> violations) {
 		addEventNameViolation(event, violations);
-		JSONArray groups = hooks.optJSONArray(event);
+		JsonNode groups = JsonNodes.arrayAt(hooks, event);
 		if (groups == null) {
 			violations.add("hook event '" + event + "' must be a JSON array");
 		} else {
@@ -104,13 +104,13 @@ public class HookCommandsValidRule extends JsonFileRule {
 		}
 	}
 
-	private void collectGroupsViolations(String event, JSONArray groups, List<String> violations) {
-		for (int i = 0; i < groups.length(); i++) {
-			collectGroupViolations(event, groups.optJSONObject(i), violations);
+	private void collectGroupsViolations(String event, JsonNode groups, List<String> violations) {
+		for (int i = 0; i < groups.size(); i++) {
+			collectGroupViolations(event, JsonNodes.objectAt(groups, i), violations);
 		}
 	}
 
-	private void collectGroupViolations(String event, JSONObject group, List<String> violations) {
+	private void collectGroupViolations(String event, JsonNode group, List<String> violations) {
 		if (group == null) {
 			violations.add("hook event '" + event + "' has an entry that is not a JSON object");
 		} else {
@@ -118,22 +118,22 @@ public class HookCommandsValidRule extends JsonFileRule {
 		}
 	}
 
-	private void collectEntriesViolations(String event, JSONObject group, List<String> violations) {
-		JSONArray entries = group.optJSONArray(HOOKS_KEY);
+	private void collectEntriesViolations(String event, JsonNode group, List<String> violations) {
+		JsonNode entries = JsonNodes.arrayAt(group, HOOKS_KEY);
 		if (entries == null) {
 			violations.add("hook event '" + event + "' entry is missing a 'hooks' array");
 		} else {
-			collectEntriesViolations(event, entries, violations);
+			collectHookEntries(event, entries, violations);
 		}
 	}
 
-	private void collectEntriesViolations(String event, JSONArray entries, List<String> violations) {
-		for (int i = 0; i < entries.length(); i++) {
-			collectEntryViolations(event, entries.optJSONObject(i), violations);
+	private void collectHookEntries(String event, JsonNode entries, List<String> violations) {
+		for (int i = 0; i < entries.size(); i++) {
+			collectEntryViolations(event, JsonNodes.objectAt(entries, i), violations);
 		}
 	}
 
-	private void collectEntryViolations(String event, JSONObject entry, List<String> violations) {
+	private void collectEntryViolations(String event, JsonNode entry, List<String> violations) {
 		if (entry == null) {
 			violations.add("hook event '" + event + "' has a hook that is not a JSON object");
 		} else {
@@ -141,8 +141,8 @@ public class HookCommandsValidRule extends JsonFileRule {
 		}
 	}
 
-	private void collectTypedEntryViolations(String event, JSONObject entry, List<String> violations) {
-		String type = entry.optString(TYPE_KEY, "").strip();
+	private void collectTypedEntryViolations(String event, JsonNode entry, List<String> violations) {
+		String type = JsonNodes.textAt(entry, TYPE_KEY, "").strip();
 		if (type.isBlank()) {
 			violations.add("hook event '" + event + "' has a hook missing 'type'");
 		} else if (type.equals(COMMAND_TYPE)) {
@@ -150,8 +150,8 @@ public class HookCommandsValidRule extends JsonFileRule {
 		}
 	}
 
-	private void collectCommandViolations(String event, JSONObject entry, List<String> violations) {
-		String command = entry.optString(COMMAND_KEY, "").strip();
+	private void collectCommandViolations(String event, JsonNode entry, List<String> violations) {
+		String command = JsonNodes.textAt(entry, COMMAND_KEY, "").strip();
 		if (command.isBlank()) {
 			violations.add("hook event '" + event + "' has a command hook with an empty 'command'");
 		} else {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
@@ -6,10 +6,10 @@ import java.util.List;
 
 import javax.inject.Named;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
+import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 
 /**
  * Enforcer rule that fails the build when {@code .claude/settings.json} is
@@ -59,11 +59,11 @@ public class SettingsJsonValidRule extends JsonFileRule {
 	}
 
 	@Override
-	protected void collectViolations(JSONObject settings, List<String> violations) {
+	protected void collectViolations(JsonNode settings, List<String> violations) {
 		collectPermissionViolations(settings, violations);
 	}
 
-	private void collectPermissionViolations(JSONObject settings, List<String> violations) {
+	private void collectPermissionViolations(JsonNode settings, List<String> violations) {
 		if (requiredPermissions == null && forbiddenPermissions == null) {
 			return;
 		}
@@ -72,16 +72,16 @@ public class SettingsJsonValidRule extends JsonFileRule {
 		collectForbiddenPermissions(allow, violations);
 	}
 
-	private List<String> allowList(JSONObject settings) {
-		JSONObject permissions = settings.optJSONObject(PERMISSIONS_KEY);
-		JSONArray allow = permissions != null ? permissions.optJSONArray(ALLOW_KEY) : null;
+	private List<String> allowList(JsonNode settings) {
+		JsonNode permissions = JsonNodes.objectAt(settings, PERMISSIONS_KEY);
+		JsonNode allow = permissions != null ? JsonNodes.arrayAt(permissions, ALLOW_KEY) : null;
 		return allow != null ? toStringList(allow) : List.of();
 	}
 
-	private List<String> toStringList(JSONArray array) {
+	private List<String> toStringList(JsonNode array) {
 		List<String> entries = new ArrayList<>();
-		for (int i = 0; i < array.length(); i++) {
-			entries.add(array.getString(i));
+		for (int i = 0; i < array.size(); i++) {
+			entries.add(array.get(i).asText());
 		}
 		return entries;
 	}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
@@ -15,8 +15,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -71,7 +72,7 @@ class JsonFileRuleTest {
 
 		assertDoesNotThrow(rule::execute);
 		assertNotNull(rule.parsedRoot, "collectViolations must receive the parsed object");
-		assertEquals("value", rule.parsedRoot.getString("name"));
+		assertEquals("value", rule.parsedRoot.get("name").asText());
 	}
 
 	@Test
@@ -123,7 +124,7 @@ class JsonFileRuleTest {
 		private File file;
 		private boolean optional;
 		private final List<String> injectedViolations = new ArrayList<>();
-		private JSONObject parsedRoot;
+		private JsonNode parsedRoot;
 
 		void setFile(File file) {
 			this.file = file;
@@ -165,7 +166,7 @@ class JsonFileRuleTest {
 		}
 
 		@Override
-		protected void collectViolations(JSONObject root, List<String> violations) {
+		protected void collectViolations(JsonNode root, List<String> violations) {
 			this.parsedRoot = root;
 			violations.addAll(injectedViolations);
 		}

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -66,10 +66,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-json-jackson2</artifactId>
 		</dependency>

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
@@ -4,7 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.json.JSONArray;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import io.github.adamw7.context.ClassContainer;
 import io.github.adamw7.context.Language;
@@ -21,6 +22,8 @@ import io.modelcontextprotocol.spec.McpSchema.Tool;
  * a clear, actionable message.
  */
 public class ContextFinderTool extends AbstractClassContextTool {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	public ContextFinderTool(PathPolicy pathPolicy) {
 		super(pathPolicy);
@@ -53,6 +56,8 @@ public class ContextFinderTool extends AbstractClassContextTool {
 				.map(ClassContainer::className)
 				.sorted()
 				.toList();
-		return new JSONArray(dependencies).toString();
+		ArrayNode array = MAPPER.createArrayNode();
+		dependencies.forEach(array::add);
+		return array.toString();
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/EstimateTokensTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/EstimateTokensTool.java
@@ -5,8 +5,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.github.adamw7.context.ClassContainer;
 import io.github.adamw7.context.Language;
@@ -24,6 +25,8 @@ import io.modelcontextprotocol.spec.McpSchema.Tool;
  * clear, actionable message.
  */
 public class EstimateTokensTool extends AbstractClassContextTool {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	private final TokenEstimator estimator;
 
@@ -60,12 +63,12 @@ public class EstimateTokensTool extends AbstractClassContextTool {
 	@Override
 	protected String result(Set<ClassContainer> containers, ClassContainer target, Language language, int depth) {
 		List<ClassContainer> context = assembleContext(containers, target, language, depth);
-		JSONArray classes = new JSONArray();
+		ArrayNode classes = MAPPER.createArrayNode();
 		int total = 0;
 		for (ClassContainer container : context) {
 			int tokens = estimator.estimate(container.originalCode());
 			total += tokens;
-			classes.put(classEntry(container, tokens));
+			classes.add(classEntry(container, tokens));
 		}
 		return report(total, classes).toString();
 	}
@@ -78,17 +81,17 @@ public class EstimateTokensTool extends AbstractClassContextTool {
 		return context;
 	}
 
-	private JSONObject classEntry(ClassContainer container, int tokens) {
-		JSONObject entry = new JSONObject();
+	private ObjectNode classEntry(ClassContainer container, int tokens) {
+		ObjectNode entry = MAPPER.createObjectNode();
 		entry.put("class", container.className());
 		entry.put("tokens", tokens);
 		return entry;
 	}
 
-	private JSONObject report(int total, JSONArray classes) {
-		JSONObject report = new JSONObject();
+	private ObjectNode report(int total, ArrayNode classes) {
+		ObjectNode report = MAPPER.createObjectNode();
 		report.put("total", total);
-		report.put("classes", classes);
+		report.set("classes", classes);
 		return report;
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeJsonSerializer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeJsonSerializer.java
@@ -1,7 +1,11 @@
 package io.github.adamw7.context.tree;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Renders a {@link ProjectTreeNode} tree as JSON. Each node becomes an object
@@ -14,6 +18,7 @@ public class ProjectTreeJsonSerializer implements ProjectTreeSerializer {
 
 	private static final String DIRECTORY_TYPE = "directory";
 	private static final String FILE_TYPE = "file";
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	@Override
 	public String serialize(ProjectTreeNode root) {
@@ -21,21 +26,39 @@ public class ProjectTreeJsonSerializer implements ProjectTreeSerializer {
 	}
 
 	public String serializePretty(ProjectTreeNode root, int indentFactor) {
-		return toJson(root).toString(indentFactor);
+		try {
+			return MAPPER.writer(prettyPrinter(indentFactor)).writeValueAsString(toJson(root));
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Failed to serialize project tree", e);
+		}
 	}
 
-	private JSONObject toJson(ProjectTreeNode node) {
-		JSONObject object = new JSONObject();
+	private DefaultPrettyPrinter prettyPrinter(int indentFactor) {
+		DefaultIndenter indenter = new DefaultIndenter(" ".repeat(indentFactor), "\n");
+		DefaultPrettyPrinter printer = new DefaultPrettyPrinter();
+		printer.indentObjectsWith(indenter);
+		printer.indentArraysWith(indenter);
+		return printer;
+	}
+
+	private ObjectNode toJson(ProjectTreeNode node) {
+		ObjectNode object = MAPPER.createObjectNode();
 		object.put("name", node.name());
 		object.put("type", node.isDirectory() ? DIRECTORY_TYPE : FILE_TYPE);
-		object.put("dependencies", new JSONArray(node.dependencies()));
-		object.put("children", childrenOf(node));
+		object.set("dependencies", dependenciesOf(node));
+		object.set("children", childrenOf(node));
 		return object;
 	}
 
-	private JSONArray childrenOf(ProjectTreeNode node) {
-		JSONArray children = new JSONArray();
-		node.children().forEach(child -> children.put(toJson(child)));
+	private ArrayNode dependenciesOf(ProjectTreeNode node) {
+		ArrayNode dependencies = MAPPER.createArrayNode();
+		node.dependencies().forEach(dependencies::add);
+		return dependencies;
+	}
+
+	private ArrayNode childrenOf(ProjectTreeNode node) {
+		ArrayNode children = MAPPER.createArrayNode();
+		node.children().forEach(child -> children.add(toJson(child)));
 		return children;
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ContextFinderToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ContextFinderToolTest.java
@@ -8,11 +8,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.json.JSONArray;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -27,6 +30,8 @@ public class ContextFinderToolTest {
 
 	@TempDir
 	Path outsideRoot;
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	private ContextFinderTool tool;
 
@@ -53,7 +58,7 @@ public class ContextFinderToolTest {
 		writeJava("A", "public class A {}");
 		writeJava("B", "public class B { A a; }");
 
-		List<Object> dependencies = dependencies(tool.apply(arguments("B")));
+		List<String> dependencies = dependencies(tool.apply(arguments("B")));
 
 		assertEquals(List.of("A.java"), dependencies);
 	}
@@ -63,7 +68,7 @@ public class ContextFinderToolTest {
 		writeJava("A", "public class A {}");
 		writeJava("B", "public class B { A a; }");
 
-		List<Object> dependencies = dependencies(tool.apply(arguments("B.java")));
+		List<String> dependencies = dependencies(tool.apply(arguments("B.java")));
 
 		assertEquals(List.of("A.java"), dependencies);
 	}
@@ -77,7 +82,7 @@ public class ContextFinderToolTest {
 		Map<String, Object> arguments = arguments("C");
 		arguments.put("depth", 2);
 
-		List<Object> dependencies = dependencies(tool.apply(arguments));
+		List<String> dependencies = dependencies(tool.apply(arguments));
 
 		assertEquals(List.of("A.java", "B.java"), dependencies);
 	}
@@ -135,8 +140,15 @@ public class ContextFinderToolTest {
 		Files.writeString(projectRoot.resolve(className + ".java"), body);
 	}
 
-	private List<Object> dependencies(CallToolResult result) {
-		return new JSONArray(text(result)).toList();
+	private List<String> dependencies(CallToolResult result) {
+		try {
+			JsonNode array = MAPPER.readTree(text(result));
+			List<String> values = new ArrayList<>();
+			array.forEach(node -> values.add(node.asText()));
+			return values;
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Invalid JSON result", e);
+		}
 	}
 
 	private String text(CallToolResult result) {

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/EstimateTokensToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/EstimateTokensToolTest.java
@@ -12,7 +12,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.json.JSONObject;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -28,6 +30,8 @@ public class EstimateTokensToolTest {
 
 	@TempDir
 	Path outsideRoot;
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	private EstimateTokensTool tool;
 
@@ -54,24 +58,24 @@ public class EstimateTokensToolTest {
 		writeJava("A", "AA");
 		writeJava("B", "A");
 
-		JSONObject report = report(tool.apply(arguments("B")));
+		JsonNode report = report(tool.apply(arguments("B")));
 
-		assertEquals(3, report.getInt("total"));
-		assertEquals(2, report.getJSONArray("classes").length());
-		assertEquals("B.java", report.getJSONArray("classes").getJSONObject(0).getString("class"));
-		assertEquals(1, report.getJSONArray("classes").getJSONObject(0).getInt("tokens"));
-		assertEquals("A.java", report.getJSONArray("classes").getJSONObject(1).getString("class"));
-		assertEquals(2, report.getJSONArray("classes").getJSONObject(1).getInt("tokens"));
+		assertEquals(3, report.get("total").asInt());
+		assertEquals(2, report.get("classes").size());
+		assertEquals("B.java", report.get("classes").get(0).get("class").asText());
+		assertEquals(1, report.get("classes").get(0).get("tokens").asInt());
+		assertEquals("A.java", report.get("classes").get(1).get("class").asText());
+		assertEquals(2, report.get("classes").get(1).get("tokens").asInt());
 	}
 
 	@Test
 	void aClassWithoutDependenciesReportsOnlyItself() throws IOException {
 		writeJava("A", "AAAA");
 
-		JSONObject report = report(tool.apply(arguments("A")));
+		JsonNode report = report(tool.apply(arguments("A")));
 
-		assertEquals(4, report.getInt("total"));
-		assertEquals(1, report.getJSONArray("classes").length());
+		assertEquals(4, report.get("total").asInt());
+		assertEquals(1, report.get("classes").size());
 	}
 
 	@Test
@@ -111,10 +115,10 @@ public class EstimateTokensToolTest {
 		writeJava("A", "a.b");
 		EstimateTokensTool defaultTool = new EstimateTokensTool(new PathPolicy(projectRoot.toString()));
 
-		JSONObject report = report(defaultTool.apply(arguments("A")));
+		JsonNode report = report(defaultTool.apply(arguments("A")));
 
-		assertFalse(report.getJSONArray("classes").isEmpty());
-		assertEquals(3, report.getInt("total"));
+		assertFalse(report.get("classes").isEmpty());
+		assertEquals(3, report.get("total").asInt());
 	}
 
 	@Test
@@ -126,13 +130,13 @@ public class EstimateTokensToolTest {
 		Map<String, Object> arguments = arguments("C");
 		arguments.put("depth", 2);
 
-		JSONObject report = report(tool.apply(arguments));
+		JsonNode report = report(tool.apply(arguments));
 
-		assertEquals(6, report.getInt("total"));
-		assertEquals(3, report.getJSONArray("classes").length());
-		assertEquals("C.java", report.getJSONArray("classes").getJSONObject(0).getString("class"));
-		assertEquals("B.java", report.getJSONArray("classes").getJSONObject(1).getString("class"));
-		assertEquals("A.java", report.getJSONArray("classes").getJSONObject(2).getString("class"));
+		assertEquals(6, report.get("total").asInt());
+		assertEquals(3, report.get("classes").size());
+		assertEquals("C.java", report.get("classes").get(0).get("class").asText());
+		assertEquals("B.java", report.get("classes").get(1).get("class").asText());
+		assertEquals("A.java", report.get("classes").get(2).get("class").asText());
 	}
 
 	@Test
@@ -141,10 +145,10 @@ public class EstimateTokensToolTest {
 		writeJava("B", "A");
 		writeJava("C", "B");
 
-		JSONObject report = report(tool.apply(arguments("C")));
+		JsonNode report = report(tool.apply(arguments("C")));
 
-		assertEquals(2, report.getJSONArray("classes").length());
-		assertEquals(2, report.getInt("total"));
+		assertEquals(2, report.get("classes").size());
+		assertEquals(2, report.get("total").asInt());
 	}
 
 	@Test
@@ -155,11 +159,11 @@ public class EstimateTokensToolTest {
 		Map<String, Object> arguments = arguments("Bar");
 		arguments.put("language", "kotlin");
 
-		JSONObject report = report(tool.apply(arguments));
+		JsonNode report = report(tool.apply(arguments));
 
-		assertEquals(5, report.getInt("total"));
-		assertEquals("Bar.kt", report.getJSONArray("classes").getJSONObject(0).getString("class"));
-		assertEquals("Foo.kt", report.getJSONArray("classes").getJSONObject(1).getString("class"));
+		assertEquals(5, report.get("total").asInt());
+		assertEquals("Bar.kt", report.get("classes").get(0).get("class").asText());
+		assertEquals("Foo.kt", report.get("classes").get(1).get("class").asText());
 	}
 
 	private TokenEstimator oneTokenPerCharacter() {
@@ -177,8 +181,12 @@ public class EstimateTokensToolTest {
 		Files.writeString(projectRoot.resolve(className + ".java"), body);
 	}
 
-	private JSONObject report(CallToolResult result) {
-		return new JSONObject(text(result));
+	private JsonNode report(CallToolResult result) {
+		try {
+			return MAPPER.readTree(text(result));
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Invalid JSON result", e);
+		}
 	}
 
 	private String text(CallToolResult result) {

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpSseIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpSseIT.java
@@ -9,7 +9,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
-import org.json.JSONArray;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -91,6 +93,14 @@ public class McpSseIT {
 
 		assertFalse(result.isError());
 		String dependencies = ((McpSchema.TextContent) result.content().getFirst()).text();
-		assertEquals("A.java", new JSONArray(dependencies).getString(0));
+		assertEquals("A.java", parse(dependencies).get(0).asText());
+	}
+
+	private JsonNode parse(String json) {
+		try {
+			return new ObjectMapper().readTree(json);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Invalid JSON: " + json, e);
+		}
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpIT.java
@@ -9,8 +9,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,8 @@ import io.modelcontextprotocol.spec.McpSchema;
 				"spring.main.banner-mode=off",
 				"context.allowed-roots=${java.io.tmpdir}" })
 public class McpStreamableHttpIT {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	@LocalServerPort
 	private int port;
@@ -91,7 +94,7 @@ public class McpStreamableHttpIT {
 
 		assertFalse(result.isError());
 		String dependencies = ((McpSchema.TextContent) result.content().getFirst()).text();
-		assertEquals("A.java", new JSONArray(dependencies).getString(0));
+		assertEquals("A.java", parse(dependencies).get(0).asText());
 	}
 
 	@Test
@@ -103,9 +106,9 @@ public class McpStreamableHttpIT {
 		McpSchema.CallToolResult result = client.callTool(request);
 
 		assertFalse(result.isError());
-		JSONObject report = new JSONObject(((McpSchema.TextContent) result.content().getFirst()).text());
-		assertTrue(report.getInt("total") > 0);
-		JSONArray classes = report.getJSONArray("classes");
+		JsonNode report = parse(((McpSchema.TextContent) result.content().getFirst()).text());
+		assertTrue(report.get("total").asInt() > 0);
+		JsonNode classes = report.get("classes");
 		assertTrue(containsClass(classes, "B.java"));
 		assertTrue(containsClass(classes, "A.java"));
 	}
@@ -138,12 +141,20 @@ public class McpStreamableHttpIT {
 		assertTrue(message.contains("Class not found: Missing"));
 	}
 
-	private boolean containsClass(JSONArray classes, String className) {
-		for (int index = 0; index < classes.length(); index++) {
-			if (className.equals(classes.getJSONObject(index).getString("class"))) {
+	private boolean containsClass(JsonNode classes, String className) {
+		for (int index = 0; index < classes.size(); index++) {
+			if (className.equals(classes.get(index).get("class").asText())) {
 				return true;
 			}
 		}
 		return false;
+	}
+
+	private JsonNode parse(String json) {
+		try {
+			return MAPPER.readTree(json);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Invalid JSON: " + json, e);
+		}
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpsIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpsIT.java
@@ -18,7 +18,9 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
-import org.json.JSONArray;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -113,7 +115,15 @@ public class McpStreamableHttpsIT {
 
 		assertFalse(result.isError());
 		String dependencies = ((McpSchema.TextContent) result.content().getFirst()).text();
-		assertEquals("A.java", new JSONArray(dependencies).getString(0));
+		assertEquals("A.java", parse(dependencies).get(0).asText());
+	}
+
+	private JsonNode parse(String json) {
+		try {
+			return new ObjectMapper().readTree(json);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Invalid JSON: " + json, e);
+		}
 	}
 
 	private static void generateKeystore() {

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
@@ -12,7 +12,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -27,6 +28,8 @@ public class ProjectTreeToolTest {
 
 	@TempDir
 	Path outsideRoot;
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	private ProjectTreeTool tool;
 
@@ -52,11 +55,11 @@ public class ProjectTreeToolTest {
 		writeJava("A", "public class A {}");
 		writeJava("B", "public class B { A a; }");
 
-		JSONObject tree = new JSONObject(text(tool.apply(arguments())));
+		JsonNode tree = MAPPER.readTree(text(tool.apply(arguments())));
 
-		assertEquals(projectRoot.getFileName().toString(), tree.getString("name"));
-		assertEquals("directory", tree.getString("type"));
-		assertEquals(2, tree.getJSONArray("children").length());
+		assertEquals(projectRoot.getFileName().toString(), tree.get("name").asText());
+		assertEquals("directory", tree.get("type").asText());
+		assertEquals(2, tree.get("children").size());
 	}
 
 	@Test

--- a/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeJsonSerializerTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeJsonSerializerTest.java
@@ -4,12 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 public class ProjectTreeJsonSerializerTest {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	private final ProjectTreeJsonSerializer serializer = new ProjectTreeJsonSerializer();
 
@@ -17,10 +22,10 @@ public class ProjectTreeJsonSerializerTest {
 	void serializesNameAndTypeForADirectory() {
 		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
 
-		JSONObject json = new JSONObject(serializer.serialize(root));
+		JsonNode json = parse(serializer.serialize(root));
 
-		assertEquals("project", json.getString("name"));
-		assertEquals("directory", json.getString("type"));
+		assertEquals("project", json.get("name").asText());
+		assertEquals("directory", json.get("type").asText());
 	}
 
 	@Test
@@ -28,11 +33,11 @@ public class ProjectTreeJsonSerializerTest {
 		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
 		root.addChild(ProjectTreeNode.file(Path.of("project/A.java")));
 
-		JSONObject json = new JSONObject(serializer.serialize(root));
-		JSONObject child = json.getJSONArray("children").getJSONObject(0);
+		JsonNode json = parse(serializer.serialize(root));
+		JsonNode child = json.get("children").get(0);
 
-		assertEquals("file", child.getString("type"));
-		assertEquals("A.java", child.getString("name"));
+		assertEquals("file", child.get("type").asText());
+		assertEquals("A.java", child.get("name").asText());
 	}
 
 	@Test
@@ -43,12 +48,12 @@ public class ProjectTreeJsonSerializerTest {
 		file.addDependency("C.java");
 		root.addChild(file);
 
-		JSONObject json = new JSONObject(serializer.serialize(root));
-		JSONArray dependencies = json.getJSONArray("children").getJSONObject(0).getJSONArray("dependencies");
+		JsonNode json = parse(serializer.serialize(root));
+		JsonNode dependencies = json.get("children").get(0).get("dependencies");
 
-		assertEquals(2, dependencies.length());
-		assertTrue(dependencies.toList().contains("A.java"));
-		assertTrue(dependencies.toList().contains("C.java"));
+		assertEquals(2, dependencies.size());
+		assertTrue(textValues(dependencies).contains("A.java"));
+		assertTrue(textValues(dependencies).contains("C.java"));
 	}
 
 	@Test
@@ -58,11 +63,11 @@ public class ProjectTreeJsonSerializerTest {
 		pkg.addChild(ProjectTreeNode.file(Path.of("project/pkg/A.java")));
 		root.addChild(pkg);
 
-		JSONObject json = new JSONObject(serializer.serialize(root));
-		JSONObject pkgJson = json.getJSONArray("children").getJSONObject(0);
+		JsonNode json = parse(serializer.serialize(root));
+		JsonNode pkgJson = json.get("children").get(0);
 
-		assertEquals("pkg", pkgJson.getString("name"));
-		assertEquals("A.java", pkgJson.getJSONArray("children").getJSONObject(0).getString("name"));
+		assertEquals("pkg", pkgJson.get("name").asText());
+		assertEquals("A.java", pkgJson.get("children").get(0).get("name").asText());
 	}
 
 	@Test
@@ -70,9 +75,23 @@ public class ProjectTreeJsonSerializerTest {
 		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
 		root.addChild(ProjectTreeNode.file(Path.of("project/A.java")));
 
-		JSONObject pretty = new JSONObject(serializer.serializePretty(root, 2));
+		JsonNode pretty = parse(serializer.serializePretty(root, 2));
 
-		assertEquals("project", pretty.getString("name"));
-		assertEquals(1, pretty.getJSONArray("children").length());
+		assertEquals("project", pretty.get("name").asText());
+		assertEquals(1, pretty.get("children").size());
+	}
+
+	private JsonNode parse(String json) {
+		try {
+			return MAPPER.readTree(json);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Invalid JSON: " + json, e);
+		}
+	}
+
+	private List<String> textValues(JsonNode array) {
+		List<String> values = new ArrayList<>();
+		array.forEach(node -> values.add(node.asText()));
+		return values;
 	}
 }

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -111,10 +111,6 @@
 			<artifactId>derbytools</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
@@ -1,12 +1,15 @@
 package io.github.adamw7.tools.data.source.file;
 
 import java.io.InputStream;
+import java.util.Map;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class InMemoryJSONDataSource extends AbstractInMemoryMapDataSource {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	public InMemoryJSONDataSource(InputStream inputStream) {
 		super(inputStream);
@@ -25,43 +28,56 @@ public class InMemoryJSONDataSource extends AbstractInMemoryMapDataSource {
 		parseJSON(jsonContent.toString());
 	}
 
-	private void parseJSON(String jsonString) throws JSONException {
-		JSONObject jsonArray = new JSONObject(jsonString);
-		extractFieldNames(jsonArray);
-		flattenJSON(jsonArray);
+	private void parseJSON(String jsonString) {
+		JsonNode root = read(jsonString);
+		extractFieldNames(root);
+		flatten(root);
 	}
 
-	private void extractFieldNames(JSONObject jsonObject) throws JSONException {
-		for (String key : jsonObject.keySet()) {
-			Object value = jsonObject.get(key);
-			fieldsMap.put(key, String.valueOf(value));
-			if (value instanceof JSONObject jsonObjectValue) {
-				extractFieldNames(jsonObjectValue);
+	private JsonNode read(String jsonString) {
+		try {
+			return MAPPER.readTree(jsonString);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Invalid JSON input", e);
+		}
+	}
+
+	private void extractFieldNames(JsonNode node) {
+		for (Map.Entry<String, JsonNode> field : node.properties()) {
+			JsonNode value = field.getValue();
+			fieldsMap.put(field.getKey(), asText(value));
+			if (value.isObject()) {
+				extractFieldNames(value);
 			}
 		}
 	}
 
-	private void flattenJSON(JSONArray jsonArray) throws JSONException {
-		for (int i = 0; i < jsonArray.length(); i++) {
-			Object value = jsonArray.get(i);
-			if (value instanceof JSONArray jsonArrayValue) {
-				flattenJSON(jsonArrayValue);
-			} else if (value instanceof JSONObject jsonObjectValue) {
-				flattenJSON(jsonObjectValue);
-			}
+	private void flatten(JsonNode node) {
+		if (node.isArray()) {
+			flattenArray(node);
+		} else if (node.isObject()) {
+			flattenObject(node);
 		}
 	}
 
-	private void flattenJSON(JSONObject jsonObject) throws JSONException {
-		for (String key : jsonObject.keySet()) {
-			Object value = jsonObject.get(key);
-			if (value instanceof JSONArray jsonArrayValue) {
-				flattenJSON(jsonArrayValue);
-			} else if (value instanceof JSONObject jsonObjectValue) {
-				flattenJSON(jsonObjectValue);
+	private void flattenArray(JsonNode array) {
+		for (JsonNode element : array) {
+			flatten(element);
+		}
+	}
+
+	private void flattenObject(JsonNode object) {
+		for (Map.Entry<String, JsonNode> field : object.properties()) {
+			JsonNode value = field.getValue();
+			if (value.isContainerNode()) {
+				flatten(value);
 			} else {
-				fieldsMap.put(key, String.valueOf(value));
+				fieldsMap.put(field.getKey(), value.asText());
 			}
 		}
+	}
+
+	private String asText(JsonNode value) {
+		return value.isContainerNode() ? value.toString() : value.asText();
 	}
 }

--- a/data/src/main/java/module-info.java
+++ b/data/src/main/java/module-info.java
@@ -1,6 +1,5 @@
 open module datamodule {
 	requires org.apache.logging.log4j;
-	requires org.json;
 	requires java.sql;
 	requires com.fasterxml.jackson.core;
 	requires com.fasterxml.jackson.databind;

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/JSONDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/JSONDataSourceTest.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.data.source.file;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.params.provider.Arguments.of;
@@ -8,6 +7,7 @@ import static org.junit.jupiter.params.provider.Arguments.of;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,8 @@ public class JSONDataSourceTest {
 		source.open();
         String[] columnNames = source.getColumnNames();
         assertEquals(10, columnNames.length);
-        assertArrayEquals(new String[]{"cars", "fruits", "year", "city", "name", "model", "state", "people", "age", "manufacturer"}, columnNames);
+        assertEquals(Set.of("cars", "fruits", "year", "city", "name", "model", "state", "people", "age", "manufacturer"),
+                Set.of(columnNames));
         source.close();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -167,11 +167,6 @@
 				<version>3.46.0</version>
 			</dependency>
 			<dependency>
-				<groupId>org.json</groupId>
-				<artifactId>json</artifactId>
-				<version>20251224</version>
-			</dependency>
-			<dependency>
 				<groupId>com.fasterxml.jackson</groupId>
 				<artifactId>jackson-bom</artifactId>
 				<version>2.22.0</version>


### PR DESCRIPTION
org.json ships under the JSON License ("The Software shall be used for
Good, not Evil"), a non-OSI, non-free clause that the ASF, Debian, Fedora
and the FSF reject. It was a compile-scope dependency reaching production
code in code/context, data and claude-code-enforcer, so it was redistributed
in the assembly. Replace all usage with Jackson (already a project
dependency) and drop org.json from dependency management and every module.

- code/context: build tool output with ObjectNode/ArrayNode; pretty-print
  via a DefaultPrettyPrinter honouring the indent factor.
- data: parse and flatten JSON with JsonNode in InMemoryJSONDataSource;
  drop the org.json module requirement.
- claude-code-enforcer: parse with ObjectMapper and navigate with a new
  null-safe JsonNodes helper; add jackson-databind (managed by jackson-bom).
- Migrate all affected tests and ITs to Jackson. The JSON column-order
  assertion is now order-independent, since column order is a HashMap
  artifact and never a contract.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015KxXCciXRDYEkY3BKXpmf2