### PR TITLE
fix(context): make coreDoesNotDependOnMcpAdapter cover subpackages

### DIFF
--- a/code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java
@@ -28,12 +28,13 @@ public class ContextArchitectureTest {
 
 	static final String CONTEXT_PACKAGE = "io.github.adamw7.context";
 
+	private static final String CONTEXT_ANY_PACKAGE = "io.github.adamw7.context..";
 	private static final String MCP_PACKAGE = "..context.mcp..";
 	private static final String MCP_COMMON_PACKAGE = "io.github.adamw7.tools.mcp..";
 
 	@ArchTest
 	static final ArchRule coreDoesNotDependOnMcpAdapter = noClasses()
-			.that().resideInAPackage(CONTEXT_PACKAGE)
+			.that().resideInAPackage(CONTEXT_ANY_PACKAGE)
 			.and().resideOutsideOfPackage(MCP_PACKAGE)
 			.should().dependOnClassesThat().resideInAPackage(MCP_PACKAGE)
 			.because("the MCP adapter is a delivery mechanism on top of the context core, not a dependency of it");


### PR DESCRIPTION
The rule reused CONTEXT_PACKAGE ("io.github.adamw7.context") in
resideInAPackage(). ArchUnit's package-pattern syntax matches only the
exact package unless the ".." wildcard is used, so the rule silently
ignored the whole io.github.adamw7.context.tree subpackage (the
ProjectTree* serializers/builders that the class Javadoc calls part of
the reusable core). A tree serializer importing the mcp adapter would
have passed undetected.

Introduce CONTEXT_ANY_PACKAGE ("io.github.adamw7.context..") for the
predicate; CONTEXT_PACKAGE stays unchanged for @AnalyzeClasses, whose
packages parameter already includes subpackages.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M4Cy2d55gHJstb9RjueEmT