### PR TITLE
build: skip GitHub Packages deploy for assembly module

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -11,6 +11,14 @@
 	<packaging>jar</packaging>
 	<name>assembly</name>
 	<url>https://maven.apache.org</url>
+	<properties>
+		<!-- This module only assembles a runnable SampleApp distribution, not a
+		     reusable library, so keep it out of the GitHub Packages deployment
+		     that maven-deploy-plugin performs on `mvn deploy`. (The Maven Central
+		     release profile already excludes it via the central-publishing
+		     plugin's skipPublishing flag below.) -->
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
The assembly module only assembles a runnable SampleApp distribution
(jar-with-dependencies / bin bundle), not a reusable library, so it does
not belong in the GitHub Packages deployment either. Set maven.deploy.skip
so the default maven-deploy-plugin skips it on `mvn deploy`, mirroring the
central-publishing skipPublishing flag that already keeps it out of the
Maven Central bundle.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013h4dWhHeXTCG8Jr86uAYbm