### PR TITLE
test(adopt): cover Main, AdoptionException, and AbstractCommandStep

### DIFF
--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionExceptionTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionExceptionTest.java
@@ -1,0 +1,25 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+class AdoptionExceptionTest {
+
+	@Test
+	void messageOnlyConstructorKeepsMessageAndHasNoCause() {
+		AdoptionException exception = new AdoptionException("clone failed");
+		assertEquals("clone failed", exception.getMessage());
+		assertNull(exception.getCause());
+	}
+
+	@Test
+	void messageAndCauseConstructorKeepsBoth() {
+		Throwable cause = new IllegalStateException("boom");
+		AdoptionException exception = new AdoptionException("push failed", cause);
+		assertEquals("push failed", exception.getMessage());
+		assertSame(cause, exception.getCause());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
@@ -1,0 +1,26 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MainTest {
+
+	@Test
+	void rejectsMissingArguments() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> Main.main(new String[0]));
+		assertTrue(exception.getMessage().contains("Usage"), exception.getMessage());
+	}
+
+	@Test
+	void rejectsNullArguments() {
+		assertThrows(IllegalArgumentException.class, () -> Main.main(null));
+	}
+
+	@Test
+	void rejectsBlankRepositoryUrl() {
+		assertThrows(IllegalArgumentException.class, () -> Main.main(new String[] { "   " }));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AbstractCommandStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AbstractCommandStepTest.java
@@ -1,0 +1,69 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class AbstractCommandStepTest {
+
+	private static final class TestStep extends AbstractCommandStep {
+
+		@Override
+		public String name() {
+			return "test-step";
+		}
+
+		@Override
+		public void execute(AdoptionContext context, CommandRunner runner) {
+			// not exercised here; the base run-and-fail-fast behaviour is under test
+		}
+
+		CommandResult run(CommandRunner runner, Path workingDirectory, List<String> command) {
+			return runOrFail(runner, workingDirectory, command);
+		}
+	}
+
+	private final Path workspace = Path.of("/tmp/workspace");
+	private final TestStep step = new TestStep();
+
+	@Test
+	void returnsResultWhenCommandSucceeds() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 0, "done"));
+		CommandResult result = step.run(runner, workspace, List.of("git", "status"));
+		assertEquals("done", result.output());
+		assertEquals(List.of("git", "status"), runner.commandAt(0));
+	}
+
+	@Test
+	void failedCommandThrowsAdoptionException() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 1, "rejected"));
+		assertThrows(AdoptionException.class,
+				() -> step.run(runner, workspace, List.of("git", "push")));
+	}
+
+	@Test
+	void failureMessageCarriesStepNameExitCodeCommandAndOutput() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 128, "fatal: rejected"));
+		AdoptionException exception = assertThrows(AdoptionException.class,
+				() -> step.run(runner, workspace, List.of("git", "push", "origin", "main")));
+		String message = exception.getMessage();
+		assertTrue(message.contains("test-step"), message);
+		assertTrue(message.contains("128"), message);
+		assertTrue(message.contains("git push origin main"), message);
+		assertTrue(message.contains("fatal: rejected"), message);
+	}
+}


### PR DESCRIPTION
Add unit tests for the three previously untested classes in the adopt
module:

- MainTest: CLI argument validation rejects missing, null, and blank
  repository URLs before any pipeline runs.
- AdoptionExceptionTest: both constructors preserve message and cause.
- AbstractCommandStepTest: runOrFail returns the result on success and
  throws an AdoptionException whose message carries the step name, exit
  code, command, and captured output on failure.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WbvHc5w2De2LRcT59BwAsw