### PR TITLE
feat(enforcer): add ReadmeConsistencyRule to guard README vs agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,14 @@ profile:
   `AGENTS.md` from contradicting each other: each configured `consistentPatterns`
   regex (one capturing group) must capture the same value in both files, e.g.
   `Java (\d+)` pins the Java version.
+- `ReadmeConsistencyRule` (`readmeConsistency`) keeps `README.md` from drifting
+  away from the agent docs (`AGENTS.md`): each configured `consistentPatterns`
+  regex (one capturing group) must capture the same value in both, e.g.
+  `proto(\d)` pins the supported protobuf major version. Unlike
+  `crossDocConsistency`, a fact the README simply does not repeat is ignored — the
+  README is allowed to document a curated subset — so only a value present in both
+  files that disagrees fails the build. Both rules share a `DocumentConsistency`
+  helper that owns the pattern validation and capture logic.
 
 The `claudeMdFormat` and `agentsMdFormat` rules share a `MarkdownFormatRule`
 base class that performs the file-existence, BOM, title, and section checks, and

--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ consistent and in their expected shape:
   agree between the two files (or be absent from both). For example
   `Java (\d+)` fails the build if one file says `Java 25` and the other `Java
   24`.
+- **`readmeConsistency`** (`ReadmeConsistencyRule`) — keeps this `README.md` from
+  drifting away from the agent docs (`AGENTS.md`, the single source of truth).
+  Each configured `consistentPattern` (one capturing group) must capture the same
+  value in both files, so a documented capability or version cannot silently
+  disagree with the agent docs. Unlike `crossDocConsistency`, a fact the README
+  simply does not repeat is ignored — the README is a curated, example-heavy view
+  and may document a subset — so only a value present in both files that disagrees
+  fails the build.
 
 The `claudeMdFormat` and `agentsMdFormat` rules share a `MarkdownFormatRule`
 base class that performs the file-existence, BOM, title, and section checks. It

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRule.java
@@ -1,16 +1,13 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.inject.Named;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
+import io.github.adamw7.tools.enforcer.doc.DocumentConsistency.Document;
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
@@ -43,14 +40,15 @@ public class CrossDocConsistencyRule extends ClaudeCodeEnforcerRule {
 	@Override
 	public void execute() throws EnforcerRuleException {
 		verifyConfigured();
-		verifyPatterns();
-		String first = MarkdownText.read(claudeMdFile, claudeMdFile.getName());
-		String second = MarkdownText.read(agentsMdFile, agentsMdFile.getName());
-		List<String> violations = new ArrayList<>();
-		for (String pattern : patterns()) {
-			collectPatternViolations(pattern, first, second, violations);
-		}
-		report("Documents are inconsistent:", violations);
+		DocumentConsistency consistency = new DocumentConsistency(consistentPatterns);
+		consistency.verifyPatterns();
+		Document first = document(claudeMdFile);
+		Document second = document(agentsMdFile);
+		report("Documents are inconsistent:", consistency.violations(first, second, true));
+	}
+
+	private Document document(File file) {
+		return new Document(file.getName(), MarkdownText.read(file, file.getName()));
 	}
 
 	private void verifyConfigured() throws EnforcerRuleException {
@@ -65,52 +63,6 @@ public class CrossDocConsistencyRule extends ClaudeCodeEnforcerRule {
 		if (!file.isFile()) {
 			throw new EnforcerRuleException(parameter + " does not exist at " + file);
 		}
-	}
-
-	/**
-	 * Each configured pattern must declare a capturing group, since the rule
-	 * compares {@code group(1)} from each document. A pattern without one is a
-	 * build-setup mistake, so it fails with a clear message instead of letting an
-	 * opaque {@link IndexOutOfBoundsException} escape at match time.
-	 */
-	private void verifyPatterns() throws EnforcerRuleException {
-		for (String pattern : patterns()) {
-			if (Pattern.compile(pattern).matcher("").groupCount() < 1) {
-				throw new EnforcerRuleException(
-						"consistentPattern '" + pattern + "' must declare a capturing group");
-			}
-		}
-	}
-
-	private void collectPatternViolations(String pattern, String first, String second, List<String> violations) {
-		Pattern compiled = Pattern.compile(pattern);
-		Optional<String> firstValue = capture(compiled, first);
-		Optional<String> secondValue = capture(compiled, second);
-		if (firstValue.isEmpty() && secondValue.isEmpty()) {
-			return;
-		}
-		addMismatchViolation(pattern, firstValue, secondValue, violations);
-	}
-
-	private void addMismatchViolation(String pattern, Optional<String> firstValue, Optional<String> secondValue,
-			List<String> violations) {
-		if (!firstValue.equals(secondValue)) {
-			violations.add("pattern '" + pattern + "' captured " + describe(claudeMdFile, firstValue) + " but "
-					+ describe(agentsMdFile, secondValue));
-		}
-	}
-
-	private String describe(File file, Optional<String> value) {
-		return file.getName() + "=" + value.map(captured -> "'" + captured + "'").orElse("<absent>");
-	}
-
-	private Optional<String> capture(Pattern pattern, String content) {
-		Matcher matcher = pattern.matcher(content);
-		return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
-	}
-
-	private List<String> patterns() {
-		return consistentPatterns != null ? consistentPatterns : List.of();
 	}
 
 	void setClaudeMdFile(File claudeMdFile) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
@@ -1,0 +1,109 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * Compares two named documents against a list of single-group regular
+ * expressions and reports where a captured value differs. Shared by
+ * {@link CrossDocConsistencyRule} and {@link ReadmeConsistencyRule} so the
+ * pattern validation and capture logic live in one place.
+ * <p>
+ * Each configured pattern must declare one capturing group; the value captured
+ * from each document is compared and a mismatch becomes a violation message.
+ * The two rules differ only in how they treat a fact that appears in one
+ * document but not the other: mirror documents (CLAUDE.md and AGENTS.md) require
+ * it in both, while a curated view (README.md against the agent docs) ignores a
+ * fact the view simply chose not to repeat. That choice is the
+ * {@code requireInBoth} flag passed to {@link #violations}.
+ */
+final class DocumentConsistency {
+
+	/** A document to compare: its content, and the name shown in violation messages. */
+	record Document(String name, String content) {
+	}
+
+	private final List<String> patterns;
+
+	DocumentConsistency(List<String> patterns) {
+		this.patterns = patterns != null ? patterns : List.of();
+	}
+
+	/**
+	 * Each pattern must declare a capturing group, since comparison reads
+	 * {@code group(1)}. A pattern without one is a build-setup mistake, so it fails
+	 * with a clear message instead of letting an opaque
+	 * {@link IndexOutOfBoundsException} escape at match time.
+	 */
+	void verifyPatterns() throws EnforcerRuleException {
+		for (String pattern : patterns) {
+			if (Pattern.compile(pattern).matcher("").groupCount() < 1) {
+				throw new EnforcerRuleException(
+						"consistentPattern '" + pattern + "' must declare a capturing group");
+			}
+		}
+	}
+
+	/**
+	 * Collects one violation per pattern whose captured values disagree. When
+	 * {@code requireInBoth} is true a fact present in only one document is a
+	 * mismatch; when false such a fact is ignored, so the second document may
+	 * document a curated subset of the first. A pattern that matches in neither
+	 * document is always ignored.
+	 */
+	List<String> violations(Document first, Document second, boolean requireInBoth) {
+		List<String> violations = new ArrayList<>();
+		for (String pattern : patterns) {
+			collect(pattern, first, second, requireInBoth, violations);
+		}
+		return violations;
+	}
+
+	private void collect(String pattern, Document first, Document second, boolean requireInBoth,
+			List<String> violations) {
+		Pattern compiled = Pattern.compile(pattern);
+		Optional<String> firstValue = capture(compiled, first.content());
+		Optional<String> secondValue = capture(compiled, second.content());
+		if (isIgnored(firstValue, secondValue, requireInBoth)) {
+			return;
+		}
+		addMismatch(pattern, first, firstValue, second, secondValue, violations);
+	}
+
+	/**
+	 * A pattern is ignored when it matches in neither document, or when it matches
+	 * in only one and the caller does not require the fact in both.
+	 */
+	private boolean isIgnored(Optional<String> firstValue, Optional<String> secondValue, boolean requireInBoth) {
+		if (firstValue.isEmpty() && secondValue.isEmpty()) {
+			return true;
+		}
+		return absentFromOne(firstValue, secondValue) && !requireInBoth;
+	}
+
+	private boolean absentFromOne(Optional<String> firstValue, Optional<String> secondValue) {
+		return firstValue.isEmpty() || secondValue.isEmpty();
+	}
+
+	private void addMismatch(String pattern, Document first, Optional<String> firstValue, Document second,
+			Optional<String> secondValue, List<String> violations) {
+		if (!firstValue.equals(secondValue)) {
+			violations.add("pattern '" + pattern + "' captured " + describe(first, firstValue) + " but "
+					+ describe(second, secondValue));
+		}
+	}
+
+	private String describe(Document document, Optional<String> value) {
+		return document.name() + "=" + value.map(captured -> "'" + captured + "'").orElse("<absent>");
+	}
+
+	private Optional<String> capture(Pattern pattern, String content) {
+		Matcher matcher = pattern.matcher(content);
+		return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRule.java
@@ -1,0 +1,86 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import java.io.File;
+import java.util.List;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.doc.DocumentConsistency.Document;
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * Enforcer rule that keeps the README from drifting away from the agent docs.
+ * {@code README.md} is a curated, example-heavy view of the same project that
+ * {@code AGENTS.md} (the single source of truth) describes, so any capability or
+ * version it documents must match. Each configured pattern is a regular
+ * expression with one capturing group; the rule captures that group from each
+ * file and fails when the README's value disagrees with the agent docs.
+ * <p>
+ * Unlike {@link CrossDocConsistencyRule}, a fact the README simply does not
+ * repeat is not a violation: the README is allowed to document a subset. Only a
+ * value present in both files that disagrees fails the build. For example the
+ * pattern {@code proto(\d)} pins the supported protobuf version: if the README
+ * claims {@code proto3} support while the agent docs say {@code proto2}, the
+ * build fails, but a fact the README omits is ignored. All mismatches are
+ * reported together.
+ */
+@Named("readmeConsistency")
+public class ReadmeConsistencyRule extends ClaudeCodeEnforcerRule {
+
+	/** The README under review. Injected from the rule configuration. */
+	private File readmeFile;
+
+	/** The agent docs treated as the source of truth. Injected from the rule configuration. */
+	private File agentDocFile;
+
+	/** Regular expressions, each with one capturing group, whose captured value must agree. */
+	private List<String> consistentPatterns;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		verifyConfigured();
+		DocumentConsistency consistency = new DocumentConsistency(consistentPatterns);
+		consistency.verifyPatterns();
+		Document readme = document(readmeFile);
+		Document agentDoc = document(agentDocFile);
+		report("README has drifted from the agent docs:", consistency.violations(readme, agentDoc, false));
+	}
+
+	private Document document(File file) {
+		return new Document(file.getName(), MarkdownText.read(file, file.getName()));
+	}
+
+	private void verifyConfigured() throws EnforcerRuleException {
+		verifyConfigured(readmeFile, "readmeFile");
+		verifyConfigured(agentDocFile, "agentDocFile");
+	}
+
+	private void verifyConfigured(File file, String parameter) throws EnforcerRuleException {
+		if (file == null) {
+			throw new EnforcerRuleException("The " + parameter + " parameter is not configured");
+		}
+		if (!file.isFile()) {
+			throw new EnforcerRuleException(parameter + " does not exist at " + file);
+		}
+	}
+
+	void setReadmeFile(File readmeFile) {
+		this.readmeFile = readmeFile;
+	}
+
+	void setAgentDocFile(File agentDocFile) {
+		this.agentDocFile = agentDocFile;
+	}
+
+	void setConsistentPatterns(List<String> consistentPatterns) {
+		this.consistentPatterns = consistentPatterns;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("ReadmeConsistencyRule[readmeFile=%s, agentDocFile=%s]", readmeFile, agentDocFile);
+	}
+}

--- a/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -4,6 +4,7 @@ io.github.adamw7.tools.enforcer.definition.SkillFilesExistRule
 io.github.adamw7.tools.enforcer.definition.SubAgentFormatRule
 io.github.adamw7.tools.enforcer.settings.SettingsJsonValidRule
 io.github.adamw7.tools.enforcer.doc.CrossDocConsistencyRule
+io.github.adamw7.tools.enforcer.doc.ReadmeConsistencyRule
 io.github.adamw7.tools.enforcer.definition.CommandFormatRule
 io.github.adamw7.tools.enforcer.settings.HookCommandsValidRule
 io.github.adamw7.tools.enforcer.mcp.McpServersValidRule

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRuleTest.java
@@ -1,0 +1,139 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+
+class ReadmeConsistencyRuleTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesWhenCapturedValuesAgree() {
+		ReadmeConsistencyRule rule = ruleFor("Supports proto2 only.", "This solution supports only proto2.");
+		rule.setConsistentPatterns(List.of("proto(\\d)"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenTheReadmeContradictsTheAgentDocs() {
+		ReadmeConsistencyRule rule = ruleFor("Now supports proto3.", "Supports only proto2.");
+		rule.setConsistentPatterns(List.of("proto(\\d)"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("'3'"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("'2'"), exception.getMessage());
+	}
+
+	@Test
+	void ignoresAFactTheReadmeDoesNotRepeat() {
+		ReadmeConsistencyRule rule = ruleFor("No version documented here.", "We target Java 25.");
+		rule.setConsistentPatterns(List.of("Java (\\d+)"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void ignoresAFactMissingFromTheAgentDocs() {
+		ReadmeConsistencyRule rule = ruleFor("We target Java 25.", "No version documented here.");
+		rule.setConsistentPatterns(List.of("Java (\\d+)"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void ignoresPatternsThatMatchNeitherDocument() {
+		ReadmeConsistencyRule rule = ruleFor("Nothing relevant.", "Also nothing.");
+		rule.setConsistentPatterns(List.of("Java (\\d+)"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void passesWhenNoPatternsAreConfigured() {
+		assertDoesNotThrow(ruleFor("a", "b")::execute);
+	}
+
+	@Test
+	void reportsEveryMismatchTogether() {
+		ReadmeConsistencyRule rule = ruleFor("proto3 and Java 24.", "proto2 and Java 25.");
+		rule.setConsistentPatterns(List.of("proto(\\d)", "Java (\\d+)"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("proto(\\d)"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("Java (\\d+)"), exception.getMessage());
+	}
+
+	@Test
+	void failsWithAClearMessageWhenAPatternHasNoCapturingGroup() {
+		ReadmeConsistencyRule rule = ruleFor("proto2.", "proto2.");
+		rule.setConsistentPatterns(List.of("proto\\d"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("must declare a capturing group"), exception.getMessage());
+	}
+
+	@Test
+	void downgradesToWarningWhenSeverityIsWarn() {
+		ReadmeConsistencyRule rule = ruleFor("Now supports proto3.", "Supports only proto2.");
+		rule.setConsistentPatterns(List.of("proto(\\d)"));
+		rule.setSeverity("warn");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("drifted")), logger.warnings().toString());
+	}
+
+	@Test
+	void failsWhenAFileIsMissing() {
+		ReadmeConsistencyRule rule = new ReadmeConsistencyRule();
+		rule.setReadmeFile(tempDir.resolve("absent-readme.md").toFile());
+		rule.setAgentDocFile(tempDir.resolve("absent-agents.md").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheReadmeFileIsNotConfigured() {
+		ReadmeConsistencyRule rule = new ReadmeConsistencyRule();
+		rule.setAgentDocFile(tempDir.resolve("AGENTS.md").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("readmeFile"), exception.getMessage());
+	}
+
+	private ReadmeConsistencyRule ruleFor(String readmeContent, String agentDocContent) {
+		Path readme = tempDir.resolve("README.md");
+		Path agents = tempDir.resolve("AGENTS.md");
+		writeString(readme, readmeContent);
+		writeString(agents, agentDocContent);
+		ReadmeConsistencyRule rule = new ReadmeConsistencyRule();
+		rule.setReadmeFile(readme.toFile());
+		rule.setAgentDocFile(agents.toFile());
+		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -547,6 +547,13 @@
 												<consistentPattern>Java (\d+)</consistentPattern>
 											</consistentPatterns>
 										</crossDocConsistency>
+										<readmeConsistency>
+											<readmeFile>${project.basedir}/README.md</readmeFile>
+											<agentDocFile>${project.basedir}/AGENTS.md</agentDocFile>
+											<consistentPatterns>
+												<consistentPattern>proto(\d)</consistentPattern>
+											</consistentPatterns>
+										</readmeConsistency>
 									</rules>
 								</configuration>
 							</execution>


### PR DESCRIPTION
Add a `readmeConsistency` enforcer rule that keeps README.md from drifting
away from AGENTS.md (the single source of truth): each configured
single-group regex must capture the same value in both files, so a
documented capability or version cannot silently disagree with the agent
docs. Unlike `crossDocConsistency`, a fact the README does not repeat is
ignored, since the README is a curated, example-heavy view that may
document a subset — only a value present in both files that disagrees
fails the build.

Extract the shared pattern-validation and capture logic from
CrossDocConsistencyRule into a DocumentConsistency helper parameterized by
whether a fact must appear in both documents, so both rules reuse one
comparison engine. Register the rule in the Sisu SPI file and wire it into
the claude-md-enforce profile with a `proto(\d)` pattern pinning the
supported protobuf major version.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HyDWfjP88VsXhkJx5xgP3u