### PR TITLE
ci: remove GPG signing from Central publish

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -1,7 +1,7 @@
-# Publishes signed artifacts to Maven Central, and offers a manual staged-only
+# Publishes artifacts to Maven Central, and offers a manual staged-only
 # dry run for validating the Maven Central bundle without releasing.
 #
-# The "central" job publishes signed artifacts to Maven Central (Sonatype
+# The "central" job publishes artifacts to Maven Central (Sonatype
 # Central Portal) via the opt-in "release" profile. Publishing is bound to
 # the deploy phase, so it runs only here and never during an ordinary
 # `mvn install` build. It runs in two modes:
@@ -16,8 +16,6 @@
 # Required repository secrets for the Maven Central job:
 #   MAVEN_CENTRAL_USERNAME  - Central Portal user token name
 #   MAVEN_CENTRAL_PASSWORD  - Central Portal user token password
-#   MAVEN_GPG_PRIVATE_KEY   - ASCII-armored GPG private key used for signing
-#   MAVEN_GPG_PASSPHRASE    - passphrase for that GPG key
 
 name: Central Publish
 
@@ -38,18 +36,15 @@ jobs:
       contents: read
 
     steps:
-      - name: Verify Maven Central signing secrets
-        # Fail fast with an actionable message. Otherwise a missing or
-        # malformed MAVEN_GPG_PRIVATE_KEY surfaces only as an opaque
-        # "gpg failed with exit code 2" from the setup-java import step.
+      - name: Verify Maven Central secrets
+        # Fail fast with an actionable message rather than letting a missing
+        # credential surface as an opaque failure during deploy.
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         run: |
           missing=""
-          for name in MAVEN_CENTRAL_USERNAME MAVEN_CENTRAL_PASSWORD MAVEN_GPG_PRIVATE_KEY MAVEN_GPG_PASSPHRASE; do
+          for name in MAVEN_CENTRAL_USERNAME MAVEN_CENTRAL_PASSWORD; do
             if [ -z "${!name}" ]; then
               missing="$missing $name"
             fi
@@ -59,15 +54,6 @@ jobs:
             echo "Set them under Settings > Secrets and variables > Actions, then re-run the release."
             exit 1
           fi
-          case "$MAVEN_GPG_PRIVATE_KEY" in
-            *"BEGIN PGP PRIVATE KEY BLOCK"*) ;;
-            *)
-              echo "::error::MAVEN_GPG_PRIVATE_KEY is not an ASCII-armored GPG private key."
-              echo "Export it with: gpg --armor --export-secret-keys <KEY_ID>"
-              echo "and paste the entire block, including the BEGIN/END header lines and newlines."
-              exit 1
-              ;;
-          esac
           echo "All required Maven Central secrets are present."
 
       - uses: actions/checkout@v6
@@ -78,13 +64,10 @@ jobs:
           distribution: 'temurin'
           cache: maven
           # Creates a settings.xml server entry with id "central" whose
-          # username/password come from the env vars below, and imports the
-          # signing key so the maven-gpg-plugin can sign artifacts.
+          # username/password come from the env vars below.
           server-id: central
           server-username: MAVEN_CENTRAL_USERNAME
           server-password: MAVEN_CENTRAL_PASSWORD
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Bootstrap CLAUDE.md enforcer rule
         # The custom enforcer rule is consumed as a plugin dependency by the
@@ -109,4 +92,3 @@ jobs:
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -330,11 +330,6 @@
 					<version>3.12.0</version>
 				</plugin>
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-gpg-plugin</artifactId>
-					<version>3.2.8</version>
-				</plugin>
-				<plugin>
 					<groupId>org.sonatype.central</groupId>
 					<artifactId>central-publishing-maven-plugin</artifactId>
 					<version>0.11.0</version>
@@ -595,27 +590,6 @@
 						<configuration>
 							<doclint>none</doclint>
 							<failOnError>false</failOnError>
-						</configuration>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<!-- Non-interactive signing for CI; the passphrase
-							     is supplied via the gpg.passphrase property. -->
-							<gpgArguments>
-								<arg>--pinentry-mode</arg>
-								<arg>loopback</arg>
-							</gpgArguments>
 						</configuration>
 					</plugin>
 					<plugin>


### PR DESCRIPTION
Drop GPG artifact signing from the Central publish workflow and the
Maven release profile. Signing is no longer required for publishing to
Maven Central, so remove the maven-gpg-plugin, the setup-java key import,
the GPG secret verification, and the MAVEN_GPG_* references.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WuKoqZic2rNwaLczyHummy