### PR TITLE
harden k8s Job to the restricted Pod Security Standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -449,9 +449,14 @@ The repository ships two Dockerfiles with different purposes:
 The `k8s/` directory runs `SampleApp` (the CSV column-uniqueness checker) on a
 local minikube cluster as a run-to-completion **Job** (not a Deployment):
 `configmap-sample-data.yaml` mounts a sample CSV, `job-uniqueness-check.yaml`
-runs the check, and `run-on-minikube.sh` / `run-on-minikube.ps1` drive the whole
-flow (build → image → minikube → load → apply → logs). Pick the column to check
-with the `COLUMN` env var (Linux/macOS) or `-Column` parameter (Windows). See
+runs the check, `kustomization.yaml` bundles both for `kubectl apply -k k8s/`,
+and `run-on-minikube.sh` / `run-on-minikube.ps1` drive the whole flow (build →
+image → minikube → load → apply → logs). The Job meets the **restricted** Pod
+Security Standard (non-root numeric UID `10001`, read-only root filesystem, all
+capabilities dropped, `RuntimeDefault` seccomp, no service-account token, an
+`emptyDir` `/tmp`, and an `activeDeadlineSeconds` runtime bound), so the
+`k8s/Dockerfile` declares a numeric `USER`. Pick the column to check with the
+`COLUMN` env var (Linux/macOS) or `-Column` parameter (Windows). See
 [k8s/README.md](k8s/README.md) for quick-start, manual steps, and the sandbox
 limitations that prevent running a minikube control plane in this repo's
 automated environment.

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -29,9 +29,12 @@ COPY --from=build /build/BOOT-INF/lib ./lib
 # Console log4j config, first on the classpath so it overrides the bundled one.
 COPY k8s/log4j2.properties ./config/log4j2.properties
 
-RUN useradd --system --no-create-home --shell /usr/sbin/nologin appuser \
-    && chown -R appuser:appuser /app
-USER appuser
+# Fixed numeric UID/GID: Kubernetes' runAsNonRoot admission check can only
+# verify a non-root image user when USER is numeric, so declare it explicitly.
+RUN groupadd --system --gid 10001 appuser \
+    && useradd --system --uid 10001 --gid 10001 --no-create-home --shell /usr/sbin/nologin appuser \
+    && chown -R 10001:10001 /app
+USER 10001:10001
 
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0"
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -16,8 +16,15 @@ for a run-to-completion workload is a **Job**, not a Deployment.
 | `log4j2.properties`          | Console log config baked into the image so results reach stdout.    |
 | `configmap-sample-data.yaml` | Sample CSV (`people.csv`) mounted at `/data`.                       |
 | `job-uniqueness-check.yaml`  | Job that runs `SampleApp` against the CSV and prints the result.    |
+| `kustomization.yaml`         | Bundles the ConfigMap + Job for `kubectl apply -k k8s/`.            |
 | `run-on-minikube.sh`         | One-shot (Linux/macOS): build → image → minikube → load → apply → logs. |
 | `run-on-minikube.ps1`        | One-shot (Windows): installs minikube/kubectl if missing, then the same. |
+
+The Job runs under the **restricted** [Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/):
+non-root numeric UID, read-only root filesystem, all Linux capabilities dropped,
+no privilege escalation, the `RuntimeDefault` seccomp profile, and no mounted
+service-account token. It writes only to an `emptyDir` `/tmp` and is bounded by
+`activeDeadlineSeconds`.
 
 ## Quick start
 
@@ -66,7 +73,7 @@ docker build -f k8s/Dockerfile -t tools-k8s:local .
 minikube start --driver=docker
 minikube image load tools-k8s:local
 
-# 3. Deploy and run
+# 3. Deploy and run (or: kubectl apply -k k8s/ to apply both at once)
 kubectl apply -f k8s/configmap-sample-data.yaml
 kubectl apply -f k8s/job-uniqueness-check.yaml
 

--- a/k8s/job-uniqueness-check.yaml
+++ b/k8s/job-uniqueness-check.yaml
@@ -16,6 +16,9 @@ metadata:
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 600
+  # Bound total runtime so a wedged run can never linger; the check finishes in
+  # well under a second, 300s is a generous ceiling that also covers image pull.
+  activeDeadlineSeconds: 300
   template:
     metadata:
       labels:
@@ -23,6 +26,16 @@ spec:
         app.kubernetes.io/component: uniqueness-check
     spec:
       restartPolicy: Never
+      # The batch check never talks to the Kubernetes API, so drop its token.
+      automountServiceAccountToken: false
+      # Pod-level context satisfies the "restricted" Pod Security Standard:
+      # run as the image's non-root UID with the default seccomp profile.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: uniqueness-check
           image: tools-k8s:local
@@ -32,6 +45,9 @@ spec:
             - name: sample-data
               mountPath: /data
               readOnly: true
+            # Writable scratch for the JVM (java.io.tmpdir) under a read-only root.
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               cpu: 100m
@@ -43,7 +59,11 @@ spec:
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
       volumes:
         - name: sample-data
           configMap:
             name: tools-sample-data
+        - name: tmp
+          emptyDir: {}

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,9 @@
+# Bundles the ConfigMap and Job so the whole workload applies in one command:
+#   kubectl apply -k k8s/
+# (the run-on-minikube scripts apply the files individually so they can swap the
+# target column on the fly, which kustomize does not do).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap-sample-data.yaml
+  - job-uniqueness-check.yaml


### PR DESCRIPTION
Bring the uniqueness-check Job into compliance with the "restricted" Pod
Security Standard and make repeated runs safer:

- Job: add pod-level securityContext (runAsNonRoot, runAsUser/runAsGroup
  10001, RuntimeDefault seccomp), a RuntimeDefault seccomp profile on the
  container, automountServiceAccountToken: false, activeDeadlineSeconds to
  bound runtime, and an emptyDir /tmp so the JVM has writable scratch under
  readOnlyRootFilesystem.
- Dockerfile: create appuser with a fixed numeric UID/GID and set USER
  10001:10001, since runAsNonRoot admission can only verify a numeric image
  user.
- Add k8s/kustomization.yaml so both manifests apply with `kubectl apply -k`.
- Document the hardening in k8s/README.md and AGENTS.md.

Verified end to end with docker under the same constraints the Job enforces
(non-root UID, read-only root, tmpfs /tmp, all caps dropped): both the
NOT-unique (country) and unique (id) cases produce correct results.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TMPq9MMA8nRs4X9PYQW1Ry