### PR TITLE
ci: validate Maven Central signing secrets before GPG import

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -51,6 +51,38 @@ jobs:
       contents: read
 
     steps:
+      - name: Verify Maven Central signing secrets
+        # Fail fast with an actionable message. Otherwise a missing or
+        # malformed MAVEN_GPG_PRIVATE_KEY surfaces only as an opaque
+        # "gpg failed with exit code 2" from the setup-java import step.
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        run: |
+          missing=""
+          for name in MAVEN_CENTRAL_USERNAME MAVEN_CENTRAL_PASSWORD MAVEN_GPG_PRIVATE_KEY MAVEN_GPG_PASSPHRASE; do
+            if [ -z "${!name}" ]; then
+              missing="$missing $name"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required repository secret(s):$missing"
+            echo "Set them under Settings > Secrets and variables > Actions, then re-run the release."
+            exit 1
+          fi
+          case "$MAVEN_GPG_PRIVATE_KEY" in
+            *"BEGIN PGP PRIVATE KEY BLOCK"*) ;;
+            *)
+              echo "::error::MAVEN_GPG_PRIVATE_KEY is not an ASCII-armored GPG private key."
+              echo "Export it with: gpg --armor --export-secret-keys <KEY_ID>"
+              echo "and paste the entire block, including the BEGIN/END header lines and newlines."
+              exit 1
+              ;;
+          esac
+          echo "All required Maven Central secrets are present."
+
       - uses: actions/checkout@v6
       - name: Set up JDK 25
         uses: actions/setup-java@v5


### PR DESCRIPTION
The central publish job failed with an opaque 'gpg failed with exit
code 2' during setup-java's key import when MAVEN_GPG_PRIVATE_KEY is
empty or malformed. Add a preflight step that checks all required
secrets are present and that the private key is a well-formed
ASCII-armored block, failing early with an actionable message.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017yoHVxKsAgxRS4f4ULmEdo