### PR TITLE
docs(adr): consistent template, honest statuses, and missing records

### DIFF
--- a/docs/adr/0001-foundational-architecture.md
+++ b/docs/adr/0001-foundational-architecture.md
@@ -2,6 +2,23 @@
 
 - **Status:** Accepted
 - **Date:** 2026-07-16
+- **Deciders:** Project maintainers
+- **Tags:** foundational, build, architecture
+- **Supersedes:** —
+- **Superseded by:** —
+
+> **Scope note — intentional exception to "one decision per file."** The repo
+> convention (see [README](README.md)) is one decision per record. This
+> foundational ADR is a deliberate exception: it captures the cross-cutting
+> decisions that shape the whole repository as a single baseline. Each numbered
+> section below is individually revisable — a later ADR supersedes just that
+> section and links back here. Capability-specific decisions that expand on the
+> rationale sketched here live in their own records (e.g.
+> [ADR 0007](0007-duckdb-parquet-data-source.md),
+> [ADR 0008](0008-log4j2-logging.md),
+> [ADR 0009](0009-mcp-servers-on-spring-boot.md),
+> [ADR 0010](0010-documentation-as-enforced-contract.md)), and the security
+> posture is recorded under [ADR 0002](0002-security-policy-and-supply-chain-posture.md).
 
 ## Context
 
@@ -62,7 +79,8 @@ Capabilities that are useful to AI assistants are exposed through **MCP servers*
 Shared server scaffolding — transport wiring and the tool SPI — is factored into
 `mcp-common`, and each server supports stdio, streamable HTTP, stateless HTTP, and
 HTTP+SSE transports. This keeps the tool logic decoupled from transport concerns
-and consistent across servers.
+and consistent across servers. The choice of Spring Boot as the server runtime is
+recorded and justified in [ADR 0009](0009-mcp-servers-on-spring-boot.md).
 
 ### 5. Documentation as an enforced contract
 
@@ -73,7 +91,9 @@ fails the build when these documents drift — format rules pin required heading
 `crossDocConsistency` keeps mirrored facts (e.g. the Java version) aligned between
 CLAUDE.md and AGENTS.md, and a README-consistency rule catches capabilities
 described in one place but missing from another. Treating the docs as a
-build-checked contract keeps agent guidance trustworthy.
+build-checked contract keeps agent guidance trustworthy. The rationale for this
+unusual "documentation as a build-failing contract" mechanism, and the rules it
+enforces, are recorded in [ADR 0010](0010-documentation-as-enforced-contract.md).
 
 ### 6. Layering and convention enforcement via ArchUnit
 

--- a/docs/adr/0002-security-policy-and-supply-chain-posture.md
+++ b/docs/adr/0002-security-policy-and-supply-chain-posture.md
@@ -2,12 +2,18 @@
 
 - **Status:** Accepted
 - **Date:** 2026-07-16
+- **Deciders:** Project maintainers
+- **Tags:** security, supply-chain
+- **Supersedes:** —
+- **Superseded by:** —
 
 ## Context
 
 `tools` is published to Maven Central and pulls a large tree of third-party
 dependencies (Spring Boot, protobuf, DuckDB, log4j2, and the MCP SDK, among
-others). As a library consumed by other projects, a vulnerability in `tools` or
+others) under the foundational architecture recorded in
+[ADR 0001](0001-foundational-architecture.md). As a library consumed by other
+projects, a vulnerability in `tools` or
 in one of its transitive dependencies propagates downstream. The project needs a
 stated, repeatable security posture rather than ad-hoc responses: a way for
 people to report issues, a defined set of supported versions, automated detection
@@ -43,9 +49,12 @@ routine version bumps, Dependabot owns security-alert remediation. This split is
 deliberate — running both for all updates would produce redundant, noisy pull
 requests. See the individual ADRs for the rationale.
 
-All of the above is enforced through the existing CI and repository
-configuration; the security posture is a property of the build and repo settings,
-not a manual checklist.
+Pillars 1 and 2 are in force today (SECURITY.md and the CodeQL workflow are
+committed). Pillars 3 and 4 are **decided but not yet implemented** — ADRs 0005
+and 0006 carry `Proposed` status until their bot configuration lands and the
+repository settings are enabled. The posture is a property of the build and repo
+settings, not a manual checklist; where a pillar is not yet wired up, its ADR
+records that explicitly.
 
 ## Consequences
 

--- a/docs/adr/0003-require-tls-1.3.md
+++ b/docs/adr/0003-require-tls-1.3.md
@@ -2,6 +2,13 @@
 
 - **Status:** Accepted
 - **Date:** 2026-07-16
+- **Deciders:** Project maintainers
+- **Tags:** security, transport, tls
+- **Supersedes:** —
+- **Superseded by:** —
+
+Refines the transport-security pillar of
+[ADR 0002](0002-security-policy-and-supply-chain-posture.md).
 
 ## Context
 
@@ -47,5 +54,17 @@ customiser, not by re-allowing 1.2.
   — such clients should use a modern TLS stack — but it is a hard cutoff.
 - The enforcement currently lives with the context MCP server. If another
   HTTPS-serving surface is added, it must apply the same customiser (or a shared
-  one) to inherit the guarantee; this is a known follow-up should a second HTTPS
-  endpoint appear.
+  one) to inherit the guarantee.
+
+## Follow-up
+
+**Extract the customiser to `mcp-common` before a second HTTPS surface ships.**
+`enforceTls13()` lives in the context module today, so the TLS 1.3 guarantee is
+not automatically inherited by any future HTTPS-serving MCP server (the data
+server, for example). The tracked follow-up is to move the
+`WebServerFactoryCustomizer` into `mcp-common`'s shared server scaffolding (see
+[ADR 0009](0009-mcp-servers-on-spring-boot.md)) so every server that enables SSL
+gets the pinned protocol set for free, and to add an ArchUnit/enforcer check that
+no MCP server enables SSL without the shared customiser on the classpath. Until
+then, any new HTTPS endpoint must apply the customiser explicitly and this ADR is
+the record of that obligation.

--- a/docs/adr/0004-codeql-code-scanning.md
+++ b/docs/adr/0004-codeql-code-scanning.md
@@ -2,6 +2,13 @@
 
 - **Status:** Accepted
 - **Date:** 2026-07-16
+- **Deciders:** Project maintainers
+- **Tags:** security, static-analysis, ci
+- **Supersedes:** —
+- **Superseded by:** —
+
+Refines the "find vulnerable code early" pillar of
+[ADR 0002](0002-security-policy-and-supply-chain-posture.md).
 
 ## Context
 

--- a/docs/adr/0005-renovate-dependency-updates.md
+++ b/docs/adr/0005-renovate-dependency-updates.md
@@ -1,7 +1,16 @@
 # 5. Renovate for routine dependency version updates
 
-- **Status:** Accepted
+- **Status:** Proposed (decided; pending implementation)
 - **Date:** 2026-07-16
+- **Deciders:** Project maintainers
+- **Tags:** dependencies, automation, ci
+- **Supersedes:** —
+- **Superseded by:** —
+
+Refines the "keep dependencies current" pillar of
+[ADR 0002](0002-security-policy-and-supply-chain-posture.md). This record stays
+`Proposed` until the Renovate configuration lands and the app is enabled (see
+*Implementation status* below); it flips to `Accepted` at that point.
 
 ## Context
 
@@ -37,7 +46,8 @@ This ADR records the decision. The Renovate configuration itself
 (`renovate.json` / `.github/renovate.json`, e.g. extending `config:recommended`
 with a schedule and grouping) is **not yet committed** and is a follow-up. Enabling
 the Renovate GitHub App on the repository is a prerequisite. Until that config
-lands, this decision is accepted but not yet in force.
+lands, this ADR stays `Proposed`: the decision is made but not yet in force. The
+status flips to `Accepted` when the config is committed and the app is enabled.
 
 ## Consequences
 

--- a/docs/adr/0006-dependabot-security-updates.md
+++ b/docs/adr/0006-dependabot-security-updates.md
@@ -1,7 +1,16 @@
 # 6. Dependabot for security-alert updates
 
-- **Status:** Accepted
+- **Status:** Proposed (decided; pending implementation)
 - **Date:** 2026-07-16
+- **Deciders:** Project maintainers
+- **Tags:** security, dependencies, automation
+- **Supersedes:** —
+- **Superseded by:** —
+
+Refines the "remediate known vulnerabilities fast" pillar of
+[ADR 0002](0002-security-policy-and-supply-chain-posture.md). This record stays
+`Proposed` until Dependabot security updates are enabled in repository settings
+(see *Implementation status* below); it flips to `Accepted` at that point.
 
 ## Context
 
@@ -43,7 +52,9 @@ This ADR records the decision. Enabling it requires:
    repo setting, not the file).
 
 The config file is **not yet committed** and is a follow-up. Until the settings are
-enabled, this decision is accepted but not yet in force.
+enabled, this ADR stays `Proposed`: the decision is made but not yet in force. The
+status flips to `Accepted` when Dependabot security updates are switched on in the
+repository's security settings.
 
 ## Consequences
 

--- a/docs/adr/0007-duckdb-parquet-data-source.md
+++ b/docs/adr/0007-duckdb-parquet-data-source.md
@@ -1,0 +1,59 @@
+# 7. DuckDB (JDBC) as the Parquet read engine
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+- **Deciders:** Project maintainers
+- **Tags:** data, dependencies
+- **Supersedes:** —
+- **Superseded by:** —
+
+Expands on the data-toolkit capability sketched in
+[ADR 0001](0001-foundational-architecture.md).
+
+## Context
+
+The `data` module exposes CSV, GZip, JDBC, and Parquet data sources behind a
+common contract, in both in-memory and iterative flavours. Parquet is a columnar
+binary format with no usable pure-Java reader in the project's existing
+dependency set; reading it requires an engine that can open a Parquet file and
+project rows. The obvious JVM option — the Apache Parquet + Hadoop stack — pulls a
+very large, Hadoop-flavoured transitive tree that is heavy for a general-purpose
+tooling library and awkward to keep on a current, CVE-free version.
+
+## Decision
+
+Read Parquet through **DuckDB via its JDBC driver** (`org.duckdb:duckdb_jdbc`,
+version-managed in the root pom like every other dependency —
+[ADR 0001](0001-foundational-architecture.md)). The Parquet data sources
+(`IterableParquetDataSource`, `InMemoryParquetDataSource`) delegate to DuckDB
+(`DuckDbParquet`), which reads the file with a SQL `SELECT` over DuckDB's native
+Parquet support and surfaces rows through the same data-source contract as the
+other formats.
+
+DuckDB is chosen because it ships a single self-contained native library behind a
+standard JDBC interface, has first-class Parquet support, and avoids the Hadoop
+dependency tree entirely. Reusing the JDBC path also means the Parquet sources sit
+naturally alongside the module's existing JDBC data source rather than introducing
+a second, unrelated I/O stack.
+
+## Consequences
+
+**Positive**
+
+- Parquet support with a small, self-contained dependency and no Hadoop tree.
+- Parquet reads reuse the JDBC-shaped data-source contract, keeping the module's
+  I/O surface uniform.
+- DuckDB's SQL engine makes column projection and filtering cheap to express if
+  the sources grow richer query needs later.
+
+**Negative / trade-offs**
+
+- DuckDB bundles a platform-specific native library; the dependency is larger than
+  a pure-Java jar and ties Parquet reads to the platforms DuckDB publishes
+  binaries for.
+- The project takes on DuckDB's release cadence for security and correctness fixes
+  — mitigated by centralised version management and the dependency-update posture
+  ([ADR 0002](0002-security-policy-and-supply-chain-posture.md)).
+- Routing Parquet through an embedded SQL engine is heavier than a direct reader
+  for the simplest "scan every row" case; accepted for the smaller dependency
+  footprint and the query headroom it buys.

--- a/docs/adr/0008-log4j2-logging.md
+++ b/docs/adr/0008-log4j2-logging.md
@@ -1,0 +1,54 @@
+# 8. log4j2 as the logging backend
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+- **Deciders:** Project maintainers
+- **Tags:** logging, observability
+- **Supersedes:** —
+- **Superseded by:** —
+
+Records a convention that [ADR 0001](0001-foundational-architecture.md) enforces
+via ArchUnit but does not itself justify.
+
+## Context
+
+Production code needs a single, consistent logging story. Left unstated, different
+modules drift toward `System.out`/`System.err`, `printStackTrace()`, or a mix of
+logging facades, which makes output impossible to configure centrally and hides
+errors from any log aggregation. The project already fails the build on ad-hoc
+console output through its ArchUnit rules ([ADR 0001](0001-foundational-architecture.md)),
+so it needs a named backend those rules can point contributors at.
+
+## Decision
+
+Log through **Apache log4j2** (`log4j-api` for call sites, `log4j-core` as the
+runtime), version-managed in the root pom. Conventions:
+
+- Loggers are declared `private static final` and obtained per class.
+- Production code logs **only** through the log4j2 API — no `System.out`/`err`, no
+  `printStackTrace()`, and no `System.exit()`. These prohibitions are enforced by
+  ArchUnit tests in each module's `...architecture` package, not left to review.
+- Application entry points and MCP servers configure log4j2; library modules
+  depend only on `log4j-api` at their call sites.
+
+log4j2 is chosen for its mature configuration model, performance, and ubiquity in
+the Java ecosystem; standardising on one backend is what matters more than the
+specific choice among mature options.
+
+## Consequences
+
+**Positive**
+
+- One configurable logging pipeline across every module; output can be routed,
+  filtered, and formatted centrally.
+- The "no console output / no `printStackTrace`" rules have a concrete, enforced
+  destination, so errors are captured rather than dropped to stderr.
+
+**Negative / trade-offs**
+
+- log4j2's history (e.g. Log4Shell) is a reminder that the logging backend is a
+  security-relevant dependency; keeping it current is covered by the
+  dependency-update posture ([ADR 0002](0002-security-policy-and-supply-chain-posture.md)).
+- Contributors used to SLF4J or plain `System.out` must adopt the project's API
+  and the `private static final` logger convention; the ArchUnit rules make the
+  requirement explicit at build time.

--- a/docs/adr/0009-mcp-servers-on-spring-boot.md
+++ b/docs/adr/0009-mcp-servers-on-spring-boot.md
@@ -1,0 +1,59 @@
+# 9. MCP servers built on Spring Boot
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+- **Deciders:** Project maintainers
+- **Tags:** mcp, integration, runtime
+- **Supersedes:** —
+- **Superseded by:** —
+
+Justifies the server runtime chosen for the MCP integration surface described in
+[ADR 0001](0001-foundational-architecture.md).
+
+## Context
+
+Two capabilities are exposed to AI assistants as MCP servers: the uniqueness
+checker in `data`, and `project_tree` / `find_context` / `estimate_tokens` in
+`code/context`. Both need the same plumbing — process/lifecycle management,
+dependency injection to assemble tool handlers, and multiple MCP transports
+(stdio, streamable HTTP, stateless HTTP, HTTP+SSE), including HTTPS with a pinned
+TLS policy ([ADR 0003](0003-require-tls-1.3.md)). Writing that plumbing by hand,
+twice, would be duplicative and error-prone; the servers need a common runtime.
+
+## Decision
+
+Build the MCP servers as **Spring Boot applications**, with the shared server
+scaffolding — transport wiring, the tool SPI, and the HTTPS/TLS customiser —
+factored into **`mcp-common`** so each server module supplies only its tool logic.
+
+Spring Boot is chosen because:
+
+- The MCP Java SDK integrates cleanly with Spring's server model, and Spring Boot
+  supplies the embedded HTTP server (Tomcat) the HTTP transports need out of the
+  box, including the `WebServerFactoryCustomizer` hook ADR 0003 relies on to pin
+  TLS 1.3.
+- Its dependency injection is a natural fit for assembling tool handlers and
+  transport beans, keeping tool logic decoupled from transport concerns.
+- Standardising both servers on one runtime means shared scaffolding in
+  `mcp-common` rather than two bespoke setups.
+
+## Consequences
+
+**Positive**
+
+- Both MCP servers share one runtime and one set of transport/TLS scaffolding in
+  `mcp-common`; a fix or a new transport is written once.
+- The embedded-server model gives the TLS 1.3 enforcement of ADR 0003 a single,
+  well-defined place to live (and a clear home to migrate it to — see that ADR's
+  follow-up).
+- New MCP servers start from `mcp-common` and inherit transports, DI wiring, and
+  the security posture for free.
+
+**Negative / trade-offs**
+
+- Spring Boot is a heavyweight runtime for what can be a small stdio tool server;
+  the startup cost and dependency footprint are larger than a minimal handwritten
+  server would carry.
+- The servers inherit Spring Boot's release cadence and its share of the dependency
+  tree that the security posture ([ADR 0002](0002-security-policy-and-supply-chain-posture.md))
+  must keep current.

--- a/docs/adr/0010-documentation-as-enforced-contract.md
+++ b/docs/adr/0010-documentation-as-enforced-contract.md
@@ -1,0 +1,62 @@
+# 10. Documentation as a build-enforced contract
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+- **Deciders:** Project maintainers
+- **Tags:** docs, build, tooling
+- **Supersedes:** —
+- **Superseded by:** —
+
+Justifies and details the doc-contract mechanism named in
+[ADR 0001](0001-foundational-architecture.md).
+
+## Context
+
+The repository maintains overlapping guidance for different audiences: `AGENTS.md`
+(the single source of truth for agents), `CLAUDE.md` (a quick-reference that
+defers to it), and `README.md` (the same capabilities for humans). Overlapping
+docs rot independently — the Java version is bumped in one file but not another, a
+new capability is added to the README but not AGENTS.md, a required heading is
+dropped in a refactor. When agent-facing docs drift, agents act on stale
+instructions, so ordinary "keep the docs updated" discipline is not enough: the
+docs need to fail the build when they disagree.
+
+## Decision
+
+Enforce documentation consistency with a **custom maven-enforcer rule module**,
+`claude-code-enforcer`, wired into the reactor build. Its rules include:
+
+- **Format rules** that pin required headings/structure in `CLAUDE.md` and
+  `AGENTS.md` (`ClaudeMdFormatRule`, `AgentsMdFormatRule`).
+- **`crossDocConsistency`**, which keeps mirrored facts (e.g. the Java version)
+  identical between `CLAUDE.md` and `AGENTS.md`.
+- **README consistency** (`ReadmeConsistencyRule`), which catches a capability
+  documented in one place but missing from another.
+- Rules validating agent/skill/command **definition files** and `settings.json`
+  hook configuration, so the agent tooling config cannot silently break.
+
+Because the checks run as enforcer rules, drift fails `mvn install` like any other
+build error rather than relying on a reviewer to notice. The enforcer module is
+itself covered by ArchUnit and unit tests
+([ADR 0001](0001-foundational-architecture.md)).
+
+## Consequences
+
+**Positive**
+
+- Agent-facing docs stay trustworthy: contradictions between `AGENTS.md`,
+  `CLAUDE.md`, and `README.md` become build failures, not latent bugs.
+- The "single source of truth" claim for `AGENTS.md` is mechanically true, not
+  aspirational.
+- Agent, skill, command, and settings config is validated, so a malformed
+  definition is caught before it ships.
+
+**Negative / trade-offs**
+
+- The enforcer rules are project-specific code that must be maintained and kept in
+  sync when the doc structure legitimately changes — a deliberate cost paid to
+  prevent drift.
+- A legitimate doc change can require touching multiple files at once to satisfy
+  the consistency rules; this is the intended friction, but it is friction.
+- The rules encode assumptions about heading structure; large doc reorganisations
+  must update the rules alongside the docs.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,23 +13,54 @@ add a new ADR that supersedes it and cross-link the two.
 ## Conventions
 
 - One decision per file, named `NNNN-short-title.md` (zero-padded, monotonically
-  increasing, e.g. `0002-adopt-duckdb-for-parquet.md`).
-- Number `0001` is reserved for the foundational record below, which captures the
-  cross-cutting decisions that shape the repository as a whole.
-- Status is one of `Proposed`, `Accepted`, `Superseded by NNNN`, or `Deprecated`.
+  increasing, e.g. `0007-duckdb-parquet-data-source.md`).
+- Number `0001` is reserved for the foundational record below. It is a deliberate
+  exception to "one decision per file": it captures the cross-cutting decisions
+  that shape the repository as a whole, each individually supersedable.
 - Keep records short and factual. Link to `AGENTS.md`, `README.md`, and the
   `docs/` diagrams for the detail rather than duplicating them.
 
+### Template
+
+Every record opens with the title (`# N. Title`) followed by a metadata block and
+the `Context` → `Decision` → `Consequences` sections:
+
+```
+- **Status:** <see below>
+- **Date:** YYYY-MM-DD          (the date the decision was actually made)
+- **Deciders:** <who>
+- **Tags:** <comma-separated>
+- **Supersedes:** <NNNN or —>
+- **Superseded by:** <NNNN or —>
+```
+
+**Status vocabulary:**
+
+- `Proposed` — decided in principle but **not yet in force** (config/settings not
+  yet committed or enabled). Such records say so and name what must land before
+  they flip to `Accepted`.
+- `Accepted` — in force.
+- `Superseded by NNNN` — replaced by a later record; cross-linked both ways.
+- `Deprecated` — no longer in force and not replaced.
+
+Records are immutable in intent once `Accepted`: rather than rewriting an accepted
+decision, add a new ADR that supersedes it and set both records' `Supersedes` /
+`Superseded by` fields.
+
 ## Index
 
-| ADR | Title | Status |
-| --- | --- | --- |
-| [0001](0001-foundational-architecture.md) | Foundational architecture of the `tools` project | Accepted |
-| [0002](0002-security-policy-and-supply-chain-posture.md) | Security policy and supply-chain posture | Accepted |
-| [0003](0003-require-tls-1.3.md) | Require TLS 1.3+ for HTTPS transports | Accepted |
-| [0004](0004-codeql-code-scanning.md) | CodeQL static analysis for code scanning | Accepted |
-| [0005](0005-renovate-dependency-updates.md) | Renovate for routine dependency version updates | Accepted |
-| [0006](0006-dependabot-security-updates.md) | Dependabot for security-alert updates | Accepted |
+| ADR | Title | Status | Date |
+| --- | --- | --- | --- |
+| [0001](0001-foundational-architecture.md) | Foundational architecture of the `tools` project | Accepted | 2026-07-16 |
+| [0002](0002-security-policy-and-supply-chain-posture.md) | Security policy and supply-chain posture | Accepted | 2026-07-16 |
+| [0003](0003-require-tls-1.3.md) | Require TLS 1.3+ for HTTPS transports | Accepted | 2026-07-16 |
+| [0004](0004-codeql-code-scanning.md) | CodeQL static analysis for code scanning | Accepted | 2026-07-16 |
+| [0005](0005-renovate-dependency-updates.md) | Renovate for routine dependency version updates | Proposed | 2026-07-16 |
+| [0006](0006-dependabot-security-updates.md) | Dependabot for security-alert updates | Proposed | 2026-07-16 |
+| [0007](0007-duckdb-parquet-data-source.md) | DuckDB (JDBC) as the Parquet read engine | Accepted | 2026-07-16 |
+| [0008](0008-log4j2-logging.md) | log4j2 as the logging backend | Accepted | 2026-07-16 |
+| [0009](0009-mcp-servers-on-spring-boot.md) | MCP servers built on Spring Boot | Accepted | 2026-07-16 |
+| [0010](0010-documentation-as-enforced-contract.md) | Documentation as a build-enforced contract | Accepted | 2026-07-16 |
 
 ## Related documents
 


### PR DESCRIPTION
Address ADR review items 1-7:

1. Consistent metadata template across every record (Status, Date,
   Deciders, Tags, Supersedes/Superseded-by); documented in the README.
2. Correct dishonest status: 0005 (Renovate) and 0006 (Dependabot) are
   decided but not yet in force, so they are now Proposed with the
   condition for flipping to Accepted stated.
3. Index gains a Date column and lists all records.
4. 0001 explicitly labelled as an intentional "one decision per file"
   exception, with forward links to the records that expand on it.
5. Add the missing decision records the codebase already made:
   - 0007 DuckDB (JDBC) as the Parquet read engine
   - 0008 log4j2 as the logging backend
   - 0009 MCP servers built on Spring Boot
   - 0010 documentation as a build-enforced contract
6. 0003 (TLS 1.3) gains a tracked Follow-up to hoist the customiser into
   mcp-common before a second HTTPS surface ships.
7. Symmetric cross-links between the foundational, security, and refining
   records.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019q1hq86Uu7bDDa9KeaJwDV