### PR TITLE
ci(release): guard Maven Central poms against unresolved coordinates

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -74,6 +74,13 @@ jobs:
         # root build, so it must be installed to the local repo first.
         run: mvn -B -ntp -X -pl claude-code-enforcer -am install
 
+      - name: Verify Maven Central release poms
+        # Fail fast (before uploading) if any module's flattened pom would be
+        # rejected by the Central Portal for unresolved/parent-only coordinates
+        # ("Failed to get coordinates from pom file") or missing required
+        # metadata, rather than surfacing it as an opaque deploy-time error.
+        run: ./scripts/linux/check-release-poms.sh
+
       - name: Publish to Maven Central
         # On release: full publish. On manual dispatch: staged-only dry run
         # (autoPublish=false, waitUntil=validated) so Central validates the

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -51,3 +51,21 @@ jobs:
           echo "::error::Build exceeded the 2 minute (120s) limit: ${duration}s"
           exit 1
         fi
+
+  # Validates the flattened poms the release build would deploy to Maven
+  # Central, catching the Central Portal "Failed to get coordinates from pom
+  # file" rejection (unresolved ${revision} / parent-only coordinates) and
+  # missing required metadata before a real release instead of during deploy.
+  # Runs as its own job so it stays outside the 120s budget of the build job.
+  verify-release-poms:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up JDK 25
+      uses: actions/setup-java@v5
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: maven
+    - name: Verify Maven Central release poms
+      run: ./scripts/linux/check-release-poms.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,6 +275,26 @@ check is `mvn -P release deploy -Dcentral.autoPublish=false -Dcentral.waitUntil=
 The `central.autoPublish` (default `true`) and `central.waitUntil` (default
 `published`) properties drive this; the defaults keep a real release publishing.
 
+### Release pom guardrail (offline, no credentials)
+
+Because every published module uses CI-friendly `${revision}` versioning and
+inherits its `groupId`/`version` from the parent, the pom that actually reaches
+Central is the **flattened** one (flatten-maven-plugin, `oss` mode, bound to
+`process-resources`). If that flattening ever regresses, Central rejects the
+upload with `Failed to get coordinates from pom file …` — it reads coordinates
+only from the flattened pom's direct `groupId`/`artifactId`/`version` and
+resolves neither properties nor parent inheritance. This is exactly what sank
+the 2.4.0 release, which predated the flatten fix.
+
+`scripts/linux/check-release-poms.sh` guards against it without needing Central
+credentials or a network upload: it runs the release-profile
+`process-resources` for the Central reactor, then asserts every module's
+flattened pom has resolved (non-`${…}`) coordinates and the metadata the Portal
+requires (`name`, `description`, `url`, `licenses`, `developers`, `scm`). It
+runs as the `verify-release-poms` job in `maven.yml` on every push/PR, and as a
+fail-fast step in `central-publish.yml` before the actual upload. Run it locally
+with `./scripts/linux/check-release-poms.sh`.
+
 ## Pull requests & commits
 
 - Use clear, descriptive, conventional commit messages.

--- a/scripts/linux/check-release-poms.sh
+++ b/scripts/linux/check-release-poms.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Guards against the Sonatype Central Portal "Failed to get coordinates from
+# pom file" rejection (and its metadata-completeness siblings) by validating
+# the *flattened* pom that each published module actually deploys.
+#
+# The build uses CI-friendly ${revision} versioning, so the source poms inherit
+# groupId/version from the parent and carry a literal ${revision}. The Central
+# Portal reads coordinates only from the direct groupId/artifactId/version of
+# the uploaded pom; it resolves neither properties nor parent inheritance, so an
+# unflattened pom is rejected. The flatten-maven-plugin (release build,
+# process-resources phase) inlines resolved coordinates plus the required
+# project metadata. This script proves that inlining happened for every module
+# in the Central reactor, so a broken release is caught in CI instead of by an
+# opaque Portal error during deploy.
+#
+# Exit status is non-zero if any published module would be rejected by Central.
+set -euo pipefail
+
+# Metadata the Central Portal requires on every published artifact.
+readonly REQUIRED_METADATA=(name description url licenses developers scm)
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Reads a direct child of the flattened pom's <project> element (not nested
+# elements such as dependency coordinates), namespace-agnostically.
+project_value() {
+  xmllint --xpath "string(//*[local-name()='project']/*[local-name()='$2'])" "$1" 2>/dev/null
+}
+
+project_has() {
+  xmllint --xpath "boolean(//*[local-name()='project']/*[local-name()='$2'])" "$1" 2>/dev/null
+}
+
+generate_flattened_poms() {
+  echo "Generating flattened poms for the Central reactor (release profile)..."
+  mvn -B -ntp -q -Prelease -pl '!assembly,!grpc-example' \
+    -Dshellcheck.skip=true -DskipTests process-resources
+}
+
+# Validates one flattened pom. Prints every problem found and returns non-zero
+# when the module would be rejected by the Central Portal.
+check_pom() {
+  local pom_file="$1"
+  local status=0
+  local coord value meta
+
+  for coord in groupId artifactId version; do
+    value="$(project_value "$pom_file" "$coord")"
+    if [ -z "$value" ]; then
+      echo "  MISSING coordinate <$coord>"
+      status=1
+    elif printf '%s' "$value" | grep -q '[$]{'; then
+      echo "  UNRESOLVED coordinate <$coord>=$value"
+      status=1
+    fi
+  done
+
+  for meta in "${REQUIRED_METADATA[@]}"; do
+    if [ "$(project_has "$pom_file" "$meta")" != "true" ]; then
+      echo "  MISSING metadata <$meta>"
+      status=1
+    fi
+  done
+
+  return "$status"
+}
+
+main() {
+  generate_flattened_poms
+
+  echo "Validating flattened poms..."
+  local overall_status=0
+  local checked=0
+  local pom_file gav
+
+  while IFS= read -r pom_file; do
+    checked=$((checked + 1))
+    gav="$(project_value "$pom_file" groupId):$(project_value "$pom_file" artifactId):$(project_value "$pom_file" version)"
+    echo "Checking $pom_file ($gav)"
+    if ! check_pom "$pom_file"; then
+      overall_status=1
+    fi
+  done < <(find . -name .flattened-pom.xml | sort)
+
+  mvn -B -ntp -q flatten:clean >/dev/null 2>&1 || true
+
+  if [ "$checked" -eq 0 ]; then
+    echo "::error::No flattened poms were generated; the release flatten step did not run."
+    exit 1
+  fi
+
+  if [ "$overall_status" -ne 0 ]; then
+    echo "::error::Release pom validation failed: one or more modules would be rejected by the Central Portal."
+    exit 1
+  fi
+
+  echo "OK: all $checked Central-reactor poms have resolved coordinates and required metadata."
+}
+
+main "$@"


### PR DESCRIPTION
The 2.4.0 Central publish failed with "Failed to get coordinates from pom
file" because it predated the flatten fix (#320): its deployed poms still
carried a literal ${revision} and inherited groupId/version from the
parent, which the Central Portal cannot resolve.

Add scripts/linux/check-release-poms.sh, which regenerates the release
flattened poms (no credentials/network) and asserts every published module
has resolved coordinates and the metadata Central requires (name,
description, url, licenses, developers, scm). Wire it in as a
verify-release-poms job on push/PR and as a fail-fast step before the
actual Central upload, and document it in AGENTS.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SqK6abjcbjPR7CwAh3V6ma