### PR TITLE
refactor: extract shared double-hashing helper for open-addressing maps

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -248,11 +248,10 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private Path expand(String token) {
-		if (token.contains(PROJECT_DIR_BRACED)) {
-			return absolute(token.replace(PROJECT_DIR_BRACED, projectDir().getPath()));
-		}
-		if (token.contains(PROJECT_DIR_PLAIN)) {
-			return absolute(token.replace(PROJECT_DIR_PLAIN, projectDir().getPath()));
+		for (String projectDirToken : List.of(PROJECT_DIR_BRACED, PROJECT_DIR_PLAIN)) {
+			if (token.contains(projectDirToken)) {
+				return absolute(token.replace(projectDirToken, projectDir().getPath()));
+			}
 		}
 		return null;
 	}

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import io.github.adamw7.tools.data.structure.internal.DoubleHashing;
 import io.github.adamw7.tools.data.structure.internal.Primes;
 
 /**
@@ -24,8 +25,7 @@ import io.github.adamw7.tools.data.structure.internal.Primes;
  */
 public class IntKeyOpenAddressingMap<V> {
 
-	private static final double MULTIPLIER = 1.2;
-	static final int DEFAULT_SIZE = 64;
+	static final int DEFAULT_SIZE = DoubleHashing.DEFAULT_SIZE;
 
 	private static final byte EMPTY = 0;
 	private static final byte LIVE = 1;
@@ -47,10 +47,7 @@ public class IntKeyOpenAddressingMap<V> {
 
 	@SuppressWarnings("unchecked")
 	private void initArrays(int size) {
-		if (size <= 0) {
-			throw new IllegalArgumentException("Wrong size: " + size);
-		}
-		int newSize = Math.max(size, 3); // array of size 2 would force prime = 1
+		int newSize = DoubleHashing.tableSize(size);
 		keys = new int[newSize];
 		values = (V[]) new Object[newSize];
 		state = new byte[newSize];
@@ -103,19 +100,7 @@ public class IntKeyOpenAddressingMap<V> {
 	}
 
 	private int hash(int key, int iteration) {
-		// double hashing, matching OpenAddressingMap
-		int hashCode = Integer.hashCode(key);
-		int h1 = h1(hashCode);
-		int h2 = h2(hashCode);
-		return Math.abs((h1 + (iteration * h2)) % keys.length);
-	}
-
-	private int h2(int hashCode) {
-		return 1 + (Math.abs(hashCode) % (keys.length - 1));
-	}
-
-	private int h1(int hashCode) {
-		return prime - (hashCode % prime);
+		return DoubleHashing.probe(Integer.hashCode(key), prime, keys.length, iteration);
 	}
 
 	public V put(int key, V value) {
@@ -183,7 +168,7 @@ public class IntKeyOpenAddressingMap<V> {
 	}
 
 	private int newSize() {
-		return (int) (keys.length * MULTIPLIER);
+		return DoubleHashing.grownSize(keys.length);
 	}
 
 	public int[] keys() {

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -7,28 +7,25 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.github.adamw7.tools.data.structure.internal.DoubleHashing;
 import io.github.adamw7.tools.data.structure.internal.Primes;
 import io.github.adamw7.tools.data.structure.internal.Wrapper;
 
 public class OpenAddressingMap<K, V> implements Map<K, V> {
 
-	private static final double MULTIPLIER = 1.2;
-	static final int DEFAULT_SIZE = 64;
+	static final int DEFAULT_SIZE = DoubleHashing.DEFAULT_SIZE;
 	int prime;
-	
+
 	protected Wrapper<K, V>[] array;
 	protected int size;
-	
+
 	public OpenAddressingMap(int size) {
 		initArray(size);
 	}
 
 	@SuppressWarnings("unchecked")
 	private void initArray(int size) {
-		if (size <= 0) {
-			throw new IllegalArgumentException("Wrong size: " + size);
-		}
-		int newSize = Math.max(size, 3); // array of size 2 would force prime = 1
+		int newSize = DoubleHashing.tableSize(size);
 		array = new Wrapper[newSize];
 		prime = Primes.findMaxSmallerThan(newSize);
 	}
@@ -86,21 +83,8 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 	private int hash(Object key, int iteration) {
 		if (key == null) {
 			throw new IllegalArgumentException("Key is null");
-		} else {
-			// double hashing
-			int hashCode = key.hashCode();
-			int h1 = h1(hashCode);
-			int h2 = h2(hashCode);
-			return Math.abs((h1 + (iteration * h2)) % array.length);
 		}
-	}
-
-	private int h2(int hashCode) {
-		return 1 + (Math.abs(hashCode) % (array.length - 1));
-	}
-
-	private int h1(int hashCode) {
-		return prime - (hashCode % prime);
+		return DoubleHashing.probe(key.hashCode(), prime, array.length, iteration);
 	}
 
 	@Override
@@ -110,17 +94,25 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 			int hash = hash(key, i);
 			Wrapper<K, V> wrapper = array[hash];
 			if (wrapper == null) {
-				array[hash] = new Wrapper<>(key, value);
-				size++;
-				return null;
+				return insert(hash, key, value);
 			} else if (wrapper.key.equals(key)) {
-				V previous = wrapper.value;
-				array[hash] = new Wrapper<>(key, value);
-				return previous;
+				return overwrite(hash, key, value);
 			} // removed are skipped
 		}
 		resize();
 		return put(key, value);
+	}
+
+	private V insert(int hash, K key, V value) {
+		array[hash] = new Wrapper<>(key, value);
+		size++;
+		return null;
+	}
+
+	private V overwrite(int hash, K key, V value) {
+		V previous = array[hash].value;
+		array[hash] = new Wrapper<>(key, value);
+		return previous;
 	}
 
 	private void checkIfResizeNeeded() {
@@ -166,7 +158,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 	}
 
 	private int newSize() {
-		return (int) (array.length * MULTIPLIER);
+		return DoubleHashing.grownSize(array.length);
 	}
 
 	@Override

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/internal/DoubleHashing.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/internal/DoubleHashing.java
@@ -1,0 +1,45 @@
+package io.github.adamw7.tools.data.structure.internal;
+
+/**
+ * The double-hashing probe arithmetic shared by the open-addressing maps.
+ * Operating purely on a precomputed {@code hashCode} keeps it independent of the
+ * key's type, so both the object-keyed {@code OpenAddressingMap} and the
+ * primitive {@code int}-keyed {@code IntKeyOpenAddressingMap} reuse the same
+ * sequence and growth policy rather than re-deriving them.
+ */
+public final class DoubleHashing {
+
+	/** Growth factor applied to the backing array on each resize. */
+	public static final double MULTIPLIER = 1.2;
+
+	/** Backing-array size for a map created without an explicit size. */
+	public static final int DEFAULT_SIZE = 64;
+
+	private DoubleHashing() {
+	}
+
+	/**
+	 * The legal backing-array size for a requested capacity. An array of size 2
+	 * would force {@code prime == 1}, so 3 is the floor.
+	 *
+	 * @throws IllegalArgumentException when {@code requestedSize} is not positive
+	 */
+	public static int tableSize(int requestedSize) {
+		if (requestedSize <= 0) {
+			throw new IllegalArgumentException("Wrong size: " + requestedSize);
+		}
+		return Math.max(requestedSize, 3);
+	}
+
+	/** The backing-array size after one growth step. */
+	public static int grownSize(int currentLength) {
+		return (int) (currentLength * MULTIPLIER);
+	}
+
+	/** The slot index probed on the given {@code iteration} of the sequence. */
+	public static int probe(int hashCode, int prime, int length, int iteration) {
+		int h1 = prime - (hashCode % prime);
+		int h2 = 1 + (Math.abs(hashCode) % (length - 1));
+		return Math.abs((h1 + (iteration * h2)) % length);
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/DoubleHashingTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/DoubleHashingTest.java
@@ -1,0 +1,72 @@
+package io.github.adamw7.tools.data.structure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import io.github.adamw7.tools.data.structure.internal.DoubleHashing;
+
+public class DoubleHashingTest {
+
+	@Test
+	public void tableSizeKeepsSizesAtOrAboveFloor() {
+		assertEquals(3, DoubleHashing.tableSize(1));
+		assertEquals(3, DoubleHashing.tableSize(2));
+		assertEquals(3, DoubleHashing.tableSize(3));
+		assertEquals(64, DoubleHashing.tableSize(64));
+	}
+
+	@Test
+	public void tableSizeRejectsZero() {
+		assertWrongSize(0, () -> DoubleHashing.tableSize(0));
+	}
+
+	@Test
+	public void tableSizeRejectsNegative() {
+		assertWrongSize(-5, () -> DoubleHashing.tableSize(-5));
+	}
+
+	private void assertWrongSize(int size, Executable executable) {
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, executable);
+		assertEquals("Wrong size: " + size, thrown.getMessage());
+	}
+
+	@Test
+	public void grownSizeAppliesTheMultiplier() {
+		assertEquals(76, DoubleHashing.grownSize(64)); // 64 * 1.2 = 76.8, truncated
+		assertEquals(12, DoubleHashing.grownSize(10));
+	}
+
+	@Test
+	public void probeFollowsTheDoubleHashingSequence() {
+		// h1 = 3 - (5 % 3) = 1, h2 = 1 + (5 % 6) = 6
+		assertEquals(1, DoubleHashing.probe(5, 3, 7, 0)); // (1 + 0*6) % 7
+		assertEquals(0, DoubleHashing.probe(5, 3, 7, 1)); // (1 + 1*6) % 7
+		assertEquals(6, DoubleHashing.probe(5, 3, 7, 2)); // (1 + 2*6) % 7
+	}
+
+	@Test
+	public void probeIsDeterministic() {
+		assertEquals(DoubleHashing.probe(42, 5, 11, 3), DoubleHashing.probe(42, 5, 11, 3));
+	}
+
+	@Test
+	public void probeStaysWithinTheTableForAnyHashCode() {
+		int length = 17;
+		int prime = 13;
+		for (int hashCode : new int[] { 0, 1, -1, 100, -100, Integer.MAX_VALUE, Integer.MIN_VALUE }) {
+			assertProbesAreValidIndices(hashCode, prime, length);
+		}
+	}
+
+	private void assertProbesAreValidIndices(int hashCode, int prime, int length) {
+		for (int iteration = 0; iteration < length; iteration++) {
+			int index = DoubleHashing.probe(hashCode, prime, length, iteration);
+			assertTrue(index >= 0 && index < length,
+					"index " + index + " out of range for hashCode " + hashCode);
+		}
+	}
+}


### PR DESCRIPTION
Deduplicate the double-hashing arithmetic, growth policy, and sizing
guard that OpenAddressingMap and IntKeyOpenAddressingMap had copied
verbatim into a new DoubleHashing helper. Give OpenAddressingMap.put
insert/overwrite helpers so it mirrors its primitive-keyed sibling, and
collapse HooksFormatRule.expand's two identical branches into a loop.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFtnyHt352f36v6gn3D7fZ