### PR TITLE
Bound external commands in adopt with a configurable timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,9 @@ Maven project. The notable capabilities are:
   (`claude init`) to generate a `CLAUDE.md`, commits and pushes that, then wires
   the `claude-code-enforcer` into the project's `pom.xml` and commits and pushes
   again. External `git`/`claude` invocations go through a `CommandRunner`
-  abstraction so the steps are unit-tested without spawning real processes.
+  abstraction so the steps are unit-tested without spawning real processes; the
+  `ProcessCommandRunner` bounds every command with a configurable timeout so a
+  stalled clone or a stuck `claude` run cannot hang the adoption.
 
 See [README.md](README.md) for worked code examples of each capability,
 [docs/c4-architecture.md](docs/c4-architecture.md) for a C4 model

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -1,22 +1,41 @@
 package io.github.adamw7.tools.adopt.command;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.concurrent.TimeUnit;
 
 import io.github.adamw7.tools.adopt.AdoptionException;
 
 /**
  * {@link CommandRunner} backed by {@link ProcessBuilder}. Standard error is
  * merged into standard output so a caller gets a single, ordered transcript of
- * what the command printed, and the process is always waited for so no child is
- * left running.
+ * what the command printed. Every command is bounded by a timeout so a hung
+ * child — a stalled {@code git clone} or a stuck {@code claude} invocation —
+ * cannot block the adoption forever: on expiry the process is destroyed and the
+ * failure is reported with whatever output was captured so far.
  */
 public class ProcessCommandRunner implements CommandRunner {
+
+	static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(10);
+
+	private final Duration timeout;
+
+	public ProcessCommandRunner() {
+		this(DEFAULT_TIMEOUT);
+	}
+
+	public ProcessCommandRunner(Duration timeout) {
+		this.timeout = requirePositive(timeout);
+	}
+
+	private static Duration requirePositive(Duration timeout) {
+		if (timeout == null || timeout.isNegative() || timeout.isZero()) {
+			throw new IllegalArgumentException("timeout must be positive");
+		}
+		return timeout;
+	}
 
 	@Override
 	public CommandResult run(Path workingDirectory, List<String> command) {
@@ -27,23 +46,35 @@ public class ProcessCommandRunner implements CommandRunner {
 	}
 
 	private CommandResult execute(ProcessBuilder builder, List<String> command) {
+		Process process = start(builder, command);
+		StreamGobbler output = StreamGobbler.consuming(process.getInputStream());
+		return await(process, command, output);
+	}
+
+	private Process start(ProcessBuilder builder, List<String> command) {
 		try {
-			Process process = builder.start();
-			String output = readOutput(process);
-			int exitCode = process.waitFor();
-			return new CommandResult(command, exitCode, output);
+			return builder.start();
 		} catch (IOException e) {
 			throw new AdoptionException("Could not start command: " + String.join(" ", command), e);
+		}
+	}
+
+	private CommandResult await(Process process, List<String> command, StreamGobbler output) {
+		try {
+			if (process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+				return new CommandResult(command, process.exitValue(), output.output());
+			}
+			throw timedOut(process, command, output);
 		} catch (InterruptedException e) {
+			process.destroyForcibly();
 			Thread.currentThread().interrupt();
 			throw new AdoptionException("Interrupted while running: " + String.join(" ", command), e);
 		}
 	}
 
-	private String readOutput(Process process) throws IOException {
-		try (BufferedReader reader = new BufferedReader(
-				new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-			return reader.lines().collect(Collectors.joining(System.lineSeparator()));
-		}
+	private AdoptionException timedOut(Process process, List<String> command, StreamGobbler output) {
+		process.destroyForcibly();
+		return new AdoptionException("Timed out after " + timeout + " running: " + String.join(" ", command)
+				+ System.lineSeparator() + output.output());
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
@@ -1,0 +1,59 @@
+package io.github.adamw7.tools.adopt.command;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+/**
+ * Drains a process's output stream on a dedicated daemon thread so the command
+ * can be waited for with a timeout. Reading the stream inline would block until
+ * the child closes it, which never happens for a hung process; consuming it in
+ * the background lets {@link ProcessCommandRunner} time out and destroy the
+ * child while its partial output is still recovered.
+ */
+final class StreamGobbler {
+
+	private final Thread thread;
+	private volatile String output = "";
+
+	private StreamGobbler(InputStream stream) {
+		this.thread = new Thread(() -> output = read(stream), "adopt-stream-gobbler");
+		this.thread.setDaemon(true);
+	}
+
+	static StreamGobbler consuming(InputStream stream) {
+		StreamGobbler gobbler = new StreamGobbler(stream);
+		gobbler.thread.start();
+		return gobbler;
+	}
+
+	/**
+	 * @return everything the stream produced, blocking until it reaches
+	 *         end-of-stream. Destroying the process closes the stream, so this
+	 *         returns promptly once a timed-out child has been killed.
+	 */
+	String output() {
+		join();
+		return output;
+	}
+
+	private void join() {
+		try {
+			thread.join();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	private static String read(InputStream stream) {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+			return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunnerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunnerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -38,5 +39,26 @@ class ProcessCommandRunnerTest {
 	void wrapsMissingExecutableInAdoptionException() {
 		assertThrows(AdoptionException.class,
 				() -> runner.run(Path.of("."), List.of("definitely-not-a-real-binary-xyz")));
+	}
+
+	@Test
+	void killsAndReportsACommandThatOutlivesTheTimeout() {
+		ProcessCommandRunner impatient = new ProcessCommandRunner(Duration.ofMillis(100));
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> impatient.run(Path.of("."), List.of("sleep", "30")));
+		assertTrue(thrown.getMessage().contains("Timed out"), thrown.getMessage());
+	}
+
+	@Test
+	void capturesOutputWhenTheCommandFinishesWithinTheTimeout() {
+		ProcessCommandRunner patient = new ProcessCommandRunner(Duration.ofSeconds(30));
+		CommandResult result = patient.run(Path.of("."), List.of("echo", "quick"));
+		assertEquals(0, result.exitCode());
+		assertEquals("quick", result.output());
+	}
+
+	@Test
+	void rejectsANonPositiveTimeout() {
+		assertThrows(IllegalArgumentException.class, () -> new ProcessCommandRunner(Duration.ZERO));
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -72,6 +73,22 @@ class PomEnforcerInstallerTest {
 			""";
 
 	private final PomEnforcerInstaller installer = new PomEnforcerInstaller("9.9.9");
+
+	/**
+	 * The JDK's JAXP factories ({@code DocumentBuilderFactory} and
+	 * {@code TransformerFactory}) pay a one-time, classpath-scanning
+	 * initialization cost the first time they are used. Charging that cold start
+	 * to whichever {@code @Test} happens to run first makes it flake against
+	 * surefire's 900ms per-test timeout, so pay it once here — a full parse and
+	 * write through the real install path — under the looser lifecycle-method
+	 * timeout instead.
+	 */
+	@BeforeAll
+	static void warmUpXmlToolchain(@TempDir Path dir) throws IOException {
+		Path pom = dir.resolve("pom.xml");
+		Files.writeString(pom, POM_WITH_BUILD);
+		new PomEnforcerInstaller("0.0.0").install(pom);
+	}
 
 	private Path write(Path dir, String content) throws IOException {
 		Path pom = dir.resolve("pom.xml");


### PR DESCRIPTION
A stalled `git clone` or a stuck `claude -p /init` could block the
adoption pipeline forever, since ProcessCommandRunner waited on the
child process indefinitely. Bound every command with a configurable
timeout: on expiry the process is destroyed and the failure is
reported with whatever output was captured.

Output is now drained on a background StreamGobbler thread so the
timed wait can actually fire even when the child never closes its
stdout — reading inline (as before) would block until EOF and defeat
the timeout. The timeout defaults to 10 minutes and is injectable via
a new constructor, keeping the no-arg constructor and existing
behaviour for callers.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FJ1gRvs8QEzhorL8AfLen4