### PR TITLE
ci: fix workflow_dispatch injection and drop dead Windows enforcer step

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -89,10 +89,10 @@ jobs:
         # ("-pl !assembly,!grpc-example,!code/protogen-maven-plugin-test") and
         # never take part in the Central publish.
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
             revision_arg=""
-            if [ -n "${{ github.event.inputs.revision }}" ]; then
-              revision_arg="-Drevision=${{ github.event.inputs.revision }}"
+            if [ -n "${REVISION}" ]; then
+              revision_arg="-Drevision=${REVISION}"
             fi
             echo "Staged-only Central dry run: autoPublish=false, waitUntil=validated $revision_arg"
             mvn -B -ntp -X -P release -pl '!assembly,!grpc-example,!code/protogen-maven-plugin-test' deploy -Dcentral.autoPublish=false -Dcentral.waitUntil=validated $revision_arg
@@ -100,5 +100,11 @@ jobs:
             mvn -B -ntp -X -P release -pl '!assembly,!grpc-example,!code/protogen-maven-plugin-test' deploy
           fi
         env:
+          # Interpolating ${{ github.event.inputs.revision }} straight into the
+          # run script would be a shell-injection sink (a crafted dispatch input
+          # runs as shell). Pass it through the environment and reference it as a
+          # quoted variable instead.
+          EVENT_NAME: ${{ github.event_name }}
+          REVISION: ${{ github.event.inputs.revision }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -22,17 +22,12 @@ jobs:
         java-version: '25'
         distribution: 'temurin'
         cache: maven
-    - name: Bootstrap CLAUDE.md enforcer rule
-      # The custom enforcer rule (tools.claude-code-enforcer) is consumed as a
-      # maven-enforcer-plugin dependency by the root build, so it must be
-      # installed to the local repo first. The claude-md-enforce profile is
-      # off here (no -DenforceClaudeMd), so the module is not asked to depend
-      # on itself while it is being built.
-      #
-      # -DskipTests: this step exists only to publish the enforcer JAR so the
-      # main build can load it as a plugin dependency. The module's own test
-      # suite is re-run as part of the "Build with Maven" install step below,
-      # so running it here as well only duplicates work.
-      run: mvn -B -ntp -pl claude-code-enforcer -am install -DskipTests
     - name: Build with Maven
+      # No enforcer bootstrap is needed here: this build does not pass
+      # -DenforceClaudeMd, so the claude-md-enforce profile stays off and the
+      # tools.claude-code-enforcer plugin dependency is never consumed. The
+      # enforcer module is still built as an ordinary reactor module by
+      # `install`. CLAUDE.md-format enforcement is platform-independent and is
+      # already covered by the Linux "Java CI with Maven" workflow; this Windows
+      # job exists to catch platform-specific regressions.
       run: mvn -B -ntp install --file pom.xml


### PR DESCRIPTION
central-publish.yml interpolated ${{ github.event.inputs.revision }}
directly into the deploy run script, a shell-injection sink where a
crafted workflow_dispatch input executes as shell. Pass github.event_name
and the revision input through the step environment and reference them as
quoted variables instead.

maven-windows.yml ran a "Bootstrap CLAUDE.md enforcer rule" step, but its
build step runs `mvn install` without -DenforceClaudeMd, so the
claude-md-enforce profile never activates and the tools.claude-code-enforcer
plugin dependency is never consumed. The step did nothing useful (and the
enforcer module is built as an ordinary reactor module anyway). Remove it;
CLAUDE.md enforcement is platform-independent and already covered by the
Linux Maven workflow.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TDiR8fRiMBkCs2CFCJ5JXy