### PR TITLE
test(data): introduce ArchUnit for package architecture rules

### DIFF
--- a/data/pom.xml
+++ b/data/pom.xml
@@ -122,6 +122,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
@@ -1,0 +1,48 @@
+package io.github.adamw7.tools.data.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+/**
+ * Architecture rules for the data module, enforced with ArchUnit so that the
+ * package layering stays intact as the code evolves. Only production classes
+ * are analysed; test classes are excluded via {@link ImportOption}.
+ */
+@AnalyzeClasses(packages = DataArchitectureTest.DATA_PACKAGE, importOptions = ImportOption.DoNotIncludeTests.class)
+public class DataArchitectureTest {
+
+	static final String DATA_PACKAGE = "io.github.adamw7.tools.data";
+
+	private static final String INTERFACES_PACKAGE = "..source.interfaces..";
+	private static final String INTERNAL_PACKAGE = "..structure.internal..";
+	private static final String STRUCTURE_PACKAGE = "..structure..";
+
+	@ArchTest
+	static final ArchRule interfacesDoNotDependOnImplementations = noClasses()
+			.that().resideInAPackage(INTERFACES_PACKAGE)
+			.should().dependOnClassesThat().resideInAnyPackage("..source.db..", "..source.file..")
+			.because("data source contracts must not know their concrete database or file implementations");
+
+	@ArchTest
+	static final ArchRule internalTypesStayInsideStructure = classes()
+			.that().resideInAPackage(INTERNAL_PACKAGE)
+			.should().onlyBeAccessed().byAnyPackage(STRUCTURE_PACKAGE)
+			.because("structure.internal is an implementation detail of the structure package");
+
+	@ArchTest
+	static final ArchRule exceptionsAreNamedConsistently = classes()
+			.that().haveSimpleNameEndingWith("Exception")
+			.should().beAssignableTo(Exception.class)
+			.because("types named *Exception must actually be exceptions");
+
+	@ArchTest
+	static final ArchRule packagesAreFreeOfCycles = slices()
+			.matching("io.github.adamw7.tools.data.(*)..")
+			.should().beFreeOfCycles();
+}

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,12 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<groupId>com.tngtech.archunit</groupId>
+				<artifactId>archunit-junit5</artifactId>
+				<version>1.4.1</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-api</artifactId>
 				<version>2.26.0</version>


### PR DESCRIPTION
Add archunit-junit5 to the root dependencyManagement (test scope, single
source of the version) and wire it into the data module. Add
DataArchitectureTest enforcing four rules on the data module's packages:

- data source interfaces must not depend on db/file implementations
- structure.internal is only accessed from within the structure package
- types named *Exception must be assignable to Exception
- the data package tree is free of cycles

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013CqSher66C7xB88hHEGKRp