### PR TITLE
ci: skip tests in enforcer bootstrap step to avoid duplicate run

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,12 @@ jobs:
       # installed to the local repo first. The claude-md-enforce profile is
       # off here (no -DenforceClaudeMd), so the module is not asked to depend
       # on itself while it is being built.
-      run: mvn -B -ntp -pl claude-code-enforcer -am install
+      #
+      # -DskipTests: this step exists only to publish the enforcer JAR so the
+      # main build can load it as a plugin dependency. The module's own test
+      # suite is re-run as part of the "Build with Maven" package step below,
+      # so running it here as well only duplicates work.
+      run: mvn -B -ntp -pl claude-code-enforcer -am install -DskipTests
     - name: Build with Maven
       # -DenforceClaudeMd activates the claude-md-enforce profile so the root
       # build fails when CLAUDE.md is missing or malformed. This is the only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,10 +138,12 @@ CI. The workflows also pass `-ntp` explicitly on each `mvn` command so the
 quiet behavior does not depend on the checkout picking up `.mvn/maven.config`.
 
 CI (`.github/workflows/maven.yml`) installs the enforcer rule
-(`mvn -B -pl claude-code-enforcer -am install`) and then runs
+(`mvn -B -pl claude-code-enforcer -am install -DskipTests`) and then runs
 `mvn -B package -DenforceClaudeMd` on JDK 25 (Temurin) for every push and for
-pull requests targeting `main`. It is the only workflow that runs the CLAUDE.md
-check; the other workflows build normally and are unaffected.
+pull requests targeting `main`. The bootstrap step skips tests because it only
+needs to publish the enforcer JAR for the plugin to load; the module's own test
+suite still runs in the `package` step. It is the only workflow that runs the
+CLAUDE.md check; the other workflows build normally and are unaffected.
 
 ## Testing, coverage & mutation testing
 


### PR DESCRIPTION
The maven.yml bootstrap step installs the claude-code-enforcer module
only so the root build can load it as a maven-enforcer-plugin
dependency. It ran the module's full 244-test suite, which then runs a
second time when the "Build with Maven" package step builds the whole
reactor (claude-code-enforcer is module 2/10). Adding -DskipTests to the
bootstrap removes that redundant run with no loss of coverage.

Update AGENTS.md to document the skip and why it is safe.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CJAUk3oMdbVzxEWrLxbpff