### PR TITLE
refactor: dedupe hook enforcer rules and tidy protogen generator

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -6,9 +6,7 @@ import java.util.List;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
@@ -29,8 +27,6 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  */
 public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 
-	private static final ObjectMapper MAPPER = new ObjectMapper();
-
 	@Override
 	public final void execute() throws EnforcerRuleException {
 		File file = jsonFile();
@@ -42,7 +38,7 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 			return;
 		}
 		List<String> violations = new ArrayList<>();
-		JsonNode root = parse(readContent(file), violations);
+		JsonNode root = JsonNodes.parseObject(readContent(file), description(), violations);
 		if (root != null) {
 			collectViolations(root, violations);
 		}
@@ -79,19 +75,5 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 			throw new EnforcerRuleException(description() + " is empty: " + file);
 		}
 		return content;
-	}
-
-	private JsonNode parse(String content, List<String> violations) {
-		try {
-			JsonNode root = MAPPER.readTree(content);
-			if (root == null || !root.isObject()) {
-				violations.add(description() + " is not valid JSON: expected a JSON object");
-				return null;
-			}
-			return root;
-		} catch (JsonProcessingException e) {
-			violations.add(description() + " is not valid JSON: " + e.getOriginalMessage());
-			return null;
-		}
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonNodes.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonNodes.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Null-safe accessors over Jackson {@link JsonNode} that mirror the optional
@@ -14,7 +16,29 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public final class JsonNodes {
 
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
 	private JsonNodes() {
+	}
+
+	/**
+	 * Parses {@code content} into a JSON object node. When it is not valid JSON or
+	 * not a JSON object, a violation naming {@code description} (e.g.
+	 * {@code settings.json}) is added and {@code null} is returned, so a parse
+	 * failure is reported alongside structural problems rather than thrown.
+	 */
+	public static JsonNode parseObject(String content, String description, List<String> violations) {
+		try {
+			JsonNode root = MAPPER.readTree(content);
+			if (root == null || !root.isObject()) {
+				violations.add(description + " is not valid JSON: expected a JSON object");
+				return null;
+			}
+			return root;
+		} catch (JsonProcessingException e) {
+			violations.add(description + " is not valid JSON: " + e.getOriginalMessage());
+			return null;
+		}
 	}
 
 	/** The child object at {@code key}, or null when it is absent or not an object. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
@@ -1,0 +1,44 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import java.io.File;
+
+/**
+ * Resolves the base directory that a hook command's {@code $CLAUDE_PROJECT_DIR}
+ * variable expands to, and performs that expansion on a single command token.
+ * Both hook rules share this so the two accepted spellings of the variable and
+ * the "grandparent of the settings file" fallback live in exactly one place.
+ */
+final class ClaudeProjectDir {
+
+	static final String BRACED = "${CLAUDE_PROJECT_DIR}";
+	static final String PLAIN = "$CLAUDE_PROJECT_DIR";
+
+	private final File override;
+	private final File settingsFile;
+
+	ClaudeProjectDir(File override, File settingsFile) {
+		this.override = override;
+		this.settingsFile = settingsFile;
+	}
+
+	/** The path {@code token} resolves to when it references the project dir, else null. */
+	String expand(String token) {
+		if (token.contains(BRACED)) {
+			return token.replace(BRACED, resolve().getPath());
+		}
+		if (token.contains(PLAIN)) {
+			return token.replace(PLAIN, resolve().getPath());
+		}
+		return null;
+	}
+
+	/** The configured override, else the settings file's grandparent, else the current directory. */
+	File resolve() {
+		if (override != null) {
+			return override;
+		}
+		File claudeDir = settingsFile.getAbsoluteFile().getParentFile();
+		File root = claudeDir != null ? claudeDir.getParentFile() : null;
+		return root != null ? root : new File(".");
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommands.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommands.java
@@ -1,0 +1,69 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+
+/**
+ * Collects the command string of every {@code command}-type hook declared in a
+ * parsed {@code settings.json}. It walks the
+ * {@code hooks -> event -> groups -> hooks -> entry} structure defensively, so a
+ * node of the wrong shape is skipped rather than throwing; validating that shape
+ * is {@link HookCommandsValidRule}'s job, not this collector's.
+ */
+final class HookCommands {
+
+	private static final String HOOKS_KEY = "hooks";
+	private static final String TYPE_KEY = "type";
+	private static final String COMMAND_KEY = "command";
+	private static final String COMMAND_TYPE = "command";
+
+	private HookCommands() {
+	}
+
+	static List<String> from(JsonNode settings) {
+		List<String> commands = new ArrayList<>();
+		JsonNode hooks = JsonNodes.objectAt(settings, HOOKS_KEY);
+		if (hooks != null) {
+			collectEvents(hooks, commands);
+		}
+		return commands;
+	}
+
+	private static void collectEvents(JsonNode hooks, List<String> commands) {
+		for (String event : JsonNodes.fieldNames(hooks)) {
+			collectGroups(JsonNodes.arrayAt(hooks, event), commands);
+		}
+	}
+
+	private static void collectGroups(JsonNode groups, List<String> commands) {
+		if (groups == null) {
+			return;
+		}
+		for (int i = 0; i < groups.size(); i++) {
+			collectEntries(JsonNodes.objectAt(groups, i), commands);
+		}
+	}
+
+	private static void collectEntries(JsonNode group, List<String> commands) {
+		if (group == null) {
+			return;
+		}
+		JsonNode entries = JsonNodes.arrayAt(group, HOOKS_KEY);
+		if (entries == null) {
+			return;
+		}
+		for (int i = 0; i < entries.size(); i++) {
+			collectCommand(JsonNodes.objectAt(entries, i), commands);
+		}
+	}
+
+	private static void collectCommand(JsonNode entry, List<String> commands) {
+		if (entry != null && COMMAND_TYPE.equals(JsonNodes.textAt(entry, TYPE_KEY, "").strip())) {
+			commands.add(JsonNodes.textAt(entry, COMMAND_KEY, "").strip());
+		}
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -38,8 +38,6 @@ public class HookCommandsValidRule extends JsonFileRule {
 	private static final String TYPE_KEY = "type";
 	private static final String COMMAND_KEY = "command";
 	private static final String COMMAND_TYPE = "command";
-	private static final String PROJECT_DIR_BRACED = "${CLAUDE_PROJECT_DIR}";
-	private static final String PROJECT_DIR_PLAIN = "$CLAUDE_PROJECT_DIR";
 
 	/** The {@code .claude/settings.json} file to validate. Injected from the rule configuration. */
 	private File settingsFile;
@@ -171,32 +169,14 @@ public class HookCommandsValidRule extends JsonFileRule {
 
 	/** The resolved on-disk path of a {@code $CLAUDE_PROJECT_DIR}-rooted token, or null when none is referenced. */
 	private String localScriptPath(String command) {
+		ClaudeProjectDir projectDirs = new ClaudeProjectDir(projectDir, settingsFile);
 		for (String token : command.split("\\s+")) {
-			String expanded = expand(token);
+			String expanded = projectDirs.expand(token);
 			if (expanded != null) {
 				return expanded;
 			}
 		}
 		return null;
-	}
-
-	private String expand(String token) {
-		if (token.contains(PROJECT_DIR_BRACED)) {
-			return token.replace(PROJECT_DIR_BRACED, projectDir().getPath());
-		}
-		if (token.contains(PROJECT_DIR_PLAIN)) {
-			return token.replace(PROJECT_DIR_PLAIN, projectDir().getPath());
-		}
-		return null;
-	}
-
-	private File projectDir() {
-		if (projectDir != null) {
-			return projectDir;
-		}
-		File claudeDir = settingsFile.getAbsoluteFile().getParentFile();
-		File root = claudeDir != null ? claudeDir.getParentFile() : null;
-		return root != null ? root : new File(".");
 	}
 
 	void setSettingsFile(File settingsFile) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -11,9 +11,7 @@ import javax.inject.Named;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.enforcer.rule.JsonNodes;
@@ -46,14 +44,7 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
 @Named("hooksFormat")
 public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 
-	private static final ObjectMapper MAPPER = new ObjectMapper();
-	private static final String HOOKS_KEY = "hooks";
-	private static final String TYPE_KEY = "type";
-	private static final String COMMAND_KEY = "command";
-	private static final String COMMAND_TYPE = "command";
 	private static final String SHEBANG = "#!";
-	private static final String PROJECT_DIR_BRACED = "${CLAUDE_PROJECT_DIR}";
-	private static final String PROJECT_DIR_PLAIN = "$CLAUDE_PROJECT_DIR";
 
 	/** The {@code .claude/hooks} directory to scan. Injected from the rule configuration. */
 	private File hooksDir;
@@ -145,22 +136,12 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private JsonNode parseSettings(File file, List<String> violations) {
-		try {
-			JsonNode root = MAPPER.readTree(MarkdownText.read(file, "settings.json"));
-			if (root == null || !root.isObject()) {
-				violations.add("settings.json is not valid JSON: expected a JSON object");
-				return null;
-			}
-			return root;
-		} catch (JsonProcessingException e) {
-			violations.add("settings.json is not valid JSON: " + e.getOriginalMessage());
-			return null;
-		}
+		return JsonNodes.parseObject(MarkdownText.read(file, "settings.json"), "settings.json", violations);
 	}
 
 	private Set<Path> collectReferencedScripts(JsonNode settings, List<String> violations) {
 		Set<Path> referenced = new LinkedHashSet<>();
-		for (String command : hookCommands(settings)) {
+		for (String command : HookCommands.from(settings)) {
 			addReferencedScript(command, referenced, violations);
 		}
 		return referenced;
@@ -192,81 +173,30 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 		}
 	}
 
-	private List<String> hookCommands(JsonNode settings) {
-		List<String> commands = new ArrayList<>();
-		JsonNode hooks = JsonNodes.objectAt(settings, HOOKS_KEY);
-		if (hooks != null) {
-			collectEventCommands(hooks, commands);
-		}
-		return commands;
-	}
-
-	private void collectEventCommands(JsonNode hooks, List<String> commands) {
-		for (String event : JsonNodes.fieldNames(hooks)) {
-			collectGroupCommands(JsonNodes.arrayAt(hooks, event), commands);
-		}
-	}
-
-	private void collectGroupCommands(JsonNode groups, List<String> commands) {
-		if (groups == null) {
-			return;
-		}
-		for (int i = 0; i < groups.size(); i++) {
-			collectEntryCommands(JsonNodes.objectAt(groups, i), commands);
-		}
-	}
-
-	private void collectEntryCommands(JsonNode group, List<String> commands) {
-		if (group == null) {
-			return;
-		}
-		JsonNode entries = JsonNodes.arrayAt(group, HOOKS_KEY);
-		if (entries == null) {
-			return;
-		}
-		for (int i = 0; i < entries.size(); i++) {
-			collectCommand(JsonNodes.objectAt(entries, i), commands);
-		}
-	}
-
-	private void collectCommand(JsonNode entry, List<String> commands) {
-		if (entry != null && COMMAND_TYPE.equals(JsonNodes.textAt(entry, TYPE_KEY, "").strip())) {
-			commands.add(JsonNodes.textAt(entry, COMMAND_KEY, "").strip());
-		}
-	}
-
 	/** The absolute path a command's {@code $CLAUDE_PROJECT_DIR} token resolves to when it lands in the hooks directory, else null. */
 	private Path scriptInHooksDir(String command) {
 		Path hooks = hooksDir.getAbsoluteFile().toPath().normalize();
+		ClaudeProjectDir projectDirs = new ClaudeProjectDir(projectDir, settingsFile);
 		for (String token : command.split("\\s+")) {
-			Path resolved = expand(token);
-			if (resolved != null && resolved.startsWith(hooks)) {
+			Path resolved = resolveInHooks(projectDirs, token, hooks);
+			if (resolved != null) {
 				return resolved;
 			}
 		}
 		return null;
 	}
 
-	private Path expand(String token) {
-		for (String projectDirToken : List.of(PROJECT_DIR_BRACED, PROJECT_DIR_PLAIN)) {
-			if (token.contains(projectDirToken)) {
-				return absolute(token.replace(projectDirToken, projectDir().getPath()));
-			}
+	private Path resolveInHooks(ClaudeProjectDir projectDirs, String token, Path hooks) {
+		String expanded = projectDirs.expand(token);
+		if (expanded == null) {
+			return null;
 		}
-		return null;
+		Path resolved = absolute(expanded);
+		return resolved.startsWith(hooks) ? resolved : null;
 	}
 
 	private Path absolute(String path) {
 		return new File(path).getAbsoluteFile().toPath().normalize();
-	}
-
-	private File projectDir() {
-		if (projectDir != null) {
-			return projectDir;
-		}
-		File claudeDir = settingsFile.getAbsoluteFile().getParentFile();
-		File root = claudeDir != null ? claudeDir.getParentFile() : null;
-		return root != null ? root : new File(".");
 	}
 
 	void setHooksDir(File hooksDir) {

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Methods.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Methods.java
@@ -26,7 +26,7 @@ public class Methods {
 		}
 		builder.append(Utils.toUpperCamelCase(field.getName()));
 		builder.append("(");
-		builder.append(field.getName()).append(");");			
+		builder.append(field.getName()).append(");");
 		builder.append("return this;}");
 
 		return builder;
@@ -66,7 +66,7 @@ public class Methods {
 		} else if (field.isRepeated()) {
 			method = ".addAll";
 		} else {
-			method = ".set";			
+			method = ".set";
 		}
 		return method + suffix;
 	}
@@ -94,8 +94,8 @@ public class Methods {
 		builder.append(" clear").append(fieldName);
 		builder.append("() {");
 		builder.append(classOrBuilder).append(".clear").append(fieldName).append("();");
-		builder.append("return new ").append(returnType.replace("Ifc", "Impl")).append("(").append(classOrBuilder)
-				.append(");}");
+		builder.append("return new ").append(returnType.replace(Utils.IFC_SUFFIX, Utils.IMPL_SUFFIX)).append("(")
+				.append(classOrBuilder).append(");}");
 
 		return builder;
 	}
@@ -144,7 +144,7 @@ public class Methods {
 		StringBuilder builder = new StringBuilder("set");
 		builder.append(Utils.toUpperCamelCase(field.getName()));
 		builder.append("(");
-		builder.append(typeMappings.get(field));					
+		builder.append(typeMappings.get(field));
 		builder.append(" ").append(field.getName()).append(")");
 
 		return builder;

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Utils.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Utils.java
@@ -7,7 +7,10 @@ import java.util.regex.Pattern;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 
 public class Utils {
-	
+
+	public static final String IFC_SUFFIX = "Ifc";
+	public static final String IMPL_SUFFIX = "Impl";
+
 	private Utils() {}
 
 	public static String to(FieldDescriptor fieldDescriptor, String suffix) {
@@ -40,11 +43,11 @@ public class Utils {
 	}
 	
 	public static String getNextIfc(String className, List<FieldDescriptor> fields, FieldDescriptor requiredField) {
-		return getNext(className, fields, requiredField, "Ifc");
+		return getNext(className, fields, requiredField, IFC_SUFFIX);
 	}
-	
+
 	public static String getNextImpl(String className, List<FieldDescriptor> fields, FieldDescriptor requiredField) {
-		return getNext(className, fields, requiredField, "Impl");
+		return getNext(className, fields, requiredField, IMPL_SUFFIX);
 	}
 
 	private static String getNext(String className, List<FieldDescriptor> fields, FieldDescriptor requiredField, String suffix) {


### PR DESCRIPTION
Extract the duplication shared by HooksFormatRule and HookCommandsValidRule:
- ClaudeProjectDir: the $CLAUDE_PROJECT_DIR variable spellings, token
  expansion, and "grandparent of the settings file" resolution
- HookCommands: the hooks -> event -> groups -> hooks tree walk that
  collects command-hook commands
- JsonNodes.parseObject: the JSON-object parse used by JsonFileRule and
  HooksFormatRule (which no longer carries its own ObjectMapper)

Protogen generator cleanup: replace the "Ifc"/"Impl" magic strings with
Utils.IFC_SUFFIX/IMPL_SUFFIX constants and strip trailing whitespace.

Behavior is unchanged; all enforcer and protogen tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H2BRqoDeTxciJYqU8EJ2DB