### PR TITLE
build: remove unused Maven dependencies

### DIFF
--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -65,9 +65,5 @@
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
-		</dependency>
 	</dependencies>
 </project>

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -87,10 +87,6 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
 		</dependency>

--- a/code/protogen-maven-plugin/pom.xml
+++ b/code/protogen-maven-plugin/pom.xml
@@ -48,10 +48,6 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
 		</dependency>
@@ -78,10 +74,6 @@
 		<dependency>
 			<groupId>org.eclipse.jdt</groupId>
 			<artifactId>org.eclipse.jdt.core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -104,6 +104,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.derby</groupId>
+			<artifactId>derbyclient</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.derby</groupId>
 			<artifactId>derbytools</artifactId>
 		</dependency>
 		<dependency>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -104,10 +104,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.derby</groupId>
-			<artifactId>derbyclient</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.derby</groupId>
 			<artifactId>derbytools</artifactId>
 		</dependency>
 		<dependency>

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -124,10 +124,6 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.derby</groupId>
+				<artifactId>derbyclient</artifactId>
+				<version>10.17.1.0</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.derby</groupId>
 				<artifactId>derbytools</artifactId>
 				<version>10.17.1.0</version>
 				<scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -83,12 +83,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.derby</groupId>
-				<artifactId>derbyclient</artifactId>
-				<version>10.17.1.0</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.derby</groupId>
 				<artifactId>derbytools</artifactId>
 				<version>10.17.1.0</version>
 				<scope>test</scope>
@@ -115,12 +109,6 @@
 				<groupId>org.apache.maven.plugin-tools</groupId>
 				<artifactId>maven-plugin-annotations</artifactId>
 				<version>4.0.0-beta-2</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.maven</groupId>
-				<artifactId>maven-core</artifactId>
-				<version>4.0.0-rc-5</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Drop dependencies that are declared but never used, verified via
maven-dependency-plugin:analyze and source inspection, with a full
`mvn install` (tests included) confirming nothing breaks:

- junit-jupiter-params: removed from claude-code-enforcer, code/context,
  grpc-example and protogen-maven-plugin (no parameterized tests in any
  of these modules; data still uses it and keeps it).
- maven-core (provided): removed from protogen-maven-plugin, which only
  uses AbstractMojo (maven-plugin-api) and the plugin annotations.
- derbyclient (test): removed from data; tests use only embedded
  in-memory Derby (EmbeddedDriver), never the network ClientDriver.

Also removed the now-orphaned dependencyManagement entries for
maven-core and derbyclient from the root pom.

Note: derbytools is kept. In Derby 10.17 the EmbeddedDriver class ships
in derbytools.jar (not derby.jar), so it is required at test runtime.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qqp4FgsYNn9wfp9cn1SSj7