### PR TITLE
refactor(data): segregate schema-aware sources into ColumnarDataSource

### DIFF
--- a/data-test/src/test/java/io/github/adamw7/tools/data/test/MemoryLeakTest.java
+++ b/data-test/src/test/java/io/github/adamw7/tools/data/test/MemoryLeakTest.java
@@ -19,6 +19,7 @@ import io.github.adamw7.tools.data.source.file.CSVDataSource;
 import io.github.adamw7.tools.data.source.file.IterableJSONDataSource;
 import io.github.adamw7.tools.data.source.file.IterableTOONDataSource;
 import io.github.adamw7.tools.data.source.file.IterableYAMLDataSource;
+import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
 import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 import io.github.adamw7.tools.data.uniqueness.AbstractUniqueness;
 import io.github.adamw7.tools.data.uniqueness.NoMemoryUniquenessCheck;
@@ -203,7 +204,7 @@ public class MemoryLeakTest {
 	@Test
 	public void seekMemoryLeakInUniquenessCheck() {
 		try {
-			IterableDataSource source = new CSVDataSource(FILE_NAME, 1);
+			ColumnarDataSource source = new CSVDataSource(FILE_NAME, 1);
 			AbstractUniqueness uniqueness = new NoMemoryUniquenessCheck(source);
 
 			Result result = uniqueness.exec("Column 1");

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -12,9 +12,9 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
+import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
 
-public class IterableSQLDataSource implements IterableDataSource {
+public class IterableSQLDataSource implements ColumnarDataSource {
 
 	private final static Logger log = LogManager.getLogger(IterableSQLDataSource.class.getName());
 
@@ -80,7 +80,7 @@ public class IterableSQLDataSource implements IterableDataSource {
 	@Override
 	public List<String[]> nextRows(int batchSize) {
 		applyFetchSize(batchSize);
-		return IterableDataSource.super.nextRows(batchSize);
+		return ColumnarDataSource.super.nextRows(batchSize);
 	}
 
 	private void applyFetchSize(int batchSize) {

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractIterableFileSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractIterableFileSource.java
@@ -72,15 +72,6 @@ public abstract class AbstractIterableFileSource implements IterableDataSource {
 		return lookahead != null;
 	}
 
-	/**
-	 * Iterable sources do not know the full set of columns up front, so this returns
-	 * {@code null}.
-	 */
-	@Override
-	public String[] getColumnNames() {
-		return null;
-	}
-
 	@Override
 	public void reset() {
 		if (fileName == null) {

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
@@ -8,7 +8,9 @@ import java.io.UncheckedIOException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class CSVDataSource extends AbstractFileSource {
+import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
+
+public class CSVDataSource extends AbstractFileSource implements ColumnarDataSource {
 
 	private static final String REGEX_SUFFIX = "(?=([^\"]*\"[^\"]*\")*[^\"]*$)";
 

--- a/data/src/main/java/io/github/adamw7/tools/data/source/interfaces/ColumnarDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/interfaces/ColumnarDataSource.java
@@ -1,0 +1,20 @@
+package io.github.adamw7.tools.data.source.interfaces;
+
+/**
+ * An {@link IterableDataSource} whose columns are known up front, so callers can
+ * ask for the schema before or while reading rows.
+ *
+ * <p>Forward-only sources that discover their keys as they stream — such as the
+ * iterable JSON, YAML and TOON sources — deliberately do not implement this: they
+ * have no fixed column set to report. Keeping {@code getColumnNames()} out of
+ * {@link IterableDataSource} and here instead means a caller that needs the schema
+ * (for example a uniqueness check) depends on this narrower contract and can never
+ * be handed a source that would only answer with {@code null}.</p>
+ */
+public interface ColumnarDataSource extends IterableDataSource {
+
+	/**
+	 * The names of the columns exposed by this source, never {@code null}.
+	 */
+	String[] getColumnNames();
+}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/interfaces/InMemoryDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/interfaces/InMemoryDataSource.java
@@ -2,7 +2,7 @@ package io.github.adamw7.tools.data.source.interfaces;
 
 import java.util.List;
 
-public interface InMemoryDataSource extends IterableDataSource {
+public interface InMemoryDataSource extends ColumnarDataSource {
 
 	List<String[]> readAll();
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/interfaces/IterableDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/interfaces/IterableDataSource.java
@@ -6,8 +6,6 @@ import java.util.List;
 
 public interface IterableDataSource extends Closeable {
 
-	String[] getColumnNames();
-
 	void open();
 
 	String[] nextRow();

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
@@ -9,9 +9,10 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
 import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 
-public abstract class AbstractUniqueness<T extends IterableDataSource> implements Uniqueness {
+public abstract class AbstractUniqueness<T extends ColumnarDataSource> implements Uniqueness {
 
 	private static final Logger log = LogManager.getLogger(AbstractUniqueness.class);
 

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
@@ -1,10 +1,10 @@
 package io.github.adamw7.tools.data.uniqueness;
 
-import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
+import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
 
-public class NoMemoryUniquenessCheck extends AbstractUniqueness<IterableDataSource> {
+public class NoMemoryUniquenessCheck extends AbstractUniqueness<ColumnarDataSource> {
 
-	public NoMemoryUniquenessCheck(IterableDataSource dataSource) {
+	public NoMemoryUniquenessCheck(ColumnarDataSource dataSource) {
 		super(dataSource);
 	}
 

--- a/data/src/test/java/io/github/adamw7/tools/data/Utils.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/Utils.java
@@ -14,7 +14,7 @@ import io.github.adamw7.tools.data.source.db.InMemorySQLDataSource;
 import io.github.adamw7.tools.data.source.db.IterableSQLDataSource;
 import io.github.adamw7.tools.data.source.file.CSVDataSource;
 import io.github.adamw7.tools.data.source.file.InMemoryCSVDataSource;
-import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
+import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
 
 public class Utils {
 
@@ -39,7 +39,7 @@ public class Utils {
 		return getFileName("industry_sic.csv.gz");
 	}
 
-	public static IterableDataSource createDataSource(String file, int columnsRow) {
+	public static ColumnarDataSource createDataSource(String file, int columnsRow) {
 		try {
 			return new CSVDataSource(file, columnsRow);
 		} catch (FileNotFoundException e) {
@@ -47,7 +47,7 @@ public class Utils {
 		}
 	}
 
-	public static IterableDataSource createDataSource(String file) {
+	public static ColumnarDataSource createDataSource(String file) {
 		try {
 			return new CSVDataSource(file);
 		} catch (FileNotFoundException e) {

--- a/data/src/test/java/io/github/adamw7/tools/data/source/DataSourceSegregationTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/DataSourceSegregationTest.java
@@ -1,0 +1,57 @@
+package io.github.adamw7.tools.data.source;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.data.source.db.InMemorySQLDataSource;
+import io.github.adamw7.tools.data.source.db.IterableSQLDataSource;
+import io.github.adamw7.tools.data.source.file.CSVDataSource;
+import io.github.adamw7.tools.data.source.file.InMemoryCSVDataSource;
+import io.github.adamw7.tools.data.source.file.InMemoryJSONDataSource;
+import io.github.adamw7.tools.data.source.file.IterableJSONDataSource;
+import io.github.adamw7.tools.data.source.file.IterableTOONDataSource;
+import io.github.adamw7.tools.data.source.file.IterableYAMLDataSource;
+import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
+import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
+import io.github.adamw7.tools.data.uniqueness.NoMemoryUniquenessCheck;
+
+/**
+ * Locks in the interface segregation between {@link IterableDataSource} (forward-only
+ * streaming) and {@link ColumnarDataSource} (a source that also exposes its column
+ * names). Before the split, {@code getColumnNames()} lived on {@code IterableDataSource}
+ * and the forward-only file sources answered it with {@code null}, which let a caller
+ * pass a schema-less source into a uniqueness check and hit a {@link NullPointerException}
+ * deep inside the scan. Keeping the schema on the narrower contract turns that mistake
+ * into a compile error; these tests guard the type relationships that make it so.
+ */
+class DataSourceSegregationTest {
+
+	@Test
+	void columnarSourcesExposeTheirSchema() {
+		assertTrue(ColumnarDataSource.class.isAssignableFrom(CSVDataSource.class));
+		assertTrue(ColumnarDataSource.class.isAssignableFrom(InMemoryCSVDataSource.class));
+		assertTrue(ColumnarDataSource.class.isAssignableFrom(InMemoryJSONDataSource.class));
+		assertTrue(ColumnarDataSource.class.isAssignableFrom(IterableSQLDataSource.class));
+		assertTrue(ColumnarDataSource.class.isAssignableFrom(InMemorySQLDataSource.class));
+	}
+
+	@Test
+	void forwardOnlyStreamingSourcesAreNotColumnar() {
+		assertTrue(IterableDataSource.class.isAssignableFrom(IterableJSONDataSource.class));
+		assertFalse(ColumnarDataSource.class.isAssignableFrom(IterableJSONDataSource.class));
+		assertFalse(ColumnarDataSource.class.isAssignableFrom(IterableYAMLDataSource.class));
+		assertFalse(ColumnarDataSource.class.isAssignableFrom(IterableTOONDataSource.class));
+	}
+
+	@Test
+	void uniquenessCheckRequiresAColumnarSource() throws NoSuchMethodException {
+		// The only public constructor takes a ColumnarDataSource; a bare
+		// IterableDataSource (which has no columns) cannot be supplied.
+		assertTrue(NoMemoryUniquenessCheck.class.getConstructor(ColumnarDataSource.class) != null);
+		assertThrows(NoSuchMethodException.class,
+				() -> NoMemoryUniquenessCheck.class.getConstructor(IterableDataSource.class));
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/CSVDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/CSVDataSourceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.adamw7.tools.data.Utils;
+import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
 import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 
 public class CSVDataSourceTest {
@@ -78,7 +79,7 @@ public class CSVDataSourceTest {
 
 	@ParameterizedTest
 	@MethodSource("happyPathWithQuotesAndColumnsArgs")
-	public void happyPathQuotesAndColumns(IterableDataSource source) {
+	public void happyPathQuotesAndColumns(ColumnarDataSource source) {
 		source.open();
 		assertEquals("SIC Code", source.getColumnNames()[0]);
 		assertEquals("Description",source.getColumnNames()[1]);

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/IterableJSONDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/IterableJSONDataSourceTest.java
@@ -1,7 +1,6 @@
 package io.github.adamw7.tools.data.source.file;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -60,14 +59,6 @@ public class IterableJSONDataSourceTest {
 			source.reset();
 			int second = drain(source);
 			assertEquals(first, second);
-		}
-	}
-
-	@Test
-	public void columnNamesAreUnknownWhileIterating() throws IOException {
-		try (IterableJSONDataSource source = new IterableJSONDataSource(Utils.getFileName("test.json"))) {
-			source.open();
-			assertNull(source.getColumnNames());
 		}
 	}
 

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/IterableTOONDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/IterableTOONDataSourceTest.java
@@ -1,7 +1,6 @@
 package io.github.adamw7.tools.data.source.file;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -92,14 +91,6 @@ public class IterableTOONDataSourceTest {
 			source.reset();
 			int second = drain(source);
 			assertEquals(first, second);
-		}
-	}
-
-	@Test
-	public void columnNamesAreUnknownWhileIterating() throws IOException {
-		try (IterableTOONDataSource source = new IterableTOONDataSource(Utils.getFileName("test.toon"))) {
-			source.open();
-			assertNull(source.getColumnNames());
 		}
 	}
 

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/IterableYAMLDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/IterableYAMLDataSourceTest.java
@@ -1,7 +1,6 @@
 package io.github.adamw7.tools.data.source.file;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -55,14 +54,6 @@ public class IterableYAMLDataSourceTest {
 			source.reset();
 			int second = drain(source);
 			assertEquals(first, second);
-		}
-	}
-
-	@Test
-	public void columnNamesAreUnknownWhileIterating() throws IOException {
-		try (IterableYAMLDataSource source = new IterableYAMLDataSource(Utils.getFileName("test.yaml"))) {
-			source.open();
-			assertNull(source.getColumnNames());
 		}
 	}
 

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/UniquenessCheckTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/UniquenessCheckTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.adamw7.tools.data.DBTest;
 import io.github.adamw7.tools.data.Utils;
-import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
+import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
 
 public class UniquenessCheckTest extends DBTest {
 
@@ -121,12 +121,12 @@ public class UniquenessCheckTest extends DBTest {
 		assertTrue(source.isClosed(), "Data source must be closed when a duplicate is found");
 	}
 
-	private static final class ClosingSpyDataSource implements IterableDataSource {
+	private static final class ClosingSpyDataSource implements ColumnarDataSource {
 
-		private final IterableDataSource delegate;
+		private final ColumnarDataSource delegate;
 		private boolean closed = false;
 
-		ClosingSpyDataSource(IterableDataSource delegate) {
+		ClosingSpyDataSource(ColumnarDataSource delegate) {
 			this.delegate = delegate;
 		}
 


### PR DESCRIPTION
Fixes a Liskov/interface-segregation violation in the data-source hierarchy.
getColumnNames() lived on IterableDataSource, but the forward-only streaming
sources (iterable JSON/YAML/TOON) have no fixed schema and answered it with
null. Since NoMemoryUniquenessCheck accepted any IterableDataSource and calls
getColumnNames(), passing such a source drove a NullPointerException deep in
the scan (Arrays.asList(toLower(null)) in checkIfCandidatesExistIn, and
exec(null) in execForAllColumns).

Move getColumnNames() to a new ColumnarDataSource interface that only the
schema-aware sources (CSV, SQL, in-memory) implement. Uniqueness checks now
depend on ColumnarDataSource, so handing them a schema-less streaming source
is a compile error instead of a runtime NPE. reset() stays on the base
contract since the streaming file sources genuinely support it.

- New ColumnarDataSource extends IterableDataSource; InMemoryDataSource now
  extends it.
- CSVDataSource and IterableSQLDataSource implement ColumnarDataSource; the
  null-returning override is removed from AbstractIterableFileSource.
- AbstractUniqueness is bound to <T extends ColumnarDataSource>;
  NoMemoryUniquenessCheck takes a ColumnarDataSource.
- Add DataSourceSegregationTest to lock in the type relationships; drop the
  tests that asserted streaming sources return null columns (method is gone).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LGiW6hCLE9Mqe9d79n4AZQ