### PR TITLE
feat(adopt): add module that adopts Claude Code into a GitHub repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,12 @@ Maven project. The notable capabilities are:
   (`OpenAddressingMap`, an `OpenAddressingSet`, and the primitive `int`-keyed
   `IntKeyOpenAddressingMap`), and an **MCP server** exposing the
   uniqueness checker as a tool for AI assistants.
+- **Claude Code adoption** (`adopt`) — an ordered pipeline that adopts Claude
+  Code into a GitHub repository: it clones the repo, runs the Claude Code CLI
+  (`claude init`) to generate a `CLAUDE.md`, commits and pushes that, then wires
+  the `claude-code-enforcer` into the project's `pom.xml` and commits and pushes
+  again. External `git`/`claude` invocations go through a `CommandRunner`
+  abstraction so the steps are unit-tested without spawning real processes.
 
 See [README.md](README.md) for worked code examples of each capability,
 [docs/c4-architecture.md](docs/c4-architecture.md) for a C4 model
@@ -58,6 +64,7 @@ tools (root pom, packaging=pom)
 │   ├── protogen-maven-plugin       # the proto2 builder-generating Maven plugin
 │   ├── protogen-maven-plugin-test  # integration tests / use cases for the plugin
 │   └── context                     # regex-based class-usage context finder
+├── adopt                       # adopts Claude Code into a GitHub repo (clone, init, commit/push, enforcer)
 ├── grpc-example                # end-to-end gRPC example with compile-time-safe builders
 ├── assembly                    # builds an executable jar-with-dependencies
 │                               #   (mainClass: io.github.adamw7.tools.data.SampleApp)
@@ -65,7 +72,7 @@ tools (root pom, packaging=pom)
 ```
 
 Root reactor modules are `claude-code-enforcer`, `mcp-common`, `data`, `code`,
-and `assembly`.
+`adopt`, and `assembly`.
 The `data-test` module is built separately (it is not in the root `<modules>`
 list).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,12 @@ run `mvn install` from the repository root. The main capabilities are:
 - **Data** (`data`) — CSV/GZip/JDBC/Parquet data sources (in-memory and iterative), a
   column-uniqueness/key finder, open-addressing map/set data structures, and an
   MCP server exposing the uniqueness checker.
+- **Claude Code adoption** (`adopt`) — a pipeline that adopts Claude Code into a
+  GitHub repo: clone, `claude init` to generate `CLAUDE.md`, commit and push,
+  then wire the `claude-code-enforcer` into the repo's `pom.xml` and push again.
 
 Module map (root reactor: `claude-code-enforcer`, `mcp-common`, `data`, `code`,
-`grpc-example`, `assembly`; `data-test` is built separately):
+`adopt`, `grpc-example`, `assembly`; `data-test` is built separately):
 
 ```
 tools (root pom, packaging=pom)
@@ -35,6 +38,7 @@ tools (root pom, packaging=pom)
 │   ├── protogen-maven-plugin       # compile-time-safe protobuf builder generator
 │   ├── protogen-maven-plugin-test  # integration tests for the plugin
 │   └── context                     # class-usage context finder + MCP server
+├── adopt                  # adopts Claude Code into a GitHub repo (clone, init, commit/push, enforcer)
 ├── grpc-example           # end-to-end gRPC example
 ├── assembly               # executable jar-with-dependencies (SampleApp)
 └── data-test              # standalone test module (not in root <modules>)

--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>io.github.adamw7</groupId>
+		<artifactId>tools</artifactId>
+		<version>${revision}</version>
+	</parent>
+	<artifactId>tools.adopt</artifactId>
+	<packaging>jar</packaging>
+	<name>Claude Code repository adoption</name>
+	<description>Adopts Claude Code into a GitHub repository: clones it, runs claude init to generate CLAUDE.md, commits and pushes, then wires the claude-code-enforcer into the project build.</description>
+	<url>https://github.com/adamw7/tools</url>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -1,0 +1,62 @@
+package io.github.adamw7.tools.adopt;
+
+import java.nio.file.Path;
+
+/**
+ * Immutable inputs shared by every adoption step: the GitHub repository URL to
+ * adopt, the workspace directory the clone is created under, and the resulting
+ * checkout directory. The repository name is derived from the URL up front so
+ * the clone target is known before the first step runs.
+ */
+public final class AdoptionContext {
+
+	private final String repositoryUrl;
+	private final Path workspace;
+	private final Path repositoryDirectory;
+
+	public AdoptionContext(String repositoryUrl, Path workspace) {
+		this.repositoryUrl = requireUrl(repositoryUrl);
+		this.workspace = requireWorkspace(workspace);
+		this.repositoryDirectory = workspace.resolve(repositoryName(this.repositoryUrl));
+	}
+
+	public String repositoryUrl() {
+		return repositoryUrl;
+	}
+
+	public Path workspace() {
+		return workspace;
+	}
+
+	public Path repositoryDirectory() {
+		return repositoryDirectory;
+	}
+
+	private static String requireUrl(String repositoryUrl) {
+		if (repositoryUrl == null || repositoryUrl.isBlank()) {
+			throw new IllegalArgumentException("repositoryUrl must not be blank");
+		}
+		return repositoryUrl.strip();
+	}
+
+	private static Path requireWorkspace(Path workspace) {
+		if (workspace == null) {
+			throw new IllegalArgumentException("workspace must not be null");
+		}
+		return workspace;
+	}
+
+	private static String repositoryName(String repositoryUrl) {
+		String withoutTrailingSlash = stripTrailingSlash(repositoryUrl);
+		String lastSegment = withoutTrailingSlash.substring(withoutTrailingSlash.lastIndexOf('/') + 1);
+		return stripGitSuffix(lastSegment);
+	}
+
+	private static String stripTrailingSlash(String value) {
+		return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+	}
+
+	private static String stripGitSuffix(String segment) {
+		return segment.endsWith(".git") ? segment.substring(0, segment.length() - ".git".length()) : segment;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionException.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionException.java
@@ -1,0 +1,19 @@
+package io.github.adamw7.tools.adopt;
+
+/**
+ * Unchecked failure raised when a step of the Claude Code adoption cannot
+ * complete — a command returned a non-zero exit code, a process could not be
+ * started, or a project file could not be edited.
+ */
+public class AdoptionException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public AdoptionException(String message) {
+		super(message);
+	}
+
+	public AdoptionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -1,0 +1,62 @@
+package io.github.adamw7.tools.adopt;
+
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+import io.github.adamw7.tools.adopt.step.AdoptionStep;
+import io.github.adamw7.tools.adopt.step.ClaudeInitStep;
+import io.github.adamw7.tools.adopt.step.CloneStep;
+import io.github.adamw7.tools.adopt.step.CommitStep;
+import io.github.adamw7.tools.adopt.step.EnforcerStep;
+import io.github.adamw7.tools.adopt.step.PushStep;
+
+/**
+ * Runs the ordered pipeline that adopts Claude Code into a GitHub repository:
+ * clone, generate {@code CLAUDE.md} with {@code claude init}, commit and push
+ * that, then wire in the {@code claude-code-enforcer} and commit and push
+ * again. Steps and the command runner are injected so the pipeline is easy to
+ * reconfigure and to test.
+ */
+public class GitHubRepoAdopter {
+
+	private static final Logger log = LogManager.getLogger(GitHubRepoAdopter.class);
+
+	private final CommandRunner runner;
+	private final List<AdoptionStep> steps;
+
+	public GitHubRepoAdopter(CommandRunner runner, List<AdoptionStep> steps) {
+		this.runner = runner;
+		this.steps = List.copyOf(steps);
+	}
+
+	public static GitHubRepoAdopter withDefaultPipeline(CommandRunner runner) {
+		return new GitHubRepoAdopter(runner, defaultSteps());
+	}
+
+	public static List<AdoptionStep> defaultSteps() {
+		return List.of(
+				new CloneStep(),
+				new ClaudeInitStep(),
+				new CommitStep("Adopt Claude Code: add CLAUDE.md"),
+				new PushStep(),
+				new EnforcerStep(),
+				new CommitStep("Add claude-code-enforcer to the build"),
+				new PushStep());
+	}
+
+	public void adopt(AdoptionContext context) {
+		log.info("Adopting Claude Code into {}", context.repositoryUrl());
+		for (AdoptionStep step : steps) {
+			runStep(step, context);
+		}
+		log.info("Adoption complete for {}", context.repositoryUrl());
+	}
+
+	private void runStep(AdoptionStep step, AdoptionContext context) {
+		log.info("Step: {}", step.name());
+		step.execute(context, runner);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -1,0 +1,46 @@
+package io.github.adamw7.tools.adopt;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
+
+/**
+ * Command-line entry point: given a GitHub repository URL (and an optional
+ * workspace directory to clone into), runs the default adoption pipeline
+ * against a real {@code git}/{@code claude} toolchain.
+ */
+public class Main {
+
+	public static void main(String[] args) {
+		String repositoryUrl = repositoryUrl(args);
+		Path workspace = workspace(args);
+		CommandRunner runner = new ProcessCommandRunner();
+		GitHubRepoAdopter.withDefaultPipeline(runner).adopt(new AdoptionContext(repositoryUrl, workspace));
+	}
+
+	private static String repositoryUrl(String[] args) {
+		if (args == null || args.length < 1 || args[0].isBlank()) {
+			throw new IllegalArgumentException("Usage: <github-repo-url> [workspace-directory]");
+		}
+		return args[0];
+	}
+
+	private static Path workspace(String[] args) {
+		if (args.length >= 2 && !args[1].isBlank()) {
+			return Path.of(args[1]);
+		}
+		return createTemporaryWorkspace();
+	}
+
+	private static Path createTemporaryWorkspace() {
+		try {
+			return Files.createTempDirectory("claude-adopt-");
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandResult.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandResult.java
@@ -1,0 +1,20 @@
+package io.github.adamw7.tools.adopt.command;
+
+import java.util.List;
+
+/**
+ * Outcome of running an external command: the exit code and the combined
+ * standard-output/standard-error text the command produced. The originating
+ * command is kept so failures can be reported without the caller having to
+ * remember what it asked for.
+ */
+public record CommandResult(List<String> command, int exitCode, String output) {
+
+	public boolean succeeded() {
+		return exitCode == 0;
+	}
+
+	public String describe() {
+		return String.join(" ", command);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandRunner.java
@@ -1,0 +1,15 @@
+package io.github.adamw7.tools.adopt.command;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Runs an external command in a given working directory and reports its result.
+ * Abstracting the process invocation behind this interface keeps every
+ * adoption step free of {@link ProcessBuilder} details and lets tests drive the
+ * steps with a recording stub instead of spawning real processes.
+ */
+public interface CommandRunner {
+
+	CommandResult run(Path workingDirectory, List<String> command);
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -1,0 +1,49 @@
+package io.github.adamw7.tools.adopt.command;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+/**
+ * {@link CommandRunner} backed by {@link ProcessBuilder}. Standard error is
+ * merged into standard output so a caller gets a single, ordered transcript of
+ * what the command printed, and the process is always waited for so no child is
+ * left running.
+ */
+public class ProcessCommandRunner implements CommandRunner {
+
+	@Override
+	public CommandResult run(Path workingDirectory, List<String> command) {
+		ProcessBuilder builder = new ProcessBuilder(command)
+				.directory(workingDirectory.toFile())
+				.redirectErrorStream(true);
+		return execute(builder, command);
+	}
+
+	private CommandResult execute(ProcessBuilder builder, List<String> command) {
+		try {
+			Process process = builder.start();
+			String output = readOutput(process);
+			int exitCode = process.waitFor();
+			return new CommandResult(command, exitCode, output);
+		} catch (IOException e) {
+			throw new AdoptionException("Could not start command: " + String.join(" ", command), e);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new AdoptionException("Interrupted while running: " + String.join(" ", command), e);
+		}
+	}
+
+	private String readOutput(Process process) throws IOException {
+		try (BufferedReader reader = new BufferedReader(
+				new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+			return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractCommandStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractCommandStep.java
@@ -1,0 +1,26 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Base for steps that shell out through a {@link CommandRunner}, sharing the
+ * run-and-fail-fast behaviour: a command that exits non-zero aborts the
+ * adoption with an {@link AdoptionException} carrying the command transcript.
+ */
+public abstract class AbstractCommandStep implements AdoptionStep {
+
+	protected final CommandResult runOrFail(CommandRunner runner, Path workingDirectory, List<String> command) {
+		CommandResult result = runner.run(workingDirectory, command);
+		if (!result.succeeded()) {
+			throw new AdoptionException(
+					name() + " failed (exit " + result.exitCode() + ") running: " + result.describe()
+							+ System.lineSeparator() + result.output());
+		}
+		return result;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionStep.java
@@ -1,0 +1,17 @@
+package io.github.adamw7.tools.adopt.step;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * A single stage of adopting Claude Code into a repository. Steps are ordered
+ * and independent: each acts on the shared {@link AdoptionContext} and runs its
+ * external commands through the injected {@link CommandRunner}, so the pipeline
+ * can be assembled, reordered, or tested one step at a time.
+ */
+public interface AdoptionStep {
+
+	String name();
+
+	void execute(AdoptionContext context, CommandRunner runner);
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -1,0 +1,54 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Files;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Runs the Claude Code CLI in headless mode against the checkout so it
+ * generates a {@code CLAUDE.md} for the project. The exact CLI invocation is
+ * configurable because the flags differ between environments; the default runs
+ * the {@code /init} command non-interactively.
+ */
+public class ClaudeInitStep extends AbstractCommandStep {
+
+	private static final Logger log = LogManager.getLogger(ClaudeInitStep.class);
+
+	static final List<String> DEFAULT_COMMAND = List.of("claude", "-p", "/init");
+
+	private static final String CLAUDE_MD = "CLAUDE.md";
+
+	private final List<String> claudeCommand;
+
+	public ClaudeInitStep() {
+		this(DEFAULT_COMMAND);
+	}
+
+	public ClaudeInitStep(List<String> claudeCommand) {
+		this.claudeCommand = List.copyOf(claudeCommand);
+	}
+
+	@Override
+	public String name() {
+		return "claude-init";
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		log.info("Running claude init in {}", context.repositoryDirectory());
+		runOrFail(runner, context.repositoryDirectory(), claudeCommand);
+		warnIfNotGenerated(context);
+	}
+
+	private void warnIfNotGenerated(AdoptionContext context) {
+		if (!Files.isRegularFile(context.repositoryDirectory().resolve(CLAUDE_MD))) {
+			log.warn("claude init completed but {} was not found in {}", CLAUDE_MD,
+					context.repositoryDirectory());
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -1,0 +1,31 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Clones the target repository into the workspace with {@code git clone}, so the
+ * remaining steps have a working checkout to operate on.
+ */
+public class CloneStep extends AbstractCommandStep {
+
+	private static final Logger log = LogManager.getLogger(CloneStep.class);
+
+	@Override
+	public String name() {
+		return "clone";
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		log.info("Cloning {} into {}", context.repositoryUrl(), context.repositoryDirectory());
+		List<String> command = List.of("git", "clone", context.repositoryUrl(),
+				context.repositoryDirectory().toString());
+		runOrFail(runner, context.workspace(), command);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
@@ -1,0 +1,57 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Stages every change in the checkout and commits it with the configured
+ * message. A commit that finds nothing to record is treated as a harmless
+ * no-op rather than a failure, so the pipeline stays idempotent when re-run.
+ */
+public class CommitStep extends AbstractCommandStep {
+
+	private static final Logger log = LogManager.getLogger(CommitStep.class);
+
+	private static final String NOTHING_TO_COMMIT = "nothing to commit";
+
+	private final String message;
+
+	public CommitStep(String message) {
+		this.message = message;
+	}
+
+	@Override
+	public String name() {
+		return "commit";
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		runOrFail(runner, context.repositoryDirectory(), List.of("git", "add", "-A"));
+		commit(context, runner);
+	}
+
+	private void commit(AdoptionContext context, CommandRunner runner) {
+		List<String> command = List.of("git", "commit", "-m", message);
+		CommandResult result = runner.run(context.repositoryDirectory(), command);
+		reportCommit(result);
+	}
+
+	private void reportCommit(CommandResult result) {
+		if (result.succeeded()) {
+			log.info("Committed: {}", message);
+		} else if (result.output().contains(NOTHING_TO_COMMIT)) {
+			log.info("No changes to commit for: {}", message);
+		} else {
+			throw new AdoptionException(name() + " failed (exit " + result.exitCode() + ") running: "
+					+ result.describe() + System.lineSeparator() + result.output());
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerStep.java
@@ -1,0 +1,57 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Wires the {@code claude-code-enforcer} into the adopted project's build so
+ * the generated {@code CLAUDE.md} keeps being validated on every build. The
+ * step edits the checkout's root {@code pom.xml}; a repository that is not a
+ * Maven project (no {@code pom.xml}) is skipped with a warning rather than
+ * failing the adoption.
+ */
+public class EnforcerStep implements AdoptionStep {
+
+	private static final Logger log = LogManager.getLogger(EnforcerStep.class);
+
+	private static final String POM = "pom.xml";
+
+	private final PomEnforcerInstaller installer;
+
+	public EnforcerStep() {
+		this(new PomEnforcerInstaller());
+	}
+
+	public EnforcerStep(PomEnforcerInstaller installer) {
+		this.installer = installer;
+	}
+
+	@Override
+	public String name() {
+		return "enforcer";
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		Path pomFile = context.repositoryDirectory().resolve(POM);
+		if (Files.isRegularFile(pomFile)) {
+			install(pomFile);
+		} else {
+			log.warn("No {} in {}; skipping enforcer wiring", POM, context.repositoryDirectory());
+		}
+	}
+
+	private void install(Path pomFile) {
+		if (installer.install(pomFile)) {
+			log.info("Added claude-code-enforcer to {}", pomFile);
+		} else {
+			log.info("{} already declares the enforcer plugin; left unchanged", pomFile);
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -1,0 +1,234 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+/**
+ * Adds the {@code claude-code-enforcer} to a Maven project's {@code pom.xml} by
+ * wiring the {@code maven-enforcer-plugin} with the {@code claudeMdFormat} rule,
+ * so the adopted repository fails its build if the freshly generated
+ * {@code CLAUDE.md} is missing or malformed.
+ *
+ * <p>The edit is performed on the JDK's DOM so no third-party XML library is
+ * needed, is namespace-aware so the new elements join the POM's default
+ * namespace, and is idempotent: a POM that already declares the enforcer plugin
+ * is left untouched.
+ */
+public class PomEnforcerInstaller {
+
+	static final String ENFORCER_GROUP_ID = "org.apache.maven.plugins";
+	static final String ENFORCER_ARTIFACT_ID = "maven-enforcer-plugin";
+	static final String RULE_ARTIFACT_ID = "tools.claude-code-enforcer";
+	static final String RULE_GROUP_ID = "io.github.adamw7";
+	static final String DEFAULT_RULE_VERSION = "2.5.0";
+
+	private final String ruleVersion;
+
+	public PomEnforcerInstaller() {
+		this(DEFAULT_RULE_VERSION);
+	}
+
+	public PomEnforcerInstaller(String ruleVersion) {
+		this.ruleVersion = ruleVersion;
+	}
+
+	/**
+	 * @return {@code true} when the plugin was added, {@code false} when the POM
+	 *         already declared it and was left unchanged.
+	 */
+	public boolean install(Path pomFile) {
+		Document document = read(pomFile);
+		Element project = document.getDocumentElement();
+		Element plugins = pluginsElement(document, project);
+		if (findEnforcerPlugin(plugins).isPresent()) {
+			return false;
+		}
+		plugins.appendChild(enforcerPlugin(document));
+		write(document, pomFile);
+		return true;
+	}
+
+	private Element pluginsElement(Document document, Element project) {
+		Element build = childOrCreate(document, project, "build");
+		return childOrCreate(document, build, "plugins");
+	}
+
+	private Optional<Element> findEnforcerPlugin(Element plugins) {
+		return children(plugins, "plugin").stream()
+				.filter(this::isEnforcerPlugin)
+				.findFirst();
+	}
+
+	private boolean isEnforcerPlugin(Element plugin) {
+		return child(plugin, "artifactId")
+				.map(Element::getTextContent)
+				.map(String::strip)
+				.filter(ENFORCER_ARTIFACT_ID::equals)
+				.isPresent();
+	}
+
+	private Element enforcerPlugin(Document document) {
+		Element plugin = create(document, "plugin");
+		appendText(document, plugin, "groupId", ENFORCER_GROUP_ID);
+		appendText(document, plugin, "artifactId", ENFORCER_ARTIFACT_ID);
+		plugin.appendChild(ruleDependencies(document));
+		plugin.appendChild(enforceExecutions(document));
+		return plugin;
+	}
+
+	private Element ruleDependencies(Document document) {
+		Element dependencies = create(document, "dependencies");
+		Element dependency = create(document, "dependency");
+		appendText(document, dependency, "groupId", RULE_GROUP_ID);
+		appendText(document, dependency, "artifactId", RULE_ARTIFACT_ID);
+		appendText(document, dependency, "version", ruleVersion);
+		dependencies.appendChild(dependency);
+		return dependencies;
+	}
+
+	private Element enforceExecutions(Document document) {
+		Element executions = create(document, "executions");
+		Element execution = create(document, "execution");
+		appendText(document, execution, "id", "enforce-claude-md");
+		appendText(document, execution, "phase", "validate");
+		Element goals = create(document, "goals");
+		appendText(document, goals, "goal", "enforce");
+		execution.appendChild(goals);
+		execution.appendChild(claudeMdConfiguration(document));
+		executions.appendChild(execution);
+		return executions;
+	}
+
+	private Element claudeMdConfiguration(Document document) {
+		Element configuration = create(document, "configuration");
+		Element rules = create(document, "rules");
+		rules.appendChild(create(document, "claudeMdFormat"));
+		configuration.appendChild(rules);
+		return configuration;
+	}
+
+	private Element childOrCreate(Document document, Element parent, String name) {
+		return child(parent, name).orElseGet(() -> appendChild(document, parent, name));
+	}
+
+	private Element appendChild(Document document, Element parent, String name) {
+		Element element = create(document, name);
+		parent.appendChild(element);
+		return element;
+	}
+
+	private void appendText(Document document, Element parent, String name, String text) {
+		Element element = create(document, name);
+		element.setTextContent(text);
+		parent.appendChild(element);
+	}
+
+	private Element create(Document document, String name) {
+		String namespace = document.getDocumentElement().getNamespaceURI();
+		return namespace == null ? document.createElement(name) : document.createElementNS(namespace, name);
+	}
+
+	private Optional<Element> child(Element parent, String name) {
+		return children(parent, name).stream().findFirst();
+	}
+
+	private List<Element> children(Element parent, String name) {
+		List<Element> matches = new ArrayList<>();
+		NodeList nodes = parent.getChildNodes();
+		for (int index = 0; index < nodes.getLength(); index++) {
+			addIfMatch(matches, nodes.item(index), name);
+		}
+		return matches;
+	}
+
+	private void addIfMatch(List<Element> matches, Node node, String name) {
+		if (node instanceof Element element && name.equals(element.getLocalName())) {
+			matches.add(element);
+		}
+	}
+
+	private Document read(Path pomFile) {
+		try {
+			return builder().parse(pomFile.toFile());
+		} catch (IOException | SAXException e) {
+			throw new AdoptionException("Could not read POM: " + pomFile, e);
+		}
+	}
+
+	private DocumentBuilder builder() {
+		try {
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setNamespaceAware(true);
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			factory.setExpandEntityReferences(false);
+			return factory.newDocumentBuilder();
+		} catch (ParserConfigurationException e) {
+			throw new AdoptionException("Could not configure XML parser", e);
+		}
+	}
+
+	private void write(Document document, Path pomFile) {
+		try {
+			stripWhitespace(document.getDocumentElement());
+			Files.createDirectories(pomFile.toAbsolutePath().getParent());
+			transformer().transform(new DOMSource(document), new StreamResult(pomFile.toFile()));
+		} catch (IOException | TransformerException e) {
+			throw new AdoptionException("Could not write POM: " + pomFile, e);
+		}
+	}
+
+	/**
+	 * Removes whitespace-only text nodes so the transformer can re-indent the
+	 * document cleanly instead of interleaving the original whitespace with
+	 * fresh indentation. Safe for a POM because it carries no mixed content.
+	 */
+	private void stripWhitespace(Node node) {
+		NodeList children = node.getChildNodes();
+		List<Node> blankTextNodes = new ArrayList<>();
+		for (int index = 0; index < children.getLength(); index++) {
+			collectBlankText(children.item(index), blankTextNodes);
+		}
+		blankTextNodes.forEach(node::removeChild);
+	}
+
+	private void collectBlankText(Node child, List<Node> blankTextNodes) {
+		if (child.getNodeType() == Node.TEXT_NODE && child.getTextContent().isBlank()) {
+			blankTextNodes.add(child);
+		} else if (child.getNodeType() == Node.ELEMENT_NODE) {
+			stripWhitespace(child);
+		}
+	}
+
+	private Transformer transformer() throws TransformerException {
+		TransformerFactory factory = TransformerFactory.newInstance();
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		Transformer transformer = factory.newTransformer();
+		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+		transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+		return transformer;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PushStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PushStep.java
@@ -1,0 +1,29 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Pushes the committed adoption changes back to the repository's origin with
+ * {@code git push}.
+ */
+public class PushStep extends AbstractCommandStep {
+
+	private static final Logger log = LogManager.getLogger(PushStep.class);
+
+	@Override
+	public String name() {
+		return "push";
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		log.info("Pushing changes from {}", context.repositoryDirectory());
+		runOrFail(runner, context.repositoryDirectory(), List.of("git", "push"));
+	}
+}

--- a/adopt/src/main/resources/log4j2.properties
+++ b/adopt/src/main/resources/log4j2.properties
@@ -1,0 +1,42 @@
+# Set to debug or trace if log4j initialization is failing
+status = info
+
+# Name of the configuration
+name = Log4jConfig
+
+property.basePath = logs
+
+# RollingFileAppender name, pattern, path and rollover policy
+appender.rolling.type = RollingFile
+appender.rolling.name = fileLogger
+appender.rolling.fileName= ${basePath}/adopt.log
+appender.rolling.filePattern= ${basePath}/adopt_%d{yyyyMMdd}.log.gz
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %level [%t] [%l] - %msg%n
+appender.rolling.policies.type = Policies
+
+# RollingFileAppender rotation policy
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size = 10MB
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.time.modulate = true
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.delete.type = Delete
+appender.rolling.strategy.delete.basePath = ${basePath}
+appender.rolling.strategy.delete.maxDepth = 10
+appender.rolling.strategy.delete.ifLastModified.type = IfLastModified
+
+# Delete all files older than 30 days
+appender.rolling.strategy.delete.ifLastModified.age = 30d
+
+# Console appender so command-line runs show progress on stdout
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %level - %msg%n
+
+# Configure root logger
+rootLogger.level = info
+rootLogger.appenderRef.rolling.ref = fileLogger
+rootLogger.appenderRef.console.ref = consoleLogger

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
@@ -1,0 +1,54 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class AdoptionContextTest {
+
+	private final Path workspace = Path.of("/tmp/workspace");
+
+	@Test
+	void derivesCheckoutDirectoryFromHttpsUrl() {
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace);
+		assertEquals(workspace.resolve("tools"), context.repositoryDirectory());
+	}
+
+	@Test
+	void derivesCheckoutDirectoryWithoutGitSuffix() {
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools", workspace);
+		assertEquals(workspace.resolve("tools"), context.repositoryDirectory());
+	}
+
+	@Test
+	void handlesTrailingSlash() {
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools/", workspace);
+		assertEquals(workspace.resolve("tools"), context.repositoryDirectory());
+	}
+
+	@Test
+	void derivesCheckoutDirectoryFromSshUrl() {
+		AdoptionContext context = new AdoptionContext("git@github.com:adamw7/tools.git", workspace);
+		assertEquals(workspace.resolve("tools"), context.repositoryDirectory());
+	}
+
+	@Test
+	void trimsAndKeepsUrl() {
+		AdoptionContext context = new AdoptionContext("  https://github.com/adamw7/tools.git  ", workspace);
+		assertEquals("https://github.com/adamw7/tools.git", context.repositoryUrl());
+	}
+
+	@Test
+	void rejectsBlankUrl() {
+		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext("  ", workspace));
+	}
+
+	@Test
+	void rejectsNullWorkspace() {
+		assertThrows(IllegalArgumentException.class,
+				() -> new AdoptionContext("https://github.com/adamw7/tools.git", null));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -1,0 +1,78 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+import io.github.adamw7.tools.adopt.step.AdoptionStep;
+
+class GitHubRepoAdopterTest {
+
+	private final AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git",
+			Path.of("/tmp/workspace"));
+
+	private static final class NamingStep implements AdoptionStep {
+
+		private final String name;
+		private final List<String> log;
+
+		NamingStep(String name, List<String> log) {
+			this.name = name;
+			this.log = log;
+		}
+
+		@Override
+		public String name() {
+			return name;
+		}
+
+		@Override
+		public void execute(AdoptionContext context, CommandRunner runner) {
+			log.add(name);
+		}
+	}
+
+	private static final class ExplodingStep implements AdoptionStep {
+
+		@Override
+		public String name() {
+			return "boom";
+		}
+
+		@Override
+		public void execute(AdoptionContext context, CommandRunner runner) {
+			throw new AdoptionException("boom");
+		}
+	}
+
+	@Test
+	void runsEveryStepInOrder() {
+		List<String> order = new ArrayList<>();
+		List<AdoptionStep> steps = List.of(new NamingStep("a", order), new NamingStep("b", order));
+		new GitHubRepoAdopter(new RecordingCommandRunner(), steps).adopt(context);
+		assertEquals(List.of("a", "b"), order);
+	}
+
+	@Test
+	void stopsAtFirstFailingStep() {
+		List<String> order = new ArrayList<>();
+		List<AdoptionStep> steps = List.of(new NamingStep("a", order), new ExplodingStep(),
+				new NamingStep("c", order));
+		GitHubRepoAdopter adopter = new GitHubRepoAdopter(new RecordingCommandRunner(), steps);
+		assertThrows(AdoptionException.class, () -> adopter.adopt(context));
+		assertEquals(List.of("a"), order);
+	}
+
+	@Test
+	void defaultPipelineIsCloneInitCommitPushEnforceCommitPush() {
+		List<String> names = GitHubRepoAdopter.defaultSteps().stream().map(AdoptionStep::name).toList();
+		assertEquals(List.of("clone", "claude-init", "commit", "push", "enforcer", "commit", "push"), names);
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
@@ -1,0 +1,72 @@
+package io.github.adamw7.tools.adopt.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+
+import org.apache.logging.log4j.Logger;
+
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.GeneralCodingRules;
+
+import io.github.adamw7.tools.adopt.step.AdoptionStep;
+
+/**
+ * Architecture rules for the adopt module, enforced with ArchUnit so the
+ * package layering and coding conventions cannot rot. Only production classes
+ * are analysed; test classes are excluded via {@link ImportOption}.
+ */
+@AnalyzeClasses(packages = AdoptArchitectureTest.ADOPT_PACKAGE, importOptions = ImportOption.DoNotIncludeTests.class)
+public class AdoptArchitectureTest {
+
+	static final String ADOPT_PACKAGE = "io.github.adamw7.tools.adopt";
+
+	private static final String COMMAND_PACKAGE = "..adopt.command..";
+	private static final String STEP_PACKAGE = "..adopt.step..";
+
+	@ArchTest
+	static final ArchRule commandLayerDoesNotDependOnSteps = noClasses()
+			.that().resideInAPackage(COMMAND_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage(STEP_PACKAGE)
+			.because("the command-runner layer must not know about the adoption steps that use it");
+
+	@ArchTest
+	static final ArchRule stepsImplementTheContract = classes()
+			.that().resideInAPackage(STEP_PACKAGE)
+			.and().haveSimpleNameEndingWith("Step")
+			.and().areNotInterfaces()
+			.and().doNotHaveModifier(JavaModifier.ABSTRACT)
+			.should().beAssignableTo(AdoptionStep.class)
+			.because("every concrete *Step must honour the AdoptionStep contract");
+
+	@ArchTest
+	static final ArchRule abstractTypesArePrefixed = classes()
+			.that().haveModifier(JavaModifier.ABSTRACT).and().areNotInterfaces()
+			.should().haveSimpleNameStartingWith("Abstract")
+			.because("abstract classes are named with an Abstract prefix for clarity");
+
+	@ArchTest
+	static final ArchRule packagesAreFreeOfCycles = slices()
+			.matching("io.github.adamw7.tools.adopt.(*)..")
+			.should().beFreeOfCycles();
+
+	@ArchTest
+	static final ArchRule loggersArePrivateStaticFinal = fields()
+			.that().haveRawType(Logger.class)
+			.should().bePrivate().andShould().beStatic().andShould().beFinal()
+			.because("loggers are private static final by convention");
+
+	@ArchTest
+	static final ArchRule noStandardStreams = GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
+
+	@ArchTest
+	static final ArchRule noJavaUtilLogging = GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+
+	@ArchTest
+	static final ArchRule noGenericExceptionsThrown = GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/TestConventionsArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/TestConventionsArchitectureTest.java
@@ -1,0 +1,54 @@
+package io.github.adamw7.tools.adopt.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
+
+import org.junit.jupiter.api.Disabled;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+/**
+ * Conventions enforced on the module's own test code, mirroring the other
+ * modules so the constraints that keep the unit suite fast and honest cannot be
+ * bypassed. Only test classes are analysed via {@link ImportOption.OnlyIncludeTests}.
+ */
+@AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
+public class TestConventionsArchitectureTest {
+
+	static final String TEST_PACKAGE = "io.github.adamw7.tools.adopt";
+
+	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
+
+	@ArchTest
+	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
+			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
+			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
+			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
+			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
+					+ "so a test method in a differently named class silently never runs");
+
+	@ArchTest
+	static final ArchRule noDisabledTestMethods = noMethods()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule noDisabledTestClasses = noClasses()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule testsUseJunit5 = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("org.junit")
+			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
+
+	@ArchTest
+	static final ArchRule testsDoNotSleep = noClasses()
+			.should().callMethod(Thread.class, "sleep", long.class)
+			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
+			.because("a test that sleeps is slow and flaky; wait on a condition instead");
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/CommandResultTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/CommandResultTest.java
@@ -1,0 +1,30 @@
+package io.github.adamw7.tools.adopt.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class CommandResultTest {
+
+	@Test
+	void zeroExitCodeSucceeds() {
+		CommandResult result = new CommandResult(List.of("git", "status"), 0, "clean");
+		assertTrue(result.succeeded());
+	}
+
+	@Test
+	void nonZeroExitCodeFails() {
+		CommandResult result = new CommandResult(List.of("git", "push"), 1, "rejected");
+		assertFalse(result.succeeded());
+	}
+
+	@Test
+	void describeJoinsCommandTokens() {
+		CommandResult result = new CommandResult(List.of("git", "commit", "-m", "msg"), 0, "");
+		assertEquals("git commit -m msg", result.describe());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunnerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunnerTest.java
@@ -1,0 +1,42 @@
+package io.github.adamw7.tools.adopt.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+class ProcessCommandRunnerTest {
+
+	private final ProcessCommandRunner runner = new ProcessCommandRunner();
+
+	@Test
+	void capturesExitCodeAndOutput() {
+		CommandResult result = runner.run(Path.of("."), List.of("echo", "hello"));
+		assertEquals(0, result.exitCode());
+		assertEquals("hello", result.output());
+	}
+
+	@Test
+	void reportsNonZeroExitCode() {
+		CommandResult result = runner.run(Path.of("."), List.of("sh", "-c", "exit 3"));
+		assertEquals(3, result.exitCode());
+	}
+
+	@Test
+	void mergesStandardErrorIntoOutput() {
+		CommandResult result = runner.run(Path.of("."), List.of("sh", "-c", "echo oops 1>&2"));
+		assertTrue(result.output().contains("oops"));
+	}
+
+	@Test
+	void wrapsMissingExecutableInAdoptionException() {
+		assertThrows(AdoptionException.class,
+				() -> runner.run(Path.of("."), List.of("definitely-not-a-real-binary-xyz")));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/RecordingCommandRunner.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/RecordingCommandRunner.java
@@ -1,0 +1,46 @@
+package io.github.adamw7.tools.adopt.command;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Test {@link CommandRunner} that records every invocation and answers each one
+ * through a configurable strategy, so step tests can assert what was run and
+ * simulate success or failure without spawning a real process.
+ */
+public class RecordingCommandRunner implements CommandRunner {
+
+	public record Invocation(Path workingDirectory, List<String> command) {
+	}
+
+	private final List<Invocation> invocations = new ArrayList<>();
+	private final Function<List<String>, CommandResult> strategy;
+
+	public RecordingCommandRunner() {
+		this(command -> new CommandResult(command, 0, ""));
+	}
+
+	public RecordingCommandRunner(Function<List<String>, CommandResult> strategy) {
+		this.strategy = strategy;
+	}
+
+	@Override
+	public CommandResult run(Path workingDirectory, List<String> command) {
+		invocations.add(new Invocation(workingDirectory, command));
+		return strategy.apply(command);
+	}
+
+	public List<Invocation> invocations() {
+		return List.copyOf(invocations);
+	}
+
+	public List<String> commandAt(int index) {
+		return invocations.get(index).command();
+	}
+
+	public int count() {
+		return invocations.size();
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
@@ -1,0 +1,51 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class ClaudeInitStepTest {
+
+	private AdoptionContext context(Path workspace) throws IOException {
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace);
+		Files.createDirectories(context.repositoryDirectory());
+		return context;
+	}
+
+	@Test
+	void runsConfiguredClaudeCommandInCheckout(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new ClaudeInitStep(List.of("claude", "init")).execute(context, runner);
+		assertEquals(List.of("claude", "init"), runner.commandAt(0));
+		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
+	}
+
+	@Test
+	void defaultsToHeadlessInitCommand(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new ClaudeInitStep().execute(context, runner);
+		assertEquals(ClaudeInitStep.DEFAULT_COMMAND, runner.commandAt(0));
+	}
+
+	@Test
+	void failedInitAbortsAdoption(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 1, "boom"));
+		assertThrows(AdoptionException.class, () -> new ClaudeInitStep().execute(context, runner));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -1,0 +1,42 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class CloneStepTest {
+
+	private final Path workspace = Path.of("/tmp/workspace");
+	private final AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace);
+	private final CloneStep step = new CloneStep();
+
+	@Test
+	void runsGitCloneIntoWorkspace() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		step.execute(context, runner);
+		assertEquals(List.of("git", "clone", "https://github.com/adamw7/tools.git",
+				workspace.resolve("tools").toString()), runner.commandAt(0));
+		assertEquals(workspace, runner.invocations().get(0).workingDirectory());
+	}
+
+	@Test
+	void failedCloneAbortsAdoption() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 128, "fatal: repository not found"));
+		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
+	}
+
+	@Test
+	void isNamedClone() {
+		assertEquals("clone", step.name());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
@@ -1,0 +1,55 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class CommitStepTest {
+
+	private final AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git",
+			Path.of("/tmp/workspace"));
+
+	@Test
+	void stagesThenCommitsWithMessage() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new CommitStep("my message").execute(context, runner);
+		assertEquals(List.of("git", "add", "-A"), runner.commandAt(0));
+		assertEquals(List.of("git", "commit", "-m", "my message"), runner.commandAt(1));
+	}
+
+	@Test
+	void emptyCommitIsTreatedAsNoOp() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::nothingToCommitOnCommit);
+		assertDoesNotThrow(() -> new CommitStep("msg").execute(context, runner));
+	}
+
+	@Test
+	void otherCommitFailureAborts() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::genuineCommitFailure);
+		assertThrows(AdoptionException.class, () -> new CommitStep("msg").execute(context, runner));
+	}
+
+	private CommandResult nothingToCommitOnCommit(List<String> command) {
+		if (command.contains("commit")) {
+			return new CommandResult(command, 1, "nothing to commit, working tree clean");
+		}
+		return new CommandResult(command, 0, "");
+	}
+
+	private CommandResult genuineCommitFailure(List<String> command) {
+		if (command.contains("commit")) {
+			return new CommandResult(command, 128, "fatal: unable to write commit object");
+		}
+		return new CommandResult(command, 0, "");
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
@@ -1,0 +1,49 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class EnforcerStepTest {
+
+	private static final String POM = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+			  <modelVersion>4.0.0</modelVersion>
+			  <groupId>com.example</groupId>
+			  <artifactId>demo</artifactId>
+			  <version>1.0.0</version>
+			</project>
+			""";
+
+	private AdoptionContext context(Path workspace) throws IOException {
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/demo.git", workspace);
+		Files.createDirectories(context.repositoryDirectory());
+		return context;
+	}
+
+	@Test
+	void wiresEnforcerIntoCheckoutPom(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), POM);
+		new EnforcerStep().execute(context, new RecordingCommandRunner());
+		assertTrue(Files.readString(context.repositoryDirectory().resolve("pom.xml"))
+				.contains("maven-enforcer-plugin"));
+	}
+
+	@Test
+	void skipsWhenNotAMavenProject(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		assertDoesNotThrow(() -> new EnforcerStep().execute(context, new RecordingCommandRunner()));
+		assertFalse(Files.exists(context.repositoryDirectory().resolve("pom.xml")));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -1,0 +1,89 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PomEnforcerInstallerTest {
+
+	private static final String POM_WITH_BUILD = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+			  <modelVersion>4.0.0</modelVersion>
+			  <groupId>com.example</groupId>
+			  <artifactId>demo</artifactId>
+			  <version>1.0.0</version>
+			  <build>
+			    <plugins>
+			      <plugin>
+			        <groupId>org.apache.maven.plugins</groupId>
+			        <artifactId>maven-compiler-plugin</artifactId>
+			      </plugin>
+			    </plugins>
+			  </build>
+			</project>
+			""";
+
+	private static final String POM_WITHOUT_BUILD = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+			  <modelVersion>4.0.0</modelVersion>
+			  <groupId>com.example</groupId>
+			  <artifactId>demo</artifactId>
+			  <version>1.0.0</version>
+			</project>
+			""";
+
+	private final PomEnforcerInstaller installer = new PomEnforcerInstaller("9.9.9");
+
+	private Path write(Path dir, String content) throws IOException {
+		Path pom = dir.resolve("pom.xml");
+		Files.writeString(pom, content);
+		return pom;
+	}
+
+	@Test
+	void addsEnforcerPluginToExistingBuild(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_BUILD);
+		assertTrue(installer.install(pom));
+		String result = Files.readString(pom);
+		assertTrue(result.contains("maven-enforcer-plugin"));
+		assertTrue(result.contains("tools.claude-code-enforcer"));
+		assertTrue(result.contains("9.9.9"));
+		assertTrue(result.contains("claudeMdFormat"));
+	}
+
+	@Test
+	void keepsExistingCompilerPlugin(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_BUILD);
+		installer.install(pom);
+		assertTrue(Files.readString(pom).contains("maven-compiler-plugin"));
+	}
+
+	@Test
+	void createsBuildAndPluginsWhenAbsent(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITHOUT_BUILD);
+		assertTrue(installer.install(pom));
+		String result = Files.readString(pom);
+		assertTrue(result.contains("<build>"));
+		assertTrue(result.contains("maven-enforcer-plugin"));
+	}
+
+	@Test
+	void secondInstallIsIdempotent(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_BUILD);
+		assertTrue(installer.install(pom));
+		assertFalse(installer.install(pom));
+	}
+
+	@Test
+	void preservesDefaultPomNamespace(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_BUILD);
+		installer.install(pom);
+		assertTrue(Files.readString(pom).contains("http://maven.apache.org/POM/4.0.0"));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PushStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PushStepTest.java
@@ -1,0 +1,36 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class PushStepTest {
+
+	private final AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git",
+			Path.of("/tmp/workspace"));
+	private final PushStep step = new PushStep();
+
+	@Test
+	void runsGitPushInCheckout() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		step.execute(context, runner);
+		assertEquals(List.of("git", "push"), runner.commandAt(0));
+		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
+	}
+
+	@Test
+	void rejectedPushAborts() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 1, "rejected"));
+		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
 		<module>mcp-common</module>
 		<module>data</module>
 		<module>code</module>
+		<module>adopt</module>
 		<module>grpc-example</module>
 		<module>assembly</module>
 	</modules>


### PR DESCRIPTION
Introduce the `adopt` reactor module. Given a GitHub repository URL it runs
an ordered pipeline: clone the repo, run the Claude Code CLI (`claude init`)
to generate CLAUDE.md, commit and push, then wire the claude-code-enforcer
into the project's pom.xml and commit and push again.

External git/claude invocations go through a CommandRunner abstraction
(ProcessCommandRunner in production, a recording stub in tests), so every
step is unit-tested without spawning real processes. The enforcer step edits
pom.xml with the JDK's XML DOM (no new dependency), is namespace-aware and
idempotent, and skips non-Maven repos gracefully.

Includes production + test-convention ArchUnit rules and updates the module
maps in AGENTS.md and CLAUDE.md. 48 tests pass; the reactor and the
CLAUDE.md/AGENTS.md enforcement build both stay green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HdGYFMAjVLZBKMZvNn8GLt