### PR TITLE
feat(adopt): create a feature branch and open a PR instead of pushing to default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,12 +39,14 @@ Maven project. The notable capabilities are:
   `IntKeyOpenAddressingMap`), and an **MCP server** exposing the
   uniqueness checker as a tool for AI assistants.
 - **Claude Code adoption** (`adopt`) — an ordered pipeline that adopts Claude
-  Code into a GitHub repository: it clones the repo, marks the checkout trusted
-  in `~/.claude.json` so the headless CLI is not blocked by the folder-trust
-  prompt, runs the Claude Code CLI (`claude init`) to generate a `CLAUDE.md`,
-  commits and pushes that, then wires the `claude-code-enforcer` into the
-  project's `pom.xml` and commits and pushes again. External `git`/`claude`
-  invocations go through a `CommandRunner`
+  Code into a GitHub repository: it clones the repo, creates a feature branch,
+  marks the checkout trusted in `~/.claude.json` so the headless CLI is not
+  blocked by the folder-trust prompt, runs the Claude Code CLI (`claude init`) to
+  generate a `CLAUDE.md` and commits it, then wires the `claude-code-enforcer`
+  into the project's `pom.xml` and commits that, and finally pushes the branch
+  and opens a pull request with the GitHub CLI (`gh pr create`) — the default
+  branch is never written to directly. External `git`/`claude`/`gh` invocations
+  go through a `CommandRunner`
   abstraction so the steps are unit-tested without spawning real processes; the
   `ProcessCommandRunner` bounds every command with a configurable timeout so a
   stalled clone or a stuck `claude` run cannot hang the adoption.
@@ -68,7 +70,7 @@ tools (root pom, packaging=pom)
 │   ├── protogen-maven-plugin       # the proto2 builder-generating Maven plugin
 │   ├── protogen-maven-plugin-test  # integration tests / use cases for the plugin
 │   └── context                     # regex-based class-usage context finder
-├── adopt                       # adopts Claude Code into a GitHub repo (clone, trust, init, commit/push, enforcer)
+├── adopt                       # adopts Claude Code into a GitHub repo (clone, branch, trust, init, enforcer, push, PR)
 ├── grpc-example                # end-to-end gRPC example with compile-time-safe builders
 ├── assembly                    # builds an executable jar-with-dependencies
 │                               #   (mainClass: io.github.adamw7.tools.data.SampleApp)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,10 @@ run `mvn install` from the repository root. The main capabilities are:
   column-uniqueness/key finder, open-addressing map/set data structures, and an
   MCP server exposing the uniqueness checker.
 - **Claude Code adoption** (`adopt`) — a pipeline that adopts Claude Code into a
-  GitHub repo: clone, `claude init` to generate `CLAUDE.md`, commit and push,
-  then wire the `claude-code-enforcer` into the repo's `pom.xml` and push again.
+  GitHub repo: clone, create a feature branch, `claude init` to generate
+  `CLAUDE.md` and commit it, wire the `claude-code-enforcer` into the repo's
+  `pom.xml` and commit that, then push the branch and open a pull request
+  (`gh pr create`); the default branch is never written to directly.
 
 Module map (root reactor: `claude-code-enforcer`, `mcp-common`, `data`, `code`,
 `adopt`, `grpc-example`, `assembly`; `data-test` is built separately):
@@ -38,7 +40,7 @@ tools (root pom, packaging=pom)
 │   ├── protogen-maven-plugin       # compile-time-safe protobuf builder generator
 │   ├── protogen-maven-plugin-test  # integration tests for the plugin
 │   └── context                     # class-usage context finder + MCP server
-├── adopt                  # adopts Claude Code into a GitHub repo (clone, trust, init, commit/push, enforcer)
+├── adopt                  # adopts Claude Code into a GitHub repo (clone, branch, trust, init, enforcer, push, PR)
 ├── grpc-example           # end-to-end gRPC example
 ├── assembly               # executable jar-with-dependencies (SampleApp)
 └── data-test              # standalone test module (not in root <modules>)

--- a/README.md
+++ b/README.md
@@ -719,27 +719,32 @@ it. See *Testing* in [AGENTS.md](AGENTS.md) for the details.
 ## Claude Code adoption
 
 The `adopt` module (`tools.adopt`) is an ordered pipeline that **adopts Claude
-Code into a GitHub repository**. Given a repository URL it clones the repo, runs
-the Claude Code CLI (`claude -p /init`) to generate a `CLAUDE.md`, commits and
-pushes that, then wires the [`claude-code-enforcer`](#claude-code-files-maven-enforcer)
-into the project's `pom.xml` and commits and pushes again — so the freshly
-generated `CLAUDE.md` keeps being validated on every build.
+Code into a GitHub repository**. Given a repository URL it clones the repo,
+creates a feature branch, runs the Claude Code CLI (`claude -p /init`) to
+generate a `CLAUDE.md` and commits it, then wires the
+[`claude-code-enforcer`](#claude-code-files-maven-enforcer) into the project's
+`pom.xml` and commits that too — so the freshly generated `CLAUDE.md` keeps
+being validated on every build. Finally it pushes the branch and opens a pull
+request with the GitHub CLI, so the change is reviewed rather than landing
+straight on the default branch, which is never written to.
 
-Run it from the command line with a GitHub repository URL and an optional
-workspace directory to clone into (a temporary directory is created when it is
-omitted). Launch it through `exec:java` so Maven puts the full runtime classpath
-(log4j2 and the rest) on the command — a bare `java -cp adopt/target/classes`
-omits the dependency jars and fails at start-up with a `NoClassDefFoundError` for
-the log4j `LogManager`:
+Run it from the command line with a GitHub repository URL, an optional workspace
+directory to clone into (a temporary directory is created when it is omitted),
+and an optional feature-branch name (defaults to `claude/adopt-claude-code`).
+Because it opens the pull request through the GitHub CLI, an authenticated `gh`
+must be on the `PATH` alongside `git` and `claude`. Launch it through `exec:java`
+so Maven puts the full runtime classpath (log4j2 and the rest) on the command — a
+bare `java -cp adopt/target/classes` omits the dependency jars and fails at
+start-up with a `NoClassDefFoundError` for the log4j `LogManager`:
 
 ```bash
 mvn -pl adopt exec:java \
-    -Dexec.args="https://github.com/owner/repo.git [workspace-directory]"
+    -Dexec.args="https://github.com/owner/repo.git [workspace-directory] [branch-name]"
 ```
 
 The pipeline is a list of ordered, independent `AdoptionStep`s, each acting on a
-shared immutable `AdoptionContext` (the repository URL, the workspace, and the
-derived checkout directory):
+shared immutable `AdoptionContext` (the repository URL, the workspace, the
+derived checkout directory, and the feature-branch name):
 
 ```java
 CommandRunner runner = new ProcessCommandRunner();
@@ -751,13 +756,15 @@ The default pipeline runs these steps in order:
 
 1. **`CloneStep`** — clones the target repository into the workspace with
    `git clone`, giving the remaining steps a working checkout.
-2. **`ClaudeInitStep`** — runs the Claude Code CLI in headless mode
+2. **`BranchStep`** — creates and checks out the adoption feature branch with
+   `git checkout -b`, so every later commit lands on that branch instead of the
+   default branch.
+3. **`ClaudeInitStep`** — runs the Claude Code CLI in headless mode
    (`claude -p /init` by default; the invocation is configurable because the
    flags differ between environments) so it generates a `CLAUDE.md`, warning if
    the file did not appear.
-3. **`CommitStep`** — commits the generated `CLAUDE.md` (`Adopt Claude Code: add
+4. **`CommitStep`** — commits the generated `CLAUDE.md` (`Adopt Claude Code: add
    CLAUDE.md`).
-4. **`PushStep`** — pushes the commit.
 5. **`EnforcerStep`** — wires the `claude-code-enforcer` into the checkout's root
    `pom.xml` via `PomEnforcerInstaller`. The edit is done on the JDK's DOM (no
    third-party XML library), is namespace-aware, and is idempotent: a POM that
@@ -766,10 +773,16 @@ The default pipeline runs these steps in order:
    adoption.
 6. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
    build`).
-7. **`PushStep`** — pushes the commit.
+7. **`PushStep`** — pushes the feature branch to origin and sets its upstream
+   (`git push -u origin <branch>`).
+8. **`PullRequestStep`** — opens a pull request from the branch with
+   `gh pr create`, targeting the repository's default branch as the base. Like
+   `CommitStep` it stays idempotent: a `gh` failure that only reports an
+   already-open pull request for the branch, or no commits between base and head,
+   is treated as a no-op rather than aborting the adoption.
 
-External `git`/`claude` invocations go through a `CommandRunner` abstraction, so
-the steps are unit-tested without spawning real processes. The default
+External `git`/`claude`/`gh` invocations go through a `CommandRunner` abstraction,
+so the steps are unit-tested without spawning real processes. The default
 `ProcessCommandRunner` merges standard error into standard output for a single
 ordered transcript, and **bounds every command with a configurable timeout**
 (10 minutes by default) so a stalled clone or a stuck `claude` run cannot hang

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -4,20 +4,31 @@ import java.nio.file.Path;
 
 /**
  * Immutable inputs shared by every adoption step: the GitHub repository URL to
- * adopt, the workspace directory the clone is created under, and the resulting
- * checkout directory. The repository name is derived from the URL up front so
- * the clone target is known before the first step runs.
+ * adopt, the workspace directory the clone is created under, the resulting
+ * checkout directory, and the feature branch the adoption commits are made on.
+ * The repository name is derived from the URL up front so the clone target is
+ * known before the first step runs. The adoption never pushes to the default
+ * branch: it works on {@code branchName} and opens a pull request from it.
  */
 public final class AdoptionContext {
+
+	/** Feature branch the adoption commits, pushes, and raises a pull request from. */
+	public static final String DEFAULT_BRANCH = "claude/adopt-claude-code";
 
 	private final String repositoryUrl;
 	private final Path workspace;
 	private final Path repositoryDirectory;
+	private final String branchName;
 
 	public AdoptionContext(String repositoryUrl, Path workspace) {
+		this(repositoryUrl, workspace, DEFAULT_BRANCH);
+	}
+
+	public AdoptionContext(String repositoryUrl, Path workspace, String branchName) {
 		this.repositoryUrl = requireUrl(repositoryUrl);
 		this.workspace = requireWorkspace(workspace);
 		this.repositoryDirectory = workspace.resolve(repositoryName(this.repositoryUrl));
+		this.branchName = requireBranch(branchName);
 	}
 
 	public String repositoryUrl() {
@@ -32,6 +43,10 @@ public final class AdoptionContext {
 		return repositoryDirectory;
 	}
 
+	public String branchName() {
+		return branchName;
+	}
+
 	private static String requireUrl(String repositoryUrl) {
 		if (repositoryUrl == null || repositoryUrl.isBlank()) {
 			throw new IllegalArgumentException("repositoryUrl must not be blank");
@@ -44,6 +59,13 @@ public final class AdoptionContext {
 			throw new IllegalArgumentException("workspace must not be null");
 		}
 		return workspace;
+	}
+
+	private static String requireBranch(String branchName) {
+		if (branchName == null || branchName.isBlank()) {
+			throw new IllegalArgumentException("branchName must not be blank");
+		}
+		return branchName.strip();
 	}
 
 	private static String repositoryName(String repositoryUrl) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -7,19 +7,22 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
+import io.github.adamw7.tools.adopt.step.BranchStep;
 import io.github.adamw7.tools.adopt.step.ClaudeInitStep;
 import io.github.adamw7.tools.adopt.step.CloneStep;
 import io.github.adamw7.tools.adopt.step.CommitStep;
 import io.github.adamw7.tools.adopt.step.EnforcerStep;
+import io.github.adamw7.tools.adopt.step.PullRequestStep;
 import io.github.adamw7.tools.adopt.step.PushStep;
 import io.github.adamw7.tools.adopt.step.TrustStep;
 
 /**
  * Runs the ordered pipeline that adopts Claude Code into a GitHub repository:
- * clone, mark the checkout trusted for Claude Code, generate {@code CLAUDE.md}
- * with {@code claude init}, commit and push that, then wire in the
- * {@code claude-code-enforcer} and commit and push again. Steps and the command
- * runner are injected so the pipeline is easy to reconfigure and to test.
+ * clone, create a feature branch, mark the checkout trusted for Claude Code,
+ * generate {@code CLAUDE.md} with {@code claude init} and commit it, wire in the
+ * {@code claude-code-enforcer} and commit that, then push the branch and open a
+ * pull request. The adoption never writes to the default branch. Steps and the
+ * command runner are injected so the pipeline is easy to reconfigure and to test.
  */
 public class GitHubRepoAdopter {
 
@@ -40,13 +43,14 @@ public class GitHubRepoAdopter {
 	public static List<AdoptionStep> defaultSteps() {
 		return List.of(
 				new CloneStep(),
+				new BranchStep(),
 				new TrustStep(),
 				new ClaudeInitStep(),
 				new CommitStep("Adopt Claude Code: add CLAUDE.md"),
-				new PushStep(),
 				new EnforcerStep(),
 				new CommitStep("Add claude-code-enforcer to the build"),
-				new PushStep());
+				new PushStep(),
+				new PullRequestStep());
 	}
 
 	public void adopt(AdoptionContext context) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -10,25 +10,36 @@ import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
 
 /**
  * Command-line entry point: given a GitHub repository URL (and an optional
- * workspace directory to clone into), runs the default adoption pipeline
- * against a real {@code git}/{@code claude} toolchain. A supplied workspace
- * directory is created when it does not yet exist, so the clone step always has
- * a directory to run in; when omitted, a temporary one is created instead.
+ * workspace directory to clone into and an optional feature-branch name), runs
+ * the default adoption pipeline against a real {@code git}/{@code claude}/
+ * {@code gh} toolchain. A supplied workspace directory is created when it does
+ * not yet exist, so the clone step always has a directory to run in; when
+ * omitted, a temporary one is created instead. When no branch name is supplied,
+ * {@link AdoptionContext#DEFAULT_BRANCH} is used.
  */
 public class Main {
 
 	public static void main(String[] args) {
 		String repositoryUrl = repositoryUrl(args);
 		Path workspace = workspace(args);
+		String branchName = branchName(args);
 		CommandRunner runner = new ProcessCommandRunner();
-		GitHubRepoAdopter.withDefaultPipeline(runner).adopt(new AdoptionContext(repositoryUrl, workspace));
+		GitHubRepoAdopter.withDefaultPipeline(runner)
+				.adopt(new AdoptionContext(repositoryUrl, workspace, branchName));
 	}
 
 	private static String repositoryUrl(String[] args) {
 		if (args == null || args.length < 1 || args[0].isBlank()) {
-			throw new IllegalArgumentException("Usage: <github-repo-url> [workspace-directory]");
+			throw new IllegalArgumentException("Usage: <github-repo-url> [workspace-directory] [branch-name]");
 		}
 		return args[0];
+	}
+
+	static String branchName(String[] args) {
+		if (args.length >= 3 && !args[2].isBlank()) {
+			return args[2];
+		}
+		return AdoptionContext.DEFAULT_BRANCH;
 	}
 
 	static Path workspace(String[] args) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
@@ -1,0 +1,32 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Creates and checks out the adoption feature branch in the fresh checkout with
+ * {@code git checkout -b}, so every subsequent commit lands on that branch
+ * rather than on the repository's default branch. The adoption pushes this
+ * branch and opens a pull request from it, leaving the default branch untouched.
+ */
+public class BranchStep extends AbstractCommandStep {
+
+	private static final Logger log = LogManager.getLogger(BranchStep.class);
+
+	@Override
+	public String name() {
+		return "branch";
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		log.info("Creating branch {} in {}", context.branchName(), context.repositoryDirectory());
+		List<String> command = List.of("git", "checkout", "-b", context.branchName());
+		runOrFail(runner, context.repositoryDirectory(), command);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -1,0 +1,74 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Opens a pull request for the adoption feature branch with the GitHub CLI
+ * ({@code gh pr create}), targeting the repository's default branch as the base.
+ * The title and body are configurable because they differ between projects; the
+ * defaults describe the Claude Code adoption.
+ *
+ * <p>Like {@link CommitStep}, the step stays idempotent when re-run: a
+ * {@code gh} failure that only reports an already-open pull request for the
+ * branch, or that there are no commits between base and head, is treated as a
+ * harmless no-op rather than aborting the adoption.
+ */
+public class PullRequestStep extends AbstractCommandStep {
+
+	private static final Logger log = LogManager.getLogger(PullRequestStep.class);
+
+	static final String DEFAULT_TITLE = "Adopt Claude Code";
+	static final String DEFAULT_BODY = "Adds a generated CLAUDE.md and wires the claude-code-enforcer "
+			+ "into the build so the file keeps being validated.";
+
+	private static final String ALREADY_EXISTS = "already exists";
+	private static final String NO_COMMITS = "No commits between";
+
+	private final String title;
+	private final String body;
+
+	public PullRequestStep() {
+		this(DEFAULT_TITLE, DEFAULT_BODY);
+	}
+
+	public PullRequestStep(String title, String body) {
+		this.title = title;
+		this.body = body;
+	}
+
+	@Override
+	public String name() {
+		return "pull-request";
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		log.info("Opening pull request for branch {}", context.branchName());
+		List<String> command = List.of("gh", "pr", "create", "--title", title, "--body", body,
+				"--head", context.branchName());
+		reportPullRequest(runner.run(context.repositoryDirectory(), command));
+	}
+
+	private void reportPullRequest(CommandResult result) {
+		if (result.succeeded()) {
+			log.info("Opened pull request: {}", result.output().strip());
+		} else if (alreadyHandled(result)) {
+			log.info("No pull request opened: {}", result.output().strip());
+		} else {
+			throw new AdoptionException(name() + " failed (exit " + result.exitCode() + ") running: "
+					+ result.describe() + System.lineSeparator() + result.output());
+		}
+	}
+
+	private boolean alreadyHandled(CommandResult result) {
+		return result.output().contains(ALREADY_EXISTS) || result.output().contains(NO_COMMITS);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PushStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PushStep.java
@@ -9,8 +9,9 @@ import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
- * Pushes the committed adoption changes back to the repository's origin with
- * {@code git push}.
+ * Pushes the adoption feature branch to the repository's origin with
+ * {@code git push -u origin <branch>}, setting the upstream so the freshly
+ * created branch is published and can be the head of a pull request.
  */
 public class PushStep extends AbstractCommandStep {
 
@@ -23,7 +24,8 @@ public class PushStep extends AbstractCommandStep {
 
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
-		log.info("Pushing changes from {}", context.repositoryDirectory());
-		runOrFail(runner, context.repositoryDirectory(), List.of("git", "push"));
+		log.info("Pushing branch {} from {}", context.branchName(), context.repositoryDirectory());
+		List<String> command = List.of("git", "push", "-u", "origin", context.branchName());
+		runOrFail(runner, context.repositoryDirectory(), command);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
@@ -42,6 +42,25 @@ class AdoptionContextTest {
 	}
 
 	@Test
+	void defaultsToTheAdoptionFeatureBranch() {
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace);
+		assertEquals(AdoptionContext.DEFAULT_BRANCH, context.branchName());
+	}
+
+	@Test
+	void keepsAndTrimsSuppliedBranchName() {
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace,
+				"  feature/x  ");
+		assertEquals("feature/x", context.branchName());
+	}
+
+	@Test
+	void rejectsBlankBranchName() {
+		assertThrows(IllegalArgumentException.class,
+				() -> new AdoptionContext("https://github.com/adamw7/tools.git", workspace, "  "));
+	}
+
+	@Test
 	void rejectsBlankUrl() {
 		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext("  ", workspace));
 	}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -71,8 +71,9 @@ class GitHubRepoAdopterTest {
 	}
 
 	@Test
-	void defaultPipelineIsCloneTrustInitCommitPushEnforceCommitPush() {
+	void defaultPipelineBranchesCommitsPushesAndOpensAPullRequest() {
 		List<String> names = GitHubRepoAdopter.defaultSteps().stream().map(AdoptionStep::name).toList();
-		assertEquals(List.of("clone", "trust", "claude-init", "commit", "push", "enforcer", "commit", "push"), names);
+		assertEquals(List.of("clone", "branch", "trust", "claude-init", "commit", "enforcer", "commit", "push",
+				"pull-request"), names);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
@@ -51,4 +51,19 @@ class MainTest {
 		Path resolved = Main.workspace(new String[] { REPO_URL });
 		assertTrue(Files.isDirectory(resolved));
 	}
+
+	@Test
+	void defaultsBranchNameWhenNoneSupplied() {
+		assertEquals(AdoptionContext.DEFAULT_BRANCH, Main.branchName(new String[] { REPO_URL, "/tmp/ws" }));
+	}
+
+	@Test
+	void usesSuppliedBranchName() {
+		assertEquals("feature/x", Main.branchName(new String[] { REPO_URL, "/tmp/ws", "feature/x" }));
+	}
+
+	@Test
+	void defaultsBranchNameWhenSuppliedBlank() {
+		assertEquals(AdoptionContext.DEFAULT_BRANCH, Main.branchName(new String[] { REPO_URL, "/tmp/ws", "  " }));
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BranchStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BranchStepTest.java
@@ -13,24 +13,29 @@ import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
-class PushStepTest {
+class BranchStepTest {
 
 	private final AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git",
 			Path.of("/tmp/workspace"), "claude/adopt-claude-code");
-	private final PushStep step = new PushStep();
+	private final BranchStep step = new BranchStep();
 
 	@Test
-	void pushesFeatureBranchWithUpstreamInCheckout() {
+	void createsFeatureBranchInCheckout() {
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		step.execute(context, runner);
-		assertEquals(List.of("git", "push", "-u", "origin", "claude/adopt-claude-code"), runner.commandAt(0));
+		assertEquals(List.of("git", "checkout", "-b", "claude/adopt-claude-code"), runner.commandAt(0));
 		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
 	}
 
 	@Test
-	void rejectedPushAborts() {
+	void failedCheckoutAbortsAdoption() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "rejected"));
+				command -> new CommandResult(command, 128, "fatal: a branch named ... already exists"));
 		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
+	}
+
+	@Test
+	void isNamedBranch() {
+		assertEquals("branch", step.name());
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -1,0 +1,65 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class PullRequestStepTest {
+
+	private final AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git",
+			Path.of("/tmp/workspace"), "claude/adopt-claude-code");
+	private final PullRequestStep step = new PullRequestStep();
+
+	@Test
+	void opensPullRequestForFeatureBranch() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		step.execute(context, runner);
+		assertEquals(List.of("gh", "pr", "create", "--title", PullRequestStep.DEFAULT_TITLE, "--body",
+				PullRequestStep.DEFAULT_BODY, "--head", "claude/adopt-claude-code"), runner.commandAt(0));
+		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
+	}
+
+	@Test
+	void usesConfiguredTitleAndBody() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new PullRequestStep("My title", "My body").execute(context, runner);
+		assertEquals(List.of("gh", "pr", "create", "--title", "My title", "--body", "My body", "--head",
+				"claude/adopt-claude-code"), runner.commandAt(0));
+	}
+
+	@Test
+	void toleratesAnAlreadyOpenPullRequest() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> new CommandResult(command, 1,
+				"a pull request for branch \"claude/adopt-claude-code\" already exists"));
+		assertDoesNotThrow(() -> step.execute(context, runner));
+	}
+
+	@Test
+	void toleratesNoCommitsBetweenBaseAndHead() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 1, "No commits between main and claude/adopt-claude-code"));
+		assertDoesNotThrow(() -> step.execute(context, runner));
+	}
+
+	@Test
+	void otherFailureAbortsAdoption() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 1, "gh: could not authenticate"));
+		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
+	}
+
+	@Test
+	void isNamedPullRequest() {
+		assertEquals("pull-request", step.name());
+	}
+}


### PR DESCRIPTION
The adoption pipeline previously committed the generated CLAUDE.md and the
enforcer wiring straight onto the checked-out (default) branch and pushed
twice. It now works on a feature branch and proposes the change for review:

- AdoptionContext carries a branchName (default claude/adopt-claude-code),
  validated non-blank; Main accepts it as an optional third CLI argument.
- BranchStep creates and checks out the feature branch (git checkout -b)
  right after clone, so every commit lands on it.
- PushStep pushes that branch and sets its upstream
  (git push -u origin <branch>) instead of a bare git push.
- PullRequestStep opens a PR with the GitHub CLI (gh pr create), targeting
  the default branch as base. Like CommitStep it is idempotent: an
  already-open PR or "no commits between" is a no-op, not a failure.
- Default pipeline is now clone, branch, trust, init, commit, enforcer,
  commit, push, pull-request; the default branch is never written to.

Adds unit tests for the new steps, context, and CLI arg, and updates
README/AGENTS/CLAUDE docs (gh is now a required CLI alongside git/claude).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AvB21wBUtB2HZBqHAeYFqa