### PR TITLE
harden claude-code-enforcer against ReDoS and symlink escapes

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/BoundedCharSequence.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/BoundedCharSequence.java
@@ -1,0 +1,58 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+/**
+ * A read-only {@link CharSequence} view that counts every character the regular
+ * expression engine reads and aborts once a step budget is exceeded. A
+ * catastrophically backtracking pattern reads characters an exponential number
+ * of times, so wrapping the match input in this sequence turns a build-hanging
+ * ReDoS into a prompt {@link BacktrackLimitExceededException} that the caller can
+ * report as a violation instead of letting the build thread spin.
+ * <p>
+ * The step counter is shared with every {@link #subSequence} view, so group
+ * extraction cannot reset the budget. {@link #toString} does not count, so a
+ * captured group's text can be materialised without spending the budget.
+ */
+final class BoundedCharSequence implements CharSequence {
+
+	/** Signals that a match read more characters than its budget allowed. */
+	static final class BacktrackLimitExceededException extends RuntimeException {
+		private static final long serialVersionUID = 1L;
+	}
+
+	private final CharSequence content;
+	private final long maxSteps;
+	private final long[] steps;
+
+	BoundedCharSequence(CharSequence content, long maxSteps) {
+		this(content, maxSteps, new long[1]);
+	}
+
+	private BoundedCharSequence(CharSequence content, long maxSteps, long[] steps) {
+		this.content = content;
+		this.maxSteps = maxSteps;
+		this.steps = steps;
+	}
+
+	@Override
+	public int length() {
+		return content.length();
+	}
+
+	@Override
+	public char charAt(int index) {
+		if (++steps[0] > maxSteps) {
+			throw new BacktrackLimitExceededException();
+		}
+		return content.charAt(index);
+	}
+
+	@Override
+	public CharSequence subSequence(int start, int end) {
+		return new BoundedCharSequence(content.subSequence(start, end), maxSteps, steps);
+	}
+
+	@Override
+	public String toString() {
+		return content.toString();
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
@@ -8,6 +8,8 @@ import java.util.regex.Pattern;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
+import io.github.adamw7.tools.enforcer.doc.BoundedCharSequence.BacktrackLimitExceededException;
+
 /**
  * Compares two named documents against a list of single-group regular
  * expressions and reports where a captured value differs. Shared by
@@ -23,6 +25,15 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
  * {@code requireInBoth} flag passed to {@link #violations}.
  */
 final class DocumentConsistency {
+
+	/**
+	 * Per-character budget granted to a single {@code find} relative to the
+	 * document length, plus a flat floor so short documents still get room. A
+	 * linear pattern reads each character a small constant number of times and
+	 * stays well within this; only exponential backtracking blows past it.
+	 */
+	private static final long STEPS_PER_CHARACTER = 10_000L;
+	private static final long MINIMUM_STEPS = 1_000_000L;
 
 	/** A document to compare: its content, and the name shown in violation messages. */
 	record Document(String name, String content) {
@@ -67,6 +78,16 @@ final class DocumentConsistency {
 	private void collect(String pattern, Document first, Document second, boolean requireInBoth,
 			List<String> violations) {
 		Pattern compiled = Pattern.compile(pattern);
+		try {
+			collectCapturedMismatch(pattern, compiled, first, second, requireInBoth, violations);
+		} catch (BacktrackLimitExceededException e) {
+			violations.add("pattern '" + pattern
+					+ "' could not be evaluated within its backtracking budget (possible catastrophic backtracking)");
+		}
+	}
+
+	private void collectCapturedMismatch(String pattern, Pattern compiled, Document first, Document second,
+			boolean requireInBoth, List<String> violations) {
 		Optional<String> firstValue = capture(compiled, first.content());
 		Optional<String> secondValue = capture(compiled, second.content());
 		if (isIgnored(firstValue, secondValue, requireInBoth)) {
@@ -103,7 +124,11 @@ final class DocumentConsistency {
 	}
 
 	private Optional<String> capture(Pattern pattern, String content) {
-		Matcher matcher = pattern.matcher(content);
+		Matcher matcher = pattern.matcher(new BoundedCharSequence(content, stepBudget(content)));
 		return matcher.find() ? Optional.ofNullable(matcher.group(1)) : Optional.empty();
+	}
+
+	private long stepBudget(String content) {
+		return Math.max(MINIMUM_STEPS, (long) content.length() * STEPS_PER_CHARACTER);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -1,6 +1,9 @@
 package io.github.adamw7.tools.enforcer.settings;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -152,7 +155,7 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 		if (script == null) {
 			return;
 		}
-		referenced.add(script.normalize());
+		referenced.add(script);
 		if (!script.toFile().exists()) {
 			violations.add("settings.json references a missing hook script: " + script);
 		}
@@ -168,14 +171,14 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private void addUnreferencedViolation(File script, Set<Path> referenced, List<String> violations) {
-		if (!referenced.contains(script.getAbsoluteFile().toPath().normalize())) {
+		if (!referenced.contains(canonical(script.toPath()))) {
 			violations.add("hook script is not referenced by any settings.json hook: " + script);
 		}
 	}
 
 	/** The absolute path a command's {@code $CLAUDE_PROJECT_DIR} token resolves to when it lands in the hooks directory, else null. */
 	private Path scriptInHooksDir(String command) {
-		Path hooks = hooksDir.getAbsoluteFile().toPath().normalize();
+		Path hooks = canonical(hooksDir.toPath());
 		ClaudeProjectDir projectDirs = new ClaudeProjectDir(projectDir, settingsFile);
 		for (String token : command.split("\\s+")) {
 			Path resolved = resolveInHooks(projectDirs, token, hooks);
@@ -191,12 +194,35 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 		if (expanded == null) {
 			return null;
 		}
-		Path resolved = absolute(expanded);
+		Path resolved = canonical(new File(expanded).toPath());
 		return resolved.startsWith(hooks) ? resolved : null;
 	}
 
-	private Path absolute(String path) {
-		return new File(path).getAbsoluteFile().toPath().normalize();
+	/**
+	 * The real, symlink-resolved path of {@code path}. Symlinks are resolved on the
+	 * portion that exists on disk and the remaining names are appended, so a hook
+	 * script that is a symlink pointing outside the hooks directory no longer
+	 * satisfies the containment check by its lexical location alone, while a missing
+	 * script is still resolved beneath the real hooks directory so it is reported.
+	 */
+	private Path canonical(Path path) {
+		Path absolute = path.toAbsolutePath().normalize();
+		Path existing = absolute;
+		while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
+			existing = existing.getParent();
+		}
+		if (existing == null) {
+			return absolute;
+		}
+		return realPath(existing).resolve(existing.relativize(absolute));
+	}
+
+	private Path realPath(Path path) {
+		try {
+			return path.toRealPath();
+		} catch (IOException e) {
+			return path.toAbsolutePath().normalize();
+		}
 	}
 
 	void setHooksDir(File hooksDir) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.stream.Stream;
 
 /**
@@ -33,13 +34,19 @@ public final class MarkdownText {
 
 	/**
 	 * Writes {@code content} to {@code file} as UTF-8, overwriting any existing
-	 * content. An {@link IOException} is wrapped in an {@link UncheckedIOException}
-	 * describing the document, mirroring {@link #read} so a write failure surfaces
-	 * the same way.
+	 * content. A path that is a symbolic link is refused rather than followed, so
+	 * an auto-fix cannot be redirected through a planted link to rewrite a file
+	 * outside the definitions it is repairing. An {@link IOException} is wrapped in
+	 * an {@link UncheckedIOException} describing the document, mirroring
+	 * {@link #read} so a write failure surfaces the same way.
 	 */
 	public static void write(File file, String content, String description) {
 		try {
-			Files.writeString(file.toPath(), content);
+			Path path = file.toPath();
+			if (Files.isSymbolicLink(path)) {
+				throw new IOException("refusing to write through a symbolic link");
+			}
+			Files.writeString(path, content);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not write " + description + " at " + file, e);
 		}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/BoundedCharSequenceTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/BoundedCharSequenceTest.java
@@ -1,0 +1,66 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.enforcer.doc.BoundedCharSequence.BacktrackLimitExceededException;
+
+class BoundedCharSequenceTest {
+
+	@Test
+	void readsCharactersUpToTheBudget() {
+		BoundedCharSequence sequence = new BoundedCharSequence("abc", 3);
+
+		assertEquals('a', sequence.charAt(0));
+		assertEquals('b', sequence.charAt(1));
+		assertEquals('c', sequence.charAt(2));
+	}
+
+	@Test
+	void throwsOnceTheBudgetIsExceeded() {
+		BoundedCharSequence sequence = new BoundedCharSequence("abc", 2);
+		sequence.charAt(0);
+		sequence.charAt(1);
+
+		assertThrows(BacktrackLimitExceededException.class, () -> sequence.charAt(2));
+	}
+
+	@Test
+	void subSequenceSharesTheBudgetWithItsParent() {
+		BoundedCharSequence sequence = new BoundedCharSequence("abc", 1);
+		sequence.charAt(0);
+
+		CharSequence sub = sequence.subSequence(0, 3);
+		assertThrows(BacktrackLimitExceededException.class, () -> sub.charAt(0));
+	}
+
+	@Test
+	void toStringDoesNotSpendTheBudget() {
+		BoundedCharSequence sequence = new BoundedCharSequence("abc", 0);
+
+		assertEquals("abc", sequence.toString());
+	}
+
+	@Test
+	void abortsARegexMatchThatExceedsTheBudget() {
+		Pattern pattern = Pattern.compile("(x+x+)+y");
+		Matcher matcher = pattern.matcher(new BoundedCharSequence("x".repeat(60) + "z", 1_000));
+
+		assertThrows(BacktrackLimitExceededException.class, matcher::find);
+	}
+
+	@Test
+	void completesAMatchThatStaysWithinTheBudget() {
+		Pattern pattern = Pattern.compile("Java (\\d+)");
+		Matcher matcher = pattern.matcher(new BoundedCharSequence("We target Java 25.", 1_000_000));
+
+		assertTrue(matcher.find());
+		assertEquals("25", matcher.group(1));
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
@@ -89,6 +89,18 @@ class CrossDocConsistencyRuleTest {
 		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
 	}
 
+	@Test
+	void failsInsteadOfHangingOnABacktrackingPattern() {
+		// A super-linear pattern over a crafted document that never matches: without
+		// the step budget the match blows up on the document length instead of failing.
+		String craftedContent = "x".repeat(800) + "z";
+		CrossDocConsistencyRule rule = ruleFor(craftedContent, craftedContent);
+		rule.setConsistentPatterns(List.of("(x+x+)+y"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("catastrophic backtracking"), exception.getMessage());
+	}
+
 	private CrossDocConsistencyRule ruleFor(String claudeContent, String agentsContent) {
 		Path claude = tempDir.resolve("CLAUDE.md");
 		Path agents = tempDir.resolve("AGENTS.md");

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -126,6 +126,22 @@ class HooksFormatRuleTest {
 	}
 
 	@Test
+	void doesNotTreatASymlinkedScriptPointingOutsideAsInsideTheHooksDirectory() {
+		Path outside = tempDir.resolve("outside.sh");
+		writeString(outside, "#!/bin/sh\n");
+		setExecutable(outside.toFile(), true);
+		Path insideLink = hooksDir().resolve("session-start.sh");
+		assumeSymlink(insideLink, outside);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setReportUnreferencedScripts(true);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("not referenced"), exception.getMessage());
+	}
+
+	@Test
 	void warnSeverityLogsInsteadOfFailing() {
 		writeScript("session-start.sh", "echo hi\n", true);
 		HooksFormatRule rule = ruleFor();
@@ -175,6 +191,14 @@ class HooksFormatRuleTest {
 
 	private boolean supportsExecutableBit() {
 		return FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+	}
+
+	private void assumeSymlink(Path link, Path target) {
+		try {
+			Files.createSymbolicLink(link, target);
+		} catch (IOException | UnsupportedOperationException e) {
+			assumeTrue(false, "filesystem does not support symbolic links");
+		}
 	}
 
 	private void writeString(Path file, String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownTextTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownTextTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -80,6 +81,28 @@ class MarkdownTextTest {
 	}
 
 	@Test
+	void writePersistsContentToARegularFile() {
+		Path file = tempDir.resolve("out.md");
+
+		MarkdownText.write(file.toFile(), "# Title\nbody", "out.md");
+
+		assertEquals("# Title\nbody", readString(file));
+	}
+
+	@Test
+	void writeRefusesToFollowASymbolicLink() {
+		Path target = tempDir.resolve("target.md");
+		writeString(target, "original");
+		Path link = tempDir.resolve("link.md");
+		assumeSymlink(link, target);
+
+		UncheckedIOException exception = assertThrows(UncheckedIOException.class,
+				() -> MarkdownText.write(link.toFile(), "overwritten", "link.md"));
+		assertTrue(exception.getMessage().contains("link.md"), exception.getMessage());
+		assertEquals("original", readString(target));
+	}
+
+	@Test
 	void readWrapsAReadFailureWithTheDescription() {
 		Path missing = tempDir.resolve("absent.md");
 
@@ -93,6 +116,22 @@ class MarkdownTextTest {
 			Files.writeString(file, content);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private static String readString(Path file) {
+		try {
+			return Files.readString(file);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read " + file, e);
+		}
+	}
+
+	private static void assumeSymlink(Path link, Path target) {
+		try {
+			Files.createSymbolicLink(link, target);
+		} catch (IOException | UnsupportedOperationException e) {
+			assumeTrue(false, "filesystem does not support symbolic links");
 		}
 	}
 }


### PR DESCRIPTION
Bound the regular-expression matching in the cross-doc/README consistency
rules with a per-character step budget (BoundedCharSequence), so a crafted,
attacker-controlled document can no longer make a super-linear maintainer
pattern spin the build thread; the pattern is reported as a violation instead.

Resolve symlinks when checking hook-script containment in HooksFormatRule so a
script that lexically sits under .claude/hooks but is a symlink pointing
elsewhere no longer passes the containment check, and refuse to write through a
symbolic link in MarkdownText.write so front-matter auto-fix cannot be
redirected to rewrite a file outside the definitions it repairs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X6jRAa4RhjhgFMW7Nt66ji