### PR TITLE
fix(data): confine uniqueness MCP tool to a base directory

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfiguration.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfiguration.java
@@ -1,18 +1,34 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
+import io.github.adamw7.tools.data.source.file.PathValidator;
 import io.github.adamw7.tools.mcp.AbstractMcpConfiguration;
 import io.github.adamw7.tools.mcp.McpTool;
 
 /**
- * Wires the uniqueness MCP server. It exposes a single uniqueness-check tool; all
- * transport wiring is inherited from {@link AbstractMcpConfiguration}.
+ * Wires the uniqueness MCP server. It exposes a single uniqueness-check tool,
+ * confined to the configured {@code data.allowed-base-dir} (defaulting to the
+ * server's working directory) so a client cannot steer the tool at arbitrary
+ * files such as {@code /etc/passwd}; all transport wiring is inherited from
+ * {@link AbstractMcpConfiguration}.
  */
 @Configuration
 public class McpConfiguration extends AbstractMcpConfiguration {
+
+	private static final Logger log = LogManager.getLogger(McpConfiguration.class);
+
+	@Value("${data.allowed-base-dir:}")
+	String allowedBaseDir;
 
 	@Override
 	protected String serverName() {
@@ -21,6 +37,24 @@ public class McpConfiguration extends AbstractMcpConfiguration {
 
 	@Override
 	protected List<McpTool> tools() {
+		confineFileAccess();
 		return List.of(new UniquenessTool());
+	}
+
+	private void confineFileAccess() {
+		Path baseDir = resolveBaseDir();
+		try {
+			PathValidator.setAllowedBaseDir(baseDir);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not confine MCP file access to " + baseDir, e);
+		}
+		log.info("Confining MCP file access to base directory: {}", baseDir);
+	}
+
+	private Path resolveBaseDir() {
+		if (allowedBaseDir == null || allowedBaseDir.isBlank()) {
+			return Path.of(System.getProperty("user.dir"));
+		}
+		return Path.of(allowedBaseDir.trim());
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
@@ -1,16 +1,24 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.adamw7.tools.data.source.file.PathValidator;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
@@ -18,6 +26,44 @@ import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTrans
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 
 public class McpConfigurationTest {
+
+    @AfterEach
+    public void clearBaseDir() {
+        // tools() confines file access through global PathValidator state; reset it
+        // so the restriction does not leak into other tests.
+        PathValidator.clearAllowedBaseDir();
+    }
+
+    @Test
+    public void confinesFileAccessToConfiguredBaseDir(@TempDir Path baseDir) throws IOException {
+        Path insideFile = Files.createFile(baseDir.resolve("data.csv"));
+        McpConfiguration config = new McpConfiguration();
+        config.allowedBaseDir = baseDir.toString();
+
+        config.tools();
+
+        assertThrows(SecurityException.class,
+                () -> PathValidator.validate(outsideBase(baseDir)));
+        assertDoesNotThrow(() -> PathValidator.validate(insideFile.toRealPath().toString()));
+    }
+
+    @Test
+    public void defaultsToWorkingDirectoryWhenBaseDirBlank(@TempDir Path outsideDir) throws IOException {
+        Path outsideFile = Files.createFile(outsideDir.resolve("data.csv"));
+        McpConfiguration config = new McpConfiguration();
+        config.allowedBaseDir = "   ";
+
+        config.tools();
+
+        // The JUnit temp dir lives outside the module's working directory, so a file
+        // there must be rejected once access is confined to the default base.
+        assertThrows(SecurityException.class,
+                () -> PathValidator.validate(outsideFile.toRealPath().toString()));
+    }
+
+    private String outsideBase(Path baseDir) {
+        return baseDir.getParent().resolve("outside-the-base-dir.csv").toString();
+    }
 
     @Test
     public void happyPath() throws Exception {


### PR DESCRIPTION
The uniqueness_check MCP tool passed the client-supplied "file" argument
straight to the filesystem, guarded only by PathValidator. PathValidator's
allowed base directory defaults to null and was never configured in
production wiring, so with no base dir set it only rejected traversal
sequences and happily returned any absolute path. A client could call
uniqueness_check with file "/etc/passwd" (or any readable absolute path)
and have the server open and parse it - remotely reachable when the server
runs over the HTTP/SSE transports.

Configure PathValidator at MCP-server startup from a new
data.allowed-base-dir property, defaulting to the server's working
directory, mirroring how the context module confines access via PathPolicy.
Absolute paths outside the base directory are now rejected.

Add regression tests covering the configured and default base directory,
and reset the global PathValidator state after each test so the
restriction does not leak across tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WutWfnjosCso6wasdyEfU8