### PR TITLE
fix(release): flatten published POMs and GPG-sign for Maven Central

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -16,6 +16,8 @@
 # Required repository secrets for the Maven Central job:
 #   MAVEN_CENTRAL_USERNAME  - Central Portal user token name
 #   MAVEN_CENTRAL_PASSWORD  - Central Portal user token password
+#   MAVEN_GPG_PRIVATE_KEY   - ASCII-armored GPG private key used to sign artifacts
+#   MAVEN_GPG_PASSPHRASE    - passphrase for that GPG key
 
 name: Central Publish
 
@@ -42,9 +44,11 @@ jobs:
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         run: |
           missing=""
-          for name in MAVEN_CENTRAL_USERNAME MAVEN_CENTRAL_PASSWORD; do
+          for name in MAVEN_CENTRAL_USERNAME MAVEN_CENTRAL_PASSWORD MAVEN_GPG_PRIVATE_KEY MAVEN_GPG_PASSPHRASE; do
             if [ -z "${!name}" ]; then
               missing="$missing $name"
             fi
@@ -68,6 +72,9 @@ jobs:
           server-id: central
           server-username: MAVEN_CENTRAL_USERNAME
           server-password: MAVEN_CENTRAL_PASSWORD
+          # Imports the signing key so maven-gpg-plugin can sign the bundle.
+          # setup-java expects the passphrase in MAVEN_GPG_PASSPHRASE at build time.
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
 
       - name: Bootstrap CLAUDE.md enforcer rule
         # The custom enforcer rule is consumed as a plugin dependency by the
@@ -98,3 +105,4 @@ jobs:
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,11 @@
 					<artifactId>central-publishing-maven-plugin</artifactId>
 					<version>0.11.0</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-gpg-plugin</artifactId>
+					<version>3.2.7</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -577,6 +582,61 @@
 			</properties>
 			<build>
 				<plugins>
+					<!-- The root pom uses a CI-friendly ${revision} version. Maven
+					     Central rejects a pom that still contains the unresolved
+					     ${revision} (and a raw child pom omits the parent-inherited
+					     license/scm/developers and the managed dependency versions).
+					     Flatten every published module into a self-contained pom so
+					     the version resolves and that metadata is inlined. Only the
+					     release build flattens; ordinary and CI builds are
+					     unaffected. -->
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>flatten-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>flatten-release</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>flatten</goal>
+								</goals>
+								<configuration>
+									<updatePomFile>true</updatePomFile>
+									<flattenMode>oss</flattenMode>
+								</configuration>
+							</execution>
+							<execution>
+								<id>flatten-release-clean</id>
+								<phase>clean</phase>
+								<goals>
+									<goal>clean</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<!-- Maven Central requires every artifact to be GPG-signed. The
+					     signing key and passphrase come from the environment
+					     (MAVEN_GPG_PRIVATE_KEY / MAVEN_GPG_PASSPHRASE); loopback
+					     pinentry keeps gpg non-interactive on CI. -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<gpgArguments>
+										<arg>--pinentry-mode</arg>
+										<arg>loopback</arg>
+									</gpgArguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
The Central Publish dry run was rejected: module POMs deployed with an
unresolved ${revision} (invalid version / file paths), without inlined
dependency versions or the parent-inherited license, SCM and developer
metadata, and no artifact was GPG-signed.

- Flatten every published module (flattenMode=oss) in the release profile
  so ${revision} resolves, dependency versions are inlined, and license/
  SCM/developers are carried into the deployed POM.
- Add maven-gpg-plugin to the release profile (loopback pinentry for CI)
  and its version to pluginManagement, restoring the artifact signing the
  release profile is documented to perform.
- Import the signing key in central-publish.yml (setup-java gpg-private-key,
  MAVEN_GPG_PASSPHRASE) and verify the two new GPG secrets up front.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VpTDXn25Z935sjMupVHdX7