### PR TITLE
docs: document HTML enforcer report in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ violations together and honours a `severity` option: the default `error` fails
 the build, while `<severity>warn</severity>` downgrades the same violations to a
 logged warning so a team can adopt a rule gradually.
 
+An optional `<reportFile>` writes the same outcome as a self-contained HTML
+report — a single table pairing what failed and why (the header plus one entry
+per violation) with the per-rule "How to fix" steps — so a build can surface the
+violations in a browser or as a CI artifact. The page is inlined (styles
+included, no external assets) so it opens anywhere, and it is written on pass and
+fail alike, so a configured report file always reflects the latest run rather
+than leaving a stale failure behind:
+```xml
+<reportFile>${project.build.directory}/claude-code-enforcer.html</reportFile>
+```
+
 The front matter rules (`skillFilesExist`, `subAgentFormat`, `commandFormat`)
 also accept an `autoFix` option. When it is enabled and a definition's front
 matter is malformed in a way that is safe to repair — a delimiter written with


### PR DESCRIPTION
Mention the optional reportFile HTML report for the Claude Code enforcer
rules in README.md, mirroring the AGENTS.md description so readmeConsistency
stays satisfied. Describes the self-contained report (what-failed/how-to-fix
table, inlined styles, written on pass and fail) with a sample configuration.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017DENSmKnV12vEgvgbjy4EN