### PR TITLE
fix(scripts): make async shell scripts wait and fail loudly

### DIFF
--- a/scripts/linux/generate-maven-update-reports.sh
+++ b/scripts/linux/generate-maven-update-reports.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-mvn versions:plugin-updates-aggregate-report &
-mvn versions:dependency-updates-aggregate-report &
+set -euo pipefail
+mvn versions:plugin-updates-aggregate-report versions:dependency-updates-aggregate-report

--- a/scripts/linux/update-git-repos-async.sh
+++ b/scripts/linux/update-git-repos-async.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 for dir in "$SCRIPT_DIR"/*/; do
-    if [ -d "$dir/.git" ]; then
+    if [ -e "$dir/.git" ]; then
         (cd "$dir" && git pull) &
     fi
 done
+wait


### PR DESCRIPTION
update-git-repos-async.sh backgrounded each git pull but never waited,
so the script exited while pulls were still running and dropped all
failures. It also missed worktrees/submodules where .git is a file, not
a directory. Add `wait`, use `[ -e ]` for .git detection, and enable
`set -euo pipefail`.

generate-maven-update-reports.sh backgrounded two mvn goals with no
`wait`, orphaning both builds on shell exit. Collapse into a single
foreground mvn invocation (one JVM/reactor scan) with `set -euo pipefail`
so build failures propagate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ma5Yp1i33gUAKd8xujvLvw