### PR TITLE
build(docker): harden and slim assembly image

### DIFF
--- a/assembly/Dockerfile
+++ b/assembly/Dockerfile
@@ -1,4 +1,25 @@
-FROM eclipse-temurin:25
+# Runtime-only image: the jar-with-dependencies is built beforehand by
+# `mvn package` (see .github/workflows/docker.yml) and lives in target/.
+# Use the slimmer JRE variant since we only need to run the jar, not compile.
+FROM eclipse-temurin:25-jre
 
+# OCI image metadata.
+LABEL org.opencontainers.image.title="tools" \
+      org.opencontainers.image.description="Runnable SampleApp distribution for the adamw7/tools project." \
+      org.opencontainers.image.source="https://github.com/adamw7/tools" \
+      org.opencontainers.image.licenses="MIT"
+
+WORKDIR /app
+
+# Copy the assembled fat jar under a fixed name.
 COPY target/tools.assembly-*-jar-with-dependencies.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+
+# Run as an unprivileged user rather than root.
+RUN useradd --system --no-create-home --shell /usr/sbin/nologin appuser \
+    && chown appuser:appuser app.jar
+USER appuser
+
+# Container-aware JVM defaults; override with `docker run -e JAVA_OPTS=...`.
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0"
+
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar \"$@\"", "--"]


### PR DESCRIPTION
Improve the assembly Dockerfile:
- Use the JRE base image (25-jre) instead of the full JDK to shrink the
  runtime image, since only a jar is executed.
- Run as an unprivileged appuser instead of root.
- Add OCI image metadata labels.
- Set container-aware JVM memory defaults (MaxRAMPercentage) via an
  overridable JAVA_OPTS env var and forward runtime args to the jar.
- Add a WORKDIR and a trailing newline.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LwsLNFtSKGdnxsfEv7xezZ