### PR TITLE
build(scm): derive scm tag from ${revision} instead of literal HEAD

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<connection>scm:git:git@github.com:adamw7/tools.git</connection>
 		<developerConnection>scm:git:git@github.com:adamw7/tools.git</developerConnection>
 		<url>https://github.com/adamw7/tools</url>
-		<tag>HEAD</tag>
+		<tag>${revision}</tag>
 	</scm>
 	<developers>
 		<developer>


### PR DESCRIPTION
The released pom recorded <scm><tag>HEAD</tag>, so a consumer inspecting
the published artifact could not tell which tag/commit it was cut from.
Drive the tag off ${revision} so each release records its real version.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LgpwwLSswWHWqq76Aq7Jbg