### PR TITLE
build: skip assembly module in Maven Central publish

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -52,4 +52,25 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<profile>
+			<!-- This module only assembles a runnable SampleApp distribution
+			     (jar-with-dependencies / bin bundle), not a reusable library,
+			     so keep it out of the Maven Central bundle that the release
+			     profile publishes. skipPublishing is honoured per module by the
+			     central-publishing-maven-plugin. -->
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<configuration>
+							<skipPublishing>true</skipPublishing>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
The assembly module has no library sources; it only assembles a runnable
SampleApp distribution (jar-with-dependencies / bin bundle), which does not
belong on Maven Central. Set skipPublishing=true for the
central-publishing-maven-plugin in the module's release profile so the
release build excludes it from the Central bundle while still building it
during ordinary installs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Amr3Atc7tK9ZXwsYuVVmQX