### PR TITLE
feat(context): add Mermaid flowchart serializer for the project tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,13 @@ String rendered = serializer.serialize(root);
 - **`ProjectTreeJsonSerializer`** — structured JSON (`name`, `type`,
   `dependencies`, `children`) for programmatic consumers; `serializePretty`
   produces indented JSON.
+- **`ProjectTreeDotSerializer`** — a Graphviz [DOT](https://graphviz.org/doc/info/lang.html)
+  digraph of the dependency edges (file → depended-on class); directories add
+  structure but are not drawn. Render it with Graphviz tooling.
+- **`ProjectTreeMermaidSerializer`** — the same dependency edges as a
+  [Mermaid](https://mermaid.js.org/syntax/flowchart.html) `flowchart`, which
+  renders inline on GitHub, in Markdown viewers and in many gen-AI agent surfaces
+  without any external tooling.
 
 ### Token-budget-aware context
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -11,7 +11,7 @@ The server exposes three tools:
 
 - **`project_tree`** — scans a Java, Kotlin or Scala project into a tree of
   folders, files and the classes each file depends on, then serialises it as JSON
-  (default), Markdown, plain text or Graphviz DOT.
+  (default), Markdown, plain text, Graphviz DOT or a Mermaid flowchart.
 - **`find_context`** — resolves the classes a single source file depends on,
   bounded by a configurable depth, and returns them as a JSON array.
 - **`estimate_tokens`** — estimates the LLM token cost of the context assembled
@@ -63,7 +63,7 @@ Scans a project into a tree of folders, files and class dependencies.
 - `path` (string, required): absolute path to the project root directory
 - `language` (string, optional): `java` (default), `kotlin` or `scala`
 - `depth` (integer, optional): levels of transitive dependencies to resolve (default `1`)
-- `format` (string, optional): `json` (default), `markdown`, `text` or `dot`
+- `format` (string, optional): `json` (default), `markdown`, `text`, `dot` or `mermaid`
 
 **Example:**
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
@@ -12,6 +12,7 @@ import io.github.adamw7.context.tree.ProjectTreeBuilder;
 import io.github.adamw7.context.tree.ProjectTreeDotSerializer;
 import io.github.adamw7.context.tree.ProjectTreeJsonSerializer;
 import io.github.adamw7.context.tree.ProjectTreeMarkdownSerializer;
+import io.github.adamw7.context.tree.ProjectTreeMermaidSerializer;
 import io.github.adamw7.context.tree.ProjectTreeNode;
 import io.github.adamw7.context.tree.ProjectTreePrinter;
 import io.github.adamw7.context.tree.ProjectTreeSerializer;
@@ -23,9 +24,9 @@ import io.modelcontextprotocol.spec.McpSchema.Tool;
  * MCP tool that scans a Java, Kotlin or Scala project into a tree of folders,
  * files and the classes each file depends on, then serialises it for a gen-AI
  * agent. The
- * output format ({@code json}, {@code markdown} or {@code text}) is chosen by the
- * caller; JSON is the default as it is the most convenient for programmatic
- * consumers.
+ * output format ({@code json}, {@code markdown}, {@code text}, {@code dot} or
+ * {@code mermaid}) is chosen by the caller; JSON is the default as it is the most
+ * convenient for programmatic consumers.
  */
 public class ProjectTreeTool implements ContextTool {
 
@@ -52,7 +53,7 @@ public class ProjectTreeTool implements ContextTool {
 							"depth", Map.of("type", "integer",
 									"description", "how many levels of transitive dependencies to resolve (default 1)"),
 							"format", Map.of("type", "string",
-									"description", "output format: json (default), markdown, text or dot")),
+									"description", "output format: json (default), markdown, text, dot or mermaid")),
 					"required", List.of("path")))
 			.description("Scan a Java, Kotlin or Scala project into a tree of folders, files and class dependencies")
 			.build();
@@ -82,6 +83,7 @@ public class ProjectTreeTool implements ContextTool {
 			case "markdown" -> new ProjectTreeMarkdownSerializer();
 			case "text" -> new ProjectTreePrinter();
 			case "dot" -> new ProjectTreeDotSerializer();
+			case "mermaid" -> new ProjectTreeMermaidSerializer();
 			default -> new ProjectTreeJsonSerializer();
 		};
 	}

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeMermaidSerializer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeMermaidSerializer.java
@@ -1,0 +1,56 @@
+package io.github.adamw7.context.tree;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Renders the dependency graph of a {@link ProjectTreeNode} tree as a
+ * <a href="https://mermaid.js.org/syntax/flowchart.html">Mermaid</a> flowchart:
+ * every file becomes a node and every dependency it carries becomes a directed
+ * edge from the file to the depended-on class. Directories contribute structure
+ * but are not drawn, so the result is a focused view of how the project's classes
+ * depend on one another — like the Graphviz DOT serializer, but in a format that
+ * renders inline on GitHub, in Markdown viewers and in many gen-AI agent surfaces
+ * without any external tooling.
+ */
+public class ProjectTreeMermaidSerializer implements ProjectTreeSerializer {
+
+	private static final String INDENT = "  ";
+	private static final String HEADER = "flowchart LR";
+	private static final String ARROW = " --> ";
+	private static final String NODE_PREFIX = "n";
+
+	@Override
+	public String serialize(ProjectTreeNode root) {
+		StringBuilder builder = new StringBuilder();
+		builder.append(HEADER).append(System.lineSeparator());
+		appendEdges(builder, root, new LinkedHashMap<>());
+		return builder.toString();
+	}
+
+	private void appendEdges(StringBuilder builder, ProjectTreeNode node, Map<String, String> ids) {
+		appendNodeEdges(builder, node, ids);
+		node.children().forEach(child -> appendEdges(builder, child, ids));
+	}
+
+	private void appendNodeEdges(StringBuilder builder, ProjectTreeNode node, Map<String, String> ids) {
+		if (node.isDirectory()) {
+			return;
+		}
+		node.dependencies().forEach(dependency -> appendEdge(builder, node.name(), dependency, ids));
+	}
+
+	private void appendEdge(StringBuilder builder, String from, String to, Map<String, String> ids) {
+		builder.append(INDENT).append(nodeFor(from, ids)).append(ARROW).append(nodeFor(to, ids))
+				.append(System.lineSeparator());
+	}
+
+	private String nodeFor(String label, Map<String, String> ids) {
+		String id = ids.computeIfAbsent(label, key -> NODE_PREFIX + ids.size());
+		return id + "[\"" + escape(label) + "\"]";
+	}
+
+	private String escape(String label) {
+		return label.replace("\"", "#quot;");
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
@@ -85,6 +85,20 @@ public class ProjectTreeToolTest {
 	}
 
 	@Test
+	void honoursTheMermaidFormat() throws IOException {
+		writeJava("A", "public class A {}");
+		writeJava("B", "public class B { A a; }");
+
+		Map<String, Object> arguments = arguments();
+		arguments.put("format", "mermaid");
+
+		String rendered = text(tool.apply(arguments));
+		assertTrue(rendered.startsWith("flowchart LR"));
+		assertTrue(rendered.contains("[\"B.java\"] --> "));
+		assertTrue(rendered.contains("[\"A.java\"]"));
+	}
+
+	@Test
 	void resolvesTransitiveDependenciesAtTheRequestedDepth() throws IOException {
 		writeJava("A", "public class A {}");
 		writeJava("B", "public class B { A a; }");

--- a/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeMermaidSerializerTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/tree/ProjectTreeMermaidSerializerTest.java
@@ -1,0 +1,128 @@
+package io.github.adamw7.context.tree;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class ProjectTreeMermaidSerializerTest {
+
+	private final ProjectTreeMermaidSerializer serializer = new ProjectTreeMermaidSerializer();
+
+	@Test
+	void opensWithAFlowchartHeader() {
+		String mermaid = serializer.serialize(ProjectTreeNode.directory(Path.of("project")));
+
+		assertTrue(mermaid.startsWith("flowchart LR"));
+	}
+
+	@Test
+	void emitsAnEdgeFromAFileToEachDependency() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/B.java"));
+		file.addDependency("A.java");
+		file.addDependency("C.java");
+		root.addChild(file);
+
+		String mermaid = serializer.serialize(root);
+
+		assertTrue(mermaid.contains("[\"B.java\"] --> "));
+		assertTrue(mermaid.contains("[\"A.java\"]"));
+		assertTrue(mermaid.contains("[\"C.java\"]"));
+	}
+
+	@Test
+	void reusesTheSameIdForARepeatedLabel() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode first = ProjectTreeNode.file(Path.of("project/B.java"));
+		first.addDependency("A.java");
+		ProjectTreeNode second = ProjectTreeNode.file(Path.of("project/C.java"));
+		second.addDependency("A.java");
+		root.addChild(first);
+		root.addChild(second);
+
+		String mermaid = serializer.serialize(root);
+
+		assertTrue(mermaid.contains("n0[\"B.java\"] --> n1[\"A.java\"]"));
+		assertTrue(mermaid.contains("n2[\"C.java\"] --> n1[\"A.java\"]"));
+	}
+
+	@Test
+	void doesNotDrawDirectoriesAsNodes() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		root.addChild(ProjectTreeNode.directory(Path.of("project/pkg")));
+
+		String mermaid = serializer.serialize(root);
+
+		assertFalse(mermaid.contains("-->"));
+	}
+
+	@Test
+	void recursesIntoNestedDirectories() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode pkg = ProjectTreeNode.directory(Path.of("project/pkg"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/pkg/B.java"));
+		file.addDependency("A.java");
+		pkg.addChild(file);
+		root.addChild(pkg);
+
+		String mermaid = serializer.serialize(root);
+
+		assertTrue(mermaid.contains("[\"B.java\"] --> "));
+		assertTrue(mermaid.contains("[\"A.java\"]"));
+	}
+
+	@Test
+	void escapesDoubleQuotesInNames() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/B.java"));
+		file.addDependency("Wei\"rd");
+		root.addChild(file);
+
+		String mermaid = serializer.serialize(root);
+
+		assertTrue(mermaid.contains("Wei#quot;rd"));
+		assertFalse(mermaid.contains("Wei\"rd"));
+	}
+
+	@Test
+	void emitsNoEdgesForAFileWithoutDependencies() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		root.addChild(ProjectTreeNode.file(Path.of("project/A.java")));
+
+		String mermaid = serializer.serialize(root);
+
+		assertFalse(mermaid.contains("-->"));
+	}
+
+	@Test
+	void preservesDependencyInsertionOrder() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode file = ProjectTreeNode.file(Path.of("project/B.java"));
+		file.addDependency("A.java");
+		file.addDependency("C.java");
+		root.addChild(file);
+
+		String mermaid = serializer.serialize(root);
+
+		assertTrue(mermaid.indexOf("\"A.java\"") < mermaid.indexOf("\"C.java\""));
+	}
+
+	@Test
+	void emitsEdgesForEveryFileInTheTree() {
+		ProjectTreeNode root = ProjectTreeNode.directory(Path.of("project"));
+		ProjectTreeNode first = ProjectTreeNode.file(Path.of("project/B.java"));
+		first.addDependency("A.java");
+		ProjectTreeNode second = ProjectTreeNode.file(Path.of("project/D.java"));
+		second.addDependency("C.java");
+		root.addChild(first);
+		root.addChild(second);
+
+		String mermaid = serializer.serialize(root);
+
+		assertTrue(mermaid.contains("[\"B.java\"] --> "));
+		assertTrue(mermaid.contains("[\"D.java\"] --> "));
+	}
+}


### PR DESCRIPTION
Add ProjectTreeMermaidSerializer, rendering the project's file→class
dependency edges as a Mermaid `flowchart LR`. It complements the existing
Graphviz DOT serializer but renders inline on GitHub, in Markdown viewers
and in gen-AI agent surfaces without external tooling — directly serving the
context module's purpose. Wire `mermaid` into the project_tree MCP tool's
format switch and document it (README, MCP_USAGE, tool javadoc/schema). The
README output-formats section also gains the previously undocumented DOT
serializer.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mf21eSEJFo1pXcShbgYiMM