### PR TITLE
refactor(data): remove unused FileNotFoundException import

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractIterableFileSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractIterableFileSource.java
@@ -1,7 +1,6 @@
 package io.github.adamw7.tools.data.source.file;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;


### PR DESCRIPTION
AbstractIterableFileSource imported java.io.FileNotFoundException but never
referenced the type. FileInputStream's checked exception is handled through
its IOException supertype, so the import was dead code.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XF1bY7CkEGfydfdmrB4RUx