### PR TITLE
docs: add ADR directory with foundational architecture record

### DIFF
--- a/docs/adr/0001-foundational-architecture.md
+++ b/docs/adr/0001-foundational-architecture.md
@@ -1,0 +1,137 @@
+# 1. Foundational architecture of the `tools` project
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+
+## Context
+
+`tools` is a library of general-purpose Java tooling that grew several distinct
+capabilities — compile-time-safe protobuf code generation, context engineering
+for gen-AI agents, and a data toolkit — alongside two MCP servers and an
+agent-facing documentation contract. These capabilities share build
+infrastructure, dependency management, testing discipline, and coding
+conventions, but each has its own domain and release surface.
+
+This record captures the cross-cutting architectural decisions that shape the
+repository as a whole. Decisions local to a single capability that later need
+revisiting should be recorded in their own ADRs, which may supersede parts of
+this one. Detailed, evolving explanations live in
+[AGENTS.md](../../AGENTS.md) (the single source of truth),
+[README.md](../../README.md), and the diagrams under [docs/](..); this ADR
+records the *decisions* and their rationale, not the how-to.
+
+## Decision
+
+### 1. Multi-module Maven reactor with centralised version management
+
+The project is a single Maven reactor (`packaging=pom`) split into focused
+modules — `claude-code-enforcer`, `mcp-common`, `data`, `code`
+(`protogen-maven-plugin`, `protogen-maven-plugin-test`, `context`),
+`grpc-example`, and `assembly` — with `data-test` built standalone outside the
+root `<modules>` list. Each capability lives in its own module so it can be built,
+tested, and depended on in isolation.
+
+All dependency **versions and scopes** are declared only in the root pom's
+`<dependencyManagement>`, and all plugin versions only in `<pluginManagement>`.
+Module poms reference dependencies and plugins **without versions**. This keeps
+versions consistent across modules and makes upgrades a single-file change.
+
+### 2. Java 25 as the baseline toolchain
+
+The whole project targets **Java 25** (`maven.compiler.source`/`target = 25`),
+built with **Maven 3.9.x**. Adopting a current LTS-track JDK lets the code use
+modern language and JDK features and keeps the toolchain requirement uniform
+across every module. Web/remote agent sessions provision the JDK through the
+`.claude/hooks/session-start.sh` hook.
+
+### 3. Shift-left required-field validation via generated builders
+
+The `protogen-maven-plugin` generates protobuf builders that make missing
+**required fields a compile-time error** instead of a runtime failure — proto2
+`required` fields are enforced through the builder chain, proto3 gets
+presence-aware accessors, and `oneof` groups get discriminator/clear support.
+Moving this validation left is the defining design bet of the code-generation
+capability; see
+[docs/compile-time-safe-builders.md](../compile-time-safe-builders.md).
+
+### 4. MCP servers as the agent integration surface
+
+Capabilities that are useful to AI assistants are exposed through **MCP servers**
+(Spring Boot apps) rather than bespoke integrations: the uniqueness checker in
+`data`, and `project_tree` / `find_context` / `estimate_tokens` in `code/context`.
+Shared server scaffolding — transport wiring and the tool SPI — is factored into
+`mcp-common`, and each server supports stdio, streamable HTTP, stateless HTTP, and
+HTTP+SSE transports. This keeps the tool logic decoupled from transport concerns
+and consistent across servers.
+
+### 5. Documentation as an enforced contract
+
+`AGENTS.md` is the **single source of truth** for the repository guide; `CLAUDE.md`
+is a quick-reference that defers to it, and `README.md` documents the same
+capabilities for humans. A **custom maven-enforcer rule** (`claude-code-enforcer`)
+fails the build when these documents drift — format rules pin required headings,
+`crossDocConsistency` keeps mirrored facts (e.g. the Java version) aligned between
+CLAUDE.md and AGENTS.md, and a README-consistency rule catches capabilities
+described in one place but missing from another. Treating the docs as a
+build-checked contract keeps agent guidance trustworthy.
+
+### 6. Layering and convention enforcement via ArchUnit
+
+Package layering and coding conventions are pinned with **ArchUnit** tests in each
+module's `...architecture` test package: data-source contracts must not depend on
+their implementations, the uniqueness core must not depend on its MCP adapter,
+loggers are `private static final`, production code logs through log4j2 (no
+`System.out`/`err`, `printStackTrace`, or `System.exit`), and packages stay free
+of cycles. A companion test pins conventions on the tests themselves. Encoding the
+architecture as executable tests stops it from rotting.
+
+### 7. Fast, hermetic, self-contained builds and tests
+
+Several decisions keep the build reproducible and safe to run anywhere,
+including networks that can only reach Maven Central:
+
+- **Unit tests run with the network off** — the `data` module engages a
+  `Switch` kill-switch before any unit test runs, so a unit test can never open an
+  outbound connection; failsafe `*IT` tests are unaffected.
+- **Tight test timeouts** — a 900 ms per-test Surefire timeout keeps unit tests
+  fast, with looser lifecycle and fork-level timeouts for legitimately heavier
+  setup.
+- **Offline shellcheck** — script linting uses the embedded shellcheck binary from
+  the plugin jar rather than downloading it from GitHub, so the build works where
+  GitHub is blocked.
+- **Integration tests, coverage, and mutation testing** are opt-in profiles
+  (`integration-tests`, `coverage` with an 80% floor, `pitest`).
+
+### 8. SOLID, clean-code style rules
+
+All code follows **SOLID principles** and clean-code conventions: short methods,
+meaningful names, no `continue`/`break`, and matching the surrounding style. New
+dependencies are added only after discussion. These rules are documented in
+`AGENTS.md`/`CLAUDE.md` and partly enforced by the ArchUnit and enforcer rules
+above.
+
+## Consequences
+
+**Positive**
+
+- New capabilities have an obvious home (a new module) and inherit dependency
+  management, testing discipline, and conventions for free.
+- Errors surface early: missing required fields at compile time, doc drift and
+  architecture violations at build time, accidental network use during unit tests.
+- Builds are reproducible and runnable in restricted networks and ephemeral agent
+  environments.
+- Agent-facing docs stay accurate because the build enforces them.
+
+**Negative / trade-offs**
+
+- The Java 25 baseline requires contributors and CI to provision a current JDK.
+- Centralised version management means module poms cannot pin a divergent version
+  without changing the root pom.
+- The enforcer and ArchUnit rules add build steps that must be kept in sync when
+  conventions legitimately change — a deliberate cost paid to prevent drift.
+
+## Superseding
+
+Later decisions that revisit any point above should be recorded as their own
+numbered ADRs and reference this record. This ADR remains `Accepted` until such a
+successor supersedes a specific section.

--- a/docs/adr/0002-security-policy-and-supply-chain-posture.md
+++ b/docs/adr/0002-security-policy-and-supply-chain-posture.md
@@ -1,0 +1,66 @@
+# 2. Security policy and supply-chain posture
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+
+## Context
+
+`tools` is published to Maven Central and pulls a large tree of third-party
+dependencies (Spring Boot, protobuf, DuckDB, log4j2, and the MCP SDK, among
+others). As a library consumed by other projects, a vulnerability in `tools` or
+in one of its transitive dependencies propagates downstream. The project needs a
+stated, repeatable security posture rather than ad-hoc responses: a way for
+people to report issues, a defined set of supported versions, automated detection
+of vulnerable code and dependencies, and automated remediation.
+
+This ADR is the umbrella record for the project's security posture. The concrete
+mechanisms it relies on are recorded in their own ADRs:
+
+- Transport security — [ADR 0003](0003-require-tls-1.3.md) (require TLS 1.3+).
+- Static code scanning — [ADR 0004](0004-codeql-code-scanning.md) (CodeQL).
+- Dependency version hygiene — [ADR 0005](0005-renovate-dependency-updates.md)
+  (Renovate).
+- Dependency vulnerability remediation —
+  [ADR 0006](0006-dependabot-security-updates.md) (Dependabot security updates).
+
+## Decision
+
+The project adopts a defence-in-depth security posture built from four pillars:
+
+1. **Coordinated disclosure.** Vulnerabilities are reported privately (see
+   [SECURITY.md](../../SECURITY.md)), not through public issues. `SECURITY.md`
+   also declares the **supported versions** that receive fixes, so reporters and
+   consumers know what is maintained.
+2. **Find vulnerable code early** with automated static analysis on a schedule and
+   surfaced as GitHub code-scanning alerts (ADR 0004).
+3. **Keep dependencies current** so the project rarely sits on a version with a
+   known CVE, via automated version-bump pull requests (ADR 0005).
+4. **Remediate known vulnerabilities fast** with automated security-only update
+   pull requests that jump straight to a patched version (ADR 0006).
+
+The two update mechanisms have **distinct, non-overlapping roles**: Renovate owns
+routine version bumps, Dependabot owns security-alert remediation. This split is
+deliberate — running both for all updates would produce redundant, noisy pull
+requests. See the individual ADRs for the rationale.
+
+All of the above is enforced through the existing CI and repository
+configuration; the security posture is a property of the build and repo settings,
+not a manual checklist.
+
+## Consequences
+
+**Positive**
+
+- Reporters have a clear, private channel; consumers know which versions are
+  supported.
+- Vulnerabilities in both first-party code and dependencies are detected and
+  remediated with minimal manual effort.
+- The posture is composed of small, independently revisable decisions rather than
+  one monolithic policy.
+
+**Negative / trade-offs**
+
+- Automated scanning and update bots generate pull-request and alert traffic that
+  a maintainer must triage.
+- The supported-versions table in `SECURITY.md` must be kept current as releases
+  are cut — stale entries mislead consumers.

--- a/docs/adr/0003-require-tls-1.3.md
+++ b/docs/adr/0003-require-tls-1.3.md
@@ -1,0 +1,51 @@
+# 3. Require TLS 1.3+ for HTTPS transports
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+
+## Context
+
+The MCP servers can serve their streamable-HTTP transport over HTTPS (SSL enabled
+through Spring Boot's `server.ssl.*` properties on the embedded Tomcat). Left to
+defaults, the server negotiates whatever protocols the JDK and configuration
+permit, which can include older, weaker TLS versions (TLS 1.0/1.1/1.2). Older TLS
+versions carry known weaknesses and are being deprecated across the ecosystem;
+allowing them to be negotiated undermines the point of enabling TLS at all.
+
+## Decision
+
+**When a transport is served over HTTPS, the only enabled TLS protocol is
+`TLSv1.3`.** This is enforced in code rather than left to deployment
+configuration: a Spring `WebServerFactoryCustomizer`
+(`enforceTls13()`) pins the embedded Tomcat's enabled protocols to `TLSv1.3`
+whenever SSL is enabled, regardless of what the configuration requested, so a
+weaker protocol can never be negotiated.
+
+- Production implementation:
+  [`code/context/src/main/java/io/github/adamw7/context/mcp/TlsConfiguration.java`](../../code/context/src/main/java/io/github/adamw7/context/mcp/TlsConfiguration.java).
+- **Plain HTTP and disabled SSL are left untouched** — there is no TLS to
+  constrain in those cases; the customiser is a no-op.
+- The behaviour is pinned by `TlsConfigurationTest`, which asserts that an enabled
+  HTTPS factory ends up with exactly `{ "TLSv1.3" }` even when TLS 1.2 was
+  requested, and that plain-HTTP / disabled-SSL factories are not modified.
+
+"TLS 1.3+" is expressed today as "TLS 1.3 only" because 1.3 is the current
+highest version; a future 1.4 would be added to the enabled set by updating the
+customiser, not by re-allowing 1.2.
+
+## Consequences
+
+**Positive**
+
+- HTTPS transports can never silently downgrade to a weak protocol, independent of
+  how the deployment sets `server.ssl.*`.
+- The requirement is executable and regression-tested, not just documented.
+
+**Negative / trade-offs**
+
+- Clients that cannot speak TLS 1.3 cannot connect over HTTPS. This is intentional
+  — such clients should use a modern TLS stack — but it is a hard cutoff.
+- The enforcement currently lives with the context MCP server. If another
+  HTTPS-serving surface is added, it must apply the same customiser (or a shared
+  one) to inherit the guarantee; this is a known follow-up should a second HTTPS
+  endpoint appear.

--- a/docs/adr/0004-codeql-code-scanning.md
+++ b/docs/adr/0004-codeql-code-scanning.md
@@ -1,0 +1,49 @@
+# 4. CodeQL static analysis for code scanning
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+
+## Context
+
+First-party code can contain security-relevant defects — injection sinks, unsafe
+deserialization, path traversal, and similar — that unit and architecture tests do
+not target. The project wants automated static analysis that understands Java,
+integrates with GitHub's security tab, and requires no third-party service beyond
+GitHub itself.
+
+## Decision
+
+Use **GitHub CodeQL** for static security analysis of the Java code, wired as a
+GitHub Actions workflow at
+[`.github/workflows/codeql.yml`](../../.github/workflows/codeql.yml).
+
+- **Language:** `java` (covers Java/Kotlin). The build is discovered via CodeQL
+  `autobuild` on JDK 25 (Temurin), matching the project's toolchain
+  ([ADR 0001](0001-foundational-architecture.md)).
+- **Cadence:** scheduled weekly (`cron: '23 21 * * 6'`, Saturdays) rather than on
+  every push, to catch newly published query updates without adding latency to the
+  normal CI path. Findings are uploaded as **code-scanning alerts**
+  (`security-events: write`).
+- **Permissions** follow least privilege: `actions: read`, `contents: read`,
+  `security-events: write`.
+
+Running scans separately from the `maven.yml` build keeps the fast feedback loop
+(compile/test/enforce) independent of the slower security scan.
+
+## Consequences
+
+**Positive**
+
+- Security defects in first-party code surface as GitHub alerts with data-flow
+  context, at no extra infrastructure cost.
+- The scan can adopt `security-extended` / `security-and-quality` query packs later
+  by uncommenting the `queries:` line, without structural change.
+
+**Negative / trade-offs**
+
+- A weekly cadence means a defect introduced just after a scan can sit up to a week
+  before CodeQL flags it. Moving to `on: [push, pull_request]` would shorten that
+  window at the cost of longer PR turnaround and more Actions minutes; this is a
+  deliberate trade-off that can be revisited.
+- `autobuild` must be able to build the reactor; if it ever fails, the workflow
+  falls back to explicit build steps (documented inline in the workflow).

--- a/docs/adr/0005-renovate-dependency-updates.md
+++ b/docs/adr/0005-renovate-dependency-updates.md
@@ -1,0 +1,56 @@
+# 5. Renovate for routine dependency version updates
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+
+## Context
+
+All dependency and plugin versions are centralised in the root pom
+([ADR 0001](0001-foundational-architecture.md)), which makes upgrades a
+single-file change but does nothing to tell the maintainer *when* a newer version
+exists. Left to manual tracking (or the periodic `generate-maven-update-reports`
+script), the project drifts onto stale versions and only discovers a needed
+upgrade when something breaks or a CVE is announced. The project wants automated,
+continuous version hygiene delivered as reviewable pull requests.
+
+## Decision
+
+Adopt **Renovate** to own **routine dependency and Maven-plugin version bumps**.
+Renovate opens pull requests that raise versions in the root pom's
+`<dependencyManagement>` / `<pluginManagement>`, where every version lives, so its
+PRs are naturally scoped to one place and run through the normal CI (build, tests,
+enforcer, ArchUnit) before merge.
+
+Renovate is chosen over Dependabot for this role because it handles a Maven
+mono-repo's centralised version management well, groups related updates, supports
+scheduling to batch noise, and (once trusted) can auto-merge low-risk updates.
+
+**Division of labour:** Renovate handles *routine version currency*; it does **not**
+own security remediation — that is Dependabot's role
+([ADR 0006](0006-dependabot-security-updates.md)). This split is deliberate; see
+[ADR 0002](0002-security-policy-and-supply-chain-posture.md). Running both bots for
+*all* updates was rejected as redundant and noisy.
+
+### Implementation status
+
+This ADR records the decision. The Renovate configuration itself
+(`renovate.json` / `.github/renovate.json`, e.g. extending `config:recommended`
+with a schedule and grouping) is **not yet committed** and is a follow-up. Enabling
+the Renovate GitHub App on the repository is a prerequisite. Until that config
+lands, this decision is accepted but not yet in force.
+
+## Consequences
+
+**Positive**
+
+- Dependencies and plugins stay current with minimal manual effort; upgrades arrive
+  as CI-verified pull requests.
+- Centralised versions mean each Renovate PR touches one file and is easy to review.
+- Scheduling/grouping keeps PR volume manageable.
+
+**Negative / trade-offs**
+
+- Adds a bot and a config file to maintain; misconfiguration can produce noise.
+- Requires the Renovate App to be installed and configured on the repository.
+- Care is needed so Renovate and Dependabot do not both open a PR for the same
+  security-driven bump; the role split in ADR 0002 exists to prevent that.

--- a/docs/adr/0006-dependabot-security-updates.md
+++ b/docs/adr/0006-dependabot-security-updates.md
@@ -1,0 +1,64 @@
+# 6. Dependabot for security-alert updates
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+
+## Context
+
+Renovate keeps dependencies on recent versions
+([ADR 0005](0005-renovate-dependency-updates.md)), but routine version currency and
+*security* remediation are different problems. When a CVE is published against a
+dependency (directly or transitively), the project needs a fast, unambiguous path
+to the patched version — ideally opened automatically the moment GitHub's advisory
+database learns of the issue, and clearly labelled as a security fix so it is
+prioritised over ordinary bumps.
+
+## Decision
+
+Use **GitHub Dependabot security updates** to own **vulnerability remediation**.
+Dependabot watches the repository's dependency graph against the GitHub Advisory
+Database and opens **security-only** pull requests that move an affected dependency
+to the minimum patched version, tied to the corresponding Dependabot alert.
+
+Dependabot is chosen for this role because it is native to GitHub, driven directly
+by the advisory database, and integrates with the repository's Dependabot alerts —
+so a security PR carries the alert context and severity. Its native integration
+makes it the better fit for security remediation, while Renovate's richer
+scheduling/grouping makes it the better fit for routine bumps.
+
+**Division of labour:** Dependabot is scoped to **security updates only**;
+routine version bumps are Renovate's job ([ADR 0005](0005-renovate-dependency-updates.md)).
+Keeping Dependabot's version-update stream disabled avoids duplicate PRs with
+Renovate. See [ADR 0002](0002-security-policy-and-supply-chain-posture.md) for the
+overall rationale.
+
+### Implementation status
+
+This ADR records the decision. Enabling it requires:
+
+1. Turning on **Dependabot alerts** and **Dependabot security updates** in the
+   repository's security settings (GitHub UI), and
+2. Optionally committing `.github/dependabot.yml` with the `maven` ecosystem
+   configured and version-updates left off (security updates are governed by the
+   repo setting, not the file).
+
+The config file is **not yet committed** and is a follow-up. Until the settings are
+enabled, this decision is accepted but not yet in force.
+
+## Consequences
+
+**Positive**
+
+- Known-vulnerable dependencies are remediated automatically, fast, with the
+  advisory/severity context attached.
+- Security PRs are visually distinct from routine Renovate PRs, so they can be
+  prioritised.
+- No third-party service beyond GitHub is required.
+
+**Negative / trade-offs**
+
+- Two update bots run against one repository; the security-only scoping in this ADR
+  and the version-only scoping in ADR 0005 are what keep them from colliding.
+- Dependabot's remediation is limited to what the GitHub Advisory Database knows;
+  it complements, but does not replace, CodeQL ([ADR 0004](0004-codeql-code-scanning.md))
+  and keeping versions current (ADR 0005).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,11 @@ add a new ADR that supersedes it and cross-link the two.
 | ADR | Title | Status |
 | --- | --- | --- |
 | [0001](0001-foundational-architecture.md) | Foundational architecture of the `tools` project | Accepted |
+| [0002](0002-security-policy-and-supply-chain-posture.md) | Security policy and supply-chain posture | Accepted |
+| [0003](0003-require-tls-1.3.md) | Require TLS 1.3+ for HTTPS transports | Accepted |
+| [0004](0004-codeql-code-scanning.md) | CodeQL static analysis for code scanning | Accepted |
+| [0005](0005-renovate-dependency-updates.md) | Renovate for routine dependency version updates | Accepted |
+| [0006](0006-dependabot-security-updates.md) | Dependabot for security-alert updates | Accepted |
 
 ## Related documents
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,34 @@
+# Architecture Decision Records
+
+This directory holds the **Architecture Decision Records (ADRs)** for the `tools`
+project. An ADR captures a single architecturally significant decision — the
+context that forced it, the choice made, and the consequences that follow — so
+the *why* behind the code survives long after the discussion that produced it.
+
+We follow the lightweight format popularised by
+[Michael Nygard](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
+Each record is immutable once accepted: rather than editing an old decision, we
+add a new ADR that supersedes it and cross-link the two.
+
+## Conventions
+
+- One decision per file, named `NNNN-short-title.md` (zero-padded, monotonically
+  increasing, e.g. `0002-adopt-duckdb-for-parquet.md`).
+- Number `0001` is reserved for the foundational record below, which captures the
+  cross-cutting decisions that shape the repository as a whole.
+- Status is one of `Proposed`, `Accepted`, `Superseded by NNNN`, or `Deprecated`.
+- Keep records short and factual. Link to `AGENTS.md`, `README.md`, and the
+  `docs/` diagrams for the detail rather than duplicating them.
+
+## Index
+
+| ADR | Title | Status |
+| --- | --- | --- |
+| [0001](0001-foundational-architecture.md) | Foundational architecture of the `tools` project | Accepted |
+
+## Related documents
+
+- [AGENTS.md](../../AGENTS.md) — single source of truth for the repository guide.
+- [docs/c4-architecture.md](../c4-architecture.md) — C4 model of modules and MCP servers.
+- [docs/compile-time-safe-builders.md](../compile-time-safe-builders.md) — how the
+  generated builder chain shifts required-field validation to compile time.


### PR DESCRIPTION
Introduce docs/adr/ following the Nygard ADR convention:
- README.md explaining the convention, numbering, and index
- 0001-foundational-architecture.md capturing the cross-cutting
  decisions that shape the whole project (multi-module Maven with
  centralised versions, Java 25 baseline, shift-left generated
  builders, MCP integration surface, docs-as-enforced-contract,
  ArchUnit layering, hermetic builds/tests, and SOLID conventions)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Aje2SVxdE2UNqh1hSDJffN