### PR TITLE
feat(mcp): add stateless HTTP transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ Maven project. The notable capabilities are:
   that scans a whole Java project into a tree of folders, files and
   dependencies, to assemble context for gen-AI agents working with Java code. An
   **MCP server** (in the `io.github.adamw7.context.mcp` package) exposes the
-  project-tree and context-finder tools over stdio, streamable HTTP or HTTP+SSE.
+  project-tree and context-finder tools over stdio, streamable HTTP, stateless
+  HTTP or HTTP+SSE.
 - **Data** (`data`) — data sources (CSV, GZip, JDBC; in-memory and iterative
   loading), a uniqueness-checking tool (finds whether a subset of columns can
   serve as a key, and searches for a smaller key), data structures
@@ -59,9 +60,10 @@ context module, `io.github.adamw7.tools.*` elsewhere).
 
 The repository ships two MCP servers, each a Spring Boot app whose entry point
 is `Main.java` and which supports stdio (default), streamable HTTP
-(`--transport.mode=streamable-http`, served at `/mcp`), or the legacy HTTP+SSE
-transport (`--transport.mode=sse`, event stream at `/sse`, messages at
-`/mcp/message`):
+(`--transport.mode=streamable-http`, served at `/mcp`), stateless HTTP
+(`--transport.mode=stateless-http`, session-less, also served at `/mcp`), or the
+legacy HTTP+SSE transport (`--transport.mode=sse`, event stream at `/sse`,
+messages at `/mcp/message`):
 
 - The uniqueness-checker server in
   `data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/`; see its

--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ It contains:
   - Transports (select with `--transport.mode`):
     - `stdio` (default) — JSON-RPC over stdin/stdout (Spring Boot, no HTTP server started)
     - `streamable-http` — the modern HTTP transport served at `/mcp`
+    - `stateless-http` — the same HTTP transport served at `/mcp`, but session-less: each JSON-RPC request is answered in isolation, which suits load-balanced or serverless deployments
     - `sse` — the legacy HTTP+SSE transport for older clients: the event stream is served at `/sse` and JSON-RPC messages are POSTed to `/mcp/message`
   - Build: `mvn clean install` produces `data/target/tools.data-<version>.jar`
   - Run: `java -jar data/target/tools.data-<version>.jar --transport.mode=stdio`

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -34,8 +34,10 @@ The server uses:
 
 - **Transport**: stdio (default), streamable HTTP
   (`--transport.mode=streamable-http`), which serves the MCP endpoint at `/mcp`,
-  or the legacy HTTP+SSE transport (`--transport.mode=sse`), which serves the
-  event stream at `/sse` and accepts JSON-RPC messages at `/mcp/message`.
+  stateless HTTP (`--transport.mode=stateless-http`), which serves the same
+  `/mcp` endpoint without keeping a session, or the legacy HTTP+SSE transport
+  (`--transport.mode=sse`), which serves the event stream at `/sse` and accepts
+  JSON-RPC messages at `/mcp/message`.
 - **MCP SDK**: `io.modelcontextprotocol.sdk` v2.0.0
 - **Framework**: Spring Boot
 - **Protocol**: Model Context Protocol (MCP)
@@ -141,6 +143,18 @@ java -jar code/context/target/tools.code.context-{version}.jar --transport.mode=
 The MCP endpoint is then served at `http://localhost:8082/mcp` (the port is
 configurable through `server.port`).
 
+### stateless HTTP
+
+```bash
+java -jar code/context/target/tools.code.context-{version}.jar --transport.mode=stateless-http
+```
+
+The MCP endpoint is served at `http://localhost:8082/mcp`, the same as
+`streamable-http`, but the server keeps no session between requests: each
+JSON-RPC call is handled in isolation. This suits horizontally scaled or
+serverless deployments where requests may land on different instances. Clients
+connect with the same streamable HTTP configuration shown below.
+
 ### HTTP+SSE (legacy)
 
 ```bash
@@ -186,9 +200,9 @@ The tools read source files from disk, so access is constrained by design:
   context.allowed-roots=/home/me/projects:/srv/code
   ```
 
-- **Loopback binding.** The HTTP transports (streamable HTTP and HTTP+SSE) bind
-  to `127.0.0.1` by default (`server.address`). The `/mcp`, `/sse` and
-  `/mcp/message` endpoints have **no authentication**, so they must not be
+- **Loopback binding.** The HTTP transports (streamable HTTP, stateless HTTP and
+  HTTP+SSE) bind to `127.0.0.1` by default (`server.address`). The `/mcp`, `/sse`
+  and `/mcp/message` endpoints have **no authentication**, so they must not be
   exposed on a routable interface. Change `server.address` only after putting
   authentication in front of them.
 

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpStatelessHttpIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpStatelessHttpIT.java
@@ -1,0 +1,100 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Integration test that serves the context-engineering MCP server over the
+ * stateless HTTP transport. The server keeps no session between requests, yet the
+ * standard streamable-HTTP client speaks the same wire protocol, so tool discovery
+ * and a real tool call must still succeed end-to-end over the {@code /mcp}
+ * endpoint.
+ */
+@SpringBootTest(
+		classes = Main.class,
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = {
+				"transport.mode=stateless-http",
+				"spring.main.banner-mode=off",
+				"context.allowed-roots=${java.io.tmpdir}" })
+public class McpStatelessHttpIT {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	@LocalServerPort
+	private int port;
+
+	@TempDir
+	Path projectRoot;
+
+	private McpSyncClient client;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		Files.writeString(projectRoot.resolve("A.java"), "public class A {}");
+		Files.writeString(projectRoot.resolve("B.java"), "public class B { A a; }");
+		HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
+				.builder("http://localhost:" + port)
+				.build();
+		client = McpClient.sync(transport)
+				.clientInfo(McpSchema.Implementation.builder("integration-test-stateless-client", "1.0").build())
+				.build();
+		client.initialize();
+	}
+
+	@AfterEach
+	void tearDown() {
+		client.close();
+	}
+
+	@Test
+	void listsAllContextTools() {
+		McpSchema.ListToolsResult tools = client.listTools();
+
+		assertTrue(tools.tools().stream().anyMatch(tool -> tool.name().equals("project_tree")));
+		assertTrue(tools.tools().stream().anyMatch(tool -> tool.name().equals("find_context")));
+		assertTrue(tools.tools().stream().anyMatch(tool -> tool.name().equals("estimate_tokens")));
+	}
+
+	@Test
+	void findContextToolReturnsDependencies() {
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("find_context")
+				.arguments(Map.of("path", projectRoot.toString(), "class_name", "B"))
+				.build();
+
+		McpSchema.CallToolResult result = client.callTool(request);
+
+		assertFalse(result.isError());
+		String dependencies = ((McpSchema.TextContent) result.content().getFirst()).text();
+		assertEquals("A.java", parse(dependencies).get(0).asText());
+	}
+
+	private JsonNode parse(String json) {
+		try {
+			return MAPPER.readTree(json);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Invalid JSON: " + json, e);
+		}
+	}
+}

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
@@ -15,7 +15,7 @@ The implementation consists of three main components:
 3. **UniquenessTool.java** - Implements the uniqueness checking tool
 
 The server uses:
-- **Transport**: stdio (default), streamable-http (`--transport.mode=streamable-http`, served at `/mcp`), or the legacy HTTP+SSE transport (`--transport.mode=sse`, event stream at `/sse`, JSON-RPC messages POSTed to `/mcp/message`)
+- **Transport**: stdio (default), streamable-http (`--transport.mode=streamable-http`, served at `/mcp`), stateless-http (`--transport.mode=stateless-http`, session-less, also served at `/mcp`), or the legacy HTTP+SSE transport (`--transport.mode=sse`, event stream at `/sse`, JSON-RPC messages POSTed to `/mcp/message`)
 - **MCP SDK**: io.modelcontextprotocol.sdk v2.0.0-RC1
 - **Framework**: Spring Boot
 - **Protocol**: Model Context Protocol (MCP)

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpStatelessHttpIT.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpStatelessHttpIT.java
@@ -1,0 +1,78 @@
+package io.github.adamw7.tools.data.uniqueness.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import io.github.adamw7.tools.data.Utils;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Integration test that serves the uniqueness MCP server over the stateless HTTP
+ * transport. The server keeps no session between requests, yet the standard
+ * streamable-HTTP client speaks the same wire protocol, so a real tool call must
+ * still succeed end-to-end over the {@code /mcp} endpoint.
+ */
+@SpringBootTest(
+		classes = Main.class,
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = { "transport.mode=stateless-http", "spring.main.banner-mode=off" })
+public class McpStatelessHttpIT {
+
+	@LocalServerPort
+	private int port;
+
+	private McpSyncClient client;
+
+	@BeforeEach
+	void setUp() {
+		HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
+				.builder("http://localhost:" + port)
+				.build();
+		client = McpClient.sync(transport)
+				.clientInfo(McpSchema.Implementation.builder("integration-test-stateless-client", "1.0").build())
+				.build();
+		client.initialize();
+	}
+
+	@AfterEach
+	void tearDown() {
+		client.close();
+	}
+
+	@Test
+	void nonUniqueColumnReturnsFalse() {
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("uniqueness_check")
+				.arguments(Map.of("file", Utils.getHouseholdFile(), "columns_row", 1, "columns_name", "year1"))
+				.build();
+
+		McpSchema.CallToolResult result = client.callTool(request);
+
+		assertFalse(result.isError());
+		McpSchema.TextContent content = (McpSchema.TextContent) result.content().getFirst();
+		assertEquals("false", content.text());
+	}
+
+	@Test
+	void uniqueColumnReturnsTrue() {
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("uniqueness_check")
+				.arguments(Map.of("file", Utils.getHouseholdFile(), "columns_row", 1, "columns_name", "income"))
+				.build();
+
+		McpSchema.CallToolResult result = client.callTool(request);
+
+		assertFalse(result.isError());
+		McpSchema.TextContent content = (McpSchema.TextContent) result.content().getFirst();
+		assertEquals("true", content.text());
+	}
+}

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
@@ -15,8 +15,11 @@ import org.springframework.context.annotation.Bean;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
+import io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport;
 import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -24,9 +27,11 @@ import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 
 /**
- * Wires an MCP server over one of three transports, selected with
+ * Wires an MCP server over one of four transports, selected with
  * {@code --transport.mode}: stdio (the default), a streamable HTTP transport
- * ({@code streamable-http}) registered at {@code /mcp}, or the legacy HTTP+SSE
+ * ({@code streamable-http}) registered at {@code /mcp}, a stateless HTTP transport
+ * ({@code stateless-http}) also registered at {@code /mcp} that answers each
+ * JSON-RPC request in isolation without keeping any session, or the legacy HTTP+SSE
  * transport ({@code sse}) registered at {@code /sse} (the event stream) and
  * {@code /mcp/message} (the JSON-RPC POST endpoint) for clients that predate
  * streamable HTTP. Concrete servers only supply their {@link #serverName() name}
@@ -39,6 +44,10 @@ public abstract class AbstractMcpConfiguration {
 	protected static final String SSE_ENDPOINT = "/sse";
 
 	protected static final String SSE_MESSAGE_ENDPOINT = "/mcp/message";
+
+	protected static final String MCP_ENDPOINT = "/mcp";
+
+	private static final String SERVER_VERSION = "0.0.1";
 
 	private static final Logger log = LogManager.getLogger(AbstractMcpConfiguration.class);
 
@@ -60,7 +69,7 @@ public abstract class AbstractMcpConfiguration {
 		log.info("Creating HttpServletStreamableServerTransport");
 		return HttpServletStreamableServerTransportProvider.builder()
 				.jsonMapper(new JacksonMcpJsonMapper(objectMapper()))
-				.mcpEndpoint("/mcp")
+				.mcpEndpoint(MCP_ENDPOINT)
 				.build();
 	}
 
@@ -69,7 +78,27 @@ public abstract class AbstractMcpConfiguration {
 	public ServletRegistrationBean<HttpServletStreamableServerTransportProvider> streamableServletRegistration(
 			HttpServletStreamableServerTransportProvider transport) {
 		ServletRegistrationBean<HttpServletStreamableServerTransportProvider> registration =
-				new ServletRegistrationBean<>(transport, "/mcp");
+				new ServletRegistrationBean<>(transport, MCP_ENDPOINT);
+		registration.setAsyncSupported(true);
+		return registration;
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stateless-http")
+	public HttpServletStatelessServerTransport statelessServerTransport() {
+		log.info("Creating HttpServletStatelessServerTransport");
+		return HttpServletStatelessServerTransport.builder()
+				.jsonMapper(new JacksonMcpJsonMapper(objectMapper()))
+				.messageEndpoint(MCP_ENDPOINT)
+				.build();
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stateless-http")
+	public ServletRegistrationBean<HttpServletStatelessServerTransport> statelessServletRegistration(
+			HttpServletStatelessServerTransport transport) {
+		ServletRegistrationBean<HttpServletStatelessServerTransport> registration =
+				new ServletRegistrationBean<>(transport, MCP_ENDPOINT);
 		registration.setAsyncSupported(true);
 		return registration;
 	}
@@ -109,14 +138,30 @@ public abstract class AbstractMcpConfiguration {
 		return buildServer(McpServer.sync(transport));
 	}
 
+	@Bean(destroyMethod = "close")
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stateless-http")
+	public McpStatelessSyncServer mcpStatelessSyncServer(HttpServletStatelessServerTransport transport) {
+		log.info("Initializing McpStatelessSyncServer with stateless transport: {}", transport);
+		McpStatelessSyncServer statelessServer = McpServer.sync(transport)
+				.serverInfo(serverName(), SERVER_VERSION)
+				.capabilities(serverCapabilities())
+				.build();
+		registerStatelessTools(statelessServer);
+		return statelessServer;
+	}
+
 	private McpSyncServer buildServer(McpServer.SyncSpecification<?> spec) {
 		McpSyncServer syncServer = spec
-				.serverInfo(serverName(), "0.0.1")
-				.capabilities(McpSchema.ServerCapabilities.builder()
-						.tools(true).resources(false, false).prompts(false).build())
+				.serverInfo(serverName(), SERVER_VERSION)
+				.capabilities(serverCapabilities())
 				.build();
 		registerTools(syncServer);
 		return syncServer;
+	}
+
+	private McpSchema.ServerCapabilities serverCapabilities() {
+		return McpSchema.ServerCapabilities.builder()
+				.tools(true).resources(false, false).prompts(false).build();
 	}
 
 	private void registerTools(McpSyncServer server) {
@@ -127,6 +172,17 @@ public abstract class AbstractMcpConfiguration {
 		return SyncToolSpecification.builder()
 				.tool(tool.getToolDefinition())
 				.callHandler((exchange, request) -> tool.apply(request.arguments()))
+				.build();
+	}
+
+	private void registerStatelessTools(McpStatelessSyncServer server) {
+		tools().forEach(tool -> server.addTool(statelessSpecificationFor(tool)));
+	}
+
+	private McpStatelessServerFeatures.SyncToolSpecification statelessSpecificationFor(McpTool tool) {
+		return McpStatelessServerFeatures.SyncToolSpecification.builder()
+				.tool(tool.getToolDefinition())
+				.callHandler((context, request) -> tool.apply(request.arguments()))
 				.build();
 	}
 

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/TransportConfigurer.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/TransportConfigurer.java
@@ -4,9 +4,11 @@ package io.github.adamw7.tools.mcp;
  * Selects the MCP transport from the command line and primes the Spring runtime
  * before the application context starts. The transport is read from
  * {@code --transport.mode} (defaulting to stdio). In stdio mode the web server is
- * disabled so nothing but JSON-RPC reaches the channel, and the banner is always
- * suppressed because it would otherwise corrupt the stdio stream. Both MCP servers
- * share this so their {@code Main} entry points stay trivial.
+ * disabled so nothing but JSON-RPC reaches the channel; every HTTP transport
+ * ({@code streamable-http}, {@code stateless-http} and {@code sse}) keeps the web
+ * server so its servlet can be exposed. The banner is always suppressed because it
+ * would otherwise corrupt the stdio stream. Both MCP servers share this so their
+ * {@code Main} entry points stay trivial.
  */
 public final class TransportConfigurer {
 

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/AbstractMcpConfigurationTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/AbstractMcpConfigurationTest.java
@@ -14,8 +14,10 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
+import io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport;
 import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -84,6 +86,18 @@ public class AbstractMcpConfigurationTest {
 	}
 
 	@Test
+	public void statelessTransportIsNotNull() {
+		assertNotNull(new TestMcpConfiguration().statelessServerTransport());
+	}
+
+	@Test
+	public void statelessServletRegistrationServesTheMcpEndpoint() {
+		TestMcpConfiguration config = new TestMcpConfiguration();
+		HttpServletStatelessServerTransport transport = config.statelessServerTransport();
+		assertTrue(config.statelessServletRegistration(transport).getUrlMappings().contains("/mcp"));
+	}
+
+	@Test
 	public void sseTransportIsNotNull() {
 		assertNotNull(new TestMcpConfiguration().sseServerTransport());
 	}
@@ -126,6 +140,15 @@ public class AbstractMcpConfigurationTest {
 		HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
 		McpSyncServer server = config.mcpSyncServerStreamable(transport);
 		assertNotNull(server.getServerCapabilities().tools());
+		server.close();
+	}
+
+	@Test
+	public void mcpStatelessSyncServerRegistersTools() {
+		TestMcpConfiguration config = new TestMcpConfiguration();
+		HttpServletStatelessServerTransport transport = config.statelessServerTransport();
+		McpStatelessSyncServer server = config.mcpStatelessSyncServer(transport);
+		assertTrue(server.listTools().stream().anyMatch(tool -> "test_tool".equals(tool.name())));
 		server.close();
 	}
 }

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/TransportConfigurerTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/TransportConfigurerTest.java
@@ -90,6 +90,16 @@ public class TransportConfigurerTest {
 	}
 
 	@Test
+	public void configureKeepsWebApplicationForStatelessHttpMode() {
+		TransportConfigurer.configure(new String[] { "--transport.mode=stateless-http" });
+
+		// The stateless HTTP transport exposes the /mcp servlet, so it needs a web
+		// server and must not be forced to "none".
+		assertEquals("stateless-http", System.getProperty(TRANSPORT_MODE));
+		assertNull(System.getProperty(WEB_APPLICATION_TYPE));
+	}
+
+	@Test
 	public void configureKeepsWebApplicationForSseMode() {
 		TransportConfigurer.configure(new String[] { "--transport.mode=sse" });
 


### PR DESCRIPTION
Add a fourth MCP transport, selected with --transport.mode=stateless-http,
alongside the existing stdio, streamable-http and sse transports. The
stateless transport serves the same /mcp endpoint as streamable-http but
answers each JSON-RPC request in isolation without keeping a session,
which suits load-balanced or serverless deployments.

The wiring lives in the shared AbstractMcpConfiguration, so both the
uniqueness (data) and context-engineering MCP servers inherit it. It uses
the SDK's HttpServletStatelessServerTransport and the corresponding
McpStatelessSyncServer, registering the same McpTool instances through a
stateless tool specification. Shared server capabilities and version are
hoisted into small helpers to avoid duplication across the stateful and
stateless build paths, and the /mcp endpoint is now a shared constant.

TransportConfigurer already keeps the web server for every non-stdio mode,
so no change was needed there beyond documentation.

Covered by new unit tests for the transport, servlet registration and
tool registration, a TransportConfigurer test asserting the web server is
kept, and end-to-end streamable-client integration tests against a live
stateless server in both modules. README, AGENTS and both MCP_USAGE docs
are updated to list the new transport.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KjFohrAaLhg1uwXydLoBmM