### PR TITLE
refactor(enforcer): remove duplication across Claude Code rules

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -34,7 +34,6 @@ import io.github.adamw7.tools.enforcer.text.NameConvention;
 public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 
 	private static final String DESCRIPTION_KEY = "description";
-	private static final String MODEL_KEY = "model";
 
 	/** The {@code .claude/commands} directory to scan. Injected from the rule configuration. */
 	private File commandsDir;
@@ -50,19 +49,13 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 
 	@Override
 	public void execute() throws EnforcerRuleException {
-		verifyConfigured();
+		requireConfigured(commandsDir, "commandsDir");
 		DefinitionFiles.verifyDirectory(commandsDir, "Commands");
 		List<String> violations = new ArrayList<>();
 		for (File command : DefinitionFiles.markdownFiles(commandsDir)) {
 			collectCommandViolations(command, violations);
 		}
 		report("Command files are not well formed:", violations);
-	}
-
-	private void verifyConfigured() throws EnforcerRuleException {
-		if (commandsDir == null) {
-			throw new EnforcerRuleException("The commandsDir parameter is not configured");
-		}
 	}
 
 	private void collectCommandViolations(File command, List<String> violations) {
@@ -85,7 +78,7 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 	private void collectFrontMatterViolations(File command, FrontMatter frontMatter, List<String> violations) {
 		collectUnknownKeys(command, frontMatter, violations);
 		collectDescriptionViolations(command, frontMatter, violations);
-		collectModelViolations(command, frontMatter, violations);
+		ModelAllowlist.collect(allowedModels, frontMatter, "Command", command, violations);
 	}
 
 	private void collectUnknownKeys(File command, FrontMatter frontMatter, List<String> violations) {
@@ -110,19 +103,6 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 	private void addDescriptionViolation(File command, String description, List<String> violations) {
 		if (description.isBlank()) {
 			violations.add("Command description must not be empty in: " + command);
-		}
-	}
-
-	private void collectModelViolations(File command, FrontMatter frontMatter, List<String> violations) {
-		if (allowedModels == null) {
-			return;
-		}
-		frontMatter.value(MODEL_KEY).ifPresent(model -> addModelViolation(command, model, violations));
-	}
-
-	private void addModelViolation(File command, String model, List<String> violations) {
-		if (!allowedModels.contains(model)) {
-			violations.add("Command declares unsupported model '" + model + "' in: " + command);
 		}
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/ModelAllowlist.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/ModelAllowlist.java
@@ -1,0 +1,40 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import java.io.File;
+import java.util.List;
+
+import io.github.adamw7.tools.enforcer.text.FrontMatter;
+
+/**
+ * Shared {@code model} front matter check for the definition format rules. When a
+ * whitelist of allowed model identifiers is configured and a definition declares
+ * a {@code model} outside it, a violation is reported, so a typo such as
+ * {@code claud-opus} cannot slip through. An unconfigured whitelist allows any
+ * model.
+ */
+final class ModelAllowlist {
+
+	private static final String MODEL_KEY = "model";
+
+	private ModelAllowlist() {
+	}
+
+	/**
+	 * @param allowedModels the configured whitelist, or {@code null} to allow any model
+	 * @param label         how the definition is named in the message (e.g. {@code Command})
+	 */
+	static void collect(List<String> allowedModels, FrontMatter frontMatter, String label, File file,
+			List<String> violations) {
+		if (allowedModels == null) {
+			return;
+		}
+		frontMatter.value(MODEL_KEY).ifPresent(model -> addViolation(allowedModels, model, label, file, violations));
+	}
+
+	private static void addViolation(List<String> allowedModels, String model, String label, File file,
+			List<String> violations) {
+		if (!allowedModels.contains(model)) {
+			violations.add(label + " declares unsupported model '" + model + "' in: " + file);
+		}
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/MultiDefinitionRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/MultiDefinitionRule.java
@@ -1,0 +1,105 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import java.io.File;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+
+/**
+ * Base for the enforcer rules that check a property across <em>every</em> Claude
+ * Code definition at once (currently uniqueness of names and of descriptions).
+ * They all scan the same three optional directories - {@code commandsDir},
+ * {@code agentsDir} and {@code skillsDir} - where a command and a sub-agent are
+ * each a {@code *.md} file and a skill is a directory containing a
+ * {@code SKILL.md}. This class owns that shared configuration and traversal so a
+ * subclass only describes what it does with each definition.
+ * <p>
+ * The three directories are independent: each is optional and at least one must
+ * be configured. A directory that is configured must exist, because that is a
+ * build-setup mistake rather than a content problem.
+ */
+abstract class MultiDefinitionRule extends ClaudeCodeEnforcerRule {
+
+	private static final String SKILL_FILE_NAME = "SKILL.md";
+
+	/** The {@code .claude/commands} directory to scan. Injected from the rule configuration. */
+	private File commandsDir;
+
+	/** The {@code .claude/agents} directory to scan. Injected from the rule configuration. */
+	private File agentsDir;
+
+	/** The {@code .claude/skills} directory to scan. Injected from the rule configuration. */
+	private File skillsDir;
+
+	/** Receives each definition discovered across the configured directories. */
+	@FunctionalInterface
+	interface DefinitionVisitor {
+		/**
+		 * @param definitionFile the Markdown file carrying the definition (the
+		 *                        {@code *.md} for commands and sub-agents, the
+		 *                        {@code SKILL.md} for skills)
+		 * @param source          the file or directory that names the definition
+		 * @param name            the definition's name (file base name, or skill
+		 *                        directory name)
+		 */
+		void visit(File definitionFile, File source, String name);
+	}
+
+	protected final void verifyConfigured() throws EnforcerRuleException {
+		if (commandsDir == null && agentsDir == null && skillsDir == null) {
+			throw new EnforcerRuleException(
+					"At least one of commandsDir, agentsDir or skillsDir must be configured");
+		}
+	}
+
+	/**
+	 * Walks every configured directory and hands each definition to {@code visitor}.
+	 * Commands and sub-agents are the {@code *.md} files in their directories; skills
+	 * are the immediate subdirectories of {@code skillsDir}.
+	 */
+	protected final void forEachDefinition(DefinitionVisitor visitor) throws EnforcerRuleException {
+		visitMarkdown(commandsDir, "Commands", visitor);
+		visitMarkdown(agentsDir, "Agents", visitor);
+		visitSkills(skillsDir, visitor);
+	}
+
+	private void visitMarkdown(File directory, String label, DefinitionVisitor visitor)
+			throws EnforcerRuleException {
+		if (directory == null) {
+			return;
+		}
+		DefinitionFiles.verifyDirectory(directory, label);
+		for (File markdown : DefinitionFiles.markdownFiles(directory)) {
+			visitor.visit(markdown, markdown, DefinitionFiles.baseName(markdown));
+		}
+	}
+
+	private void visitSkills(File directory, DefinitionVisitor visitor) throws EnforcerRuleException {
+		if (directory == null) {
+			return;
+		}
+		DefinitionFiles.verifyDirectory(directory, "Skills");
+		for (File skill : DefinitionFiles.subdirectories(directory)) {
+			visitor.visit(new File(skill, SKILL_FILE_NAME), skill, skill.getName());
+		}
+	}
+
+	void setCommandsDir(File commandsDir) {
+		this.commandsDir = commandsDir;
+	}
+
+	void setAgentsDir(File agentsDir) {
+		this.agentsDir = agentsDir;
+	}
+
+	void setSkillsDir(File skillsDir) {
+		this.skillsDir = skillsDir;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%s[commandsDir=%s, agentsDir=%s, skillsDir=%s]",
+				getClass().getSimpleName(), commandsDir, agentsDir, skillsDir);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -58,19 +58,13 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 
 	@Override
 	public void execute() throws EnforcerRuleException {
-		verifyConfigured();
+		requireConfigured(skillsDir, "skillsDir");
 		DefinitionFiles.verifyDirectory(skillsDir, "Skills");
 		List<String> violations = new ArrayList<>();
 		for (File skillDirectory : DefinitionFiles.subdirectories(skillsDir)) {
 			collectSkillViolations(skillDirectory, violations);
 		}
 		report("Skill files are not well formed:", violations);
-	}
-
-	private void verifyConfigured() throws EnforcerRuleException {
-		if (skillsDir == null) {
-			throw new EnforcerRuleException("The skillsDir parameter is not configured");
-		}
 	}
 
 	private void collectSkillViolations(File skillDirectory, List<String> violations) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -32,7 +32,6 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 
 	private static final String NAME_KEY = "name";
 	private static final String DESCRIPTION_KEY = "description";
-	private static final String MODEL_KEY = "model";
 	private static final List<String> DEFAULT_REQUIRED_KEYS = List.of(NAME_KEY, DESCRIPTION_KEY);
 
 	/** The {@code .claude/agents} directory to scan. Injected from the rule configuration. */
@@ -49,19 +48,13 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 
 	@Override
 	public void execute() throws EnforcerRuleException {
-		verifyConfigured();
+		requireConfigured(agentsDir, "agentsDir");
 		DefinitionFiles.verifyDirectory(agentsDir, "Agents");
 		List<String> violations = new ArrayList<>();
 		for (File definition : DefinitionFiles.markdownFiles(agentsDir)) {
 			collectDefinitionViolations(definition, violations);
 		}
 		report("Sub-agent files are not well formed:", violations);
-	}
-
-	private void verifyConfigured() throws EnforcerRuleException {
-		if (agentsDir == null) {
-			throw new EnforcerRuleException("The agentsDir parameter is not configured");
-		}
 	}
 
 	private void collectDefinitionViolations(File definition, List<String> violations) {
@@ -87,7 +80,7 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 	private void collectFrontMatterViolations(File definition, FrontMatter frontMatter, List<String> violations) {
 		collectMissingKeys(definition, frontMatter, violations);
 		collectNameViolations(definition, frontMatter, violations);
-		collectModelViolations(definition, frontMatter, violations);
+		ModelAllowlist.collect(allowedModels, frontMatter, "Sub-agent", definition, violations);
 	}
 
 	private void collectMissingKeys(File definition, FrontMatter frontMatter, List<String> violations) {
@@ -101,19 +94,6 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 	private void collectNameViolations(File definition, FrontMatter frontMatter, List<String> violations) {
 		frontMatter.value(NAME_KEY).ifPresent(
 				name -> NameConvention.collect(name, DefinitionFiles.baseName(definition), definition.toString(), violations));
-	}
-
-	private void collectModelViolations(File definition, FrontMatter frontMatter, List<String> violations) {
-		if (allowedModels == null) {
-			return;
-		}
-		frontMatter.value(MODEL_KEY).ifPresent(model -> addModelViolation(definition, model, violations));
-	}
-
-	private void addModelViolation(File definition, String model, List<String> violations) {
-		if (!allowedModels.contains(model)) {
-			violations.add("Sub-agent declares unsupported model '" + model + "' in: " + definition);
-		}
 	}
 
 	private List<String> requiredKeys() {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRule.java
@@ -11,7 +11,6 @@ import javax.inject.Named;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
-import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.enforcer.text.FrontMatter;
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
@@ -28,63 +27,19 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * Comparison ignores case and runs of whitespace, so {@code Reviews code.} and
  * {@code reviews   code.} are treated as the same description. Definitions with
  * no description, or a blank one, are skipped here because the format rules
- * already report those. The three directories ({@code commandsDir},
- * {@code agentsDir}, {@code skillsDir}) are each optional and at least one must
- * be configured; a configured directory must exist. All clashes are reported
- * together.
+ * already report those. All clashes are reported together.
  */
 @Named("uniqueDescriptions")
-public class UniqueDescriptionsRule extends ClaudeCodeEnforcerRule {
+public class UniqueDescriptionsRule extends MultiDefinitionRule {
 
 	private static final String DESCRIPTION_KEY = "description";
-	private static final String SKILL_FILE_NAME = "SKILL.md";
-
-	/** The {@code .claude/commands} directory to scan. Injected from the rule configuration. */
-	private File commandsDir;
-
-	/** The {@code .claude/agents} directory to scan. Injected from the rule configuration. */
-	private File agentsDir;
-
-	/** The {@code .claude/skills} directory to scan. Injected from the rule configuration. */
-	private File skillsDir;
 
 	@Override
 	public void execute() throws EnforcerRuleException {
 		verifyConfigured();
 		Map<String, Description> byNormalizedText = new LinkedHashMap<>();
-		collectMarkdownDescriptions(commandsDir, "Commands", byNormalizedText);
-		collectMarkdownDescriptions(agentsDir, "Agents", byNormalizedText);
-		collectSkillDescriptions(skillsDir, byNormalizedText);
+		forEachDefinition((definitionFile, source, name) -> record(definitionFile, source, byNormalizedText));
 		report("Claude Code descriptions must be unique:", duplicates(byNormalizedText));
-	}
-
-	private void verifyConfigured() throws EnforcerRuleException {
-		if (commandsDir == null && agentsDir == null && skillsDir == null) {
-			throw new EnforcerRuleException(
-					"At least one of commandsDir, agentsDir or skillsDir must be configured");
-		}
-	}
-
-	private void collectMarkdownDescriptions(File directory, String label, Map<String, Description> byText)
-			throws EnforcerRuleException {
-		if (directory == null) {
-			return;
-		}
-		DefinitionFiles.verifyDirectory(directory, label);
-		for (File markdown : DefinitionFiles.markdownFiles(directory)) {
-			record(markdown, markdown, byText);
-		}
-	}
-
-	private void collectSkillDescriptions(File directory, Map<String, Description> byText)
-			throws EnforcerRuleException {
-		if (directory == null) {
-			return;
-		}
-		DefinitionFiles.verifyDirectory(directory, "Skills");
-		for (File skill : DefinitionFiles.subdirectories(directory)) {
-			record(new File(skill, SKILL_FILE_NAME), skill, byText);
-		}
 	}
 
 	private void record(File definitionFile, File source, Map<String, Description> byText) {
@@ -115,24 +70,6 @@ public class UniqueDescriptionsRule extends ClaudeCodeEnforcerRule {
 			description.addDuplicateViolation(violations);
 		}
 		return violations;
-	}
-
-	void setCommandsDir(File commandsDir) {
-		this.commandsDir = commandsDir;
-	}
-
-	void setAgentsDir(File agentsDir) {
-		this.agentsDir = agentsDir;
-	}
-
-	void setSkillsDir(File skillsDir) {
-		this.skillsDir = skillsDir;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("UniqueDescriptionsRule[commandsDir=%s, agentsDir=%s, skillsDir=%s]",
-				commandsDir, agentsDir, skillsDir);
 	}
 
 	/** A description's original text and the sources that declare an equivalent of it. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRule.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.enforcer.definition;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -9,8 +8,6 @@ import java.util.Map;
 import javax.inject.Named;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-
-import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 
 /**
  * Enforcer rule that fails the build when two Claude Code definitions claim the
@@ -21,63 +18,19 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
  * from every configured directory and reports each name that is used more than
  * once, naming every file or directory that uses it.
  * <p>
- * The three directories are independent: {@code commandsDir}, {@code agentsDir}
- * and {@code skillsDir} are each optional, and at least one must be configured.
- * A directory that is configured must exist, because that is a build-setup
- * mistake rather than a naming problem. Uniqueness is checked across every
- * configured directory at once, so a clash between a command and a skill is
- * caught just like a clash between two commands. All clashes found are reported
- * together.
+ * Uniqueness is checked across every configured directory at once, so a clash
+ * between a command and a skill is caught just like a clash between two commands.
+ * All clashes found are reported together.
  */
 @Named("uniqueNames")
-public class UniqueNamesRule extends ClaudeCodeEnforcerRule {
-
-	/** The {@code .claude/commands} directory to scan. Injected from the rule configuration. */
-	private File commandsDir;
-
-	/** The {@code .claude/agents} directory to scan. Injected from the rule configuration. */
-	private File agentsDir;
-
-	/** The {@code .claude/skills} directory to scan. Injected from the rule configuration. */
-	private File skillsDir;
+public class UniqueNamesRule extends MultiDefinitionRule {
 
 	@Override
 	public void execute() throws EnforcerRuleException {
 		verifyConfigured();
 		Map<String, List<String>> sourcesByName = new LinkedHashMap<>();
-		collectMarkdownNames(commandsDir, "Commands", sourcesByName);
-		collectMarkdownNames(agentsDir, "Agents", sourcesByName);
-		collectSkillNames(skillsDir, sourcesByName);
+		forEachDefinition((definitionFile, source, name) -> record(name, source.toString(), sourcesByName));
 		report("Claude Code names must be unique:", duplicates(sourcesByName));
-	}
-
-	private void verifyConfigured() throws EnforcerRuleException {
-		if (commandsDir == null && agentsDir == null && skillsDir == null) {
-			throw new EnforcerRuleException(
-					"At least one of commandsDir, agentsDir or skillsDir must be configured");
-		}
-	}
-
-	private void collectMarkdownNames(File directory, String label, Map<String, List<String>> sourcesByName)
-			throws EnforcerRuleException {
-		if (directory == null) {
-			return;
-		}
-		DefinitionFiles.verifyDirectory(directory, label);
-		for (File markdown : DefinitionFiles.markdownFiles(directory)) {
-			record(DefinitionFiles.baseName(markdown), markdown.toString(), sourcesByName);
-		}
-	}
-
-	private void collectSkillNames(File directory, Map<String, List<String>> sourcesByName)
-			throws EnforcerRuleException {
-		if (directory == null) {
-			return;
-		}
-		DefinitionFiles.verifyDirectory(directory, "Skills");
-		for (File skill : DefinitionFiles.subdirectories(directory)) {
-			record(skill.getName(), skill.toString(), sourcesByName);
-		}
 	}
 
 	private void record(String name, String source, Map<String, List<String>> sourcesByName) {
@@ -98,23 +51,5 @@ public class UniqueNamesRule extends ClaudeCodeEnforcerRule {
 			violations.add("name '" + entry.getKey() + "' is used by " + sources.size()
 					+ " definitions: " + String.join(", ", sources));
 		}
-	}
-
-	void setCommandsDir(File commandsDir) {
-		this.commandsDir = commandsDir;
-	}
-
-	void setAgentsDir(File agentsDir) {
-		this.agentsDir = agentsDir;
-	}
-
-	void setSkillsDir(File skillsDir) {
-		this.skillsDir = skillsDir;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("UniqueNamesRule[commandsDir=%s, agentsDir=%s, skillsDir=%s]",
-				commandsDir, agentsDir, skillsDir);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -51,6 +51,17 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 		return WARN.equalsIgnoreCase(severity);
 	}
 
+	/**
+	 * Fails when a required directory parameter was not configured, which is a
+	 * build-setup mistake rather than a content problem and so always fails
+	 * regardless of {@link #severity}.
+	 */
+	protected final void requireConfigured(Object parameter, String name) throws EnforcerRuleException {
+		if (parameter == null) {
+			throw new EnforcerRuleException("The " + name + " parameter is not configured");
+		}
+	}
+
 	public void setSeverity(String severity) {
 		this.severity = severity;
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -78,7 +78,7 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 
 	@Override
 	public void execute() throws EnforcerRuleException {
-		verifyConfigured();
+		requireConfigured(hooksDir, "hooksDir");
 		List<String> violations = new ArrayList<>();
 		List<File> scripts = scriptFiles();
 		for (File script : scripts) {
@@ -86,12 +86,6 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 		}
 		collectWiringViolations(scripts, violations);
 		report("Hook scripts are not well formed:", violations);
-	}
-
-	private void verifyConfigured() throws EnforcerRuleException {
-		if (hooksDir == null) {
-			throw new EnforcerRuleException("The hooksDir parameter is not configured");
-		}
 	}
 
 	private List<File> scriptFiles() {


### PR DESCRIPTION
Extract a MultiDefinitionRule base for the rules that scan all three
definition directories (UniqueNamesRule, UniqueDescriptionsRule),
owning the shared commandsDir/agentsDir/skillsDir configuration, the
"at least one configured" check, directory traversal, and toString.

Add a shared requireConfigured(...) helper on ClaudeCodeEnforcerRule for
the single-directory rules, and a ModelAllowlist helper for the model
front-matter check shared by CommandFormatRule and SubAgentFormatRule.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013T8PYaqwuKnq7W6QvTqYkD