### PR TITLE
test(data): run unit tests with the network kill-switch engaged

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,20 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
   hang; and surefire's `forkedProcessTimeoutInSeconds` (**300 s**) kills a fork
   that wedges outright (a deadlock or a non-daemon thread that never dies), which
   a per-method JUnit timeout only reports after the fact and cannot interrupt.
+- **Unit tests run with the network off.** So that a unit test can never open an
+  outbound connection (deliberately or by accident), the `data` module registers
+  a `NetworkOffExtension` — a JUnit `BeforeAllCallback` discovered through
+  `META-INF/services` and JUnit's extension auto-detection — that calls
+  `Switch.off()` before any test runs, engaging the network kill-switch described
+  under *Network kill-switch* in the README. Both the auto-detection
+  (`junit.jupiter.extensions.autodetection.enabled`) and the
+  `tools.test.network.off` guard property are set only on the surefire plugin in
+  the root `pom.xml`, so the `data` failsafe integration tests (`*IT`), which need
+  real network, are unaffected. Because `ServiceLoader` ignores `META-INF/services`
+  for a named JPMS module, the `data` module runs its unit tests from the
+  classpath (`<useModulePath>false</useModulePath>` on surefire); the published
+  `data` artifact stays a proper module. A `NetworkOffDuringUnitTestsTest`
+  verifies the switch is already engaged by the time a unit test executes.
 - **Architecture tests** (ArchUnit) run in every module as ordinary JUnit tests,
   under an `...architecture` test package (e.g.
   `io.github.adamw7.tools.data.architecture.DataArchitectureTest`). They analyse

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,10 @@ paths.
   **10-second lifecycle-method timeout** (15 s under coverage) covers heavier
   shared setup like `@BeforeAll`, and surefire's **300-second
   `forkedProcessTimeoutInSeconds`** kills a fork that hangs outright.
+- **Unit tests run with the network off.** The `data` module's
+  `NetworkOffExtension` engages the `Switch` kill-switch before any test runs, so
+  a unit test can never open an outbound connection; the failsafe `*IT` tests are
+  unaffected. See *Testing* in AGENTS.md.
 - **Architecture tests** (ArchUnit) live in each module's `.architecture` test
   package and enforce package layering and coding rules — data-source contracts
   must not depend on their implementations, the uniqueness core must not depend

--- a/README.md
+++ b/README.md
@@ -686,8 +686,13 @@ any subsequent attempt to open an outbound connection fails fast. The method is:
   `volatile` flag; calling it again is a no-op that logs a warning and returns
   `false`.
   
-The switch can be used for example if there is a need to make sure no network connections
-are open while running unit tests.
+The switch is wired into the `data` module's unit-test run for exactly this
+reason: a `NetworkOffExtension` (a JUnit `BeforeAllCallback` discovered through
+`META-INF/services` and JUnit's extension auto-detection) calls `Switch.off()`
+before any unit test runs, so a unit test can never open an outbound connection.
+Auto-detection and the `tools.test.network.off` guard property are set only on
+surefire, so the failsafe integration tests (`*IT`), which need real network, keep
+it. See *Testing* in [AGENTS.md](AGENTS.md) for the details.
 
 ## Architecture tests (ArchUnit)
 

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -28,7 +28,13 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<argLine>@{argLine} --add-reads datamodule=ALL-UNNAMED</argLine>
+					<!-- Run unit tests from the classpath, not the module path, so the
+					     NetworkOffExtension registered through META-INF/services is
+					     discovered by JUnit's extension auto-detection. ServiceLoader
+					     ignores META-INF/services for a named module, and surefire
+					     otherwise patches the test classes into the datamodule module. -->
+					<argLine>@{argLine}</argLine>
+					<useModulePath>false</useModulePath>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/data/src/test/java/io/github/adamw7/tools/data/network/NetworkOffDuringUnitTestsTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/network/NetworkOffDuringUnitTestsTest.java
@@ -1,0 +1,31 @@
+package io.github.adamw7.tools.data.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.ProxySelector;
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Proves that the {@link NetworkOffExtension} really engaged the kill-switch for
+ * the unit-test run: by the time any unit test executes, the network is already
+ * off, so this test does not call {@link Switch#off()} itself. The test is gated
+ * on the {@code tools.test.network.off} property so it only asserts the guarantee
+ * where it is expected to hold — the surefire build — and is simply skipped when a
+ * developer runs a single test from an IDE without that property.
+ */
+@EnabledIfSystemProperty(named = "tools.test.network.off", matches = "true")
+public class NetworkOffDuringUnitTestsTest {
+
+	@Test
+	public void networkIsAlreadyOffBeforeTheTestRuns() {
+		UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
+				() -> ProxySelector.getDefault().select(URI.create("http://192.0.2.1")),
+				"The kill-switch should have blocked proxy selection before the test ran");
+
+		assertEquals("The network is off", thrown.getMessage());
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/network/NetworkOffExtension.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/network/NetworkOffExtension.java
@@ -1,0 +1,34 @@
+package io.github.adamw7.tools.data.network;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Engages the {@link Switch} network kill-switch before any unit test runs, so a
+ * unit test can never open an outbound connection. The extension is discovered
+ * automatically (JUnit Jupiter extension auto-detection, registered through
+ * {@code META-INF/services}) and enabled only for the surefire unit-test run:
+ * failsafe leaves auto-detection off, so the MCP {@code *IT} integration tests
+ * that need real network are unaffected. The {@code tools.test.network.off}
+ * system property — set by surefire, absent under failsafe — is a second guard
+ * so the kill-switch stays off unless the unit-test run explicitly asked for it.
+ */
+public class NetworkOffExtension implements BeforeAllCallback {
+
+	private static final String NETWORK_OFF_PROPERTY = "tools.test.network.off";
+
+	private static volatile boolean engaged = false;
+
+	/**
+	 * Runs before every test class, but engages the kill-switch only once per fork:
+	 * {@link Switch#off()} is idempotent and would otherwise log an "already off"
+	 * warning for every class after the first.
+	 */
+	@Override
+	public void beforeAll(ExtensionContext context) {
+		if (!engaged && Boolean.getBoolean(NETWORK_OFF_PROPERTY)) {
+			Switch.off();
+			engaged = true;
+		}
+	}
+}

--- a/data/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/data/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+io.github.adamw7.tools.data.network.NetworkOffExtension

--- a/pom.xml
+++ b/pom.xml
@@ -286,10 +286,21 @@
 						     method. The coverage profile raises the limit because
 						     JaCoCo instrumentation slows the timed methods. -->
 						<forkedProcessTimeoutInSeconds>${unit.test.fork.timeout}</forkedProcessTimeoutInSeconds>
+						<!-- Engage the network kill-switch for every unit test: the
+						     data module registers a NetworkOffExtension via
+						     META-INF/services that turns the network off before any
+						     test runs, so a unit test can never open an outbound
+						     connection. Auto-detection and the guard property are set
+						     only here on surefire, so failsafe integration tests (*IT),
+						     which need real network, keep it. -->
+						<systemPropertyVariables>
+							<tools.test.network.off>true</tools.test.network.off>
+						</systemPropertyVariables>
 						<properties>
 							<configurationParameters>
 								junit.jupiter.execution.timeout.testable.method.default = ${unit.test.method.timeout}
 								junit.jupiter.execution.timeout.lifecycle.method.default = ${unit.test.lifecycle.timeout}
+								junit.jupiter.extensions.autodetection.enabled = true
 							</configurationParameters>
 						</properties>
 					</configuration>


### PR DESCRIPTION
Wire the existing Switch network kill-switch into the unit-test run so a
unit test can never open an outbound connection. A NetworkOffExtension
(a JUnit BeforeAllCallback discovered via META-INF/services and JUnit's
extension auto-detection) calls Switch.off() once before any test runs.

Auto-detection and the tools.test.network.off guard property are set only
on the surefire plugin in the root pom, so the failsafe *IT integration
tests, which need real network, are unaffected. Because ServiceLoader
ignores META-INF/services for a named JPMS module, the data module runs
its unit tests from the classpath (useModulePath=false); the published
data artifact stays a proper module.

NetworkOffDuringUnitTestsTest verifies the switch is already engaged by
the time a unit test executes. Docs updated in README/AGENTS.md/CLAUDE.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W2Frz2761FJeVtiheiF4N8