### PR TITLE
fix(release): exclude example modules from Maven Central via skipPublishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,9 +246,10 @@ ordinary and CI builds never need GPG keys or Central credentials. The release
 job requires four repository secrets: `MAVEN_CENTRAL_USERNAME` and
 `MAVEN_CENTRAL_PASSWORD` (a Central Portal user token), plus
 `MAVEN_GPG_PRIVATE_KEY` and `MAVEN_GPG_PASSPHRASE` (the signing key). Only the
-reusable library modules are published; the example/test/app modules
-(`grpc-example`, `protogen-maven-plugin-test`, `assembly`) set
-`maven.deploy.skip` and are excluded from both deployments.
+reusable library modules are published to Central; the example/test/app modules
+(`grpc-example`, `protogen-maven-plugin-test`, `assembly`) set the
+central-publishing plugin's `skipPublishing` property, so they are left out of
+the Central bundle while still deploying to GitHub Packages as before.
 
 To publish from a workstation: `mvn -P release deploy` with the same `central`
 server credentials in `~/.m2/settings.xml` and a GPG key on the keyring.

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -13,8 +13,8 @@
 	<url>https://maven.apache.org</url>
 	<properties>
 		<!-- Executable jar-with-dependencies bundle, not a reusable library;
-		     keep it out of Maven Central / GitHub Packages deployments. -->
-		<maven.deploy.skip>true</maven.deploy.skip>
+		     keep it out of the Maven Central deployment (release profile). -->
+		<skipPublishing>true</skipPublishing>
 	</properties>
 	<build>
 		<plugins>

--- a/code/protogen-maven-plugin-test/pom.xml
+++ b/code/protogen-maven-plugin-test/pom.xml
@@ -15,8 +15,9 @@
 		<!-- This module only exercises generated protobuf classes, so the
 		     instruction-coverage gate is not meaningful here. -->
 		<jacoco.skip>true</jacoco.skip>
-		<!-- Integration-test module, not a published library. -->
-		<maven.deploy.skip>true</maven.deploy.skip>
+		<!-- Integration-test module, not a published library; keep it out of
+		     the Maven Central deployment (release profile). -->
+		<skipPublishing>true</skipPublishing>
 	</properties>
 	<build>
 		<plugins>

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -15,8 +15,9 @@
 		<!-- This module only exercises generated protobuf/gRPC classes, so the
 		     instruction-coverage gate is not meaningful here. -->
 		<jacoco.skip>true</jacoco.skip>
-		<!-- End-to-end example, not a published library. -->
-		<maven.deploy.skip>true</maven.deploy.skip>
+		<!-- End-to-end example, not a published library; keep it out of the
+		     Maven Central deployment (release profile). -->
+		<skipPublishing>true</skipPublishing>
 	</properties>
 	<build>
 		<plugins>


### PR DESCRIPTION
## Summary

Follow-up to #300 (Maven Central publishing). Local end-to-end testing of the merged release build revealed that the example/test/app modules were **not** actually excluded from the Maven Central bundle, so this corrects the exclusion mechanism.

## The problem

#300 excluded `grpc-example`, `protogen-maven-plugin-test`, and `assembly` from publishing using `maven.deploy.skip`. The `central-publishing-maven-plugin` **does not honor `maven.deploy.skip`** — it has its own `skipPublishing` parameter. Two consequences:

- Those three non-library modules would have been published to Maven Central anyway (and Central is immutable).
- As a side effect, `maven.deploy.skip` dropped them from the existing **GitHub Packages** deployment, which was never intended.

## The fix

Switch the three modules from `maven.deploy.skip` to the plugin's `skipPublishing` property. This excludes them from the Central bundle while leaving the GitHub Packages deployment unchanged (the `release` profile, where the Central plugin is active, is the only place affected).

## Verification

Reproduced the full release flow locally (throwaway GPG key, dummy Central credentials):

- `mvn -Prelease package` builds `-sources` + `-javadoc` jars for every library module.
- GPG signing produces `.asc` files for each jar/sources/javadoc/pom.
- The assembled `central-bundle.zip` contains **only the seven library components** (root pom, `tools.code` pom, and the `claude-code-enforcer`, `mcp-common`, `data`, `context`, `protogen-maven-plugin` jars), each with signature and checksums.
- `grpc-example`, `protogen-maven-plugin-test`, and `assembly` are confirmed **absent** from the bundle.

The only step not exercisable locally is the final authenticated upload, which requires real Central credentials and a verified `io.github.adamw7` namespace.

## Notes for the first real release

- Verify the `io.github.adamw7` namespace in the Central Portal.
- Add repo secrets: `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `MAVEN_GPG_PRIVATE_KEY`, `MAVEN_GPG_PASSPHRASE`.
- Central rejects `-SNAPSHOT`; publish from a release `revision` (already in the AGENTS.md release steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVWY3VhiBKrDDye62S3gZt)_