### PR TITLE
perf(data): drop per-row boxing in uniqueness key scan

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
@@ -41,7 +41,7 @@ public abstract class AbstractUniqueness<T extends ColumnarDataSource> implement
 				.toArray(String[]::new);
 	}
 
-	protected Integer[] getIndiciesOf(String[] keyCandidates, String[] allColumns) {
+	protected int[] getIndiciesOf(String[] keyCandidates, String[] allColumns) {
 		List<Integer> indicies = new ArrayList<>();
 
 		for (int i = 0; i < allColumns.length; ++i) {
@@ -52,7 +52,11 @@ public abstract class AbstractUniqueness<T extends ColumnarDataSource> implement
 			}
 		}
 
-		return indicies.toArray(new Integer[keyCandidates.length]);
+		int[] result = new int[indicies.size()];
+		for (int i = 0; i < result.length; ++i) {
+			result[i] = indicies.get(i);
+		}
+		return result;
 	}
 	
 	protected void check(String[] keyCandidates) {

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/InMemoryUniquenessCheck.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/InMemoryUniquenessCheck.java
@@ -16,11 +16,11 @@ public class InMemoryUniquenessCheck extends AbstractUniqueness<InMemoryDataSour
 		dataSource.open();
 		checkIfCandidatesExistIn(keyCandidates, dataSource.getColumnNames());
 
-		Integer[] indices = getIndiciesOf(keyCandidates, dataSource.getColumnNames());
+		int[] indices = getIndiciesOf(keyCandidates, dataSource.getColumnNames());
 		return findUnique(indices, keyCandidates);
 	}
 
-	private Result findUnique(Integer[] indices, String... keyCandidates) {
+	private Result findUnique(int[] indices, String... keyCandidates) {
 		dataSource.reset();
 		List<String[]> data = dataSource.readAll();
 		close(dataSource);
@@ -36,7 +36,7 @@ public class InMemoryUniquenessCheck extends AbstractUniqueness<InMemoryDataSour
 
 	@Override
 	protected Result checkSubset(String[] newCandidates) {
-		Integer[] indices = getIndiciesOf(newCandidates, dataSource.getColumnNames());
+		int[] indices = getIndiciesOf(newCandidates, dataSource.getColumnNames());
 		return findUnique(indices, newCandidates);
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/KeyFinder.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/KeyFinder.java
@@ -1,15 +1,14 @@
 package io.github.adamw7.tools.data.uniqueness;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 public class KeyFinder {
 
-	private final Integer[] indices;
+	private final int[] indices;
 	private final Set<Key> set = new HashSet<>();
 
-	public KeyFinder(Integer[] indices) {
+	public KeyFinder(int[] indices) {
 		this.indices = indices;
 	}
 
@@ -20,8 +19,11 @@ public class KeyFinder {
 		return !set.add(key(row, indices));
 	}
 
-	protected Key key(String[] row, Integer[] indices) {
-		String[] values = Arrays.stream(indices).map(index -> row[index]).toArray(String[]::new);
+	protected Key key(String[] row, int[] indices) {
+		String[] values = new String[indices.length];
+		for (int i = 0; i < indices.length; ++i) {
+			values[i] = row[indices[i]];
+		}
 		return new Key(values);
 	}
 

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
@@ -13,7 +13,7 @@ public class NoMemoryUniquenessCheck extends AbstractUniqueness<ColumnarDataSour
 		check(keyCandidates);
 		dataSource.open();
 		checkIfCandidatesExistIn(keyCandidates, dataSource.getColumnNames());
-		Integer[] indices = getIndiciesOf(keyCandidates, dataSource.getColumnNames());
+		int[] indices = getIndiciesOf(keyCandidates, dataSource.getColumnNames());
 		KeyFinder finder = new KeyFinder(indices);
 		while (dataSource.hasMoreData()) {
 			String[] row = dataSource.nextRow();

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/KeyFinderTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/KeyFinderTest.java
@@ -9,21 +9,21 @@ public class KeyFinderTest {
 
 	@Test
 	public void nullRowIsNeverFound() {
-		KeyFinder finder = new KeyFinder(new Integer[] { 0 });
+		KeyFinder finder = new KeyFinder(new int[] { 0 });
 
 		assertFalse(finder.found(null));
 	}
 
 	@Test
 	public void firstRowIsNotADuplicate() {
-		KeyFinder finder = new KeyFinder(new Integer[] { 0 });
+		KeyFinder finder = new KeyFinder(new int[] { 0 });
 
 		assertFalse(finder.found(new String[] { "a", "b" }));
 	}
 
 	@Test
 	public void repeatedRowIsADuplicate() {
-		KeyFinder finder = new KeyFinder(new Integer[] { 0 });
+		KeyFinder finder = new KeyFinder(new int[] { 0 });
 
 		finder.found(new String[] { "a", "b" });
 
@@ -32,7 +32,7 @@ public class KeyFinderTest {
 
 	@Test
 	public void onlyConfiguredColumnsFormTheKey() {
-		KeyFinder finder = new KeyFinder(new Integer[] { 0 });
+		KeyFinder finder = new KeyFinder(new int[] { 0 });
 
 		finder.found(new String[] { "a", "b" });
 
@@ -41,7 +41,7 @@ public class KeyFinderTest {
 
 	@Test
 	public void differenceInUncheckedColumnDoesNotCollideOnCheckedColumn() {
-		KeyFinder finder = new KeyFinder(new Integer[] { 1 });
+		KeyFinder finder = new KeyFinder(new int[] { 1 });
 
 		finder.found(new String[] { "a", "b" });
 
@@ -50,7 +50,7 @@ public class KeyFinderTest {
 
 	@Test
 	public void multiColumnKeyMatchesOnAllConfiguredColumns() {
-		KeyFinder finder = new KeyFinder(new Integer[] { 0, 2 });
+		KeyFinder finder = new KeyFinder(new int[] { 0, 2 });
 
 		finder.found(new String[] { "a", "b", "c" });
 
@@ -59,7 +59,7 @@ public class KeyFinderTest {
 
 	@Test
 	public void multiColumnKeyDiffersWhenAnyConfiguredColumnDiffers() {
-		KeyFinder finder = new KeyFinder(new Integer[] { 0, 2 });
+		KeyFinder finder = new KeyFinder(new int[] { 0, 2 });
 
 		finder.found(new String[] { "a", "b", "c" });
 
@@ -68,7 +68,7 @@ public class KeyFinderTest {
 
 	@Test
 	public void distinctRowsAreNotDuplicates() {
-		KeyFinder finder = new KeyFinder(new Integer[] { 0 });
+		KeyFinder finder = new KeyFinder(new int[] { 0 });
 
 		assertFalse(finder.found(new String[] { "a" }));
 		assertFalse(finder.found(new String[] { "b" }));
@@ -77,9 +77,9 @@ public class KeyFinderTest {
 
 	@Test
 	public void keyProjectsConfiguredColumnsInOrder() {
-		KeyFinder finder = new KeyFinder(new Integer[] { 2, 0 });
+		KeyFinder finder = new KeyFinder(new int[] { 2, 0 });
 
-		Key key = finder.key(new String[] { "x", "y", "z" }, new Integer[] { 2, 0 });
+		Key key = finder.key(new String[] { "x", "y", "z" }, new int[] { 2, 0 });
 
 		assertTrue(key.equals(new Key(new String[] { "z", "x" })));
 	}


### PR DESCRIPTION
The uniqueness checks call KeyFinder.found once per row over the whole
dataset, and KeyFinder.key built each key via
Arrays.stream(indices).map(...).toArray(). With indices held as Integer[],
every row paid a Stream setup, a lambda dispatch, and an Integer unbox per
projected column on the hottest loop of the scan.

Hold column indices as a primitive int[] end to end (getIndiciesOf,
KeyFinder) and project the key with a plain indexed loop. This removes the
per-row stream allocation and the per-column unboxing while preserving the
exact projection order and duplicate-detection behavior.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013DucDNzxMnkS6usPEsm6dw