### PR TITLE
Update project URLs and fix SCM inheritance in pom.xml files

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>jar</packaging>
 	<name>assembly</name>
 	<description>Builds an executable jar-with-dependencies bundling the tools modules (mainClass: io.github.adamw7.tools.data.SampleApp).</description>
-	<url>https://maven.apache.org</url>
+	<url>https://github.com/adamw7/tools</url>
 	<developers>
 		<developer>
 			<id>adamw7</id>

--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>jar</packaging>
 	<name>CLAUDE.md enforcer rule</name>
 	<description>Custom maven-enforcer rule that validates CLAUDE.md documents for structure and naming conventions during the build.</description>
-	<url>https://maven.apache.org</url>
+	<url>https://github.com/adamw7/tools</url>
 	<developers>
 		<developer>
 			<id>adamw7</id>

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>jar</packaging>
 	<name>Context engineering</name>
 	<description>Fast, regex-based finder that builds the tree of classes used by a given class and assembles context for gen-AI agents, exposed over an MCP server.</description>
-	<url>https://maven.apache.org</url>
+	<url>https://github.com/adamw7/tools</url>
 	<developers>
 		<developer>
 			<id>adamw7</id>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>pom</packaging>
 	<name>Tooling for code</name>
 	<description>Aggregator module for code-oriented tooling: the protobuf builder-generating Maven plugin and the regex-based class-usage context finder.</description>
-	<url>https://maven.apache.org</url>
+	<url>https://github.com/adamw7/tools</url>
 	<developers>
 		<developer>
 			<id>adamw7</id>

--- a/code/protogen-maven-plugin-test/pom.xml
+++ b/code/protogen-maven-plugin-test/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>jar</packaging>
 	<name>protogen-maven-plugin-test</name>
 	<description>Integration test module that exercises the protogen-maven-plugin by generating and compiling protobuf builders end to end.</description>
-	<url>https://maven.apache.org</url>
+	<url>https://github.com/adamw7/tools</url>
 	<developers>
 		<developer>
 			<id>adamw7</id>

--- a/code/protogen-maven-plugin/pom.xml
+++ b/code/protogen-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>maven-plugin</packaging>
 	<name>protogen-maven-plugin</name>
 	<description>Maven plugin that generates fluent, type-safe builders for protobuf-generated message classes during the generate-sources phase.</description>
-	<url>https://maven.apache.org</url>
+	<url>https://github.com/adamw7/tools</url>
 	<developers>
 		<developer>
 			<id>adamw7</id>

--- a/data-test/pom.xml
+++ b/data-test/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>jar</packaging>
 	<name>Test for data</name>
 	<description>Standalone test module that validates the data module's sources, uniqueness checks and data structures independently of the root reactor.</description>
-	<url>https://maven.apache.org</url>
+	<url>https://github.com/adamw7/tools</url>
 	<developers>
 		<developer>
 			<id>adamw7</id>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>jar</packaging>
 	<name>Tooling for data</name>
 	<description>Data sources (CSV, GZip, JDBC; in-memory and iterative), a uniqueness-checking tool, data structures, and an MCP server exposing the uniqueness checker.</description>
-	<url>https://maven.apache.org</url>
+	<url>https://github.com/adamw7/tools</url>
 	<developers>
 		<developer>
 			<id>adamw7</id>

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>jar</packaging>
 	<name>grpc-example</name>
 	<description>End-to-end gRPC example demonstrating the protogen-generated, compile-time-safe protobuf builders in a working service.</description>
-	<url>https://maven.apache.org</url>
+	<url>https://github.com/adamw7/tools</url>
 	<developers>
 		<developer>
 			<id>adamw7</id>

--- a/mcp-common/pom.xml
+++ b/mcp-common/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>jar</packaging>
 	<name>Shared MCP server scaffolding</name>
 	<description>Shared MCP server scaffolding providing transport wiring and the tool SPI reused by the repository's MCP servers.</description>
-	<url>https://maven.apache.org</url>
+	<url>https://github.com/adamw7/tools</url>
 	<developers>
 		<developer>
 			<id>adamw7</id>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,9 @@
 			<url>https://www.opensource.org/licenses/mit-license.php</url>
 		</license>
 	</licenses>
-	<scm>
+	<scm child.scm.connection.inherit.append.path="false"
+		child.scm.developerConnection.inherit.append.path="false"
+		child.scm.url.inherit.append.path="false">
 		<connection>scm:git:git@github.com:adamw7/tools.git</connection>
 		<developerConnection>scm:git:git@github.com:adamw7/tools.git</developerConnection>
 		<url>https://github.com/adamw7/tools</url>


### PR DESCRIPTION
## Summary
This PR updates all module pom.xml files to reference the correct project URL and configures proper SCM inheritance behavior in the root pom.xml.

## Key Changes
- **Root pom.xml**: Added SCM inheritance configuration attributes (`child.scm.connection.inherit.append.path`, `child.scm.developerConnection.inherit.append.path`, `child.scm.url.inherit.append.path`) set to `false` to prevent Maven from appending paths to SCM URLs in child modules
- **All module pom.xml files**: Updated project URL from the generic `https://maven.apache.org` to the actual project repository `https://github.com/adamw7/tools` across 11 modules:
  - assembly
  - claude-code-enforcer
  - code/context
  - code
  - code/protogen-maven-plugin-test
  - code/protogen-maven-plugin
  - data-test
  - data
  - grpc-example
  - mcp-common

## Implementation Details
The SCM inheritance configuration ensures that child modules inherit the parent's SCM connection details without Maven automatically appending their module paths, which is the correct behavior for a multi-module project where all modules share the same repository.

https://claude.ai/code/session_01VcFX6pp99nzF2ns5Se1wru