### PR TITLE
test(hooks): make HooksFormatRuleTest pass on Windows

### DIFF
--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -3,10 +3,12 @@ package io.github.adamw7.tools.enforcer.settings;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -53,6 +55,7 @@ class HooksFormatRuleTest {
 
 	@Test
 	void failsWhenScriptIsNotExecutable() {
+		assumeTrue(supportsExecutableBit(), "filesystem has no executable bit to clear");
 		writeScript("session-start.sh", "#!/bin/sh\n", false);
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
@@ -157,9 +160,21 @@ class HooksFormatRuleTest {
 	private void writeScript(String name, String content, boolean executable) {
 		Path file = hooksDir().resolve(name);
 		writeString(file, content);
-		if (!file.toFile().setExecutable(executable)) {
-			throw new IllegalStateException("Could not set executable bit on " + file);
+		setExecutable(file.toFile(), executable);
+	}
+
+	private void setExecutable(File file, boolean executable) {
+		if (file.setExecutable(executable) || file.canExecute() == executable) {
+			return;
 		}
+		if (!executable) {
+			return; // Windows cannot clear the executable bit; every file stays executable
+		}
+		throw new IllegalStateException("Could not set executable bit on " + file);
+	}
+
+	private boolean supportsExecutableBit() {
+		return FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
 	}
 
 	private void writeString(Path file, String content) {


### PR DESCRIPTION
## Problem

`mvn install` fails on Windows with two errors in `HooksFormatRuleTest`:

```
HooksFormatRuleTest.failsWhenScriptIsNotExecutable ... IllegalState Could not set executable bit on ...session-start.sh
HooksFormatRuleTest.passesWhenScriptChecksAreDisabled ... IllegalState Could not set executable bit on ...session-start.sh
```

The `writeScript` test helper calls `File.setExecutable(false)`, which returns `false` on Windows — NTFS has no POSIX executable bit to clear — so the helper throws `IllegalStateException`. Compounding this, `File.canExecute()` always returns `true` on Windows, so a genuinely non-executable file cannot even be constructed there.

## Fix (test-only)

- Extract a tolerant `setExecutable` helper that no longer throws when the platform cannot clear the executable bit for a non-executable request (covers `passesWhenScriptChecksAreDisabled`, where executability is incidental).
- Gate `failsWhenScriptIsNotExecutable` with `assumeTrue(supportsExecutableBit())` so it skips on filesystems without a POSIX executable bit, where the check is not meaningful.

No production code changes — the enforcer's `requireExecutable` check (`File.canExecute()`) is inherently POSIX-only and is effectively a no-op on Windows regardless.

## Verification

`mvn -pl claude-code-enforcer -am test -Dtest=HooksFormatRuleTest` on Windows: **12 run, 0 failures, 0 errors, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)