### PR TITLE
refactor(data): unify TOON grammar in ToonSyntax

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryTOONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryTOONDataSource.java
@@ -92,7 +92,7 @@ public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 		}
 
 		if (!inlineValues.isEmpty()) {
-			parseInlineArray(key, inlineValues);
+			ToonSyntax.emitInlineArray(fieldsMap::put, key, inlineValues);
 			return index + 1;
 		}
 
@@ -100,16 +100,12 @@ public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 	}
 
 	private int parseTabularArray(List<String> lines, int startIndex, String arrayKey, int count, String fieldsStr, String inlineValues) {
-		String[] fields = fieldsStr.split(",");
-		fieldsMap.put(arrayKey, String.valueOf(count));
-
-		for (String field : fields) {
-			fieldsMap.put(field.trim(), field.trim());
-		}
+		String[] fields = ToonSyntax.splitFields(fieldsStr);
+		ToonSyntax.emitTabularHeader(fieldsMap::put, arrayKey, count, fields);
 
 		int rowIndex = 0;
 		if (inlineValues != null && !inlineValues.trim().isEmpty()) {
-			parseTabularRow(arrayKey, fields, inlineValues.trim(), rowIndex++);
+			ToonSyntax.emitTabularRow(fieldsMap::put, arrayKey, fields, inlineValues.trim(), rowIndex++);
 		}
 
 		return parseTabularRows(lines, startIndex + 1, arrayKey, count, rowIndex, fields);
@@ -122,7 +118,7 @@ public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 		while (i < lines.size() && rowIndex < count && !isNewSection(lines, i)) {
 			String trimmed = lines.get(i).trim();
 			if (!trimmed.isEmpty()) {
-				parseTabularRow(arrayKey, fields, trimmed, rowIndex++);
+				ToonSyntax.emitTabularRow(fieldsMap::put, arrayKey, fields, trimmed, rowIndex++);
 			}
 			i++;
 		}
@@ -132,36 +128,7 @@ public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 
 	private boolean isNewSection(List<String> lines, int index) {
 		String line = lines.get(index);
-		String trimmed = line.trim();
-
-		if (trimmed.isEmpty()) {
-			return false;
-		}
-
-		boolean isTopLevel = ToonSyntax.indentationOf(line) == 0;
-		boolean isKeyValue = ToonSyntax.KEY_VALUE_PATTERN.matcher(trimmed).matches();
-		boolean isArrayHeader = ToonSyntax.ARRAY_HEADER_PATTERN.matcher(trimmed).matches();
-
-		return isTopLevel && (isKeyValue || isArrayHeader);
-	}
-
-	private void parseTabularRow(String arrayKey, String[] fields, String rowData, int rowIndex) {
-		String[] values = ToonSyntax.splitRow(rowData);
-		int limit = Math.min(fields.length, values.length);
-
-		for (int j = 0; j < limit; j++) {
-			String key = arrayKey + "[" + rowIndex + "]." + fields[j].trim();
-			fieldsMap.put(key, ToonSyntax.unquote(values[j].trim()));
-		}
-	}
-
-	private void parseInlineArray(String key, String values) {
-		String[] items = ToonSyntax.splitRow(values);
-		fieldsMap.put(key, String.valueOf(items.length));
-
-		for (int j = 0; j < items.length; j++) {
-			fieldsMap.put(key + "[" + j + "]", ToonSyntax.unquote(items[j].trim()));
-		}
+		return ToonSyntax.isTopLevelSection(ToonSyntax.indentationOf(line), line.trim());
 	}
 
 	private int parseNestedArray(List<String> lines, int startIndex, String arrayKey, int count) {
@@ -173,7 +140,7 @@ public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 			String line = lines.get(i);
 			String trimmed = line.trim();
 
-			if (shouldExitNestedContext(trimmed, ToonSyntax.indentationOf(line), baseIndent)) {
+			if (shouldExitNested(trimmed, ToonSyntax.indentationOf(line), baseIndent)) {
 				fieldsMap.put(arrayKey, String.valueOf(count));
 				return i;
 			}
@@ -199,14 +166,10 @@ public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 		return 0;
 	}
 
-	private boolean shouldExitNestedContext(String trimmed, int currentIndent, int baseIndent) {
-		return !trimmed.isEmpty() && baseIndent > 0 && currentIndent < baseIndent;
-	}
-
 	private int processListItem(String arrayKey, String trimmed, int itemIndex) {
 		String content = trimmed.substring(1).trim();
 
-		if (isArrayHeader(content)) {
+		if (ToonSyntax.ARRAY_HEADER_PATTERN.matcher(content).matches()) {
 			return itemIndex;
 		}
 
@@ -215,10 +178,6 @@ public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 		}
 
 		return itemIndex + 1;
-	}
-
-	private boolean isArrayHeader(String content) {
-		return ToonSyntax.ARRAY_HEADER_PATTERN.matcher(content).matches();
 	}
 
 	private int parseNestedObject(List<String> lines, int startIndex, String parentKey) {
@@ -230,7 +189,7 @@ public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 			String trimmed = line.trim();
 			int currentIndent = ToonSyntax.indentationOf(line);
 
-			if (shouldExitNestedObject(trimmed, currentIndent, baseIndent)) {
+			if (shouldExitNested(trimmed, currentIndent, baseIndent)) {
 				return i;
 			}
 
@@ -244,7 +203,7 @@ public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 		return i;
 	}
 
-	private boolean shouldExitNestedObject(String trimmed, int currentIndent, int baseIndent) {
+	private boolean shouldExitNested(String trimmed, int currentIndent, int baseIndent) {
 		return !trimmed.isEmpty() && baseIndent > 0 && currentIndent < baseIndent;
 	}
 

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/IterableTOONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/IterableTOONDataSource.java
@@ -140,18 +140,15 @@ public class IterableTOONDataSource extends AbstractIterableFileSource {
 		if (fields != null && !fields.isEmpty()) {
 			startTabular(arrayKey, count, indent, fields, inline);
 		} else if (!inline.isEmpty()) {
-			parseInlineArray(arrayKey, inline);
+			ToonSyntax.emitInlineArray(this::enqueue, arrayKey, inline);
 		} else {
 			block = new NestedArrayBlock(arrayKey, count);
 		}
 	}
 
 	private void startTabular(String arrayKey, int count, int indent, String fieldsText, String inline) {
-		String[] fields = splitFields(fieldsText);
-		enqueue(arrayKey, String.valueOf(count));
-		for (String field : fields) {
-			enqueue(field, field);
-		}
+		String[] fields = ToonSyntax.splitFields(fieldsText);
+		ToonSyntax.emitTabularHeader(this::enqueue, arrayKey, count, fields);
 
 		TabularBlock tabular = new TabularBlock(arrayKey, fields, count);
 		block = tabular;
@@ -161,23 +158,6 @@ public class IterableTOONDataSource extends AbstractIterableFileSource {
 			if (tabular.isComplete()) {
 				closeBlock();
 			}
-		}
-	}
-
-	private String[] splitFields(String fieldsText) {
-		String[] raw = fieldsText.split(",");
-		String[] trimmed = new String[raw.length];
-		for (int i = 0; i < raw.length; i++) {
-			trimmed[i] = raw[i].trim();
-		}
-		return trimmed;
-	}
-
-	private void parseInlineArray(String arrayKey, String inline) {
-		String[] items = ToonSyntax.splitRow(inline);
-		enqueue(arrayKey, String.valueOf(items.length));
-		for (int j = 0; j < items.length; j++) {
-			enqueue(arrayKey + "[" + j + "]", ToonSyntax.unquote(items[j].trim()));
 		}
 	}
 
@@ -223,24 +203,12 @@ public class IterableTOONDataSource extends AbstractIterableFileSource {
 
 		@Override
 		boolean continues(int indent, String trimmed) {
-			return rowIndex < count && !isNewSection(indent, trimmed);
-		}
-
-		private boolean isNewSection(int indent, String trimmed) {
-			if (indent != 0) {
-				return false;
-			}
-			return ToonSyntax.KEY_VALUE_PATTERN.matcher(trimmed).matches()
-					|| ToonSyntax.ARRAY_HEADER_PATTERN.matcher(trimmed).matches();
+			return rowIndex < count && !ToonSyntax.isTopLevelSection(indent, trimmed);
 		}
 
 		@Override
 		void consume(int indent, String trimmed) {
-			String[] values = ToonSyntax.splitRow(trimmed);
-			int limit = Math.min(fields.length, values.length);
-			for (int j = 0; j < limit; j++) {
-				enqueue(arrayKey + "[" + rowIndex + "]." + fields[j], ToonSyntax.unquote(values[j].trim()));
-			}
+			ToonSyntax.emitTabularRow(IterableTOONDataSource.this::enqueue, arrayKey, fields, trimmed, rowIndex);
 			rowIndex++;
 		}
 

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/ToonSyntax.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/ToonSyntax.java
@@ -2,12 +2,16 @@ package io.github.adamw7.tools.data.source.file;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
 
 /**
- * Lexical helpers shared by the TOON (Token-Oriented Object Notation) data sources:
- * the line patterns, indentation measurement and value tokenising used to interpret a
- * single line of TOON text.
+ * Lexical and grammar helpers shared by the TOON (Token-Oriented Object Notation) data sources:
+ * the line patterns, indentation measurement and value tokenising used to interpret a single
+ * line of TOON text, plus the rules that flatten array headers and rows into {@code key/value}
+ * pairs. The pairs are handed to a {@link BiConsumer} sink so the in-memory source can collect
+ * them in a map while the iterable source enqueues them as rows, without either re-implementing
+ * the grammar.
  */
 final class ToonSyntax {
 
@@ -15,6 +19,56 @@ final class ToonSyntax {
 	static final Pattern KEY_VALUE_PATTERN = Pattern.compile("^(\\w+(?:\\.\\w+)*):\\s*(.*)$");
 
 	private ToonSyntax() {
+	}
+
+	/**
+	 * Whether {@code trimmed} at the given indentation starts a new top-level section, i.e. a
+	 * key-value pair or array header at column zero. Used to detect where a tabular array's rows
+	 * end and the surrounding document resumes.
+	 */
+	static boolean isTopLevelSection(int indent, String trimmed) {
+		if (indent != 0 || trimmed.isEmpty()) {
+			return false;
+		}
+		return KEY_VALUE_PATTERN.matcher(trimmed).matches()
+				|| ARRAY_HEADER_PATTERN.matcher(trimmed).matches();
+	}
+
+	/** Splits a comma-separated tabular field list, trimming each field name. */
+	static String[] splitFields(String fieldsText) {
+		String[] raw = fieldsText.split(",");
+		String[] trimmed = new String[raw.length];
+		for (int i = 0; i < raw.length; i++) {
+			trimmed[i] = raw[i].trim();
+		}
+		return trimmed;
+	}
+
+	/** Emits the header pairs of a tabular array: its declared count, then each field as its own key. */
+	static void emitTabularHeader(BiConsumer<String, String> sink, String arrayKey, int count, String[] fields) {
+		sink.accept(arrayKey, String.valueOf(count));
+		for (String field : fields) {
+			sink.accept(field, field);
+		}
+	}
+
+	/** Emits one tabular row as {@code arrayKey[rowIndex].field = value} pairs, ignoring surplus values. */
+	static void emitTabularRow(BiConsumer<String, String> sink, String arrayKey, String[] fields,
+			String rowData, int rowIndex) {
+		String[] values = splitRow(rowData);
+		int limit = Math.min(fields.length, values.length);
+		for (int j = 0; j < limit; j++) {
+			sink.accept(arrayKey + "[" + rowIndex + "]." + fields[j], unquote(values[j].trim()));
+		}
+	}
+
+	/** Emits an inline primitive array as its element count followed by each {@code key[j] = value} pair. */
+	static void emitInlineArray(BiConsumer<String, String> sink, String key, String values) {
+		String[] items = splitRow(values);
+		sink.accept(key, String.valueOf(items.length));
+		for (int j = 0; j < items.length; j++) {
+			sink.accept(key + "[" + j + "]", unquote(items[j].trim()));
+		}
 	}
 
 	static int indentationOf(String line) {

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/ToonSyntaxTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/ToonSyntaxTest.java
@@ -2,9 +2,12 @@ package io.github.adamw7.tools.data.source.file;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 
 import org.junit.jupiter.api.Test;
@@ -119,5 +122,58 @@ public class ToonSyntaxTest {
 		assertEquals("rows", matcher.group(1));
 		assertEquals("2", matcher.group(2));
 		assertEquals("id,name", matcher.group(4));
+	}
+
+	@Test
+	public void topLevelSectionRecognisesKeyValueAtColumnZero() {
+		assertTrue(ToonSyntax.isTopLevelSection(0, "name: value"));
+	}
+
+	@Test
+	public void topLevelSectionRecognisesArrayHeaderAtColumnZero() {
+		assertTrue(ToonSyntax.isTopLevelSection(0, "rows[2]{id,name}:"));
+	}
+
+	@Test
+	public void indentedLineIsNotTopLevelSection() {
+		assertFalse(ToonSyntax.isTopLevelSection(2, "name: value"));
+	}
+
+	@Test
+	public void emptyLineIsNotTopLevelSection() {
+		assertFalse(ToonSyntax.isTopLevelSection(0, ""));
+	}
+
+	@Test
+	public void splitFieldsTrimsEachName() {
+		assertArrayEquals(new String[] { "id", "name", "age" }, ToonSyntax.splitFields("id, name , age"));
+	}
+
+	@Test
+	public void emitTabularHeaderEmitsCountThenFields() {
+		Map<String, String> sink = new LinkedHashMap<>();
+		ToonSyntax.emitTabularHeader(sink::put, "rows", 3, new String[] { "id", "name" });
+		assertEquals("3", sink.get("rows"));
+		assertEquals("id", sink.get("id"));
+		assertEquals("name", sink.get("name"));
+	}
+
+	@Test
+	public void emitTabularRowFlattensValuesAndIgnoresSurplus() {
+		Map<String, String> sink = new LinkedHashMap<>();
+		ToonSyntax.emitTabularRow(sink::put, "rows", new String[] { "id", "name" }, "7,\"Alice\",extra", 1);
+		assertEquals("7", sink.get("rows[1].id"));
+		assertEquals("Alice", sink.get("rows[1].name"));
+		assertEquals(2, sink.size());
+	}
+
+	@Test
+	public void emitInlineArrayEmitsLengthThenElements() {
+		Map<String, String> sink = new LinkedHashMap<>();
+		ToonSyntax.emitInlineArray(sink::put, "tags", "a, b, c");
+		assertEquals("3", sink.get("tags"));
+		assertEquals("a", sink.get("tags[0]"));
+		assertEquals("b", sink.get("tags[1]"));
+		assertEquals("c", sink.get("tags[2]"));
 	}
 }


### PR DESCRIPTION
Both TOON data sources re-implemented the same grammar: tabular header/row
emission, inline-array flattening and top-level-section detection existed in
parallel in InMemoryTOONDataSource and IterableTOONDataSource, risking drift.

Move the flattening rules into ToonSyntax behind a BiConsumer sink so the
in-memory source can collect pairs in a map while the iterable source enqueues
them as rows, without either duplicating the grammar. Also collapse the two
identical shouldExitNested* helpers and drop the trivial isArrayHeader wrapper
in InMemoryTOONDataSource.

Add direct unit tests for the new ToonSyntax helpers. All 319 data tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016htc8iy6exBbBp2xEm7Qu6