### PR TITLE
refactor(data): inject data source into Uniqueness at construction

### DIFF
--- a/data-test/src/test/java/io/github/adamw7/tools/data/test/MemoryLeakTest.java
+++ b/data-test/src/test/java/io/github/adamw7/tools/data/test/MemoryLeakTest.java
@@ -202,11 +202,9 @@ public class MemoryLeakTest {
 
 	@Test
 	public void seekMemoryLeakInUniquenessCheck() {
-		AbstractUniqueness uniqueness = new NoMemoryUniquenessCheck();
-
 		try {
 			IterableDataSource source = new CSVDataSource(FILE_NAME, 1);
-			uniqueness.setDataSource(source);
+			AbstractUniqueness uniqueness = new NoMemoryUniquenessCheck(source);
 
 			Result result = uniqueness.exec("Column 1");
 			source.close();

--- a/data/src/main/java/io/github/adamw7/tools/data/SampleApp.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/SampleApp.java
@@ -8,9 +8,9 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.data.source.file.InMemoryCSVDataSource;
 import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
-import io.github.adamw7.tools.data.uniqueness.AbstractUniqueness;
 import io.github.adamw7.tools.data.uniqueness.InMemoryUniquenessCheck;
 import io.github.adamw7.tools.data.uniqueness.Result;
+import io.github.adamw7.tools.data.uniqueness.Uniqueness;
 
 public class SampleApp {
 	
@@ -27,12 +27,11 @@ public class SampleApp {
 	private static void executeUniquenessCheck(String fileName, String columnName) {
 		try {
 			InMemoryDataSource source = new InMemoryCSVDataSource(fileName, 1);
-			AbstractUniqueness check = new InMemoryUniquenessCheck();
-			
+			Uniqueness check = new InMemoryUniquenessCheck(source);
+
 			source.readAll();
-			
-			check.setDataSource(source);
-			print(check.exec(columnName), columnName);			
+
+			print(check.exec(columnName), columnName);
 		} catch (FileNotFoundException e) {
 			throw new UncheckedIOException(e);
 		}

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
@@ -11,15 +11,17 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 
-public abstract class AbstractUniqueness<T extends IterableDataSource> implements Uniqueness<T> {
+public abstract class AbstractUniqueness<T extends IterableDataSource> implements Uniqueness {
 
 	private static final Logger log = LogManager.getLogger(AbstractUniqueness.class);
 
-	protected T dataSource;
+	protected final T dataSource;
 
-	@Override
-	public void setDataSource(T source) {
-		this.dataSource = source;
+	protected AbstractUniqueness(T dataSource) {
+		if (dataSource == null) {
+			throw new IllegalArgumentException("dataSource must not be null");
+		}
+		this.dataSource = dataSource;
 	}
 
 	protected void checkIfCandidatesExistIn(String[] keyCandidates, String[] allColumns) {
@@ -99,7 +101,7 @@ public abstract class AbstractUniqueness<T extends IterableDataSource> implement
 	protected abstract Set<Result> findPotentiallySmallerSetOfCandidates(String[] keyCandidates);
 	
 	@Override
-	public Result exec() {
+	public Result execForAllColumns() {
 		dataSource.open();
 		return exec(dataSource.getColumnNames());
 	}

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/InMemoryUniquenessCheck.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/InMemoryUniquenessCheck.java
@@ -8,11 +8,8 @@ import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
 
 public class InMemoryUniquenessCheck extends AbstractUniqueness<InMemoryDataSource> {
 
-	public InMemoryUniquenessCheck() {
-	}
-
 	public InMemoryUniquenessCheck(InMemoryDataSource dataSource) {
-		setDataSource(dataSource);
+		super(dataSource);
 	}
 
 	@Override

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
@@ -7,10 +7,8 @@ import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 
 public class NoMemoryUniquenessCheck extends AbstractUniqueness<IterableDataSource> {
 
-	public NoMemoryUniquenessCheck() { }
-
 	public NoMemoryUniquenessCheck(IterableDataSource dataSource) {
-		this.dataSource = dataSource;
+		super(dataSource);
 	}
 
 	@Override

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/Uniqueness.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/Uniqueness.java
@@ -1,11 +1,25 @@
 package io.github.adamw7.tools.data.uniqueness;
 
-import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
+/**
+ * Checks whether a set of columns forms a unique key over a data source. The
+ * source is supplied when the check is created, so an instance is always ready
+ * to {@link #exec} and can never be left in a half-initialised state.
+ */
+public interface Uniqueness {
 
-public interface Uniqueness<T extends IterableDataSource> {
+	/**
+	 * Checks the given columns for uniqueness.
+	 *
+	 * @param keyCandidates the columns to check, must be non-empty and free of
+	 *                      {@code null}s and duplicates
+	 * @return the result of the check
+	 */
 	Result exec(String... keyCandidates);
 
-	Result exec();
-
-	void setDataSource(T source);
+	/**
+	 * Checks every column of the data source for uniqueness.
+	 *
+	 * @return the result of the check
+	 */
+	Result execForAllColumns();
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
@@ -11,9 +11,9 @@ import org.springframework.stereotype.Component;
 
 import io.github.adamw7.tools.data.source.file.InMemoryCSVDataSource;
 import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
-import io.github.adamw7.tools.data.uniqueness.AbstractUniqueness;
 import io.github.adamw7.tools.data.uniqueness.InMemoryUniquenessCheck;
 import io.github.adamw7.tools.data.uniqueness.Result;
+import io.github.adamw7.tools.data.uniqueness.Uniqueness;
 import io.github.adamw7.tools.mcp.McpTool;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -56,9 +56,7 @@ public class UniquenessTool implements McpTool {
 		String columnName = String.valueOf(arguments.get("columns_name"));
 		int columnsRow = Integer.parseInt(String.valueOf(arguments.get("columns_row")));
 		try (InMemoryDataSource source = new InMemoryCSVDataSource(fileName, columnsRow)) {
-			AbstractUniqueness check = new InMemoryUniquenessCheck();
-
-			check.setDataSource(source);
+			Uniqueness check = new InMemoryUniquenessCheck(source);
 			Result result = check.exec(columnName);
 			print(result, columnName);
 			return String.valueOf(result.isUnique());

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/UniquenessCheckTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/UniquenessCheckTest.java
@@ -3,7 +3,6 @@ package io.github.adamw7.tools.data.uniqueness;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -26,44 +25,29 @@ public class UniquenessCheckTest extends DBTest {
 	static Stream<Arguments> happyPath() {
 		String householdFile = Utils.getHouseholdFile();
 
-		return Stream.of(of(NoMemoryUniquenessCheck.class, Utils.createDataSource(householdFile, COLUMNS_ROW)),
-				of(InMemoryUniquenessCheck.class, Utils.createInMemoryDataSource(householdFile, COLUMNS_ROW)),
-				of(NoMemoryUniquenessCheck.class, Utils.createIterableSQLDataSource(connection, query)),
-				of(InMemoryUniquenessCheck.class, Utils.createInMemorySQLDataSource(connection, query)));
+		return Stream.of(of(new NoMemoryUniquenessCheck(Utils.createDataSource(householdFile, COLUMNS_ROW))),
+				of(new InMemoryUniquenessCheck(Utils.createInMemoryDataSource(householdFile, COLUMNS_ROW))),
+				of(new NoMemoryUniquenessCheck(Utils.createIterableSQLDataSource(connection, query))),
+				of(new InMemoryUniquenessCheck(Utils.createInMemorySQLDataSource(connection, query))));
 	}
 
 	@ParameterizedTest
 	@MethodSource("happyPath")
-	public void happyPathNotUnique(Class<AbstractUniqueness> uniquenessClass, IterableDataSource source)
-			throws Exception {
-		AbstractUniqueness uniqueness = initUniquenessCheck(uniquenessClass, source);
-
+	public void happyPathNotUnique(Uniqueness uniqueness) throws Exception {
 		Result result = uniqueness.exec(NOT_UNIQUE_COLUMNS);
 		assertFalse(result.isUnique());
 	}
 
-	private AbstractUniqueness initUniquenessCheck(Class<AbstractUniqueness> uniquenessClass, IterableDataSource source)
-			throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
-			NoSuchMethodException, SecurityException {
-		AbstractUniqueness uniqueness = uniquenessClass.getConstructor().newInstance();
-		uniqueness.setDataSource(source);
-		return uniqueness;
-	}
-
 	@ParameterizedTest
 	@MethodSource("happyPath")
-	public void happyPathUnique(Class<AbstractUniqueness> uniquenessClass, IterableDataSource source) throws Exception {
-		AbstractUniqueness uniqueness = initUniquenessCheck(uniquenessClass, source);
-
+	public void happyPathUnique(Uniqueness uniqueness) throws Exception {
 		Result result = uniqueness.exec(UNIQUE_COLUMNS);
 		assertTrue(result.isUnique());
 	}
 
 	@ParameterizedTest
 	@MethodSource("happyPath")
-	public void happyPathUniqueShouldFindBetterOptions(Class<AbstractUniqueness> uniquenessClass,
-			IterableDataSource source) throws Exception {
-		AbstractUniqueness uniqueness = initUniquenessCheck(uniquenessClass, source);
+	public void happyPathUniqueShouldFindBetterOptions(Uniqueness uniqueness) throws Exception {
 		Result result = uniqueness.exec("year1", "hlpi_name", "income");
 		assertTrue(result.isUnique());
 		Set<Result> betterOptions = result.getBetterOptions();
@@ -77,9 +61,7 @@ public class UniquenessCheckTest extends DBTest {
 
 	@ParameterizedTest
 	@MethodSource("happyPath")
-	public void happyPathUniqueShouldNotFindBetterOptions(Class<AbstractUniqueness> uniquenessClass,
-			IterableDataSource source) throws Exception {
-		AbstractUniqueness uniqueness = initUniquenessCheck(uniquenessClass, source);
+	public void happyPathUniqueShouldNotFindBetterOptions(Uniqueness uniqueness) throws Exception {
 		Result result = uniqueness.exec("income");
 		assertTrue(result.isUnique());
 		assertEquals(0, result.getBetterOptions().size());
@@ -87,8 +69,7 @@ public class UniquenessCheckTest extends DBTest {
 
 	@ParameterizedTest
 	@MethodSource("happyPath")
-	void negativeWrongColumn(Class<AbstractUniqueness> uniquenessClass, IterableDataSource source) throws Exception {
-		AbstractUniqueness uniqueness = initUniquenessCheck(uniquenessClass, source);
+	void negativeWrongColumn(Uniqueness uniqueness) throws Exception {
 		String columnName = "notExistingColumn";
 		ColumnNotFoundException thrown = assertThrows(ColumnNotFoundException.class, () -> uniqueness.exec(columnName), "Expected exec method to throw, but it didn't");
 		String expectedMessage = columnName
@@ -98,9 +79,7 @@ public class UniquenessCheckTest extends DBTest {
 
 	@ParameterizedTest
 	@MethodSource("happyPath")
-	void negativeEmptyInputArray(Class<AbstractUniqueness> uniquenessClass, IterableDataSource source)
-			throws Exception {
-		AbstractUniqueness uniqueness = initUniquenessCheck(uniquenessClass, source);
+	void negativeEmptyInputArray(Uniqueness uniqueness) throws Exception {
 		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> uniqueness.exec(new String[] {}), "Expected exec method to throw, but it didn't");
 
 		assertEquals("Wrong input: []", thrown.getMessage());
@@ -108,8 +87,7 @@ public class UniquenessCheckTest extends DBTest {
 
 	@ParameterizedTest
 	@MethodSource("happyPath")
-	void negativeNullInputArray(Class<AbstractUniqueness> uniquenessClass, IterableDataSource source) throws Exception {
-		AbstractUniqueness uniqueness = initUniquenessCheck(uniquenessClass, source);
+	void negativeNullInputArray(Uniqueness uniqueness) throws Exception {
 		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> uniqueness.exec((String[]) null), "Expected exec method to throw, but it didn't");
 
 		assertEquals("Wrong input: null", thrown.getMessage());
@@ -117,9 +95,7 @@ public class UniquenessCheckTest extends DBTest {
 
 	@ParameterizedTest
 	@MethodSource("happyPath")
-	void negativeNullsInInputArray(Class<AbstractUniqueness> uniquenessClass, IterableDataSource source)
-			throws Exception {
-		AbstractUniqueness uniqueness = initUniquenessCheck(uniquenessClass, source);
+	void negativeNullsInInputArray(Uniqueness uniqueness) throws Exception {
 		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> uniqueness.exec("hlpi_name", null, "year1"), "Expected exec method to throw, but it didn't");
 
 		assertEquals("Input columns cannot be null", thrown.getMessage());
@@ -127,9 +103,7 @@ public class UniquenessCheckTest extends DBTest {
 
 	@ParameterizedTest
 	@MethodSource("happyPath")
-	void negativeDuplicatesInInputArray(Class<AbstractUniqueness> uniquenessClass, IterableDataSource source)
-			throws Exception {
-		AbstractUniqueness uniqueness = initUniquenessCheck(uniquenessClass, source);
+	void negativeDuplicatesInInputArray(Uniqueness uniqueness) throws Exception {
 		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> uniqueness.exec("year1", "year1"), "Expected exec method to throw, but it didn't");
 
 		assertEquals("Duplicate in input: year1", thrown.getMessage());
@@ -139,8 +113,7 @@ public class UniquenessCheckTest extends DBTest {
 	public void notUniquePathClosesDataSource() throws Exception {
 		ClosingSpyDataSource source = new ClosingSpyDataSource(
 				Utils.createDataSource(Utils.getHouseholdFile(), COLUMNS_ROW));
-		NoMemoryUniquenessCheck uniqueness = new NoMemoryUniquenessCheck();
-		uniqueness.setDataSource(source);
+		NoMemoryUniquenessCheck uniqueness = new NoMemoryUniquenessCheck(source);
 
 		Result result = uniqueness.exec(NOT_UNIQUE_COLUMNS);
 
@@ -195,10 +168,10 @@ public class UniquenessCheckTest extends DBTest {
 
 	@Test
 	public void happyPathAllColumns() {
-		InMemoryUniquenessCheck uniqueness = new InMemoryUniquenessCheck();
-		uniqueness.setDataSource(Utils.createInMemorySQLDataSource(connection, "SELECT * FROM PEOPLE"));
+		InMemoryUniquenessCheck uniqueness = new InMemoryUniquenessCheck(
+				Utils.createInMemorySQLDataSource(connection, "SELECT * FROM PEOPLE"));
 
-		Result result = uniqueness.exec();
+		Result result = uniqueness.execForAllColumns();
 		assertTrue(result.isUnique());
 		assertEquals(3, result.getBetterOptions().size());
 		Result id = new Result(true, new String[] { "ID" });


### PR DESCRIPTION
Remove the setDataSource setter from the Uniqueness interface, which
created temporal coupling: a caller had to remember to set the source
before exec(), and forgetting left the object in a half-initialised
state that failed with an NPE.

The source is now a required constructor argument on AbstractUniqueness
(stored in a final field, null-checked), so an instance is always ready
to use and illegal states are unrepresentable. The interface no longer
needs its type parameter.

Also rename the no-arg exec() to execForAllColumns() to remove the
confusing overlap with exec(String...) and make the "check every column"
intent explicit at call sites.

Callers (UniquenessTool, SampleApp) and tests updated accordingly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FJ8ZMdMtpsH2aQX2yjfBip