### PR TITLE
feat(data): add OpenAddressingMap siblings (Set and primitive int-keyed map)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Library of tooling for various purposes.
   - [Token-budget-aware context](#token-budget-aware-context)
 - [Data](#data)
   - [Open-addressing map](#open-addressing-map)
+  - [Open-addressing set](#open-addressing-set)
+  - [Primitive int-keyed map](#primitive-int-keyed-map)
   - [Network kill-switch](#network-kill-switch)
 - [Building](#building)
 - [Releasing](#releasing)
@@ -559,6 +561,50 @@ Caveats:
   mapped to a `null` value is reported as absent. Avoid storing `null` values.
 - It is **not thread-safe**; guard external synchronization if shared across
   threads.
+
+### Open-addressing set
+
+`OpenAddressingSet<E>` is a `java.util.Set` backed by an `OpenAddressingMap`, in
+the same way that `java.util.HashSet` is backed by a `java.util.HashMap`.
+Elements are stored as keys of the underlying map against a shared sentinel
+value, so all of the open-addressing behaviour (double hashing, tombstone
+removal and automatic resizing) is **reused rather than re-implemented**.
+
+```java
+Set<String> set = new OpenAddressingSet<>(); // default capacity 64
+set.add("a");          // true  (newly added)
+set.add("a");          // false (already present)
+set.contains("a");     // true
+set.remove("a");       // true
+```
+
+It inherits the map's caveats: **null elements are not supported** (they are
+rejected with `IllegalArgumentException`) and it is **not thread-safe**. The
+initial capacity can be set via `new OpenAddressingSet<>(size)`.
+
+### Primitive int-keyed map
+
+`IntKeyOpenAddressingMap<V>` is a primitive `int`-keyed sibling of
+`OpenAddressingMap`. It uses the same double-hashing open-addressing strategy,
+but stores keys in an `int[]` so that lookups and inserts **never box the key**.
+That makes it an allocation-light choice for large, integer-keyed maps where the
+autoboxing of a `Map<Integer, V>` would otherwise dominate.
+
+```java
+IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+map.put(1, "a");
+map.get(1);              // "a"
+map.getOrDefault(2, ""); // ""  (absent)
+map.remove(1);           // "a"
+int[] keys = map.keys(); // live keys, unboxed
+```
+
+It deliberately does **not** implement `java.util.Map`, because that interface is
+defined in terms of `Object` keys and would reintroduce the very boxing this
+class exists to avoid; instead it mirrors the relevant map operations with
+primitive `int` keys. Unlike `OpenAddressingMap`, **`null` values are stored
+faithfully** and reported by `containsKey(int)` — only `get(int)` cannot tell a
+stored `null` from an absent key. It is **not thread-safe**.
 
 ### Network kill-switch
 

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
@@ -1,0 +1,209 @@
+package io.github.adamw7.tools.data.structure;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import io.github.adamw7.tools.data.structure.internal.Primes;
+
+/**
+ * A primitive {@code int}-keyed sibling of {@link OpenAddressingMap}. It uses
+ * the same double-hashing open-addressing strategy, but stores keys in an
+ * {@code int[]} so that lookups and inserts never box the key. This makes it an
+ * allocation-light choice for large, integer-keyed maps where the autoboxing of
+ * a {@code Map<Integer, V>} would dominate.
+ *
+ * <p>It deliberately does <em>not</em> implement {@link java.util.Map}, because
+ * that interface is defined in terms of {@code Object} keys and would reintroduce
+ * the boxing this class exists to avoid. The API mirrors the relevant map
+ * operations with primitive {@code int} keys instead.
+ *
+ * <p>Unlike {@link OpenAddressingMap}, {@code null} values are stored faithfully
+ * and reported by {@link #containsKey(int)}; only {@link #get(int)} cannot tell a
+ * stored {@code null} from an absent key. The class is not thread-safe.
+ */
+public class IntKeyOpenAddressingMap<V> {
+
+	private static final double MULTIPLIER = 1.2;
+	static final int DEFAULT_SIZE = 64;
+
+	private static final byte EMPTY = 0;
+	private static final byte LIVE = 1;
+	private static final byte TOMBSTONE = 2;
+
+	private int prime;
+	private int[] keys;
+	private V[] values;
+	private byte[] state;
+	private int size;
+
+	public IntKeyOpenAddressingMap(int size) {
+		initArrays(size);
+	}
+
+	public IntKeyOpenAddressingMap() {
+		this(DEFAULT_SIZE);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void initArrays(int size) {
+		if (size <= 0) {
+			throw new IllegalArgumentException("Wrong size: " + size);
+		}
+		int newSize = Math.max(size, 3); // array of size 2 would force prime = 1
+		keys = new int[newSize];
+		values = (V[]) new Object[newSize];
+		state = new byte[newSize];
+		prime = Primes.findMaxSmallerThan(newSize);
+	}
+
+	public int size() {
+		return size;
+	}
+
+	public boolean isEmpty() {
+		return size == 0;
+	}
+
+	public boolean containsKey(int key) {
+		return indexOf(key) >= 0;
+	}
+
+	public boolean containsValue(Object value) {
+		return values().contains(value);
+	}
+
+	public V get(int key) {
+		int index = indexOf(key);
+		return index < 0 ? null : values[index];
+	}
+
+	public V getOrDefault(int key, V defaultValue) {
+		int index = indexOf(key);
+		return index < 0 ? defaultValue : values[index];
+	}
+
+	/**
+	 * Probes the double-hashing sequence for {@code key} and returns the index of
+	 * its live slot, or {@code -1} when the key is absent. An {@link #EMPTY} slot
+	 * ends the search; {@link #TOMBSTONE} slots are skipped because live entries
+	 * may sit past them in the probe chain.
+	 */
+	private int indexOf(int key) {
+		for (int i = 0; i < keys.length; ++i) {
+			int index = hash(key, i);
+			if (state[index] == EMPTY) {
+				return -1;
+			}
+			if (state[index] == LIVE && keys[index] == key) {
+				return index;
+			}
+		}
+		return -1;
+	}
+
+	private int hash(int key, int iteration) {
+		// double hashing, matching OpenAddressingMap
+		int hashCode = Integer.hashCode(key);
+		int h1 = h1(hashCode);
+		int h2 = h2(hashCode);
+		return Math.abs((h1 + (iteration * h2)) % keys.length);
+	}
+
+	private int h2(int hashCode) {
+		return 1 + (Math.abs(hashCode) % (keys.length - 1));
+	}
+
+	private int h1(int hashCode) {
+		return prime - (hashCode % prime);
+	}
+
+	public V put(int key, V value) {
+		checkIfResizeNeeded();
+		for (int i = 0; i < keys.length; ++i) {
+			int index = hash(key, i);
+			if (state[index] == EMPTY) {
+				return insert(index, key, value);
+			} else if (state[index] == LIVE && keys[index] == key) {
+				return overwrite(index, value);
+			} // tombstones are skipped
+		}
+		resize();
+		return put(key, value);
+	}
+
+	private V insert(int index, int key, V value) {
+		keys[index] = key;
+		values[index] = value;
+		state[index] = LIVE;
+		size++;
+		return null;
+	}
+
+	private V overwrite(int index, V value) {
+		V previous = values[index];
+		values[index] = value;
+		return previous;
+	}
+
+	private void checkIfResizeNeeded() {
+		if (size + 1 >= keys.length) {
+			resize();
+		}
+	}
+
+	private void resize() {
+		int[] oldKeys = keys;
+		V[] oldValues = values;
+		byte[] oldState = state;
+		initArrays(newSize());
+		size = 0;
+		for (int i = 0; i < oldState.length; ++i) {
+			if (oldState[i] == LIVE) {
+				put(oldKeys[i], oldValues[i]);
+			}
+		}
+	}
+
+	public V remove(int key) {
+		int index = indexOf(key);
+		if (index < 0) {
+			return null;
+		}
+		V previous = values[index];
+		state[index] = TOMBSTONE;
+		values[index] = null;
+		size--;
+		return previous;
+	}
+
+	public void clear() {
+		initArrays(keys.length);
+		size = 0;
+	}
+
+	private int newSize() {
+		return (int) (keys.length * MULTIPLIER);
+	}
+
+	public int[] keys() {
+		int[] result = new int[size];
+		int next = 0;
+		for (int i = 0; i < state.length; ++i) {
+			if (state[i] == LIVE) {
+				result[next++] = keys[i];
+			}
+		}
+		return result;
+	}
+
+	public Collection<V> values() {
+		List<V> result = new ArrayList<>(size);
+		for (int i = 0; i < state.length; ++i) {
+			if (state[i] == LIVE) {
+				result.add(values[i]);
+			}
+		}
+		return result;
+	}
+}

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -161,7 +161,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 
 	@Override
 	public void clear() {
-		initArray(size >= array.length ? newSize() : size);
+		initArray(size >= array.length ? newSize() : Math.max(size, 1));
 		size = 0;
 	}
 

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingSet.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingSet.java
@@ -1,0 +1,66 @@
+package io.github.adamw7.tools.data.structure;
+
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * A {@link Set} backed by an {@link OpenAddressingMap}, in the same way that
+ * {@link java.util.HashSet} is backed by a {@link java.util.HashMap}. Elements
+ * are stored as keys of the underlying map against a shared sentinel value, so
+ * all of the open-addressing behaviour (double hashing, tombstone removal and
+ * automatic resizing) is reused rather than re-implemented.
+ *
+ * <p>Like the underlying map this set does not support {@code null} elements
+ * (they are rejected with {@link IllegalArgumentException}) and is not
+ * thread-safe.
+ */
+public class OpenAddressingSet<E> extends AbstractSet<E> implements Set<E> {
+
+	private static final Object PRESENT = new Object();
+
+	private final OpenAddressingMap<E, Object> map;
+
+	public OpenAddressingSet() {
+		map = new OpenAddressingMap<>();
+	}
+
+	public OpenAddressingSet(int size) {
+		map = new OpenAddressingMap<>(size);
+	}
+
+	@Override
+	public int size() {
+		return map.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return map.isEmpty();
+	}
+
+	@Override
+	public boolean contains(Object element) {
+		return map.containsKey(element);
+	}
+
+	@Override
+	public boolean add(E element) {
+		return map.put(element, PRESENT) == null;
+	}
+
+	@Override
+	public boolean remove(Object element) {
+		return map.remove(element) != null;
+	}
+
+	@Override
+	public void clear() {
+		map.clear();
+	}
+
+	@Override
+	public Iterator<E> iterator() {
+		return map.keySet().iterator();
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMapTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMapTest.java
@@ -1,0 +1,211 @@
+package io.github.adamw7.tools.data.structure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.jupiter.api.Test;
+
+public class IntKeyOpenAddressingMapTest {
+
+	@Test
+	public void happyPath() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		assertNull(map.put(1, "A"));
+		assertNull(map.put(2, "B"));
+		assertEquals(2, map.size());
+		assertEquals("A", map.get(1));
+		assertEquals("B", map.get(2));
+	}
+
+	@Test
+	public void overwriteReturnsPreviousValue() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(1, "A");
+		assertEquals("A", map.put(1, "B"));
+		assertEquals(1, map.size());
+		assertEquals("B", map.get(1));
+	}
+
+	@Test
+	public void getMissingKeyReturnsNull() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		assertNull(map.get(42));
+	}
+
+	@Test
+	public void getOrDefault() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(1, "A");
+		assertEquals("A", map.getOrDefault(1, "fallback"));
+		assertEquals("fallback", map.getOrDefault(2, "fallback"));
+	}
+
+	@Test
+	public void containsKey() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(1, "A");
+		assertTrue(map.containsKey(1));
+		assertFalse(map.containsKey(2));
+	}
+
+	@Test
+	public void nullValueIsStoredAndReportedByContainsKey() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(7, null);
+		assertTrue(map.containsKey(7));
+		assertNull(map.get(7));
+		assertEquals(1, map.size());
+	}
+
+	@Test
+	public void containsValue() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(1, "A");
+		map.put(2, "B");
+		assertTrue(map.containsValue("A"));
+		assertFalse(map.containsValue("C"));
+	}
+
+	@Test
+	public void removeReturnsValueAndShrinks() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(1, "A");
+		map.put(2, "B");
+		assertEquals("A", map.remove(1));
+		assertNull(map.get(1));
+		assertEquals("B", map.get(2));
+		assertEquals(1, map.size());
+	}
+
+	@Test
+	public void removeMissingKeyReturnsNull() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(1, "A");
+		assertNull(map.remove(999));
+		assertEquals(1, map.size());
+	}
+
+	@Test
+	public void liveEntryFoundPastTombstone() {
+		// In the default capacity-64 table (prime 61) the keys 0, 61 and 122 all
+		// begin probing at the same slot, so they share a probe chain. Removing
+		// key 0 leaves a tombstone that 61 and 122 must probe past to be found.
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(0, "A");
+		map.put(61, "B");
+		map.put(122, "C");
+		assertEquals("A", map.remove(0));
+		assertEquals("B", map.get(61));
+		assertEquals("C", map.get(122));
+		assertNull(map.get(0));
+		assertEquals(2, map.size());
+	}
+
+	@Test
+	public void negativeKeysAreSupported() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(-1, "minus one");
+		map.put(Integer.MIN_VALUE, "min");
+		assertEquals("minus one", map.get(-1));
+		assertEquals("min", map.get(Integer.MIN_VALUE));
+	}
+
+	@Test
+	public void resizeKeepsAllEntries() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		int count = 500; // forces multiple resizes from the default capacity
+		for (int i = 0; i < count; ++i) {
+			map.put(i, String.valueOf(i));
+		}
+		assertEquals(count, map.size());
+		for (int i = 0; i < count; ++i) {
+			assertEquals(String.valueOf(i), map.get(i));
+		}
+	}
+
+	@Test
+	public void keysReturnsEveryLiveKey() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		for (int i = 0; i < 100; ++i) {
+			map.put(i, String.valueOf(i));
+		}
+		map.remove(50);
+		int[] keys = map.keys();
+		Arrays.sort(keys);
+		assertEquals(99, keys.length);
+		assertTrue(Arrays.binarySearch(keys, 0) >= 0);
+		assertFalse(Arrays.binarySearch(keys, 50) >= 0);
+	}
+
+	@Test
+	public void valuesReturnsEveryLiveValue() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		for (int i = 0; i < 50; ++i) {
+			map.put(i, String.valueOf(i));
+		}
+		Collection<String> values = map.values();
+		assertEquals(50, values.size());
+		for (int i = 0; i < 50; ++i) {
+			assertTrue(values.contains(String.valueOf(i)), i + " is missing in values");
+		}
+	}
+
+	@Test
+	public void clearEmptiesTheMap() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		for (int i = 0; i < 100; ++i) {
+			map.put(i, String.valueOf(i));
+		}
+		map.clear();
+		assertEquals(0, map.size());
+		assertTrue(map.isEmpty());
+		assertNull(map.get(0));
+	}
+
+	@Test
+	public void clearOnEmptyMapDoesNotThrow() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.clear();
+		assertEquals(0, map.size());
+	}
+
+	@Test
+	public void reuseAfterClear() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(1, "A");
+		map.clear();
+		map.put(2, "B");
+		assertNull(map.get(1));
+		assertEquals("B", map.get(2));
+		assertEquals(1, map.size());
+	}
+
+	@Test
+	public void zeroSizeIsRejected() {
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+				() -> new IntKeyOpenAddressingMap<>(0));
+		assertEquals("Wrong size: 0", thrown.getMessage());
+	}
+
+	@Test
+	public void negativeSizeIsRejected() {
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+				() -> new IntKeyOpenAddressingMap<>(-10));
+		assertEquals("Wrong size: -10", thrown.getMessage());
+	}
+
+	@Test
+	public void emptyMap() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		assertTrue(map.isEmpty());
+		assertEquals(0, map.size());
+		assertEquals(0, map.keys().length);
+		assertTrue(map.values().isEmpty());
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/OpenAddressingSetTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/OpenAddressingSetTest.java
@@ -1,0 +1,140 @@
+package io.github.adamw7.tools.data.structure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class OpenAddressingSetTest {
+
+	static Stream<Arguments> implementations() {
+		return Stream.of(of(new HashSet<Integer>()), of(new OpenAddressingSet<Integer>()),
+				of(new OpenAddressingSet<Integer>(16)));
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void addReturnsTrueForNewElement(Set<Integer> set) {
+		assertTrue(set.add(1));
+		assertEquals(1, set.size());
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void addReturnsFalseForDuplicate(Set<Integer> set) {
+		set.add(1);
+		assertFalse(set.add(1));
+		assertEquals(1, set.size());
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void contains(Set<Integer> set) {
+		set.add(1);
+		set.add(2);
+		assertTrue(set.contains(1));
+		assertTrue(set.contains(2));
+		assertFalse(set.contains(3));
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void removeReturnsTrueWhenPresent(Set<Integer> set) {
+		set.add(1);
+		assertTrue(set.remove(1));
+		assertFalse(set.contains(1));
+		assertEquals(0, set.size());
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void removeReturnsFalseWhenAbsent(Set<Integer> set) {
+		set.add(1);
+		assertFalse(set.remove(999));
+		assertEquals(1, set.size());
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void emptyThenNotEmpty(Set<Integer> set) {
+		assertTrue(set.isEmpty());
+		set.add(1);
+		assertFalse(set.isEmpty());
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void iteratorVisitsEveryElement(Set<Integer> set) {
+		int count = 200; // forces several resizes
+		for (int i = 0; i < count; ++i) {
+			set.add(i);
+		}
+		Set<Integer> seen = new HashSet<>();
+		for (Integer element : set) {
+			seen.add(element);
+		}
+		assertEquals(count, set.size());
+		assertEquals(count, seen.size());
+		for (int i = 0; i < count; ++i) {
+			assertTrue(seen.contains(i), i + " was not iterated");
+		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void clearOnEmptySet(Set<Integer> set) {
+		set.clear();
+		assertEquals(0, set.size());
+		assertTrue(set.isEmpty());
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void clearAfterInserts(Set<Integer> set) {
+		for (int i = 0; i < 100; ++i) {
+			set.add(i);
+		}
+		set.clear();
+		assertEquals(0, set.size());
+		assertFalse(set.contains(0));
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void addAllAndContainsAll(Set<Integer> set) {
+		Set<Integer> source = new HashSet<>();
+		for (int i = 0; i < 50; ++i) {
+			source.add(i);
+		}
+		assertTrue(set.addAll(source));
+		assertTrue(set.containsAll(source));
+		assertEquals(50, set.size());
+	}
+
+	@Test
+	public void conflictingHashesAreDistinctElements() {
+		Set<ConflictingKey> set = new OpenAddressingSet<>();
+		ConflictingKey first = new ConflictingKey(1, "1");
+		ConflictingKey second = new ConflictingKey(2, "2");
+		set.add(first);
+		set.add(second);
+		assertEquals(2, set.size());
+		assertTrue(set.contains(first));
+		assertTrue(set.contains(second));
+	}
+
+	@Test
+	public void nullElementIsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> new OpenAddressingSet<Integer>().add(null));
+	}
+}


### PR DESCRIPTION
Add two siblings to OpenAddressingMap that reuse its double-hashing,
tombstone-removal and resizing strategy:

- OpenAddressingSet<E>: a java.util.Set backed by OpenAddressingMap against a
  shared sentinel value, the same way HashSet is backed by HashMap. All probing
  logic is reused rather than duplicated.
- IntKeyOpenAddressingMap<V>: a primitive int-keyed map storing keys in an
  int[] to avoid autoboxing. It does not implement java.util.Map (which would
  reintroduce boxing) and instead exposes a primitive-keyed API. Null values are
  stored faithfully and reported by containsKey(int).

Also fix a latent bug in OpenAddressingMap.clear(): calling clear() on an empty
map passed size 0 to initArray and threw IllegalArgumentException. This now
surfaces through OpenAddressingSet.clear(), so guard the lower bound.

Add unit tests for both new classes (parity with HashSet/HashMap, tombstone
probe chains, resizing, null handling, clear) and document them in the README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015SqgzYTB1wp9iAKtnzJwdG