### PR TITLE
feat(bpmn): introduce BPMN 2.0 parser and process validator module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,11 @@ Maven project. The notable capabilities are:
   serve as a key, and searches for a smaller key), data structures (an
   open-addressing `Map` implementation), and an **MCP server** exposing the
   uniqueness checker as a tool for AI assistants.
+- **BPMN** (`bpmn`) — a dependency-free BPMN 2.0 parser that reads `.bpmn` XML
+  (using only the JDK XML APIs, hardened against XXE) into a Java process model
+  of flow nodes and sequence flows, plus a `ProcessValidator` that flags
+  structural defects such as a missing start/end event, sequence flows that
+  reference unknown nodes, and unreachable or dead-end nodes.
 
 See [README.md](README.md) for worked code examples of each capability, and
 [docs/c4-architecture.md](docs/c4-architecture.md) for a C4 model
@@ -42,6 +47,7 @@ tools (root pom, packaging=pom)
 │   ├── protogen-maven-plugin       # the proto2 builder-generating Maven plugin
 │   ├── protogen-maven-plugin-test  # integration tests / use cases for the plugin
 │   └── context                     # regex-based class-usage context finder
+├── bpmn                        # dependency-free BPMN 2.0 parser + process validator
 ├── grpc-example                # end-to-end gRPC example with compile-time-safe builders
 ├── assembly                    # builds an executable jar-with-dependencies
 │                               #   (mainClass: io.github.adamw7.tools.data.SampleApp)
@@ -49,7 +55,7 @@ tools (root pom, packaging=pom)
 ```
 
 Root reactor modules are `claude-code-enforcer`, `mcp-common`, `data`, `code`,
-and `assembly`.
+`bpmn`, and `assembly`.
 The `data-test` module is built separately (it is not in the root `<modules>`
 list).
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Library of tooling for various purposes.
   - [Open-addressing set](#open-addressing-set)
   - [Primitive int-keyed map](#primitive-int-keyed-map)
   - [Network kill-switch](#network-kill-switch)
+- [BPMN](#bpmn)
+  - [Parsing a process](#parsing-a-process)
+  - [Validating a process](#validating-a-process)
 - [Building](#building)
 - [Releasing](#releasing)
 - [License](#license)
@@ -664,6 +667,57 @@ any subsequent attempt to open an outbound connection fails fast. The method is:
   
 The switch can be used for example if there is a need to make sure no network connections
 are open while running unit tests.
+
+## BPMN
+
+The `bpmn` module reads [BPMN 2.0](https://www.omg.org/spec/BPMN/2.0/) process
+definitions into a small, immutable Java model and checks them for common
+structural defects. It depends only on the JDK XML APIs — no third-party BPMN
+engine — and its parser is namespace-aware and hardened against XML external
+entity (XXE) attacks (DOCTYPE declarations and external entities are rejected).
+
+### Parsing a process
+
+`BpmnParser` turns a `.bpmn` document (from an `InputStream`, `Path`, or
+`String`) into a `BpmnModel`: the document's `targetNamespace` and the
+`Process`es it declares. Each `Process` holds its `FlowNode`s (events,
+activities and gateways, each tagged with a `FlowNodeType`) and its
+`SequenceFlow`s, with lookup helpers for navigating the graph. Elements the
+parser does not recognise — documentation, lane sets, diagram interchange — are
+ignored.
+
+```java
+BpmnModel model = new BpmnParser().parse(Path.of("order-process.bpmn"));
+
+Process process = model.processes().get(0);
+process.nodesOfType(FlowNodeType.USER_TASK)      // every user task
+       .forEach(task -> System.out.println(task.name()));
+
+process.outgoing("approved");  // the sequence flows leaving the "approved" gateway
+```
+
+Malformed XML, a root element other than `<definitions>`, or an unreadable file
+all raise a `BpmnParseException`.
+
+### Validating a process
+
+`ProcessValidator` runs a set of structural rules over a parsed `Process` and
+returns the `ValidationIssue`s it finds. Errors mean the process is
+structurally invalid; warnings flag suspicious but tolerable traits.
+
+```java
+ProcessValidator validator = new ProcessValidator();
+
+List<ValidationIssue> issues = validator.validate(process);
+issues.forEach(issue ->
+        System.out.println(issue.severity() + ": " + issue.message()));
+
+boolean ok = validator.isValid(process); // true when there are no ERROR issues
+```
+
+The rules cover a missing start or end event, sequence flows whose `sourceRef`
+or `targetRef` match no node, and nodes that are unreachable (no incoming flow)
+or dead ends (no outgoing flow).
 
 # Building
 ```

--- a/bpmn/pom.xml
+++ b/bpmn/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>io.github.adamw7</groupId>
+		<artifactId>tools</artifactId>
+		<version>${revision}</version>
+	</parent>
+	<artifactId>tools.bpmn</artifactId>
+	<packaging>jar</packaging>
+	<name>Tooling for BPMN</name>
+	<description>A dependency-free BPMN 2.0 parser that reads .bpmn XML into a Java process model, plus a structural validator for the parsed processes.</description>
+	<url>https://github.com/adamw7/tools</url>
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/bpmn/src/main/java/io/github/adamw7/tools/bpmn/model/BpmnModel.java
+++ b/bpmn/src/main/java/io/github/adamw7/tools/bpmn/model/BpmnModel.java
@@ -1,0 +1,35 @@
+package io.github.adamw7.tools.bpmn.model;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The result of parsing a BPMN 2.0 document: its target namespace and the
+ * processes it defines. Immutable.
+ */
+public final class BpmnModel {
+
+	private final String targetNamespace;
+	private final List<Process> processes;
+
+	public BpmnModel(String targetNamespace, List<Process> processes) {
+		this.targetNamespace = Objects.requireNonNull(targetNamespace, "targetNamespace");
+		this.processes = List.copyOf(processes);
+	}
+
+	/** The document's {@code targetNamespace}, or empty when it declares none. */
+	public String targetNamespace() {
+		return targetNamespace;
+	}
+
+	public List<Process> processes() {
+		return processes;
+	}
+
+	/** The process carrying the given id, if any. */
+	public Optional<Process> findProcess(String processId) {
+		Objects.requireNonNull(processId, "processId");
+		return processes.stream().filter(process -> process.id().equals(processId)).findFirst();
+	}
+}

--- a/bpmn/src/main/java/io/github/adamw7/tools/bpmn/model/FlowNode.java
+++ b/bpmn/src/main/java/io/github/adamw7/tools/bpmn/model/FlowNode.java
@@ -1,0 +1,19 @@
+package io.github.adamw7.tools.bpmn.model;
+
+import java.util.Objects;
+
+/**
+ * A single activity, event or gateway inside a {@link Process}. Immutable.
+ *
+ * @param id   the BPMN element id, unique within its process; never blank
+ * @param name the human-readable label, or empty when the element has none
+ * @param type the recognised BPMN type of this node
+ */
+public record FlowNode(String id, String name, FlowNodeType type) {
+
+	public FlowNode {
+		Objects.requireNonNull(id, "id");
+		Objects.requireNonNull(name, "name");
+		Objects.requireNonNull(type, "type");
+	}
+}

--- a/bpmn/src/main/java/io/github/adamw7/tools/bpmn/model/FlowNodeType.java
+++ b/bpmn/src/main/java/io/github/adamw7/tools/bpmn/model/FlowNodeType.java
@@ -1,0 +1,83 @@
+package io.github.adamw7.tools.bpmn.model;
+
+import java.util.Optional;
+
+/**
+ * The kinds of BPMN 2.0 flow node this parser recognises, each bound to its
+ * BPMN XML element local name and its broad {@link Category}.
+ *
+ * <p>Sequence flows are edges rather than nodes and are therefore modelled by
+ * {@link SequenceFlow}, not by this enum.
+ */
+public enum FlowNodeType {
+
+	START_EVENT("startEvent", Category.EVENT),
+	END_EVENT("endEvent", Category.EVENT),
+	INTERMEDIATE_CATCH_EVENT("intermediateCatchEvent", Category.EVENT),
+	INTERMEDIATE_THROW_EVENT("intermediateThrowEvent", Category.EVENT),
+	BOUNDARY_EVENT("boundaryEvent", Category.EVENT),
+
+	TASK("task", Category.ACTIVITY),
+	USER_TASK("userTask", Category.ACTIVITY),
+	SERVICE_TASK("serviceTask", Category.ACTIVITY),
+	SCRIPT_TASK("scriptTask", Category.ACTIVITY),
+	MANUAL_TASK("manualTask", Category.ACTIVITY),
+	BUSINESS_RULE_TASK("businessRuleTask", Category.ACTIVITY),
+	SEND_TASK("sendTask", Category.ACTIVITY),
+	RECEIVE_TASK("receiveTask", Category.ACTIVITY),
+	CALL_ACTIVITY("callActivity", Category.ACTIVITY),
+	SUB_PROCESS("subProcess", Category.ACTIVITY),
+
+	EXCLUSIVE_GATEWAY("exclusiveGateway", Category.GATEWAY),
+	PARALLEL_GATEWAY("parallelGateway", Category.GATEWAY),
+	INCLUSIVE_GATEWAY("inclusiveGateway", Category.GATEWAY),
+	EVENT_BASED_GATEWAY("eventBasedGateway", Category.GATEWAY),
+	COMPLEX_GATEWAY("complexGateway", Category.GATEWAY);
+
+	/** Broad grouping shared by several concrete node types. */
+	public enum Category {
+		EVENT, ACTIVITY, GATEWAY
+	}
+
+	private final String elementName;
+	private final Category category;
+
+	FlowNodeType(String elementName, Category category) {
+		this.elementName = elementName;
+		this.category = category;
+	}
+
+	/** The BPMN XML element local name that maps to this type. */
+	public String elementName() {
+		return elementName;
+	}
+
+	public Category category() {
+		return category;
+	}
+
+	public boolean isEvent() {
+		return category == Category.EVENT;
+	}
+
+	public boolean isActivity() {
+		return category == Category.ACTIVITY;
+	}
+
+	public boolean isGateway() {
+		return category == Category.GATEWAY;
+	}
+
+	/**
+	 * Resolves the flow node type for a BPMN element local name.
+	 *
+	 * @param elementName the XML element local name, e.g. {@code "userTask"}
+	 * @return the matching type, or empty when the element is not a recognised
+	 *         flow node
+	 */
+	public static Optional<FlowNodeType> fromElementName(String elementName) {
+		return java.util.Arrays.stream(values())
+				.filter(type -> type.elementName.equals(elementName))
+				.findFirst();
+	}
+}

--- a/bpmn/src/main/java/io/github/adamw7/tools/bpmn/model/Process.java
+++ b/bpmn/src/main/java/io/github/adamw7/tools/bpmn/model/Process.java
@@ -1,0 +1,64 @@
+package io.github.adamw7.tools.bpmn.model;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A single BPMN process: its flow nodes and the sequence flows connecting them.
+ * Immutable; the collections handed in are defensively copied.
+ */
+public final class Process {
+
+	private final String id;
+	private final String name;
+	private final List<FlowNode> flowNodes;
+	private final List<SequenceFlow> sequenceFlows;
+
+	public Process(String id, String name, List<FlowNode> flowNodes, List<SequenceFlow> sequenceFlows) {
+		this.id = Objects.requireNonNull(id, "id");
+		this.name = Objects.requireNonNull(name, "name");
+		this.flowNodes = List.copyOf(flowNodes);
+		this.sequenceFlows = List.copyOf(sequenceFlows);
+	}
+
+	public String id() {
+		return id;
+	}
+
+	public String name() {
+		return name;
+	}
+
+	public List<FlowNode> flowNodes() {
+		return flowNodes;
+	}
+
+	public List<SequenceFlow> sequenceFlows() {
+		return sequenceFlows;
+	}
+
+	/** All flow nodes of the given type, in document order. */
+	public List<FlowNode> nodesOfType(FlowNodeType type) {
+		Objects.requireNonNull(type, "type");
+		return flowNodes.stream().filter(node -> node.type() == type).toList();
+	}
+
+	/** The flow node carrying the given id, if any. */
+	public Optional<FlowNode> findNode(String nodeId) {
+		Objects.requireNonNull(nodeId, "nodeId");
+		return flowNodes.stream().filter(node -> node.id().equals(nodeId)).findFirst();
+	}
+
+	/** Sequence flows leaving the node with the given id. */
+	public List<SequenceFlow> outgoing(String nodeId) {
+		Objects.requireNonNull(nodeId, "nodeId");
+		return sequenceFlows.stream().filter(flow -> flow.sourceRef().equals(nodeId)).toList();
+	}
+
+	/** Sequence flows entering the node with the given id. */
+	public List<SequenceFlow> incoming(String nodeId) {
+		Objects.requireNonNull(nodeId, "nodeId");
+		return sequenceFlows.stream().filter(flow -> flow.targetRef().equals(nodeId)).toList();
+	}
+}

--- a/bpmn/src/main/java/io/github/adamw7/tools/bpmn/model/SequenceFlow.java
+++ b/bpmn/src/main/java/io/github/adamw7/tools/bpmn/model/SequenceFlow.java
@@ -1,0 +1,22 @@
+package io.github.adamw7.tools.bpmn.model;
+
+import java.util.Objects;
+
+/**
+ * A directed connection between two {@link FlowNode}s within a {@link Process}.
+ * Immutable.
+ *
+ * @param id        the BPMN element id of the flow; never blank
+ * @param name      the human-readable label, or empty when the flow has none
+ * @param sourceRef the id of the node the flow leaves
+ * @param targetRef the id of the node the flow enters
+ */
+public record SequenceFlow(String id, String name, String sourceRef, String targetRef) {
+
+	public SequenceFlow {
+		Objects.requireNonNull(id, "id");
+		Objects.requireNonNull(name, "name");
+		Objects.requireNonNull(sourceRef, "sourceRef");
+		Objects.requireNonNull(targetRef, "targetRef");
+	}
+}

--- a/bpmn/src/main/java/io/github/adamw7/tools/bpmn/parse/BpmnParseException.java
+++ b/bpmn/src/main/java/io/github/adamw7/tools/bpmn/parse/BpmnParseException.java
@@ -1,0 +1,16 @@
+package io.github.adamw7.tools.bpmn.parse;
+
+/**
+ * Thrown when a BPMN document cannot be read into a model, for example because
+ * the XML is malformed or its root element is not {@code definitions}.
+ */
+public class BpmnParseException extends RuntimeException {
+
+	public BpmnParseException(String message) {
+		super(message);
+	}
+
+	public BpmnParseException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/bpmn/src/main/java/io/github/adamw7/tools/bpmn/parse/BpmnParser.java
+++ b/bpmn/src/main/java/io/github/adamw7/tools/bpmn/parse/BpmnParser.java
@@ -1,0 +1,157 @@
+package io.github.adamw7.tools.bpmn.parse;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import io.github.adamw7.tools.bpmn.model.BpmnModel;
+import io.github.adamw7.tools.bpmn.model.FlowNode;
+import io.github.adamw7.tools.bpmn.model.FlowNodeType;
+import io.github.adamw7.tools.bpmn.model.Process;
+import io.github.adamw7.tools.bpmn.model.SequenceFlow;
+
+/**
+ * Reads a BPMN 2.0 XML document into a {@link BpmnModel} using only the JDK XML
+ * APIs. The parser is namespace-aware, hardened against XML external entity
+ * (XXE) attacks, and ignores elements it does not recognise (documentation,
+ * lane sets, diagram interchange, and so on).
+ */
+public final class BpmnParser {
+
+	private static final String DEFINITIONS = "definitions";
+	private static final String PROCESS = "process";
+	private static final String SEQUENCE_FLOW = "sequenceFlow";
+
+	/** Parses BPMN XML read from the given stream. The stream is not closed. */
+	public BpmnModel parse(InputStream bpmnXml) {
+		Objects.requireNonNull(bpmnXml, "bpmnXml");
+		return toModel(buildDocument(bpmnXml));
+	}
+
+	/** Parses the BPMN file at the given path. */
+	public BpmnModel parse(Path bpmnFile) {
+		Objects.requireNonNull(bpmnFile, "bpmnFile");
+		try (InputStream stream = Files.newInputStream(bpmnFile)) {
+			return parse(stream);
+		} catch (IOException e) {
+			throw new BpmnParseException("Cannot read BPMN file: " + bpmnFile, e);
+		}
+	}
+
+	/** Parses BPMN XML held in the given string. */
+	public BpmnModel parse(String bpmnXml) {
+		Objects.requireNonNull(bpmnXml, "bpmnXml");
+		return parse(new ByteArrayInputStream(bpmnXml.getBytes(StandardCharsets.UTF_8)));
+	}
+
+	private Document buildDocument(InputStream bpmnXml) {
+		try {
+			return newSecureBuilder().parse(bpmnXml);
+		} catch (SAXException | IOException e) {
+			throw new BpmnParseException("Malformed BPMN XML", e);
+		} catch (ParserConfigurationException e) {
+			throw new BpmnParseException("Cannot configure the XML parser", e);
+		}
+	}
+
+	private DocumentBuilder newSecureBuilder() throws ParserConfigurationException {
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setNamespaceAware(true);
+		factory.setExpandEntityReferences(false);
+		factory.setXIncludeAware(false);
+		harden(factory);
+		return factory.newDocumentBuilder();
+	}
+
+	private void harden(DocumentBuilderFactory factory) throws ParserConfigurationException {
+		factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+		factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+		factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+	}
+
+	private BpmnModel toModel(Document document) {
+		Element definitions = document.getDocumentElement();
+		requireDefinitions(definitions);
+		List<Process> processes = childElements(definitions).stream()
+				.filter(element -> isNamed(element, PROCESS))
+				.map(this::toProcess)
+				.toList();
+		return new BpmnModel(attr(definitions, "targetNamespace"), processes);
+	}
+
+	private void requireDefinitions(Element root) {
+		if (root == null || !isNamed(root, DEFINITIONS)) {
+			throw new BpmnParseException("Root element must be <definitions>, but was: " + describe(root));
+		}
+	}
+
+	private String describe(Element root) {
+		return root == null ? "<empty document>" : "<" + localName(root) + ">";
+	}
+
+	private Process toProcess(Element processElement) {
+		List<FlowNode> nodes = new ArrayList<>();
+		List<SequenceFlow> flows = new ArrayList<>();
+		childElements(processElement).forEach(child -> collect(child, nodes, flows));
+		return new Process(attr(processElement, "id"), attr(processElement, "name"), nodes, flows);
+	}
+
+	private void collect(Element element, List<FlowNode> nodes, List<SequenceFlow> flows) {
+		if (isNamed(element, SEQUENCE_FLOW)) {
+			flows.add(toSequenceFlow(element));
+		} else {
+			FlowNodeType.fromElementName(localName(element))
+					.ifPresent(type -> nodes.add(toFlowNode(element, type)));
+		}
+	}
+
+	private FlowNode toFlowNode(Element element, FlowNodeType type) {
+		return new FlowNode(attr(element, "id"), attr(element, "name"), type);
+	}
+
+	private SequenceFlow toSequenceFlow(Element element) {
+		return new SequenceFlow(attr(element, "id"), attr(element, "name"),
+				attr(element, "sourceRef"), attr(element, "targetRef"));
+	}
+
+	private List<Element> childElements(Element parent) {
+		List<Element> elements = new ArrayList<>();
+		NodeList children = parent.getChildNodes();
+		java.util.stream.IntStream.range(0, children.getLength())
+				.mapToObj(children::item)
+				.filter(node -> node.getNodeType() == Node.ELEMENT_NODE)
+				.map(Element.class::cast)
+				.forEach(elements::add);
+		return elements;
+	}
+
+	private boolean isNamed(Element element, String localName) {
+		return localName.equals(localName(element));
+	}
+
+	private String localName(Element element) {
+		return Optional.ofNullable(element.getLocalName()).orElseGet(element::getNodeName);
+	}
+
+	private String attr(Element element, String name) {
+		return element.getAttribute(name);
+	}
+}

--- a/bpmn/src/main/java/io/github/adamw7/tools/bpmn/validation/ProcessValidator.java
+++ b/bpmn/src/main/java/io/github/adamw7/tools/bpmn/validation/ProcessValidator.java
@@ -1,0 +1,88 @@
+package io.github.adamw7.tools.bpmn.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.github.adamw7.tools.bpmn.model.FlowNode;
+import io.github.adamw7.tools.bpmn.model.FlowNodeType;
+import io.github.adamw7.tools.bpmn.model.Process;
+import io.github.adamw7.tools.bpmn.model.SequenceFlow;
+
+/**
+ * Checks a parsed {@link Process} for common structural defects: a missing
+ * start or end event, sequence flows that reference unknown nodes, and nodes
+ * that are unreachable or lead nowhere.
+ *
+ * <p>Errors mean the process is structurally invalid; warnings flag suspicious
+ * but tolerable traits. The order of the returned issues is not significant.
+ */
+public final class ProcessValidator {
+
+	/** Runs every rule and returns all issues found, most severe rules first. */
+	public List<ValidationIssue> validate(Process process) {
+		Objects.requireNonNull(process, "process");
+		List<ValidationIssue> issues = new ArrayList<>();
+		checkProcessId(process, issues);
+		checkHasEvent(process, FlowNodeType.START_EVENT, "start", issues);
+		checkHasEvent(process, FlowNodeType.END_EVENT, "end", issues);
+		checkFlowReferences(process, issues);
+		checkConnectivity(process, issues);
+		return issues;
+	}
+
+	/** True when the process has no {@link Severity#ERROR} issues. */
+	public boolean isValid(Process process) {
+		return validate(process).stream().noneMatch(ValidationIssue::isError);
+	}
+
+	private void checkProcessId(Process process, List<ValidationIssue> issues) {
+		if (process.id().isBlank()) {
+			issues.add(ValidationIssue.error("", "Process has no id"));
+		}
+	}
+
+	private void checkHasEvent(Process process, FlowNodeType type, String label, List<ValidationIssue> issues) {
+		if (process.nodesOfType(type).isEmpty()) {
+			issues.add(ValidationIssue.error(process.id(), "Process has no " + label + " event"));
+		}
+	}
+
+	private void checkFlowReferences(Process process, List<ValidationIssue> issues) {
+		process.sequenceFlows().forEach(flow -> checkFlowEnds(process, flow, issues));
+	}
+
+	private void checkFlowEnds(Process process, SequenceFlow flow, List<ValidationIssue> issues) {
+		checkReference(process, flow.id(), flow.sourceRef(), "source", issues);
+		checkReference(process, flow.id(), flow.targetRef(), "target", issues);
+	}
+
+	private void checkReference(Process process, String flowId, String nodeId, String end,
+			List<ValidationIssue> issues) {
+		if (process.findNode(nodeId).isEmpty()) {
+			issues.add(ValidationIssue.error(flowId,
+					"Sequence flow " + end + "Ref '" + nodeId + "' does not match any node"));
+		}
+	}
+
+	private void checkConnectivity(Process process, List<ValidationIssue> issues) {
+		process.flowNodes().forEach(node -> checkNodeConnectivity(process, node, issues));
+	}
+
+	private void checkNodeConnectivity(Process process, FlowNode node, List<ValidationIssue> issues) {
+		if (needsIncoming(node) && process.incoming(node.id()).isEmpty()) {
+			issues.add(ValidationIssue.warning(node.id(), "Node '" + node.id() + "' is unreachable (no incoming flow)"));
+		}
+		if (needsOutgoing(node) && process.outgoing(node.id()).isEmpty()) {
+			issues.add(ValidationIssue.warning(node.id(), "Node '" + node.id() + "' is a dead end (no outgoing flow)"));
+		}
+	}
+
+	private boolean needsIncoming(FlowNode node) {
+		return node.type() != FlowNodeType.START_EVENT && node.type() != FlowNodeType.BOUNDARY_EVENT;
+	}
+
+	private boolean needsOutgoing(FlowNode node) {
+		return node.type() != FlowNodeType.END_EVENT;
+	}
+}

--- a/bpmn/src/main/java/io/github/adamw7/tools/bpmn/validation/Severity.java
+++ b/bpmn/src/main/java/io/github/adamw7/tools/bpmn/validation/Severity.java
@@ -1,0 +1,11 @@
+package io.github.adamw7.tools.bpmn.validation;
+
+/** How serious a {@link ValidationIssue} is. */
+public enum Severity {
+
+	/** A structural defect that makes the process invalid. */
+	ERROR,
+
+	/** A suspicious but tolerable trait, such as an unreachable node. */
+	WARNING
+}

--- a/bpmn/src/main/java/io/github/adamw7/tools/bpmn/validation/ValidationIssue.java
+++ b/bpmn/src/main/java/io/github/adamw7/tools/bpmn/validation/ValidationIssue.java
@@ -1,0 +1,32 @@
+package io.github.adamw7.tools.bpmn.validation;
+
+import java.util.Objects;
+
+/**
+ * A single problem found while validating a process. Immutable.
+ *
+ * @param severity  how serious the problem is
+ * @param elementId the id of the offending element, or empty when the issue is
+ *                  about the process as a whole
+ * @param message   a human-readable description of the problem
+ */
+public record ValidationIssue(Severity severity, String elementId, String message) {
+
+	public ValidationIssue {
+		Objects.requireNonNull(severity, "severity");
+		Objects.requireNonNull(elementId, "elementId");
+		Objects.requireNonNull(message, "message");
+	}
+
+	public static ValidationIssue error(String elementId, String message) {
+		return new ValidationIssue(Severity.ERROR, elementId, message);
+	}
+
+	public static ValidationIssue warning(String elementId, String message) {
+		return new ValidationIssue(Severity.WARNING, elementId, message);
+	}
+
+	public boolean isError() {
+		return severity == Severity.ERROR;
+	}
+}

--- a/bpmn/src/test/java/io/github/adamw7/tools/bpmn/model/FlowNodeTypeTest.java
+++ b/bpmn/src/test/java/io/github/adamw7/tools/bpmn/model/FlowNodeTypeTest.java
@@ -1,0 +1,47 @@
+package io.github.adamw7.tools.bpmn.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class FlowNodeTypeTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"startEvent,START_EVENT",
+			"userTask,USER_TASK",
+			"serviceTask,SERVICE_TASK",
+			"exclusiveGateway,EXCLUSIVE_GATEWAY",
+			"callActivity,CALL_ACTIVITY"
+	})
+	void resolvesKnownElementNames(String elementName, FlowNodeType expected) {
+		assertEquals(Optional.of(expected), FlowNodeType.fromElementName(elementName));
+	}
+
+	@Test
+	void returnsEmptyForUnknownElementName() {
+		assertTrue(FlowNodeType.fromElementName("sequenceFlow").isEmpty());
+		assertTrue(FlowNodeType.fromElementName("laneSet").isEmpty());
+	}
+
+	@Test
+	void classifiesCategories() {
+		assertTrue(FlowNodeType.START_EVENT.isEvent());
+		assertFalse(FlowNodeType.START_EVENT.isGateway());
+		assertTrue(FlowNodeType.USER_TASK.isActivity());
+		assertTrue(FlowNodeType.PARALLEL_GATEWAY.isGateway());
+		assertEquals(FlowNodeType.Category.GATEWAY, FlowNodeType.PARALLEL_GATEWAY.category());
+	}
+
+	@Test
+	void everyTypeRoundTripsThroughItsElementName() {
+		java.util.Arrays.stream(FlowNodeType.values()).forEach(type ->
+				assertEquals(Optional.of(type), FlowNodeType.fromElementName(type.elementName())));
+	}
+}

--- a/bpmn/src/test/java/io/github/adamw7/tools/bpmn/model/ModelTest.java
+++ b/bpmn/src/test/java/io/github/adamw7/tools/bpmn/model/ModelTest.java
@@ -1,0 +1,47 @@
+package io.github.adamw7.tools.bpmn.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class ModelTest {
+
+	@Test
+	void flowNodeRejectsNullComponents() {
+		assertThrows(NullPointerException.class, () -> new FlowNode(null, "", FlowNodeType.TASK));
+		assertThrows(NullPointerException.class, () -> new FlowNode("id", null, FlowNodeType.TASK));
+		assertThrows(NullPointerException.class, () -> new FlowNode("id", "", null));
+	}
+
+	@Test
+	void sequenceFlowRejectsNullComponents() {
+		assertThrows(NullPointerException.class, () -> new SequenceFlow(null, "", "a", "b"));
+		assertThrows(NullPointerException.class, () -> new SequenceFlow("id", "", "a", null));
+	}
+
+	@Test
+	void processDefensivelyCopiesItsCollections() {
+		List<FlowNode> nodes = new ArrayList<>(List.of(new FlowNode("s", "", FlowNodeType.START_EVENT)));
+		Process process = new Process("p", "", nodes, List.of());
+
+		nodes.clear();
+
+		assertEquals(1, process.flowNodes().size());
+		assertThrows(UnsupportedOperationException.class,
+				() -> process.flowNodes().add(new FlowNode("x", "", FlowNodeType.TASK)));
+	}
+
+	@Test
+	void findsProcessByIdWithinModel() {
+		Process process = new Process("p", "Payments", List.of(), List.of());
+		BpmnModel model = new BpmnModel("", List.of(process));
+
+		assertEquals("Payments", model.findProcess("p").orElseThrow().name());
+		assertTrue(model.findProcess("absent").isEmpty());
+	}
+}

--- a/bpmn/src/test/java/io/github/adamw7/tools/bpmn/parse/BpmnParserTest.java
+++ b/bpmn/src/test/java/io/github/adamw7/tools/bpmn/parse/BpmnParserTest.java
@@ -1,0 +1,118 @@
+package io.github.adamw7.tools.bpmn.parse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.bpmn.model.BpmnModel;
+import io.github.adamw7.tools.bpmn.model.FlowNodeType;
+import io.github.adamw7.tools.bpmn.model.Process;
+
+class BpmnParserTest {
+
+	private final BpmnParser parser = new BpmnParser();
+
+	private BpmnModel parseResource() {
+		try (InputStream stream = getClass().getResourceAsStream("/order-process.bpmn")) {
+			return parser.parse(stream);
+		} catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	@Test
+	void readsTargetNamespaceAndSingleProcess() {
+		BpmnModel model = parseResource();
+
+		assertEquals("http://example.com/orders", model.targetNamespace());
+		assertEquals(1, model.processes().size());
+		assertEquals("orderProcess", model.processes().get(0).id());
+		assertEquals("Order handling", model.processes().get(0).name());
+	}
+
+	@Test
+	void readsEveryFlowNodeWithItsType() {
+		Process process = parseResource().processes().get(0);
+
+		assertEquals(6, process.flowNodes().size());
+		assertEquals(FlowNodeType.START_EVENT, process.findNode("start").orElseThrow().type());
+		assertEquals(FlowNodeType.USER_TASK, process.findNode("review").orElseThrow().type());
+		assertEquals(FlowNodeType.EXCLUSIVE_GATEWAY, process.findNode("approved").orElseThrow().type());
+		assertEquals(FlowNodeType.SERVICE_TASK, process.findNode("ship").orElseThrow().type());
+		assertEquals(2, process.nodesOfType(FlowNodeType.END_EVENT).size());
+	}
+
+	@Test
+	void readsSequenceFlowsWithEndsAndNames() {
+		Process process = parseResource().processes().get(0);
+
+		assertEquals(5, process.sequenceFlows().size());
+		assertEquals(2, process.outgoing("approved").size());
+		assertEquals("yes", process.sequenceFlows().get(2).name());
+		assertEquals("approved", process.incoming("ship").get(0).sourceRef());
+	}
+
+	@Test
+	void leavesNameEmptyWhenAbsent() {
+		Process process = parseResource().processes().get(0);
+
+		assertEquals("", process.sequenceFlows().get(0).name());
+	}
+
+	@Test
+	void ignoresUnrecognisedElementsSuchAsDiagram() {
+		Process process = parseResource().processes().get(0);
+
+		assertTrue(process.findNode("diagram").isEmpty());
+	}
+
+	@Test
+	void parsesFromStringToo() {
+		String xml = """
+				<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+				  <process id="p">
+				    <startEvent id="s"/>
+				    <endEvent id="e"/>
+				    <sequenceFlow id="f" sourceRef="s" targetRef="e"/>
+				  </process>
+				</definitions>
+				""";
+
+		BpmnModel model = parser.parse(xml);
+
+		assertEquals(1, model.processes().size());
+		assertEquals("", model.targetNamespace());
+		assertEquals(2, model.processes().get(0).flowNodes().size());
+	}
+
+	@Test
+	void rejectsMalformedXml() {
+		assertThrows(BpmnParseException.class, () -> parser.parse("<definitions><process></definitions>"));
+	}
+
+	@Test
+	void rejectsWrongRootElement() {
+		BpmnParseException thrown = assertThrows(BpmnParseException.class,
+				() -> parser.parse("<notDefinitions/>"));
+		assertTrue(thrown.getMessage().contains("definitions"));
+	}
+
+	@Test
+	void rejectsDocumentTypeDeclarationToBlockXxe() {
+		String withDoctype = "<?xml version=\"1.0\"?><!DOCTYPE foo><definitions/>";
+
+		assertThrows(BpmnParseException.class, () -> parser.parse(withDoctype));
+	}
+
+	@Test
+	void reportsMissingFile() {
+		Path missing = Path.of("does-not-exist.bpmn");
+
+		assertThrows(BpmnParseException.class, () -> parser.parse(missing));
+	}
+}

--- a/bpmn/src/test/java/io/github/adamw7/tools/bpmn/validation/ProcessValidatorTest.java
+++ b/bpmn/src/test/java/io/github/adamw7/tools/bpmn/validation/ProcessValidatorTest.java
@@ -1,0 +1,116 @@
+package io.github.adamw7.tools.bpmn.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.bpmn.model.FlowNode;
+import io.github.adamw7.tools.bpmn.model.FlowNodeType;
+import io.github.adamw7.tools.bpmn.model.Process;
+import io.github.adamw7.tools.bpmn.model.SequenceFlow;
+
+class ProcessValidatorTest {
+
+	private final ProcessValidator validator = new ProcessValidator();
+
+	private FlowNode node(String id, FlowNodeType type) {
+		return new FlowNode(id, "", type);
+	}
+
+	private SequenceFlow flow(String id, String source, String target) {
+		return new SequenceFlow(id, "", source, target);
+	}
+
+	private Process straightLine() {
+		return new Process("p", "", List.of(
+				node("s", FlowNodeType.START_EVENT),
+				node("t", FlowNodeType.TASK),
+				node("e", FlowNodeType.END_EVENT)),
+				List.of(flow("f1", "s", "t"), flow("f2", "t", "e")));
+	}
+
+	private boolean hasError(List<ValidationIssue> issues, String fragment) {
+		return issues.stream().anyMatch(issue -> issue.isError() && issue.message().contains(fragment));
+	}
+
+	private boolean hasWarning(List<ValidationIssue> issues, String fragment) {
+		return issues.stream()
+				.anyMatch(issue -> issue.severity() == Severity.WARNING && issue.message().contains(fragment));
+	}
+
+	@Test
+	void wellFormedProcessHasNoIssues() {
+		assertTrue(validator.validate(straightLine()).isEmpty());
+		assertTrue(validator.isValid(straightLine()));
+	}
+
+	@Test
+	void flagsMissingStartEvent() {
+		Process process = new Process("p", "", List.of(node("e", FlowNodeType.END_EVENT)), List.of());
+
+		assertTrue(hasError(validator.validate(process), "no start event"));
+	}
+
+	@Test
+	void flagsMissingEndEvent() {
+		Process process = new Process("p", "", List.of(node("s", FlowNodeType.START_EVENT)), List.of());
+
+		assertTrue(hasError(validator.validate(process), "no end event"));
+	}
+
+	@Test
+	void flagsBlankProcessId() {
+		Process process = new Process("", "", List.of(
+				node("s", FlowNodeType.START_EVENT), node("e", FlowNodeType.END_EVENT)),
+				List.of(flow("f", "s", "e")));
+
+		assertTrue(hasError(validator.validate(process), "no id"));
+		assertFalse(validator.isValid(process));
+	}
+
+	@Test
+	void flagsSequenceFlowWithUnknownTarget() {
+		Process process = new Process("p", "", List.of(
+				node("s", FlowNodeType.START_EVENT), node("e", FlowNodeType.END_EVENT)),
+				List.of(flow("f", "s", "ghost")));
+
+		assertTrue(hasError(validator.validate(process), "targetRef 'ghost'"));
+	}
+
+	@Test
+	void warnsAboutUnreachableNode() {
+		Process process = new Process("p", "", List.of(
+				node("s", FlowNodeType.START_EVENT),
+				node("island", FlowNodeType.TASK),
+				node("e", FlowNodeType.END_EVENT)),
+				List.of(flow("f", "s", "e")));
+
+		List<ValidationIssue> issues = validator.validate(process);
+		assertTrue(hasWarning(issues, "unreachable"));
+		assertTrue(hasWarning(issues, "dead end"));
+		assertTrue(validator.isValid(process));
+	}
+
+	@Test
+	void startEventNeedsNoIncomingAndEndEventNeedsNoOutgoing() {
+		List<ValidationIssue> issues = validator.validate(straightLine());
+
+		assertFalse(hasWarning(issues, "unreachable"));
+		assertFalse(hasWarning(issues, "dead end"));
+	}
+
+	@Test
+	void reportsSeverityCountsForACompletelyBrokenProcess() {
+		Process process = new Process("", "", List.of(node("t", FlowNodeType.TASK)),
+				List.of(flow("f", "t", "missing")));
+
+		List<ValidationIssue> issues = validator.validate(process);
+
+		long errors = issues.stream().filter(ValidationIssue::isError).count();
+		assertEquals(4, errors, "blank id, no start, no end, plus dangling target");
+	}
+}

--- a/bpmn/src/test/resources/order-process.bpmn
+++ b/bpmn/src/test/resources/order-process.bpmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  targetNamespace="http://example.com/orders">
+  <bpmn:process id="orderProcess" name="Order handling">
+    <bpmn:startEvent id="start" name="Order received"/>
+    <bpmn:userTask id="review" name="Review order"/>
+    <bpmn:exclusiveGateway id="approved" name="Approved?"/>
+    <bpmn:serviceTask id="ship" name="Ship order"/>
+    <bpmn:endEvent id="done" name="Order shipped"/>
+    <bpmn:endEvent id="rejected" name="Order rejected"/>
+
+    <bpmn:sequenceFlow id="f1" sourceRef="start" targetRef="review"/>
+    <bpmn:sequenceFlow id="f2" sourceRef="review" targetRef="approved"/>
+    <bpmn:sequenceFlow id="f3" name="yes" sourceRef="approved" targetRef="ship"/>
+    <bpmn:sequenceFlow id="f4" name="no" sourceRef="approved" targetRef="rejected"/>
+    <bpmn:sequenceFlow id="f5" sourceRef="ship" targetRef="done"/>
+  </bpmn:process>
+
+  <bpmndi:BPMNDiagram id="diagram">
+    <bpmndi:BPMNPlane bpmnElement="orderProcess"/>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 		<module>mcp-common</module>
 		<module>data</module>
 		<module>code</module>
+		<module>bpmn</module>
 		<module>grpc-example</module>
 		<module>assembly</module>
 	</modules>


### PR DESCRIPTION
Add a new dependency-free `bpmn` module that reads BPMN 2.0 `.bpmn` XML
into an immutable Java process model and validates its structure.

- model: BpmnModel, Process, FlowNode (with FlowNodeType), SequenceFlow,
  with graph-navigation helpers (findNode, outgoing, incoming).
- parse: BpmnParser reads from InputStream/Path/String using only the JDK
  XML APIs; namespace-aware and hardened against XXE (DOCTYPE and external
  entities rejected). Unrecognised elements are ignored. Failures raise
  BpmnParseException.
- validation: ProcessValidator flags missing start/end events, sequence
  flows referencing unknown nodes, and unreachable/dead-end nodes as
  ValidationIssues (ERROR/WARNING).

Register the module in the root reactor and document it in AGENTS.md and
README.md. 30 unit tests cover parsing, validation, model invariants and
error paths; the full reactor build passes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PBorNF5GcTQBbEbiJT1AJd