### PR TITLE
Exclude grpc-example from Maven Central publish

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -79,9 +79,11 @@ jobs:
         # (autoPublish=false, waitUntil=validated) so Central validates the
         # bundle but nothing is released.
         #
-        # The assembly module only builds a runnable SampleApp distribution,
-        # not a reusable library, so it is excluded from the reactor here
-        # ("-pl !assembly") and never takes part in the Central publish.
+        # The assembly module only builds a runnable SampleApp distribution and
+        # the grpc-example module is only a protobuf/gRPC example, not reusable
+        # libraries, so they are excluded from the reactor here
+        # ("-pl !assembly,!grpc-example") and never take part in the Central
+        # publish.
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             revision_arg=""
@@ -89,9 +91,9 @@ jobs:
               revision_arg="-Drevision=${{ github.event.inputs.revision }}"
             fi
             echo "Staged-only Central dry run: autoPublish=false, waitUntil=validated $revision_arg"
-            mvn -B -P release -pl '!assembly' deploy -Dcentral.autoPublish=false -Dcentral.waitUntil=validated $revision_arg
+            mvn -B -P release -pl '!assembly,!grpc-example' deploy -Dcentral.autoPublish=false -Dcentral.waitUntil=validated $revision_arg
           else
-            mvn -B -P release -pl '!assembly' deploy
+            mvn -B -P release -pl '!assembly,!grpc-example' deploy
           fi
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -132,4 +132,24 @@
 			<artifactId>log4j-core</artifactId>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<profile>
+			<!-- This module only exercises generated protobuf/gRPC classes as an
+			     example, not a reusable library, so keep it out of the Maven
+			     Central bundle that the release profile publishes. skipPublishing
+			     is honoured per module by the central-publishing-maven-plugin. -->
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<configuration>
+							<skipPublishing>true</skipPublishing>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
The grpc-example module is only a protobuf/gRPC example, not a reusable
library. Mirror the assembly module's handling: add skipPublishing to its
release profile (honoured per module by the central-publishing plugin) and
exclude it from the deploy reactor in the Central Publish workflow.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CvzbCHH5CPeb8gCSQqckSM