### PR TITLE
refactor: extract shared markdown-scanning scaffolding for definition rules

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -33,7 +33,6 @@ import io.github.adamw7.tools.enforcer.text.NameConvention;
 @Named("commandFormat")
 public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 
-	private static final String MARKDOWN_SUFFIX = ".md";
 	private static final String DESCRIPTION_KEY = "description";
 	private static final String MODEL_KEY = "model";
 
@@ -49,9 +48,9 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 	@Override
 	public void execute() throws EnforcerRuleException {
 		verifyConfigured();
-		verifyDirectory();
+		DefinitionFiles.verifyDirectory(commandsDir, "Commands");
 		List<String> violations = new ArrayList<>();
-		for (File command : listCommands()) {
+		for (File command : DefinitionFiles.markdownFiles(commandsDir)) {
 			collectCommandViolations(command, violations);
 		}
 		report("Command files are not well formed:", violations);
@@ -61,21 +60,6 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 		if (commandsDir == null) {
 			throw new EnforcerRuleException("The commandsDir parameter is not configured");
 		}
-	}
-
-	private void verifyDirectory() throws EnforcerRuleException {
-		if (!commandsDir.isDirectory()) {
-			throw new EnforcerRuleException("Commands directory does not exist at " + commandsDir);
-		}
-	}
-
-	private File[] listCommands() {
-		File[] commands = commandsDir.listFiles(this::isMarkdownFile);
-		return commands != null ? commands : new File[0];
-	}
-
-	private boolean isMarkdownFile(File file) {
-		return file.isFile() && file.getName().endsWith(MARKDOWN_SUFFIX);
 	}
 
 	private void collectCommandViolations(File command, List<String> violations) {
@@ -88,7 +72,7 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private void collectNonEmptyViolations(File command, String content, List<String> violations) {
-		String baseName = baseName(command);
+		String baseName = DefinitionFiles.baseName(command);
 		NameConvention.collect(baseName, baseName, command.toString(), violations);
 		FrontMatter.parse(content)
 				.ifPresent(frontMatter -> collectFrontMatterViolations(command, frontMatter, violations));
@@ -136,11 +120,6 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 		if (!allowedModels.contains(model)) {
 			violations.add("Command declares unsupported model '" + model + "' in: " + command);
 		}
-	}
-
-	private String baseName(File command) {
-		String name = command.getName();
-		return name.substring(0, name.length() - MARKDOWN_SUFFIX.length());
 	}
 
 	void setCommandsDir(File commandsDir) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFiles.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFiles.java
@@ -1,0 +1,49 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import java.io.File;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * Shared file-system helpers for the definition rules, which all scan a
+ * {@code .claude} directory of Markdown definitions. Centralises the
+ * {@code .md} handling, the null-safe {@link File#listFiles} wrappers and the
+ * "directory must exist" check, so each rule keeps only its own validation
+ * logic.
+ */
+final class DefinitionFiles {
+
+	private static final String MARKDOWN_SUFFIX = ".md";
+
+	private DefinitionFiles() {
+	}
+
+	/** Fails when a configured directory is missing, which is a build-setup mistake. */
+	static void verifyDirectory(File directory, String label) throws EnforcerRuleException {
+		if (!directory.isDirectory()) {
+			throw new EnforcerRuleException(label + " directory does not exist at " + directory);
+		}
+	}
+
+	/** The {@code *.md} files directly in {@code directory}, never null. */
+	static File[] markdownFiles(File directory) {
+		File[] files = directory.listFiles(DefinitionFiles::isMarkdownFile);
+		return files != null ? files : new File[0];
+	}
+
+	/** The immediate subdirectories of {@code directory}, never null. */
+	static File[] subdirectories(File directory) {
+		File[] directories = directory.listFiles(File::isDirectory);
+		return directories != null ? directories : new File[0];
+	}
+
+	/** The file name with the {@code .md} suffix stripped. */
+	static String baseName(File markdown) {
+		String name = markdown.getName();
+		return name.substring(0, name.length() - MARKDOWN_SUFFIX.length());
+	}
+
+	private static boolean isMarkdownFile(File file) {
+		return file.isFile() && file.getName().endsWith(MARKDOWN_SUFFIX);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -56,9 +56,9 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 	@Override
 	public void execute() throws EnforcerRuleException {
 		verifyConfigured();
-		verifyDirectory();
+		DefinitionFiles.verifyDirectory(skillsDir, "Skills");
 		List<String> violations = new ArrayList<>();
-		for (File skillDirectory : listSkillDirectories()) {
+		for (File skillDirectory : DefinitionFiles.subdirectories(skillsDir)) {
 			collectSkillViolations(skillDirectory, violations);
 		}
 		report("Skill files are not well formed:", violations);
@@ -68,17 +68,6 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 		if (skillsDir == null) {
 			throw new EnforcerRuleException("The skillsDir parameter is not configured");
 		}
-	}
-
-	private void verifyDirectory() throws EnforcerRuleException {
-		if (!skillsDir.isDirectory()) {
-			throw new EnforcerRuleException("Skills directory does not exist at " + skillsDir);
-		}
-	}
-
-	private File[] listSkillDirectories() {
-		File[] skillDirectories = skillsDir.listFiles(File::isDirectory);
-		return skillDirectories != null ? skillDirectories : new File[0];
 	}
 
 	private void collectSkillViolations(File skillDirectory, List<String> violations) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -30,7 +30,6 @@ import io.github.adamw7.tools.enforcer.text.NameConvention;
 @Named("subAgentFormat")
 public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 
-	private static final String MARKDOWN_SUFFIX = ".md";
 	private static final String NAME_KEY = "name";
 	private static final String DESCRIPTION_KEY = "description";
 	private static final String MODEL_KEY = "model";
@@ -48,9 +47,9 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 	@Override
 	public void execute() throws EnforcerRuleException {
 		verifyConfigured();
-		verifyDirectory();
+		DefinitionFiles.verifyDirectory(agentsDir, "Agents");
 		List<String> violations = new ArrayList<>();
-		for (File definition : listDefinitions()) {
+		for (File definition : DefinitionFiles.markdownFiles(agentsDir)) {
 			collectDefinitionViolations(definition, violations);
 		}
 		report("Sub-agent files are not well formed:", violations);
@@ -60,21 +59,6 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 		if (agentsDir == null) {
 			throw new EnforcerRuleException("The agentsDir parameter is not configured");
 		}
-	}
-
-	private void verifyDirectory() throws EnforcerRuleException {
-		if (!agentsDir.isDirectory()) {
-			throw new EnforcerRuleException("Agents directory does not exist at " + agentsDir);
-		}
-	}
-
-	private File[] listDefinitions() {
-		File[] definitions = agentsDir.listFiles(this::isMarkdownFile);
-		return definitions != null ? definitions : new File[0];
-	}
-
-	private boolean isMarkdownFile(File file) {
-		return file.isFile() && file.getName().endsWith(MARKDOWN_SUFFIX);
 	}
 
 	private void collectDefinitionViolations(File definition, List<String> violations) {
@@ -112,7 +96,7 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 
 	private void collectNameViolations(File definition, FrontMatter frontMatter, List<String> violations) {
 		frontMatter.value(NAME_KEY).ifPresent(
-				name -> NameConvention.collect(name, baseName(definition), definition.toString(), violations));
+				name -> NameConvention.collect(name, DefinitionFiles.baseName(definition), definition.toString(), violations));
 	}
 
 	private void collectModelViolations(File definition, FrontMatter frontMatter, List<String> violations) {
@@ -126,11 +110,6 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 		if (!allowedModels.contains(model)) {
 			violations.add("Sub-agent declares unsupported model '" + model + "' in: " + definition);
 		}
-	}
-
-	private String baseName(File definition) {
-		String name = definition.getName();
-		return name.substring(0, name.length() - MARKDOWN_SUFFIX.length());
 	}
 
 	private List<String> requiredKeys() {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRule.java
@@ -32,8 +32,6 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 @Named("uniqueNames")
 public class UniqueNamesRule extends ClaudeCodeEnforcerRule {
 
-	private static final String MARKDOWN_SUFFIX = ".md";
-
 	/** The {@code .claude/commands} directory to scan. Injected from the rule configuration. */
 	private File commandsDir;
 
@@ -65,9 +63,9 @@ public class UniqueNamesRule extends ClaudeCodeEnforcerRule {
 		if (directory == null) {
 			return;
 		}
-		verifyDirectory(directory, label);
-		for (File markdown : listMarkdownFiles(directory)) {
-			record(baseName(markdown), markdown.toString(), sourcesByName);
+		DefinitionFiles.verifyDirectory(directory, label);
+		for (File markdown : DefinitionFiles.markdownFiles(directory)) {
+			record(DefinitionFiles.baseName(markdown), markdown.toString(), sourcesByName);
 		}
 	}
 
@@ -76,15 +74,9 @@ public class UniqueNamesRule extends ClaudeCodeEnforcerRule {
 		if (directory == null) {
 			return;
 		}
-		verifyDirectory(directory, "Skills");
-		for (File skill : listSubdirectories(directory)) {
+		DefinitionFiles.verifyDirectory(directory, "Skills");
+		for (File skill : DefinitionFiles.subdirectories(directory)) {
 			record(skill.getName(), skill.toString(), sourcesByName);
-		}
-	}
-
-	private void verifyDirectory(File directory, String label) throws EnforcerRuleException {
-		if (!directory.isDirectory()) {
-			throw new EnforcerRuleException(label + " directory does not exist at " + directory);
 		}
 	}
 
@@ -106,25 +98,6 @@ public class UniqueNamesRule extends ClaudeCodeEnforcerRule {
 			violations.add("name '" + entry.getKey() + "' is used by " + sources.size()
 					+ " definitions: " + String.join(", ", sources));
 		}
-	}
-
-	private File[] listMarkdownFiles(File directory) {
-		File[] files = directory.listFiles(this::isMarkdownFile);
-		return files != null ? files : new File[0];
-	}
-
-	private File[] listSubdirectories(File directory) {
-		File[] directories = directory.listFiles(File::isDirectory);
-		return directories != null ? directories : new File[0];
-	}
-
-	private boolean isMarkdownFile(File file) {
-		return file.isFile() && file.getName().endsWith(MARKDOWN_SUFFIX);
-	}
-
-	private String baseName(File markdown) {
-		String name = markdown.getName();
-		return name.substring(0, name.length() - MARKDOWN_SUFFIX.length());
 	}
 
 	void setCommandsDir(File commandsDir) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
@@ -48,6 +48,37 @@ class CommandFormatRuleTest {
 	}
 
 	@Test
+	void ignoresSubdirectoriesNamedLikeMarkdown() {
+		createDirectory(tempDir.resolve("nested.md"));
+
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
+	@Test
+	void passesWhenModelIsAllowed() {
+		writeString(tempDir.resolve("review.md"), """
+				---
+				model: claude-opus-4-8
+				---
+				Review the diff.
+				""");
+		CommandFormatRule rule = ruleFor(tempDir);
+		rule.setAllowedModels(List.of("claude-opus-4-8", "claude-sonnet-4-6"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void reportsEveryCommandProblemTogether() {
+		writeString(tempDir.resolve("blank.md"), "   ");
+		writeString(tempDir.resolve("BadName.md"), "Review the pull request.");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("blank.md"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("BadName.md"), exception.getMessage());
+	}
+
+	@Test
 	void failsWhenNotConfigured() {
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new CommandFormatRule()::execute);
 		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
@@ -142,6 +173,14 @@ class CommandFormatRuleTest {
 			Files.writeString(file, content);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private static void createDirectory(Path dir) {
+		try {
+			Files.createDirectory(dir);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create " + dir, e);
 		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/DefinitionFilesTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/DefinitionFilesTest.java
@@ -1,0 +1,129 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Comparator;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DefinitionFilesTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void verifyDirectoryPassesForAnExistingDirectory() {
+		assertDoesNotThrow(() -> DefinitionFiles.verifyDirectory(tempDir.toFile(), "Commands"));
+	}
+
+	@Test
+	void verifyDirectoryFailsWithLabelWhenDirectoryIsMissing() {
+		File absent = tempDir.resolve("absent").toFile();
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				() -> DefinitionFiles.verifyDirectory(absent, "Agents"));
+		assertTrue(exception.getMessage().contains("Agents directory does not exist at"), exception.getMessage());
+		assertTrue(exception.getMessage().contains(absent.toString()), exception.getMessage());
+	}
+
+	@Test
+	void verifyDirectoryFailsWhenPathIsAFileRatherThanADirectory() {
+		File file = writeString(tempDir.resolve("review.md"), "body");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				() -> DefinitionFiles.verifyDirectory(file, "Skills"));
+		assertTrue(exception.getMessage().contains("Skills directory does not exist at"), exception.getMessage());
+	}
+
+	@Test
+	void markdownFilesReturnsOnlyMarkdownFiles() {
+		writeString(tempDir.resolve("review.md"), "body");
+		writeString(tempDir.resolve("commit.md"), "body");
+		writeString(tempDir.resolve("notes.txt"), "ignored");
+
+		assertArrayEquals(new String[] { "commit.md", "review.md" }, sortedNames(DefinitionFiles.markdownFiles(tempDir.toFile())));
+	}
+
+	@Test
+	void markdownFilesExcludesSubdirectoriesEvenWhenNamedLikeMarkdown() {
+		createDirectory(tempDir.resolve("nested.md"));
+		writeString(tempDir.resolve("real.md"), "body");
+
+		assertArrayEquals(new String[] { "real.md" }, sortedNames(DefinitionFiles.markdownFiles(tempDir.toFile())));
+	}
+
+	@Test
+	void markdownFilesReturnsEmptyArrayForAnEmptyDirectory() {
+		assertEquals(0, DefinitionFiles.markdownFiles(tempDir.toFile()).length);
+	}
+
+	@Test
+	void markdownFilesReturnsEmptyArrayWhenPathIsNotAListableDirectory() {
+		File file = writeString(tempDir.resolve("review.md"), "body");
+
+		assertArrayEquals(new File[0], DefinitionFiles.markdownFiles(file));
+	}
+
+	@Test
+	void subdirectoriesReturnsOnlyDirectories() {
+		createDirectory(tempDir.resolve("commands"));
+		createDirectory(tempDir.resolve("agents"));
+		writeString(tempDir.resolve("review.md"), "body");
+
+		assertArrayEquals(new String[] { "agents", "commands" }, sortedNames(DefinitionFiles.subdirectories(tempDir.toFile())));
+	}
+
+	@Test
+	void subdirectoriesReturnsEmptyArrayForAnEmptyDirectory() {
+		assertEquals(0, DefinitionFiles.subdirectories(tempDir.toFile()).length);
+	}
+
+	@Test
+	void subdirectoriesReturnsEmptyArrayWhenPathIsNotAListableDirectory() {
+		File file = writeString(tempDir.resolve("review.md"), "body");
+
+		assertArrayEquals(new File[0], DefinitionFiles.subdirectories(file));
+	}
+
+	@Test
+	void baseNameStripsTheMarkdownSuffix() {
+		assertEquals("git-commit", DefinitionFiles.baseName(tempDir.resolve("git-commit.md").toFile()));
+	}
+
+	@Test
+	void baseNameStripsOnlyTheTrailingSuffix() {
+		assertEquals("notes.md.backup", DefinitionFiles.baseName(tempDir.resolve("notes.md.backup.md").toFile()));
+	}
+
+	private static String[] sortedNames(File[] files) {
+		return Arrays.stream(files).map(File::getName).sorted(Comparator.naturalOrder()).toArray(String[]::new);
+	}
+
+	private static File writeString(Path file, String content) {
+		try {
+			return Files.writeString(file, content).toFile();
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private static void createDirectory(Path dir) {
+		try {
+			Files.createDirectory(dir);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create " + dir, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
@@ -40,6 +40,23 @@ class SubAgentFormatRuleTest {
 	}
 
 	@Test
+	void ignoresSubdirectoriesNamedLikeMarkdown() {
+		createDirectory(tempDir.resolve("nested.md"));
+
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
+	@Test
+	void reportsEveryDefinitionProblemTogether() {
+		writeString(tempDir.resolve("reviewer.md"), "# Reviewer\nNo front matter.");
+		writeString(tempDir.resolve("planner.md"), "# Planner\nNo front matter either.");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("reviewer.md"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("planner.md"), exception.getMessage());
+	}
+
+	@Test
 	void failsWhenNotConfigured() {
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new SubAgentFormatRule()::execute);
 		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
@@ -128,6 +145,14 @@ class SubAgentFormatRuleTest {
 			Files.writeString(file, content);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private static void createDirectory(Path dir) {
+		try {
+			Files.createDirectory(dir);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create " + dir, e);
 		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRuleTest.java
@@ -65,6 +65,18 @@ class UniqueNamesRuleTest {
 	}
 
 	@Test
+	void ignoresSubdirectoriesNamedLikeMarkdownInTheCommandsDirectory() {
+		Path commands = createDir("commands");
+		createDir("commands/review.md");
+		writeMarkdown(commands.resolve("review.md/inner.md"));
+
+		UniqueNamesRule rule = new UniqueNamesRule();
+		rule.setCommandsDir(commands.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
 	void failsWhenNotConfigured() {
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new UniqueNamesRule()::execute);
 		assertTrue(exception.getMessage().contains("must be configured"), exception.getMessage());


### PR DESCRIPTION
The four enforcer rules in the definition package each re-implemented the
same .md handling, null-safe File.listFiles wrappers and "directory must
exist" check. Pull these into a package-private DefinitionFiles helper so
each rule keeps only its own validation logic.

Net removal of duplicated scaffolding across CommandFormatRule,
SubAgentFormatRule, UniqueNamesRule and SkillFilesExistRule with no
behaviour change; the existing rule tests still pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fu7agrGDpchdvr8XA27831