### PR TITLE
docs: add project description to all module pom.xml files

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -10,6 +10,7 @@
 	<artifactId>tools.assembly</artifactId>
 	<packaging>jar</packaging>
 	<name>assembly</name>
+	<description>Builds an executable jar-with-dependencies bundling the tools modules (mainClass: io.github.adamw7.tools.data.SampleApp).</description>
 	<url>https://maven.apache.org</url>
 	<properties>
 		<!-- This module only assembles a runnable SampleApp distribution, not a

--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -10,6 +10,7 @@
 	<artifactId>tools.claude-code-enforcer</artifactId>
 	<packaging>jar</packaging>
 	<name>CLAUDE.md enforcer rule</name>
+	<description>Custom maven-enforcer rule that validates CLAUDE.md documents for structure and naming conventions during the build.</description>
 	<url>https://maven.apache.org</url>
 	<build>
 		<plugins>

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -10,6 +10,7 @@
 	<artifactId>tools.code.context</artifactId>
 	<packaging>jar</packaging>
 	<name>Context engineering</name>
+	<description>Fast, regex-based finder that builds the tree of classes used by a given class and assembles context for gen-AI agents, exposed over an MCP server.</description>
 	<url>https://maven.apache.org</url>
 	<build>
 		<plugins>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -10,6 +10,7 @@
 	<artifactId>tools.code</artifactId>
 	<packaging>pom</packaging>
 	<name>Tooling for code</name>
+	<description>Aggregator module for code-oriented tooling: the protobuf builder-generating Maven plugin and the regex-based class-usage context finder.</description>
 	<url>https://maven.apache.org</url>
 	<modules>
 		<module>protogen-maven-plugin</module>

--- a/code/protogen-maven-plugin-test/pom.xml
+++ b/code/protogen-maven-plugin-test/pom.xml
@@ -10,6 +10,7 @@
 	<artifactId>protogen-maven-plugin-test</artifactId>
 	<packaging>jar</packaging>
 	<name>protogen-maven-plugin-test</name>
+	<description>Integration test module that exercises the protogen-maven-plugin by generating and compiling protobuf builders end to end.</description>
 	<url>https://maven.apache.org</url>
 	<properties>
 		<!-- This module only exercises generated protobuf classes, so the

--- a/data-test/pom.xml
+++ b/data-test/pom.xml
@@ -10,6 +10,7 @@
 	<artifactId>tools.data-test</artifactId>
 	<packaging>jar</packaging>
 	<name>Test for data</name>
+	<description>Standalone test module that validates the data module's sources, uniqueness checks and data structures independently of the root reactor.</description>
 	<url>https://maven.apache.org</url>
 	<build>
 		<plugins>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -10,6 +10,7 @@
 	<artifactId>tools.data</artifactId>
 	<packaging>jar</packaging>
 	<name>Tooling for data</name>
+	<description>Data sources (CSV, GZip, JDBC; in-memory and iterative), a uniqueness-checking tool, data structures, and an MCP server exposing the uniqueness checker.</description>
 	<url>https://maven.apache.org</url>
 	<build>
 		<plugins>

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -10,6 +10,7 @@
 	<artifactId>grpc-example</artifactId>
 	<packaging>jar</packaging>
 	<name>grpc-example</name>
+	<description>End-to-end gRPC example demonstrating the protogen-generated, compile-time-safe protobuf builders in a working service.</description>
 	<url>https://maven.apache.org</url>
 	<properties>
 		<!-- This module only exercises generated protobuf/gRPC classes, so the

--- a/mcp-common/pom.xml
+++ b/mcp-common/pom.xml
@@ -10,6 +10,7 @@
 	<artifactId>tools.mcp-common</artifactId>
 	<packaging>jar</packaging>
 	<name>Shared MCP server scaffolding</name>
+	<description>Shared MCP server scaffolding providing transport wiring and the tool SPI reused by the repository's MCP servers.</description>
 	<url>https://maven.apache.org</url>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
Add a <description> element to each module POM that lacked one so every
module documents its purpose. The root pom and protogen-maven-plugin
already had descriptions.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wcazi8wjBASRfbQaoFTUQu