### PR TITLE
fix(data): let uniqueness checks read map-backed in-memory sources

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryMapDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryMapDataSource.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.data.source.file;
 
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -62,8 +63,8 @@ public abstract class AbstractInMemoryMapDataSource extends AbstractFileSource i
 
 	@Override
 	public void reset() {
-		checkIfOpen();
 		mapIterator = fieldsMap.keySet().iterator();
+		opened = true;
 	}
 
 	public Iterator<String[]> iterator() {
@@ -85,8 +86,19 @@ public abstract class AbstractInMemoryMapDataSource extends AbstractFileSource i
 		return fieldsMap.keySet().toArray(new String[] {});
 	}
 
+	/**
+	 * Returns every {@code {key, value}} pair, built straight from {@link #fieldsMap}.
+	 * The document is already fully parsed into the map, so this neither needs nor
+	 * calls {@link #open()} &mdash; which lets callers that have already opened the
+	 * source (such as the uniqueness checks) read it without tripping the
+	 * open-once guard, and makes {@code readAll} usable regardless of open state.
+	 */
 	@Override
 	public List<String[]> readAll() {
-		return super.readAll();
+		List<String[]> data = new ArrayList<>(fieldsMap.size());
+		for (Map.Entry<String, String> entry : fieldsMap.entrySet()) {
+			data.add(new String[] { entry.getKey(), entry.getValue() });
+		}
+		return data;
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/MapSourceUniquenessCheckTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/MapSourceUniquenessCheckTest.java
@@ -1,0 +1,59 @@
+package io.github.adamw7.tools.data.uniqueness;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.github.adamw7.tools.data.source.file.InMemoryJSONDataSource;
+import io.github.adamw7.tools.data.source.file.InMemoryTOONDataSource;
+import io.github.adamw7.tools.data.source.file.InMemoryYAMLDataSource;
+import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
+
+/**
+ * Regression tests for running {@link InMemoryUniquenessCheck} against the
+ * map-backed in-memory sources (JSON/YAML/TOON). These used to fail with
+ * {@code IllegalStateException: DataSource is already open} because the check
+ * opens the source and then calls {@code readAll()}, which re-opened it.
+ */
+public class MapSourceUniquenessCheckTest {
+
+	static Stream<Arguments> sources() {
+		return Stream.of(
+				Arguments.of("json", (Function<String, InMemoryDataSource>) InMemoryJSONDataSource::new),
+				Arguments.of("yaml", (Function<String, InMemoryDataSource>) InMemoryYAMLDataSource::new),
+				Arguments.of("toon", (Function<String, InMemoryDataSource>) InMemoryTOONDataSource::new));
+	}
+
+	private static String fileFor(String format) {
+		return "src/test/resources/test." + format;
+	}
+
+	@ParameterizedTest
+	@MethodSource("sources")
+	void singleColumnDoesNotCrash(String format, Function<String, InMemoryDataSource> factory) {
+		InMemoryDataSource source = factory.apply(fileFor(format));
+		InMemoryUniquenessCheck check = new InMemoryUniquenessCheck(source);
+		String column = source.getColumnNames()[0];
+
+		Result result = check.exec(column);
+
+		assertNotNull(result);
+	}
+
+	@ParameterizedTest
+	@MethodSource("sources")
+	void multiColumnDoesNotCrash(String format, Function<String, InMemoryDataSource> factory) {
+		InMemoryDataSource source = factory.apply(fileFor(format));
+		InMemoryUniquenessCheck check = new InMemoryUniquenessCheck(source);
+		String[] columns = source.getColumnNames();
+
+		Result result = check.exec(columns[0], columns[1]);
+
+		assertNotNull(result);
+	}
+}


### PR DESCRIPTION
InMemoryUniquenessCheck opens its data source and then calls readAll().
For the map-backed in-memory sources (JSON/YAML/TOON) that inherited
AbstractFileSource.readAll(), readAll() called open() a second time,
which those sources reject with "DataSource is already open" — so any
uniqueness check against a JSON, YAML or TOON source crashed with an
IllegalStateException (CSV and SQL sources have idempotent open() and
were unaffected).

The document is already fully parsed into fieldsMap, so readAll() needs
no open() at all: build the row list straight from the map, independent
of open state. reset() likewise re-establishes iteration from any state
(matching CSVDataSource), so the multi-column path that resets after
close() no longer trips the open guard.

Add MapSourceUniquenessCheckTest covering single- and multi-column
checks across all three map formats.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wqooz7qJoLBN8gRZrhFGzz