### PR TITLE
docs: expand CLAUDE.md and document ArchUnit tests and ColumnarDataSource

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,11 @@ Maven project. The notable capabilities are:
   project-tree and context-finder tools over stdio, streamable HTTP, stateless
   HTTP or HTTP+SSE.
 - **Data** (`data`) — data sources (CSV, GZip, JDBC; in-memory and iterative
-  loading), a uniqueness-checking tool (finds whether a subset of columns can
+  loading). Schema-aware sources that know their columns up front implement
+  `ColumnarDataSource` (a narrower contract than `IterableDataSource`), so
+  callers that need the schema — such as the uniqueness check — cannot be handed
+  a forward-only source (JSON/YAML/TOON) that would only answer with `null`.
+  Also a uniqueness-checking tool (finds whether a subset of columns can
   serve as a key, and searches for a smaller key), data structures
   (`OpenAddressingMap`, an `OpenAddressingSet`, and the primitive `int`-keyed
   `IntKeyOpenAddressingMap`), and an **MCP server** exposing the
@@ -150,6 +154,18 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
 - **Unit tests** run in the normal `test`/`package` lifecycle
   (`mvn -pl <module> test`). Write tests for all new logic — behavior, edge
   cases, and error paths.
+- **Architecture tests** (ArchUnit) run in every module as ordinary JUnit tests,
+  under an `...architecture` test package (e.g.
+  `io.github.adamw7.tools.data.architecture.DataArchitectureTest`). They analyse
+  only production classes and pin the package layering and coding rules so they
+  cannot rot: data-source contracts in `source.interfaces` must not depend on
+  their `source.db`/`source.file` implementations; the uniqueness core must not
+  depend on its MCP adapter; the `structure` collections stay decoupled from data
+  sources; loggers are `private static final`; abstract types carry an `Abstract`
+  prefix; public fields are `final`; and production code logs through log4j2
+  (never `System.out`/`err`, `java.util.logging`, `printStackTrace`, or
+  `System.exit`), with packages kept free of cycles. New code must satisfy these
+  rules or the module's test suite fails.
 - **MCP integration tests** are gated behind the `integration-tests` profile
   (defined in `data` and `code/context`) and exercise the MCP servers over
   streamable HTTP: `mvn -P integration-tests verify`. Test classes ending in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,97 @@
 # CLAUDE.md
 
-See [AGENTS.md](AGENTS.md) for the full agent guide (module layout, build/test
-commands, environment, and release process). The essentials are repeated below.
+See [AGENTS.md](AGENTS.md) for the full agent guide (repository overview, module
+layout, build/test commands, CI, environment, and release process). AGENTS.md is
+the single source of truth; this file is a quick-reference summary of the
+essentials. When the two ever disagree, AGENTS.md wins — and the build's
+`crossDocConsistency` enforcer rule fails if key facts (e.g. the Java version)
+drift apart between the two.
 
 ## Project
 
-Java project built with Maven 3.9.X. Run `mvn install` from the root to build.
+`tools` is a multi-module Maven library of Java tooling. Build with Maven 3.9.X:
+run `mvn install` from the repository root. The main capabilities are:
+
+- **Code generation** (`code/protogen-maven-plugin`) — a Maven plugin that
+  generates protobuf builders enforcing missing required fields at **compile
+  time** (proto2 `required`, proto3 presence-aware accessors, `oneof`
+  discriminators).
+- **Context engineering** (`code/context`) — a regex-based class-usage finder and
+  project-tree builder that assembles context for gen-AI agents, plus an MCP
+  server exposing `project_tree`, `find_context`, and `estimate_tokens`.
+- **Data** (`data`) — CSV/GZip/JDBC data sources (in-memory and iterative), a
+  column-uniqueness/key finder, open-addressing map/set data structures, and an
+  MCP server exposing the uniqueness checker.
+
+Module map (root reactor: `claude-code-enforcer`, `mcp-common`, `data`, `code`,
+`grpc-example`, `assembly`; `data-test` is built separately):
+
+```
+tools (root pom, packaging=pom)
+├── claude-code-enforcer   # custom maven-enforcer rules validating CLAUDE.md/AGENTS.md & agent config
+├── mcp-common             # shared MCP server scaffolding
+├── data                   # data sources, uniqueness checks, structures, MCP server
+├── code
+│   ├── protogen-maven-plugin       # compile-time-safe protobuf builder generator
+│   ├── protogen-maven-plugin-test  # integration tests for the plugin
+│   └── context                     # class-usage context finder + MCP server
+├── grpc-example           # end-to-end gRPC example
+├── assembly               # executable jar-with-dependencies (SampleApp)
+└── data-test              # standalone test module (not in root <modules>)
+```
+
+Base Java package: `io.github.adamw7` (`io.github.adamw7.context` for the context
+module, `io.github.adamw7.tools.*` elsewhere).
 
 ## Java version
-Java 25.
+
+Java 25. A JDK 25 must be on the `PATH` with `JAVA_HOME` set. In Claude Code
+web/remote sessions the `.claude/hooks/session-start.sh` hook installs
+`openjdk-25-jdk` and pre-fetches dependencies.
 
 ## Maven
-All versions and scopes are defined only in root pom.xml in dependency management.
-All maven plugin versions are defined only in root pom.xml in plugin management.
+
+All dependency versions and scopes are defined only in the root `pom.xml` under
+`<dependencyManagement>`. All Maven plugin versions are defined only in the root
+`pom.xml` under `<pluginManagement>`. Module poms reference dependencies and
+plugins without versions.
+
+Common commands (run from the repository root):
+
+```bash
+mvn clean install                 # full clean build + install to local repo
+mvn install                       # faster incremental build
+mvn -pl data test                 # tests for a single module
+mvn -P integration-tests verify   # MCP integration tests (*IT)
+mvn -Pcoverage verify             # JaCoCo coverage (fails under 80%)
+mvn -Ppitest test                 # PIT mutation testing
+```
+
+Use `clean` after removing a code-generation source, so stale generated builders
+in `target/` cannot mask the change.
 
 ## Principles for Java Development
-Use SOLID Principles for all code.
-Use clean code. No continue or break instructions. Short methods. Meaningful parameter names.
+
+- **SOLID principles** for all code.
+- **Clean code**: short methods, meaningful parameter names.
+- **No `continue` or `break`** statements.
+- **Match the surrounding code** — naming, comment density, and idiom.
 
 ## Testing
-Write unit tests for all new logic. Focus on behavior, edge cases, and error paths.
+
+Write unit tests for all new logic. Focus on behavior, edge cases, and error
+paths.
+
+- **Unit tests** run in the normal `test`/`package` lifecycle.
+- **Architecture tests** (ArchUnit) live in each module's `.architecture` test
+  package and enforce package layering and coding rules — data-source contracts
+  must not depend on their implementations, the uniqueness core must not depend
+  on its MCP adapter, loggers are `private static final`, production code logs
+  through log4j2 (no `System.out`/`err`, `printStackTrace`, or `System.exit`),
+  and packages stay free of cycles. Keep new code within these rules.
+- **MCP integration tests** (`*IT`) are gated behind the `integration-tests`
+  profile.
 
 ## Dependencies
-Use the existing maven dependencies. Always ask before adding a new one.
+
+Use the existing Maven dependencies. **Always ask before adding a new one.**


### PR DESCRIPTION
Turn CLAUDE.md into a useful standalone quick-reference (repository
purpose, module map, common Maven commands, ArchUnit note) while keeping
it deferring to AGENTS.md as the source of truth. Record the recently
added ArchUnit architecture tests and the ColumnarDataSource contract in
AGENTS.md so the agent docs match the current codebase.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019GZTe5yerCd7CgR1fynbMx