### PR TITLE
Fix OpenAddressingMap to allow reinsertion of removed keys

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -96,8 +96,8 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 			if (wrapper == null) {
 				return insert(hash, key, value);
 			} else if (wrapper.key.equals(key)) {
-				return overwrite(hash, key, value);
-			} // removed are skipped
+				return wrapper.removed ? insert(hash, key, value) : overwrite(hash, key, value);
+			} // removed entries with a different key are skipped
 		}
 		resize();
 		return put(key, value);

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
@@ -118,6 +118,18 @@ public class MapTest {
 
 	@ParameterizedTest
 	@MethodSource("allImplementations")
+	public void reinsertRemovedKey(Map<Integer, String> map) {
+		map.put(1, "A");
+		map.remove(1);
+		assertNull(map.put(1, "B"));
+		assertEquals(1, map.size());
+		assertFalse(map.isEmpty());
+		assertEquals("B", map.get(1));
+		assertTrue(map.containsKey(1));
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
 	public void containsKey(Map<Integer, String> map) {
 		map.put(1, "A");
 		map.put(2, "B");


### PR DESCRIPTION
## Summary
Fixed a bug in `OpenAddressingMap` where previously removed keys could not be reinserted. The implementation was incorrectly treating removed entries as occupied slots, preventing new values from being inserted at those positions.

## Changes
- **OpenAddressingMap.put()**: Modified the logic to distinguish between removed entries with matching keys versus removed entries with different keys. When a removed entry is found with a matching key, it now correctly inserts the new value instead of attempting to overwrite a non-existent entry.
- **MapTest.reinsertRemovedKey()**: Added a new parameterized test to verify that keys can be successfully reinserted after removal, ensuring the fix works across all Map implementations.

## Implementation Details
The fix changes the condition from always calling `overwrite()` when a matching key is found to checking if the entry was previously removed. If removed, it calls `insert()` to properly reinitialize the slot; otherwise, it calls `overwrite()` as before. This maintains the open addressing invariant while correctly handling the tombstone entries used to mark deleted slots.

https://claude.ai/code/session_01Xkj1DJACmpvvuYZhQpD7SE