### PR TITLE
fix(pom): restrict shellcheck to .sh files only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,9 @@
 							<sourceDirs>
 								<sourceDir>
 									<directory>${project.basedir}/scripts</directory>
+									<includes>
+										<include>**/*.sh</include>
+									</includes>
 								</sourceDir>
 							</sourceDirs>
 						</configuration>


### PR DESCRIPTION
## Problem

Every `mvn install` printed a large block of shellcheck warnings (SC2148, SC2288, SC1017, SC1083, ...) against files that are **not** shell scripts:

- `scripts/windows/*.bat`
- `scripts/windows/install-jdk-25.ps1`
- `scripts/windows/.claude/settings.local.json`

## Root cause

The `shellcheck-maven-plugin`'s built-in `**/*.sh` filter is only applied to its **default** source dir. Once an explicit `<sourceDir>` is configured with just a `<directory>` and no `<includes>`, `SourceDir` (which `extends FileSet`) falls back to the FileSet default include of `**` — matching *every* file in the tree. So the Windows batch/PowerShell/JSON files were being linted as shell scripts.

## Fix

Add an `<includes>**/*.sh</includes>` to the configured source dir so only real shell scripts (`scripts/linux/*.sh`) are checked.

## Verification

`mvn install` now completes with `BUILD SUCCESS` and no shellcheck warning block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)