### PR TITLE
build: add Maven Central publishing via Sonatype Central Portal

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -1,0 +1,51 @@
+# Publishes signed library artifacts to Maven Central (Sonatype Central Portal)
+# when a GitHub release is created. The example/test/app modules
+# (grpc-example, protogen-maven-plugin-test, assembly) set maven.deploy.skip
+# and are excluded from the deployment.
+#
+# Required repository secrets:
+#   MAVEN_CENTRAL_USERNAME  - Central Portal user token name
+#   MAVEN_CENTRAL_PASSWORD  - Central Portal user token password
+#   MAVEN_GPG_PRIVATE_KEY   - ASCII-armored GPG private key used for signing
+#   MAVEN_GPG_PASSPHRASE    - passphrase for that GPG key
+
+name: Publish to Maven Central
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+          # Creates a settings.xml server entry with id "central" whose
+          # username/password come from the env vars below, and imports the
+          # signing key so the maven-gpg-plugin can sign artifacts.
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Bootstrap CLAUDE.md enforcer rule
+        # The custom enforcer rule is consumed as a plugin dependency by the
+        # root build, so it must be installed to the local repo first.
+        run: mvn -B -pl claude-code-enforcer -am install
+
+      - name: Publish to Maven Central
+        run: mvn -B -P release deploy
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,27 @@ To release version `X`:
 3. Confirm all builds pass.
 4. Release and mark as latest in GitHub.
 
+Creating the GitHub release fires two workflows:
+
+- `maven-publish.yml` deploys to **GitHub Packages** (the default `mvn deploy`,
+  using the `distributionManagement` repository).
+- `central-publish.yml` deploys to **Maven Central** via the Sonatype Central
+  Portal. It runs `mvn -P release deploy`; the `release` profile attaches the
+  sources and javadoc jars, GPG-signs every artifact, and hands the bundle to
+  the `central-publishing-maven-plugin` (`autoPublish=true`).
+
+Maven Central publishing is **opt-in** through the `release` profile, so
+ordinary and CI builds never need GPG keys or Central credentials. The release
+job requires four repository secrets: `MAVEN_CENTRAL_USERNAME` and
+`MAVEN_CENTRAL_PASSWORD` (a Central Portal user token), plus
+`MAVEN_GPG_PRIVATE_KEY` and `MAVEN_GPG_PASSPHRASE` (the signing key). Only the
+reusable library modules are published; the example/test/app modules
+(`grpc-example`, `protogen-maven-plugin-test`, `assembly`) set
+`maven.deploy.skip` and are excluded from both deployments.
+
+To publish from a workstation: `mvn -P release deploy` with the same `central`
+server credentials in `~/.m2/settings.xml` and a GPG key on the keyring.
+
 ## Pull requests & commits
 
 - Use clear, descriptive, conventional commit messages.

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -11,6 +11,11 @@
 	<packaging>jar</packaging>
 	<name>assembly</name>
 	<url>https://maven.apache.org</url>
+	<properties>
+		<!-- Executable jar-with-dependencies bundle, not a reusable library;
+		     keep it out of Maven Central / GitHub Packages deployments. -->
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
 	<build>
 		<plugins>
 			<plugin>

--- a/code/protogen-maven-plugin-test/pom.xml
+++ b/code/protogen-maven-plugin-test/pom.xml
@@ -15,6 +15,8 @@
 		<!-- This module only exercises generated protobuf classes, so the
 		     instruction-coverage gate is not meaningful here. -->
 		<jacoco.skip>true</jacoco.skip>
+		<!-- Integration-test module, not a published library. -->
+		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
 	<build>
 		<plugins>

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -15,6 +15,8 @@
 		<!-- This module only exercises generated protobuf/gRPC classes, so the
 		     instruction-coverage gate is not meaningful here. -->
 		<jacoco.skip>true</jacoco.skip>
+		<!-- End-to-end example, not a published library. -->
+		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
 	<build>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
 	<version>${revision}</version>
 	<packaging>pom</packaging>
 	<name>Tools root pom</name>
-	<url>https://maven.apache.org</url>
+	<description>A library of Java tooling: compile-time-safe protobuf builder generation, a regex-based code-context finder with an MCP server, and data sources with uniqueness checking.</description>
+	<url>https://github.com/adamw7/tools</url>
 	<properties>
 		<revision>2.2.0-SNAPSHOT</revision>
 		<maven.compiler.source>25</maven.compiler.source>
@@ -37,6 +38,14 @@
 		<url>https://github.com/adamw7/tools</url>
 		<tag>HEAD</tag>
 	</scm>
+	<developers>
+		<developer>
+			<id>adamw7</id>
+			<name>Adam Witkowski</name>
+			<email>adamwitkowski3@gmail.com</email>
+			<url>https://github.com/adamw7</url>
+		</developer>
+	</developers>
 	<modules>
 		<module>claude-code-enforcer</module>
 		<module>mcp-common</module>
@@ -304,6 +313,26 @@
 						</dependency>
 					</dependencies>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>3.4.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>3.12.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-gpg-plugin</artifactId>
+					<version>3.2.8</version>
+				</plugin>
+				<plugin>
+					<groupId>org.sonatype.central</groupId>
+					<artifactId>central-publishing-maven-plugin</artifactId>
+					<version>0.11.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -520,6 +549,79 @@
 								</goals>
 							</execution>
 						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<!-- Publishes signed artifacts (sources, javadoc, GPG signatures)
+			     to Maven Central via the Sonatype Central Portal. Opt-in with
+			     -Prelease so ordinary and CI builds never need GPG keys or
+			     Central credentials. The central-publishing-maven-plugin runs
+			     with extensions enabled, so it takes over the deploy phase in
+			     place of the default maven-deploy-plugin (GitHub Packages). -->
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<doclint>none</doclint>
+							<failOnError>false</failOnError>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<!-- Non-interactive signing for CI; the passphrase
+							     is supplied via the gpg.passphrase property. -->
+							<gpgArguments>
+								<arg>--pinentry-mode</arg>
+								<arg>loopback</arg>
+							</gpgArguments>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<extensions>true</extensions>
+						<configuration>
+							<!-- Server credentials live under this id in settings.xml. -->
+							<publishingServerId>central</publishingServerId>
+							<autoPublish>true</autoPublish>
+							<waitUntil>published</waitUntil>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
Publish signed library artifacts to Maven Central in addition to the
existing GitHub Packages deployment.

- Add a `release` profile (opt-in via -Prelease) that attaches sources
  and javadoc jars, GPG-signs all artifacts, and deploys through the
  central-publishing-maven-plugin with autoPublish enabled.
- Add the required Central POM metadata: description, real project url,
  and developer information.
- Register maven-source, maven-javadoc, maven-gpg and
  central-publishing plugin versions in pluginManagement.
- Exclude the example/test/app modules (grpc-example,
  protogen-maven-plugin-test, assembly) from deployment via
  maven.deploy.skip, since Central is immutable and they are not
  reusable libraries.
- Add the central-publish.yml workflow that runs on GitHub releases.
- Document the release flow and required secrets in AGENTS.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MVWY3VhiBKrDDye62S3gZt