### PR TITLE
perf(data): hoist invariant double-hashing work out of the probe loop

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
@@ -87,8 +87,9 @@ public class IntKeyOpenAddressingMap<V> {
 	 * may sit past them in the probe chain.
 	 */
 	private int indexOf(int key) {
+		DoubleHashing.Probe probe = probe(key);
 		for (int i = 0; i < keys.length; ++i) {
-			int index = hash(key, i);
+			int index = probe.slot(i);
 			if (state[index] == EMPTY) {
 				return -1;
 			}
@@ -99,14 +100,15 @@ public class IntKeyOpenAddressingMap<V> {
 		return -1;
 	}
 
-	private int hash(int key, int iteration) {
-		return DoubleHashing.probe(Integer.hashCode(key), prime, keys.length, iteration);
+	private DoubleHashing.Probe probe(int key) {
+		return DoubleHashing.sequence(Integer.hashCode(key), prime, keys.length);
 	}
 
 	public V put(int key, V value) {
 		checkIfResizeNeeded();
+		DoubleHashing.Probe probe = probe(key);
 		for (int i = 0; i < keys.length; ++i) {
-			int index = hash(key, i);
+			int index = probe.slot(i);
 			if (state[index] == EMPTY) {
 				return insert(index, key, value);
 			} else if (state[index] == LIVE && keys[index] == key) {

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -68,8 +68,9 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 	 * treated as terminal, because live entries may sit past them.
 	 */
 	private Wrapper<K, V> find(Object key) {
+		DoubleHashing.Probe probe = probe(key);
 		for (int i = 0; i < array.length; ++i) {
-			Wrapper<K, V> wrapper = array[hash(key, i)];
+			Wrapper<K, V> wrapper = array[probe.slot(i)];
 			if (wrapper == null) {
 				return null;
 			}
@@ -80,18 +81,19 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 		return null;
 	}
 
-	private int hash(Object key, int iteration) {
+	private DoubleHashing.Probe probe(Object key) {
 		if (key == null) {
 			throw new IllegalArgumentException("Key is null");
 		}
-		return DoubleHashing.probe(key.hashCode(), prime, array.length, iteration);
+		return DoubleHashing.sequence(key.hashCode(), prime, array.length);
 	}
 
 	@Override
 	public V put(K key, V value) {
 		checkIfResizeNeeded();
+		DoubleHashing.Probe probe = probe(key);
 		for (int i = 0; i < array.length; ++i) {
-			int hash = hash(key, i);
+			int hash = probe.slot(i);
 			Wrapper<K, V> wrapper = array[hash];
 			if (wrapper == null) {
 				return insert(hash, key, value);

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/internal/DoubleHashing.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/internal/DoubleHashing.java
@@ -46,15 +46,53 @@ public final class DoubleHashing {
 	/**
 	 * The slot index probed on the given {@code iteration} of the sequence.
 	 *
-	 * <p>The step {@code h2} is derived from {@code Math.abs(hashCode % (length - 1))}
-	 * rather than {@code Math.abs(hashCode) % (length - 1)}: the two agree for every
-	 * {@code hashCode} except {@link Integer#MIN_VALUE}, whose {@code Math.abs} stays
-	 * negative and would otherwise yield a non-positive step that folds the probe
-	 * sequence back onto a handful of slots.
+	 * <p>Equivalent to {@code sequence(hashCode, prime, length).slot(iteration)};
+	 * kept as a convenience for callers that need a single, isolated index. Callers
+	 * that walk a whole probe chain should build one {@link Probe} and reuse it, so
+	 * the iteration-independent components are derived only once.
 	 */
 	public static int probe(int hashCode, int prime, int length, int iteration) {
-		int h1 = prime - (hashCode % prime);
-		int h2 = 1 + Math.abs(hashCode % (length - 1));
-		return Math.abs((h1 + (iteration * h2)) % length);
+		return sequence(hashCode, prime, length).slot(iteration);
+	}
+
+	/**
+	 * A reusable probe sequence for a single key. The two components that do not
+	 * depend on the iteration &mdash; the starting offset {@code h1} and the step
+	 * {@code h2} &mdash; are derived once here rather than on every probe, so a
+	 * lookup or insert that walks several slots pays for the key's {@code hashCode}
+	 * and the modulo arithmetic exactly once instead of once per probe.
+	 */
+	public static Probe sequence(int hashCode, int prime, int length) {
+		return new Probe(hashCode, prime, length);
+	}
+
+	/**
+	 * The iteration-independent state of a double-hashing probe sequence for one
+	 * key. Immutable and cheap to allocate; it does not escape the lookup or insert
+	 * that builds it, so the JIT can keep it on the stack.
+	 */
+	public static final class Probe {
+
+		private final int h1;
+		private final int h2;
+		private final int length;
+
+		/**
+		 * The step {@code h2} is derived from {@code Math.abs(hashCode % (length - 1))}
+		 * rather than {@code Math.abs(hashCode) % (length - 1)}: the two agree for every
+		 * {@code hashCode} except {@link Integer#MIN_VALUE}, whose {@code Math.abs} stays
+		 * negative and would otherwise yield a non-positive step that folds the probe
+		 * sequence back onto a handful of slots.
+		 */
+		private Probe(int hashCode, int prime, int length) {
+			this.h1 = prime - (hashCode % prime);
+			this.h2 = 1 + Math.abs(hashCode % (length - 1));
+			this.length = length;
+		}
+
+		/** The slot index probed on the given {@code iteration} of the sequence. */
+		public int slot(int iteration) {
+			return Math.abs((h1 + (iteration * h2)) % length);
+		}
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/DoubleHashingTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/DoubleHashingTest.java
@@ -67,6 +67,20 @@ public class DoubleHashingTest {
 	}
 
 	@Test
+	public void reusedSequenceMatchesTheStandaloneProbe() {
+		// The hot paths build one Probe per key and reuse it across the chain; each
+		// reused slot must equal the standalone probe for the same iteration.
+		int hashCode = 42;
+		int prime = 5;
+		int length = 11;
+		DoubleHashing.Probe probe = DoubleHashing.sequence(hashCode, prime, length);
+		for (int iteration = 0; iteration < length; iteration++) {
+			assertEquals(DoubleHashing.probe(hashCode, prime, length, iteration),
+					probe.slot(iteration));
+		}
+	}
+
+	@Test
 	public void probeStaysWithinTheTableForAnyHashCode() {
 		int length = 17;
 		int prime = 13;


### PR DESCRIPTION
The open-addressing maps recomputed the key's hashCode and the two
iteration-independent probe components (h1, h2) on every step of the
probe chain, since find/indexOf/put called hash(key, i) once per slot.

Introduce a reusable DoubleHashing.Probe that derives h1/h2 (and pays
for hashCode) once, then yields each slot via slot(iteration). Lookups
and inserts build one Probe per operation and reuse it across the chain,
so per-probe cost drops to a single add, multiply and modulo. The slot
formula is unchanged, so the probe order is bit-identical to before.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017DfrwtDuwZ1hq1EkJuh51d