### PR TITLE
fix(data): release JDBC statement on repeated open() in Parquet/SQL sources

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -19,6 +19,7 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 	private final static Logger log = LogManager.getLogger(IterableSQLDataSource.class.getName());
 
 	private ResultSet resultSet;
+	private Statement statement;
 	protected boolean hasMoreData = true;
 	protected final String query;
 	protected final Connection connection;
@@ -30,15 +31,22 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 
 	@Override
 	public void close() {
-		if (resultSet != null) {
-			try {
-				if (!resultSet.isClosed()) {
-					resultSet.getStatement().close();
-					resultSet.close();					
-				}
-			} catch (SQLException e) {
-				throw new UncheckedIOException(new IOException(e));
+		closeQueryResources();
+	}
+
+	private void closeQueryResources() {
+		try {
+			if (resultSet != null) {
+				resultSet.close();
 			}
+			if (statement != null) {
+				statement.close();
+			}
+		} catch (SQLException e) {
+			throw new UncheckedIOException(new IOException(e));
+		} finally {
+			resultSet = null;
+			statement = null;
 		}
 	}
 
@@ -53,8 +61,9 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 
 	@Override
 	public void open() {
+		closeQueryResources();
 		try {
-			Statement statement = connection.createStatement();
+			statement = connection.createStatement();
 			log.info("Executing query: {}", query);
 			resultSet = statement.executeQuery(query);
 		} catch (SQLException e) {

--- a/data/src/test/java/io/github/adamw7/tools/data/source/db/ParquetDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/db/ParquetDataSourceTest.java
@@ -7,12 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 import java.io.UncheckedIOException;
+import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -140,6 +142,46 @@ public class ParquetDataSourceTest {
 		assertTrue(ColumnarDataSource.class.isAssignableFrom(IterableParquetDataSource.class));
 		assertTrue(ColumnarDataSource.class.isAssignableFrom(InMemoryParquetDataSource.class));
 		assertFalse(IterableParquetDataSource.class.isInterface());
+	}
+
+	@Test
+	public void repeatedOpenDoesNotLeakPreviousStatement() throws Exception {
+		List<Statement> created = new ArrayList<>();
+		try (Connection real = DriverManager.getConnection("jdbc:duckdb:")) {
+			Connection recording = recordingConnection(real, created);
+			IterableSQLDataSource source = new IterableSQLDataSource(recording,
+					DuckDbParquet.readQuery(parquetFile.toString()));
+			source.open();
+			source.open();
+			// The second open() must release the first statement instead of leaking it on the
+			// (owned) connection until it is disposed.
+			assertEquals(2, created.size());
+			assertTrue(created.get(0).isClosed(), "first statement leaked on repeated open()");
+			source.close();
+			assertTrue(created.get(1).isClosed(), "second statement leaked on close()");
+		}
+	}
+
+	@Test
+	public void repeatedOpenReReadsFromStart() {
+		IterableParquetDataSource source = new IterableParquetDataSource(parquetFile.toString());
+		source.open();
+		assertEquals("1", source.nextRow()[0]);
+		source.open();
+		// Re-opening starts a fresh read rather than continuing the exhausted one.
+		assertEquals("1", source.nextRow()[0]);
+		Utils.close(source);
+	}
+
+	private static Connection recordingConnection(Connection real, List<Statement> created) {
+		return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(),
+				new Class<?>[] { Connection.class }, (proxy, method, args) -> {
+					Object result = method.invoke(real, args);
+					if (method.getName().equals("createStatement")) {
+						created.add((Statement) result);
+					}
+					return result;
+				});
 	}
 
 	private static int drain(IterableParquetDataSource source) {


### PR DESCRIPTION
open() overwrote the ResultSet/Statement fields without closing the
previous ones, leaking a Statement on every re-open until the connection
was disposed. This matters most for the Parquet data sources, which own a
long-lived DuckDB connection, so leaked statements accumulate on it.

close() also reached the Statement only through resultSet.getStatement(),
so a closed-ResultSet-but-open-Statement state would have leaked the
Statement.

Track the Statement in its own field and release both resources (nulling
them) from a single closeQueryResources() helper invoked by both close()
and the start of open(). The helper is private so open() cannot trip the
Parquet close() override that disposes the owned connection.

Add a recording-connection test proving the previous statement is closed
on repeated open() and a behavioural test that re-opening re-reads from
the start.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018mNNybwxsURTwrzbY7zMAq