### PR TITLE
build: silence Maven artifact-transfer noise via .mvn/maven.config

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Bootstrap CLAUDE.md enforcer rule
         # The custom enforcer rule is consumed as a plugin dependency by the
         # root build, so it must be installed to the local repo first.
-        run: mvn -B -X -pl claude-code-enforcer -am install
+        run: mvn -B -ntp -X -pl claude-code-enforcer -am install
 
       - name: Publish to Maven Central
         # On release: full publish. On manual dispatch: staged-only dry run
@@ -91,9 +91,9 @@ jobs:
               revision_arg="-Drevision=${{ github.event.inputs.revision }}"
             fi
             echo "Staged-only Central dry run: autoPublish=false, waitUntil=validated $revision_arg"
-            mvn -B -X -P release -pl '!assembly,!grpc-example' deploy -Dcentral.autoPublish=false -Dcentral.waitUntil=validated $revision_arg
+            mvn -B -ntp -X -P release -pl '!assembly,!grpc-example' deploy -Dcentral.autoPublish=false -Dcentral.waitUntil=validated $revision_arg
           else
-            mvn -B -X -P release -pl '!assembly,!grpc-example' deploy
+            mvn -B -ntp -X -P release -pl '!assembly,!grpc-example' deploy
           fi
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Run tests with JaCoCo
-      run: mvn -B verify -Pcoverage --file pom.xml
+      run: mvn -B -ntp verify -Pcoverage --file pom.xml
     - name: Upload coverage reports
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
           cache: maven
 
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn -B -ntp package --file pom.xml
 
       - name: Build Docker image from assembly
         run: docker build -t tools:latest .

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,4 +18,4 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Run MCP streamable HTTP integration tests
-      run: mvn -B verify -P integration-tests --file pom.xml
+      run: mvn -B -ntp verify -P integration-tests --file pom.xml

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,6 +36,6 @@ jobs:
       # The github-packages profile attaches the javadoc jar so the GitHub
       # Packages coordinates ship javadoc alongside the main jar (the default
       # maven-deploy-plugin would otherwise publish the main jar only).
-      run: mvn -B deploy -P github-packages -s $GITHUB_WORKSPACE/settings.xml --file pom.xml
+      run: mvn -B -ntp deploy -P github-packages -s $GITHUB_WORKSPACE/settings.xml --file pom.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,14 +36,14 @@ jobs:
       # installed to the local repo first. The claude-md-enforce profile is
       # off here (no -DenforceClaudeMd), so the module is not asked to depend
       # on itself while it is being built.
-      run: mvn -B -pl claude-code-enforcer -am install
+      run: mvn -B -ntp -pl claude-code-enforcer -am install
     - name: Build with Maven
       # -DenforceClaudeMd activates the claude-md-enforce profile so the root
       # build fails when CLAUDE.md is missing or malformed. This is the only
       # workflow that runs the check.
       run: |
         start=$(date +%s)
-        mvn -B package -DenforceClaudeMd --file pom.xml
+        mvn -B -ntp package -DenforceClaudeMd --file pom.xml
         end=$(date +%s)
         duration=$((end - start))
         echo "Build took ${duration} seconds."

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -20,7 +20,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Run PIT mutation testing
-      run: mvn -B test -Ppitest --file pom.xml
+      run: mvn -B -ntp test -Ppitest --file pom.xml
     - name: Upload mutation testing reports
       uses: actions/upload-artifact@v4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ release.properties
 dependency-reduced-pom.xml
 .flattened-pom.xml
 buildNumber.properties
-.mvn/
+.mvn/*
+!.mvn/maven.config
 
 logs/
 data/derby.log

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--no-transfer-progress

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,8 @@ removed anything, plain `mvn install` is fine and faster.
 **Quiet builds.** `.mvn/maven.config` passes `--no-transfer-progress` to every
 `mvn` invocation from the repo root, so builds never print the
 `Downloading from.../Downloaded from...` artifact-transfer noise — locally or in
-CI. It is the one place that flag lives; individual commands and workflows do not
-need to repeat it.
+CI. The workflows also pass `-ntp` explicitly on each `mvn` command so the
+quiet behavior does not depend on the checkout picking up `.mvn/maven.config`.
 
 CI (`.github/workflows/maven.yml`) installs the enforcer rule
 (`mvn -B -pl claude-code-enforcer -am install`) and then runs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,12 @@ generates protobuf builders into `target/`; stale generated output from a
 previous build can otherwise linger and mask the change. If you have not
 removed anything, plain `mvn install` is fine and faster.
 
+**Quiet builds.** `.mvn/maven.config` passes `--no-transfer-progress` to every
+`mvn` invocation from the repo root, so builds never print the
+`Downloading from.../Downloaded from...` artifact-transfer noise — locally or in
+CI. It is the one place that flag lives; individual commands and workflows do not
+need to repeat it.
+
 CI (`.github/workflows/maven.yml`) installs the enforcer rule
 (`mvn -B -pl claude-code-enforcer -am install`) and then runs
 `mvn -B package -DenforceClaudeMd` on JDK 25 (Temurin) for every push and for


### PR DESCRIPTION
Add .mvn/maven.config with --no-transfer-progress so every mvn
invocation from the repo root (local and CI) stops printing the
"Downloading from.../Downloaded from..." download noise. Un-ignore
.mvn/maven.config in .gitignore so the config is tracked, and document
the behavior in AGENTS.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016v4GbKUkd2xqoquYE9t6yG