### PR TITLE
test: add lifecycle/fork timeouts and test-convention ArchUnit rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,15 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
   that shells out to `protoc` or streams a large data set) opts out with an
   explicit class- or method-level `@Timeout` carrying a comment that says why.
   Failsafe integration tests (`*IT`) do not inherit this limit, and ArchUnit
-  tests run on a separate engine that the JUnit timeout does not apply to.
+  tests run on a separate engine that the JUnit timeout does not apply to. Two
+  companion limits guard the rest of the fork: a looser
+  `junit.jupiter.execution.timeout.lifecycle.method.default` (**10 s**, **15 s**
+  under coverage) caps lifecycle methods (`@BeforeAll`/`@BeforeEach`/`@AfterEach`/
+  `@AfterAll`), whose shared one-time setup — e.g. `DBTest` booting an embedded
+  Derby database — is legitimately heavier than a test method but must still not
+  hang; and surefire's `forkedProcessTimeoutInSeconds` (**300 s**) kills a fork
+  that wedges outright (a deadlock or a non-daemon thread that never dies), which
+  a per-method JUnit timeout only reports after the fact and cannot interrupt.
 - **Architecture tests** (ArchUnit) run in every module as ordinary JUnit tests,
   under an `...architecture` test package (e.g.
   `io.github.adamw7.tools.data.architecture.DataArchitectureTest`). They analyse
@@ -181,7 +189,13 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
   prefix; public fields are `final`; and production code logs through log4j2
   (never `System.out`/`err`, `java.util.logging`, `printStackTrace`, or
   `System.exit`), with packages kept free of cycles. New code must satisfy these
-  rules or the module's test suite fails.
+  rules or the module's test suite fails. A companion
+  `TestConventionsArchitectureTest` in the same `...architecture` package
+  analyses only the *test* classes (via `ImportOption.OnlyIncludeTests`) and pins
+  conventions on the tests themselves: every `@Testable` method must live in a
+  `*Test` or `*IT` class so surefire/failsafe actually runs it, no test is
+  `@Disabled`, tests use JUnit 5 only (no JUnit 4 `org.junit` API), and no test
+  calls `Thread.sleep` (sleeping is slow and flaky — wait on a condition).
 - **MCP integration tests** are gated behind the `integration-tests` profile
   (defined in `data` and `code/context`) and exercise the MCP servers over
   streamable HTTP: `mvn -P integration-tests verify`. Test classes ending in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,13 +86,19 @@ paths.
   a **900-millisecond per-test timeout** (configured on the surefire plugin in the
   root `pom.xml`) — above the one-time cold-JVM warmup but low enough to catch a
   test doing real work — so keep unit tests fast; a genuinely heavier test opts
-  out with an explicit `@Timeout` and a comment explaining why.
+  out with an explicit `@Timeout` and a comment explaining why. A looser
+  **10-second lifecycle-method timeout** (15 s under coverage) covers heavier
+  shared setup like `@BeforeAll`, and surefire's **300-second
+  `forkedProcessTimeoutInSeconds`** kills a fork that hangs outright.
 - **Architecture tests** (ArchUnit) live in each module's `.architecture` test
   package and enforce package layering and coding rules — data-source contracts
   must not depend on their implementations, the uniqueness core must not depend
   on its MCP adapter, loggers are `private static final`, production code logs
   through log4j2 (no `System.out`/`err`, `printStackTrace`, or `System.exit`),
-  and packages stay free of cycles. Keep new code within these rules.
+  and packages stay free of cycles. A companion `TestConventionsArchitectureTest`
+  pins conventions on the tests themselves — test methods must sit in `*Test`/`*IT`
+  classes, no `@Disabled`, JUnit 5 only, and no `Thread.sleep`. Keep new code
+  within these rules.
 - **MCP integration tests** (`*IT`) are gated behind the `integration-tests`
   profile.
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/TestConventionsArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/TestConventionsArchitectureTest.java
@@ -1,0 +1,55 @@
+package io.github.adamw7.tools.enforcer.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
+
+import org.junit.jupiter.api.Disabled;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+/**
+ * Conventions enforced on the module's own test code, so the constraints that
+ * keep the unit suite fast and honest cannot be bypassed by how a test is
+ * written. Unlike the production architecture rules, this class analyses only
+ * the test classes via {@link ImportOption.OnlyIncludeTests}.
+ */
+@AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
+public class TestConventionsArchitectureTest {
+
+	static final String TEST_PACKAGE = "io.github.adamw7.tools.enforcer";
+
+	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
+
+	@ArchTest
+	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
+			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
+			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
+			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
+			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
+					+ "so a test method in a differently named class silently never runs");
+
+	@ArchTest
+	static final ArchRule noDisabledTestMethods = noMethods()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule noDisabledTestClasses = noClasses()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule testsUseJunit5 = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("org.junit")
+			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
+
+	@ArchTest
+	static final ArchRule testsDoNotSleep = noClasses()
+			.should().callMethod(Thread.class, "sleep", long.class)
+			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
+			.because("a test that sleeps is slow and flaky; wait on a condition instead");
+}

--- a/code/context/src/test/java/io/github/adamw7/context/architecture/TestConventionsArchitectureTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/architecture/TestConventionsArchitectureTest.java
@@ -1,0 +1,55 @@
+package io.github.adamw7.context.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
+
+import org.junit.jupiter.api.Disabled;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+/**
+ * Conventions enforced on the module's own test code, so the constraints that
+ * keep the unit suite fast and honest cannot be bypassed by how a test is
+ * written. Unlike the production architecture rules, this class analyses only
+ * the test classes via {@link ImportOption.OnlyIncludeTests}.
+ */
+@AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
+public class TestConventionsArchitectureTest {
+
+	static final String TEST_PACKAGE = "io.github.adamw7.context";
+
+	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
+
+	@ArchTest
+	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
+			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
+			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
+			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
+			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
+					+ "so a test method in a differently named class silently never runs");
+
+	@ArchTest
+	static final ArchRule noDisabledTestMethods = noMethods()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule noDisabledTestClasses = noClasses()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule testsUseJunit5 = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("org.junit")
+			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
+
+	@ArchTest
+	static final ArchRule testsDoNotSleep = noClasses()
+			.should().callMethod(Thread.class, "sleep", long.class)
+			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
+			.because("a test that sleeps is slow and flaky; wait on a condition instead");
+}

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/TestConventionsArchitectureTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/TestConventionsArchitectureTest.java
@@ -1,0 +1,55 @@
+package io.github.adamw7.tools.code.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
+
+import org.junit.jupiter.api.Disabled;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+/**
+ * Conventions enforced on the module's own test code, so the constraints that
+ * keep the unit suite fast and honest cannot be bypassed by how a test is
+ * written. Unlike the production architecture rules, this class analyses only
+ * the test classes via {@link ImportOption.OnlyIncludeTests}.
+ */
+@AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
+public class TestConventionsArchitectureTest {
+
+	static final String TEST_PACKAGE = "io.github.adamw7.tools.code";
+
+	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
+
+	@ArchTest
+	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
+			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
+			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
+			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
+			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
+					+ "so a test method in a differently named class silently never runs");
+
+	@ArchTest
+	static final ArchRule noDisabledTestMethods = noMethods()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule noDisabledTestClasses = noClasses()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule testsUseJunit5 = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("org.junit")
+			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
+
+	@ArchTest
+	static final ArchRule testsDoNotSleep = noClasses()
+			.should().callMethod(Thread.class, "sleep", long.class)
+			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
+			.because("a test that sleeps is slow and flaky; wait on a condition instead");
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/TestConventionsArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/TestConventionsArchitectureTest.java
@@ -1,0 +1,55 @@
+package io.github.adamw7.tools.data.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
+
+import org.junit.jupiter.api.Disabled;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+/**
+ * Conventions enforced on the module's own test code, so the constraints that
+ * keep the unit suite fast and honest cannot be bypassed by how a test is
+ * written. Unlike the production architecture rules, this class analyses only
+ * the test classes via {@link ImportOption.OnlyIncludeTests}.
+ */
+@AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
+public class TestConventionsArchitectureTest {
+
+	static final String TEST_PACKAGE = "io.github.adamw7.tools.data";
+
+	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
+
+	@ArchTest
+	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
+			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
+			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
+			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
+			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
+					+ "so a test method in a differently named class silently never runs");
+
+	@ArchTest
+	static final ArchRule noDisabledTestMethods = noMethods()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule noDisabledTestClasses = noClasses()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule testsUseJunit5 = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("org.junit")
+			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
+
+	@ArchTest
+	static final ArchRule testsDoNotSleep = noClasses()
+			.should().callMethod(Thread.class, "sleep", long.class)
+			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
+			.because("a test that sleeps is slow and flaky; wait on a condition instead");
+}

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/TestConventionsArchitectureTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/TestConventionsArchitectureTest.java
@@ -1,0 +1,55 @@
+package io.github.adamw7.tools.mcp.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
+
+import org.junit.jupiter.api.Disabled;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+/**
+ * Conventions enforced on the module's own test code, so the constraints that
+ * keep the unit suite fast and honest cannot be bypassed by how a test is
+ * written. Unlike the production architecture rules, this class analyses only
+ * the test classes via {@link ImportOption.OnlyIncludeTests}.
+ */
+@AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
+public class TestConventionsArchitectureTest {
+
+	static final String TEST_PACKAGE = "io.github.adamw7.tools.mcp";
+
+	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
+
+	@ArchTest
+	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
+			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
+			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
+			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
+			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
+					+ "so a test method in a differently named class silently never runs");
+
+	@ArchTest
+	static final ArchRule noDisabledTestMethods = noMethods()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule noDisabledTestClasses = noClasses()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule testsUseJunit5 = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("org.junit")
+			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
+
+	@ArchTest
+	static final ArchRule testsDoNotSleep = noClasses()
+			.should().callMethod(Thread.class, "sleep", long.class)
+			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
+			.because("a test that sleeps is slow and flaky; wait on a condition instead");
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,21 @@
 		     larger value because the JaCoCo agent's bytecode instrumentation roughly
 		     doubles first-use class-loading time. -->
 		<unit.test.method.timeout>900 ms</unit.test.method.timeout>
+		<!-- Companion limit for lifecycle methods (@BeforeAll/@BeforeEach/@AfterEach/
+		     @AfterAll). Deliberately far looser than the per-test method timeout:
+		     lifecycle methods legitimately do shared, one-time setup that a test
+		     method must not (e.g. DBTest boots an embedded Derby database and loads
+		     fixtures, ~2s on a cold fork). This still fails a fixture that is truly
+		     stuck (deadlock, infinite retry) rather than merely heavy; a total hang
+		     that never returns is caught by forkedProcessTimeoutInSeconds. The
+		     coverage profile raises it because JaCoCo instrumentation slows setup. -->
+		<unit.test.lifecycle.timeout>10 s</unit.test.lifecycle.timeout>
+		<!-- Whole-fork wall-clock cap (seconds). JUnit's per-method timeout only
+		     reports after a method returns; it cannot unwedge a thread that never
+		     yields (deadlock, non-daemon thread that never dies). Surefire kills the
+		     forked JVM after this many seconds, so a genuinely hung test still fails
+		     the build. Sized far above a full module's fast unit run. -->
+		<unit.test.fork.timeout>300</unit.test.fork.timeout>
 		<!-- Maven Central publishing behavior for the release profile. Defaults
 		     publish on release; overridable so the maven-publish.yml
 		     workflow_dispatch dry run can upload and validate without
@@ -270,9 +285,11 @@
 						     byte-buddy self-attach is not billed to the first timed
 						     method. The coverage profile raises the limit because
 						     JaCoCo instrumentation slows the timed methods. -->
+						<forkedProcessTimeoutInSeconds>${unit.test.fork.timeout}</forkedProcessTimeoutInSeconds>
 						<properties>
 							<configurationParameters>
 								junit.jupiter.execution.timeout.testable.method.default = ${unit.test.method.timeout}
+								junit.jupiter.execution.timeout.lifecycle.method.default = ${unit.test.lifecycle.timeout}
 							</configurationParameters>
 						</properties>
 					</configuration>
@@ -598,8 +615,9 @@
 			<properties>
 				<!-- JaCoCo's bytecode instrumentation roughly doubles the time a
 				     timed test method spends loading classes on first use, so give
-				     the per-test timeout extra headroom under coverage. -->
+				     the per-test timeouts extra headroom under coverage. -->
 				<unit.test.method.timeout>2 s</unit.test.method.timeout>
+				<unit.test.lifecycle.timeout>15 s</unit.test.lifecycle.timeout>
 			</properties>
 			<build>
 				<plugins>


### PR DESCRIPTION
Extend the unit-test constraints beyond the existing per-test method
timeout.

Timeouts (root pom surefire config):
- junit.jupiter.execution.timeout.lifecycle.method.default caps
  @BeforeAll/@BeforeEach/@AfterEach/@AfterAll at 10s (15s under
  coverage) — looser than the per-test cap because shared one-time
  setup (e.g. DBTest booting embedded Derby) is legitimately heavier.
- forkedProcessTimeoutInSeconds (300s) kills a fork that hangs
  outright, which a per-method JUnit timeout can only report after the
  fact and cannot interrupt.

Test conventions (new TestConventionsArchitectureTest per module,
analysing only test classes via ImportOption.OnlyIncludeTests):
- @Testable methods must live in *Test/*IT classes so surefire/failsafe
  actually run them.
- no @Disabled tests.
- JUnit 5 only (no JUnit 4 org.junit API).
- no Thread.sleep in tests.

Document both in AGENTS.md and CLAUDE.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FkAF1naS1YvvKgjw2MQjNd