### PR TITLE
fix(adopt): stop hung subprocesses from blocking the pipeline forever

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -13,8 +13,14 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  * merged into standard output so a caller gets a single, ordered transcript of
  * what the command printed. Every command is bounded by a timeout so a hung
  * child — a stalled {@code git clone} or a stuck {@code claude} invocation —
- * cannot block the adoption forever: on expiry the process is destroyed and the
- * failure is reported with whatever output was captured so far.
+ * cannot block the adoption forever: on expiry the whole process tree is
+ * destroyed and the failure is reported with whatever output was captured so
+ * far.
+ *
+ * <p>The child's standard input is closed as soon as it starts, so a tool that
+ * reads from it — a {@code git} credential prompt, a {@code gh} authentication
+ * prompt — sees end-of-stream and fails fast instead of blocking on an input
+ * that never arrives until the timeout kills it.
  */
 public class ProcessCommandRunner implements CommandRunner {
 
@@ -47,6 +53,7 @@ public class ProcessCommandRunner implements CommandRunner {
 
 	private CommandResult execute(ProcessBuilder builder, List<String> command) {
 		Process process = start(builder, command);
+		closeStandardInput(process, command);
 		StreamGobbler output = StreamGobbler.consuming(process.getInputStream());
 		return await(process, command, output);
 	}
@@ -59,6 +66,14 @@ public class ProcessCommandRunner implements CommandRunner {
 		}
 	}
 
+	private void closeStandardInput(Process process, List<String> command) {
+		try {
+			process.getOutputStream().close();
+		} catch (IOException e) {
+			throw new AdoptionException("Could not close standard input for: " + String.join(" ", command), e);
+		}
+	}
+
 	private CommandResult await(Process process, List<String> command, StreamGobbler output) {
 		try {
 			if (process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
@@ -66,15 +81,26 @@ public class ProcessCommandRunner implements CommandRunner {
 			}
 			throw timedOut(process, command, output);
 		} catch (InterruptedException e) {
-			process.destroyForcibly();
+			destroyTree(process);
 			Thread.currentThread().interrupt();
 			throw new AdoptionException("Interrupted while running: " + String.join(" ", command), e);
 		}
 	}
 
 	private AdoptionException timedOut(Process process, List<String> command, StreamGobbler output) {
-		process.destroyForcibly();
+		destroyTree(process);
 		return new AdoptionException("Timed out after " + timeout + " running: " + String.join(" ", command)
 				+ System.lineSeparator() + output.output());
+	}
+
+	/**
+	 * Destroys the process together with every descendant it spawned.
+	 * {@link Process#destroyForcibly()} kills only the direct child; a helper or
+	 * daemon it forked can outlive it and keep the merged output pipe open, which
+	 * would otherwise stop the stream from ever reaching end-of-stream.
+	 */
+	private void destroyTree(Process process) {
+		process.descendants().forEach(ProcessHandle::destroyForcibly);
+		process.destroyForcibly();
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
@@ -6,7 +6,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.util.stream.Collectors;
+import java.time.Duration;
 
 /**
  * Drains a process's output stream on a dedicated daemon thread so the command
@@ -14,14 +14,28 @@ import java.util.stream.Collectors;
  * the child closes it, which never happens for a hung process; consuming it in
  * the background lets {@link ProcessCommandRunner} time out and destroy the
  * child while its partial output is still recovered.
+ *
+ * <p>Each line is accumulated as it is read, and {@link #output()} bounds its
+ * wait for the reader thread. A direct child can exit while a descendant it
+ * spawned keeps the output pipe open, in which case the stream never reaches
+ * end-of-stream; the bounded join stops that from hanging the caller forever
+ * and still returns whatever was captured before the wait elapsed.
  */
 final class StreamGobbler {
 
+	/**
+	 * How long {@link #output()} waits for the reader thread to reach
+	 * end-of-stream. A live child's pipe reaches EOF the instant it is destroyed,
+	 * so this is only ever spent when a surviving descendant holds the pipe open.
+	 */
+	static final Duration JOIN_TIMEOUT = Duration.ofSeconds(5);
+
 	private final Thread thread;
-	private volatile String output = "";
+	private final StringBuilder output = new StringBuilder();
+	private boolean firstLine = true;
 
 	private StreamGobbler(InputStream stream) {
-		this.thread = new Thread(() -> output = read(stream), "adopt-stream-gobbler");
+		this.thread = new Thread(() -> drain(stream), "adopt-stream-gobbler");
 		this.thread.setDaemon(true);
 	}
 
@@ -32,28 +46,50 @@ final class StreamGobbler {
 	}
 
 	/**
-	 * @return everything the stream produced, blocking until it reaches
-	 *         end-of-stream. Destroying the process closes the stream, so this
-	 *         returns promptly once a timed-out child has been killed.
+	 * @return everything the stream produced, waiting up to {@link #JOIN_TIMEOUT}
+	 *         for it to reach end-of-stream. Destroying the process closes the
+	 *         stream, so this returns promptly once a timed-out child has been
+	 *         killed; a descendant that keeps the pipe open only delays it by the
+	 *         bounded wait rather than blocking forever.
 	 */
 	String output() {
 		join();
-		return output;
+		synchronized (output) {
+			return output.toString();
+		}
 	}
 
 	private void join() {
 		try {
-			thread.join();
+			thread.join(JOIN_TIMEOUT.toMillis());
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 		}
 	}
 
-	private static String read(InputStream stream) {
+	private void drain(InputStream stream) {
 		try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
-			return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+			append(reader);
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
+		}
+	}
+
+	private void append(BufferedReader reader) throws IOException {
+		String line = reader.readLine();
+		while (line != null) {
+			appendLine(line);
+			line = reader.readLine();
+		}
+	}
+
+	private void appendLine(String line) {
+		synchronized (output) {
+			if (!firstLine) {
+				output.append(System.lineSeparator());
+			}
+			output.append(line);
+			firstLine = false;
 		}
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/PlatformCommands.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/PlatformCommands.java
@@ -44,6 +44,16 @@ final class PlatformCommands {
 	}
 
 	/**
+	 * A command that reads standard input to end-of-stream and then exits. With
+	 * the child's standard input closed it sees EOF at once and finishes; left
+	 * open it would block until killed, which is what the stdin-closing test
+	 * guards against. {@code cat} and {@code sort} both echo stdin and exit 0.
+	 */
+	static List<String> readingStandardInput() {
+		return WINDOWS ? cmd("sort") : List.of("cat");
+	}
+
+	/**
 	 * Windows has no {@code sleep} executable, and {@code timeout} refuses to run
 	 * with redirected input, which is exactly how a child of
 	 * {@link ProcessBuilder} is started. Pinging the loopback address once a

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunnerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunnerTest.java
@@ -61,4 +61,11 @@ class ProcessCommandRunnerTest {
 	void rejectsANonPositiveTimeout() {
 		assertThrows(IllegalArgumentException.class, () -> new ProcessCommandRunner(Duration.ZERO));
 	}
+
+	@Test
+	void closesStandardInputSoAStdinReaderFinishesInsteadOfHanging() {
+		ProcessCommandRunner patient = new ProcessCommandRunner(Duration.ofSeconds(30));
+		CommandResult result = patient.run(Path.of("."), PlatformCommands.readingStandardInput());
+		assertEquals(0, result.exitCode());
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/StreamGobblerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/StreamGobblerTest.java
@@ -1,0 +1,65 @@
+package io.github.adamw7.tools.adopt.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+class StreamGobblerTest {
+
+	@Test
+	void joinsMultipleLinesWithTheLineSeparator() {
+		String text = "first" + System.lineSeparator() + "second" + System.lineSeparator() + "third";
+		StreamGobbler gobbler = StreamGobbler.consuming(
+				new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)));
+		assertEquals(text, gobbler.output());
+	}
+
+	@Test
+	void keepsAnEmptyLeadingLine() {
+		String text = System.lineSeparator() + "second";
+		StreamGobbler gobbler = StreamGobbler.consuming(
+				new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)));
+		assertEquals(text, gobbler.output());
+	}
+
+	@Test
+	void returnsEmptyForAStreamWithNoOutput() {
+		StreamGobbler gobbler = StreamGobbler.consuming(new ByteArrayInputStream(new byte[0]));
+		assertEquals("", gobbler.output());
+	}
+
+	/**
+	 * A descendant of a destroyed child can keep the output pipe open, so the
+	 * stream never reaches end-of-stream. {@link StreamGobbler#output()} must
+	 * still return — with whatever it captured — rather than block forever. This
+	 * deliberately waits out {@link StreamGobbler#JOIN_TIMEOUT}, so it opts out of
+	 * the fast per-test timeout with its own generous bound.
+	 */
+	@Test
+	@Timeout(30)
+	void returnsCapturedOutputWhenTheStreamNeverEnds() throws IOException {
+		PipedOutputStream sink = new PipedOutputStream();
+		PipedInputStream source = new PipedInputStream(sink);
+		sink.write(("partial" + System.lineSeparator()).getBytes(StandardCharsets.UTF_8));
+		sink.flush();
+
+		StreamGobbler gobbler = StreamGobbler.consuming(source);
+		long startNanos = System.nanoTime();
+		String output = gobbler.output();
+		Duration elapsed = Duration.ofNanos(System.nanoTime() - startNanos);
+
+		assertTrue(output.contains("partial"), output);
+		assertTrue(elapsed.compareTo(StreamGobbler.JOIN_TIMEOUT.plusSeconds(10)) < 0,
+				"output() must return around the bounded join, not hang: " + elapsed);
+		sink.close();
+	}
+}


### PR DESCRIPTION
The ProcessCommandRunner claimed a hung child could not block the
adoption forever, but two gaps defeated that guarantee:

- The child's standard input was left open, so any tool that reads
  stdin (a git credential prompt, a gh auth prompt) blocked until the
  timeout instead of seeing EOF. Close it as soon as the child starts.

- On timeout/interrupt only the direct child was destroyed, and the
  gobbler was joined with no bound. A helper the child forked can keep
  the merged output pipe open, so the stream never reaches EOF and the
  unbounded join hangs forever despite the timeout. Destroy the whole
  process tree and bound the join, accumulating output incrementally so
  partial output is still recovered when the wait elapses.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L898s9EJvtYU6n2q6VTZnY