### PR TITLE
ci(security): wire up Renovate and Dependabot configs (ADR 0005, 0006)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Dependabot configuration (ADR 0006).
+#
+# Dependabot owns SECURITY remediation only; routine version bumps are
+# Renovate's job (ADR 0005). Dependabot security updates are governed by the
+# repository's security settings, not by this file, and they honour the
+# ecosystem configuration below (schedule, labels). Version updates are kept
+# OFF — open-pull-requests-limit: 0 disables Dependabot's version-update stream
+# so it cannot open duplicate PRs alongside Renovate.
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # 0 disables version updates; security updates (repo setting) still apply.
+    open-pull-requests-limit: 0
+    labels:
+      - "security"
+      - "dependencies"

--- a/docs/adr/0005-renovate-dependency-updates.md
+++ b/docs/adr/0005-renovate-dependency-updates.md
@@ -1,6 +1,6 @@
 # 5. Renovate for routine dependency version updates
 
-- **Status:** Proposed (decided; pending implementation)
+- **Status:** Proposed (config committed; pending Renovate App enablement)
 - **Date:** 2026-07-16
 - **Deciders:** Project maintainers
 - **Tags:** dependencies, automation, ci
@@ -8,9 +8,10 @@
 - **Superseded by:** —
 
 Refines the "keep dependencies current" pillar of
-[ADR 0002](0002-security-policy-and-supply-chain-posture.md). This record stays
-`Proposed` until the Renovate configuration lands and the app is enabled (see
-*Implementation status* below); it flips to `Accepted` at that point.
+[ADR 0002](0002-security-policy-and-supply-chain-posture.md). The Renovate
+configuration has now landed (see *Implementation status* below); this record
+stays `Proposed` only until the Renovate GitHub App is enabled on the
+repository, at which point it flips to `Accepted`.
 
 ## Context
 
@@ -42,12 +43,16 @@ own security remediation — that is Dependabot's role
 
 ### Implementation status
 
-This ADR records the decision. The Renovate configuration itself
-(`renovate.json` / `.github/renovate.json`, e.g. extending `config:recommended`
-with a schedule and grouping) is **not yet committed** and is a follow-up. Enabling
-the Renovate GitHub App on the repository is a prerequisite. Until that config
-lands, this ADR stays `Proposed`: the decision is made but not yet in force. The
-status flips to `Accepted` when the config is committed and the app is enabled.
+The Renovate configuration is now committed at
+[`renovate.json`](../../renovate.json): it extends `config:recommended`, runs on
+a weekly schedule, groups non-major Maven bumps into a single PR (every version
+lives in the root pom, so a grouped PR touches one file), and disables Renovate's
+own vulnerability alerts so security remediation stays solely with Dependabot
+([ADR 0006](0006-dependabot-security-updates.md)). The one remaining step is
+enabling the Renovate GitHub App on the repository — a settings action that
+cannot be committed. Until the app is enabled the config is inert, so this ADR
+stays `Proposed`; it flips to `Accepted` once the app is installed and opening
+PRs.
 
 ## Consequences
 

--- a/docs/adr/0006-dependabot-security-updates.md
+++ b/docs/adr/0006-dependabot-security-updates.md
@@ -1,6 +1,6 @@
 # 6. Dependabot for security-alert updates
 
-- **Status:** Proposed (decided; pending implementation)
+- **Status:** Proposed (config committed; pending repo security-settings enablement)
 - **Date:** 2026-07-16
 - **Deciders:** Project maintainers
 - **Tags:** security, dependencies, automation
@@ -8,9 +8,11 @@
 - **Superseded by:** —
 
 Refines the "remediate known vulnerabilities fast" pillar of
-[ADR 0002](0002-security-policy-and-supply-chain-posture.md). This record stays
-`Proposed` until Dependabot security updates are enabled in repository settings
-(see *Implementation status* below); it flips to `Accepted` at that point.
+[ADR 0002](0002-security-policy-and-supply-chain-posture.md). The
+`.github/dependabot.yml` configuration has now landed (see *Implementation
+status* below); this record stays `Proposed` only until Dependabot alerts and
+security updates are switched on in the repository's security settings, at which
+point it flips to `Accepted`.
 
 ## Context
 
@@ -43,18 +45,22 @@ overall rationale.
 
 ### Implementation status
 
-This ADR records the decision. Enabling it requires:
+Step 2 below — the config file — is now done;
+[`.github/dependabot.yml`](../../.github/dependabot.yml) declares the `maven`
+ecosystem with `open-pull-requests-limit: 0`, which disables Dependabot's
+version-update stream (Renovate's job, [ADR 0005](0005-renovate-dependency-updates.md))
+while leaving the ecosystem configuration — schedule and labels — to apply to the
+security updates governed by the repository setting. What remains is step 1, a
+settings action that cannot be committed:
 
 1. Turning on **Dependabot alerts** and **Dependabot security updates** in the
-   repository's security settings (GitHub UI), and
-2. Optionally committing `.github/dependabot.yml` with the `maven` ecosystem
-   configured and version-updates left off (security updates are governed by the
-   repo setting, not the file).
+   repository's security settings (GitHub UI) — **still pending**, and
+2. Committing `.github/dependabot.yml` with the `maven` ecosystem configured and
+   version-updates left off — **done**.
 
-The config file is **not yet committed** and is a follow-up. Until the settings are
-enabled, this ADR stays `Proposed`: the decision is made but not yet in force. The
-status flips to `Accepted` when Dependabot security updates are switched on in the
-repository's security settings.
+Until the settings are enabled, security updates do not run, so this ADR stays
+`Proposed`. The status flips to `Accepted` when Dependabot security updates are
+switched on in the repository's security settings.
 
 ## Consequences
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Routine dependency and Maven-plugin version currency (ADR 0005). Security remediation is Dependabot's job (ADR 0006), so Renovate's own vulnerability alerts are disabled here to keep the two bots from opening duplicate PRs for the same security-driven bump.",
+  "extends": [
+    "config:recommended",
+    "schedule:weekly"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "description": "Batch non-major Maven dependency and plugin bumps into one weekly PR; every version lives in the root pom, so a grouped PR touches one file.",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "maven non-major updates"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
Land the two dependency-automation pillars that ADRs 0005 and 0006 had
decided but never committed:

- renovate.json owns routine version currency: extends config:recommended
  on a weekly schedule, groups non-major Maven bumps (all versions live in
  the root pom), and disables its own vulnerability alerts so security
  remediation stays solely with Dependabot.
- .github/dependabot.yml owns security remediation: declares the maven
  ecosystem with open-pull-requests-limit: 0 to keep version updates off
  (Renovate's job) while letting the schedule/labels apply to the
  security updates governed by the repo setting.

Update both ADRs' status/implementation-status to reflect that the config
files have landed; they stay Proposed only until the Renovate App and the
repo's Dependabot security settings are enabled — settings actions that
cannot be committed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SpuyydxFWoxdZfjDdgqUvi