### PR TITLE
docs: fix stale versions and under-counted data structures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,9 @@ Maven project. The notable capabilities are:
   project-tree and context-finder tools over stdio, streamable HTTP or HTTP+SSE.
 - **Data** (`data`) — data sources (CSV, GZip, JDBC; in-memory and iterative
   loading), a uniqueness-checking tool (finds whether a subset of columns can
-  serve as a key, and searches for a smaller key), data structures (an
-  open-addressing `Map` implementation), and an **MCP server** exposing the
+  serve as a key, and searches for a smaller key), data structures
+  (`OpenAddressingMap`, an `OpenAddressingSet`, and the primitive `int`-keyed
+  `IntKeyOpenAddressingMap`), and an **MCP server** exposing the
   uniqueness checker as a tool for AI assistants.
 
 See [README.md](README.md) for worked code examples of each capability, and
@@ -289,7 +290,7 @@ These are hard requirements for any code you add or modify:
 To release version `X`:
 
 1. Change the `revision` property in the root `pom.xml` to `X` (it is currently
-   a `-SNAPSHOT`, e.g. `2.2.0-SNAPSHOT`).
+   a `-SNAPSHOT`, e.g. `2.5.0-SNAPSHOT`).
 2. Commit and push.
 3. Confirm all builds pass.
 4. Release and mark as latest in GitHub.

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -129,13 +129,13 @@ class is reported as an error result.
 ### stdio (default)
 
 ```bash
-java -jar code/context/target/tools.code.context-2.2.0-SNAPSHOT.jar
+java -jar code/context/target/tools.code.context-{version}.jar
 ```
 
 ### streamable HTTP
 
 ```bash
-java -jar code/context/target/tools.code.context-2.2.0-SNAPSHOT.jar --transport.mode=streamable-http
+java -jar code/context/target/tools.code.context-{version}.jar --transport.mode=streamable-http
 ```
 
 The MCP endpoint is then served at `http://localhost:8082/mcp` (the port is
@@ -144,7 +144,7 @@ configurable through `server.port`).
 ### HTTP+SSE (legacy)
 
 ```bash
-java -jar code/context/target/tools.code.context-2.2.0-SNAPSHOT.jar --transport.mode=sse
+java -jar code/context/target/tools.code.context-{version}.jar --transport.mode=sse
 ```
 
 This is the legacy HTTP+SSE transport (MCP protocol revision 2024-11-05),
@@ -206,7 +206,7 @@ The tools read source files from disk, so access is constrained by design:
       "command": "java",
       "args": [
         "-jar",
-        "/absolute/path/to/tools/code/context/target/tools.code.context-2.2.0-SNAPSHOT.jar"
+        "/absolute/path/to/tools/code/context/target/tools.code.context-{version}.jar"
       ]
     }
   }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
@@ -70,7 +70,7 @@ Add the following to your Claude Desktop configuration file:
       "command": "java",
       "args": [
         "-jar",
-        "/absolute/path/to/tools/data/target/tools.data-2.0.0-SNAPSHOT.jar"
+        "/absolute/path/to/tools/data/target/tools.data-{version}.jar"
       ]
     }
   }
@@ -90,7 +90,7 @@ In VS Code settings (settings.json):
       "command": "java",
       "args": [
         "-jar",
-        "/absolute/path/to/tools/data/target/tools.data-2.0.0-SNAPSHOT.jar"
+        "/absolute/path/to/tools/data/target/tools.data-{version}.jar"
       ]
     }
   }
@@ -104,7 +104,7 @@ For any MCP client that supports stdio transport:
 ```json
 {
   "command": "java",
-  "args": ["-jar", "/path/to/tools.data-2.0.0-SNAPSHOT.jar"],
+  "args": ["-jar", "/path/to/tools.data-{version}.jar"],
   "transport": "stdio"
 }
 ```
@@ -234,7 +234,7 @@ mvn test
 To enable debug logging, modify the Log4j2 configuration or set system properties:
 
 ```bash
-java -Dlog4j.configurationFile=log4j2-debug.xml -jar tools.data-2.0.0-SNAPSHOT.jar
+java -Dlog4j.configurationFile=log4j2-debug.xml -jar tools.data-{version}.jar
 ```
 
 ## Extending the Server

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -81,7 +81,7 @@ flowchart TB
         context["<b>code/context</b><br/><i>Library + MCP server</i><br/>Class-usage finder + ProjectTreeBuilder"]
         contextMcp(["🟪 Context MCP server<br/><i>Spring Boot · stdio / HTTP</i><br/>project_tree · find_context · estimate_tokens"])
 
-        data["<b>data</b><br/><i>Library + MCP server</i><br/>Data sources · uniqueness/key finder ·<br/>OpenAddressingMap"]
+        data["<b>data</b><br/><i>Library + MCP server</i><br/>Data sources · uniqueness/key finder ·<br/>OpenAddressingMap · OpenAddressingSet · IntKeyOpenAddressingMap"]
         dataMcp(["🟪 Uniqueness MCP server<br/><i>Spring Boot · stdio / HTTP</i><br/>check uniqueness"])
 
         context --- contextMcp
@@ -148,7 +148,7 @@ flowchart TB
             fileSrc["<b>File sources</b><br/>CSV · JSON · YAML · TOON"]
             dbSrc["<b>SQL sources</b><br/><i>JDBC</i>"]
             compression["<b>ZipUtils</b><br/><i>GZip</i>"]
-            structure["<b>OpenAddressingMap</b>"]
+            structure["<b>OpenAddressingMap</b><br/>OpenAddressingSet · IntKeyOpenAddressingMap"]
         end
     end
 


### PR DESCRIPTION
- AGENTS.md: list all three data structures (OpenAddressingMap,
  OpenAddressingSet, IntKeyOpenAddressingMap) and bump the release-example
  revision to 2.5.0-SNAPSHOT.
- docs/c4-architecture.md: show OpenAddressingSet and IntKeyOpenAddressingMap
  alongside OpenAddressingMap in the container and component diagrams.
- MCP_USAGE.md (data, code/context): replace hardcoded jar versions with the
  {version} placeholder so the run/config examples no longer rot each release.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017Momxr4Fw54tS7o6ysrPzL