### PR TITLE
build: make Maven Central publishing self-sufficient in POMs

### DIFF
--- a/code/protogen-maven-plugin-test/pom.xml
+++ b/code/protogen-maven-plugin-test/pom.xml
@@ -93,4 +93,27 @@
 			<artifactId>protobuf-java</artifactId>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<profile>
+			<!-- This module is an integration-test harness for the
+			     protogen-maven-plugin, not a reusable library: it has no main
+			     Java sources (only src/main/proto), so its -sources.jar is empty
+			     and Central validation rejects it. Keep it out of the Maven
+			     Central bundle that the release profile publishes. skipPublishing
+			     is honoured per module by the central-publishing-maven-plugin, so
+			     the exclusion holds even without the reactor -pl filter. -->
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<configuration>
+							<skipPublishing>true</skipPublishing>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,10 @@
 		<url>https://github.com/adamw7/tools</url>
 		<tag>${revision}</tag>
 	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/adamw7/tools/issues</url>
+	</issueManagement>
 	<developers>
 		<developer>
 			<id>adamw7</id>


### PR DESCRIPTION
Fix 1: protogen-maven-plugin-test is an integration-test harness with no
main Java sources, so its -sources.jar is empty and Central validation
rejects it. It was previously kept out of the Central publish only by the
central-publish.yml reactor -pl exclusion. Add the same release-profile
skipPublishing guard that grpc-example and assembly already carry, so a
plain `mvn -Prelease deploy` can no longer accidentally publish it.

Fix 3: Add issueManagement (GitHub Issues) to the root POM so the
flattened POM deployed to Central carries a populated element instead of
the empty <issueManagement/> that flattenMode=oss emitted.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015VEbrBQPdY5NQCNQSBTGmu