### PR TITLE
test(data): extend ArchUnit rules for contracts, loggers and streams

### DIFF
--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
@@ -1,13 +1,18 @@
 package io.github.adamw7.tools.data.architecture;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+
+import org.apache.logging.log4j.Logger;
 
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
+
+import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 
 /**
  * Architecture rules for the data module, enforced with ArchUnit so that the
@@ -45,4 +50,31 @@ public class DataArchitectureTest {
 	static final ArchRule packagesAreFreeOfCycles = slices()
 			.matching("io.github.adamw7.tools.data.(*)..")
 			.should().beFreeOfCycles();
+
+	@ArchTest
+	static final ArchRule interfacesPackageHoldsOnlyInterfaces = classes()
+			.that().resideInAPackage(INTERFACES_PACKAGE)
+			.should().beInterfaces()
+			.because("source.interfaces is reserved for data source contracts, not implementations");
+
+	@ArchTest
+	static final ArchRule dataSourcesImplementTheContract = classes()
+			.that().haveSimpleNameEndingWith("DataSource")
+			.and().areNotInterfaces()
+			.should().beAssignableTo(IterableDataSource.class)
+			.because("every concrete data source must honour the IterableDataSource contract");
+
+	@ArchTest
+	static final ArchRule loggersAreConstants = fields()
+			.that().haveRawType(Logger.class)
+			.should().bePrivate()
+			.andShould().beStatic()
+			.andShould().beFinal()
+			.because("loggers are shared, immutable, class-scoped collaborators");
+
+	@ArchTest
+	static final ArchRule productionCodeDoesNotUseStandardStreams = noClasses()
+			.should().accessField(System.class, "out")
+			.orShould().accessField(System.class, "err")
+			.because("production code must log through log4j2 instead of the console");
 }


### PR DESCRIPTION
Add four architecture rules to DataArchitectureTest:
- source.interfaces package must contain only interfaces
- every *DataSource class must implement IterableDataSource
- Logger fields must be private, static and final
- production code must not access System.out/System.err

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016PUE8vR2aDwjyWvLE5j3Rw