### PR TITLE
Add optional HTML report to Claude Code enforcer rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,7 +374,11 @@ offer optional checks switched on from configuration: `forbiddenTokens`,
 links to local files must resolve on disk). Every rule extends a common
 `ClaudeCodeEnforcerRule` base that reports all violations together and supports a
 `severity` of `error` (default, fails the build) or `warn` (logs the same
-violations), so a new rule can be adopted gradually.
+violations), so a new rule can be adopted gradually. An optional `reportFile`
+writes the same outcome as a self-contained HTML report — what failed and why
+(the header and one entry per violation) plus per-rule "How to fix" steps — for a
+browser or CI artifact; it is written on pass and fail alike, so it always
+reflects the latest run.
 
 The front-matter rules (`skillFilesExist`, `subAgentFormat`, `commandFormat`)
 also accept an `autoFix` option (off by default). When enabled and a definition's

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -20,6 +20,12 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * governs collected structural violations; a misconfigured rule (missing file or
  * directory parameter) always fails, because that is a build-setup mistake rather
  * than a document-quality problem.
+ * <p>
+ * When {@code <reportFile>} is configured the same outcome is also written as a
+ * self-contained HTML report — what failed and why, plus the {@link #howToFix()}
+ * steps — so a build can surface the violations in a browser or CI artifact
+ * regardless of severity. The report is written whether the check passes or
+ * fails, so it always reflects the latest run.
  */
 public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 
@@ -28,12 +34,17 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	/** Optional override: {@code error} (default) fails the build, {@code warn} only logs. */
 	private String severity;
 
+	/** Optional path for an HTML report of the outcome. When null, no report is written. */
+	private File reportFile;
+
 	/**
-	 * Reports the violations as a single grouped message. Throws when severity is
-	 * {@code error} and there is at least one violation; logs a warning when
-	 * severity is {@code warn}; does nothing when there are no violations.
+	 * Reports the violations as a single grouped message. Writes the HTML report
+	 * first when {@link #reportFile} is configured, then throws when severity is
+	 * {@code error} and there is at least one violation, logs a warning when
+	 * severity is {@code warn}, or does nothing when there are no violations.
 	 */
 	protected final void report(String header, List<String> violations) throws EnforcerRuleException {
+		writeReport(header, violations);
 		if (violations.isEmpty()) {
 			return;
 		}
@@ -43,6 +54,24 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 		} else {
 			throw new EnforcerRuleException(message);
 		}
+	}
+
+	private void writeReport(String header, List<String> violations) throws EnforcerRuleException {
+		if (reportFile == null) {
+			return;
+		}
+		new HtmlReport(header, violations, howToFix()).writeTo(reportFile);
+	}
+
+	/**
+	 * The ordered remediation steps shown under "How to fix" in the HTML report.
+	 * The default is generic advice; a rule with a more specific fix overrides it.
+	 */
+	protected List<String> howToFix() {
+		return List.of(
+				"Open the file named in each message above.",
+				"Correct every listed item so it matches what the rule expects.",
+				"Re-run the build to confirm the rule passes.");
 	}
 
 	private String format(String header, List<String> violations) {
@@ -94,5 +123,9 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 
 	public void setSeverity(String severity) {
 		this.severity = severity;
+	}
+
+	public void setReportFile(File reportFile) {
+		this.reportFile = reportFile;
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
@@ -10,11 +10,11 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 /**
  * Renders a self-contained HTML report of a rule's outcome and writes it to a
- * file. The page states what failed and why — the header plus one entry per
- * collected violation — and how to fix it — the ordered remediation steps the
- * rule supplies. When there are no violations it renders a short "passed" page,
- * so a configured report file always reflects the latest run rather than leaving
- * a stale failure behind.
+ * file. The page states what failed and why — a numbered table with the header
+ * plus one row per collected violation — and how to fix it — a numbered table of
+ * the remediation steps the rule supplies. When there are no violations it
+ * renders a short "passed" page, so a configured report file always reflects the
+ * latest run rather than leaving a stale failure behind.
  * <p>
  * The document is inlined (styles included, no external assets) so it opens
  * anywhere, and every piece of rule-supplied text is HTML-escaped so a violation
@@ -75,22 +75,32 @@ final class HtmlReport {
 	private void appendFailures(StringBuilder html) {
 		html.append("<section>\n<h2>What failed and why</h2>\n");
 		html.append("<p>").append(escape(header)).append("</p>\n");
-		html.append("<ul class=\"violations\">\n");
-		for (String violation : violations) {
-			html.append("<li>").append(escape(violation)).append("</li>\n");
-		}
-		html.append("</ul>\n</section>\n");
+		html.append("<table class=\"violations\">\n");
+		html.append("<thead>\n<tr><th class=\"num\">#</th><th>What failed and why</th></tr>\n</thead>\n");
+		html.append("<tbody>\n");
+		appendNumberedRows(html, violations);
+		html.append("</tbody>\n</table>\n</section>\n");
 	}
 
 	private void appendHowToFix(StringBuilder html) {
 		if (howToFix.isEmpty()) {
 			return;
 		}
-		html.append("<section>\n<h2>How to fix</h2>\n<ol class=\"how-to-fix\">\n");
-		for (String step : howToFix) {
-			html.append("<li>").append(escape(step)).append("</li>\n");
+		html.append("<section>\n<h2>How to fix</h2>\n");
+		html.append("<table class=\"how-to-fix\">\n");
+		html.append("<thead>\n<tr><th class=\"num\">Step</th><th>Action</th></tr>\n</thead>\n");
+		html.append("<tbody>\n");
+		appendNumberedRows(html, howToFix);
+		html.append("</tbody>\n</table>\n</section>\n");
+	}
+
+	private void appendNumberedRows(StringBuilder html, List<String> cells) {
+		int number = 1;
+		for (String cell : cells) {
+			html.append("<tr><td class=\"num\">").append(number).append("</td><td>")
+					.append(escape(cell)).append("</td></tr>\n");
+			number++;
 		}
-		html.append("</ol>\n</section>\n");
 	}
 
 	private String css() {
@@ -102,8 +112,12 @@ final class HtmlReport {
 				+ ".status{display:inline-block;font-weight:600;padding:.25rem .75rem;border-radius:999px;}"
 				+ ".status.failed{background:#fdecea;color:#b3261e;}"
 				+ ".status.passed{background:#e6f4ea;color:#1e7e34;}"
-				+ ".violations li{color:#b3261e;margin:.35rem 0;}"
-				+ ".how-to-fix li{margin:.35rem 0;}";
+				+ "table{border-collapse:collapse;width:100%;margin:.25rem 0;}"
+				+ "th,td{border:1px solid #e0e0e0;padding:.5rem .75rem;text-align:left;vertical-align:top;}"
+				+ "thead th{background:#f0f1f3;font-weight:600;}"
+				+ "td.num,th.num{width:3rem;text-align:right;color:#666;white-space:nowrap;}"
+				+ ".violations td{color:#b3261e;}"
+				+ ".violations td.num{color:#666;}";
 	}
 
 	/** Escapes the five characters that are significant in HTML text and attributes. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
@@ -1,0 +1,117 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * Renders a self-contained HTML report of a rule's outcome and writes it to a
+ * file. The page states what failed and why — the header plus one entry per
+ * collected violation — and how to fix it — the ordered remediation steps the
+ * rule supplies. When there are no violations it renders a short "passed" page,
+ * so a configured report file always reflects the latest run rather than leaving
+ * a stale failure behind.
+ * <p>
+ * The document is inlined (styles included, no external assets) so it opens
+ * anywhere, and every piece of rule-supplied text is HTML-escaped so a violation
+ * message containing {@code <} or {@code &} cannot break or inject markup.
+ */
+final class HtmlReport {
+
+	private final String header;
+	private final List<String> violations;
+	private final List<String> howToFix;
+
+	HtmlReport(String header, List<String> violations, List<String> howToFix) {
+		this.header = header;
+		this.violations = violations;
+		this.howToFix = howToFix;
+	}
+
+	/** Writes the rendered report to {@code file}, failing the build if it cannot be written. */
+	void writeTo(File file) throws EnforcerRuleException {
+		try {
+			Files.writeString(file.toPath(), render(), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new EnforcerRuleException("Could not write HTML report to " + file, e);
+		}
+	}
+
+	String render() {
+		StringBuilder html = new StringBuilder();
+		html.append("<!DOCTYPE html>\n");
+		html.append("<html lang=\"en\">\n<head>\n");
+		html.append("<meta charset=\"utf-8\">\n");
+		html.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+		html.append("<title>Claude Code Enforcer report</title>\n");
+		html.append("<style>").append(css()).append("</style>\n");
+		html.append("</head>\n<body>\n");
+		html.append("<main>\n");
+		appendHeading(html);
+		if (violations.isEmpty()) {
+			appendPassed(html);
+		} else {
+			appendFailures(html);
+			appendHowToFix(html);
+		}
+		html.append("</main>\n</body>\n</html>\n");
+		return html.toString();
+	}
+
+	private void appendHeading(StringBuilder html) {
+		String status = violations.isEmpty() ? "passed" : "failed";
+		html.append("<h1>Claude Code Enforcer report</h1>\n");
+		html.append("<p class=\"status ").append(status).append("\">Check ").append(status).append("</p>\n");
+	}
+
+	private void appendPassed(StringBuilder html) {
+		html.append("<p>No violations were found.</p>\n");
+	}
+
+	private void appendFailures(StringBuilder html) {
+		html.append("<section>\n<h2>What failed and why</h2>\n");
+		html.append("<p>").append(escape(header)).append("</p>\n");
+		html.append("<ul class=\"violations\">\n");
+		for (String violation : violations) {
+			html.append("<li>").append(escape(violation)).append("</li>\n");
+		}
+		html.append("</ul>\n</section>\n");
+	}
+
+	private void appendHowToFix(StringBuilder html) {
+		if (howToFix.isEmpty()) {
+			return;
+		}
+		html.append("<section>\n<h2>How to fix</h2>\n<ol class=\"how-to-fix\">\n");
+		for (String step : howToFix) {
+			html.append("<li>").append(escape(step)).append("</li>\n");
+		}
+		html.append("</ol>\n</section>\n");
+	}
+
+	private String css() {
+		return "body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;"
+				+ "line-height:1.5;color:#1a1a1a;background:#f6f7f9;margin:0;padding:2rem;}"
+				+ "main{max-width:52rem;margin:0 auto;background:#fff;padding:1.5rem 2rem;"
+				+ "border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,.1);}"
+				+ "h1{font-size:1.5rem;margin:0 0 .5rem;}h2{font-size:1.15rem;margin:1.5rem 0 .5rem;}"
+				+ ".status{display:inline-block;font-weight:600;padding:.25rem .75rem;border-radius:999px;}"
+				+ ".status.failed{background:#fdecea;color:#b3261e;}"
+				+ ".status.passed{background:#e6f4ea;color:#1e7e34;}"
+				+ ".violations li{color:#b3261e;margin:.35rem 0;}"
+				+ ".how-to-fix li{margin:.35rem 0;}";
+	}
+
+	/** Escapes the five characters that are significant in HTML text and attributes. */
+	private String escape(String text) {
+		return text.replace("&", "&amp;")
+				.replace("<", "&lt;")
+				.replace(">", "&gt;")
+				.replace("\"", "&quot;")
+				.replace("'", "&#39;");
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -56,6 +56,14 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 	/** Document-specific checks against the parsed JSON. */
 	protected abstract void collectViolations(JsonNode root, List<String> violations);
 
+	@Override
+	protected List<String> howToFix() {
+		return List.of(
+				"Open " + description() + " and confirm it parses as valid JSON.",
+				"Correct every structural item listed above so it matches what the rule expects.",
+				"Re-run the build to confirm " + description() + " is well formed.");
+	}
+
 	/**
 	 * How to react when the file is absent. The default fails the build, because a
 	 * missing required file is a build-setup mistake. A rule whose file is optional

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -92,6 +92,15 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	protected void collectAdditionalViolations(MarkdownDocument document, List<String> violations) {
 	}
 
+	@Override
+	protected List<String> howToFix() {
+		return List.of(
+				"Open " + documentName() + " and make its first non-blank line the '" + titleHeading() + "' title heading.",
+				"Add every missing section heading listed above, each with non-empty content beneath it.",
+				"Resolve any remaining item — section order, forbidden tokens, line length, or broken file links.",
+				"Re-run the build to confirm " + documentName() + " is well formed.");
+	}
+
 	final String titleHeading() {
 		return titleHeading != null ? titleHeading : defaultTitleHeading();
 	}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
@@ -1,0 +1,78 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class HtmlReportTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void rendersHeaderViolationsAndHowToFixWhenThereAreViolations() {
+		String html = new HtmlReport("CLAUDE.md is not well formed:",
+				List.of("missing section: ## Build"),
+				List.of("Add the ## Build section.")).render();
+
+		assertTrue(html.contains("Check failed"), html);
+		assertTrue(html.contains("What failed and why"), html);
+		assertTrue(html.contains("CLAUDE.md is not well formed:"), html);
+		assertTrue(html.contains("missing section: ## Build"), html);
+		assertTrue(html.contains("How to fix"), html);
+		assertTrue(html.contains("Add the ## Build section."), html);
+	}
+
+	@Test
+	void rendersAPassedPageWithNoHowToFixWhenThereAreNoViolations() {
+		String html = new HtmlReport("CLAUDE.md is not well formed:",
+				List.of(),
+				List.of("Add the ## Build section.")).render();
+
+		assertTrue(html.contains("Check passed"), html);
+		assertTrue(html.contains("No violations were found."), html);
+		assertFalse(html.contains("How to fix"), html);
+	}
+
+	@Test
+	void escapesMarkupInRuleSuppliedText() {
+		String html = new HtmlReport("<header> & \"stuff\"",
+				List.of("token <script> must not appear"),
+				List.of("Remove <script> & re-run.")).render();
+
+		assertFalse(html.contains("<script>"), html);
+		assertTrue(html.contains("&lt;script&gt;"), html);
+		assertTrue(html.contains("&amp;"), html);
+		assertTrue(html.contains("&quot;stuff&quot;"), html);
+	}
+
+	@Test
+	void writesTheRenderedReportToDisk() throws Exception {
+		File report = tempDir.resolve("report.html").toFile();
+
+		new HtmlReport("header", List.of("boom"), List.of("fix it")).writeTo(report);
+
+		String written = Files.readString(report.toPath());
+		assertTrue(written.contains("boom"), written);
+		assertTrue(written.contains("fix it"), written);
+		assertTrue(written.startsWith("<!DOCTYPE html>"), written);
+	}
+
+	@Test
+	void failsWhenTheReportCannotBeWritten() {
+		File unwritable = tempDir.resolve("missing-dir").resolve("report.html").toFile();
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				() -> new HtmlReport("header", List.of("boom"), List.of("fix it")).writeTo(unwritable));
+		assertTrue(exception.getMessage().contains("Could not write HTML report"), exception.getMessage());
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
@@ -33,6 +33,18 @@ class HtmlReportTest {
 	}
 
 	@Test
+	void rendersViolationsAndHowToFixAsHtmlTables() {
+		String html = new HtmlReport("CLAUDE.md is not well formed:",
+				List.of("missing section: ## Build"),
+				List.of("Add the ## Build section.")).render();
+
+		assertTrue(html.contains("<table class=\"violations\">"), html);
+		assertTrue(html.contains("<th>What failed and why</th>"), html);
+		assertTrue(html.contains("<table class=\"how-to-fix\">"), html);
+		assertTrue(html.contains("<td>missing section: ## Build</td>"), html);
+	}
+
+	@Test
 	void rendersAPassedPageWithNoHowToFixWhenThereAreNoViolations() {
 		String html = new HtmlReport("CLAUDE.md is not well formed:",
 				List.of(),

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
@@ -98,6 +98,31 @@ class JsonFileRuleTest {
 		assertTrue(logger.warnings().get(0).contains("something is wrong"), logger.warnings().get(0));
 	}
 
+	@Test
+	void writesAnHtmlReportOfTheViolationsWhenAReportFileIsConfigured() throws IOException {
+		TestJsonRule rule = ruleFor("{ }");
+		rule.addViolation("something is wrong");
+		File report = tempDir.resolve("report.html").toFile();
+		rule.setReportFile(report);
+
+		assertThrows(EnforcerRuleException.class, rule::execute);
+		String html = Files.readString(report.toPath());
+		assertTrue(html.contains("Check failed"), html);
+		assertTrue(html.contains("something is wrong"), html);
+		assertTrue(html.contains("How to fix"), html);
+	}
+
+	@Test
+	void writesAPassedHtmlReportWhenThereAreNoViolations() throws IOException {
+		TestJsonRule rule = ruleFor("{ \"name\": \"value\" }");
+		File report = tempDir.resolve("report.html").toFile();
+		rule.setReportFile(report);
+
+		assertDoesNotThrow(rule::execute);
+		String html = Files.readString(report.toPath());
+		assertTrue(html.contains("Check passed"), html);
+	}
+
 	private TestJsonRule ruleFor(String content) {
 		Path file = tempDir.resolve("test.json");
 		writeString(file, content);


### PR DESCRIPTION
Introduce an optional <reportFile> parameter on the shared
ClaudeCodeEnforcerRule base. When configured, every rule writes a
self-contained HTML report of its outcome alongside the usual build
failure or warning: what failed and why (the header plus one entry per
collected violation) and how to fix it (per-rule remediation steps).

The report is rendered by a new HtmlReport class that escapes all
rule-supplied text and writes a passed or failed page, so a configured
report always reflects the latest run. A howToFix() hook supplies the
remediation steps, with a generic default and tailored overrides in the
MarkdownFormatRule and JsonFileRule base classes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NEVNbQ1QQtwi6iN5Ppha4j