### PR TITLE
refactor: readable code-gen templates and drop unchecked YAML casts

### DIFF
--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Methods.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Methods.java
@@ -15,21 +15,10 @@ public class Methods {
 	}
 
 	public StringBuilder setter(FieldDescriptor field, String returnType) {
-		StringBuilder builder = newOverride();
-		builder.append("public ").append(returnType).append(" ");
-		builder.append(generateSetter(field)).append(" {");
-		builder.append("builder.");
-		if (isPureRepeated(field)) {
-			builder.append("addAll");
-		} else {
-			builder.append("set");
-		}
-		builder.append(Utils.toUpperCamelCase(field.getName()));
-		builder.append("(");
-		builder.append(field.getName()).append(");");
-		builder.append("return this;}");
-
-		return builder;
+		String call = isPureRepeated(field) ? "addAll" : "set";
+		String fieldName = Utils.toUpperCamelCase(field.getName());
+		return override("public %s %s {builder.%s%s(%s);return this;}"
+				.formatted(returnType, generateSetter(field), call, fieldName, field.getName()));
 	}
 
 	private boolean isPureRepeated(FieldDescriptor field) {
@@ -37,25 +26,16 @@ public class Methods {
 	}
 
 	public StringBuilder build() {
-		StringBuilder builder = newOverride();
-		builder.append("public ").append(className).append(" build() {return builder.build();}");
-
-		return builder;
+		return override("public %s build() {return builder.build();}".formatted(className));
 	}
 
 	public StringBuilder requiredSetter(String classOrBuilder, FieldDescriptor field,
 			List<FieldDescriptor> requiredFields) {
-		StringBuilder builder = newOverride();
 		String returnType = Utils.getNextIfc(className, requiredFields, field);
-		builder.append("public ").append(returnType).append(" ").append(generateSetter(field))
-				.append(" {");
-		builder.append(classOrBuilder).append(builderMethodName(field));
-		builder.append("(");
-		builder.append(field.getName()).append("); return new ");
-		builder.append(Utils.getNextImpl(className, requiredFields, field)).append("(")
-				.append(classOrBuilder).append(");}");
-
-		return builder;
+		String nextImpl = Utils.getNextImpl(className, requiredFields, field);
+		return override("public %s %s {%s%s(%s); return new %s(%s);}".formatted(returnType,
+				generateSetter(field), classOrBuilder, builderMethodName(field), field.getName(),
+				nextImpl, classOrBuilder));
 	}
 
 	private String builderMethodName(FieldDescriptor field) {
@@ -75,12 +55,9 @@ public class Methods {
 		if (!needsHas(field)) {
 			return new StringBuilder();
 		}
-		StringBuilder builder = newOverride();
 		String fieldName = Utils.toUpperCamelCase(field.getName());
-		builder.append("public boolean has").append(fieldName);
-		builder.append("() {return ").append(classOrBuilder).append(".has").append(fieldName).append("();}");
-
-		return builder;
+		return override("public boolean has%s() {return %s.has%s();}"
+				.formatted(fieldName, classOrBuilder, fieldName));
 	}
 
 	private boolean needsHas(FieldDescriptor field) {
@@ -88,66 +65,41 @@ public class Methods {
 	}
 
 	public StringBuilder clear(String classOrBuilder, FieldDescriptor field, String returnType) {
-		StringBuilder builder = newOverride();
 		String fieldName = Utils.toUpperCamelCase(field.getName());
-		builder.append("public ").append(returnType);
-		builder.append(" clear").append(fieldName);
-		builder.append("() {");
-		builder.append(classOrBuilder).append(".clear").append(fieldName).append("();");
-		builder.append("return new ").append(returnType.replace(Utils.IFC_SUFFIX, Utils.IMPL_SUFFIX)).append("(")
-				.append(classOrBuilder).append(");}");
-
-		return builder;
+		String impl = returnType.replace(Utils.IFC_SUFFIX, Utils.IMPL_SUFFIX);
+		return override("public %s clear%s() {%s.clear%s();return new %s(%s);}"
+				.formatted(returnType, fieldName, classOrBuilder, fieldName, impl, classOrBuilder));
 	}
 
-	private StringBuilder newOverride() {
-		return new StringBuilder("@Override").append(System.lineSeparator());
+	private StringBuilder override(String body) {
+		return new StringBuilder("@Override").append(System.lineSeparator()).append(body);
 	}
 
 	public StringBuilder constructor(String implName, String classOrBuilder) {
-		StringBuilder builder = new StringBuilder("public ");
-		builder.append(implName).append("(Builder ").append(classOrBuilder);
-		builder.append(") {this.").append(classOrBuilder).append(" = ").append(classOrBuilder).append(";}");
-		return builder;
+		return new StringBuilder("public %s(Builder %s) {this.%s = %s;}"
+				.formatted(implName, classOrBuilder, classOrBuilder, classOrBuilder));
 	}
 
 	public StringBuilder declareSetter(FieldDescriptor field, String returnType) {
-		StringBuilder builder = new StringBuilder(returnType);
-		builder.append(" ");
-		builder.append(generateSetter(field));
-		builder.append(";");
-
-		return builder;
+		return new StringBuilder("%s %s;".formatted(returnType, generateSetter(field)));
 	}
 
 	public StringBuilder declareHas(FieldDescriptor field) {
 		if (!needsHas(field)) {
 			return new StringBuilder();
 		}
-		StringBuilder builder = new StringBuilder("boolean has");
-		builder.append(Utils.toUpperCamelCase(field.getName()));
-		builder.append("();");
-
-		return builder;
+		return new StringBuilder(
+				"boolean has%s();".formatted(Utils.toUpperCamelCase(field.getName())));
 	}
 
 	public StringBuilder declareClear(FieldDescriptor field, String returnType) {
-		StringBuilder builder = new StringBuilder(returnType);
-		builder.append(" clear");
-		builder.append(Utils.toUpperCamelCase(field.getName()));
-		builder.append("();");
-
-		return builder;
+		return new StringBuilder(
+				"%s clear%s();".formatted(returnType, Utils.toUpperCamelCase(field.getName())));
 	}
 
-	private StringBuilder generateSetter(FieldDescriptor field) {
-		StringBuilder builder = new StringBuilder("set");
-		builder.append(Utils.toUpperCamelCase(field.getName()));
-		builder.append("(");
-		builder.append(typeMappings.get(field));
-		builder.append(" ").append(field.getName()).append(")");
-
-		return builder;
+	private String generateSetter(FieldDescriptor field) {
+		return "set%s(%s %s)".formatted(Utils.toUpperCamelCase(field.getName()),
+				typeMappings.get(field), field.getName());
 	}
 
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryYAMLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryYAMLDataSource.java
@@ -26,48 +26,41 @@ public class InMemoryYAMLDataSource extends AbstractInMemoryMapDataSource {
 		parseYAML(yamlContent.toString());
 	}
 
-	@SuppressWarnings("unchecked")
 	private void parseYAML(String yamlString) {
 		try {
 			ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 			Object parsed = yamlMapper.readValue(yamlString, Object.class);
-			if (parsed instanceof Map) {
-				flattenMap("", (Map<String, Object>) parsed);
-			} else if (parsed instanceof List) {
-				flattenList("", (List<Object>) parsed);
+			if (parsed instanceof Map<?, ?> map) {
+				flattenMap("", map);
+			} else if (parsed instanceof List<?> list) {
+				flattenList("", list);
 			}
 		} catch (Exception e) {
 			throw new IllegalArgumentException("Failed to parse YAML", e);
 		}
 	}
 
-	@SuppressWarnings("unchecked")
-	private void flattenMap(String prefix, Map<String, Object> map) {
-		for (Map.Entry<String, Object> entry : map.entrySet()) {
-			String key = prefix.isEmpty() ? entry.getKey() : prefix + "." + entry.getKey();
-			Object value = entry.getValue();
-			if (value instanceof Map) {
-				flattenMap(key, (Map<String, Object>) value);
-			} else if (value instanceof List) {
-				flattenList(key, (List<Object>) value);
-			} else {
-				fieldsMap.put(key, String.valueOf(value));
-			}
+	private void flattenMap(String prefix, Map<?, ?> map) {
+		for (Map.Entry<?, ?> entry : map.entrySet()) {
+			String key = prefix.isEmpty() ? String.valueOf(entry.getKey())
+					: prefix + "." + entry.getKey();
+			flattenValue(key, entry.getValue());
 		}
 	}
 
-	@SuppressWarnings("unchecked")
-	private void flattenList(String prefix, List<Object> list) {
+	private void flattenList(String prefix, List<?> list) {
 		for (int i = 0; i < list.size(); i++) {
-			String key = prefix + "[" + i + "]";
-			Object value = list.get(i);
-			if (value instanceof Map) {
-				flattenMap(key, (Map<String, Object>) value);
-			} else if (value instanceof List) {
-				flattenList(key, (List<Object>) value);
-			} else {
-				fieldsMap.put(key, String.valueOf(value));
-			}
+			flattenValue(prefix + "[" + i + "]", list.get(i));
+		}
+	}
+
+	private void flattenValue(String key, Object value) {
+		if (value instanceof Map<?, ?> map) {
+			flattenMap(key, map);
+		} else if (value instanceof List<?> list) {
+			flattenList(key, list);
+		} else {
+			fieldsMap.put(key, String.valueOf(value));
 		}
 	}
 }


### PR DESCRIPTION
Rewrite Methods.java to build generated source with single formatted
templates instead of interleaved StringBuilder.append() calls and
embedded punctuation, so each emitted method reads as its target shape.

Replace the raw-type Map/List casts in InMemoryYAMLDataSource with
instanceof pattern matching over wildcard types, removing all three
@SuppressWarnings("unchecked") and folding the duplicated map/list
branching into a shared flattenValue helper. Output is unchanged
(JDT-formatted); protogen GeneretedCodeTest and YAML source tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012BGjTYpBDWzLxij9tpx6af