### PR TITLE
test: add ArchUnit architecture tests to mcp-common, context and protogen modules

### DIFF
--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -84,6 +84,11 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java
@@ -1,0 +1,92 @@
+package io.github.adamw7.context.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+
+import org.apache.logging.log4j.Logger;
+
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.GeneralCodingRules;
+
+import io.github.adamw7.context.tree.ProjectTreeSerializer;
+
+/**
+ * Architecture rules for the context module. The context finder and project
+ * tree form a reusable core; the {@code mcp} package is a delivery mechanism on
+ * top of that core and the only place allowed to know the shared MCP
+ * scaffolding. These rules keep that separation intact. Only production classes
+ * are analysed; test classes are excluded via {@link ImportOption}.
+ */
+@AnalyzeClasses(packages = ContextArchitectureTest.CONTEXT_PACKAGE, importOptions = ImportOption.DoNotIncludeTests.class)
+public class ContextArchitectureTest {
+
+	static final String CONTEXT_PACKAGE = "io.github.adamw7.context";
+
+	private static final String MCP_PACKAGE = "..context.mcp..";
+	private static final String MCP_COMMON_PACKAGE = "io.github.adamw7.tools.mcp..";
+
+	@ArchTest
+	static final ArchRule coreDoesNotDependOnMcpAdapter = noClasses()
+			.that().resideInAPackage(CONTEXT_PACKAGE)
+			.and().resideOutsideOfPackage(MCP_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage(MCP_PACKAGE)
+			.because("the MCP adapter is a delivery mechanism on top of the context core, not a dependency of it");
+
+	@ArchTest
+	static final ArchRule onlyTheMcpAdapterKnowsTheScaffolding = noClasses()
+			.that().resideOutsideOfPackage(MCP_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage(MCP_COMMON_PACKAGE)
+			.because("only the mcp delivery package builds on the shared MCP scaffolding");
+
+	@ArchTest
+	static final ArchRule packagesAreFreeOfCycles = slices()
+			.matching("io.github.adamw7.context.(*)..")
+			.should().beFreeOfCycles();
+
+	@ArchTest
+	static final ArchRule serializersImplementTheContract = classes()
+			.that().haveSimpleNameEndingWith("Serializer")
+			.and().areNotInterfaces()
+			.should().beAssignableTo(ProjectTreeSerializer.class)
+			.because("every concrete *Serializer must honour the ProjectTreeSerializer contract");
+
+	@ArchTest
+	static final ArchRule loggersArePrivateAndFinal = fields()
+			.that().haveRawType(Logger.class)
+			.should().bePrivate()
+			.andShould().beFinal()
+			.because("loggers are private, immutable collaborators owned by their declaring class");
+
+	@ArchTest
+	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()
+			.that().areNotInterfaces()
+			.and().areTopLevelClasses()
+			.and().haveModifier(JavaModifier.ABSTRACT)
+			.should().haveSimpleNameStartingWith("Abstract")
+			.because("an Abstract prefix signals at a glance that a type is meant to be extended, not used directly");
+
+	@ArchTest
+	static final ArchRule exceptionsAreNamedConsistently = classes()
+			.that().haveSimpleNameEndingWith("Exception")
+			.should().beAssignableTo(Exception.class)
+			.because("types named *Exception must actually be exceptions")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule noAccessToStandardStreams =
+			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
+
+	@ArchTest
+	static final ArchRule noGenericExceptionsAreThrown =
+			GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
+
+	@ArchTest
+	static final ArchRule noJavaUtilLogging =
+			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+}

--- a/code/protogen-maven-plugin/pom.xml
+++ b/code/protogen-maven-plugin/pom.xml
@@ -71,5 +71,10 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/ProtogenArchitectureTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/ProtogenArchitectureTest.java
@@ -1,0 +1,86 @@
+package io.github.adamw7.tools.code.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.maven.plugin.Mojo;
+
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.GeneralCodingRules;
+
+/**
+ * Architecture rules for the protogen Maven plugin. The {@code format} package
+ * is a self-contained foundation for source-code formatting; the {@code gen}
+ * package builds the generated builders on top of it. These rules keep that
+ * one-directional dependency, and pin the conventions the plugin already
+ * follows. Only production classes are analysed; test classes are excluded via
+ * {@link ImportOption}.
+ */
+@AnalyzeClasses(packages = ProtogenArchitectureTest.CODE_PACKAGE, importOptions = ImportOption.DoNotIncludeTests.class)
+public class ProtogenArchitectureTest {
+
+	static final String CODE_PACKAGE = "io.github.adamw7.tools.code";
+
+	private static final String FORMAT_PACKAGE = "..code.format..";
+	private static final String GEN_PACKAGE = "..code.gen..";
+
+	@ArchTest
+	static final ArchRule formatDoesNotDependOnGeneration = noClasses()
+			.that().resideInAPackage(FORMAT_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage(GEN_PACKAGE)
+			.because("the format package is a reusable foundation and must not couple to the code generator that builds on it");
+
+	@ArchTest
+	static final ArchRule packagesAreFreeOfCycles = slices()
+			.matching("io.github.adamw7.tools.code.(*)..")
+			.should().beFreeOfCycles();
+
+	@ArchTest
+	static final ArchRule mojosImplementTheMojoContract = classes()
+			.that().haveSimpleNameEndingWith("Mojo")
+			.and().areNotInterfaces()
+			.and().doNotHaveModifier(JavaModifier.ABSTRACT)
+			.should().beAssignableTo(Mojo.class)
+			.because("every concrete *Mojo is a Maven goal and must implement the Mojo contract");
+
+	@ArchTest
+	static final ArchRule loggersAreConstants = fields()
+			.that().haveRawType(Logger.class)
+			.should().bePrivate()
+			.andShould().beStatic()
+			.andShould().beFinal()
+			.because("loggers are shared, immutable, class-scoped collaborators");
+
+	@ArchTest
+	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()
+			.that().areNotInterfaces()
+			.and().areTopLevelClasses()
+			.and().haveModifier(JavaModifier.ABSTRACT)
+			.should().haveSimpleNameStartingWith("Abstract")
+			.because("an Abstract prefix signals at a glance that a type is meant to be extended, not used directly");
+
+	@ArchTest
+	static final ArchRule exceptionsAreNamedConsistently = classes()
+			.that().haveSimpleNameEndingWith("Exception")
+			.should().beAssignableTo(Exception.class)
+			.because("types named *Exception must actually be exceptions");
+
+	@ArchTest
+	static final ArchRule noAccessToStandardStreams =
+			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
+
+	@ArchTest
+	static final ArchRule noGenericExceptionsAreThrown =
+			GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
+
+	@ArchTest
+	static final ArchRule noJavaUtilLogging =
+			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+}

--- a/mcp-common/pom.xml
+++ b/mcp-common/pom.xml
@@ -38,5 +38,10 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/McpCommonArchitectureTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/McpCommonArchitectureTest.java
@@ -1,0 +1,84 @@
+package io.github.adamw7.tools.mcp.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import org.apache.logging.log4j.Logger;
+
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.GeneralCodingRules;
+
+import io.github.adamw7.tools.mcp.McpTool;
+
+/**
+ * Architecture rules for the shared MCP scaffolding module. They keep the
+ * reusable transport wiring and tool SPI honest as the code evolves: the tool
+ * contract stays an interface, logging goes through log4j2, and the module
+ * never terminates or writes to the console of the server that embeds it. Only
+ * production classes are analysed; test classes are excluded via
+ * {@link ImportOption}.
+ */
+@AnalyzeClasses(packages = McpCommonArchitectureTest.MCP_PACKAGE, importOptions = ImportOption.DoNotIncludeTests.class)
+public class McpCommonArchitectureTest {
+
+	static final String MCP_PACKAGE = "io.github.adamw7.tools.mcp";
+
+	@ArchTest
+	static final ArchRule toolSpiIsAContract = classes()
+			.that().haveSimpleName("McpTool")
+			.should().beInterfaces()
+			.because("McpTool is the tool SPI that concrete servers implement, not a concrete tool");
+
+	@ArchTest
+	static final ArchRule toolsImplementTheContract = classes()
+			.that().haveSimpleNameEndingWith("Tool")
+			.and().areNotInterfaces()
+			.should().beAssignableTo(McpTool.class)
+			.because("every concrete *Tool must honour the McpTool contract")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule loggersAreConstants = fields()
+			.that().haveRawType(Logger.class)
+			.should().bePrivate()
+			.andShould().beStatic()
+			.andShould().beFinal()
+			.because("loggers are shared, immutable, class-scoped collaborators");
+
+	@ArchTest
+	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()
+			.that().areNotInterfaces()
+			.and().areTopLevelClasses()
+			.and().haveModifier(JavaModifier.ABSTRACT)
+			.should().haveSimpleNameStartingWith("Abstract")
+			.because("an Abstract prefix signals at a glance that a type is meant to be extended, not used directly");
+
+	@ArchTest
+	static final ArchRule exceptionsAreNamedConsistently = classes()
+			.that().haveSimpleNameEndingWith("Exception")
+			.should().beAssignableTo(Exception.class)
+			.because("types named *Exception must actually be exceptions")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule scaffoldingDoesNotHaltTheJvm = noClasses()
+			.should().callMethod(System.class, "exit", int.class)
+			.because("shared scaffolding must never terminate the host server; it should throw instead");
+
+	@ArchTest
+	static final ArchRule noAccessToStandardStreams =
+			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
+
+	@ArchTest
+	static final ArchRule noGenericExceptionsAreThrown =
+			GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
+
+	@ArchTest
+	static final ArchRule noJavaUtilLogging =
+			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+}


### PR DESCRIPTION
Extend ArchUnit coverage (previously only in the data and claude-code-enforcer
modules) to the remaining modules with production logic:

- mcp-common: the McpTool SPI stays an interface, loggers are constants, no
  standard-stream access, no JVM halt, no generic exceptions or java.util.logging.
- code/context: the reusable core and tree stay independent of the mcp delivery
  adapter, and only the mcp package knows the shared MCP scaffolding; packages
  stay cycle-free; serializers honour the ProjectTreeSerializer contract.
  Loggers are required private+final (not static) since AbstractClassContextTool
  uses a per-instance getClass() logger.
- protogen-maven-plugin: the format package stays a foundation the gen package
  builds on (not the reverse), packages stay cycle-free, and every *Mojo
  implements the Maven Mojo contract.

Each module declares the root-managed archunit-junit5 test dependency.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YPL2wzzdGw5o6TeJav2ZEG