### PR TITLE
test(protogen): extend integration proto fixtures for oneof, enum and map staging

### DIFF
--- a/code/protogen-maven-plugin-test/src/main/proto/contact.proto
+++ b/code/protogen-maven-plugin-test/src/main/proto/contact.proto
@@ -1,0 +1,18 @@
+syntax = "proto2";
+
+package test;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.code.test";
+
+// Exercises a proto2 oneof, complementing the proto3 oneof covered by Payment.
+// In proto2 the oneof members carry explicit presence, so the generated builder
+// must expose has-accessors for them alongside the case getter and group clear,
+// while the required field still drives the staged builder entry point.
+message Contact {
+  required string name = 1;
+  oneof channel {
+    string email = 2;
+    string phone = 3;
+  }
+}

--- a/code/protogen-maven-plugin-test/src/main/proto/inventory.proto
+++ b/code/protogen-maven-plugin-test/src/main/proto/inventory.proto
@@ -1,0 +1,14 @@
+syntax = "proto2";
+
+package test;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.code.test";
+
+// Exercises a map field as the staged builder entry point. Map fields are
+// non-optional for staging purposes, so the builder must start from the map
+// setter (which delegates to putAll) before exposing the optional field.
+message Inventory {
+  map<string, int32> stock = 1;
+  optional string warehouse = 2;
+}

--- a/code/protogen-maven-plugin-test/src/main/proto/shipment.proto
+++ b/code/protogen-maven-plugin-test/src/main/proto/shipment.proto
@@ -1,0 +1,21 @@
+syntax = "proto2";
+
+package test;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.code.test";
+
+// Exercises a required enum-typed field as the staged builder entry point
+// followed by a repeated field. The entry point chains from the enum setter to
+// the repeated setter (which delegates to addAll) before collapsing to the
+// optional interface, covering both mappings in a single staged sequence.
+message Shipment {
+  required Priority priority = 1;
+  repeated string items = 2;
+  optional string tracking = 3;
+
+  enum Priority {
+    STANDARD = 0;
+    EXPRESS = 1;
+  }
+}

--- a/code/protogen-maven-plugin-test/src/test/java/io/github/adamw7/tools/code/usecase/GeneretedCodeTest.java
+++ b/code/protogen-maven-plugin-test/src/test/java/io/github/adamw7/tools/code/usecase/GeneretedCodeTest.java
@@ -12,14 +12,18 @@ import org.output.generated.AccountOptionalIfc;
 import org.output.generated.CarBuilder;
 import org.output.generated.ComputerBuilder;
 import org.output.generated.ComputerOptionalIfc;
+import org.output.generated.ContactBuilder;
+import org.output.generated.ContactOptionalIfc;
 import org.output.generated.GroupBuilder;
 import org.output.generated.GroupingBuilder;
+import org.output.generated.InventoryBuilder;
 import org.output.generated.MeasurementBuilder;
 import org.output.generated.MyMessageBuilder;
 import org.output.generated.OneOptionalFieldOnlyBuilder;
 import org.output.generated.PaymentBuilder;
 import org.output.generated.ProfileBuilder;
 import org.output.generated.ServerBuilder;
+import org.output.generated.ShipmentBuilder;
 import org.output.generated.TeamBuilder;
 import org.output.generated.UserBuilder;
 import org.output.generated.WheelBuilder;
@@ -30,11 +34,14 @@ import io.github.adamw7.tools.code.foo.Foo;
 import io.github.adamw7.tools.code.test.Account;
 import io.github.adamw7.tools.code.test.Car;
 import io.github.adamw7.tools.code.test.Computer;
+import io.github.adamw7.tools.code.test.Contact;
 import io.github.adamw7.tools.code.test.Extension;
 import io.github.adamw7.tools.code.test.Grouping;
+import io.github.adamw7.tools.code.test.Inventory;
 import io.github.adamw7.tools.code.test.Measurement;
 import io.github.adamw7.tools.code.test.MyMessage;
 import io.github.adamw7.tools.code.test.Server;
+import io.github.adamw7.tools.code.test.Shipment;
 import io.github.adamw7.tools.code.test.Wheel;
 import io.github.adamw7.tools.code.test4.Payment;
 import io.github.adamw7.tools.code.test4.Profile;
@@ -234,6 +241,56 @@ public class GeneretedCodeTest {
 		assertEquals(Payment.MethodCase.METHOD_NOT_SET, payment.getMethodCase());
 		assertEquals("order-1", payment.getReference());
 		assertFalse(payment.hasCard());
+	}
+
+	@Test
+	public void proto2OneofTracksSelectedMemberWithPresence() {
+		ContactBuilder builder = new ContactBuilder();
+		ContactOptionalIfc optional = builder.setName("alice");
+		assertEquals(Contact.ChannelCase.CHANNEL_NOT_SET, optional.getChannelCase());
+
+		optional.setEmail("alice@example.com");
+		assertEquals(Contact.ChannelCase.EMAIL, optional.getChannelCase());
+		assertTrue(optional.hasEmail());
+		assertFalse(optional.hasPhone());
+
+		optional.setPhone("555-1234");
+		assertEquals(Contact.ChannelCase.PHONE, optional.getChannelCase());
+		assertTrue(optional.hasPhone());
+		assertFalse(optional.hasEmail());
+	}
+
+	@Test
+	public void proto2OneofClearResetsSelection() {
+		ContactBuilder builder = new ContactBuilder();
+		ContactOptionalIfc optional = builder.setName("bob");
+		optional.setEmail("bob@example.com");
+
+		Contact contact = optional.clearChannel().build();
+		assertEquals(Contact.ChannelCase.CHANNEL_NOT_SET, contact.getChannelCase());
+		assertEquals("bob", contact.getName());
+		assertFalse(contact.hasEmail());
+	}
+
+	@Test
+	public void requiredEnumEntryChainsThroughRepeatedField() {
+		ShipmentBuilder builder = new ShipmentBuilder();
+		Shipment shipment = builder.setPriority(Shipment.Priority.EXPRESS)
+				.setItems(java.util.List.of("book", "pen")).setTracking("TRK-1").build();
+		assertNotNull(shipment);
+		assertEquals(Shipment.Priority.EXPRESS, shipment.getPriority());
+		assertEquals(java.util.List.of("book", "pen"), shipment.getItemsList());
+		assertEquals("TRK-1", shipment.getTracking());
+		assertTrue(builder.hasPriority());
+	}
+
+	@Test
+	public void mapFieldDrivesStagedBuilderEntry() {
+		Inventory inventory = new InventoryBuilder().setStock(java.util.Map.of("widgets", 5))
+				.setWarehouse("east").build();
+		assertNotNull(inventory);
+		assertEquals(5, inventory.getStockOrDefault("widgets", 0));
+		assertEquals("east", inventory.getWarehouse());
 	}
 
 }


### PR DESCRIPTION
Add three proto fixtures to the protogen-maven-plugin-test collection to cover
generated-builder paths not yet exercised end to end:

- contact.proto: a proto2 oneof (complements the proto3 oneof in Payment),
  verifying per-member presence accessors alongside the case getter and clear.
- shipment.proto: a required enum-typed field as the staged builder entry point
  chaining into a repeated field before the optional interface.
- inventory.proto: a map field driving the staged builder entry via putAll.

Cover each fixture with matching cases in GeneretedCodeTest.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017jVjuvvTyVjuBrMbdUyxhq