### PR TITLE
fix(central): exclude protogen-maven-plugin-test from Maven Central publish

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -79,11 +79,15 @@ jobs:
         # (autoPublish=false, waitUntil=validated) so Central validates the
         # bundle but nothing is released.
         #
-        # The assembly module only builds a runnable SampleApp distribution and
-        # the grpc-example module is only a protobuf/gRPC example, not reusable
-        # libraries, so they are excluded from the reactor here
-        # ("-pl !assembly,!grpc-example") and never take part in the Central
-        # publish.
+        # The assembly module only builds a runnable SampleApp distribution, the
+        # grpc-example module is only a protobuf/gRPC example, and
+        # protogen-maven-plugin-test is an integration-test harness with no
+        # main sources (it only generates and compiles test builders to exercise
+        # the plugin). None are reusable libraries, and the test harness would
+        # additionally fail Central validation with an empty -sources.jar, so
+        # they are excluded from the reactor here
+        # ("-pl !assembly,!grpc-example,!code/protogen-maven-plugin-test") and
+        # never take part in the Central publish.
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             revision_arg=""
@@ -91,9 +95,9 @@ jobs:
               revision_arg="-Drevision=${{ github.event.inputs.revision }}"
             fi
             echo "Staged-only Central dry run: autoPublish=false, waitUntil=validated $revision_arg"
-            mvn -B -ntp -X -P release -pl '!assembly,!grpc-example' deploy -Dcentral.autoPublish=false -Dcentral.waitUntil=validated $revision_arg
+            mvn -B -ntp -X -P release -pl '!assembly,!grpc-example,!code/protogen-maven-plugin-test' deploy -Dcentral.autoPublish=false -Dcentral.waitUntil=validated $revision_arg
           else
-            mvn -B -ntp -X -P release -pl '!assembly,!grpc-example' deploy
+            mvn -B -ntp -X -P release -pl '!assembly,!grpc-example,!code/protogen-maven-plugin-test' deploy
           fi
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,8 +302,11 @@ Creating the GitHub release fires two separate workflows:
   published coordinates ship javadoc alongside the main jar; the default
   `mvn deploy` would otherwise publish the main jar only.
 - `central-publish.yml` deploys to **Maven Central** via the Sonatype Central
-  Portal. It runs `mvn -P release deploy` (excluding the `assembly` and
-  `grpc-example` modules, which are not reusable libraries); the `release`
+  Portal. It runs `mvn -P release deploy` (excluding the `assembly`,
+  `grpc-example`, and `protogen-maven-plugin-test` modules, which are not
+  reusable libraries — the last is an integration-test harness with no main
+  sources, so it would also fail Central validation with an empty
+  `-sources.jar`); the `release`
   profile attaches the sources and javadoc jars, GPG-signs every artifact, and
   hands the bundle to the `central-publishing-maven-plugin` (`autoPublish=true`).
 


### PR DESCRIPTION
The protogen-maven-plugin-test module is jar-packaged but has no
src/main/java: it only generates and compiles protobuf builders as test
sources to exercise protogen-maven-plugin end to end. Its main jar is
therefore empty and maven-source-plugin:jar-no-fork produces an empty
-sources.jar, which the Sonatype Central Portal rejects during bundle
validation.

It is an integration-test harness, not a reusable library, so exclude it
from the release reactor alongside assembly and grpc-example
(-pl '!assembly,!grpc-example,!code/protogen-maven-plugin-test') in both
the release and dry-run invocations. Update the workflow comment and
AGENTS.md to explain the exclusion.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0169cmM4S6dUeHsiWbowNpGz