### PR TITLE
docs: document shellcheck binary download failure and skip workaround

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,19 @@ removed anything, plain `mvn install` is fine and faster.
 CI. The workflows also pass `-ntp` explicitly on each `mvn` command so the
 quiet behavior does not depend on the checkout picking up `.mvn/maven.config`.
 
+**Shellcheck in restricted networks.** The root pom runs the
+`shellcheck-maven-plugin` (`check` goal) to lint `scripts/**/*.sh`. On first use
+the plugin downloads the `shellcheck` binary from GitHub releases
+(`github.com/koalaman/shellcheck`). In sandboxes where outbound access to that
+host is blocked — including Claude Code web/remote sessions, whose proxy scopes
+GitHub to this repo only — the download returns a non-archive error body and the
+build fails on the root pom with `Input is not in the XZ format`, before any
+Java module is reached. Skip the goal with `mvn install -Dskip.shellcheck=true`
+(property `skip.shellcheck`), or point the plugin at a pre-installed binary via
+`binaryResolutionMethod=external` and `externalBinaryPath`. CI runs on GitHub
+runners with unrestricted access, so the download succeeds there and the lint
+still gates every push.
+
 CI (`.github/workflows/maven.yml`) installs the enforcer rule
 (`mvn -B -pl claude-code-enforcer -am install -DskipTests`) and then runs
 `mvn -B package -DenforceClaudeMd` on JDK 25 (Temurin) for every push and for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,13 @@ mvn -Ppitest test                 # PIT mutation testing
 Use `clean` after removing a code-generation source, so stale generated builders
 in `target/` cannot mask the change.
 
+The root pom's `shellcheck-maven-plugin` downloads the `shellcheck` binary from
+GitHub releases on first use. In sandboxes where that host is blocked (e.g.
+Claude Code web/remote sessions), the build fails on the root pom with `Input is
+not in the XZ format` before any module builds; run `mvn install
+-Dskip.shellcheck=true` to skip the lint. See *Build, test, and run* in
+AGENTS.md.
+
 ## Principles for Java Development
 
 - **SOLID principles** for all code.


### PR DESCRIPTION
The root pom's shellcheck-maven-plugin downloads the shellcheck binary
from GitHub releases on first use. In sandboxes that block that host
(e.g. Claude Code web/remote sessions, whose proxy scopes GitHub to this
repo), the download returns a non-archive error body and the build fails
on the root pom with "Input is not in the XZ format" before any Java
module is reached.

Document the cause and the `-Dskip.shellcheck=true` workaround (plus the
external-binary alternative) in AGENTS.md, with a short summary in
CLAUDE.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016wYZLXv9AP9eZZTUjnDKsx