### PR TITLE
ci: stop duplicate/overlapping Maven builds in Actions

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -28,13 +28,14 @@ jobs:
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
-
     - name: Publish to GitHub Packages Apache Maven
+      # A single `mvn deploy` runs the full lifecycle (compile, test, package)
+      # before deploying, so there is no separate `mvn package` step: adding one
+      # would just build the whole reactor twice in this job.
+      #
       # The github-packages profile attaches the javadoc jar so the GitHub
       # Packages coordinates ship javadoc alongside the main jar (the default
       # maven-deploy-plugin would otherwise publish the main jar only).
-      run: mvn deploy -P github-packages -s $GITHUB_WORKSPACE/settings.xml
+      run: mvn -B deploy -P github-packages -s $GITHUB_WORKSPACE/settings.xml --file pom.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,8 +8,12 @@
 
 name: Java CI with Maven
 
+# Only build main on push and PRs targeting main. Leaving `push` unfiltered
+# meant a push to a branch that also had an open PR fired both the `push` and
+# `pull_request` events, running the whole build twice for the same commit.
 on:
   push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
maven-publish.yml ran an explicit `mvn package` step immediately before
`mvn deploy`. Since deploy is a later lifecycle phase, deploy already runs
package, so the reactor was built twice in the same job. Drop the redundant
package step.

maven.yml had an unfiltered `push:` trigger alongside `pull_request:
[main]`, so pushing to a branch with an open PR fired both events and ran
the build twice for one commit. Restrict push to the main branch.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015wnb7WfeKgXa5HqMVdz6ZF