### PR TITLE
feat(enforcer): merge "how to fix" into the violations report table

### DIFF
--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -38,5 +38,10 @@
 			<artifactId>archunit-junit5</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.jsoup</groupId>
+			<artifactId>jsoup</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -22,10 +22,10 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * than a document-quality problem.
  * <p>
  * When {@code <reportFile>} is configured the same outcome is also written as a
- * self-contained HTML report — what failed and why, plus the {@link #howToFix()}
- * steps — so a build can surface the violations in a browser or CI artifact
- * regardless of severity. The report is written whether the check passes or
- * fails, so it always reflects the latest run.
+ * self-contained HTML report — a single table pairing what failed and why with
+ * the {@link #howToFix()} steps in a "How to fix" column — so a build can surface
+ * the violations in a browser or CI artifact regardless of severity. The report is
+ * written whether the check passes or fails, so it always reflects the latest run.
  */
 public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
@@ -47,8 +47,8 @@ final class HtmlReport {
 		StringBuilder html = new StringBuilder();
 		html.append("<!DOCTYPE html>\n");
 		html.append("<html lang=\"en\">\n<head>\n");
-		html.append("<meta charset=\"utf-8\"/>\n");
-		html.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"/>\n");
+		html.append("<meta charset=\"utf-8\">\n");
+		html.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
 		html.append("<title>Claude Code Enforcer report</title>\n");
 		html.append("<style>").append(css()).append("</style>\n");
 		html.append("</head>\n<body>\n");

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
@@ -47,8 +47,8 @@ final class HtmlReport {
 		StringBuilder html = new StringBuilder();
 		html.append("<!DOCTYPE html>\n");
 		html.append("<html lang=\"en\">\n<head>\n");
-		html.append("<meta charset=\"utf-8\">\n");
-		html.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+		html.append("<meta charset=\"utf-8\"/>\n");
+		html.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"/>\n");
 		html.append("<title>Claude Code Enforcer report</title>\n");
 		html.append("<style>").append(css()).append("</style>\n");
 		html.append("</head>\n<body>\n");

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
@@ -10,11 +10,13 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 /**
  * Renders a self-contained HTML report of a rule's outcome and writes it to a
- * file. The page states what failed and why — a numbered table with the header
- * plus one row per collected violation — and how to fix it — a numbered table of
- * the remediation steps the rule supplies. When there are no violations it
- * renders a short "passed" page, so a configured report file always reflects the
- * latest run rather than leaving a stale failure behind.
+ * file. When there are violations the page shows a single numbered table with the
+ * header plus a "What failed and why" column (one collected violation per row) and
+ * a "How to fix" column (the remediation steps the rule supplies). The two lists
+ * are independent, so rows run to the longer of the two and the shorter column is
+ * left blank once it runs out. When there are no violations it renders a short
+ * "passed" page, so a configured report file always reflects the latest run rather
+ * than leaving a stale failure behind.
  * <p>
  * The document is inlined (styles included, no external assets) so it opens
  * anywhere, and every piece of rule-supplied text is HTML-escaped so a violation
@@ -56,7 +58,6 @@ final class HtmlReport {
 			appendPassed(html);
 		} else {
 			appendFailures(html);
-			appendHowToFix(html);
 		}
 		html.append("</main>\n</body>\n</html>\n");
 		return html.toString();
@@ -73,34 +74,27 @@ final class HtmlReport {
 	}
 
 	private void appendFailures(StringBuilder html) {
-		html.append("<section>\n<h2>What failed and why</h2>\n");
+		html.append("<section>\n<h2>What failed and how to fix it</h2>\n");
 		html.append("<p>").append(escape(header)).append("</p>\n");
-		html.append("<table class=\"violations\">\n");
-		html.append("<thead>\n<tr><th class=\"num\">#</th><th>What failed and why</th></tr>\n</thead>\n");
+		html.append("<table class=\"report\">\n");
+		html.append("<thead>\n<tr><th class=\"num\">#</th><th>What failed and why</th>"
+				+ "<th>How to fix</th></tr>\n</thead>\n");
 		html.append("<tbody>\n");
-		appendNumberedRows(html, violations);
+		appendCombinedRows(html);
 		html.append("</tbody>\n</table>\n</section>\n");
 	}
 
-	private void appendHowToFix(StringBuilder html) {
-		if (howToFix.isEmpty()) {
-			return;
+	private void appendCombinedRows(StringBuilder html) {
+		int rows = Math.max(violations.size(), howToFix.size());
+		for (int index = 0; index < rows; index++) {
+			html.append("<tr><td class=\"num\">").append(index + 1).append("</td>")
+					.append("<td class=\"failure\">").append(cell(violations, index)).append("</td>")
+					.append("<td class=\"fix\">").append(cell(howToFix, index)).append("</td></tr>\n");
 		}
-		html.append("<section>\n<h2>How to fix</h2>\n");
-		html.append("<table class=\"how-to-fix\">\n");
-		html.append("<thead>\n<tr><th class=\"num\">Step</th><th>Action</th></tr>\n</thead>\n");
-		html.append("<tbody>\n");
-		appendNumberedRows(html, howToFix);
-		html.append("</tbody>\n</table>\n</section>\n");
 	}
 
-	private void appendNumberedRows(StringBuilder html, List<String> cells) {
-		int number = 1;
-		for (String cell : cells) {
-			html.append("<tr><td class=\"num\">").append(number).append("</td><td>")
-					.append(escape(cell)).append("</td></tr>\n");
-			number++;
-		}
+	private String cell(List<String> cells, int index) {
+		return index < cells.size() ? escape(cells.get(index)) : "";
 	}
 
 	private String css() {
@@ -116,8 +110,8 @@ final class HtmlReport {
 				+ "th,td{border:1px solid #e0e0e0;padding:.5rem .75rem;text-align:left;vertical-align:top;}"
 				+ "thead th{background:#f0f1f3;font-weight:600;}"
 				+ "td.num,th.num{width:3rem;text-align:right;color:#666;white-space:nowrap;}"
-				+ ".violations td{color:#b3261e;}"
-				+ ".violations td.num{color:#666;}";
+				+ ".report td.failure{color:#b3261e;}"
+				+ ".report td.fix{color:#1a1a1a;}";
 	}
 
 	/** Escapes the five characters that are significant in HTML text and attributes. */

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
@@ -1,29 +1,22 @@
 package io.github.adamw7.tools.enforcer.rule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 class HtmlReportTest {
 
@@ -32,63 +25,73 @@ class HtmlReportTest {
 
 	@Test
 	void rendersHeaderViolationsAndHowToFixWhenThereAreViolations() {
-		String html = new HtmlReport("CLAUDE.md is not well formed:",
+		Document document = Jsoup.parse(new HtmlReport("CLAUDE.md is not well formed:",
 				List.of("missing section: ## Build"),
-				List.of("Add the ## Build section.")).render();
+				List.of("Add the ## Build section.")).render());
 
-		assertTrue(html.contains("Check failed"), html);
-		assertTrue(html.contains("What failed and why"), html);
-		assertTrue(html.contains("CLAUDE.md is not well formed:"), html);
-		assertTrue(html.contains("missing section: ## Build"), html);
-		assertTrue(html.contains("How to fix"), html);
-		assertTrue(html.contains("Add the ## Build section."), html);
+		assertEquals("Check failed", document.selectFirst("p.status").text());
+		assertEquals("CLAUDE.md is not well formed:", document.selectFirst("section p").text());
+		Element row = document.selectFirst("table.report tbody tr");
+		assertEquals("missing section: ## Build", row.selectFirst("td.failure").text());
+		assertEquals("Add the ## Build section.", row.selectFirst("td.fix").text());
 	}
 
 	@Test
 	void rendersViolationsAndHowToFixAsColumnsOfOneTable() {
-		String html = new HtmlReport("CLAUDE.md is not well formed:",
+		Document document = Jsoup.parse(new HtmlReport("CLAUDE.md is not well formed:",
 				List.of("missing section: ## Build"),
-				List.of("Add the ## Build section.")).render();
+				List.of("Add the ## Build section.")).render());
 
-		assertTrue(html.contains("<table class=\"report\">"), html);
-		assertFalse(html.contains("<table class=\"how-to-fix\">"), html);
-		assertTrue(html.contains("<th>What failed and why</th>"), html);
-		assertTrue(html.contains("<th>How to fix</th>"), html);
-		assertTrue(html.contains("<td class=\"failure\">missing section: ## Build</td>"), html);
-		assertTrue(html.contains("<td class=\"fix\">Add the ## Build section.</td>"), html);
+		assertEquals(1, document.select("table").size());
+		assertEquals(List.of("#", "What failed and why", "How to fix"),
+				document.select("table.report thead th").eachText());
 	}
 
 	@Test
 	void padsTheShorterColumnWhenViolationsAndFixesDiffer() {
-		String html = new HtmlReport("CLAUDE.md is not well formed:",
+		Document document = Jsoup.parse(new HtmlReport("CLAUDE.md is not well formed:",
 				List.of("missing section: ## Build", "missing section: ## Test"),
-				List.of("Add the missing sections.")).render();
+				List.of("Add the missing sections.")).render());
 
-		assertTrue(html.contains("<td class=\"failure\">missing section: ## Test</td>"), html);
-		assertTrue(html.contains("<td class=\"fix\"></td>"), html);
+		Elements rows = document.select("table.report tbody tr");
+		assertEquals(2, rows.size());
+		assertEquals("missing section: ## Test", rows.get(1).selectFirst("td.failure").text());
+		assertEquals("", rows.get(1).selectFirst("td.fix").text());
 	}
 
 	@Test
 	void rendersAPassedPageWithNoHowToFixWhenThereAreNoViolations() {
-		String html = new HtmlReport("CLAUDE.md is not well formed:",
+		Document document = Jsoup.parse(new HtmlReport("CLAUDE.md is not well formed:",
 				List.of(),
-				List.of("Add the ## Build section.")).render();
+				List.of("Add the ## Build section.")).render());
 
-		assertTrue(html.contains("Check passed"), html);
-		assertTrue(html.contains("No violations were found."), html);
-		assertFalse(html.contains("How to fix"), html);
+		assertEquals("Check passed", document.selectFirst("p.status").text());
+		assertTrue(document.select("table").isEmpty(), document.html());
+		assertTrue(document.body().text().contains("No violations were found."), document.html());
 	}
 
 	@Test
 	void escapesMarkupInRuleSuppliedText() {
-		String html = new HtmlReport("<header> & \"stuff\"",
+		Document document = Jsoup.parse(new HtmlReport("<header> & \"stuff\"",
 				List.of("token <script> must not appear"),
-				List.of("Remove <script> & re-run.")).render();
+				List.of("Remove <script> & re-run.")).render());
 
-		assertFalse(html.contains("<script>"), html);
-		assertTrue(html.contains("&lt;script&gt;"), html);
-		assertTrue(html.contains("&amp;"), html);
-		assertTrue(html.contains("&quot;stuff&quot;"), html);
+		assertTrue(document.select("script").isEmpty(), document.html());
+		assertEquals("token <script> must not appear",
+				document.selectFirst("td.failure").text());
+		assertEquals("Remove <script> & re-run.", document.selectFirst("td.fix").text());
+	}
+
+	@Test
+	void producesValidMarkupWithoutParseErrors() {
+		assertNoParseErrors(new HtmlReport("CLAUDE.md is not well formed:",
+				List.of("missing section: ## Build"),
+				List.of("Add the ## Build section.")).render());
+		assertNoParseErrors(new HtmlReport("<header> & \"stuff\"",
+				List.of("token <script> must not appear"),
+				List.of("Remove <script> & re-run.")).render());
+		assertNoParseErrors(new HtmlReport("CLAUDE.md is not well formed:", List.of(),
+				List.of("Add the ## Build section.")).render());
 	}
 
 	@Test
@@ -98,9 +101,10 @@ class HtmlReportTest {
 		new HtmlReport("header", List.of("boom"), List.of("fix it")).writeTo(report);
 
 		String written = Files.readString(report.toPath());
-		assertTrue(written.contains("boom"), written);
-		assertTrue(written.contains("fix it"), written);
+		Document document = Jsoup.parse(written);
 		assertTrue(written.startsWith("<!DOCTYPE html>"), written);
+		assertEquals("boom", document.selectFirst("td.failure").text());
+		assertEquals("fix it", document.selectFirst("td.fix").text());
 	}
 
 	@Test
@@ -112,61 +116,10 @@ class HtmlReportTest {
 		assertTrue(exception.getMessage().contains("Could not write HTML report"), exception.getMessage());
 	}
 
-	@Test
-	void producesWellFormedMarkupForTheFailurePage() throws Exception {
-		String html = new HtmlReport("CLAUDE.md is not well formed:",
-				List.of("missing section: ## Build"),
-				List.of("Add the ## Build section.")).render();
-
-		Document document = parse(html);
-
-		assertEquals("html", document.getDocumentElement().getTagName());
-		Element table = firstElementByTag(document, "table");
-		assertEquals(List.of("#", "What failed and why", "How to fix"), headerCells(table));
-	}
-
-	@Test
-	void producesWellFormedMarkupForThePassedPage() throws Exception {
-		String html = new HtmlReport("CLAUDE.md is not well formed:", List.of(),
-				List.of("Add the ## Build section.")).render();
-
-		Document document = parse(html);
-
-		assertEquals("html", document.getDocumentElement().getTagName());
-		assertEquals(0, document.getElementsByTagName("table").getLength());
-	}
-
-	@Test
-	void keepsMarkupWellFormedWhenRuleTextContainsSpecialCharacters() throws Exception {
-		String html = new HtmlReport("<header> & \"stuff\"",
-				List.of("token <script> must not appear"),
-				List.of("Remove <script> & re-run.")).render();
-
-		Document document = parse(html);
-
-		assertEquals("html", document.getDocumentElement().getTagName());
-	}
-
-	/** Parses the rendered report as XML, which fails the test if the markup is not well formed. */
-	private Document parse(String html) throws Exception {
-		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-		DocumentBuilder builder = factory.newDocumentBuilder();
-		return builder.parse(new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8)));
-	}
-
-	private Element firstElementByTag(Document document, String tag) {
-		return (Element) document.getElementsByTagName(tag).item(0);
-	}
-
-	private List<String> headerCells(Element table) {
-		List<String> headers = new ArrayList<>();
-		NodeList cells = table.getElementsByTagName("th");
-		for (int index = 0; index < cells.getLength(); index++) {
-			Node cell = cells.item(index);
-			headers.add(cell.getTextContent());
-		}
-		return headers;
+	/** Parses with the HTML5 parser in error-tracking mode and fails on any reported problem. */
+	private void assertNoParseErrors(String html) {
+		Parser parser = Parser.htmlParser().setTrackErrors(10);
+		parser.parseInput(html, "");
+		assertTrue(parser.getErrors().isEmpty(), parser.getErrors().toString());
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
@@ -33,15 +33,27 @@ class HtmlReportTest {
 	}
 
 	@Test
-	void rendersViolationsAndHowToFixAsHtmlTables() {
+	void rendersViolationsAndHowToFixAsColumnsOfOneTable() {
 		String html = new HtmlReport("CLAUDE.md is not well formed:",
 				List.of("missing section: ## Build"),
 				List.of("Add the ## Build section.")).render();
 
-		assertTrue(html.contains("<table class=\"violations\">"), html);
+		assertTrue(html.contains("<table class=\"report\">"), html);
+		assertFalse(html.contains("<table class=\"how-to-fix\">"), html);
 		assertTrue(html.contains("<th>What failed and why</th>"), html);
-		assertTrue(html.contains("<table class=\"how-to-fix\">"), html);
-		assertTrue(html.contains("<td>missing section: ## Build</td>"), html);
+		assertTrue(html.contains("<th>How to fix</th>"), html);
+		assertTrue(html.contains("<td class=\"failure\">missing section: ## Build</td>"), html);
+		assertTrue(html.contains("<td class=\"fix\">Add the ## Build section.</td>"), html);
+	}
+
+	@Test
+	void padsTheShorterColumnWhenViolationsAndFixesDiffer() {
+		String html = new HtmlReport("CLAUDE.md is not well formed:",
+				List.of("missing section: ## Build", "missing section: ## Test"),
+				List.of("Add the missing sections.")).render();
+
+		assertTrue(html.contains("<td class=\"failure\">missing section: ## Test</td>"), html);
+		assertTrue(html.contains("<td class=\"fix\"></td>"), html);
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
@@ -1,17 +1,29 @@
 package io.github.adamw7.tools.enforcer.rule;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 class HtmlReportTest {
 
@@ -98,5 +110,63 @@ class HtmlReportTest {
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
 				() -> new HtmlReport("header", List.of("boom"), List.of("fix it")).writeTo(unwritable));
 		assertTrue(exception.getMessage().contains("Could not write HTML report"), exception.getMessage());
+	}
+
+	@Test
+	void producesWellFormedMarkupForTheFailurePage() throws Exception {
+		String html = new HtmlReport("CLAUDE.md is not well formed:",
+				List.of("missing section: ## Build"),
+				List.of("Add the ## Build section.")).render();
+
+		Document document = parse(html);
+
+		assertEquals("html", document.getDocumentElement().getTagName());
+		Element table = firstElementByTag(document, "table");
+		assertEquals(List.of("#", "What failed and why", "How to fix"), headerCells(table));
+	}
+
+	@Test
+	void producesWellFormedMarkupForThePassedPage() throws Exception {
+		String html = new HtmlReport("CLAUDE.md is not well formed:", List.of(),
+				List.of("Add the ## Build section.")).render();
+
+		Document document = parse(html);
+
+		assertEquals("html", document.getDocumentElement().getTagName());
+		assertEquals(0, document.getElementsByTagName("table").getLength());
+	}
+
+	@Test
+	void keepsMarkupWellFormedWhenRuleTextContainsSpecialCharacters() throws Exception {
+		String html = new HtmlReport("<header> & \"stuff\"",
+				List.of("token <script> must not appear"),
+				List.of("Remove <script> & re-run.")).render();
+
+		Document document = parse(html);
+
+		assertEquals("html", document.getDocumentElement().getTagName());
+	}
+
+	/** Parses the rendered report as XML, which fails the test if the markup is not well formed. */
+	private Document parse(String html) throws Exception {
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		DocumentBuilder builder = factory.newDocumentBuilder();
+		return builder.parse(new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8)));
+	}
+
+	private Element firstElementByTag(Document document, String tag) {
+		return (Element) document.getElementsByTagName(tag).item(0);
+	}
+
+	private List<String> headerCells(Element table) {
+		List<String> headers = new ArrayList<>();
+		NodeList cells = table.getElementsByTagName("th");
+		for (int index = 0; index < cells.getLength(); index++) {
+			Node cell = cells.item(index);
+			headers.add(cell.getTextContent());
+		}
+		return headers;
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<groupId>org.jsoup</groupId>
+				<artifactId>jsoup</artifactId>
+				<version>1.18.3</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-api</artifactId>
 				<version>2.26.1</version>


### PR DESCRIPTION
Combine the HTML report's two tables into a single table with a new
"How to fix" column alongside "What failed and why". Rows run to the
longer of the violations and fix-step lists; the shorter column is left
blank once it runs out. Update tests and rule javadoc accordingly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N7KAJ5CzaKzCfC51cwjZs8