### PR TITLE
feat(protogen): support proto3 syntax with presence-aware builders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,11 @@ Maven project. The notable capabilities are:
 
 - **Code generation** (`code/protogen-maven-plugin`) — a Maven plugin that
   generates protobuf builders which detect missing required fields at
-  **compile time** instead of runtime (shift-left). Supports proto2 only,
-  because proto3 has no concept of required fields.
+  **compile time** instead of runtime (shift-left). Supports both proto2 and
+  proto3: proto2 `required` fields are enforced by the builder chain, while
+  proto3 (which has no required fields) generates all-optional builders with
+  presence-aware `hasXxx()` accessors (only for message fields and explicit
+  `optional` fields).
 - **Context engineering** (`code/context`) — a fast, regex-based finder that
   builds the tree of classes used by a given class, plus a `ProjectTreeBuilder`
   that scans a whole Java project into a tree of folders, files and

--- a/README.md
+++ b/README.md
@@ -299,7 +299,14 @@ public class ExampleTest {
 	}
 }
 ```
-Since in proto3 there is no concept of required fields - this solution supports only proto2. 
+Both proto2 and proto3 are supported. In proto2 the generated builder enforces
+that every `required` field is set before `build()` can be called. proto3 has no
+`required` fields, so there is nothing to enforce there; the builder simply
+exposes all fields as optional. Presence-tracking is handled correctly for each
+syntax: a `hasXxx()` accessor is generated only for fields that actually track
+presence — every singular field in proto2, but in proto3 only message fields and
+those declared with the explicit `optional` keyword (implicit-presence proto3
+scalars, which have no `hasXxx()`, are left alone).
 
 ## gRPC example
 

--- a/code/protogen-maven-plugin-test/pom.xml
+++ b/code/protogen-maven-plugin-test/pom.xml
@@ -47,6 +47,7 @@
 						<param>io.github.adamw7.tools.code.test</param>
 						<param>io.github.adamw7.tools.code.test2</param>
 						<param>io.github.adamw7.tools.code.test3</param>
+						<param>io.github.adamw7.tools.code.test4</param>
 					</pkgs>
 					<outputpackage>
 						org.output.generated

--- a/code/protogen-maven-plugin-test/src/main/proto/test4.proto
+++ b/code/protogen-maven-plugin-test/src/main/proto/test4.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package test4;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.code.test4";
+
+message Profile {
+  string username = 1;
+  optional string nickname = 2;
+  int32 age = 3;
+}
+
+message Team {
+  Profile lead = 1;
+  repeated string members = 2;
+}

--- a/code/protogen-maven-plugin-test/src/test/java/io/github/adamw7/tools/code/usecase/GeneretedCodeTest.java
+++ b/code/protogen-maven-plugin-test/src/test/java/io/github/adamw7/tools/code/usecase/GeneretedCodeTest.java
@@ -17,7 +17,9 @@ import org.output.generated.GroupingBuilder;
 import org.output.generated.MeasurementBuilder;
 import org.output.generated.MyMessageBuilder;
 import org.output.generated.OneOptionalFieldOnlyBuilder;
+import org.output.generated.ProfileBuilder;
 import org.output.generated.ServerBuilder;
+import org.output.generated.TeamBuilder;
 import org.output.generated.UserBuilder;
 import org.output.generated.WheelBuilder;
 
@@ -33,6 +35,8 @@ import io.github.adamw7.tools.code.test.Measurement;
 import io.github.adamw7.tools.code.test.MyMessage;
 import io.github.adamw7.tools.code.test.Server;
 import io.github.adamw7.tools.code.test.Wheel;
+import io.github.adamw7.tools.code.test4.Profile;
+import io.github.adamw7.tools.code.test4.Team;
 
 public class GeneretedCodeTest {
 
@@ -164,6 +168,42 @@ public class GeneretedCodeTest {
 		builder.setEnabled(true);
 		assertTrue(builder.hasEnabled());
 		assertFalse(builder.clearEnabled().build().getEnabled());
+	}
+
+	@Test
+	public void proto3MessageWithoutRequiredFieldsBuilds() {
+		Profile profile = new ProfileBuilder().setUsername("neo").setNickname("the one").setAge(30).build();
+		assertNotNull(profile);
+		assertEquals("neo", profile.getUsername());
+		assertEquals("the one", profile.getNickname());
+		assertEquals(30, profile.getAge());
+	}
+
+	@Test
+	public void proto3ExplicitOptionalFieldTracksPresence() {
+		ProfileBuilder builder = new ProfileBuilder();
+		builder.setNickname("trinity");
+		assertTrue(builder.hasNickname());
+		assertFalse(builder.clearNickname().build().hasNickname());
+	}
+
+	@Test
+	public void proto3ImplicitFieldDefaultsToZeroValue() {
+		Profile profile = new ProfileBuilder().build();
+		assertNotNull(profile);
+		assertEquals("", profile.getUsername());
+		assertEquals(0, profile.getAge());
+		assertFalse(profile.hasNickname());
+	}
+
+	@Test
+	public void proto3MessageFieldAndRepeatedFieldBuild() {
+		Profile lead = new ProfileBuilder().setUsername("morpheus").build();
+		Team team = new TeamBuilder().setMembers(java.util.List.of("neo", "trinity")).setLead(lead).build();
+		assertNotNull(team);
+		assertEquals("morpheus", team.getLead().getUsername());
+		assertEquals(java.util.List.of("neo", "trinity"), team.getMembersList());
+		assertTrue(team.hasLead());
 	}
 
 }

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Code.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Code.java
@@ -116,8 +116,8 @@ public class Code {
 	private void checkSyntax(Descriptor descriptor) {
 		FileDescriptorProto proto = descriptor.getFile().toProto();
 		String syntax = proto.getSyntax();
-		if (!"proto2".equals(syntax) && !syntax.isEmpty()) {
-			throw new IllegalStateException("Only proto2 syntax supported. The input contains: " + syntax);
+		if (!"proto2".equals(syntax) && !"proto3".equals(syntax) && !syntax.isEmpty()) {
+			throw new IllegalStateException("Only proto2 and proto3 syntax are supported. The input contains: " + syntax);
 		}
 	}
 

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Methods.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Methods.java
@@ -61,7 +61,7 @@ public class Methods {
 	}
 
 	private boolean needsHas(FieldDescriptor field) {
-		return !field.isMapField() && !field.isRepeated();
+		return field.hasPresence();
 	}
 
 	public StringBuilder clear(String classOrBuilder, FieldDescriptor field, String returnType) {

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/MojoTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/MojoTest.java
@@ -61,6 +61,22 @@ public class MojoTest {
 		compileSources(GENERATED_SOURCES + File.separator + mojo.outputpackage.replace(".", File.separator));
 	}
 
+	@Test
+	public void proto3GeneratesAndCompiles() {
+		CodeMojo mojo = new CodeMojo();
+		mojo.generatedSourcesDir = GENERATED_SOURCES;
+		mojo.pkgs = new String[] { "io.github.adamw7.tools.code.proto3" };
+		mojo.outputpackage = "com.sth.generated.proto3";
+		mojo.runtimeClasspathElements = List.of();
+
+		mojo.execute();
+		File dir = new File(GENERATED_SOURCES);
+		Set<String> dirSet = new HashSet<>(Arrays.asList(dir.list()));
+		assertTrue(dirSet.contains("com"));
+
+		compileSources(GENERATED_SOURCES + File.separator + mojo.outputpackage.replace(".", File.separator));
+	}
+
 	private void compileSources(String dir) {
 		List<String> generatedSources = getAllGeneratedSources(dir);
 		compileFiles(generatedSources);

--- a/code/protogen-maven-plugin/src/test/proto/proto3sample.proto
+++ b/code/protogen-maven-plugin/src/test/proto/proto3sample.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package tutorial3;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.code.proto3";
+
+message Proto3Sample {
+  string username = 1;
+  optional string nickname = 2;
+  int32 age = 3;
+  Proto3Nested nested = 4;
+  repeated string roles = 5;
+  map<string, int32> scores = 6;
+}
+
+message Proto3Nested {
+  string city = 1;
+  optional string zipcode = 2;
+}


### PR DESCRIPTION
The builder generator previously rejected any non-proto2 input. Extend it
to proto3, whose messages have no required fields, by generating
all-optional builders that reach build() immediately (the existing
optional-only generation path already handled this shape).

Presence handling now drives hasXxx() generation off
FieldDescriptor.hasPresence() instead of "not map and not repeated". This
is behaviourally identical for proto2 (every singular field tracks
presence there) but correct for proto3, where implicit-presence scalars
have no hasXxx() accessor while message fields and explicit `optional`
fields do.

- Code.checkSyntax now accepts proto2 and proto3.
- Methods.needsHas delegates to FieldDescriptor.hasPresence().
- MojoTest generates and compiles a proto3 sample.
- GeneretedCodeTest exercises proto3 builders at runtime (implicit fields,
  explicit optional presence, message and repeated fields).
- Docs updated to reflect proto3 support.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NdHcq4PErpdgK468UEV5GB