### PR TITLE
build: attach javadoc jar to GitHub Packages deploy

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -32,6 +32,9 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      # The github-packages profile attaches the javadoc jar so the GitHub
+      # Packages coordinates ship javadoc alongside the main jar (the default
+      # maven-deploy-plugin would otherwise publish the main jar only).
+      run: mvn deploy -P github-packages -s $GITHUB_WORKSPACE/settings.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,8 +234,11 @@ To release version `X`:
 
 Creating the GitHub release fires `maven-publish.yml`, which runs two jobs:
 
-- `github-packages` deploys to **GitHub Packages** (the default `mvn deploy`,
-  using the `distributionManagement` repository).
+- `github-packages` deploys to **GitHub Packages** (`mvn deploy -P github-packages`,
+  using the `distributionManagement` repository). The `github-packages` profile
+  attaches the javadoc jar so the published coordinates ship javadoc alongside
+  the main jar; the default `mvn deploy` would otherwise publish the main jar
+  only.
 - `central` deploys to **Maven Central** via the Sonatype Central Portal. It
   runs `mvn -P release deploy`; the `release` profile attaches the sources and
   javadoc jars, GPG-signs every artifact, and hands the bundle to the

--- a/pom.xml
+++ b/pom.xml
@@ -555,6 +555,36 @@
 			</build>
 		</profile>
 		<profile>
+			<!-- Attaches the javadoc jar to the GitHub Packages deployment that
+			     maven-publish.yml performs on release. The default `mvn deploy`
+			     (maven-deploy-plugin) only publishes the main jar, so without
+			     this the GitHub Packages coordinates would ship no javadoc.
+			     Opt-in via -Pgithub-packages so ordinary `mvn install` builds
+			     stay fast and never generate javadoc. (The Maven Central bundle
+			     gets its javadoc from the separate `release` profile instead.) -->
+			<id>github-packages</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<doclint>none</doclint>
+							<failOnError>false</failOnError>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<!-- Publishes signed artifacts (sources, javadoc, GPG signatures)
 			     to Maven Central via the Sonatype Central Portal. Opt-in with
 			     -Prelease so ordinary and CI builds never need GPG keys or


### PR DESCRIPTION
The github-packages release job ran a plain `mvn deploy`, so the
maven-deploy-plugin published only the main jar to GitHub Packages while
the javadoc jar (produced only by the opt-in `release` profile) was never
attached. Only the Maven Central bundle shipped javadoc.

Add a `github-packages` profile that attaches the javadoc jar and activate
it from the maven-publish.yml deploy step, so the GitHub Packages
coordinates ship javadoc alongside the main jar. Keeping it opt-in leaves
ordinary `mvn install` builds fast, matching how the `release` profile is
structured.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PEhHkP4WqS4JmAt6PDEMqi