### PR TITLE
test(arch): fix logging rule and broaden ArchUnit coverage

### DIFF
--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -33,5 +33,10 @@
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
@@ -1,0 +1,82 @@
+package io.github.adamw7.tools.enforcer.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.GeneralCodingRules;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+
+/**
+ * Architecture rules for the enforcer module. They pin the layering that the
+ * package structure already follows today: {@code text} is the foundation,
+ * {@code rule} builds on it, and the feature packages ({@code definition},
+ * {@code doc}, {@code mcp}, {@code settings}) build on {@code rule} without
+ * reaching sideways into one another. Only production classes are analysed.
+ */
+@AnalyzeClasses(packages = EnforcerArchitectureTest.ENFORCER_PACKAGE, importOptions = ImportOption.DoNotIncludeTests.class)
+public class EnforcerArchitectureTest {
+
+	static final String ENFORCER_PACKAGE = "io.github.adamw7.tools.enforcer";
+
+	@ArchTest
+	static final ArchRule layersDependInOneDirection = layeredArchitecture()
+			.consideringOnlyDependenciesInLayers()
+			.layer("Text").definedBy("..enforcer.text..")
+			.layer("Rule").definedBy("..enforcer.rule..")
+			.layer("Definition").definedBy("..enforcer.definition..")
+			.layer("Doc").definedBy("..enforcer.doc..")
+			.layer("Mcp").definedBy("..enforcer.mcp..")
+			.layer("Settings").definedBy("..enforcer.settings..")
+			.whereLayer("Text").mayNotAccessAnyLayer()
+			.whereLayer("Rule").mayOnlyAccessLayers("Text")
+			.whereLayer("Definition").mayOnlyAccessLayers("Rule", "Text")
+			.whereLayer("Doc").mayOnlyAccessLayers("Rule", "Text")
+			.whereLayer("Mcp").mayOnlyAccessLayers("Rule", "Text")
+			.whereLayer("Settings").mayOnlyAccessLayers("Rule", "Text")
+			.as("text is the foundation, rule builds on it, and the feature packages "
+					+ "build on rule without depending on each other");
+
+	@ArchTest
+	static final ArchRule packagesAreFreeOfCycles = slices()
+			.matching("io.github.adamw7.tools.enforcer.(*)..")
+			.should().beFreeOfCycles();
+
+	@ArchTest
+	static final ArchRule concreteRulesHonourTheContract = classes()
+			.that().haveSimpleNameEndingWith("Rule")
+			.and().areNotInterfaces()
+			.and().doNotHaveModifier(com.tngtech.archunit.core.domain.JavaModifier.ABSTRACT)
+			.should().beAssignableTo(ClaudeCodeEnforcerRule.class)
+			.because("every concrete *Rule is an enforcer rule and must extend the shared base");
+
+	@ArchTest
+	static final ArchRule exceptionsAreNamedConsistently = classes()
+			.that().haveSimpleNameEndingWith("Exception")
+			.should().beAssignableTo(Exception.class)
+			.because("types named *Exception must actually be exceptions")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule noAccessToStandardStreams =
+			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
+
+	@ArchTest
+	static final ArchRule noGenericExceptionsAreThrown =
+			GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
+
+	@ArchTest
+	static final ArchRule noJavaUtilLogging =
+			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+
+	@ArchTest
+	static final ArchRule enforcerDoesNotHaltTheJvm = noClasses()
+			.should().callMethod(System.class, "exit", int.class)
+			.because("an enforcer rule reports violations by throwing, never by killing the JVM");
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.data.architecture;
 
+import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
@@ -12,6 +13,7 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.GeneralCodingRules;
 
 import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 
@@ -98,18 +100,6 @@ public class DataArchitectureTest {
 			.because("the structure package is a reusable collections library and must not couple to data sources");
 
 	@ArchTest
-	static final ArchRule fileSourcesDoNotDependOnDatabaseSources = noClasses()
-			.that().resideInAPackage(FILE_PACKAGE)
-			.should().dependOnClassesThat().resideInAPackage(DB_PACKAGE)
-			.because("file and database data sources are interchangeable implementations that must stay decoupled");
-
-	@ArchTest
-	static final ArchRule databaseSourcesDoNotDependOnFileSources = noClasses()
-			.that().resideInAPackage(DB_PACKAGE)
-			.should().dependOnClassesThat().resideInAPackage(FILE_PACKAGE)
-			.because("file and database data sources are interchangeable implementations that must stay decoupled");
-
-	@ArchTest
 	static final ArchRule uniquenessCoreDoesNotDependOnMcpAdapter = noClasses()
 			.that().resideInAPackage(UNIQUENESS_PACKAGE)
 			.and().resideOutsideOfPackage(MCP_PACKAGE)
@@ -118,6 +108,41 @@ public class DataArchitectureTest {
 
 	@ArchTest
 	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
-			.should().dependOnClassesThat().resideInAnyPackage("java.util.logging..", "java.lang.System$Logger")
+			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
 			.because("logging must go through log4j2 so configuration stays in one place");
+
+	@ArchTest
+	static final ArchRule noAccessToStandardStreams =
+			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
+
+	@ArchTest
+	static final ArchRule noGenericExceptionsAreThrown =
+			GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
+
+	@ArchTest
+	static final ArchRule noJavaUtilLogging =
+			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+
+	@ArchTest
+	static final ArchRule noJodaTime =
+			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
+
+	@ArchTest
+	static final ArchRule productionCodeDoesNotHaltTheJvm = noClasses()
+			.should().callMethod(System.class, "exit", int.class)
+			.because("a library must never terminate the host JVM; it should throw instead");
+
+	@ArchTest
+	static final ArchRule sourceLayersDependInOneDirection = layeredArchitecture()
+			.consideringOnlyDependenciesInLayers()
+			.layer("Contracts").definedBy(INTERFACES_PACKAGE)
+			.layer("Compression").definedBy("..compression..")
+			.layer("FileSources").definedBy(FILE_PACKAGE)
+			.layer("DbSources").definedBy(DB_PACKAGE)
+			.whereLayer("FileSources").mayOnlyAccessLayers("Contracts", "Compression")
+			.whereLayer("DbSources").mayOnlyAccessLayers("Contracts")
+			.whereLayer("Compression").mayNotAccessAnyLayer()
+			.as("the source layers must depend only downwards: concrete sources on their "
+					+ "contracts (and, for files, on compression), never on each other");
 }


### PR DESCRIPTION
Data module:
- Fix productionCodeLogsThroughLog4j: the second argument to
  resideInAnyPackage was a class name (java.lang.System$Logger), so it
  matched no package and silently checked nothing. Split into a package
  rule plus a fully-qualified-name rule so System.Logger use is caught.
- Add GeneralCodingRules guards: no standard-stream access (also catches
  printStackTrace), no generic exceptions thrown, no java.util.logging,
  no Joda-Time; plus a rule forbidding System.exit in a library.
- Replace the two pairwise file/db decoupling rules with a
  layeredArchitecture that also pins dependency direction across the
  source contracts, file, db and compression packages.

Enforcer module:
- Add archunit-junit5 test dependency and a new EnforcerArchitectureTest
  pinning the text <- rule <- {definition,doc,mcp,settings} layering,
  package cycle freedom, the *Rule -> ClaudeCodeEnforcerRule contract,
  and the shared coding guards.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FDs7rmxovm42M7ZRYdM8cA