### PR TITLE
fix(adopt): pin enforcer plugin version and bind rule to root module only

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -42,6 +42,7 @@ public class PomEnforcerInstaller {
 
 	static final String ENFORCER_GROUP_ID = "org.apache.maven.plugins";
 	static final String ENFORCER_ARTIFACT_ID = "maven-enforcer-plugin";
+	static final String ENFORCER_VERSION = "3.6.3";
 	static final String RULE_ARTIFACT_ID = "tools.claude-code-enforcer";
 	static final String RULE_GROUP_ID = "io.github.adamw7";
 	static final String DEFAULT_RULE_VERSION = "2.5.0";
@@ -126,6 +127,7 @@ public class PomEnforcerInstaller {
 		Element plugin = create(document, "plugin");
 		appendText(document, plugin, "groupId", ENFORCER_GROUP_ID);
 		appendText(document, plugin, "artifactId", ENFORCER_ARTIFACT_ID);
+		appendText(document, plugin, "version", ENFORCER_VERSION);
 		plugins.appendChild(plugin);
 		return plugin;
 	}
@@ -142,6 +144,7 @@ public class PomEnforcerInstaller {
 		Element execution = create(document, "execution");
 		appendText(document, execution, "id", "enforce-claude-md");
 		appendText(document, execution, "phase", "validate");
+		appendText(document, execution, "inherited", "false");
 		Element goals = create(document, "goals");
 		appendText(document, goals, "goal", "enforce");
 		execution.appendChild(goals);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -91,6 +91,24 @@ class PomEnforcerInstallerTest {
 	}
 
 	@Test
+	void pinsEnforcerPluginVersionWhenCreatingIt(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_BUILD);
+		installer.install(pom);
+		String result = Files.readString(pom);
+		assertTrue(result.contains("<version>" + PomEnforcerInstaller.ENFORCER_VERSION + "</version>"),
+				"a freshly created maven-enforcer-plugin must declare a version so the adopted build validates");
+	}
+
+	@Test
+	void bindsExecutionToTheRootModuleOnly(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_BUILD);
+		installer.install(pom);
+		String result = Files.readString(pom);
+		assertTrue(result.contains("<inherited>false</inherited>"),
+				"CLAUDE.md lives only at the repository root, so child modules must not inherit the execution");
+	}
+
+	@Test
 	void configuresClaudeMdFileForTheRule(@TempDir Path dir) throws IOException {
 		Path pom = write(dir, POM_WITH_BUILD);
 		installer.install(pom);


### PR DESCRIPTION
PomEnforcerInstaller wired the maven-enforcer-plugin into an adopted
repository's pom.xml without a <version> and without
<inherited>false</inherited> on the execution. Both broke the build the
step is meant to protect:

- Missing plugin version: a target repo that does not already manage the
  enforcer plugin version fails Maven validation with
  "'build.plugins.plugin.version' ... is missing". Only the rule
  dependency carried a version, not the plugin itself. Now a freshly
  created plugin declares version 3.6.3.

- Missing inherited=false: in a multi-module repo the execution was
  inherited by every child module, each resolving
  ${project.basedir}/CLAUDE.md against its own basedir where no CLAUDE.md
  exists, failing the build. CLAUDE.md lives only at the repository root,
  so the execution now runs at the root reactor module only, matching the
  wiring this project uses for itself.

Both fixes apply only when the installer creates the plugin/execution;
an existing enforcer plugin the project already declares is left as-is.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0119Vn4MJtgb3xXwBrMgtqq1