### PR TITLE
ci: trigger docker build only on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,8 @@
 name: Java Maven Build and Docker
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  release:
+    types: [created]
 
 jobs:
   build:


### PR DESCRIPTION
Change the Docker workflow trigger from push/pull_request on main to
release created, matching the release-only convention used by the
maven-publish workflow.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L1hyzLTLGYbLdpNPzEuajY