### PR TITLE
Configure exec-maven-plugin for adopt module CLI execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,11 +727,14 @@ generated `CLAUDE.md` keeps being validated on every build.
 
 Run it from the command line with a GitHub repository URL and an optional
 workspace directory to clone into (a temporary directory is created when it is
-omitted):
+omitted). Launch it through `exec:java` so Maven puts the full runtime classpath
+(log4j2 and the rest) on the command — a bare `java -cp adopt/target/classes`
+omits the dependency jars and fails at start-up with a `NoClassDefFoundError` for
+the log4j `LogManager`:
 
 ```bash
-java -cp adopt/target/classes io.github.adamw7.tools.adopt.Main \
-    https://github.com/owner/repo.git [workspace-directory]
+mvn -pl adopt exec:java \
+    -Dexec.args="https://github.com/owner/repo.git [workspace-directory]"
 ```
 
 The pipeline is a list of ordered, independent `AdoptionStep`s, each acting on a

--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -12,6 +12,22 @@
 	<name>Claude Code repository adoption</name>
 	<description>Adopts Claude Code into a GitHub repository: clones it, runs claude init to generate CLAUDE.md, commits and pushes, then wires the claude-code-enforcer into the project build.</description>
 	<url>https://github.com/adamw7/tools</url>
+	<build>
+		<plugins>
+			<!-- Lets the pipeline be launched with `mvn -pl adopt exec:java`, which
+			     resolves the full runtime classpath (log4j2 and the rest) from the
+			     module's dependencies. Running the Main class with a bare
+			     `java -cp adopt/target/classes` omits those jars and fails at
+			     start-up with NoClassDefFoundError for the log4j LogManager. -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<configuration>
+					<mainClass>io.github.adamw7.tools.adopt.Main</mainClass>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
## Summary

Configures the `exec-maven-plugin` in the `adopt` module to enable launching the adoption pipeline via `mvn -pl adopt exec:java`, ensuring the full runtime classpath (including log4j2 and other dependencies) is available at startup.

## Changes

- **pom.xml**: Added `<build>` section with `exec-maven-plugin` configuration pointing to `io.github.adamw7.tools.adopt.Main` as the main class. This allows Maven to resolve and include all transitive dependencies on the classpath, preventing `NoClassDefFoundError` for log4j's `LogManager` that occurs when running with a bare `java -cp` command.

- **README.md**: Updated the usage documentation to reflect the correct invocation method:
  - Changed from `java -cp adopt/target/classes io.github.adamw7.tools.adopt.Main ...` to `mvn -pl adopt exec:java -Dexec.args="..."`
  - Added explanation of why the Maven approach is necessary (dependency jar resolution)

## Implementation Details

The plugin configuration includes a detailed comment explaining the rationale: running the Main class directly with `java -cp adopt/target/classes` omits dependency jars from the classpath, causing startup failures. Using `exec:java` through Maven ensures the full runtime classpath is constructed and passed to the JVM, resolving all transitive dependencies including log4j2.

https://claude.ai/code/session_01AX1reqHiVhc5JxTEbkfEGq