### PR TITLE
ci: split Maven Central publish into its own workflow

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -1,0 +1,112 @@
+# Publishes signed artifacts to Maven Central, and offers a manual staged-only
+# dry run for validating the Maven Central bundle without releasing.
+#
+# The "central" job publishes signed artifacts to Maven Central (Sonatype
+# Central Portal) via the opt-in "release" profile. Publishing is bound to
+# the deploy phase, so it runs only here and never during an ordinary
+# `mvn install` build. It runs in two modes:
+#   * on release        -> full publish (autoPublish=true, waitUntil=published)
+#   * on workflow_dispatch -> staged-only dry run (autoPublish=false,
+#                            waitUntil=validated): the bundle is uploaded and
+#                            validated by Central but left staged, so nothing is
+#                            released. Drop or publish it manually in the portal.
+# Central rejects -SNAPSHOT versions, so trigger the dry run from a commit whose
+# revision is a real version, or pass a non-SNAPSHOT "revision" input.
+#
+# Required repository secrets for the Maven Central job:
+#   MAVEN_CENTRAL_USERNAME  - Central Portal user token name
+#   MAVEN_CENTRAL_PASSWORD  - Central Portal user token password
+#   MAVEN_GPG_PRIVATE_KEY   - ASCII-armored GPG private key used for signing
+#   MAVEN_GPG_PASSPHRASE    - passphrase for that GPG key
+
+name: Central Publish
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      revision:
+        description: "Version for the staged-only Central dry run (must NOT be a -SNAPSHOT). Leave blank to use the pom's revision."
+        required: false
+        default: ""
+
+jobs:
+  central:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Verify Maven Central signing secrets
+        # Fail fast with an actionable message. Otherwise a missing or
+        # malformed MAVEN_GPG_PRIVATE_KEY surfaces only as an opaque
+        # "gpg failed with exit code 2" from the setup-java import step.
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        run: |
+          missing=""
+          for name in MAVEN_CENTRAL_USERNAME MAVEN_CENTRAL_PASSWORD MAVEN_GPG_PRIVATE_KEY MAVEN_GPG_PASSPHRASE; do
+            if [ -z "${!name}" ]; then
+              missing="$missing $name"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required repository secret(s):$missing"
+            echo "Set them under Settings > Secrets and variables > Actions, then re-run the release."
+            exit 1
+          fi
+          case "$MAVEN_GPG_PRIVATE_KEY" in
+            *"BEGIN PGP PRIVATE KEY BLOCK"*) ;;
+            *)
+              echo "::error::MAVEN_GPG_PRIVATE_KEY is not an ASCII-armored GPG private key."
+              echo "Export it with: gpg --armor --export-secret-keys <KEY_ID>"
+              echo "and paste the entire block, including the BEGIN/END header lines and newlines."
+              exit 1
+              ;;
+          esac
+          echo "All required Maven Central secrets are present."
+
+      - uses: actions/checkout@v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+          # Creates a settings.xml server entry with id "central" whose
+          # username/password come from the env vars below, and imports the
+          # signing key so the maven-gpg-plugin can sign artifacts.
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Bootstrap CLAUDE.md enforcer rule
+        # The custom enforcer rule is consumed as a plugin dependency by the
+        # root build, so it must be installed to the local repo first.
+        run: mvn -B -pl claude-code-enforcer -am install
+
+      - name: Publish to Maven Central
+        # On release: full publish. On manual dispatch: staged-only dry run
+        # (autoPublish=false, waitUntil=validated) so Central validates the
+        # bundle but nothing is released.
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            revision_arg=""
+            if [ -n "${{ github.event.inputs.revision }}" ]; then
+              revision_arg="-Drevision=${{ github.event.inputs.revision }}"
+            fi
+            echo "Staged-only Central dry run: autoPublish=false, waitUntil=validated $revision_arg"
+            mvn -B -P release deploy -Dcentral.autoPublish=false -Dcentral.waitUntil=validated $revision_arg
+          else
+            mvn -B -P release deploy
+          fi
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,43 +1,18 @@
-# Publishes packages when a GitHub release is created, and offers a manual
-# staged-only dry run for validating the Maven Central bundle without releasing.
+# Publishes packages to GitHub Packages when a GitHub release is created.
 #
 # The "github-packages" job builds and deploys to GitHub Packages. It runs on
 # release only.
 #
-# The "central" job publishes signed artifacts to Maven Central (Sonatype
-# Central Portal) via the opt-in "release" profile. Publishing is bound to
-# the deploy phase, so it runs only here and never during an ordinary
-# `mvn install` build. It runs in two modes:
-#   * on release        -> full publish (autoPublish=true, waitUntil=published)
-#   * on workflow_dispatch -> staged-only dry run (autoPublish=false,
-#                            waitUntil=validated): the bundle is uploaded and
-#                            validated by Central but left staged, so nothing is
-#                            released. Drop or publish it manually in the portal.
-# Central rejects -SNAPSHOT versions, so trigger the dry run from a commit whose
-# revision is a real version, or pass a non-SNAPSHOT "revision" input.
-#
-# Required repository secrets for the Maven Central job:
-#   MAVEN_CENTRAL_USERNAME  - Central Portal user token name
-#   MAVEN_CENTRAL_PASSWORD  - Central Portal user token password
-#   MAVEN_GPG_PRIVATE_KEY   - ASCII-armored GPG private key used for signing
-#   MAVEN_GPG_PASSPHRASE    - passphrase for that GPG key
+# Publishing to Maven Central lives in its own workflow, central-publish.yml.
 
 name: Maven Publish
 
 on:
   release:
     types: [created]
-  workflow_dispatch:
-    inputs:
-      revision:
-        description: "Version for the staged-only Central dry run (must NOT be a -SNAPSHOT). Leave blank to use the pom's revision."
-        required: false
-        default: ""
 
 jobs:
   github-packages:
-    # Publish to GitHub Packages only for real releases, not the manual dry run.
-    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -60,82 +35,3 @@ jobs:
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}
-
-  central:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Verify Maven Central signing secrets
-        # Fail fast with an actionable message. Otherwise a missing or
-        # malformed MAVEN_GPG_PRIVATE_KEY surfaces only as an opaque
-        # "gpg failed with exit code 2" from the setup-java import step.
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-        run: |
-          missing=""
-          for name in MAVEN_CENTRAL_USERNAME MAVEN_CENTRAL_PASSWORD MAVEN_GPG_PRIVATE_KEY MAVEN_GPG_PASSPHRASE; do
-            if [ -z "${!name}" ]; then
-              missing="$missing $name"
-            fi
-          done
-          if [ -n "$missing" ]; then
-            echo "::error::Missing required repository secret(s):$missing"
-            echo "Set them under Settings > Secrets and variables > Actions, then re-run the release."
-            exit 1
-          fi
-          case "$MAVEN_GPG_PRIVATE_KEY" in
-            *"BEGIN PGP PRIVATE KEY BLOCK"*) ;;
-            *)
-              echo "::error::MAVEN_GPG_PRIVATE_KEY is not an ASCII-armored GPG private key."
-              echo "Export it with: gpg --armor --export-secret-keys <KEY_ID>"
-              echo "and paste the entire block, including the BEGIN/END header lines and newlines."
-              exit 1
-              ;;
-          esac
-          echo "All required Maven Central secrets are present."
-
-      - uses: actions/checkout@v6
-      - name: Set up JDK 25
-        uses: actions/setup-java@v5
-        with:
-          java-version: '25'
-          distribution: 'temurin'
-          cache: maven
-          # Creates a settings.xml server entry with id "central" whose
-          # username/password come from the env vars below, and imports the
-          # signing key so the maven-gpg-plugin can sign artifacts.
-          server-id: central
-          server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_PASSWORD
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-
-      - name: Bootstrap CLAUDE.md enforcer rule
-        # The custom enforcer rule is consumed as a plugin dependency by the
-        # root build, so it must be installed to the local repo first.
-        run: mvn -B -pl claude-code-enforcer -am install
-
-      - name: Publish to Maven Central
-        # On release: full publish. On manual dispatch: staged-only dry run
-        # (autoPublish=false, waitUntil=validated) so Central validates the
-        # bundle but nothing is released.
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            revision_arg=""
-            if [ -n "${{ github.event.inputs.revision }}" ]; then
-              revision_arg="-Drevision=${{ github.event.inputs.revision }}"
-            fi
-            echo "Staged-only Central dry run: autoPublish=false, waitUntil=validated $revision_arg"
-            mvn -B -P release deploy -Dcentral.autoPublish=false -Dcentral.waitUntil=validated $revision_arg
-          else
-            mvn -B -P release deploy
-          fi
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}


### PR DESCRIPTION
Move the "central" job out of maven-publish.yml into a dedicated
central-publish.yml. Maven Publish now only deploys to GitHub Packages
on release; Central Publish handles the signed Maven Central deploy on
release and the manual staged-only dry run via workflow_dispatch.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019cDNVaGgrJEDN4Wtvp9yxF