### PR TITLE
ci: exclude assembly module from central-publish reactor

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -78,6 +78,10 @@ jobs:
         # On release: full publish. On manual dispatch: staged-only dry run
         # (autoPublish=false, waitUntil=validated) so Central validates the
         # bundle but nothing is released.
+        #
+        # The assembly module only builds a runnable SampleApp distribution,
+        # not a reusable library, so it is excluded from the reactor here
+        # ("-pl !assembly") and never takes part in the Central publish.
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             revision_arg=""
@@ -85,9 +89,9 @@ jobs:
               revision_arg="-Drevision=${{ github.event.inputs.revision }}"
             fi
             echo "Staged-only Central dry run: autoPublish=false, waitUntil=validated $revision_arg"
-            mvn -B -P release deploy -Dcentral.autoPublish=false -Dcentral.waitUntil=validated $revision_arg
+            mvn -B -P release -pl '!assembly' deploy -Dcentral.autoPublish=false -Dcentral.waitUntil=validated $revision_arg
           else
-            mvn -B -P release deploy
+            mvn -B -P release -pl '!assembly' deploy
           fi
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}


### PR DESCRIPTION
The assembly module only builds a runnable SampleApp distribution, not a
reusable library. Exclude it from the Maven reactor in central-publish.yml
via -pl '!assembly' so it never participates in the Central publish.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EkeNTpbMapbWisRfkjGm9j