### PR TITLE
refactor: unify duplicated TOON parsing grammar

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryTOONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryTOONDataSource.java
@@ -1,10 +1,6 @@
 package io.github.adamw7.tools.data.source.file;
 
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.regex.Matcher;
 
 /**
  * Data source for TOON (Token-Oriented Object Notation) format files.
@@ -15,6 +11,10 @@ import java.util.regex.Matcher;
  * - Primitive arrays (key[N]: val1,val2,...)
  * - Tabular arrays (key[N]{field1,field2}: row1,row2...)
  * - Nested objects via indentation
+ *
+ * <p>The whole document is flattened eagerly into {@link #fieldsMap}; parsing is delegated to
+ * the shared {@link ToonFlattener}, the same grammar the streaming
+ * {@link IterableTOONDataSource} drives, so the two cannot diverge.</p>
  */
 public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 
@@ -28,201 +28,10 @@ public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 
 	@Override
 	protected void parse() {
-		List<String> lines = new ArrayList<>();
+		ToonFlattener flattener = new ToonFlattener(fieldsMap::put);
 		while (scanner.hasNextLine()) {
-			lines.add(scanner.nextLine());
+			flattener.accept(scanner.nextLine());
 		}
-		parseTOON(lines);
-	}
-
-	private void parseTOON(List<String> lines) {
-		int i = 0;
-		while (i < lines.size()) {
-			i = processLine(lines, i);
-		}
-	}
-
-	private int processLine(List<String> lines, int index) {
-		String line = lines.get(index);
-		String trimmed = line.trim();
-
-		if (trimmed.isEmpty()) {
-			return index + 1;
-		}
-
-		return tryParseArrayHeader(lines, index, trimmed)
-				.or(() -> tryParseKeyValue(lines, index, trimmed))
-				.orElseGet(() -> index + 1);
-    }
-
-	private Optional<Integer> tryParseArrayHeader(List<String> lines, int index, String trimmed) {
-		Matcher arrayMatcher = ToonSyntax.ARRAY_HEADER_PATTERN.matcher(trimmed);
-		if (!arrayMatcher.matches()) {
-			return Optional.empty();
-		}
-
-		String key = arrayMatcher.group(1);
-		int count = Integer.parseInt(arrayMatcher.group(2));
-		String fields = arrayMatcher.group(4);
-		String inlineValues = arrayMatcher.group(5);
-
-		return Optional.of(parseArray(lines, index, key, count, fields, inlineValues));
-	}
-
-	private Optional<Integer> tryParseKeyValue(List<String> lines, int index, String trimmed) {
-		Matcher kvMatcher = ToonSyntax.KEY_VALUE_PATTERN.matcher(trimmed);
-		if (!kvMatcher.matches()) {
-			return Optional.empty();
-		}
-
-		String key = kvMatcher.group(1);
-		String value = kvMatcher.group(2);
-
-		if (value.isEmpty()) {
-			return Optional.of(parseNestedObject(lines, index, key));
-		}
-
-		fieldsMap.put(key, ToonSyntax.unquote(value));
-		return Optional.of(index + 1);
-	}
-
-	private int parseArray(List<String> lines, int index, String key, int count, String fields, String inlineValues) {
-		if (fields != null && !fields.isEmpty()) {
-			return parseTabularArray(lines, index, key, count, fields, inlineValues);
-		}
-
-		if (!inlineValues.isEmpty()) {
-			ToonSyntax.emitInlineArray(fieldsMap::put, key, inlineValues);
-			return index + 1;
-		}
-
-		return parseNestedArray(lines, index, key, count);
-	}
-
-	private int parseTabularArray(List<String> lines, int startIndex, String arrayKey, int count, String fieldsStr, String inlineValues) {
-		String[] fields = ToonSyntax.splitFields(fieldsStr);
-		ToonSyntax.emitTabularHeader(fieldsMap::put, arrayKey, count, fields);
-
-		int rowIndex = 0;
-		if (inlineValues != null && !inlineValues.trim().isEmpty()) {
-			ToonSyntax.emitTabularRow(fieldsMap::put, arrayKey, fields, inlineValues.trim(), rowIndex++);
-		}
-
-		return parseTabularRows(lines, startIndex + 1, arrayKey, count, rowIndex, fields);
-	}
-
-	private int parseTabularRows(List<String> lines, int startIndex, String arrayKey, int count, int initialRowIndex, String[] fields) {
-		int i = startIndex;
-		int rowIndex = initialRowIndex;
-
-		while (i < lines.size() && rowIndex < count && !isNewSection(lines, i)) {
-			String trimmed = lines.get(i).trim();
-			if (!trimmed.isEmpty()) {
-				ToonSyntax.emitTabularRow(fieldsMap::put, arrayKey, fields, trimmed, rowIndex++);
-			}
-			i++;
-		}
-
-		return i;
-	}
-
-	private boolean isNewSection(List<String> lines, int index) {
-		String line = lines.get(index);
-		return ToonSyntax.isTopLevelSection(ToonSyntax.indentationOf(line), line.trim());
-	}
-
-	private int parseNestedArray(List<String> lines, int startIndex, String arrayKey, int count) {
-		int i = startIndex + 1;
-		int itemIndex = 0;
-		int baseIndent = findBaseIndent(lines, i);
-
-		while (i < lines.size() && itemIndex < count) {
-			String line = lines.get(i);
-			String trimmed = line.trim();
-
-			if (shouldExitNested(trimmed, ToonSyntax.indentationOf(line), baseIndent)) {
-				fieldsMap.put(arrayKey, String.valueOf(count));
-				return i;
-			}
-
-			if (trimmed.startsWith("-")) {
-				itemIndex = processListItem(arrayKey, trimmed, itemIndex);
-			}
-
-			i++;
-		}
-
-		fieldsMap.put(arrayKey, String.valueOf(count));
-		return i;
-	}
-
-	private int findBaseIndent(List<String> lines, int startIndex) {
-		for (int i = startIndex; i < lines.size(); i++) {
-			String line = lines.get(i);
-			if (!line.trim().isEmpty()) {
-				return ToonSyntax.indentationOf(line);
-			}
-		}
-		return 0;
-	}
-
-	private int processListItem(String arrayKey, String trimmed, int itemIndex) {
-		String content = trimmed.substring(1).trim();
-
-		if (ToonSyntax.ARRAY_HEADER_PATTERN.matcher(content).matches()) {
-			return itemIndex;
-		}
-
-		if (!content.isEmpty()) {
-			fieldsMap.put(arrayKey + "[" + itemIndex + "]", ToonSyntax.unquote(content));
-		}
-
-		return itemIndex + 1;
-	}
-
-	private int parseNestedObject(List<String> lines, int startIndex, String parentKey) {
-		int i = startIndex + 1;
-		int baseIndent = findBaseIndent(lines, i);
-
-		while (i < lines.size()) {
-			String line = lines.get(i);
-			String trimmed = line.trim();
-			int currentIndent = ToonSyntax.indentationOf(line);
-
-			if (shouldExitNested(trimmed, currentIndent, baseIndent)) {
-				return i;
-			}
-
-			if (!trimmed.isEmpty()) {
-				i = parseNestedKeyValue(lines, i, parentKey, trimmed);
-			} else {
-				i++;
-			}
-		}
-
-		return i;
-	}
-
-	private boolean shouldExitNested(String trimmed, int currentIndent, int baseIndent) {
-		return !trimmed.isEmpty() && baseIndent > 0 && currentIndent < baseIndent;
-	}
-
-	private int parseNestedKeyValue(List<String> lines, int index, String parentKey, String trimmed) {
-		Matcher kvMatcher = ToonSyntax.KEY_VALUE_PATTERN.matcher(trimmed);
-
-		if (!kvMatcher.matches()) {
-			return index + 1;
-		}
-
-		String key = kvMatcher.group(1);
-		String value = kvMatcher.group(2);
-		String fullKey = parentKey + "." + key;
-
-		if (value.isEmpty()) {
-			return parseNestedObject(lines, index, fullKey);
-		}
-
-		fieldsMap.put(fullKey, ToonSyntax.unquote(value));
-		return index + 1;
+		flattener.finish();
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/IterableTOONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/IterableTOONDataSource.java
@@ -7,20 +7,18 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.regex.Matcher;
 
 /**
  * Iterable counterpart of {@link InMemoryTOONDataSource}. Reads TOON one line at a time and
- * emits flattened {@code {key, value}} rows, keeping only a stack of the enclosing objects
- * and the array block currently being read, so memory use is bounded by nesting depth and
+ * emits flattened {@code {key, value}} rows through the shared {@link ToonFlattener}, buffering
+ * only the pairs produced by the line just read, so memory use is bounded by nesting depth and
  * the widest single line rather than by document size.
  */
 public class IterableTOONDataSource extends AbstractIterableFileSource {
 
 	private final Deque<String[]> pending = new ArrayDeque<>();
-	private final Deque<ObjectFrame> objectStack = new ArrayDeque<>();
 	private BufferedReader reader;
-	private Block block;
+	private ToonFlattener flattener;
 	private boolean exhausted;
 
 	public IterableTOONDataSource(String fileName) {
@@ -35,9 +33,7 @@ public class IterableTOONDataSource extends AbstractIterableFileSource {
 	protected void initialise(InputStream stream) throws IOException {
 		reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
 		pending.clear();
-		objectStack.clear();
-		objectStack.push(new ObjectFrame("", -1));
-		block = null;
+		flattener = new ToonFlattener(this::enqueue);
 		exhausted = false;
 	}
 
@@ -54,110 +50,10 @@ public class IterableTOONDataSource extends AbstractIterableFileSource {
 	private void pullLine() throws IOException {
 		String line = reader.readLine();
 		if (line == null) {
-			finishInput();
+			exhausted = true;
+			flattener.finish();
 		} else {
-			processLine(line);
-		}
-	}
-
-	private void finishInput() {
-		exhausted = true;
-		closeBlock();
-	}
-
-	private void processLine(String line) {
-		String trimmed = line.trim();
-		if (trimmed.isEmpty()) {
-			return;
-		}
-		int indent = ToonSyntax.indentationOf(line);
-		if (continuesBlock(indent, trimmed)) {
-			return;
-		}
-		interpret(indent, trimmed);
-	}
-
-	private boolean continuesBlock(int indent, String trimmed) {
-		if (block == null) {
-			return false;
-		}
-		if (!block.continues(indent, trimmed)) {
-			closeBlock();
-			return false;
-		}
-		block.consume(indent, trimmed);
-		if (block.isComplete()) {
-			closeBlock();
-		}
-		return true;
-	}
-
-	private void closeBlock() {
-		if (block != null) {
-			block.close();
-			block = null;
-		}
-	}
-
-	private void interpret(int indent, String trimmed) {
-		popFramesTo(indent);
-		String prefix = objectStack.peek().prefix;
-
-		Matcher arrayMatcher = ToonSyntax.ARRAY_HEADER_PATTERN.matcher(trimmed);
-		if (arrayMatcher.matches()) {
-			startArray(prefix, indent, arrayMatcher);
-			return;
-		}
-
-		Matcher kvMatcher = ToonSyntax.KEY_VALUE_PATTERN.matcher(trimmed);
-		if (kvMatcher.matches()) {
-			handleKeyValue(prefix, indent, kvMatcher);
-		}
-	}
-
-	private void popFramesTo(int indent) {
-		while (objectStack.peek().indent >= indent) {
-			objectStack.pop();
-		}
-	}
-
-	private void handleKeyValue(String prefix, int indent, Matcher matcher) {
-		String key = matcher.group(1);
-		String value = matcher.group(2);
-		if (value.isEmpty()) {
-			objectStack.push(new ObjectFrame(prefix + key + ".", indent));
-		} else {
-			enqueue(prefix + key, ToonSyntax.unquote(value));
-		}
-	}
-
-	private void startArray(String prefix, int indent, Matcher matcher) {
-		String arrayKey = prefix + matcher.group(1);
-		int count = Integer.parseInt(matcher.group(2));
-		String fields = matcher.group(4);
-		String inline = matcher.group(5);
-
-		if (fields != null && !fields.isEmpty()) {
-			startTabular(arrayKey, count, indent, fields, inline);
-		} else if (!inline.isEmpty()) {
-			ToonSyntax.emitInlineArray(this::enqueue, arrayKey, inline);
-		} else {
-			block = new NestedArrayBlock(arrayKey, count);
-		}
-	}
-
-	private void startTabular(String arrayKey, int count, int indent, String fieldsText, String inline) {
-		String[] fields = ToonSyntax.splitFields(fieldsText);
-		ToonSyntax.emitTabularHeader(this::enqueue, arrayKey, count, fields);
-
-		TabularBlock tabular = new TabularBlock(arrayKey, fields, count);
-		block = tabular;
-
-		if (inline != null && !inline.trim().isEmpty()) {
-			tabular.consume(indent, inline.trim());
-			if (tabular.isComplete()) {
-				closeBlock();
-			}
+			flattener.accept(line);
 		}
 	}
 
@@ -168,103 +64,9 @@ public class IterableTOONDataSource extends AbstractIterableFileSource {
 	@Override
 	protected void releaseResources() throws IOException {
 		pending.clear();
-		objectStack.clear();
-		block = null;
+		flattener = null;
 		if (reader != null) {
 			reader.close();
-		}
-	}
-
-	private record ObjectFrame(String prefix, int indent) {
-	}
-
-	private abstract static class Block {
-		abstract boolean continues(int indent, String trimmed);
-
-		abstract void consume(int indent, String trimmed);
-
-		abstract boolean isComplete();
-
-		void close() {
-		}
-	}
-
-	private final class TabularBlock extends Block {
-		private final String arrayKey;
-		private final String[] fields;
-		private final int count;
-		private int rowIndex;
-
-		private TabularBlock(String arrayKey, String[] fields, int count) {
-			this.arrayKey = arrayKey;
-			this.fields = fields;
-			this.count = count;
-		}
-
-		@Override
-		boolean continues(int indent, String trimmed) {
-			return rowIndex < count && !ToonSyntax.isTopLevelSection(indent, trimmed);
-		}
-
-		@Override
-		void consume(int indent, String trimmed) {
-			ToonSyntax.emitTabularRow(IterableTOONDataSource.this::enqueue, arrayKey, fields, trimmed, rowIndex);
-			rowIndex++;
-		}
-
-		@Override
-		boolean isComplete() {
-			return rowIndex >= count;
-		}
-	}
-
-	private final class NestedArrayBlock extends Block {
-		private final String arrayKey;
-		private final int count;
-		private int itemIndex;
-		private int baseIndent = -1;
-
-		private NestedArrayBlock(String arrayKey, int count) {
-			this.arrayKey = arrayKey;
-			this.count = count;
-		}
-
-		@Override
-		boolean continues(int indent, String trimmed) {
-			if (itemIndex >= count) {
-				return false;
-			}
-			return baseIndent <= 0 || indent >= baseIndent;
-		}
-
-		@Override
-		void consume(int indent, String trimmed) {
-			if (baseIndent == -1) {
-				baseIndent = indent;
-			}
-			if (trimmed.startsWith("-")) {
-				processItem(trimmed.substring(1).trim());
-			}
-		}
-
-		private void processItem(String content) {
-			if (ToonSyntax.ARRAY_HEADER_PATTERN.matcher(content).matches()) {
-				return;
-			}
-			if (!content.isEmpty()) {
-				enqueue(arrayKey + "[" + itemIndex + "]", ToonSyntax.unquote(content));
-			}
-			itemIndex++;
-		}
-
-		@Override
-		boolean isComplete() {
-			return itemIndex >= count;
-		}
-
-		@Override
-		void close() {
-			enqueue(arrayKey, String.valueOf(count));
 		}
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/ToonFlattener.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/ToonFlattener.java
@@ -1,0 +1,225 @@
+package io.github.adamw7.tools.data.source.file;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
+
+/**
+ * The single, line-driven TOON grammar. Lines are fed one at a time through {@link #accept}
+ * and flattened {@code key/value} pairs are pushed to a {@link BiConsumer} sink; {@link #finish}
+ * closes any array block still open at end of input.
+ *
+ * <p>Only a stack of the enclosing objects and the array block currently being read are held,
+ * so a caller that drains the sink between lines (the iterable source) keeps memory bounded by
+ * nesting depth, while a caller that collects into a map (the in-memory source) reuses the exact
+ * same grammar rather than re-implementing it.</p>
+ */
+final class ToonFlattener {
+
+	private final BiConsumer<String, String> sink;
+	private final Deque<ObjectFrame> objectStack = new ArrayDeque<>();
+	private Block block;
+
+	ToonFlattener(BiConsumer<String, String> sink) {
+		this.sink = sink;
+		objectStack.push(new ObjectFrame("", -1));
+	}
+
+	void accept(String line) {
+		String trimmed = line.trim();
+		if (trimmed.isEmpty()) {
+			return;
+		}
+		int indent = ToonSyntax.indentationOf(line);
+		if (continuesBlock(indent, trimmed)) {
+			return;
+		}
+		interpret(indent, trimmed);
+	}
+
+	void finish() {
+		closeBlock();
+	}
+
+	private boolean continuesBlock(int indent, String trimmed) {
+		if (block == null) {
+			return false;
+		}
+		if (!block.continues(indent, trimmed)) {
+			closeBlock();
+			return false;
+		}
+		block.consume(indent, trimmed);
+		if (block.isComplete()) {
+			closeBlock();
+		}
+		return true;
+	}
+
+	private void closeBlock() {
+		if (block != null) {
+			block.close();
+			block = null;
+		}
+	}
+
+	private void interpret(int indent, String trimmed) {
+		popFramesTo(indent);
+		String prefix = objectStack.peek().prefix;
+
+		Matcher arrayMatcher = ToonSyntax.ARRAY_HEADER_PATTERN.matcher(trimmed);
+		if (arrayMatcher.matches()) {
+			startArray(prefix, indent, arrayMatcher);
+			return;
+		}
+
+		Matcher kvMatcher = ToonSyntax.KEY_VALUE_PATTERN.matcher(trimmed);
+		if (kvMatcher.matches()) {
+			handleKeyValue(prefix, indent, kvMatcher);
+		}
+	}
+
+	private void popFramesTo(int indent) {
+		while (objectStack.peek().indent >= indent) {
+			objectStack.pop();
+		}
+	}
+
+	private void handleKeyValue(String prefix, int indent, Matcher matcher) {
+		String key = matcher.group(1);
+		String value = matcher.group(2);
+		if (value.isEmpty()) {
+			objectStack.push(new ObjectFrame(prefix + key + ".", indent));
+		} else {
+			enqueue(prefix + key, ToonSyntax.unquote(value));
+		}
+	}
+
+	private void startArray(String prefix, int indent, Matcher matcher) {
+		String arrayKey = prefix + matcher.group(1);
+		int count = Integer.parseInt(matcher.group(2));
+		String fields = matcher.group(4);
+		String inline = matcher.group(5);
+
+		if (fields != null && !fields.isEmpty()) {
+			startTabular(arrayKey, count, indent, fields, inline);
+		} else if (!inline.isEmpty()) {
+			ToonSyntax.emitInlineArray(this::enqueue, arrayKey, inline);
+		} else {
+			block = new NestedArrayBlock(arrayKey, count);
+		}
+	}
+
+	private void startTabular(String arrayKey, int count, int indent, String fieldsText, String inline) {
+		String[] fields = ToonSyntax.splitFields(fieldsText);
+		ToonSyntax.emitTabularHeader(this::enqueue, arrayKey, count, fields);
+
+		TabularBlock tabular = new TabularBlock(arrayKey, fields, count);
+		block = tabular;
+
+		if (inline != null && !inline.trim().isEmpty()) {
+			tabular.consume(indent, inline.trim());
+			if (tabular.isComplete()) {
+				closeBlock();
+			}
+		}
+	}
+
+	private void enqueue(String key, String value) {
+		sink.accept(key, value);
+	}
+
+	private record ObjectFrame(String prefix, int indent) {
+	}
+
+	private abstract static class Block {
+		abstract boolean continues(int indent, String trimmed);
+
+		abstract void consume(int indent, String trimmed);
+
+		abstract boolean isComplete();
+
+		void close() {
+		}
+	}
+
+	private final class TabularBlock extends Block {
+		private final String arrayKey;
+		private final String[] fields;
+		private final int count;
+		private int rowIndex;
+
+		private TabularBlock(String arrayKey, String[] fields, int count) {
+			this.arrayKey = arrayKey;
+			this.fields = fields;
+			this.count = count;
+		}
+
+		@Override
+		boolean continues(int indent, String trimmed) {
+			return rowIndex < count && !ToonSyntax.isTopLevelSection(indent, trimmed);
+		}
+
+		@Override
+		void consume(int indent, String trimmed) {
+			ToonSyntax.emitTabularRow(ToonFlattener.this::enqueue, arrayKey, fields, trimmed, rowIndex);
+			rowIndex++;
+		}
+
+		@Override
+		boolean isComplete() {
+			return rowIndex >= count;
+		}
+	}
+
+	private final class NestedArrayBlock extends Block {
+		private final String arrayKey;
+		private final int count;
+		private int itemIndex;
+		private int baseIndent = -1;
+
+		private NestedArrayBlock(String arrayKey, int count) {
+			this.arrayKey = arrayKey;
+			this.count = count;
+		}
+
+		@Override
+		boolean continues(int indent, String trimmed) {
+			if (itemIndex >= count) {
+				return false;
+			}
+			return baseIndent <= 0 || indent >= baseIndent;
+		}
+
+		@Override
+		void consume(int indent, String trimmed) {
+			if (baseIndent == -1) {
+				baseIndent = indent;
+			}
+			if (trimmed.startsWith("-")) {
+				processItem(trimmed.substring(1).trim());
+			}
+		}
+
+		private void processItem(String content) {
+			if (ToonSyntax.ARRAY_HEADER_PATTERN.matcher(content).matches()) {
+				return;
+			}
+			if (!content.isEmpty()) {
+				enqueue(arrayKey + "[" + itemIndex + "]", ToonSyntax.unquote(content));
+			}
+			itemIndex++;
+		}
+
+		@Override
+		boolean isComplete() {
+			return itemIndex >= count;
+		}
+
+		@Override
+		void close() {
+			enqueue(arrayKey, String.valueOf(count));
+		}
+	}
+}


### PR DESCRIPTION
InMemoryTOONDataSource and IterableTOONDataSource each reimplemented the
entire TOON grammar state machine (array headers, tabular rows, nested
arrays, nested objects, indentation/exit rules), sharing only token-level
helpers via ToonSyntax. The two forks could drift, so a fix in one would
not reach the other.

Extract the line-driven grammar into a shared ToonFlattener that pushes
flattened key/value pairs to a BiConsumer sink. The iterable source feeds
it one line at a time and drains the buffered pairs, keeping memory bounded;
the in-memory source feeds every line and collects into its map. Both now
drive the same grammar instead of duplicating it.

Behavior is unchanged: all 378 data-module tests pass, including the
cross-check asserting the in-memory and iterable flattenings are equal.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UVdk5RigkkGQNq4cVYtpX2