### PR TITLE
feat(data): add Parquet data source backed by DuckDB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,10 @@ Maven project. The notable capabilities are:
   **MCP server** (in the `io.github.adamw7.context.mcp` package) exposes the
   project-tree and context-finder tools over stdio, streamable HTTP, stateless
   HTTP or HTTP+SSE.
-- **Data** (`data`) — data sources (CSV, GZip, JDBC; in-memory and iterative
-  loading). Schema-aware sources that know their columns up front implement
+- **Data** (`data`) — data sources (CSV, GZip, JDBC, Parquet; in-memory and
+  iterative loading). Parquet files are read through an in-process DuckDB engine,
+  so they expose their columns and rows like any other JDBC-backed source.
+  Schema-aware sources that know their columns up front implement
   `ColumnarDataSource` (a narrower contract than `IterableDataSource`), so
   callers that need the schema — such as the uniqueness check — cannot be handed
   a forward-only source (JSON/YAML/TOON) that would only answer with `null`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ run `mvn install` from the repository root. The main capabilities are:
 - **Context engineering** (`code/context`) — a regex-based class-usage finder and
   project-tree builder that assembles context for gen-AI agents, plus an MCP
   server exposing `project_tree`, `find_context`, and `estimate_tokens`.
-- **Data** (`data`) — CSV/GZip/JDBC data sources (in-memory and iterative), a
+- **Data** (`data`) — CSV/GZip/JDBC/Parquet data sources (in-memory and iterative), a
   column-uniqueness/key finder, open-addressing map/set data structures, and an
   MCP server exposing the uniqueness checker.
 

--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ It contains:
   - support relational data loading
   - in memory and iterative loading
   - CSV, JDBC support
+  - Parquet (`InMemoryParquetDataSource`, `IterableParquetDataSource`) — read through an in-process DuckDB engine, exposing the file's columns and rows like any other JDBC-backed source
   - JSON (`InMemoryJSONDataSource`, `IterableJSONDataSource`) — nested objects are flattened with dotted-path keys (e.g. `people[0].address.city`)
   - YAML (`InMemoryYAMLDataSource`, `IterableYAMLDataSource`) — same flattening convention; no document-size limit
   - TOON (`InMemoryTOONDataSource`, `IterableTOONDataSource`) — a compact, LLM-friendly format that minimises tokens; supports key-value pairs, primitive arrays, tabular arrays, and nested objects

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -10,7 +10,7 @@
 	<artifactId>tools.data</artifactId>
 	<packaging>jar</packaging>
 	<name>Tooling for data</name>
-	<description>Data sources (CSV, GZip, JDBC; in-memory and iterative), a uniqueness-checking tool, data structures, and an MCP server exposing the uniqueness checker.</description>
+	<description>Data sources (CSV, GZip, JDBC, Parquet; in-memory and iterative), a uniqueness-checking tool, data structures, and an MCP server exposing the uniqueness checker.</description>
 	<url>https://github.com/adamw7/tools</url>
 	<build>
 		<plugins>
@@ -104,6 +104,10 @@
 		<dependency>
 			<groupId>org.apache.derby</groupId>
 			<artifactId>derbytools</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.duckdb</groupId>
+			<artifactId>duckdb_jdbc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/DuckDbParquet.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/DuckDbParquet.java
@@ -1,0 +1,50 @@
+package io.github.adamw7.tools.data.source.db;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+/**
+ * Builds the in-process DuckDB plumbing that lets the Parquet data sources reuse the JDBC
+ * {@code source.db} machinery: an in-memory DuckDB connection and a {@code read_parquet} query
+ * over a given file. Keeping this here means both the iterable and in-memory Parquet sources
+ * share one definition of how a Parquet file is turned into a JDBC result set.
+ */
+final class DuckDbParquet {
+
+	private static final String IN_MEMORY_URL = "jdbc:duckdb:";
+
+	private DuckDbParquet() {
+	}
+
+	static Connection connect() {
+		try {
+			return DriverManager.getConnection(IN_MEMORY_URL);
+		} catch (SQLException e) {
+			throw new UncheckedIOException(new IOException(e));
+		}
+	}
+
+	static String readQuery(String filePath) {
+		if (filePath == null || filePath.trim().isEmpty()) {
+			throw new IllegalArgumentException("Parquet file path must not be null or empty");
+		}
+		return "SELECT * FROM read_parquet('" + escape(filePath) + "')";
+	}
+
+	private static String escape(String filePath) {
+		return filePath.replace("'", "''");
+	}
+
+	static void close(Connection connection) {
+		try {
+			if (connection != null && !connection.isClosed()) {
+				connection.close();
+			}
+		} catch (SQLException e) {
+			throw new UncheckedIOException(new IOException(e));
+		}
+	}
+}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/InMemoryParquetDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/InMemoryParquetDataSource.java
@@ -1,0 +1,32 @@
+package io.github.adamw7.tools.data.source.db;
+
+/**
+ * In-memory counterpart of {@link IterableParquetDataSource}: it reads a Parquet file through an
+ * in-process DuckDB engine and, via {@link #readAll()}, materialises every row at once.
+ *
+ * <p>Like the iterable source it owns the DuckDB connection it queries, so {@link #close()} disposes
+ * of that connection while {@link #reset()} keeps it for a fresh read.</p>
+ */
+public class InMemoryParquetDataSource extends InMemorySQLDataSource {
+
+	public InMemoryParquetDataSource(String filePath) {
+		super(DuckDbParquet.connect(), DuckDbParquet.readQuery(filePath));
+	}
+
+	@Override
+	public void reset() {
+		releaseQueryResources();
+		hasMoreData = true;
+		open();
+	}
+
+	@Override
+	public void close() {
+		releaseQueryResources();
+		DuckDbParquet.close(connection);
+	}
+
+	private void releaseQueryResources() {
+		super.close();
+	}
+}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableParquetDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableParquetDataSource.java
@@ -1,0 +1,36 @@
+package io.github.adamw7.tools.data.source.db;
+
+import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
+
+/**
+ * Reads a Parquet file as a {@link ColumnarDataSource} by streaming it through an in-process
+ * DuckDB engine, so a Parquet file's columns and rows are exposed exactly like any other
+ * JDBC-backed source.
+ *
+ * <p>Unlike {@link IterableSQLDataSource}, which borrows a caller-owned {@link java.sql.Connection},
+ * this source creates and owns the DuckDB connection it queries. {@link #close()} therefore disposes
+ * of that connection, while {@link #reset()} keeps it so the file can be re-read.</p>
+ */
+public class IterableParquetDataSource extends IterableSQLDataSource {
+
+	public IterableParquetDataSource(String filePath) {
+		super(DuckDbParquet.connect(), DuckDbParquet.readQuery(filePath));
+	}
+
+	@Override
+	public void reset() {
+		releaseQueryResources();
+		hasMoreData = true;
+		open();
+	}
+
+	@Override
+	public void close() {
+		releaseQueryResources();
+		DuckDbParquet.close(connection);
+	}
+
+	private void releaseQueryResources() {
+		super.close();
+	}
+}

--- a/data/src/main/java/module-info.java
+++ b/data/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 open module datamodule {
 	requires org.apache.logging.log4j;
 	requires java.sql;
+	requires duckdb.jdbc;
 	requires com.fasterxml.jackson.core;
 	requires com.fasterxml.jackson.databind;
 	requires com.fasterxml.jackson.dataformat.yaml;

--- a/data/src/test/java/io/github/adamw7/tools/data/source/DataSourceSegregationTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/DataSourceSegregationTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import io.github.adamw7.tools.data.source.db.InMemoryParquetDataSource;
 import io.github.adamw7.tools.data.source.db.InMemorySQLDataSource;
+import io.github.adamw7.tools.data.source.db.IterableParquetDataSource;
 import io.github.adamw7.tools.data.source.db.IterableSQLDataSource;
 import io.github.adamw7.tools.data.source.file.CSVDataSource;
 import io.github.adamw7.tools.data.source.file.InMemoryCSVDataSource;
@@ -36,6 +38,8 @@ class DataSourceSegregationTest {
 		assertTrue(ColumnarDataSource.class.isAssignableFrom(InMemoryJSONDataSource.class));
 		assertTrue(ColumnarDataSource.class.isAssignableFrom(IterableSQLDataSource.class));
 		assertTrue(ColumnarDataSource.class.isAssignableFrom(InMemorySQLDataSource.class));
+		assertTrue(ColumnarDataSource.class.isAssignableFrom(IterableParquetDataSource.class));
+		assertTrue(ColumnarDataSource.class.isAssignableFrom(InMemoryParquetDataSource.class));
 	}
 
 	@Test

--- a/data/src/test/java/io/github/adamw7/tools/data/source/db/ParquetDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/db/ParquetDataSourceTest.java
@@ -1,0 +1,155 @@
+package io.github.adamw7.tools.data.source.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.github.adamw7.tools.data.Utils;
+import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
+
+public class ParquetDataSourceTest {
+
+	private static Path parquetFile;
+
+	@BeforeAll
+	public static void createParquetFixture() throws Exception {
+		parquetFile = Paths.get("target", "people.parquet").toAbsolutePath();
+		Files.deleteIfExists(parquetFile);
+		try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+				Statement statement = connection.createStatement()) {
+			statement.execute("CREATE TABLE people (id INTEGER, name VARCHAR, surname VARCHAR)");
+			statement.execute("INSERT INTO people VALUES (1, 'Adam', 'W'), (2, 'Ewa', 'K'), (3, 'Jan', 'N')");
+			statement.execute("COPY people TO '" + parquetFile + "' (FORMAT PARQUET)");
+		}
+	}
+
+	static Stream<Arguments> happyPathSources() {
+		IterableParquetDataSource iterable = new IterableParquetDataSource(parquetFile.toString());
+		InMemoryParquetDataSource inMemory = new InMemoryParquetDataSource(parquetFile.toString());
+		return Stream.of(of(Utils.named(iterable)), of(Utils.named(inMemory)));
+	}
+
+	@ParameterizedTest
+	@MethodSource("happyPathSources")
+	public void happyPath(ColumnarDataSource source) {
+		source.open();
+
+		String[] columnNames = source.getColumnNames();
+		assertEquals("id", columnNames[0]);
+		assertEquals("name", columnNames[1]);
+		assertEquals("surname", columnNames[2]);
+
+		String[] row = source.nextRow();
+		assertEquals("1", row[0]);
+		assertEquals("Adam", row[1]);
+		assertEquals("W", row[2]);
+
+		int rows = 1;
+		while (source.hasMoreData()) {
+			String[] next = source.nextRow();
+			if (next != null) {
+				++rows;
+			}
+		}
+		Utils.close(source);
+		assertEquals(3, rows);
+	}
+
+	@Test
+	public void inMemoryReadAll() {
+		InMemoryParquetDataSource source = new InMemoryParquetDataSource(parquetFile.toString());
+		List<String[]> all = source.readAll();
+		Utils.close(source);
+		assertEquals(3, all.size());
+		assertEquals("Adam", all.get(0)[1]);
+	}
+
+	@Test
+	public void nextRowsLoadsRequestedBatch() {
+		IterableParquetDataSource source = new IterableParquetDataSource(parquetFile.toString());
+		source.open();
+
+		List<String[]> firstBatch = source.nextRows(2);
+		assertEquals(2, firstBatch.size());
+
+		List<String[]> rest = source.nextRows(1000);
+		assertEquals(1, rest.size());
+
+		assertTrue(source.nextRows(10).isEmpty());
+		Utils.close(source);
+	}
+
+	@Test
+	public void resetReopensSourceAfterExhaustion() {
+		IterableParquetDataSource source = new IterableParquetDataSource(parquetFile.toString());
+		source.open();
+		int firstPass = drain(source);
+		source.reset();
+		int secondPass = drain(source);
+		Utils.close(source);
+		// reset() releases the query resources but keeps the owned DuckDB connection, so the
+		// same rows are produced again instead of an empty (or failed) read.
+		assertEquals(3, firstPass);
+		assertEquals(firstPass, secondPass);
+	}
+
+	@Test
+	public void closeDisposesOwnedConnection() {
+		IterableParquetDataSource source = new IterableParquetDataSource(parquetFile.toString());
+		source.open();
+		Utils.close(source);
+		// The source owns its DuckDB connection, so once closed a fresh read must fail fast
+		// rather than silently querying a disposed connection.
+		assertThrows(UncheckedIOException.class, source::open);
+	}
+
+	@Test
+	public void missingFileFailsOnOpen() {
+		String missing = Paths.get("target", "does-not-exist.parquet").toAbsolutePath().toString();
+		IterableParquetDataSource source = new IterableParquetDataSource(missing);
+		assertThrows(UncheckedIOException.class, source::open);
+		Utils.close(source);
+	}
+
+	@Test
+	public void nullPathIsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> new IterableParquetDataSource(null));
+		assertThrows(IllegalArgumentException.class, () -> new InMemoryParquetDataSource("  "));
+	}
+
+	@Test
+	public void parquetSourcesAreColumnar() {
+		assertTrue(ColumnarDataSource.class.isAssignableFrom(IterableParquetDataSource.class));
+		assertTrue(ColumnarDataSource.class.isAssignableFrom(InMemoryParquetDataSource.class));
+		assertFalse(IterableParquetDataSource.class.isInterface());
+	}
+
+	private static int drain(IterableParquetDataSource source) {
+		int rows = 0;
+		while (source.hasMoreData()) {
+			String[] row = source.nextRow();
+			if (row != null) {
+				++rows;
+			}
+		}
+		return rows;
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,11 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<groupId>org.duckdb</groupId>
+				<artifactId>duckdb_jdbc</artifactId>
+				<version>1.5.4.0</version>
+			</dependency>
+			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-plugin-api</artifactId>
 				<version>4.0.0-rc-5</version>


### PR DESCRIPTION
Introduce IterableParquetDataSource and InMemoryParquetDataSource in the
source.db package. They read a Parquet file through an in-process DuckDB
engine (SELECT * FROM read_parquet(...)), reusing the existing JDBC
ColumnarDataSource machinery so a Parquet file's columns and rows are
exposed like any other tabular source.

Unlike the SQL sources, the Parquet sources create and own their DuckDB
connection: close() disposes of it while reset() keeps it for a fresh
read. A shared DuckDbParquet helper builds the connection and query.

- Add org.duckdb:duckdb_jdbc dependency (root dependencyManagement +
  data module) and require the duckdb.jdbc module.
- Cover both sources with ParquetDataSourceTest (fixture generated via
  DuckDB) and extend DataSourceSegregationTest.
- Document the new source in AGENTS.md, CLAUDE.md and README.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VGKcADpqh77k8QTtAaNUab