### PR TITLE
fix(data): flatten InMemoryJSONDataSource to dotted-path leaf keys

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
@@ -7,6 +7,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+/**
+ * In-memory JSON data source that flattens a document into {@link #fieldsMap} as
+ * {@code key -> value} pairs keyed by dotted path, using {@code .} for nested
+ * object fields and {@code [index]} for array elements (for example
+ * {@code people[0].address.city}). This mirrors {@link InMemoryYAMLDataSource}
+ * and the streaming {@link IterableJSONDataSource}, so the same document read as
+ * JSON, YAML or through either access mode yields the same rows.
+ */
 public class InMemoryJSONDataSource extends AbstractInMemoryMapDataSource {
 
 	private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -25,13 +33,7 @@ public class InMemoryJSONDataSource extends AbstractInMemoryMapDataSource {
 		while (scanner.hasNextLine()) {
 			jsonContent.append(scanner.nextLine());
 		}
-		parseJSON(jsonContent.toString());
-	}
-
-	private void parseJSON(String jsonString) {
-		JsonNode root = read(jsonString);
-		extractFieldNames(root);
-		flatten(root);
+		flattenValue("", read(jsonContent.toString()));
 	}
 
 	private JsonNode read(String jsonString) {
@@ -42,42 +44,26 @@ public class InMemoryJSONDataSource extends AbstractInMemoryMapDataSource {
 		}
 	}
 
-	private void extractFieldNames(JsonNode node) {
-		for (Map.Entry<String, JsonNode> field : node.properties()) {
-			JsonNode value = field.getValue();
-			fieldsMap.put(field.getKey(), asText(value));
-			if (value.isObject()) {
-				extractFieldNames(value);
-			}
+	private void flattenValue(String key, JsonNode value) {
+		if (value.isObject()) {
+			flattenObject(key, value);
+		} else if (value.isArray()) {
+			flattenArray(key, value);
+		} else {
+			fieldsMap.put(key, value.asText());
 		}
 	}
 
-	private void flatten(JsonNode node) {
-		if (node.isArray()) {
-			flattenArray(node);
-		} else if (node.isObject()) {
-			flattenObject(node);
-		}
-	}
-
-	private void flattenArray(JsonNode array) {
-		for (JsonNode element : array) {
-			flatten(element);
-		}
-	}
-
-	private void flattenObject(JsonNode object) {
+	private void flattenObject(String prefix, JsonNode object) {
 		for (Map.Entry<String, JsonNode> field : object.properties()) {
-			JsonNode value = field.getValue();
-			if (value.isContainerNode()) {
-				flatten(value);
-			} else {
-				fieldsMap.put(field.getKey(), value.asText());
-			}
+			String key = prefix.isEmpty() ? field.getKey() : prefix + "." + field.getKey();
+			flattenValue(key, field.getValue());
 		}
 	}
 
-	private String asText(JsonNode value) {
-		return value.isContainerNode() ? value.toString() : value.asText();
+	private void flattenArray(String prefix, JsonNode array) {
+		for (int index = 0; index < array.size(); index++) {
+			flattenValue(prefix + "[" + index + "]", array.get(index));
+		}
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/JSONDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/JSONDataSourceTest.java
@@ -2,11 +2,16 @@ package io.github.adamw7.tools.data.source.file;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -19,7 +24,7 @@ import io.github.adamw7.tools.data.Utils;
 import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 
 public class JSONDataSourceTest {
-    
+
 	static Stream<Arguments> dataSources() {
 		IterableDataSource zippedDataSource = new InMemoryJSONDataSource(Utils.getFileName("test.json.gz"));
 		IterableDataSource unzippedDataSource = new InMemoryJSONDataSource(Utils.getFileName("test.json"));
@@ -31,9 +36,8 @@ public class JSONDataSourceTest {
     public void testGetColumnNames(InMemoryJSONDataSource source) throws IOException {
 		source.open();
         String[] columnNames = source.getColumnNames();
-        assertEquals(10, columnNames.length);
-        assertEquals(Set.of("cars", "fruits", "year", "city", "name", "model", "state", "people", "age", "manufacturer"),
-                Set.of(columnNames));
+        assertEquals(17, columnNames.length);
+        assertEquals(expectedColumnNames(), Set.of(columnNames));
         source.close();
     }
 
@@ -50,24 +54,58 @@ public class JSONDataSourceTest {
             assertNotNull(row[0]);
             assertNotNull(row[1]);
         }
-        assertEquals(10, rowCount);
+        assertEquals(17, rowCount);
         source.close();
     }
+
+	@Test
+	public void testSpecificValues() throws IOException {
+		InMemoryJSONDataSource source = new InMemoryJSONDataSource(Utils.getFileName("test.json"));
+		List<String[]> data = source.readAll();
+		HashMap<String, String> map = new HashMap<>();
+		for (String[] row : data) {
+			map.put(row[0], row[1]);
+		}
+		assertEquals("Alice", map.get("people[0].name"));
+		assertEquals("30", map.get("people[0].age"));
+		assertEquals("New York", map.get("people[0].address.city"));
+		assertEquals("NY", map.get("people[0].address.state"));
+		assertEquals("Bob", map.get("people[1].name"));
+		assertEquals("25", map.get("people[1].age"));
+		assertEquals("Toyota", map.get("cars[0].manufacturer"));
+		assertEquals("Camry", map.get("cars[0].model"));
+		assertEquals("2020", map.get("cars[0].year"));
+		assertEquals("Honda", map.get("cars[1].manufacturer"));
+		assertEquals("apple", map.get("fruits[0]"));
+		assertEquals("banana", map.get("fruits[1]"));
+		assertEquals("orange", map.get("fruits[2]"));
+	}
 
 	@Test
 	public void readsFromInputStream() throws IOException {
 		try (InputStream stream = new FileInputStream(Utils.getFileName("test.json"))) {
 			InMemoryJSONDataSource source = new InMemoryJSONDataSource(stream);
 			source.open();
-			assertEquals(10, source.getColumnNames().length);
+			Set<String> names = new HashSet<>(Arrays.asList(source.getColumnNames()));
+			assertEquals(17, names.size());
+			assertTrue(names.contains("people[0].address.city"));
+			assertTrue(names.contains("fruits[2]"));
 			int rowCount = 0;
 			while (source.hasMoreData()) {
 				assertNotNull(source.nextRow());
 				rowCount++;
 			}
-			assertEquals(10, rowCount);
+			assertEquals(17, rowCount);
 			source.close();
 		}
 	}
-}
 
+	private static Set<String> expectedColumnNames() {
+		return Set.of(
+				"people[0].name", "people[0].age", "people[0].address.city", "people[0].address.state",
+				"people[1].name", "people[1].age", "people[1].address.city", "people[1].address.state",
+				"cars[0].manufacturer", "cars[0].model", "cars[0].year",
+				"cars[1].manufacturer", "cars[1].model", "cars[1].year",
+				"fruits[0]", "fruits[1]", "fruits[2]");
+	}
+}


### PR DESCRIPTION
InMemoryJSONDataSource diverged from its YAML/TOON siblings and the
streaming IterableJSONDataSource, causing silent data loss:

- Array-of-object elements collapsed to the last one (keyed by simple
  field name, so people[1] overwrote people[0]).
- Arrays of primitives (e.g. fruits) were dropped entirely, since the
  recursive flatten no-oped on scalar leaves.
- A separate extractFieldNames pass added container fields (people,
  cars, fruits) as pseudo-columns whose value was the whole sub-tree
  serialized back to JSON.

Rewrite the flattener to emit dotted-path leaf keys (a.b, people[0].city)
mirroring InMemoryYAMLDataSource, so the same document read as JSON, YAML,
or through either access mode yields identical rows. Update
JSONDataSourceTest to assert the corrected keys and values (17 rows) and
add a testSpecificValues check matching the YAML test.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UdpRerqtM3Gv2djbnSEDSh