### PR TITLE
Harden the adopt pipeline: verify the enforcer, fail on missing CLAUDE.md, robust idempotency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,9 @@ Maven project. The notable capabilities are:
   marks the checkout trusted in `~/.claude.json` so the headless CLI is not
   blocked by the folder-trust prompt, runs the Claude Code CLI (`claude init`) to
   generate a `CLAUDE.md` and commits it, then wires the `claude-code-enforcer`
-  into the project's `pom.xml` and commits that, and finally pushes the branch
-  and opens a pull request with the GitHub CLI (`gh pr create`) — the default
+  into the project's `pom.xml` and commits that, verifies the enforcer passes on
+  the generated file with a non-recursive `mvn -N validate`, and finally pushes
+  the branch and opens a pull request with the GitHub CLI (`gh pr create`) — the default
   branch is never written to directly. External `git`/`claude`/`gh` invocations
   go through a `CommandRunner`
   abstraction so the steps are unit-tested without spawning real processes; the
@@ -70,7 +71,7 @@ tools (root pom, packaging=pom)
 │   ├── protogen-maven-plugin       # the proto2 builder-generating Maven plugin
 │   ├── protogen-maven-plugin-test  # integration tests / use cases for the plugin
 │   └── context                     # regex-based class-usage context finder
-├── adopt                       # adopts Claude Code into a GitHub repo (clone, branch, trust, init, enforcer, push, PR)
+├── adopt                       # adopts Claude Code into a GitHub repo (clone, branch, trust, init, enforcer, verify, push, PR)
 ├── grpc-example                # end-to-end gRPC example with compile-time-safe builders
 ├── assembly                    # builds an executable jar-with-dependencies
 │                               #   (mainClass: io.github.adamw7.tools.data.SampleApp)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,9 @@ run `mvn install` from the repository root. The main capabilities are:
 - **Claude Code adoption** (`adopt`) — a pipeline that adopts Claude Code into a
   GitHub repo: clone, create a feature branch, `claude init` to generate
   `CLAUDE.md` and commit it, wire the `claude-code-enforcer` into the repo's
-  `pom.xml` and commit that, then push the branch and open a pull request
-  (`gh pr create`); the default branch is never written to directly.
+  `pom.xml` and commit that, verify the enforcer passes on the generated file,
+  then push the branch and open a pull request (`gh pr create`); the default
+  branch is never written to directly.
 
 Module map (root reactor: `claude-code-enforcer`, `mcp-common`, `data`, `code`,
 `adopt`, `grpc-example`, `assembly`; `data-test` is built separately):
@@ -40,7 +41,7 @@ tools (root pom, packaging=pom)
 │   ├── protogen-maven-plugin       # compile-time-safe protobuf builder generator
 │   ├── protogen-maven-plugin-test  # integration tests for the plugin
 │   └── context                     # class-usage context finder + MCP server
-├── adopt                  # adopts Claude Code into a GitHub repo (clone, branch, trust, init, enforcer, push, PR)
+├── adopt                  # adopts Claude Code into a GitHub repo (clone, branch, trust, init, enforcer, verify, push, PR)
 ├── grpc-example           # end-to-end gRPC example
 ├── assembly               # executable jar-with-dependencies (SampleApp)
 └── data-test              # standalone test module (not in root <modules>)

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -15,14 +15,16 @@ import io.github.adamw7.tools.adopt.step.EnforcerStep;
 import io.github.adamw7.tools.adopt.step.PullRequestStep;
 import io.github.adamw7.tools.adopt.step.PushStep;
 import io.github.adamw7.tools.adopt.step.TrustStep;
+import io.github.adamw7.tools.adopt.step.VerifyStep;
 
 /**
  * Runs the ordered pipeline that adopts Claude Code into a GitHub repository:
  * clone, create a feature branch, mark the checkout trusted for Claude Code,
  * generate {@code CLAUDE.md} with {@code claude init} and commit it, wire in the
- * {@code claude-code-enforcer} and commit that, then push the branch and open a
- * pull request. The adoption never writes to the default branch. Steps and the
- * command runner are injected so the pipeline is easy to reconfigure and to test.
+ * {@code claude-code-enforcer} and commit that, verify the enforcer passes on the
+ * generated file, then push the branch and open a pull request. The adoption
+ * never writes to the default branch. Steps and the command runner are injected
+ * so the pipeline is easy to reconfigure and to test.
  */
 public class GitHubRepoAdopter {
 
@@ -49,6 +51,7 @@ public class GitHubRepoAdopter {
 				new CommitStep("Adopt Claude Code: add CLAUDE.md"),
 				new EnforcerStep(),
 				new CommitStep("Add claude-code-enforcer to the build"),
+				new VerifyStep(),
 				new PushStep(),
 				new PullRequestStep());
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
@@ -10,9 +10,14 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
  * Creates and checks out the adoption feature branch in the fresh checkout with
- * {@code git checkout -b}, so every subsequent commit lands on that branch
+ * {@code git checkout -B}, so every subsequent commit lands on that branch
  * rather than on the repository's default branch. The adoption pushes this
  * branch and opens a pull request from it, leaving the default branch untouched.
+ *
+ * <p>{@code -B} resets the branch to the current {@code HEAD} whether or not it
+ * already exists, so re-running the adoption against a checkout that already
+ * carries the branch starts the feature branch afresh rather than aborting on an
+ * "already exists" failure.
  */
 public class BranchStep extends AbstractCommandStep {
 
@@ -26,7 +31,7 @@ public class BranchStep extends AbstractCommandStep {
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
 		log.info("Creating branch {} in {}", context.branchName(), context.repositoryDirectory());
-		List<String> command = List.of("git", "checkout", "-b", context.branchName());
+		List<String> command = List.of("git", "checkout", "-B", context.branchName());
 		runOrFail(runner, context.repositoryDirectory(), command);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
@@ -14,6 +15,11 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * generates a {@code CLAUDE.md} for the project. The exact CLI invocation is
  * configurable because the flags differ between environments; the default runs
  * the {@code /init} command non-interactively.
+ *
+ * <p>The generated {@code CLAUDE.md} is the whole point of the adoption, so a run
+ * that exits cleanly but leaves no {@code CLAUDE.md} behind aborts the adoption
+ * rather than letting the pipeline push a branch and open a pull request with
+ * nothing in it.
  */
 public class ClaudeInitStep extends AbstractCommandStep {
 
@@ -42,13 +48,13 @@ public class ClaudeInitStep extends AbstractCommandStep {
 	public void execute(AdoptionContext context, CommandRunner runner) {
 		log.info("Running claude init in {}", context.repositoryDirectory());
 		runOrFail(runner, context.repositoryDirectory(), claudeCommand);
-		warnIfNotGenerated(context);
+		requireGenerated(context);
 	}
 
-	private void warnIfNotGenerated(AdoptionContext context) {
+	private void requireGenerated(AdoptionContext context) {
 		if (!Files.isRegularFile(context.repositoryDirectory().resolve(CLAUDE_MD))) {
-			log.warn("claude init completed but {} was not found in {}", CLAUDE_MD,
-					context.repositoryDirectory());
+			throw new AdoptionException(name() + " completed but " + CLAUDE_MD + " was not found in "
+					+ context.repositoryDirectory());
 		}
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -1,5 +1,7 @@
 package io.github.adamw7.tools.adopt.step;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -10,7 +12,10 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
  * Clones the target repository into the workspace with {@code git clone}, so the
- * remaining steps have a working checkout to operate on.
+ * remaining steps have a working checkout to operate on. The step is idempotent:
+ * a checkout that already exists (its {@code .git} directory is present) is
+ * reused rather than re-cloned, so re-running the adoption against the same
+ * workspace does not abort on an "already exists" clone failure.
  */
 public class CloneStep extends AbstractCommandStep {
 
@@ -23,9 +28,18 @@ public class CloneStep extends AbstractCommandStep {
 
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
+		if (alreadyCloned(context)) {
+			log.info("{} already contains a checkout; skipping clone", context.repositoryDirectory());
+			return;
+		}
 		log.info("Cloning {} into {}", context.repositoryUrl(), context.repositoryDirectory());
 		List<String> command = List.of("git", "clone", context.repositoryUrl(),
 				context.repositoryDirectory().toString());
 		runOrFail(runner, context.workspace(), command);
+	}
+
+	private boolean alreadyCloned(AdoptionContext context) {
+		Path gitDirectory = context.repositoryDirectory().resolve(".git");
+		return Files.isDirectory(gitDirectory);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
@@ -6,20 +6,19 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
-import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
  * Stages every change in the checkout and commits it with the configured
- * message. A commit that finds nothing to record is treated as a harmless
- * no-op rather than a failure, so the pipeline stays idempotent when re-run.
+ * message. Whether there is anything to commit is decided by asking git
+ * ({@code git diff --cached --quiet}) rather than by matching the wording of a
+ * failed commit's output, so an empty commit is a harmless no-op regardless of
+ * git's locale or version and the pipeline stays idempotent when re-run.
  */
 public class CommitStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(CommitStep.class);
-
-	private static final String NOTHING_TO_COMMIT = "nothing to commit";
 
 	private final String message;
 
@@ -35,23 +34,21 @@ public class CommitStep extends AbstractCommandStep {
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
 		runOrFail(runner, context.repositoryDirectory(), List.of("git", "add", "-A"));
-		commit(context, runner);
+		if (hasStagedChanges(context, runner)) {
+			commit(context, runner);
+		} else {
+			log.info("No changes to commit for: {}", message);
+		}
+	}
+
+	private boolean hasStagedChanges(AdoptionContext context, CommandRunner runner) {
+		CommandResult result = runner.run(context.repositoryDirectory(),
+				List.of("git", "diff", "--cached", "--quiet"));
+		return !result.succeeded();
 	}
 
 	private void commit(AdoptionContext context, CommandRunner runner) {
-		List<String> command = List.of("git", "commit", "-m", message);
-		CommandResult result = runner.run(context.repositoryDirectory(), command);
-		reportCommit(result);
-	}
-
-	private void reportCommit(CommandResult result) {
-		if (result.succeeded()) {
-			log.info("Committed: {}", message);
-		} else if (result.output().contains(NOTHING_TO_COMMIT)) {
-			log.info("No changes to commit for: {}", message);
-		} else {
-			throw new AdoptionException(name() + " failed (exit " + result.exitCode() + ") running: "
-					+ result.describe() + System.lineSeparator() + result.output());
-		}
+		runOrFail(runner, context.repositoryDirectory(), List.of("git", "commit", "-m", message));
+		log.info("Committed: {}", message);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -6,7 +6,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
-import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
@@ -16,10 +15,10 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * The title and body are configurable because they differ between projects; the
  * defaults describe the Claude Code adoption.
  *
- * <p>Like {@link CommitStep}, the step stays idempotent when re-run: a
- * {@code gh} failure that only reports an already-open pull request for the
- * branch, or that there are no commits between base and head, is treated as a
- * harmless no-op rather than aborting the adoption.
+ * <p>The step stays idempotent when re-run: it asks {@code gh pr view} whether a
+ * pull request already exists for the branch and skips creation when one does,
+ * rather than creating unconditionally and then matching the wording of a
+ * failure. That keeps the decision robust across {@code gh} versions and locales.
  */
 public class PullRequestStep extends AbstractCommandStep {
 
@@ -28,9 +27,6 @@ public class PullRequestStep extends AbstractCommandStep {
 	static final String DEFAULT_TITLE = "Adopt Claude Code";
 	static final String DEFAULT_BODY = "Adds a generated CLAUDE.md and wires the claude-code-enforcer "
 			+ "into the build so the file keeps being validated.";
-
-	private static final String ALREADY_EXISTS = "already exists";
-	private static final String NO_COMMITS = "No commits between";
 
 	private final String title;
 	private final String body;
@@ -51,24 +47,19 @@ public class PullRequestStep extends AbstractCommandStep {
 
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
+		if (pullRequestExists(context, runner)) {
+			log.info("Pull request already open for branch {}; left unchanged", context.branchName());
+			return;
+		}
 		log.info("Opening pull request for branch {}", context.branchName());
 		List<String> command = List.of("gh", "pr", "create", "--title", title, "--body", body,
 				"--head", context.branchName());
-		reportPullRequest(runner.run(context.repositoryDirectory(), command));
+		CommandResult result = runOrFail(runner, context.repositoryDirectory(), command);
+		log.info("Opened pull request: {}", result.output().strip());
 	}
 
-	private void reportPullRequest(CommandResult result) {
-		if (result.succeeded()) {
-			log.info("Opened pull request: {}", result.output().strip());
-		} else if (alreadyHandled(result)) {
-			log.info("No pull request opened: {}", result.output().strip());
-		} else {
-			throw new AdoptionException(name() + " failed (exit " + result.exitCode() + ") running: "
-					+ result.describe() + System.lineSeparator() + result.output());
-		}
-	}
-
-	private boolean alreadyHandled(CommandResult result) {
-		return result.output().contains(ALREADY_EXISTS) || result.output().contains(NO_COMMITS);
+	private boolean pullRequestExists(AdoptionContext context, CommandRunner runner) {
+		List<String> command = List.of("gh", "pr", "view", context.branchName(), "--json", "url");
+		return runner.run(context.repositoryDirectory(), command).succeeded();
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/VerifyStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/VerifyStep.java
@@ -1,0 +1,60 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Runs the adopted project's {@code validate} phase so the freshly wired
+ * {@code claude-code-enforcer} actually executes against the generated
+ * {@code CLAUDE.md} before the branch is pushed and a pull request is opened. A
+ * malformed or missing {@code CLAUDE.md} therefore fails the adoption locally
+ * instead of breaking the contributor's build after the pull request lands.
+ *
+ * <p>The enforcer execution is bound to the root module's {@code validate} phase
+ * with {@code inherited=false}, so a non-recursive {@code mvn -N validate} is
+ * enough to exercise it. The Maven invocation is configurable because it differs
+ * between environments. A repository that is not a Maven project (no
+ * {@code pom.xml}) has nothing to verify and is skipped, mirroring
+ * {@link EnforcerStep}.
+ */
+public class VerifyStep extends AbstractCommandStep {
+
+	private static final Logger log = LogManager.getLogger(VerifyStep.class);
+
+	static final List<String> DEFAULT_COMMAND = List.of("mvn", "-q", "-N", "validate");
+
+	private static final String POM = "pom.xml";
+
+	private final List<String> mavenCommand;
+
+	public VerifyStep() {
+		this(DEFAULT_COMMAND);
+	}
+
+	public VerifyStep(List<String> mavenCommand) {
+		this.mavenCommand = List.copyOf(mavenCommand);
+	}
+
+	@Override
+	public String name() {
+		return "verify";
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		Path pomFile = context.repositoryDirectory().resolve(POM);
+		if (Files.isRegularFile(pomFile)) {
+			log.info("Verifying the enforcer passes in {}", context.repositoryDirectory());
+			runOrFail(runner, context.repositoryDirectory(), mavenCommand);
+		} else {
+			log.warn("No {} in {}; skipping build verification", POM, context.repositoryDirectory());
+		}
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -73,7 +73,7 @@ class GitHubRepoAdopterTest {
 	@Test
 	void defaultPipelineBranchesCommitsPushesAndOpensAPullRequest() {
 		List<String> names = GitHubRepoAdopter.defaultSteps().stream().map(AdoptionStep::name).toList();
-		assertEquals(List.of("clone", "branch", "trust", "claude-init", "commit", "enforcer", "commit", "push",
-				"pull-request"), names);
+		assertEquals(List.of("clone", "branch", "trust", "claude-init", "commit", "enforcer", "commit", "verify",
+				"push", "pull-request"), names);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BranchStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BranchStepTest.java
@@ -23,7 +23,7 @@ class BranchStepTest {
 	void createsFeatureBranchInCheckout() {
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		step.execute(context, runner);
-		assertEquals(List.of("git", "checkout", "-b", "claude/adopt-claude-code"), runner.commandAt(0));
+		assertEquals(List.of("git", "checkout", "-B", "claude/adopt-claude-code"), runner.commandAt(0));
 		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -3,10 +3,13 @@ package io.github.adamw7.tools.adopt.step;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
@@ -26,6 +29,15 @@ class CloneStepTest {
 		assertEquals(List.of("git", "clone", "https://github.com/adamw7/tools.git",
 				workspace.resolve("tools").toString()), runner.commandAt(0));
 		assertEquals(workspace, runner.invocations().get(0).workingDirectory());
+	}
+
+	@Test
+	void skipsCloneWhenCheckoutAlreadyExists(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = new AdoptionContext("https://github.com/adamw7/tools.git", existingWorkspace);
+		Files.createDirectories(existing.repositoryDirectory().resolve(".git"));
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		step.execute(existing, runner);
+		assertEquals(0, runner.count());
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.adopt.step;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -20,33 +19,39 @@ class CommitStepTest {
 			Path.of("/tmp/workspace"));
 
 	@Test
-	void stagesThenCommitsWithMessage() {
-		RecordingCommandRunner runner = new RecordingCommandRunner();
+	void stagesChecksThenCommitsWithMessage() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::stagedChanges);
 		new CommitStep("my message").execute(context, runner);
 		assertEquals(List.of("git", "add", "-A"), runner.commandAt(0));
-		assertEquals(List.of("git", "commit", "-m", "my message"), runner.commandAt(1));
+		assertEquals(List.of("git", "diff", "--cached", "--quiet"), runner.commandAt(1));
+		assertEquals(List.of("git", "commit", "-m", "my message"), runner.commandAt(2));
 	}
 
 	@Test
-	void emptyCommitIsTreatedAsNoOp() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(this::nothingToCommitOnCommit);
-		assertDoesNotThrow(() -> new CommitStep("msg").execute(context, runner));
+	void skipsCommitWhenNothingIsStaged() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new CommitStep("msg").execute(context, runner);
+		assertEquals(2, runner.count());
+		assertEquals(List.of("git", "diff", "--cached", "--quiet"), runner.commandAt(1));
 	}
 
 	@Test
-	void otherCommitFailureAborts() {
+	void commitFailureAborts() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::genuineCommitFailure);
 		assertThrows(AdoptionException.class, () -> new CommitStep("msg").execute(context, runner));
 	}
 
-	private CommandResult nothingToCommitOnCommit(List<String> command) {
-		if (command.contains("commit")) {
-			return new CommandResult(command, 1, "nothing to commit, working tree clean");
+	private CommandResult stagedChanges(List<String> command) {
+		if (command.contains("diff")) {
+			return new CommandResult(command, 1, "");
 		}
 		return new CommandResult(command, 0, "");
 	}
 
 	private CommandResult genuineCommitFailure(List<String> command) {
+		if (command.contains("diff")) {
+			return new CommandResult(command, 1, "");
+		}
 		if (command.contains("commit")) {
 			return new CommandResult(command, 128, "fatal: unable to write commit object");
 		}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.adopt.step;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -22,40 +21,50 @@ class PullRequestStepTest {
 
 	@Test
 	void opensPullRequestForFeatureBranch() {
-		RecordingCommandRunner runner = new RecordingCommandRunner();
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::noExistingPullRequest);
 		step.execute(context, runner);
+		assertEquals(List.of("gh", "pr", "view", "claude/adopt-claude-code", "--json", "url"),
+				runner.commandAt(0));
 		assertEquals(List.of("gh", "pr", "create", "--title", PullRequestStep.DEFAULT_TITLE, "--body",
-				PullRequestStep.DEFAULT_BODY, "--head", "claude/adopt-claude-code"), runner.commandAt(0));
-		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
+				PullRequestStep.DEFAULT_BODY, "--head", "claude/adopt-claude-code"), runner.commandAt(1));
+		assertEquals(context.repositoryDirectory(), runner.invocations().get(1).workingDirectory());
 	}
 
 	@Test
 	void usesConfiguredTitleAndBody() {
-		RecordingCommandRunner runner = new RecordingCommandRunner();
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::noExistingPullRequest);
 		new PullRequestStep("My title", "My body").execute(context, runner);
 		assertEquals(List.of("gh", "pr", "create", "--title", "My title", "--body", "My body", "--head",
-				"claude/adopt-claude-code"), runner.commandAt(0));
+				"claude/adopt-claude-code"), runner.commandAt(1));
 	}
 
 	@Test
-	void toleratesAnAlreadyOpenPullRequest() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(command -> new CommandResult(command, 1,
-				"a pull request for branch \"claude/adopt-claude-code\" already exists"));
-		assertDoesNotThrow(() -> step.execute(context, runner));
+	void skipsCreationWhenAPullRequestAlreadyExists() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		step.execute(context, runner);
+		assertEquals(1, runner.count());
+		assertEquals(List.of("gh", "pr", "view", "claude/adopt-claude-code", "--json", "url"),
+				runner.commandAt(0));
 	}
 
 	@Test
-	void toleratesNoCommitsBetweenBaseAndHead() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "No commits between main and claude/adopt-claude-code"));
-		assertDoesNotThrow(() -> step.execute(context, runner));
-	}
-
-	@Test
-	void otherFailureAbortsAdoption() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "gh: could not authenticate"));
+	void failedCreationAbortsAdoption() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::createFails);
 		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
+	}
+
+	private CommandResult noExistingPullRequest(List<String> command) {
+		if (command.contains("view")) {
+			return new CommandResult(command, 1, "no pull requests found");
+		}
+		return new CommandResult(command, 0, "https://github.com/adamw7/tools/pull/1");
+	}
+
+	private CommandResult createFails(List<String> command) {
+		if (command.contains("view")) {
+			return new CommandResult(command, 1, "no pull requests found");
+		}
+		return new CommandResult(command, 1, "gh: could not authenticate");
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
@@ -16,49 +16,56 @@ import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
-class ClaudeInitStepTest {
+class VerifyStepTest {
 
 	private AdoptionContext context(Path workspace) throws IOException {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace);
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/demo.git", workspace);
 		Files.createDirectories(context.repositoryDirectory());
 		return context;
 	}
 
-	private void generateClaudeMd(AdoptionContext context) throws IOException {
-		Files.writeString(context.repositoryDirectory().resolve("CLAUDE.md"), "# CLAUDE.md");
+	private void writePom(AdoptionContext context) throws IOException {
+		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), "<project/>");
 	}
 
 	@Test
-	void runsConfiguredClaudeCommandInCheckout(@TempDir Path workspace) throws IOException {
+	void runsMavenValidateInCheckout(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
-		generateClaudeMd(context);
+		writePom(context);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
-		new ClaudeInitStep(List.of("claude", "init")).execute(context, runner);
-		assertEquals(List.of("claude", "init"), runner.commandAt(0));
+		new VerifyStep().execute(context, runner);
+		assertEquals(VerifyStep.DEFAULT_COMMAND, runner.commandAt(0));
 		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
 	}
 
 	@Test
-	void defaultsToHeadlessInitCommand(@TempDir Path workspace) throws IOException {
+	void runsConfiguredMavenCommand(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
-		generateClaudeMd(context);
+		writePom(context);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
-		new ClaudeInitStep().execute(context, runner);
-		assertEquals(ClaudeInitStep.DEFAULT_COMMAND, runner.commandAt(0));
+		new VerifyStep(List.of("mvn", "verify")).execute(context, runner);
+		assertEquals(List.of("mvn", "verify"), runner.commandAt(0));
 	}
 
 	@Test
-	void failedInitAbortsAdoption(@TempDir Path workspace) throws IOException {
+	void failedVerificationAbortsAdoption(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
+		writePom(context);
 		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "boom"));
-		assertThrows(AdoptionException.class, () -> new ClaudeInitStep().execute(context, runner));
+				command -> new CommandResult(command, 1, "CLAUDE.md is malformed"));
+		assertThrows(AdoptionException.class, () -> new VerifyStep().execute(context, runner));
 	}
 
 	@Test
-	void missingClaudeMdAbortsAdoption(@TempDir Path workspace) throws IOException {
+	void skipsWhenNotAMavenProject(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
-		assertThrows(AdoptionException.class, () -> new ClaudeInitStep().execute(context, runner));
+		new VerifyStep().execute(context, runner);
+		assertEquals(0, runner.count());
+	}
+
+	@Test
+	void isNamedVerify() {
+		assertEquals("verify", new VerifyStep().name());
 	}
 }


### PR DESCRIPTION
Four improvements to the adopt module:

1. Add VerifyStep after the enforcer commit and before push, running a
   non-recursive `mvn -N validate` so the freshly wired claude-code-enforcer
   actually executes against the generated CLAUDE.md. A malformed or missing
   file now fails the adoption locally instead of breaking the contributor's
   build after the pull request lands. Non-Maven repos are skipped, mirroring
   EnforcerStep.

2. Make a missing CLAUDE.md fatal in ClaudeInitStep. A claude run that exits
   cleanly but leaves no CLAUDE.md behind previously only logged a warning and
   let the pipeline open an empty pull request; it now aborts.

3. Make the git steps idempotent on re-run: CloneStep reuses an existing
   checkout (detected via its .git directory) instead of failing on an
   "already exists" clone, and BranchStep uses `git checkout -B` so an
   existing feature branch is reset rather than aborting the adoption.

4. Replace English-substring idempotency checks with state checks that are
   robust across git/gh versions and locales: CommitStep decides whether to
   commit with `git diff --cached --quiet`, and PullRequestStep detects an
   existing pull request with `gh pr view` before creating one.

Docs updated to describe the new verification step.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018MXuzgV4A5vF6sDBc2yzBo