### PR TITLE
Add hooksFormat, mcpConfigFormat, uniqueDescriptions rules and front matter auto-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,32 @@ consistent and in their expected shape:
   catching a mistyped `htttp`. `requiredServers` must all be present and
   `forbiddenServers` must all be absent, so a project can mandate an MCP server
   it relies on or ban one it does not want committed.
+- **`mcpConfigFormat`** (`McpConfigFormatRule`) — validates the details of each
+  `.mcp.json` server entry that `mcpServersValid` leaves unchecked: `args` must
+  be an array of strings, `env` and `headers` must be objects whose values are
+  all strings, a `url` must be a syntactically valid `http`/`https` URL (and
+  `https` only when `requireHttps` is set), and a server must not mix transports
+  by declaring both a `command` and a `url`. Like `mcpServersValid` it treats an
+  absent file as a pass.
+- **`hooksFormat`** (`HooksFormatRule`) — validates the hook scripts under a
+  configured `hooksDir` (e.g. `.claude/hooks`): every regular file must be
+  non-empty, start with a `#!` shebang (`requireShebang`), and carry the
+  executable bit (`requireExecutable`), and an optional `allowedExtensions`
+  whitelist rejects a stray file. Where `hookCommandsValid` validates the JSON
+  shape of the `hooks` section, this rule validates the scripts themselves; when
+  a `settingsFile` is configured it also cross-checks the wiring, so a command
+  hook whose `$CLAUDE_PROJECT_DIR` path lands in the hooks directory must point
+  at a script that exists there, and `reportUnreferencedScripts` flags a script
+  no hook references. An absent `hooksDir` is a pass because hooks are optional.
+- **`uniqueDescriptions`** (`UniqueDescriptionsRule`) — reads the `description`
+  from the front matter of every sub-agent (`*.md`), command (`*.md`), and skill
+  (`SKILL.md`) in the configured `commandsDir`, `agentsDir`, and `skillsDir`, and
+  fails when one description is used by more than one definition, naming every
+  file that uses it. Because Claude routes by matching intent against these
+  descriptions, two identical descriptions are ambiguous and one shadows the
+  other. Comparison ignores case and runs of whitespace; missing or blank
+  descriptions are left to the format rules. As with `uniqueNames`, at least one
+  directory must be configured and uniqueness is checked across all of them.
 - **`uniqueNames`** (`UniqueNamesRule`) — gathers the names of every command,
   sub-agent, and skill from the configured `commandsDir`, `agentsDir`, and
   `skillsDir` (a command's and a sub-agent's name is its `*.md` file name, a
@@ -110,6 +136,16 @@ Every rule extends a common `ClaudeCodeEnforcerRule` base that reports all
 violations together and honours a `severity` option: the default `error` fails
 the build, while `<severity>warn</severity>` downgrades the same violations to a
 logged warning so a team can adopt a rule gradually.
+
+The front matter rules (`skillFilesExist`, `subAgentFormat`, `commandFormat`)
+also accept an `autoFix` option. When it is enabled and a definition's front
+matter is malformed in a way that is safe to repair — a delimiter written with
+too many dashes such as `----`, or an opening `---` whose closing delimiter is
+missing — the rule rewrites the file in place and continues against the
+corrected content instead of failing the build. The repair is conservative: it
+only acts when the document opens with a dashes line enclosing real
+`key: value` entries, so a lone `---` thematic break is never mistaken for front
+matter. `autoFix` is off by default.
 
 The rules are wired into the root `pom.xml` and run at the repository root only.
 The check is **opt-in** via the `enforceClaudeMd` property, so ordinary builds

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -45,6 +45,9 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 	/** Optional whitelist of model identifiers a command may declare. */
 	private List<String> allowedModels;
 
+	/** When true, a malformed front matter block is rewritten in place instead of failing the build. */
+	private boolean autoFix;
+
 	@Override
 	public void execute() throws EnforcerRuleException {
 		verifyConfigured();
@@ -74,7 +77,8 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 	private void collectNonEmptyViolations(File command, String content, List<String> violations) {
 		String baseName = DefinitionFiles.baseName(command);
 		NameConvention.collect(baseName, baseName, command.toString(), violations);
-		FrontMatter.parse(content)
+		String fixed = FrontMatterAutoFix.apply(command, "command definition", content, autoFix, getLog());
+		FrontMatter.parse(fixed)
 				.ifPresent(frontMatter -> collectFrontMatterViolations(command, frontMatter, violations));
 	}
 
@@ -132,6 +136,10 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 
 	void setAllowedModels(List<String> allowedModels) {
 		this.allowedModels = allowedModels;
+	}
+
+	void setAutoFix(boolean autoFix) {
+		this.autoFix = autoFix;
 	}
 
 	@Override

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/FrontMatterAutoFix.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/FrontMatterAutoFix.java
@@ -1,0 +1,39 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+
+import io.github.adamw7.tools.enforcer.text.FrontMatterFixer;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * Bridges {@link FrontMatterFixer} to the definition rules that read a Markdown
+ * file before validating its front matter. When auto-fix is enabled and the
+ * content has a repairable front matter block, it rewrites the file on disk,
+ * logs what it did, and hands the rule the repaired content so the rest of the
+ * checks run against the corrected document instead of failing the build.
+ */
+final class FrontMatterAutoFix {
+
+	private FrontMatterAutoFix() {
+	}
+
+	/**
+	 * Returns {@code content} unchanged when auto-fix is off or there is nothing
+	 * to repair; otherwise writes and returns the repaired content.
+	 */
+	static String apply(File file, String description, String content, boolean autoFix, EnforcerLogger log) {
+		if (!autoFix) {
+			return content;
+		}
+		Optional<String> repaired = FrontMatterFixer.repair(content);
+		if (repaired.isEmpty()) {
+			return content;
+		}
+		MarkdownText.write(file, repaired.get(), description);
+		log.info("Auto-fixed malformed front matter in " + file);
+		return repaired.get();
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -53,6 +53,9 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 	/** Maximum allowed description length. */
 	private int maxDescriptionLength = DEFAULT_MAX_DESCRIPTION_LENGTH;
 
+	/** When true, a malformed front matter block is rewritten in place instead of failing the build. */
+	private boolean autoFix;
+
 	@Override
 	public void execute() throws EnforcerRuleException {
 		verifyConfigured();
@@ -84,7 +87,8 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 		if (content.isBlank()) {
 			violations.add(SKILL_FILE_NAME + " is empty: " + skillFile);
 		} else {
-			collectFrontMatterViolations(skillDirectory, skillFile, content, violations);
+			String fixed = FrontMatterAutoFix.apply(skillFile, SKILL_FILE_NAME, content, autoFix, getLog());
+			collectFrontMatterViolations(skillDirectory, skillFile, fixed, violations);
 		}
 	}
 
@@ -168,6 +172,10 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 
 	void setMaxDescriptionLength(int maxDescriptionLength) {
 		this.maxDescriptionLength = maxDescriptionLength;
+	}
+
+	void setAutoFix(boolean autoFix) {
+		this.autoFix = autoFix;
 	}
 
 	@Override

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -44,6 +44,9 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 	/** Optional whitelist of model identifiers a sub-agent may declare. */
 	private List<String> allowedModels;
 
+	/** When true, a malformed front matter block is rewritten in place instead of failing the build. */
+	private boolean autoFix;
+
 	@Override
 	public void execute() throws EnforcerRuleException {
 		verifyConfigured();
@@ -66,7 +69,8 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 		if (content.isBlank()) {
 			violations.add("Sub-agent definition is empty: " + definition);
 		} else {
-			collectFrontMatterViolations(definition, content, violations);
+			String fixed = FrontMatterAutoFix.apply(definition, "sub-agent definition", content, autoFix, getLog());
+			collectFrontMatterViolations(definition, fixed, violations);
 		}
 	}
 
@@ -126,6 +130,10 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 
 	void setAllowedModels(List<String> allowedModels) {
 		this.allowedModels = allowedModels;
+	}
+
+	void setAutoFix(boolean autoFix) {
+		this.autoFix = autoFix;
 	}
 
 	@Override

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRule.java
@@ -1,0 +1,159 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.FrontMatter;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * Enforcer rule that fails the build when two Claude Code definitions share the
+ * same {@code description}. Claude routes to a skill, sub-agent, or command by
+ * matching the user's intent against these descriptions, so two definitions that
+ * describe themselves identically are ambiguous and one will shadow the other.
+ * The rule reads the {@code description} from the front matter of every
+ * sub-agent ({@code *.md}), command ({@code *.md}), and skill ({@code SKILL.md})
+ * in the configured directories and reports each description used more than once,
+ * naming every file that uses it.
+ * <p>
+ * Comparison ignores case and runs of whitespace, so {@code Reviews code.} and
+ * {@code reviews   code.} are treated as the same description. Definitions with
+ * no description, or a blank one, are skipped here because the format rules
+ * already report those. The three directories ({@code commandsDir},
+ * {@code agentsDir}, {@code skillsDir}) are each optional and at least one must
+ * be configured; a configured directory must exist. All clashes are reported
+ * together.
+ */
+@Named("uniqueDescriptions")
+public class UniqueDescriptionsRule extends ClaudeCodeEnforcerRule {
+
+	private static final String DESCRIPTION_KEY = "description";
+	private static final String SKILL_FILE_NAME = "SKILL.md";
+
+	/** The {@code .claude/commands} directory to scan. Injected from the rule configuration. */
+	private File commandsDir;
+
+	/** The {@code .claude/agents} directory to scan. Injected from the rule configuration. */
+	private File agentsDir;
+
+	/** The {@code .claude/skills} directory to scan. Injected from the rule configuration. */
+	private File skillsDir;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		verifyConfigured();
+		Map<String, Description> byNormalizedText = new LinkedHashMap<>();
+		collectMarkdownDescriptions(commandsDir, "Commands", byNormalizedText);
+		collectMarkdownDescriptions(agentsDir, "Agents", byNormalizedText);
+		collectSkillDescriptions(skillsDir, byNormalizedText);
+		report("Claude Code descriptions must be unique:", duplicates(byNormalizedText));
+	}
+
+	private void verifyConfigured() throws EnforcerRuleException {
+		if (commandsDir == null && agentsDir == null && skillsDir == null) {
+			throw new EnforcerRuleException(
+					"At least one of commandsDir, agentsDir or skillsDir must be configured");
+		}
+	}
+
+	private void collectMarkdownDescriptions(File directory, String label, Map<String, Description> byText)
+			throws EnforcerRuleException {
+		if (directory == null) {
+			return;
+		}
+		DefinitionFiles.verifyDirectory(directory, label);
+		for (File markdown : DefinitionFiles.markdownFiles(directory)) {
+			record(markdown, markdown, byText);
+		}
+	}
+
+	private void collectSkillDescriptions(File directory, Map<String, Description> byText)
+			throws EnforcerRuleException {
+		if (directory == null) {
+			return;
+		}
+		DefinitionFiles.verifyDirectory(directory, "Skills");
+		for (File skill : DefinitionFiles.subdirectories(directory)) {
+			record(new File(skill, SKILL_FILE_NAME), skill, byText);
+		}
+	}
+
+	private void record(File definitionFile, File source, Map<String, Description> byText) {
+		descriptionOf(definitionFile).ifPresent(text -> add(text, source, byText));
+	}
+
+	private Optional<String> descriptionOf(File definitionFile) {
+		if (!definitionFile.isFile()) {
+			return Optional.empty();
+		}
+		String content = MarkdownText.read(definitionFile, "definition");
+		return FrontMatter.parse(content)
+				.flatMap(frontMatter -> frontMatter.value(DESCRIPTION_KEY))
+				.filter(value -> !value.isBlank());
+	}
+
+	private void add(String text, File source, Map<String, Description> byText) {
+		byText.computeIfAbsent(normalize(text), key -> new Description(text)).addSource(source.toString());
+	}
+
+	private String normalize(String text) {
+		return text.strip().toLowerCase().replaceAll("\\s+", " ");
+	}
+
+	private List<String> duplicates(Map<String, Description> byText) {
+		List<String> violations = new ArrayList<>();
+		for (Description description : byText.values()) {
+			description.addDuplicateViolation(violations);
+		}
+		return violations;
+	}
+
+	void setCommandsDir(File commandsDir) {
+		this.commandsDir = commandsDir;
+	}
+
+	void setAgentsDir(File agentsDir) {
+		this.agentsDir = agentsDir;
+	}
+
+	void setSkillsDir(File skillsDir) {
+		this.skillsDir = skillsDir;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("UniqueDescriptionsRule[commandsDir=%s, agentsDir=%s, skillsDir=%s]",
+				commandsDir, agentsDir, skillsDir);
+	}
+
+	/** A description's original text and the sources that declare an equivalent of it. */
+	private static final class Description {
+
+		private final String text;
+		private final List<String> sources = new ArrayList<>();
+
+		private Description(String text) {
+			this.text = text;
+		}
+
+		private void addSource(String source) {
+			sources.add(source);
+		}
+
+		private void addDuplicateViolation(List<String> violations) {
+			if (sources.size() > 1) {
+				violations.add("description '" + text + "' is used by " + sources.size()
+						+ " definitions: " + String.join(", ", sources));
+			}
+		}
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
@@ -1,0 +1,190 @@
+package io.github.adamw7.tools.enforcer.mcp;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import javax.inject.Named;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
+import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+
+/**
+ * Enforcer rule that fails the build when an {@code .mcp.json} server entry is
+ * structurally well formed at the transport level but wrong in its details.
+ * Where {@link McpServersValidRule} checks that a server declares the right
+ * {@code command} or {@code url} for its transport, this rule validates the
+ * optional fields around them so a subtle mistake cannot reach Claude Code:
+ * <ul>
+ * <li>{@code args} must be an array of strings;</li>
+ * <li>{@code env} and {@code headers} must be objects whose values are all
+ * strings;</li>
+ * <li>{@code url} must be a syntactically valid {@code http} or {@code https}
+ * URL (and {@code https} only when {@code requireHttps} is set); and</li>
+ * <li>a server must not declare both a {@code command} and a {@code url}, which
+ * mixes a stdio and a remote transport in one entry.</li>
+ * </ul>
+ * <p>
+ * A project-level {@code .mcp.json} is optional, so an absent file is a pass; the
+ * rule only fails when the file is present and a server entry is malformed. All
+ * problems found are reported together.
+ */
+@Named("mcpConfigFormat")
+public class McpConfigFormatRule extends JsonFileRule {
+
+	private static final String MCP_SERVERS_KEY = "mcpServers";
+	private static final String COMMAND_KEY = "command";
+	private static final String ARGS_KEY = "args";
+	private static final String ENV_KEY = "env";
+	private static final String HEADERS_KEY = "headers";
+	private static final String URL_KEY = "url";
+	private static final String HTTP_SCHEME = "http";
+	private static final String HTTPS_SCHEME = "https";
+
+	/** The {@code .mcp.json} file to validate. Injected from the rule configuration. */
+	private File mcpFile;
+
+	/** When true, a server {@code url} must use {@code https} rather than plain {@code http}. */
+	private boolean requireHttps;
+
+	@Override
+	protected File jsonFile() {
+		return mcpFile;
+	}
+
+	@Override
+	protected String fileParameter() {
+		return "mcpFile";
+	}
+
+	@Override
+	protected String description() {
+		return "mcp.json";
+	}
+
+	@Override
+	protected String header() {
+		return "mcp.json server configuration is not well formed:";
+	}
+
+	/** A project-level {@code .mcp.json} is optional in Claude Code, so an absent file is a pass. */
+	@Override
+	protected void handleMissingFile(File file) {
+	}
+
+	@Override
+	protected void collectViolations(JsonNode mcp, List<String> violations) {
+		JsonNode servers = JsonNodes.objectAt(mcp, MCP_SERVERS_KEY);
+		if (servers == null) {
+			return;
+		}
+		for (String name : JsonNodes.fieldNames(servers)) {
+			collectServerViolations(name, JsonNodes.objectAt(servers, name), violations);
+		}
+	}
+
+	private void collectServerViolations(String name, JsonNode server, List<String> violations) {
+		if (server == null) {
+			return;
+		}
+		collectTransportConflict(name, server, violations);
+		collectArgsViolations(name, server, violations);
+		collectStringMapViolations(name, server, ENV_KEY, violations);
+		collectStringMapViolations(name, server, HEADERS_KEY, violations);
+		collectUrlViolations(name, server, violations);
+	}
+
+	private void collectTransportConflict(String name, JsonNode server, List<String> violations) {
+		if (server.has(COMMAND_KEY) && server.has(URL_KEY)) {
+			violations.add("mcp.json server '" + name + "' declares both a 'command' and a 'url'");
+		}
+	}
+
+	private void collectArgsViolations(String name, JsonNode server, List<String> violations) {
+		JsonNode args = server.get(ARGS_KEY);
+		if (args == null) {
+			return;
+		}
+		if (!args.isArray()) {
+			violations.add("mcp.json server '" + name + "' has an 'args' that is not an array");
+		} else {
+			collectArgElements(name, args, violations);
+		}
+	}
+
+	private void collectArgElements(String name, JsonNode args, List<String> violations) {
+		for (int i = 0; i < args.size(); i++) {
+			if (!args.get(i).isTextual()) {
+				violations.add("mcp.json server '" + name + "' has a non-string entry in 'args'");
+			}
+		}
+	}
+
+	private void collectStringMapViolations(String name, JsonNode server, String key, List<String> violations) {
+		JsonNode map = server.get(key);
+		if (map == null) {
+			return;
+		}
+		if (!map.isObject()) {
+			violations.add("mcp.json server '" + name + "' has a '" + key + "' that is not an object");
+		} else {
+			collectStringMapValues(name, key, map, violations);
+		}
+	}
+
+	private void collectStringMapValues(String name, String key, JsonNode map, List<String> violations) {
+		for (String field : JsonNodes.fieldNames(map)) {
+			if (!map.get(field).isTextual()) {
+				violations.add("mcp.json server '" + name + "' has a non-string value for '" + key + "." + field + "'");
+			}
+		}
+	}
+
+	private void collectUrlViolations(String name, JsonNode server, List<String> violations) {
+		JsonNode url = server.get(URL_KEY);
+		if (url == null || !url.isTextual()) {
+			return;
+		}
+		addUrlViolation(name, url.asText(), violations);
+	}
+
+	private void addUrlViolation(String name, String url, List<String> violations) {
+		String scheme = schemeOf(url);
+		if (scheme == null) {
+			violations.add("mcp.json server '" + name + "' has a malformed 'url': " + url);
+		} else if (requireHttps && !scheme.equals(HTTPS_SCHEME)) {
+			violations.add("mcp.json server '" + name + "' must use an https 'url': " + url);
+		}
+	}
+
+	/** The {@code http}/{@code https} scheme of a syntactically valid absolute URL, or null otherwise. */
+	private String schemeOf(String url) {
+		try {
+			URI uri = new URI(url);
+			String scheme = uri.getScheme();
+			if (scheme == null || uri.getHost() == null) {
+				return null;
+			}
+			String lower = scheme.toLowerCase();
+			return lower.equals(HTTP_SCHEME) || lower.equals(HTTPS_SCHEME) ? lower : null;
+		} catch (URISyntaxException e) {
+			return null;
+		}
+	}
+
+	void setMcpFile(File mcpFile) {
+		this.mcpFile = mcpFile;
+	}
+
+	void setRequireHttps(boolean requireHttps) {
+		this.requireHttps = requireHttps;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("McpConfigFormatRule[mcpFile=%s]", mcpFile);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -1,0 +1,311 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * Enforcer rule that fails the build when a hook script under {@code .claude/hooks}
+ * is not a well-formed executable, or when {@code .claude/settings.json} wires a
+ * command hook to a script that should live in that directory but does not.
+ * <p>
+ * Where {@link HookCommandsValidRule} validates the JSON shape of the
+ * {@code hooks} section, this rule validates the scripts themselves: every
+ * regular file directly under {@code hooksDir} must be non-empty, start with a
+ * {@code #!} shebang line, and carry the executable bit, so a hook that Claude
+ * Code would try to run cannot be committed broken. Each of the script checks can
+ * be switched off ({@code requireShebang}, {@code requireExecutable}), and an
+ * optional {@code allowedExtensions} whitelist rejects a stray file such as a
+ * {@code .txt} note left in the hooks directory.
+ * <p>
+ * When {@code settingsFile} is configured, the rule cross-checks the wiring: any
+ * command hook whose command resolves a {@code $CLAUDE_PROJECT_DIR} path into the
+ * hooks directory must point at a script that exists there, catching a hook
+ * renamed on disk but not in settings. With {@code reportUnreferencedScripts} a
+ * script in the directory that no hook references is reported too.
+ * <p>
+ * The {@code hooksDir} parameter must be configured, but an absent directory is a
+ * pass because hooks are optional in Claude Code. All problems found are reported
+ * together.
+ */
+@Named("hooksFormat")
+public class HooksFormatRule extends ClaudeCodeEnforcerRule {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private static final String HOOKS_KEY = "hooks";
+	private static final String TYPE_KEY = "type";
+	private static final String COMMAND_KEY = "command";
+	private static final String COMMAND_TYPE = "command";
+	private static final String SHEBANG = "#!";
+	private static final String PROJECT_DIR_BRACED = "${CLAUDE_PROJECT_DIR}";
+	private static final String PROJECT_DIR_PLAIN = "$CLAUDE_PROJECT_DIR";
+
+	/** The {@code .claude/hooks} directory to scan. Injected from the rule configuration. */
+	private File hooksDir;
+
+	/** Optional {@code .claude/settings.json} used to cross-check hook wiring. */
+	private File settingsFile;
+
+	/** Base directory that {@code $CLAUDE_PROJECT_DIR} resolves to. Defaults to the settings file's grandparent. */
+	private File projectDir;
+
+	/** Optional whitelist of file extensions a hook script may use, e.g. {@code sh}, {@code py}. */
+	private List<String> allowedExtensions;
+
+	/** When true (default), each hook script must start with a {@code #!} shebang line. */
+	private boolean requireShebang = true;
+
+	/** When true (default), each hook script must carry the executable bit. */
+	private boolean requireExecutable = true;
+
+	/** When true, a script in the directory referenced by no settings hook is reported. */
+	private boolean reportUnreferencedScripts;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		verifyConfigured();
+		List<String> violations = new ArrayList<>();
+		List<File> scripts = scriptFiles();
+		for (File script : scripts) {
+			collectScriptViolations(script, violations);
+		}
+		collectWiringViolations(scripts, violations);
+		report("Hook scripts are not well formed:", violations);
+	}
+
+	private void verifyConfigured() throws EnforcerRuleException {
+		if (hooksDir == null) {
+			throw new EnforcerRuleException("The hooksDir parameter is not configured");
+		}
+	}
+
+	private List<File> scriptFiles() {
+		File[] files = hooksDir.listFiles(File::isFile);
+		return files != null ? List.of(files) : List.of();
+	}
+
+	private void collectScriptViolations(File script, List<String> violations) {
+		String content = MarkdownText.read(script, "hook script");
+		if (content.isBlank()) {
+			violations.add("hook script is empty: " + script);
+			return;
+		}
+		collectShebangViolation(script, content, violations);
+		collectExecutableViolation(script, violations);
+		collectExtensionViolation(script, violations);
+	}
+
+	private void collectShebangViolation(File script, String content, List<String> violations) {
+		if (requireShebang && !content.startsWith(SHEBANG)) {
+			violations.add("hook script must start with a '#!' shebang line: " + script);
+		}
+	}
+
+	private void collectExecutableViolation(File script, List<String> violations) {
+		if (requireExecutable && !script.canExecute()) {
+			violations.add("hook script is not executable: " + script);
+		}
+	}
+
+	private void collectExtensionViolation(File script, List<String> violations) {
+		if (allowedExtensions != null && !allowedExtensions.contains(extensionOf(script))) {
+			violations.add("hook script has a disallowed extension: " + script);
+		}
+	}
+
+	private String extensionOf(File script) {
+		String name = script.getName();
+		int dot = name.lastIndexOf('.');
+		return dot < 0 ? "" : name.substring(dot + 1);
+	}
+
+	private void collectWiringViolations(List<File> scripts, List<String> violations) {
+		if (settingsFile == null) {
+			return;
+		}
+		if (!settingsFile.isFile()) {
+			violations.add("settings.json does not exist at " + settingsFile);
+			return;
+		}
+		JsonNode settings = parseSettings(settingsFile, violations);
+		if (settings == null) {
+			return;
+		}
+		Set<Path> referenced = collectReferencedScripts(settings, violations);
+		collectUnreferencedScripts(scripts, referenced, violations);
+	}
+
+	private JsonNode parseSettings(File file, List<String> violations) {
+		try {
+			JsonNode root = MAPPER.readTree(MarkdownText.read(file, "settings.json"));
+			if (root == null || !root.isObject()) {
+				violations.add("settings.json is not valid JSON: expected a JSON object");
+				return null;
+			}
+			return root;
+		} catch (JsonProcessingException e) {
+			violations.add("settings.json is not valid JSON: " + e.getOriginalMessage());
+			return null;
+		}
+	}
+
+	private Set<Path> collectReferencedScripts(JsonNode settings, List<String> violations) {
+		Set<Path> referenced = new LinkedHashSet<>();
+		for (String command : hookCommands(settings)) {
+			addReferencedScript(command, referenced, violations);
+		}
+		return referenced;
+	}
+
+	private void addReferencedScript(String command, Set<Path> referenced, List<String> violations) {
+		Path script = scriptInHooksDir(command);
+		if (script == null) {
+			return;
+		}
+		referenced.add(script.normalize());
+		if (!script.toFile().exists()) {
+			violations.add("settings.json references a missing hook script: " + script);
+		}
+	}
+
+	private void collectUnreferencedScripts(List<File> scripts, Set<Path> referenced, List<String> violations) {
+		if (!reportUnreferencedScripts) {
+			return;
+		}
+		for (File script : scripts) {
+			addUnreferencedViolation(script, referenced, violations);
+		}
+	}
+
+	private void addUnreferencedViolation(File script, Set<Path> referenced, List<String> violations) {
+		if (!referenced.contains(script.getAbsoluteFile().toPath().normalize())) {
+			violations.add("hook script is not referenced by any settings.json hook: " + script);
+		}
+	}
+
+	private List<String> hookCommands(JsonNode settings) {
+		List<String> commands = new ArrayList<>();
+		JsonNode hooks = JsonNodes.objectAt(settings, HOOKS_KEY);
+		if (hooks != null) {
+			collectEventCommands(hooks, commands);
+		}
+		return commands;
+	}
+
+	private void collectEventCommands(JsonNode hooks, List<String> commands) {
+		for (String event : JsonNodes.fieldNames(hooks)) {
+			collectGroupCommands(JsonNodes.arrayAt(hooks, event), commands);
+		}
+	}
+
+	private void collectGroupCommands(JsonNode groups, List<String> commands) {
+		if (groups == null) {
+			return;
+		}
+		for (int i = 0; i < groups.size(); i++) {
+			collectEntryCommands(JsonNodes.objectAt(groups, i), commands);
+		}
+	}
+
+	private void collectEntryCommands(JsonNode group, List<String> commands) {
+		if (group == null) {
+			return;
+		}
+		JsonNode entries = JsonNodes.arrayAt(group, HOOKS_KEY);
+		if (entries == null) {
+			return;
+		}
+		for (int i = 0; i < entries.size(); i++) {
+			collectCommand(JsonNodes.objectAt(entries, i), commands);
+		}
+	}
+
+	private void collectCommand(JsonNode entry, List<String> commands) {
+		if (entry != null && COMMAND_TYPE.equals(JsonNodes.textAt(entry, TYPE_KEY, "").strip())) {
+			commands.add(JsonNodes.textAt(entry, COMMAND_KEY, "").strip());
+		}
+	}
+
+	/** The absolute path a command's {@code $CLAUDE_PROJECT_DIR} token resolves to when it lands in the hooks directory, else null. */
+	private Path scriptInHooksDir(String command) {
+		Path hooks = hooksDir.getAbsoluteFile().toPath().normalize();
+		for (String token : command.split("\\s+")) {
+			Path resolved = expand(token);
+			if (resolved != null && resolved.startsWith(hooks)) {
+				return resolved;
+			}
+		}
+		return null;
+	}
+
+	private Path expand(String token) {
+		if (token.contains(PROJECT_DIR_BRACED)) {
+			return absolute(token.replace(PROJECT_DIR_BRACED, projectDir().getPath()));
+		}
+		if (token.contains(PROJECT_DIR_PLAIN)) {
+			return absolute(token.replace(PROJECT_DIR_PLAIN, projectDir().getPath()));
+		}
+		return null;
+	}
+
+	private Path absolute(String path) {
+		return new File(path).getAbsoluteFile().toPath().normalize();
+	}
+
+	private File projectDir() {
+		if (projectDir != null) {
+			return projectDir;
+		}
+		File claudeDir = settingsFile.getAbsoluteFile().getParentFile();
+		File root = claudeDir != null ? claudeDir.getParentFile() : null;
+		return root != null ? root : new File(".");
+	}
+
+	void setHooksDir(File hooksDir) {
+		this.hooksDir = hooksDir;
+	}
+
+	void setSettingsFile(File settingsFile) {
+		this.settingsFile = settingsFile;
+	}
+
+	void setProjectDir(File projectDir) {
+		this.projectDir = projectDir;
+	}
+
+	void setAllowedExtensions(List<String> allowedExtensions) {
+		this.allowedExtensions = allowedExtensions;
+	}
+
+	void setRequireShebang(boolean requireShebang) {
+		this.requireShebang = requireShebang;
+	}
+
+	void setRequireExecutable(boolean requireExecutable) {
+		this.requireExecutable = requireExecutable;
+	}
+
+	void setReportUnreferencedScripts(boolean reportUnreferencedScripts) {
+		this.reportUnreferencedScripts = reportUnreferencedScripts;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("HooksFormatRule[hooksDir=%s]", hooksDir);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
@@ -1,0 +1,144 @@
+package io.github.adamw7.tools.enforcer.text;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Repairs the two unambiguous ways a Claude Code front matter block is commonly
+ * malformed, so an auto-fixing rule can rewrite the file rather than only fail
+ * the build:
+ * <ul>
+ * <li>a delimiter written with too many dashes, such as {@code ----}, which
+ * {@link FrontMatter} does not recognise as the canonical {@code ---}; and</li>
+ * <li>an opening {@code ---} whose closing delimiter is missing, which leaves
+ * the block unterminated.</li>
+ * </ul>
+ * <p>
+ * The repair is deliberately conservative: it only acts when the document opens
+ * with a dashes-only line and the region that would become the block actually
+ * contains at least one {@code key: value} entry, so a lone {@code ---} thematic
+ * break is never mistaken for front matter. A document whose front matter
+ * already parses, or whose problem is not one of the two above, is left
+ * untouched and reported by the rule as before.
+ */
+public final class FrontMatterFixer {
+
+	private static final char DASH = '-';
+	private static final int MIN_DELIMITER_DASHES = 3;
+	private static final String CANONICAL_DELIMITER = "---";
+	private static final Pattern KEY_ENTRY = Pattern.compile("[A-Za-z0-9_][A-Za-z0-9_. -]*:(\\s.*)?");
+
+	private FrontMatterFixer() {
+	}
+
+	/**
+	 * Returns the repaired document when {@code content} has a malformed front
+	 * matter block this fixer can safely correct, or empty when there is nothing
+	 * to fix or the problem is outside its scope. The returned content always
+	 * parses as front matter and never equals the input.
+	 */
+	public static Optional<String> repair(String content) {
+		if (FrontMatter.parse(content).isPresent()) {
+			return Optional.empty();
+		}
+		List<String> lines = new ArrayList<>(content.lines().toList());
+		int open = firstNonBlankIndex(lines);
+		if (open < 0 || !isDelimiterLike(lines.get(open))) {
+			return Optional.empty();
+		}
+		return repairFrom(lines, open).map(fixed -> render(fixed, content));
+	}
+
+	private static Optional<List<String>> repairFrom(List<String> lines, int open) {
+		int close = nextDelimiterLike(lines, open + 1);
+		if (close > 0) {
+			return normalizeDelimiters(lines, open, close);
+		}
+		return insertClosingDelimiter(lines, open);
+	}
+
+	private static Optional<List<String>> normalizeDelimiters(List<String> lines, int open, int close) {
+		if (!containsKeyEntry(lines, open + 1, close)) {
+			return Optional.empty();
+		}
+		List<String> fixed = new ArrayList<>(lines);
+		fixed.set(open, CANONICAL_DELIMITER);
+		fixed.set(close, CANONICAL_DELIMITER);
+		return Optional.of(fixed);
+	}
+
+	private static Optional<List<String>> insertClosingDelimiter(List<String> lines, int open) {
+		int end = endOfBlock(lines, open + 1);
+		if (!containsKeyEntry(lines, open + 1, end)) {
+			return Optional.empty();
+		}
+		List<String> fixed = new ArrayList<>(lines);
+		fixed.set(open, CANONICAL_DELIMITER);
+		fixed.add(end, CANONICAL_DELIMITER);
+		return Optional.of(fixed);
+	}
+
+	/** The first index at or after {@code from} that is no longer a front-matter entry. */
+	private static int endOfBlock(List<String> lines, int from) {
+		int index = from;
+		while (index < lines.size() && isFrontMatterLine(lines.get(index))) {
+			index++;
+		}
+		return index;
+	}
+
+	private static boolean containsKeyEntry(List<String> lines, int from, int toExclusive) {
+		for (int i = from; i < toExclusive; i++) {
+			if (KEY_ENTRY.matcher(lines.get(i).strip()).matches()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isFrontMatterLine(String line) {
+		String stripped = line.strip();
+		if (stripped.isEmpty() || line.charAt(0) == ' ' || line.charAt(0) == '\t' || stripped.startsWith("-")) {
+			return !isDelimiterLike(line);
+		}
+		return KEY_ENTRY.matcher(stripped).matches();
+	}
+
+	private static int firstNonBlankIndex(List<String> lines) {
+		for (int i = 0; i < lines.size(); i++) {
+			if (!lines.get(i).isBlank()) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private static int nextDelimiterLike(List<String> lines, int from) {
+		for (int i = from; i < lines.size(); i++) {
+			if (isDelimiterLike(lines.get(i))) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private static boolean isDelimiterLike(String line) {
+		String stripped = line.strip();
+		return stripped.length() >= MIN_DELIMITER_DASHES && allDashes(stripped);
+	}
+
+	private static boolean allDashes(String value) {
+		return value.chars().allMatch(character -> character == DASH);
+	}
+
+	private static String render(List<String> lines, String original) {
+		String joined = String.join("\n", lines);
+		return endsWithNewline(original) ? joined + "\n" : joined;
+	}
+
+	private static boolean endsWithNewline(String content) {
+		return content.endsWith("\n") || content.endsWith("\r");
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
@@ -31,6 +31,20 @@ public final class MarkdownText {
 		}
 	}
 
+	/**
+	 * Writes {@code content} to {@code file} as UTF-8, overwriting any existing
+	 * content. An {@link IOException} is wrapped in an {@link UncheckedIOException}
+	 * describing the document, mirroring {@link #read} so a write failure surfaces
+	 * the same way.
+	 */
+	public static void write(File file, String content, String description) {
+		try {
+			Files.writeString(file.toPath(), content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + description + " at " + file, e);
+		}
+	}
+
 	/** Removes a single leading UTF-8 byte-order mark, if present. */
 	public static String stripByteOrderMark(String content) {
 		if (!content.isEmpty() && content.charAt(0) == BYTE_ORDER_MARK) {

--- a/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -8,3 +8,6 @@ io.github.adamw7.tools.enforcer.definition.CommandFormatRule
 io.github.adamw7.tools.enforcer.settings.HookCommandsValidRule
 io.github.adamw7.tools.enforcer.mcp.McpServersValidRule
 io.github.adamw7.tools.enforcer.definition.UniqueNamesRule
+io.github.adamw7.tools.enforcer.settings.HooksFormatRule
+io.github.adamw7.tools.enforcer.mcp.McpConfigFormatRule
+io.github.adamw7.tools.enforcer.definition.UniqueDescriptionsRule

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
@@ -162,6 +162,22 @@ class CommandFormatRuleTest {
 		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("blank.md")), logger.warnings().toString());
 	}
 
+	@Test
+	void autoFixRewritesMalformedFrontMatterInPlace() {
+		Path file = tempDir.resolve("review.md");
+		writeString(file, """
+				---
+				description: Reviews the diff.
+				Review the diff.
+				""");
+		CommandFormatRule rule = ruleFor(tempDir);
+		rule.setAutoFix(true);
+		rule.setLog(new CapturingLogger());
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(readString(file).contains("---\nReview the diff."), readString(file));
+	}
+
 	private CommandFormatRule ruleFor(Path commandsDir) {
 		CommandFormatRule rule = new CommandFormatRule();
 		rule.setCommandsDir(commandsDir.toFile());
@@ -173,6 +189,14 @@ class CommandFormatRuleTest {
 			Files.writeString(file, content);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private static String readString(Path file) {
+		try {
+			return Files.readString(file);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read " + file, e);
 		}
 	}
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
@@ -202,6 +202,24 @@ class SkillFilesExistRuleTest {
 		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("broken-skill")), logger.warnings().toString());
 	}
 
+	@Test
+	void autoFixRepairsAMissingClosingDelimiter() {
+		Path skillDir = createDirectory(tempDir.resolve("git-commit"));
+		Path file = skillDir.resolve("SKILL.md");
+		writeString(file, """
+				---
+				name: git-commit
+				description: A skill named git-commit.
+				# Body
+				""");
+		SkillFilesExistRule rule = ruleFor(tempDir);
+		rule.setAutoFix(true);
+		rule.setLog(new CapturingLogger());
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(readString(file).contains("---\n# Body"), readString(file));
+	}
+
 	private void createSkill(String name) {
 		Path skillDir = createDirectory(tempDir.resolve(name));
 		writeString(skillDir.resolve("SKILL.md"), """
@@ -224,6 +242,14 @@ class SkillFilesExistRuleTest {
 			Files.writeString(file, content);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private static String readString(Path file) {
+		try {
+			return Files.readString(file);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read " + file, e);
 		}
 	}
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
@@ -14,6 +14,8 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+
 class SubAgentFormatRuleTest {
 
 	@TempDir
@@ -123,6 +125,36 @@ class SubAgentFormatRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
+	@Test
+	void autoFixRepairsAMissingClosingDelimiter() {
+		Path file = tempDir.resolve("reviewer.md");
+		writeString(file, """
+				---
+				name: reviewer
+				description: Reviews code.
+				# Reviewer
+				""");
+		SubAgentFormatRule rule = ruleFor(tempDir);
+		rule.setAutoFix(true);
+		rule.setLog(new CapturingLogger());
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(readString(file).contains("---\n# Reviewer"), readString(file));
+	}
+
+	@Test
+	void malformedFrontMatterStillFailsWithoutAutoFix() {
+		writeString(tempDir.resolve("reviewer.md"), """
+				---
+				name: reviewer
+				description: Reviews code.
+				# Reviewer
+				""");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("front matter"), exception.getMessage());
+	}
+
 	private void createAgent(String name, String model) {
 		writeString(tempDir.resolve(name + ".md"), """
 				---
@@ -145,6 +177,14 @@ class SubAgentFormatRuleTest {
 			Files.writeString(file, content);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private static String readString(Path file) {
+		try {
+			return Files.readString(file);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read " + file, e);
 		}
 	}
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
@@ -1,0 +1,164 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+
+class UniqueDescriptionsRuleTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesWhenDescriptionsAreUnique() {
+		writeAgent("reviewer", "Reviews code.");
+		writeAgent("planner", "Plans the work.");
+
+		assertDoesNotThrow(agentsRule()::execute);
+	}
+
+	@Test
+	void passesWhenNoDefinitionsExist() {
+		assertDoesNotThrow(agentsRule()::execute);
+	}
+
+	@Test
+	void failsWhenTwoAgentsShareADescription() {
+		writeAgent("reviewer", "Reviews code.");
+		writeAgent("checker", "Reviews code.");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, agentsRule()::execute);
+		assertTrue(exception.getMessage().contains("Reviews code."), exception.getMessage());
+		assertTrue(exception.getMessage().contains("reviewer.md"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("checker.md"), exception.getMessage());
+	}
+
+	@Test
+	void ignoresCaseAndWhitespaceWhenComparing() {
+		writeAgent("reviewer", "Reviews   code.");
+		writeAgent("checker", "reviews code.");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, agentsRule()::execute);
+		assertTrue(exception.getMessage().contains("is used by 2"), exception.getMessage());
+	}
+
+	@Test
+	void catchesAClashBetweenAnAgentAndASkill() {
+		writeAgent("reviewer", "Reviews code.");
+		writeSkill("inspect", "Reviews code.");
+		UniqueDescriptionsRule rule = new UniqueDescriptionsRule();
+		rule.setAgentsDir(agentsDir().toFile());
+		rule.setSkillsDir(skillsDir().toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("is used by 2"), exception.getMessage());
+	}
+
+	@Test
+	void skipsBlankAndMissingDescriptions() {
+		writeAgent("reviewer", " ");
+		writeAgentWithoutDescription("planner");
+
+		assertDoesNotThrow(agentsRule()::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				new UniqueDescriptionsRule()::execute);
+		assertTrue(exception.getMessage().contains("must be configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenDirectoryIsMissing() {
+		UniqueDescriptionsRule rule = new UniqueDescriptionsRule();
+		rule.setAgentsDir(tempDir.resolve("absent").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void warnsInsteadOfFailingWhenSeverityIsWarn() {
+		writeAgent("reviewer", "Reviews code.");
+		writeAgent("checker", "Reviews code.");
+		UniqueDescriptionsRule rule = agentsRule();
+		rule.setSeverity("warn");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("Reviews code.")), logger.warnings().toString());
+	}
+
+	private UniqueDescriptionsRule agentsRule() {
+		UniqueDescriptionsRule rule = new UniqueDescriptionsRule();
+		rule.setAgentsDir(agentsDir().toFile());
+		return rule;
+	}
+
+	private void writeAgent(String name, String description) {
+		writeString(agentsDir().resolve(name + ".md"), """
+				---
+				name: %s
+				description: %s
+				---
+				# %s
+				""".formatted(name, description, name));
+	}
+
+	private void writeAgentWithoutDescription(String name) {
+		writeString(agentsDir().resolve(name + ".md"), """
+				---
+				name: %s
+				---
+				# %s
+				""".formatted(name, name));
+	}
+
+	private void writeSkill(String name, String description) {
+		writeString(skillsDir().resolve(name).resolve("SKILL.md"), """
+				---
+				name: %s
+				description: %s
+				---
+				# %s
+				""".formatted(name, description, name));
+	}
+
+	private Path agentsDir() {
+		return createDirectories(tempDir.resolve("agents"));
+	}
+
+	private Path skillsDir() {
+		return createDirectories(tempDir.resolve("skills"));
+	}
+
+	private void writeString(Path file, String content) {
+		try {
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private static Path createDirectories(Path dir) {
+		try {
+			return Files.createDirectories(dir);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create " + dir, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
@@ -1,0 +1,155 @@
+package io.github.adamw7.tools.enforcer.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+
+class McpConfigFormatRuleTest {
+
+	private static final String VALID_MCP = """
+			{
+			  "mcpServers": {
+			    "filesystem": {
+			      "command": "npx",
+			      "args": [ "-y", "@modelcontextprotocol/server-filesystem" ],
+			      "env": { "ROOT": "/srv" }
+			    },
+			    "remote": {
+			      "type": "sse",
+			      "url": "https://example.com/sse",
+			      "headers": { "Authorization": "Bearer x" }
+			    }
+			  }
+			}
+			""";
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesForAValidConfiguration() {
+		assertDoesNotThrow(ruleFor(VALID_MCP)::execute);
+	}
+
+	@Test
+	void passesWhenFileIsAbsentBecauseMcpJsonIsOptional() {
+		McpConfigFormatRule rule = new McpConfigFormatRule();
+		rule.setMcpFile(tempDir.resolve("absent.json").toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new McpConfigFormatRule()::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenArgsIsNotAnArray() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"args\": \"-y\" } } }")::execute);
+		assertTrue(exception.getMessage().contains("'args' that is not an array"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenArgsHasANonStringEntry() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"args\": [ 7 ] } } }")::execute);
+		assertTrue(exception.getMessage().contains("non-string entry in 'args'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenEnvIsNotAnObject() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"env\": [ ] } } }")::execute);
+		assertTrue(exception.getMessage().contains("'env' that is not an object"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAnEnvValueIsNotAString() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"env\": { \"PORT\": 8080 } } } }")::execute);
+		assertTrue(exception.getMessage().contains("non-string value for 'env.PORT'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAHeaderValueIsNotAString() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(
+				"{ \"mcpServers\": { \"r\": { \"type\": \"http\", \"url\": \"https://x.io\", \"headers\": { \"X\": 1 } } } }")
+						::execute);
+		assertTrue(exception.getMessage().contains("non-string value for 'headers.X'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenUrlIsMalformed() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"r\": { \"type\": \"sse\", \"url\": \"not a url\" } } }")::execute);
+		assertTrue(exception.getMessage().contains("malformed 'url'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAServerDeclaresBothCommandAndUrl() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(
+				"{ \"mcpServers\": { \"x\": { \"command\": \"npx\", \"url\": \"https://x.io\" } } }")::execute);
+		assertTrue(exception.getMessage().contains("declares both a 'command' and a 'url'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenHttpsIsRequiredButUrlIsPlainHttp() {
+		McpConfigFormatRule rule = ruleFor(
+				"{ \"mcpServers\": { \"r\": { \"type\": \"http\", \"url\": \"http://x.io\" } } }");
+		rule.setRequireHttps(true);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("must use an https 'url'"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenHttpsIsRequiredAndUrlIsHttps() {
+		McpConfigFormatRule rule = ruleFor(
+				"{ \"mcpServers\": { \"r\": { \"type\": \"http\", \"url\": \"https://x.io\" } } }");
+		rule.setRequireHttps(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void warnsInsteadOfFailingWhenSeverityIsWarn() {
+		McpConfigFormatRule rule = ruleFor(
+				"{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"args\": \"-y\" } } }");
+		rule.setSeverity("warn");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("args")), logger.warnings().toString());
+	}
+
+	private McpConfigFormatRule ruleFor(String content) {
+		Path file = tempDir.resolve(".mcp.json");
+		writeString(file, content);
+		McpConfigFormatRule rule = new McpConfigFormatRule();
+		rule.setMcpFile(file.toFile());
+		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -1,0 +1,181 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+
+class HooksFormatRuleTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesWhenHooksDirectoryIsAbsent() {
+		HooksFormatRule rule = new HooksFormatRule();
+		rule.setHooksDir(tempDir.resolve("hooks").toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void passesForAWellFormedExecutableScript() {
+		writeScript("session-start.sh", "#!/bin/sh\necho hi\n", true);
+
+		assertDoesNotThrow(ruleFor()::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new HooksFormatRule()::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenScriptHasNoShebang() {
+		writeScript("session-start.sh", "echo hi\n", true);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
+		assertTrue(exception.getMessage().contains("shebang"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenScriptIsNotExecutable() {
+		writeScript("session-start.sh", "#!/bin/sh\n", false);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
+		assertTrue(exception.getMessage().contains("not executable"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenScriptIsEmpty() {
+		writeScript("session-start.sh", "   \n", true);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
+		assertTrue(exception.getMessage().contains("empty"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenExtensionIsNotAllowed() {
+		writeScript("notes.txt", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setAllowedExtensions(List.of("sh"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("disallowed extension"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenScriptChecksAreDisabled() {
+		writeScript("session-start.sh", "echo hi\n", false);
+		HooksFormatRule rule = ruleFor();
+		rule.setRequireShebang(false);
+		rule.setRequireExecutable(false);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenSettingsReferencesAMissingHookScript() {
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("$CLAUDE_PROJECT_DIR/.claude/hooks/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("references a missing hook script"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenSettingsReferencesAnExistingScript() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenAScriptIsUnreferenced() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		writeScript("orphan.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setReportUnreferencedScripts(true);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("not referenced"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("orphan.sh"), exception.getMessage());
+	}
+
+	@Test
+	void warnSeverityLogsInsteadOfFailing() {
+		writeScript("session-start.sh", "echo hi\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSeverity("warn");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("shebang")), logger.warnings().toString());
+	}
+
+	private HooksFormatRule ruleFor() {
+		HooksFormatRule rule = new HooksFormatRule();
+		rule.setHooksDir(hooksDir().toFile());
+		return rule;
+	}
+
+	private File settingsReferencing(String command) {
+		Path file = tempDir.resolve(".claude").resolve("settings.json");
+		writeString(file, """
+				{ "hooks": { "SessionStart": [ { "hooks": [ { "type": "command", "command": "%s" } ] } ] } }
+				""".formatted(command));
+		return file.toFile();
+	}
+
+	private Path hooksDir() {
+		Path dir = tempDir.resolve(".claude").resolve("hooks");
+		createDirectories(dir);
+		return dir;
+	}
+
+	private void writeScript(String name, String content, boolean executable) {
+		Path file = hooksDir().resolve(name);
+		writeString(file, content);
+		if (!file.toFile().setExecutable(executable)) {
+			throw new IllegalStateException("Could not set executable bit on " + file);
+		}
+	}
+
+	private void writeString(Path file, String content) {
+		try {
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private static void createDirectories(Path dir) {
+		try {
+			Files.createDirectories(dir);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create " + dir, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
@@ -1,0 +1,118 @@
+package io.github.adamw7.tools.enforcer.text;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+class FrontMatterFixerTest {
+
+	@Test
+	void leavesWellFormedFrontMatterUntouched() {
+		String content = """
+				---
+				name: reviewer
+				description: Reviews code.
+				---
+				# Reviewer
+				""";
+
+		assertTrue(FrontMatterFixer.repair(content).isEmpty());
+	}
+
+	@Test
+	void insertsAMissingClosingDelimiter() {
+		String content = """
+				---
+				name: reviewer
+				description: Reviews code.
+				# Reviewer
+				""";
+
+		Optional<String> repaired = FrontMatterFixer.repair(content);
+
+		assertTrue(repaired.isPresent());
+		assertTrue(FrontMatter.parse(repaired.get()).isPresent(), repaired.get());
+		assertTrue(FrontMatter.parse(repaired.get()).get().hasKey("description"), repaired.get());
+	}
+
+	@Test
+	void normalizesAnOverDashedClosingDelimiter() {
+		String content = """
+				---
+				name: reviewer
+				----
+				# Reviewer
+				""";
+
+		Optional<String> repaired = FrontMatterFixer.repair(content);
+
+		assertTrue(repaired.isPresent());
+		assertTrue(FrontMatter.parse(repaired.get()).isPresent(), repaired.get());
+	}
+
+	@Test
+	void normalizesOverDashedOpeningAndClosingDelimiters() {
+		String content = """
+				----
+				name: reviewer
+				description: Reviews code.
+				----
+				body
+				""";
+
+		Optional<String> repaired = FrontMatterFixer.repair(content);
+
+		assertTrue(repaired.isPresent());
+		assertTrue(repaired.get().startsWith("---\n"), repaired.get());
+		assertTrue(FrontMatter.parse(repaired.get()).get().hasKey("name"), repaired.get());
+	}
+
+	@Test
+	void doesNotMistakeALoneThematicBreakForFrontMatter() {
+		String content = """
+				---
+				Just some prose, no keys here.
+				""";
+
+		assertTrue(FrontMatterFixer.repair(content).isEmpty());
+	}
+
+	@Test
+	void leavesContentWithoutAFrontMatterIntentUntouched() {
+		String content = """
+				# Title
+
+				Body text.
+				""";
+
+		assertTrue(FrontMatterFixer.repair(content).isEmpty());
+	}
+
+	@Test
+	void preservesTheAbsenceOfATrailingNewline() {
+		String content = "---\nname: reviewer\ndescription: Reviews code.\n# Reviewer";
+
+		Optional<String> repaired = FrontMatterFixer.repair(content);
+
+		assertTrue(repaired.isPresent());
+		assertFalse(repaired.get().endsWith("\n"), repaired.get());
+	}
+
+	@Test
+	void closesFrontMatterThatHasNoBody() {
+		String content = """
+				---
+				name: reviewer
+				description: Reviews code.
+				""";
+
+		Optional<String> repaired = FrontMatterFixer.repair(content);
+
+		assertTrue(repaired.isPresent());
+		assertEquals("---\nname: reviewer\ndescription: Reviews code.\n---\n", repaired.get());
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,9 @@
 										<uniqueNames>
 											<skillsDir>${project.basedir}/.claude/skills</skillsDir>
 										</uniqueNames>
+										<uniqueDescriptions>
+											<skillsDir>${project.basedir}/.claude/skills</skillsDir>
+										</uniqueDescriptions>
 										<settingsJsonValid>
 											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
 										</settingsJsonValid>
@@ -417,9 +420,17 @@
 											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
 											<projectDir>${project.basedir}</projectDir>
 										</hookCommandsValid>
+										<hooksFormat>
+											<hooksDir>${project.basedir}/.claude/hooks</hooksDir>
+											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
+											<projectDir>${project.basedir}</projectDir>
+										</hooksFormat>
 										<mcpServersValid>
 											<mcpFile>${project.basedir}/.mcp.json</mcpFile>
 										</mcpServersValid>
+										<mcpConfigFormat>
+											<mcpFile>${project.basedir}/.mcp.json</mcpFile>
+										</mcpConfigFormat>
 										<crossDocConsistency>
 											<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
 											<agentsMdFile>${project.basedir}/AGENTS.md</agentsMdFile>


### PR DESCRIPTION
Extend claude-code-enforcer with three new rules and an auto-fix mode:

- hooksFormat: validates .claude/hooks/* scripts (non-empty, shebang,
  executable bit, optional extension whitelist) and cross-checks
  settings.json command hooks that resolve into the hooks directory,
  with optional reporting of unreferenced scripts.
- mcpConfigFormat: validates the details of each .mcp.json server entry
  left unchecked by mcpServersValid (args/env/headers types, url syntax,
  optional https requirement, and conflicting command+url transports).
- uniqueDescriptions: fails when two sub-agents, commands, or skills
  share a description (case- and whitespace-insensitive), since Claude
  routes by matching intent against descriptions.
- autoFix option on skillFilesExist, subAgentFormat and commandFormat:
  rewrites safely-repairable malformed front matter (over-dashed or
  missing closing delimiters) in place instead of failing the build,
  backed by a conservative FrontMatterFixer.

Register the new rules in the sisu index, wire them into the root pom
enforce profile, document them in the README, and add unit tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014f46T9YStNsdpmHchd1bWM