### PR TITLE
build: flatten ${revision} for all published modules

### DIFF
--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -26,35 +26,11 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 			</plugin>
-			<!-- The root pom uses a CI-friendly ${revision} version. This module
-			     is consumed as a maven-enforcer-plugin dependency, i.e. resolved
-			     from a repository outside the reactor, so its installed pom must
-			     not contain the unresolved ${revision}. Flatten it into a
-			     self-contained pom on install. -->
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>flatten-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>flatten</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>flatten</goal>
-						</goals>
-						<configuration>
-							<updatePomFile>true</updatePomFile>
-							<flattenMode>oss</flattenMode>
-						</configuration>
-					</execution>
-					<execution>
-						<id>flatten-clean</id>
-						<phase>clean</phase>
-						<goals>
-							<goal>clean</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+			<!-- flatten-maven-plugin is inherited from the root pom, which
+			     flattens the CI-friendly ${revision} out of every module's pom.
+			     This module needs it because it is consumed as a
+			     maven-enforcer-plugin dependency resolved from a repository
+			     outside the reactor. -->
 		</plugins>
 	</build>
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,38 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- The root pom uses a CI-friendly ${revision} version, so the
+			     installed/deployed pom of every module would otherwise still
+			     contain the literal ${revision} in its <parent> and in
+			     inter-module dependency versions. Flatten every module (this
+			     execution is inherited by all reactor modules and their
+			     submodules) into a self-contained pom whose versions are
+			     resolved, which is required for Maven Central and for the
+			     claude-code-enforcer module consumed as a plugin dependency. -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+						<configuration>
+							<updatePomFile>true</updatePomFile>
+							<flattenMode>oss</flattenMode>
+						</configuration>
+					</execution>
+					<execution>
+						<id>flatten-clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
The central publish reactor (root, mcp-common, data, code and its
submodules) emitted POMs that still contained the CI-friendly
${revision} in their <parent> and inter-module dependency versions,
producing unresolvable POMs that Maven Central rejects. Only
claude-code-enforcer ran flatten-maven-plugin.

Move the flatten execution to the root <build><plugins> so every
reactor module and submodule inherits it, and drop the now-redundant
copy from claude-code-enforcer.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D5gbf4kEmK7qodbAYiqj5H