### PR TITLE
test(data): verify documented thread-safety claims for Switch and structures

### DIFF
--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
@@ -3,7 +3,9 @@ package io.github.adamw7.tools.data.architecture;
 import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 import java.io.PrintStream;
@@ -37,6 +39,8 @@ public class DataArchitectureTest {
 	private static final String DB_PACKAGE = "..source.db..";
 	private static final String MCP_PACKAGE = "..uniqueness.mcp..";
 	private static final String UNIQUENESS_PACKAGE = "..uniqueness..";
+	private static final String NETWORK_PACKAGE = "..network..";
+	private static final String CONCURRENT_PACKAGE = "java.util.concurrent..";
 
 	@ArchTest
 	static final ArchRule interfacesDoNotDependOnImplementations = noClasses()
@@ -107,6 +111,36 @@ public class DataArchitectureTest {
 			.that().resideInAPackage(STRUCTURE_PACKAGE)
 			.should().dependOnClassesThat().resideInAnyPackage("..source..", "..network..", "..compression..")
 			.because("the structure package is a reusable collections library and must not couple to data sources");
+
+	@ArchTest
+	static final ArchRule dataStructuresDeclareNoSynchronizedMethods = noMethods()
+			.that().areDeclaredInClassesThat().resideInAPackage(STRUCTURE_PACKAGE)
+			.should().haveModifier(JavaModifier.SYNCHRONIZED)
+			.because("the open-addressing structures are documented as not thread-safe; a synchronized "
+					+ "method would silently contradict that contract");
+
+	@ArchTest
+	static final ArchRule dataStructuresUseNoConcurrencyUtilities = noClasses()
+			.that().resideInAPackage(STRUCTURE_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage(CONCURRENT_PACKAGE)
+			.because("the structures make no thread-safety provisions, so a java.util.concurrent "
+					+ "dependency would misleadingly suggest they are safe to share across threads");
+
+	@ArchTest
+	static final ArchRule networkSwitchGuardsWithSynchronization = methods()
+			.that().haveName("off")
+			.and().areDeclaredInClassesThat().resideInAPackage(NETWORK_PACKAGE)
+			.should().haveModifier(JavaModifier.SYNCHRONIZED)
+			.because("Switch.off() is documented as synchronized so concurrent callers cannot race "
+					+ "while installing the blocking proxy selector");
+
+	@ArchTest
+	static final ArchRule networkSwitchFlagIsVolatile = fields()
+			.that().haveName("isOff")
+			.and().areDeclaredInClassesThat().resideInAPackage(NETWORK_PACKAGE)
+			.should().haveModifier(JavaModifier.VOLATILE)
+			.because("Switch is documented as guarded by a volatile flag so its off state publishes "
+					+ "across threads without further locking");
 
 	@ArchTest
 	static final ArchRule uniquenessCoreDoesNotDependOnMcpAdapter = noClasses()

--- a/data/src/test/java/io/github/adamw7/tools/data/network/SwitchThreadSafetyTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/network/SwitchThreadSafetyTest.java
@@ -1,0 +1,86 @@
+package io.github.adamw7.tools.data.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.ProxySelector;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Verifies the thread-safety guarantee documented for {@link Switch}: that
+ * {@link Switch#off()} is safe to call concurrently and idempotent. The one-way,
+ * process-global flag is already off by the time any unit test runs (the
+ * {@link NetworkOffExtension} engages it first), so this test cannot observe the
+ * one-time {@code true} return. Instead it engages the switch itself and then
+ * hammers {@code off()} from many threads released together, proving that every
+ * concurrent call is a consistent, exception-free no-op that returns {@code false}
+ * and leaves the network sealed.
+ */
+public class SwitchThreadSafetyTest {
+
+	private static final int THREADS = 16;
+
+	/**
+	 * Opts out of the 900 ms per-test timeout: spinning up and joining a pool of
+	 * threads to force real contention is heavier than a plain unit test, though it
+	 * still completes in well under a second.
+	 */
+	@Test
+	@Timeout(value = 10, unit = TimeUnit.SECONDS)
+	public void concurrentOffCallsAreSafeAndIdempotent() throws InterruptedException, ExecutionException {
+		Switch.off(); // engage the one-way switch before the concurrent burst
+
+		ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+		try {
+			CyclicBarrier startLine = new CyclicBarrier(THREADS);
+			List<Future<Boolean>> results = submitConcurrentOffCalls(pool, startLine);
+			assertEveryCallIsANoOp(results);
+		} finally {
+			pool.shutdownNow();
+		}
+
+		assertNetworkStaysOff();
+	}
+
+	private List<Future<Boolean>> submitConcurrentOffCalls(ExecutorService pool, CyclicBarrier startLine) {
+		List<Future<Boolean>> results = new ArrayList<>(THREADS);
+		for (int i = 0; i < THREADS; ++i) {
+			results.add(pool.submit(offAfterBarrier(startLine)));
+		}
+		return results;
+	}
+
+	private Callable<Boolean> offAfterBarrier(CyclicBarrier startLine) {
+		return () -> {
+			startLine.await();
+			return Switch.off();
+		};
+	}
+
+	private void assertEveryCallIsANoOp(List<Future<Boolean>> results)
+			throws InterruptedException, ExecutionException {
+		for (Future<Boolean> result : results) {
+			assertFalse(result.get(), "off() must be a no-op once the switch is already engaged");
+		}
+	}
+
+	private void assertNetworkStaysOff() {
+		UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
+				() -> ProxySelector.getDefault().select(URI.create("http://192.0.2.1")),
+				"the switch must keep the network off after concurrent calls");
+		assertEquals("The network is off", thrown.getMessage());
+	}
+}


### PR DESCRIPTION
Add checks that confirm the "(not) thread-safe" guarantees documented in the
README and Javadoc actually hold in the bytecode and at runtime.

SwitchThreadSafetyTest engages the one-way kill-switch and then hammers
Switch.off() from a pool of threads released together, proving the documented
thread-safe/idempotent contract: every concurrent call is an exception-free
no-op returning false, and the network stays sealed afterwards. It opts out of
the 900ms per-test timeout via @Timeout with a comment, since spinning up a
thread pool is heavier than a plain unit test.

Four ArchUnit rules verify the mechanisms deterministically:
- the open-addressing structures declare no synchronized methods and pull in no
  java.util.concurrent types, so the "not thread-safe" contract stays honest;
- Switch.off() is synchronized and its isOff flag is volatile, matching the
  documented "synchronized and guarded by a volatile flag".

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MJqZjkRqpAJ94JuFCRStVV