### PR TITLE
fix(data): grow small open-addressing tables past their initial capacity

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/structure/internal/DoubleHashing.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/internal/DoubleHashing.java
@@ -31,9 +31,16 @@ public final class DoubleHashing {
 		return Math.max(requestedSize, 3);
 	}
 
-	/** The backing-array size after one growth step. */
+	/**
+	 * The backing-array size after one growth step. The multiplier alone does not
+	 * guarantee progress for small arrays &mdash; {@code (int) (3 * 1.2) == 3} and
+	 * {@code (int) (4 * 1.2) == 4} &mdash; so growth is floored at
+	 * {@code currentLength + 1} to ensure the table always gets strictly larger.
+	 * Without this the open-addressing maps recurse forever in {@code put} once a
+	 * small table fills up.
+	 */
 	public static int grownSize(int currentLength) {
-		return (int) (currentLength * MULTIPLIER);
+		return Math.max((int) (currentLength * MULTIPLIER), currentLength + 1);
 	}
 
 	/** The slot index probed on the given {@code iteration} of the sequence. */

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/DoubleHashingTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/DoubleHashingTest.java
@@ -41,6 +41,16 @@ public class DoubleHashingTest {
 	}
 
 	@Test
+	public void grownSizeAlwaysGrowsForSmallTables() {
+		// (int) (3 * 1.2) == 3 and (int) (4 * 1.2) == 4, so the multiplier alone
+		// would never grow the smallest tables and put() would recurse forever.
+		assertEquals(4, DoubleHashing.grownSize(3));
+		assertEquals(5, DoubleHashing.grownSize(4));
+		assertTrue(DoubleHashing.grownSize(3) > 3);
+		assertTrue(DoubleHashing.grownSize(4) > 4);
+	}
+
+	@Test
 	public void probeFollowsTheDoubleHashingSequence() {
 		// h1 = 3 - (5 % 3) = 1, h2 = 1 + (5 % 6) = 6
 		assertEquals(1, DoubleHashing.probe(5, 3, 7, 0)); // (1 + 0*6) % 7

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMapTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMapTest.java
@@ -208,4 +208,16 @@ public class IntKeyOpenAddressingMapTest {
 		assertEquals(0, map.keys().length);
 		assertTrue(map.values().isEmpty());
 	}
+
+	@Test
+	public void growsBeyondSmallInitialCapacity() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>(3);
+		for (int i = 0; i < 100; ++i) {
+			map.put(i, "v" + i);
+		}
+		assertEquals(100, map.size());
+		for (int i = 0; i < 100; ++i) {
+			assertEquals("v" + i, map.get(i));
+		}
+	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
@@ -359,4 +359,16 @@ public class MapTest {
 		map.put(1, "A");
 		assertFalse(map.isEmpty());
 	}
+
+	@Test
+	public void growsBeyondSmallInitialCapacity() {
+		OpenAddressingMap<Integer, String> map = new OpenAddressingMap<>(3);
+		for (int i = 0; i < 100; ++i) {
+			map.put(i, "v" + i);
+		}
+		assertEquals(100, map.size());
+		for (int i = 0; i < 100; ++i) {
+			assertEquals("v" + i, map.get(i));
+		}
+	}
 }


### PR DESCRIPTION
DoubleHashing.grownSize computed the next backing-array length as
(int) (currentLength * 1.2), which truncates to the same value for the
smallest tables: 3 -> 3 and 4 -> 4. A map created with a small initial
size (e.g. new OpenAddressingMap<>(3), floor is 3) that fills up then
resizes to the same length, so put() can never find a free slot and
recurses forever, throwing StackOverflowError. Both OpenAddressingMap
and IntKeyOpenAddressingMap share this growth policy and are affected.

Floor the growth at currentLength + 1 so the table always gets strictly
larger. Add regression tests: grownSize growth for small lengths, and
filling a size-3 map of each type well past its initial capacity.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CxcEdnagvEwNXcUi3QBxTc