### PR TITLE
Improve logging quality and consistency

### DIFF
--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/CodeMojo.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/CodeMojo.java
@@ -23,7 +23,7 @@ import io.github.adamw7.tools.code.gen.Code;
 @Mojo(name = "code-generator", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = false, requiresDependencyResolution = ResolutionScope.RUNTIME)
 public class CodeMojo extends AbstractMojo {
 
-	private final static Logger log = LogManager.getLogger(CodeMojo.class.getName());
+	private static final Logger log = LogManager.getLogger(CodeMojo.class.getName());
 
 	@Parameter(property = "generatedsourcesdir", required = true)
 	protected String generatedSourcesDir;

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/MessagesFinder.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/MessagesFinder.java
@@ -13,7 +13,7 @@ import com.google.protobuf.GeneratedMessage;
 
 public class MessagesFinder {
 
-	private final static Logger log = LogManager.getLogger(MessagesFinder.class.getName());
+	private static final Logger log = LogManager.getLogger(MessagesFinder.class.getName());
 	private final String[] pkg;
 
 	public MessagesFinder(String... pkg) {
@@ -24,10 +24,7 @@ public class MessagesFinder {
 		Reflections reflections = new Reflections(new ConfigurationBuilder().forPackages(pkg));
 		Set<Class<? extends GeneratedMessage>> classes = reflections.getSubTypesOf(GeneratedMessage.class);
 		Set<Class<? extends GeneratedMessage>> messages = onlyConcreteMessages(classes);
-		log.info("Found these proto classes:");
-		for (Class<? extends GeneratedMessage> cl : messages) {
-			log.info(cl);
-		}
+		log.info("Found {} concrete proto class(es): {}", messages::size, () -> messages);
 		return messages;
 	}
 

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Code.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Code.java
@@ -25,7 +25,7 @@ import io.github.adamw7.tools.code.MojoException;
 
 public class Code {
 
-	private final static Logger log = LogManager.getLogger(Code.class.getName());
+	private static final Logger log = LogManager.getLogger(Code.class.getName());
 	
 	private final String generatedSourcesDir;
 	private TypeMappings typeMappings;

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/MojoTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/MojoTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Timeout;
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
 public class MojoTest {
 	
-	private final static Logger log = LogManager.getLogger(MojoTest.class.getName());
+	private static final Logger log = LogManager.getLogger(MojoTest.class.getName());
 
 	protected static String GENERATED_SOURCES;
 	protected static String TARGET;

--- a/data-test/src/test/java/io/github/adamw7/tools/data/test/MemoryLeakTest.java
+++ b/data-test/src/test/java/io/github/adamw7/tools/data/test/MemoryLeakTest.java
@@ -32,7 +32,7 @@ import io.github.adamw7.tools.data.uniqueness.Result;
 // generous bound that still catches a genuine hang while iterating a source.
 @Timeout(value = 60, unit = TimeUnit.SECONDS)
 public class MemoryLeakTest {
-	private final static Logger log = LogManager.getLogger(MemoryLeakTest.class.getName());
+	private static final Logger log = LogManager.getLogger(MemoryLeakTest.class.getName());
 
 	private static final String PARENT = new File(getSourceLocation()).getParent();
 

--- a/data/src/main/java/io/github/adamw7/tools/data/SampleApp.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/SampleApp.java
@@ -15,7 +15,7 @@ import io.github.adamw7.tools.data.uniqueness.Uniqueness;
 public class SampleApp {
 	
 
-	private final static Logger log = LogManager.getLogger(SampleApp.class.getName());
+	private static final Logger log = LogManager.getLogger(SampleApp.class.getName());
 
 	public static void main(String[] args) {
 		checkArgs(args);

--- a/data/src/main/java/io/github/adamw7/tools/data/compression/ZipUtils.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/compression/ZipUtils.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.Logger;
 
 public class ZipUtils {
 
-	private final static Logger log = LogManager.getLogger(ZipUtils.class.getName());
+	private static final Logger log = LogManager.getLogger(ZipUtils.class.getName());
 
 	private ZipUtils() {}
 	

--- a/data/src/main/java/io/github/adamw7/tools/data/network/Switch.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/network/Switch.java
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.Logger;
 
 public class Switch {
 
-	private final static Logger log = LogManager.getLogger(Switch.class.getName());
+	private static final Logger log = LogManager.getLogger(Switch.class.getName());
 
 	private static volatile boolean isOff = false;
 

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/InMemorySQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/InMemorySQLDataSource.java
@@ -16,7 +16,7 @@ import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
 
 public class InMemorySQLDataSource extends IterableSQLDataSource implements InMemoryDataSource {
 	
-	private final static Logger log = LogManager.getLogger(InMemorySQLDataSource.class.getName());
+	private static final Logger log = LogManager.getLogger(InMemorySQLDataSource.class.getName());
 
 	
 	public InMemorySQLDataSource(Connection connection, String query) {
@@ -34,7 +34,7 @@ public class InMemorySQLDataSource extends IterableSQLDataSource implements InMe
 			log.info("Loaded {} rows into memory", allData::size);
 			return allData;
 		} catch (SQLException e) {
-			log.error(e);
+			log.error("Failed to load query result into memory: {}", query, e);
 			throw new UncheckedIOException(new IOException(e));
 		}
 

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -16,7 +16,7 @@ import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
 
 public class IterableSQLDataSource implements ColumnarDataSource {
 
-	private final static Logger log = LogManager.getLogger(IterableSQLDataSource.class.getName());
+	private static final Logger log = LogManager.getLogger(IterableSQLDataSource.class.getName());
 
 	private ResultSet resultSet;
 	private Statement statement;

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
@@ -14,7 +14,7 @@ public class CSVDataSource extends AbstractFileSource implements ColumnarDataSou
 
 	private static final String REGEX_SUFFIX = "(?=([^\"]*\"[^\"]*\")*[^\"]*$)";
 
-	private final static Logger log = LogManager.getLogger(CSVDataSource.class.getName());
+	private static final Logger log = LogManager.getLogger(CSVDataSource.class.getName());
 
 	public final static String DEFAULT_DELIMITER = ",";
 

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
@@ -22,7 +22,7 @@ import io.modelcontextprotocol.spec.McpSchema.Tool;
 @Component
 public class UniquenessTool implements McpTool {
 	
-	private final static Logger log = LogManager.getLogger(UniquenessTool.class.getName());
+	private static final Logger log = LogManager.getLogger(UniquenessTool.class.getName());
 
     private final Tool toolDefinition = Tool.builder("uniqueness_check",
                     Map.of(
@@ -45,7 +45,7 @@ public class UniquenessTool implements McpTool {
 
 	@Override
 	public CallToolResult apply(Map<String, Object> arguments) {
-		log.info("Calling MCP unquieness tool for {}", arguments);
+		log.info("Calling MCP uniqueness tool for {}", arguments);
 		String result = runUniqueness(arguments);
 
 		return CallToolResult.builder().content(List.of(TextContent.builder(result).build())).isError(false).build();


### PR DESCRIPTION
- Add query context to the SQL load-failure log in InMemorySQLDataSource
  instead of logging a bare exception object.
- Collapse MessagesFinder's header + per-class log spam into a single
  lazily-evaluated line reporting the count and the found classes.
- Fix "unquieness" typo in the UniquenessTool MCP log message.
- Standardize logger declarations to the canonical `private static final`
  modifier order across all modules.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013PmkVXZE4zWyT7p3csS46B