### PR TITLE
fix(enforcer): two latent bugs in doc consistency and section ordering

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
@@ -104,6 +104,6 @@ final class DocumentConsistency {
 
 	private Optional<String> capture(Pattern pattern, String content) {
 		Matcher matcher = pattern.matcher(content);
-		return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
+		return matcher.find() ? Optional.ofNullable(matcher.group(1)) : Optional.empty();
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -95,7 +95,13 @@ public final class MarkdownDocument {
 		return index >= 0 && hasBodyAt(index);
 	}
 
-	/** The headings from {@code wanted} that are present, in the order they appear in the document. */
+	/**
+	 * The headings from {@code wanted} that are present, in the order they first
+	 * appear in the document, each listed once. A required heading that appears
+	 * more than once is reported by its first occurrence, so the order comparison
+	 * matches the de-duplicated set of present sections rather than reporting a
+	 * spurious out-of-order failure.
+	 */
 	public List<String> headingsInOrder(List<String> wanted) {
 		Set<String> required = new LinkedHashSet<>(wanted);
 		List<String> ordered = new ArrayList<>();
@@ -106,7 +112,7 @@ public final class MarkdownDocument {
 	}
 
 	private void addIfRequiredHeading(String line, boolean lineInsideFence, Set<String> required, List<String> ordered) {
-		if (!lineInsideFence && required.contains(line)) {
+		if (!lineInsideFence && required.remove(line)) {
 			ordered.add(line);
 		}
 	}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -272,6 +272,20 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
+	void doesNotReportOutOfOrderWhenARequiredSectionAppearsTwice() {
+		String duplicated = VALID_CONTENT + """
+				## Testing
+				More notes on testing.
+				""";
+		ClaudeMdFormatRule rule = ruleFor(duplicated);
+		rule.setEnforceSectionOrder(true);
+
+		// The sections are in the configured order; a repeated "## Testing" must be
+		// counted once by its first occurrence, not flagged as out of order.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
 	void failsWhenALineExceedsTheMaximumLength() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n" + "x".repeat(200) + "\n");
 		rule.setMaxLineLength(120);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
@@ -69,6 +69,17 @@ class CrossDocConsistencyRuleTest {
 	}
 
 	@Test
+	void treatsANonParticipatingOptionalGroupAsAbsent() {
+		CrossDocConsistencyRule rule = ruleFor("Uses proto3 here.", "No proto mentioned.");
+		rule.setConsistentPatterns(List.of("proto(\\d)?"));
+
+		// The group is optional, so a bare "proto" match captures null. That must be
+		// treated as a mismatch against the concrete "3", not throw a NullPointerException.
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("'3'"), exception.getMessage());
+	}
+
+	@Test
 	void failsWhenAFileIsMissing() {
 		CrossDocConsistencyRule rule = new CrossDocConsistencyRule();
 		rule.setClaudeMdFile(tempDir.resolve("absent-claude.md").toFile());


### PR DESCRIPTION
- DocumentConsistency.capture threw NullPointerException when a valid
  single-group pattern's group did not participate in the match (e.g. an
  optional group like proto(\d)?). Optional.of(null) blew up instead of
  treating the fact as absent; use Optional.ofNullable so the mismatch is
  reported cleanly.
- MarkdownDocument.headingsInOrder collected every occurrence of a required
  heading while the compared "expected" list is de-duplicated, so a required
  section appearing twice produced a spurious "sections are out of order"
  failure. De-duplicate to first occurrence.

Add regression tests for both.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LP9LjCJWatVErftj5NiqVP