### PR TITLE
style: fix shellcheck warnings in shell scripts

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+# CLAUDE_ENV_FILE and CLAUDE_PROJECT_DIR are provided by the Claude Code runtime.
+# shellcheck disable=SC2154
 set -euo pipefail
 
-if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+if [[ "${CLAUDE_CODE_REMOTE:-}" != "true" ]]; then
   exit 0
 fi
 
@@ -13,11 +15,11 @@ fi
 
 JAVA_HOME_25=$(find /usr/lib/jvm -maxdepth 1 -name "java-25-openjdk*" -type d | head -1)
 
-echo "export JAVA_HOME=${JAVA_HOME_25}" >> "$CLAUDE_ENV_FILE"
-echo "export PATH=${JAVA_HOME_25}/bin:\$PATH" >> "$CLAUDE_ENV_FILE"
+echo "export JAVA_HOME=${JAVA_HOME_25}" >> "${CLAUDE_ENV_FILE}"
+echo "export PATH=${JAVA_HOME_25}/bin:\$PATH" >> "${CLAUDE_ENV_FILE}"
 
 export JAVA_HOME="${JAVA_HOME_25}"
-export PATH="${JAVA_HOME_25}/bin:$PATH"
+export PATH="${JAVA_HOME_25}/bin:${PATH}"
 
 # Pre-download all Maven dependencies to local repo for faster builds
 cd "${CLAUDE_PROJECT_DIR}"

--- a/k8s/run-on-minikube.sh
+++ b/k8s/run-on-minikube.sh
@@ -13,30 +13,30 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-K8S_DIR="$ROOT_DIR/k8s"
+K8S_DIR="${ROOT_DIR}/k8s"
 IMAGE="${IMAGE:-tools-k8s:local}"
 COLUMN="${COLUMN:-country}"
 
 echo "==> Building the application (mvn -DskipTests package)"
-(cd "$ROOT_DIR" && mvn -B -ntp -DskipTests package)
+(cd "${ROOT_DIR}" && mvn -B -ntp -DskipTests package)
 
-echo "==> Building the Docker image: $IMAGE"
-docker build -f "$K8S_DIR/Dockerfile" -t "$IMAGE" "$ROOT_DIR"
+echo "==> Building the Docker image: ${IMAGE}"
+docker build -f "${K8S_DIR}/Dockerfile" -t "${IMAGE}" "${ROOT_DIR}"
 
 echo "==> Ensuring minikube is running"
 if ! minikube status >/dev/null 2>&1; then
   minikube start --driver=docker
 fi
 
-echo "==> Loading $IMAGE into minikube"
-minikube image load "$IMAGE"
+echo "==> Loading ${IMAGE} into minikube"
+minikube image load "${IMAGE}"
 
 echo "==> Applying manifests"
-kubectl apply -f "$K8S_DIR/configmap-sample-data.yaml"
+kubectl apply -f "${K8S_DIR}/configmap-sample-data.yaml"
 # Recreate the Job so repeated runs pick up new data/image.
 kubectl delete job tools-uniqueness-check --ignore-not-found
 # Substitute the target column (default 'country') into the manifest on the fly.
-sed "s|\"country\"|\"$COLUMN\"|" "$K8S_DIR/job-uniqueness-check.yaml" | kubectl apply -f -
+sed "s|\"country\"|\"${COLUMN}\"|" "${K8S_DIR}/job-uniqueness-check.yaml" | kubectl apply -f -
 
 echo "==> Waiting for the Job to complete"
 kubectl wait --for=condition=complete --timeout=120s job/tools-uniqueness-check \

--- a/scripts/linux/install-jdk-25.sh
+++ b/scripts/linux/install-jdk-25.sh
@@ -20,7 +20,9 @@ test_jdk_already_installed() {
         return 1
     fi
     if java -version 2>&1 | grep -q '"25'; then
-        success "JDK 25 is already installed: $(java -version 2>&1 | head -1)"
+        local version_line
+        version_line=$(java -version 2>&1 | head -1)
+        success "JDK 25 is already installed: ${version_line}"
         return 0
     fi
     return 1
@@ -29,55 +31,55 @@ test_jdk_already_installed() {
 download_from_adoptium() {
     step "Resolving download URL from Adoptium API..."
     local resolved_url
-    resolved_url=$(curl -Ls -o /dev/null -w '%{url_effective}' "$ADOPTIUM_API")
-    echo "    URL: $resolved_url"
+    resolved_url=$(curl -Ls -o /dev/null -w '%{url_effective}' "${ADOPTIUM_API}")
+    echo "    URL: ${resolved_url}"
 
     step "Downloading JDK 25 archive..."
-    mkdir -p "$TEMP_DIR"
-    curl -L --progress-bar -o "$ARCHIVE_PATH" "$resolved_url"
+    mkdir -p "${TEMP_DIR}"
+    curl -L --progress-bar -o "${ARCHIVE_PATH}" "${resolved_url}"
 
     local size_mb
-    size_mb=$(du -m "$ARCHIVE_PATH" | cut -f1)
-    success "Downloaded ${size_mb} MB -> $ARCHIVE_PATH"
+    size_mb=$(du -m "${ARCHIVE_PATH}" | cut -f1)
+    success "Downloaded ${size_mb} MB -> ${ARCHIVE_PATH}"
 }
 
 install_jdk() {
     step "Installing JDK 25..."
-    mkdir -p "$INSTALL_DIR"
-    tar -xzf "$ARCHIVE_PATH" -C "$INSTALL_DIR" --strip-components=1
-    success "JDK 25 installed to: $INSTALL_DIR"
+    mkdir -p "${INSTALL_DIR}"
+    tar -xzf "${ARCHIVE_PATH}" -C "${INSTALL_DIR}" --strip-components=1
+    success "JDK 25 installed to: ${INSTALL_DIR}"
 }
 
 set_java_home() {
     step "Setting JAVA_HOME and updating PATH..."
     local profile_script="/etc/profile.d/jdk25.sh"
 
-    sudo tee "$profile_script" > /dev/null <<EOF
+    sudo tee "${profile_script}" > /dev/null <<EOF
 export JAVA_HOME="${INSTALL_DIR}"
 export PATH="\${JAVA_HOME}/bin:\${PATH}"
 EOF
 
-    export JAVA_HOME="$INSTALL_DIR"
+    export JAVA_HOME="${INSTALL_DIR}"
     export PATH="${JAVA_HOME}/bin:${PATH}"
 
-    success "JAVA_HOME = $INSTALL_DIR"
-    success "Profile script written to $profile_script"
+    success "JAVA_HOME = ${INSTALL_DIR}"
+    success "Profile script written to ${profile_script}"
 }
 
 test_installation() {
     step "Verifying installation..."
     local java_exe="${INSTALL_DIR}/bin/java"
-    if [ ! -x "$java_exe" ]; then
-        failure "java binary not found at: $java_exe"
+    if [[ ! -x "${java_exe}" ]]; then
+        failure "java binary not found at: ${java_exe}"
         exit 1
     fi
     success "java -version output:"
-    "$java_exe" -version 2>&1 | sed 's/^/    /'
+    "${java_exe}" -version 2>&1 | sed 's/^/    /'
 }
 
 remove_temp_files() {
-    if [ -d "$TEMP_DIR" ]; then
-        rm -rf "$TEMP_DIR"
+    if [[ -d "${TEMP_DIR}" ]]; then
+        rm -rf "${TEMP_DIR}"
         success "Cleaned up temporary files"
     fi
 }
@@ -87,6 +89,8 @@ remove_temp_files() {
 echo -e "\nJDK 25 Installer for Linux"
 printf "==========================\n\n"
 
+# test_jdk_already_installed is a predicate; it manages its own control flow.
+# shellcheck disable=SC2310
 if test_jdk_already_installed; then
     echo -e "\nJDK 25 is already present. Nothing to do."
     exit 0

--- a/scripts/linux/update-git-repos-async.sh
+++ b/scripts/linux/update-git-repos-async.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-for dir in "$SCRIPT_DIR"/*/; do
-    if [ -e "$dir/.git" ]; then
-        (cd "$dir" && git pull) &
+for dir in "${SCRIPT_DIR}"/*/; do
+    if [[ -e "${dir}/.git" ]]; then
+        (cd "${dir}" && git pull) &
     fi
 done
 wait


### PR DESCRIPTION
Make all repository shell scripts pass shellcheck with all optional
checks enabled (shellcheck --enable=all):

- Brace all variable references (SC2250).
- Prefer [[ ]] over [ ] for tests (SC2292).
- Avoid masking a command's return value in a command substitution by
  capturing java -version into a local first (SC2312).
- Suppress SC2310 on the test_jdk_already_installed predicate, which
  manages its own control flow.
- Suppress SC2154 for CLAUDE_ENV_FILE/CLAUDE_PROJECT_DIR, which the
  Claude Code runtime provides.

No behavioral change.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0163AuqoA8eCMiX6jtNqzcU1