### PR TITLE
build(k8s): add minikube deployment for SampleApp uniqueness check

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,0 +1,41 @@
+# Kubernetes deployment image for running SampleApp (the CSV uniqueness checker).
+#
+# Why this exists (and is separate from ../assembly/Dockerfile):
+# The assembly fat jar bundles the `data` module's spring-boot:repackage output,
+# so it has a nested Spring Boot layout (BOOT-INF/classes + BOOT-INF/lib) while its
+# manifest Main-Class points at SampleApp. `java -jar` therefore cannot find the
+# class. This image expands the fat jar into a flat classpath in a JDK build stage
+# (the runtime JRE has no `jar`/`unzip`), and adds a console log4j2 config so the
+# result reaches stdout / `kubectl logs` instead of a rolling file.
+#
+# Build from the repo root AFTER `mvn -DskipTests package`:
+#   docker build -f k8s/Dockerfile -t tools-k8s:local .
+
+FROM eclipse-temurin:25-jdk AS build
+WORKDIR /build
+COPY assembly/target/tools.assembly-*-jar-with-dependencies.jar app.jar
+# Expand the fat jar into a flat classpath (BOOT-INF/classes + BOOT-INF/lib).
+RUN jar xf app.jar BOOT-INF/classes BOOT-INF/lib
+
+FROM eclipse-temurin:25-jre
+LABEL org.opencontainers.image.title="tools-k8s" \
+      org.opencontainers.image.description="SampleApp (CSV uniqueness checker) for Kubernetes/minikube." \
+      org.opencontainers.image.source="https://github.com/adamw7/tools" \
+      org.opencontainers.image.licenses="MIT"
+
+WORKDIR /app
+COPY --from=build /build/BOOT-INF/classes ./classes
+COPY --from=build /build/BOOT-INF/lib ./lib
+# Console log4j config, first on the classpath so it overrides the bundled one.
+COPY k8s/log4j2.properties ./config/log4j2.properties
+
+RUN useradd --system --no-create-home --shell /usr/sbin/nologin appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0"
+
+# /app/config is first so its console log4j2.properties wins over classes/.
+ENTRYPOINT ["sh", "-c", \
+  "exec java $JAVA_OPTS -cp '/app/config:/app/classes:/app/lib/*' io.github.adamw7.tools.data.SampleApp \"$@\"", \
+  "--"]

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,111 @@
+# Running the tools app on minikube
+
+This directory contains everything needed to run the project's `SampleApp`
+(the CSV column-uniqueness checker, `io.github.adamw7.tools.data.SampleApp`) on a
+local [minikube](https://minikube.sigs.k8s.io/) cluster.
+
+`SampleApp` is a **batch** program: it reads a CSV file, checks whether a chosen
+column is unique, logs the result, and exits. The correct Kubernetes primitive
+for a run-to-completion workload is a **Job**, not a Deployment.
+
+## Contents
+
+| File                         | Purpose                                                             |
+| ---------------------------- | ------------------------------------------------------------------- |
+| `Dockerfile`                 | Runnable deployment image (flat classpath + console logging).       |
+| `log4j2.properties`          | Console log config baked into the image so results reach stdout.    |
+| `configmap-sample-data.yaml` | Sample CSV (`people.csv`) mounted at `/data`.                       |
+| `job-uniqueness-check.yaml`  | Job that runs `SampleApp` against the CSV and prints the result.    |
+| `run-on-minikube.sh`         | One-shot: build → image → minikube → load → apply → logs.           |
+
+## Quick start
+
+Prerequisites on your machine: `docker`, `minikube`, `kubectl`, JDK 25 + Maven.
+
+```bash
+./k8s/run-on-minikube.sh
+# check a different column:
+COLUMN=id ./k8s/run-on-minikube.sh
+```
+
+Expected output (default column `country`, which repeats):
+
+```
+... country is NOT unique
+```
+
+With `COLUMN=id` (unique):
+
+```
+... id is unique
+```
+
+## Manual steps
+
+```bash
+# 1. Build the fat jar, then the deployment image
+mvn -B -DskipTests package
+docker build -f k8s/Dockerfile -t tools-k8s:local .
+
+# 2. Start minikube and load the locally built image
+minikube start --driver=docker
+minikube image load tools-k8s:local
+
+# 3. Deploy and run
+kubectl apply -f k8s/configmap-sample-data.yaml
+kubectl apply -f k8s/job-uniqueness-check.yaml
+
+# 4. Watch it complete and read the result
+kubectl wait --for=condition=complete --timeout=120s job/tools-uniqueness-check
+kubectl logs -l app.kubernetes.io/component=uniqueness-check
+```
+
+Clean up with `kubectl delete -f k8s/configmap-sample-data.yaml -f k8s/job-uniqueness-check.yaml`
+(the Job also self-deletes 10 minutes after finishing via `ttlSecondsAfterFinished`).
+
+## Why a dedicated deployment image (not `assembly/Dockerfile`)
+
+`../assembly/Dockerfile` builds a fat jar that **cannot launch `SampleApp` with
+`java -jar`**. The `data` module is built with `spring-boot:repackage`, so its jar
+has a nested Spring Boot layout (`BOOT-INF/classes` + `BOOT-INF/lib`); the assembly
+`jar-with-dependencies` inherits that layout, yet its manifest `Main-Class` points
+straight at `SampleApp`. Running it fails with
+`ClassNotFoundException: io.github.adamw7.tools.data.SampleApp`, because the class
+lives under `BOOT-INF/classes`, not on the flat classpath. (The project's CI builds
+that image but never runs it, so the problem is latent.)
+
+`k8s/Dockerfile` sidesteps this without touching the project build: a JDK build
+stage expands the fat jar into a flat `classes/` + `lib/` classpath, and the
+runtime stage runs `SampleApp` directly against it. It also adds a console
+`log4j2.properties` first on the classpath, because `SampleApp` otherwise logs only
+to a rolling file (`logs/app.log`, no console appender) — with the console config
+the result appears directly in `kubectl logs`.
+
+A cleaner long-term fix belongs in the project build: give the assembly a directly
+runnable main class (or a proper Spring Boot `Start-Class`) and add a Console
+appender to `data/src/main/resources/log4j2.properties`.
+
+## Note on this repository's automated environment
+
+These manifests were authored and the container workload verified with plain
+`docker run` in the Claude Code sandbox, but the sandbox itself **cannot host a
+minikube control plane**, so the `kubectl` steps above were not executed there.
+Three independent constraints prevented it:
+
+1. **cgroup v1 host + nested containers.** The `docker` (and `kind`/`k3d`) drivers
+   run the control plane in a nested container; on this cgroup-v1 host the inner
+   `runc` fails every sandbox with
+   `runc create failed: unable to start container process: can't get final child's PID from pipe: EOF`.
+   Both the `cri-dockerd` and `containerd` runtimes fail identically.
+2. **No systemd.** PID 1 is not systemd and `systemctl` is offline, so minikube's
+   `none` driver (which supervises `kubelet` via systemd) cannot be used either.
+3. **Restricted egress.** The egress policy 403-blocks Docker Hub,
+   `registry.k8s.io`, the Kubernetes package CDN, and GitHub release assets, so the
+   `none` driver's `crictl`/`cri-dockerd` prerequisites can't be fetched. (The
+   docker driver still reaches the point above because minikube's `kicbase` image
+   and preloaded component images come from Google-hosted registries, which are
+   allowed. The images above are built with the base pulled through the allowed
+   `mirror.gcr.io` Docker Hub mirror.)
+
+On a normal workstation none of these apply and `run-on-minikube.sh` runs the Job
+end to end.

--- a/k8s/configmap-sample-data.yaml
+++ b/k8s/configmap-sample-data.yaml
@@ -1,0 +1,16 @@
+# Sample CSV data mounted into the uniqueness-check Job at /data.
+# SampleApp reads a CSV file and reports whether a chosen column is unique.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tools-sample-data
+  labels:
+    app.kubernetes.io/name: tools
+    app.kubernetes.io/component: sample-data
+data:
+  # 'id' is unique, 'country' repeats (PL twice) -> NOT unique.
+  people.csv: |
+    id,name,country
+    1,Alice,PL
+    2,Bob,US
+    3,Carol,PL

--- a/k8s/job-uniqueness-check.yaml
+++ b/k8s/job-uniqueness-check.yaml
@@ -1,0 +1,49 @@
+# Runs io.github.adamw7.tools.data.SampleApp as a run-to-completion Job.
+# SampleApp is a batch CLI (read CSV -> check column uniqueness -> log -> exit),
+# so a Job is the correct primitive, not a Deployment.
+#
+# Uses the tools-k8s image (built from k8s/Dockerfile), which repackages the
+# assembly fat jar into a runnable flat classpath and logs to stdout, so the
+# result shows up directly in `kubectl logs`. The two positional args are the
+# CSV path (mounted from the ConfigMap at /data) and the column to check.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tools-uniqueness-check
+  labels:
+    app.kubernetes.io/name: tools
+    app.kubernetes.io/component: uniqueness-check
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tools
+        app.kubernetes.io/component: uniqueness-check
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: uniqueness-check
+          image: tools-k8s:local
+          imagePullPolicy: IfNotPresent
+          args: ["/data/people.csv", "country"]
+          volumeMounts:
+            - name: sample-data
+              mountPath: /data
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: sample-data
+          configMap:
+            name: tools-sample-data

--- a/k8s/log4j2.properties
+++ b/k8s/log4j2.properties
@@ -1,0 +1,13 @@
+# Console logging config for the Kubernetes deployment image.
+# Placed first on the classpath so it wins over the data module's bundled
+# file-only config, sending SampleApp's result to stdout for `kubectl logs`.
+status = warn
+name = ConsoleConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %level - %msg%n
+
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/k8s/run-on-minikube.sh
+++ b/k8s/run-on-minikube.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# End-to-end: build the app, build the Docker image, start minikube, load the
+# image, run the uniqueness-check Job, and print its result.
+#
+# Requirements on the host: docker, minikube, kubectl, a JDK 25 + Maven (or use
+# the Maven wrapper). Run from the repository root or from k8s/.
+#
+# Usage:
+#   ./k8s/run-on-minikube.sh
+#   COLUMN=id ./k8s/run-on-minikube.sh      # check a different column
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+K8S_DIR="$ROOT_DIR/k8s"
+IMAGE="${IMAGE:-tools-k8s:local}"
+COLUMN="${COLUMN:-country}"
+
+echo "==> Building the application (mvn -DskipTests package)"
+(cd "$ROOT_DIR" && mvn -B -ntp -DskipTests package)
+
+echo "==> Building the Docker image: $IMAGE"
+docker build -f "$K8S_DIR/Dockerfile" -t "$IMAGE" "$ROOT_DIR"
+
+echo "==> Ensuring minikube is running"
+if ! minikube status >/dev/null 2>&1; then
+  minikube start --driver=docker
+fi
+
+echo "==> Loading $IMAGE into minikube"
+minikube image load "$IMAGE"
+
+echo "==> Applying manifests"
+kubectl apply -f "$K8S_DIR/configmap-sample-data.yaml"
+# Recreate the Job so repeated runs pick up new data/image.
+kubectl delete job tools-uniqueness-check --ignore-not-found
+# Substitute the target column (default 'country') into the manifest on the fly.
+sed "s|\"country\"|\"$COLUMN\"|" "$K8S_DIR/job-uniqueness-check.yaml" | kubectl apply -f -
+
+echo "==> Waiting for the Job to complete"
+kubectl wait --for=condition=complete --timeout=120s job/tools-uniqueness-check \
+  || kubectl wait --for=condition=failed --timeout=10s job/tools-uniqueness-check || true
+
+echo "==> Job logs"
+kubectl logs -l app.kubernetes.io/component=uniqueness-check --tail=-1


### PR DESCRIPTION
Adds a k8s/ directory to run io.github.adamw7.tools.data.SampleApp (the CSV
column-uniqueness checker) on minikube as a Job — the correct primitive for a
run-to-completion batch app.

Includes:
- Dockerfile: a deployment image that expands the assembly fat jar into a flat
  classpath and adds a console log4j2 config, so SampleApp launches and prints
  its result to stdout. This works around the assembly fat jar's nested Spring
  Boot layout (BOOT-INF/*), which makes its flat Main-Class unrunnable via
  `java -jar`, and its file-only logging.
- ConfigMap with sample CSV data, and a Job that checks a chosen column.
- run-on-minikube.sh: build -> image -> minikube -> load -> apply -> logs.
- README documenting usage, the packaging workaround, and the sandbox
  constraints (cgroup v1 nested runc, no systemd, restricted egress) that
  prevent hosting a live minikube control plane in this environment.

Container workload verified with docker run (unique / not-unique / error paths,
including read-only rootfs).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gw75Jes7qC6gLX3Fp6kjAX