### PR TITLE
refactor(data): hoist candidate-reduction loop into AbstractUniqueness

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
@@ -83,13 +83,34 @@ public abstract class AbstractUniqueness<T extends IterableDataSource> implement
 		Set<Result> set = findPotentiallySmallerSetOfCandidates(keyCandidates);
 		return new Result(true, keyCandidates, null, set);
 	}
-	
-	protected Set<String> createSmallerSet(String[] keyCandidates, String candidate) {
+
+	private Set<Result> findPotentiallySmallerSetOfCandidates(String[] keyCandidates) {
+		Set<Result> uniqueCandidates = new HashSet<>();
+		for (String candidate : keyCandidates) {
+			Set<String> smaller = createSmallerSet(keyCandidates, candidate);
+			addIfUnique(uniqueCandidates, smaller, keyCandidates.length);
+		}
+		return uniqueCandidates;
+	}
+
+	private void addIfUnique(Set<Result> uniqueCandidates, Set<String> smaller, int originalSize) {
+		if (smaller.isEmpty()) {
+			return;
+		}
+		dataSource.reset();
+		String[] newCandidates = smaller.toArray(new String[originalSize - 1]);
+		Result result = checkSubset(newCandidates);
+		if (result.unique) {
+			uniqueCandidates.add(result);
+		}
+	}
+
+	private Set<String> createSmallerSet(String[] keyCandidates, String candidate) {
 		Set<String> set = new HashSet<>(Arrays.asList(keyCandidates));
 		set.remove(candidate);
 		return set;
 	}
-	
+
 	protected void close(IterableDataSource dataSource) {
 		try {
 			dataSource.close();
@@ -97,8 +118,8 @@ public abstract class AbstractUniqueness<T extends IterableDataSource> implement
 			log.warn("Failed to close data source: {}", dataSource, e);
 		}
 	}
-	
-	protected abstract Set<Result> findPotentiallySmallerSetOfCandidates(String[] keyCandidates);
+
+	protected abstract Result checkSubset(String[] newCandidates);
 	
 	@Override
 	public Result execForAllColumns() {

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/InMemoryUniquenessCheck.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/InMemoryUniquenessCheck.java
@@ -1,8 +1,6 @@
 package io.github.adamw7.tools.data.uniqueness;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
 
@@ -36,21 +34,9 @@ public class InMemoryUniquenessCheck extends AbstractUniqueness<InMemoryDataSour
 		return handleSuccessfulCheck(keyCandidates);
 	}
 
-	protected Set<Result> findPotentiallySmallerSetOfCandidates(String[] keyCandidates) {
-		Set<Result> uniqueCandidates = new HashSet<>();
-		for (String candidate : keyCandidates) {
-			Set<String> set = createSmallerSet(keyCandidates, candidate);
-			if (!set.isEmpty()) {
-				dataSource.reset();
-				String[] newCandidates = set.toArray(new String[keyCandidates.length - 1]);
-				Integer[] indices = getIndiciesOf(newCandidates, dataSource.getColumnNames());
-				Result result = findUnique(indices, newCandidates);
-				if (result.unique) {
-					uniqueCandidates.add(result);
-				}
-			}
-		}
-
-		return uniqueCandidates;
+	@Override
+	protected Result checkSubset(String[] newCandidates) {
+		Integer[] indices = getIndiciesOf(newCandidates, dataSource.getColumnNames());
+		return findUnique(indices, newCandidates);
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
@@ -1,8 +1,5 @@
 package io.github.adamw7.tools.data.uniqueness;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 
 public class NoMemoryUniquenessCheck extends AbstractUniqueness<IterableDataSource> {
@@ -31,18 +28,8 @@ public class NoMemoryUniquenessCheck extends AbstractUniqueness<IterableDataSour
 		return result;
 	}
 
-	protected Set<Result> findPotentiallySmallerSetOfCandidates(String[] keyCandidates) {
-		Set<Result> uniqueCandidates  = new HashSet<>();
-		for (String candidate : keyCandidates) {
-			Set<String> set = createSmallerSet(keyCandidates, candidate);
-			if (!set.isEmpty()) {
-				dataSource.reset();
-				Result result = exec(set.toArray(new String[keyCandidates.length - 1]));
-				if (result.unique) {
-					uniqueCandidates.add(result);
-				}
-			}
-		}
-		return uniqueCandidates;
+	@Override
+	protected Result checkSubset(String[] newCandidates) {
+		return exec(newCandidates);
 	}
 }


### PR DESCRIPTION
InMemoryUniquenessCheck and NoMemoryUniquenessCheck each carried a
near-identical findPotentiallySmallerSetOfCandidates: the same loop that
drops one column at a time, resets the source and keeps any subset that
is still unique. Only the per-subset check differed.

Pull that loop up into AbstractUniqueness as a Template Method and
expose a single abstract checkSubset(String[]) hook. The in-memory check
computes indices and scans the buffered rows; the no-memory check simply
re-runs exec over the smaller set. This removes the duplication (DRY),
keeps the shared traversal in one place (SRP) and lets a new uniqueness
strategy vary only the subset check (Open/Closed).

The two subclasses no longer reference HashSet/Set/createSmallerSet, so
those imports and the now-private helpers move to the base class.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KcSGXumTxFyTwk3F4zqgqe