### PR TITLE
ci: run CodeQL only on Saturday schedule

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,12 +12,8 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
   schedule:
+    # Run only on Saturday (day-of-week 6)
     - cron: '23 21 * * 6'
 
 jobs:


### PR DESCRIPTION
Remove push and pull_request triggers so CodeQL only runs via the
weekly Saturday cron schedule.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HEXG6oyyExXUFJGifRs31e