### PR TITLE
test(arch): extend ArchUnit rules across all modules

### DIFF
--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
@@ -1,9 +1,13 @@
 package io.github.adamw7.tools.enforcer.architecture;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
 
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
@@ -64,6 +68,13 @@ public class EnforcerArchitectureTest {
 			.allowEmptyShould(true);
 
 	@ArchTest
+	static final ArchRule publicFieldsAreImmutable = fields()
+			.that().arePublic()
+			.should().beFinal()
+			.because("a public field is part of the type's API surface and must not be reassignable")
+			.allowEmptyShould(true);
+
+	@ArchTest
 	static final ArchRule noAccessToStandardStreams =
 			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
 
@@ -74,6 +85,17 @@ public class EnforcerArchitectureTest {
 	@ArchTest
 	static final ArchRule noJavaUtilLogging =
 			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+
+	@ArchTest
+	static final ArchRule noJodaTime =
+			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
+
+	@ArchTest
+	static final ArchRule noPrintStackTrace = noClasses()
+			.should().callMethod(Throwable.class, "printStackTrace")
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
+			.because("failures must be reported through log4j2, never printed as a raw stack trace");
 
 	@ArchTest
 	static final ArchRule enforcerDoesNotHaltTheJvm = noClasses()

--- a/code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java
@@ -5,6 +5,9 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
 import org.apache.logging.log4j.Logger;
 
 import com.tngtech.archunit.core.domain.JavaModifier;
@@ -65,6 +68,13 @@ public class ContextArchitectureTest {
 			.because("loggers are private, immutable collaborators owned by their declaring class");
 
 	@ArchTest
+	static final ArchRule publicFieldsAreImmutable = fields()
+			.that().arePublic()
+			.should().beFinal()
+			.because("a public field is part of the type's API surface and must not be reassignable")
+			.allowEmptyShould(true);
+
+	@ArchTest
 	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()
 			.that().areNotInterfaces()
 			.and().areTopLevelClasses()
@@ -80,6 +90,18 @@ public class ContextArchitectureTest {
 			.allowEmptyShould(true);
 
 	@ArchTest
+	static final ArchRule noPrintStackTrace = noClasses()
+			.should().callMethod(Throwable.class, "printStackTrace")
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
+			.because("failures must be reported through log4j2, never printed as a raw stack trace");
+
+	@ArchTest
+	static final ArchRule contextCoreDoesNotHaltTheJvm = noClasses()
+			.should().callMethod(System.class, "exit", int.class)
+			.because("the context core is a reusable library and must never terminate the host JVM; it should throw instead");
+
+	@ArchTest
 	static final ArchRule noAccessToStandardStreams =
 			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
 
@@ -90,4 +112,8 @@ public class ContextArchitectureTest {
 	@ArchTest
 	static final ArchRule noJavaUtilLogging =
 			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+
+	@ArchTest
+	static final ArchRule noJodaTime =
+			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
 }

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/ProtogenArchitectureTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/ProtogenArchitectureTest.java
@@ -5,6 +5,9 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
 import org.apache.logging.log4j.Logger;
 import org.apache.maven.plugin.Mojo;
 
@@ -59,6 +62,13 @@ public class ProtogenArchitectureTest {
 			.because("loggers are shared, immutable, class-scoped collaborators");
 
 	@ArchTest
+	static final ArchRule publicFieldsAreImmutable = fields()
+			.that().arePublic()
+			.should().beFinal()
+			.because("a public field is part of the type's API surface and must not be reassignable")
+			.allowEmptyShould(true);
+
+	@ArchTest
 	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()
 			.that().areNotInterfaces()
 			.and().areTopLevelClasses()
@@ -73,6 +83,18 @@ public class ProtogenArchitectureTest {
 			.because("types named *Exception must actually be exceptions");
 
 	@ArchTest
+	static final ArchRule noPrintStackTrace = noClasses()
+			.should().callMethod(Throwable.class, "printStackTrace")
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
+			.because("failures must be reported through log4j2, never printed as a raw stack trace");
+
+	@ArchTest
+	static final ArchRule pluginDoesNotHaltTheJvm = noClasses()
+			.should().callMethod(System.class, "exit", int.class)
+			.because("a Maven plugin must fail the build by throwing MojoExecutionException, never by terminating the JVM");
+
+	@ArchTest
 	static final ArchRule noAccessToStandardStreams =
 			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
 
@@ -83,4 +105,8 @@ public class ProtogenArchitectureTest {
 	@ArchTest
 	static final ArchRule noJavaUtilLogging =
 			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+
+	@ArchTest
+	static final ArchRule noJodaTime =
+			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -57,7 +57,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 	@Override
 	public V get(Object key) {
 		Wrapper<K, V> wrapper = find(key);
-		return wrapper == null ? null : wrapper.value;
+		return wrapper == null ? null : wrapper.getValue();
 	}
 
 	/**
@@ -73,7 +73,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 			if (wrapper == null) {
 				return null;
 			}
-			if (valid(wrapper) && wrapper.key.equals(key)) {
+			if (valid(wrapper) && wrapper.getKey().equals(key)) {
 				return wrapper;
 			}
 		}
@@ -95,8 +95,8 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 			Wrapper<K, V> wrapper = array[hash];
 			if (wrapper == null) {
 				return insert(hash, key, value);
-			} else if (wrapper.key.equals(key)) {
-				return wrapper.removed ? insert(hash, key, value) : overwrite(hash, key, value);
+			} else if (wrapper.getKey().equals(key)) {
+				return wrapper.isRemoved() ? insert(hash, key, value) : overwrite(hash, key, value);
 			} // removed entries with a different key are skipped
 		}
 		resize();
@@ -110,7 +110,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 	}
 
 	private V overwrite(int hash, K key, V value) {
-		V previous = array[hash].value;
+		V previous = array[hash].getValue();
 		array[hash] = new Wrapper<>(key, value);
 		return previous;
 	}
@@ -127,7 +127,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 		size = 0;
 		for (Wrapper<K, V> wrapper : old) {
 			if (valid(wrapper)) {
-				put(wrapper.key, wrapper.value);
+				put(wrapper.getKey(), wrapper.getValue());
 			}
 		}
 	}
@@ -138,9 +138,9 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 		if (wrapper == null) {
 			return null;
 		}
-		wrapper.removed = true;
+		wrapper.markRemoved();
 		size--;
-		return wrapper.value;
+		return wrapper.getValue();
 	}
 
 	@Override
@@ -163,12 +163,12 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 
 	@Override
 	public Set<K> keySet() {
-		return validWrappers().map(wrapper -> wrapper.key).collect(Collectors.toSet());
+		return validWrappers().map(wrapper -> wrapper.getKey()).collect(Collectors.toSet());
 	}
 
 	@Override
 	public Collection<V> values() {
-		return validWrappers().map(wrapper -> wrapper.value).collect(Collectors.toList());
+		return validWrappers().map(wrapper -> wrapper.getValue()).collect(Collectors.toList());
 	}
 
 	@Override
@@ -181,7 +181,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 	}
 
 	private boolean valid(Wrapper<K, V> wrapper) {
-		return wrapper != null && !wrapper.removed;
+		return wrapper != null && !wrapper.isRemoved();
 	}
 
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/internal/Wrapper.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/internal/Wrapper.java
@@ -5,10 +5,10 @@ import java.util.Map.Entry;
 public class Wrapper<K, V> implements Entry<K, V>{
 
 
-	public final K key;
-	public V value;
-	public boolean removed = false;
-	
+	private final K key;
+	private V value;
+	private boolean removed = false;
+
 	public Wrapper(K key, V value) {
 		this.key = key;
 		this.value = value;
@@ -29,5 +29,13 @@ public class Wrapper<K, V> implements Entry<K, V>{
 		this.value = value;
 		return value;
 	}
-	
+
+	public boolean isRemoved() {
+		return removed;
+	}
+
+	public void markRemoved() {
+		this.removed = true;
+	}
+
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
@@ -6,6 +6,9 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
 import org.apache.logging.log4j.Logger;
 
 import com.tngtech.archunit.core.domain.JavaModifier;
@@ -80,6 +83,12 @@ public class DataArchitectureTest {
 			.because("loggers are shared, immutable, class-scoped collaborators");
 
 	@ArchTest
+	static final ArchRule publicFieldsAreImmutable = fields()
+			.that().arePublic()
+			.should().beFinal()
+			.because("a public field is part of the type's API surface and must not be reassignable");
+
+	@ArchTest
 	static final ArchRule productionCodeDoesNotUseStandardStreams = noClasses()
 			.should().accessField(System.class, "out")
 			.orShould().accessField(System.class, "err")
@@ -127,6 +136,13 @@ public class DataArchitectureTest {
 	@ArchTest
 	static final ArchRule noJodaTime =
 			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
+
+	@ArchTest
+	static final ArchRule noPrintStackTrace = noClasses()
+			.should().callMethod(Throwable.class, "printStackTrace")
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
+			.because("failures must be reported through log4j2, never printed as a raw stack trace");
 
 	@ArchTest
 	static final ArchRule productionCodeDoesNotHaltTheJvm = noClasses()

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/McpCommonArchitectureTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/McpCommonArchitectureTest.java
@@ -4,6 +4,9 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
 import org.apache.logging.log4j.Logger;
 
 import com.tngtech.archunit.core.domain.JavaModifier;
@@ -51,6 +54,13 @@ public class McpCommonArchitectureTest {
 			.because("loggers are shared, immutable, class-scoped collaborators");
 
 	@ArchTest
+	static final ArchRule publicFieldsAreImmutable = fields()
+			.that().arePublic()
+			.should().beFinal()
+			.because("a public field is part of the type's API surface and must not be reassignable")
+			.allowEmptyShould(true);
+
+	@ArchTest
 	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()
 			.that().areNotInterfaces()
 			.and().areTopLevelClasses()
@@ -71,6 +81,13 @@ public class McpCommonArchitectureTest {
 			.because("shared scaffolding must never terminate the host server; it should throw instead");
 
 	@ArchTest
+	static final ArchRule noPrintStackTrace = noClasses()
+			.should().callMethod(Throwable.class, "printStackTrace")
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
+			.because("failures must be reported through log4j2, never printed as a raw stack trace");
+
+	@ArchTest
 	static final ArchRule noAccessToStandardStreams =
 			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
 
@@ -81,4 +98,8 @@ public class McpCommonArchitectureTest {
 	@ArchTest
 	static final ArchRule noJavaUtilLogging =
 			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+
+	@ArchTest
+	static final ArchRule noJodaTime =
+			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
 }


### PR DESCRIPTION
Add three broadly-applicable architecture rules and fill consistency
gaps so every module shares the same baseline:

- publicFieldsAreImmutable: public fields must be final (immutable API
  surface). Encapsulate Wrapper's mutable value/removed fields behind
  the existing Map.Entry accessors plus isRemoved()/markRemoved() so the
  data module satisfies the rule.
- noPrintStackTrace: failures must be reported through log4j2, never
  printed as a raw stack trace (all modules).
- noJodaTime: added to context, mcp-common, protogen and enforcer
  (data already had it).
- ...DoesNotHaltTheJvm: added to context and protogen (a reusable core
  and a Maven plugin must throw, not terminate the JVM).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013uu1Mw5YexyKmF64HQzjDr