### PR TITLE
test: tighten unit-test timeout to 900ms, preload Mockito agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,18 +155,21 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
 
 - **Unit tests** run in the normal `test`/`package` lifecycle
   (`mvn -pl <module> test`). Write tests for all new logic — behavior, edge
-  cases, and error paths. Surefire enforces a **1-second per-test timeout** (the
-  `junit.jupiter.execution.timeout.testable.method.default` JUnit config
-  parameter set on the surefire plugin in the root `pom.xml`), so a unit test
-  that runs 1 second or longer fails the build. The limit sits above the
+  cases, and error paths. Surefire enforces a **900-millisecond per-test
+  timeout** (the `junit.jupiter.execution.timeout.testable.method.default` JUnit
+  config parameter set on the surefire plugin in the root `pom.xml`), so a unit
+  test that runs 900 ms or longer fails the build. The limit sits above the
   one-time JVM/class-loading warmup a cold fork pays (~0.7s at most, and only
   for the first test to touch a heavy dependency) so it stays green when a
   single class is run in isolation, while still catching a test that does real
-  work. Keep unit tests fast; a genuinely heavier test (e.g. one that shells out
-  to `protoc` or streams a large data set) opts out with an explicit class- or
-  method-level `@Timeout` carrying a comment that says why. Failsafe integration
-  tests (`*IT`) do not inherit this limit, and ArchUnit tests run on a separate
-  engine that the JUnit timeout does not apply to.
+  work. To keep that warmup below the limit, the one module that uses Mockito
+  (`protogen-maven-plugin`) pre-loads it as a `-javaagent` in surefire, so the
+  byte-buddy self-attach happens at JVM startup rather than inside the first
+  timed test method. Keep unit tests fast; a genuinely heavier test (e.g. one
+  that shells out to `protoc` or streams a large data set) opts out with an
+  explicit class- or method-level `@Timeout` carrying a comment that says why.
+  Failsafe integration tests (`*IT`) do not inherit this limit, and ArchUnit
+  tests run on a separate engine that the JUnit timeout does not apply to.
 - **Architecture tests** (ArchUnit) run in every module as ordinary JUnit tests,
   under an `...architecture` test package (e.g.
   `io.github.adamw7.tools.data.architecture.DataArchitectureTest`). They analyse

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,10 +83,10 @@ Write unit tests for all new logic. Focus on behavior, edge cases, and error
 paths.
 
 - **Unit tests** run in the normal `test`/`package` lifecycle. Surefire enforces
-  a **1-second per-test timeout** (configured on the surefire plugin in the root
-  `pom.xml`) — above the one-time cold-JVM warmup but low enough to catch a test
-  doing real work — so keep unit tests fast; a genuinely heavier test opts out
-  with an explicit `@Timeout` and a comment explaining why.
+  a **900-millisecond per-test timeout** (configured on the surefire plugin in the
+  root `pom.xml`) — above the one-time cold-JVM warmup but low enough to catch a
+  test doing real work — so keep unit tests fast; a genuinely heavier test opts
+  out with an explicit `@Timeout` and a comment explaining why.
 - **Architecture tests** (ArchUnit) live in each module's `.architecture` test
   package and enforce package layering and coding rules — data-source contracts
   must not depend on their implementations, the uniqueness core must not depend

--- a/code/protogen-maven-plugin/pom.xml
+++ b/code/protogen-maven-plugin/pom.xml
@@ -14,6 +14,34 @@
 	<url>https://github.com/adamw7/tools</url>
 	<build>
 		<plugins>
+			<!-- Expose the mockito-core jar path so it can be pre-loaded as a Java
+			     agent below, avoiding Mockito's slow runtime self-attach. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>resolve-mockito-agent</id>
+						<goals>
+							<goal>properties</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- Pre-load Mockito as a Java agent at JVM startup. This module is the
+			     only one that uses Mockito; loading the agent up front (instead of
+			     letting Mockito self-attach on first mock creation) both silences the
+			     "Mockito is currently self-attaching" deprecation warning and moves
+			     the ~0.8s byte-buddy attach cost out of the timed test method, so the
+			     surefire per-test timeout can stay tight. @{argLine} keeps the JaCoCo
+			     agent (coverage profile) composed in. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>io.github.ascopes</groupId>
 				<artifactId>protobuf-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
 		<protobuf.version>4.33.4</protobuf.version>
 		<grpc.version>1.82.1</grpc.version>
 		<argLine/>
+		<!-- Per-test timeout for unit tests (see the surefire plugin config). The
+		     plain build uses a tight limit; the coverage profile overrides it to a
+		     larger value because the JaCoCo agent's bytecode instrumentation roughly
+		     doubles first-use class-loading time. -->
+		<unit.test.method.timeout>900 ms</unit.test.method.timeout>
 		<!-- Maven Central publishing behavior for the release profile. Defaults
 		     publish on release; overridable so the maven-publish.yml
 		     workflow_dispatch dry run can upload and validate without
@@ -251,18 +256,23 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>3.5.6</version>
 					<configuration>
-						<!-- Fail any unit test whose testable method runs 1 second
-						     or longer, so a test doing real work (rather than the
-						     unavoidable one-time JVM/class-loading warmup a cold
-						     fork pays, ~0.7s at most) is caught. Applies to @Test,
-						     @ParameterizedTest, @RepeatedTest, @TestFactory and
-						     @TestTemplate methods (not lifecycle setup/teardown).
-						     Only surefire (unit tests) inherits this; failsafe
-						     integration tests are unaffected. A genuinely heavier
-						     test opts out with an explicit @Timeout. -->
+						<!-- Fail any unit test whose testable method runs
+						     ${unit.test.method.timeout} or longer, so a test doing
+						     real work (rather than the unavoidable one-time
+						     JVM/class-loading warmup a cold fork pays, ~0.7s at most)
+						     is caught. Applies to @Test, @ParameterizedTest,
+						     @RepeatedTest, @TestFactory and @TestTemplate methods (not
+						     lifecycle setup/teardown). Only surefire (unit tests)
+						     inherits this; failsafe integration tests are unaffected.
+						     A genuinely heavier test opts out with an explicit
+						     @Timeout. The one module using Mockito pre-loads it as a
+						     -javaagent (see protogen-maven-plugin/pom.xml) so its
+						     byte-buddy self-attach is not billed to the first timed
+						     method. The coverage profile raises the limit because
+						     JaCoCo instrumentation slows the timed methods. -->
 						<properties>
 							<configurationParameters>
-								junit.jupiter.execution.timeout.testable.method.default = 1 s
+								junit.jupiter.execution.timeout.testable.method.default = ${unit.test.method.timeout}
 							</configurationParameters>
 						</properties>
 					</configuration>
@@ -585,6 +595,12 @@
 		</profile>
 		<profile>
 			<id>coverage</id>
+			<properties>
+				<!-- JaCoCo's bytecode instrumentation roughly doubles the time a
+				     timed test method spends loading classes on first use, so give
+				     the per-test timeout extra headroom under coverage. -->
+				<unit.test.method.timeout>2 s</unit.test.method.timeout>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>


### PR DESCRIPTION
The surefire per-test timeout was 1s, but UtilsTest.testGetNext ran at
~0.89s — its whole cost was Mockito's runtime self-attach on first mock
creation, billed to the timed method body and sitting at 89% of the
limit (and violating the documented "~0.7s at most" warmup ceiling).

protogen-maven-plugin is the only module that uses Mockito, so it now
pre-loads mockito-core as a -javaagent (resolved via the dependency
plugin's properties goal). The byte-buddy self-attach happens at JVM
startup instead of inside the first test method, which both silences the
"Mockito is currently self-attaching" deprecation warning and drops
testGetNext to ~0.55s. With the true warmup ceiling back at ~0.7s, the
plain per-test timeout is tightened to 900ms (~1.29x margin).

The timeout is now driven by the unit.test.method.timeout property. The
coverage profile overrides it to 2s because JaCoCo's bytecode
instrumentation roughly doubles first-use class-loading time (measured
~1.4s), which would otherwise trip the tighter limit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015eYhkoxLumwqV65gAkZjdF