### PR TITLE
fix(data): track backslash parity when splitting TOON rows

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/ToonSyntax.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/ToonSyntax.java
@@ -92,20 +92,16 @@ final class ToonSyntax {
 	static String[] splitRow(String row) {
 		List<String> values = new ArrayList<>();
 		StringBuilder current = new StringBuilder();
-		boolean inQuotes = false;
+		QuoteTracker tracker = new QuoteTracker();
 
 		for (int i = 0; i < row.length(); i++) {
 			char c = row.charAt(i);
-			boolean isUnescapedQuote = c == '"' && (i == 0 || row.charAt(i - 1) != '\\');
-
-			if (isUnescapedQuote) {
-				inQuotes = !inQuotes;
-				current.append(c);
-			} else if (c == ',' && !inQuotes) {
+			if (c == ',' && tracker.outsideQuotes()) {
 				values.add(current.toString());
 				current = new StringBuilder();
 			} else {
 				current.append(c);
+				tracker.accept(c);
 			}
 		}
 
@@ -114,6 +110,32 @@ final class ToonSyntax {
 		}
 
 		return values.toArray(new String[0]);
+	}
+
+	/**
+	 * Tracks whether the scan is currently inside a quoted field. A {@code "} toggles the state
+	 * unless it is escaped by a preceding backslash; escapes are only honoured inside quotes and
+	 * a backslash escapes exactly the next character, so an escaped backslash ({@code \\}) does
+	 * not spill over onto the following {@code "}. This backslash-parity awareness is why field
+	 * separation stays correct for values whose text ends in a backslash.
+	 */
+	private static final class QuoteTracker {
+		private boolean inQuotes;
+		private boolean escaped;
+
+		boolean outsideQuotes() {
+			return !inQuotes;
+		}
+
+		void accept(char c) {
+			if (escaped) {
+				escaped = false;
+			} else if (inQuotes && c == '\\') {
+				escaped = true;
+			} else if (c == '"') {
+				inQuotes = !inQuotes;
+			}
+		}
 	}
 
 	static String unquote(String value) {

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/ToonSyntaxTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/ToonSyntaxTest.java
@@ -55,6 +55,20 @@ public class ToonSyntaxTest {
 	}
 
 	@Test
+	public void escapedBackslashBeforeClosingQuoteDoesNotSwallowSeparator() {
+		// First field is the quoted value  "a\\"  (text ending in a backslash); the escaped
+		// backslash must not make the closing quote look escaped, so the comma still splits.
+		assertArrayEquals(new String[] { "\"a\\\\\"", "c" }, ToonSyntax.splitRow("\"a\\\\\",c"));
+	}
+
+	@Test
+	public void escapedBackslashKeepsCommaInsideQuotesProtected() {
+		// Value  "a\\,b"  contains an escaped backslash followed by a literal comma inside the
+		// quotes, so the whole thing is a single field.
+		assertArrayEquals(new String[] { "\"a\\\\,b\"", "c" }, ToonSyntax.splitRow("\"a\\\\,b\",c"));
+	}
+
+	@Test
 	public void leadingCommaProducesEmptyValue() {
 		assertArrayEquals(new String[] { "", "a" }, ToonSyntax.splitRow(",a"));
 	}


### PR DESCRIPTION
ToonSyntax.splitRow decided whether a quote was escaped by looking only at
whether the immediately preceding character was a backslash. An escaped
backslash (\\) right before a closing quote fooled this heuristic: the
closing quote was treated as escaped, the field stayed "open", and a
following comma was swallowed instead of separating fields. A tabular row
such as "a\\",c collapsed into a single field.

This is the same class of bug that the escape decoder had before it was
rewritten to consume each escape exactly once. Replace the look-behind
heuristic with a small quote/escape state machine that honours backslash
parity inside quotes, so an escaped backslash no longer spills onto the
next character.

Add regression tests for an escaped backslash before a closing quote and
before a quoted comma.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018qp66btACyDscRSarkBfV3