### PR TITLE
docs: fix inaccuracies in data MCP_USAGE.md and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Solution:
 	<groupId>io.github.adamw7</groupId>
 	<artifactId>protogen-maven-plugin</artifactId>
 	<!-- Use the latest release: https://github.com/adamw7/tools/releases/latest -->
-	<version>2.1.0</version>
+	<version>2.4.0</version>
 	<configuration>
 		<generatedSourcesDir>${project.basedir}/target/generated-sources/</generatedSourcesDir>
 		<pkgs>

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
@@ -10,13 +10,13 @@ The MCP server exposes a `uniqueness_check` tool that allows AI assistants to an
 
 The implementation consists of three main components:
 
-1. **Main.java** - Spring Boot application entry point that configures stdio transport
+1. **Main.java** - Spring Boot application entry point that selects the transport (stdio by default)
 2. **McpConfiguration.java** - Spring configuration that sets up the MCP server and registers tools
 3. **UniquenessTool.java** - Implements the uniqueness checking tool
 
 The server uses:
 - **Transport**: stdio (default), streamable-http (`--transport.mode=streamable-http`, served at `/mcp`), stateless-http (`--transport.mode=stateless-http`, session-less, also served at `/mcp`), or the legacy HTTP+SSE transport (`--transport.mode=sse`, event stream at `/sse`, JSON-RPC messages POSTed to `/mcp/message`)
-- **MCP SDK**: io.modelcontextprotocol.sdk v2.0.0-RC1
+- **MCP SDK**: io.modelcontextprotocol.sdk v2.0.0
 - **Framework**: Spring Boot
 - **Protocol**: Model Context Protocol (MCP)
 
@@ -281,8 +281,9 @@ syncServer.addTool(toolSpec.build());
 
 - [Model Context Protocol Specification](https://modelcontextprotocol.io/)
 - [MCP Java SDK Documentation](https://github.com/modelcontextprotocol/java-sdk)
-- [Main Project README](../../../../../../../../../README.md)
-- [Data Module Documentation](../../../../../../../../../README.md#data)
+- [Main Project README](../../../../../../../../../../../README.md)
+- [Data Module Documentation](../../../../../../../../../../../README.md#data)
+- [Context module MCP server](../../../../../../../../../../../code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md)
 
 ## License
 


### PR DESCRIPTION
- Fix broken relative links in the data uniqueness MCP_USAGE.md: they used
  9 `../` and resolved to a non-existent data/src/README.md; the file is
  11 levels below the repo root, so the links now use 11 `../`.
- Correct the stale MCP SDK version (v2.0.0-RC1 -> v2.0.0) to match the
  root pom (mcp-bom 2.0.0) and the context server's MCP_USAGE.md.
- Update the Main.java description to reflect that it selects among the
  supported transports (stdio by default), not stdio only.
- Add a cross-link to the context module's MCP server, mirroring the link
  that server already has back to this one.
- Bump the protogen-maven-plugin example version in README.md to the
  current latest release (2.4.0).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014GyRLdGsuwb2wte5SPSFpX