### PR TITLE
test(data): add ArchUnit rules for layering, naming and logging

### DIFF
--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
@@ -7,6 +7,7 @@ import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.sli
 
 import org.apache.logging.log4j.Logger;
 
+import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -27,6 +28,10 @@ public class DataArchitectureTest {
 	private static final String INTERFACES_PACKAGE = "..source.interfaces..";
 	private static final String INTERNAL_PACKAGE = "..structure.internal..";
 	private static final String STRUCTURE_PACKAGE = "..structure..";
+	private static final String FILE_PACKAGE = "..source.file..";
+	private static final String DB_PACKAGE = "..source.db..";
+	private static final String MCP_PACKAGE = "..uniqueness.mcp..";
+	private static final String UNIQUENESS_PACKAGE = "..uniqueness..";
 
 	@ArchTest
 	static final ArchRule interfacesDoNotDependOnImplementations = noClasses()
@@ -77,4 +82,42 @@ public class DataArchitectureTest {
 			.should().accessField(System.class, "out")
 			.orShould().accessField(System.class, "err")
 			.because("production code must log through log4j2 instead of the console");
+
+	@ArchTest
+	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()
+			.that().areNotInterfaces()
+			.and().areTopLevelClasses()
+			.and().haveModifier(JavaModifier.ABSTRACT)
+			.should().haveSimpleNameStartingWith("Abstract")
+			.because("an Abstract prefix signals at a glance that a type is meant to be extended, not used directly");
+
+	@ArchTest
+	static final ArchRule dataStructuresStayIndependentOfDataSources = noClasses()
+			.that().resideInAPackage(STRUCTURE_PACKAGE)
+			.should().dependOnClassesThat().resideInAnyPackage("..source..", "..network..", "..compression..")
+			.because("the structure package is a reusable collections library and must not couple to data sources");
+
+	@ArchTest
+	static final ArchRule fileSourcesDoNotDependOnDatabaseSources = noClasses()
+			.that().resideInAPackage(FILE_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage(DB_PACKAGE)
+			.because("file and database data sources are interchangeable implementations that must stay decoupled");
+
+	@ArchTest
+	static final ArchRule databaseSourcesDoNotDependOnFileSources = noClasses()
+			.that().resideInAPackage(DB_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage(FILE_PACKAGE)
+			.because("file and database data sources are interchangeable implementations that must stay decoupled");
+
+	@ArchTest
+	static final ArchRule uniquenessCoreDoesNotDependOnMcpAdapter = noClasses()
+			.that().resideInAPackage(UNIQUENESS_PACKAGE)
+			.and().resideOutsideOfPackage(MCP_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage(MCP_PACKAGE)
+			.because("the MCP adapter is a delivery mechanism on top of the uniqueness core, not a dependency of it");
+
+	@ArchTest
+	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
+			.should().dependOnClassesThat().resideInAnyPackage("java.util.logging..", "java.lang.System$Logger")
+			.because("logging must go through log4j2 so configuration stays in one place");
 }


### PR DESCRIPTION
Extend the data module architecture tests with rules that:
- require top-level abstract classes to carry an Abstract prefix
- keep the structure package independent of data sources
- keep file and database data sources decoupled from each other
- keep the uniqueness core independent of its MCP adapter
- enforce logging through log4j2 rather than java.util.logging

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EU8aDfWC8iWajB8LkRLebb