### PR TITLE
build(pom): centralize mcp-bom import in root dependency management

### DIFF
--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -61,18 +61,6 @@
 		</profile>
 	</profiles>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>io.modelcontextprotocol.sdk</groupId>
-				<artifactId>mcp-bom</artifactId>
-				<version>2.0.0</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<dependencies>
 		<dependency>
 			<groupId>io.github.adamw7</groupId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -75,17 +75,6 @@
 			</build>
 		</profile>
 	</profiles>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>io.modelcontextprotocol.sdk</groupId>
-				<artifactId>mcp-bom</artifactId>
-				<version>2.0.0</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>io.github.adamw7</groupId>

--- a/mcp-common/pom.xml
+++ b/mcp-common/pom.xml
@@ -20,17 +20,6 @@
 			<url>https://github.com/adamw7</url>
 		</developer>
 	</developers>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>io.modelcontextprotocol.sdk</groupId>
-				<artifactId>mcp-bom</artifactId>
-				<version>2.0.0</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>io.modelcontextprotocol.sdk</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,13 @@
 				<scope>import</scope>
 			</dependency>
 			<dependency>
+				<groupId>io.modelcontextprotocol.sdk</groupId>
+				<artifactId>mcp-bom</artifactId>
+				<version>2.0.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter</artifactId>
 				<version>3.5.16</version>


### PR DESCRIPTION
Maven Central rejected the last deploy with "dependency version
information is missing" for io.modelcontextprotocol.sdk:mcp-json-jackson2.
The mcp-bom was imported in each consuming module's own
dependencyManagement, so the MCP artifacts carried no explicit
version in their own POMs; the version was only supplied by the
imported BOM at build time.

Move the single mcp-bom import into the root pom dependency
management (matching the project rule that all versions live only in
the root) and drop the three duplicate import blocks from mcp-common,
data and code/context. The flatten-maven-plugin then inlines the
resolved 2.0.0 version into every published POM, so Central sees a
concrete version for mcp-json-jackson2 and the other MCP artifacts.

Verified: mvn validate (enforcer, incl. banDuplicatePomDependencyVersions
and reactorModuleConvergence) and a full install pass; the installed
POMs for mcp-common, data and code.context all show
mcp-json-jackson2:2.0.0.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0186g1bxhmzc9WrueiMTVxQH