### PR TITLE
feat(adopt): preflight the toolchain so a missing git/claude/gh fails fast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,9 @@ Maven project. The notable capabilities are:
   `IntKeyOpenAddressingMap`), and an **MCP server** exposing the
   uniqueness checker as a tool for AI assistants.
 - **Claude Code adoption** (`adopt`) — an ordered pipeline that adopts Claude
-  Code into a GitHub repository: it clones the repo, creates a feature branch,
+  Code into a GitHub repository: it first checks the required tools (`git`,
+  `claude`, `gh`) are on the `PATH` so a missing one fails fast, then clones the
+  repo, creates a feature branch,
   marks the checkout trusted in `~/.claude.json` so the headless CLI is not
   blocked by the folder-trust prompt, runs the Claude Code CLI (`claude init`) to
   generate a `CLAUDE.md` and commits it, then wires the `claude-code-enforcer`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ run `mvn install` from the repository root. The main capabilities are:
   column-uniqueness/key finder, open-addressing map/set data structures, and an
   MCP server exposing the uniqueness checker.
 - **Claude Code adoption** (`adopt`) — a pipeline that adopts Claude Code into a
-  GitHub repo: clone, create a feature branch, `claude init` to generate
+  GitHub repo: check the required tools (`git`, `claude`, `gh`) are installed,
+  clone, create a feature branch, `claude init` to generate
   `CLAUDE.md` and commit it, wire the `claude-code-enforcer` into the repo's
   `pom.xml` and commit that, verify the enforcer passes on the generated file,
   then push the branch and open a pull request (`gh pr create`); the default

--- a/README.md
+++ b/README.md
@@ -754,28 +754,39 @@ GitHubRepoAdopter.withDefaultPipeline(runner)
 
 The default pipeline runs these steps in order:
 
-1. **`CloneStep`** — clones the target repository into the workspace with
+1. **`ToolchainStep`** — probes the external tools the pipeline shells out to
+   (`git`, `claude`, `gh`) with a `--version` check before any real work, so a
+   missing tool aborts the adoption immediately with a message naming every
+   absent one instead of failing minutes later after a clone, a `claude init`,
+   and a Maven build have already run.
+2. **`CloneStep`** — clones the target repository into the workspace with
    `git clone`, giving the remaining steps a working checkout.
-2. **`BranchStep`** — creates and checks out the adoption feature branch with
-   `git checkout -b`, so every later commit lands on that branch instead of the
+3. **`BranchStep`** — creates and checks out the adoption feature branch with
+   `git checkout -B`, so every later commit lands on that branch instead of the
    default branch.
-3. **`ClaudeInitStep`** — runs the Claude Code CLI in headless mode
+4. **`TrustStep`** — marks the checkout trusted in `~/.claude.json` so the
+   headless `claude` run is not blocked by the interactive folder-trust prompt.
+5. **`ClaudeInitStep`** — runs the Claude Code CLI in headless mode
    (`claude -p /init` by default; the invocation is configurable because the
-   flags differ between environments) so it generates a `CLAUDE.md`, warning if
+   flags differ between environments) so it generates a `CLAUDE.md`, aborting if
    the file did not appear.
-4. **`CommitStep`** — commits the generated `CLAUDE.md` (`Adopt Claude Code: add
+6. **`CommitStep`** — commits the generated `CLAUDE.md` (`Adopt Claude Code: add
    CLAUDE.md`).
-5. **`EnforcerStep`** — wires the `claude-code-enforcer` into the checkout's root
+7. **`EnforcerStep`** — wires the `claude-code-enforcer` into the checkout's root
    `pom.xml` via `PomEnforcerInstaller`. The edit is done on the JDK's DOM (no
    third-party XML library), is namespace-aware, and is idempotent: a POM that
    already declares the rule is left unchanged, and a repository that is not a
    Maven project (no `pom.xml`) is skipped with a warning rather than failing the
    adoption.
-6. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
+8. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
    build`).
-7. **`PushStep`** — pushes the feature branch to origin and sets its upstream
-   (`git push -u origin <branch>`).
-8. **`PullRequestStep`** — opens a pull request from the branch with
+9. **`VerifyStep`** — runs a non-recursive `mvn -N validate` so the freshly wired
+   enforcer actually executes against the generated `CLAUDE.md`, failing the
+   adoption locally if the file is missing or malformed rather than after the
+   pull request lands.
+10. **`PushStep`** — pushes the feature branch to origin and sets its upstream
+    (`git push -u origin <branch>`).
+11. **`PullRequestStep`** — opens a pull request from the branch with
    `gh pr create`, targeting the repository's default branch as the base. Like
    `CommitStep` it stays idempotent: a `gh` failure that only reports an
    already-open pull request for the branch, or no commits between base and head,

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -14,17 +14,20 @@ import io.github.adamw7.tools.adopt.step.CommitStep;
 import io.github.adamw7.tools.adopt.step.EnforcerStep;
 import io.github.adamw7.tools.adopt.step.PullRequestStep;
 import io.github.adamw7.tools.adopt.step.PushStep;
+import io.github.adamw7.tools.adopt.step.ToolchainStep;
 import io.github.adamw7.tools.adopt.step.TrustStep;
 import io.github.adamw7.tools.adopt.step.VerifyStep;
 
 /**
  * Runs the ordered pipeline that adopts Claude Code into a GitHub repository:
- * clone, create a feature branch, mark the checkout trusted for Claude Code,
- * generate {@code CLAUDE.md} with {@code claude init} and commit it, wire in the
- * {@code claude-code-enforcer} and commit that, verify the enforcer passes on the
- * generated file, then push the branch and open a pull request. The adoption
- * never writes to the default branch. Steps and the command runner are injected
- * so the pipeline is easy to reconfigure and to test.
+ * check the required tools are installed, clone, create a feature branch, mark
+ * the checkout trusted for Claude Code, generate {@code CLAUDE.md} with
+ * {@code claude init} and commit it, wire in the {@code claude-code-enforcer} and
+ * commit that, verify the enforcer passes on the generated file, then push the
+ * branch and open a pull request. The toolchain check runs first so a missing
+ * {@code git}, {@code claude}, or {@code gh} fails the adoption before any
+ * expensive work. The adoption never writes to the default branch. Steps and the
+ * command runner are injected so the pipeline is easy to reconfigure and to test.
  */
 public class GitHubRepoAdopter {
 
@@ -44,6 +47,7 @@ public class GitHubRepoAdopter {
 
 	public static List<AdoptionStep> defaultSteps() {
 		return List.of(
+				new ToolchainStep(),
 				new CloneStep(),
 				new BranchStep(),
 				new TrustStep(),

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
@@ -1,0 +1,90 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Verifies up front that every external tool the pipeline shells out to is
+ * available — {@code git} to clone and commit, {@code claude} to generate the
+ * {@code CLAUDE.md}, and {@code gh} to open the pull request. Probing the
+ * toolchain before any real work begins turns a missing {@code gh} into an
+ * immediate, self-explanatory failure instead of one that only surfaces at the
+ * very end, after a full clone, a {@code claude init}, and a Maven build have
+ * already run.
+ *
+ * <p>A tool counts as available when its {@code --version} probe starts and exits
+ * zero. Every required tool is probed even after one is found missing, so a
+ * single failure can name all of the absent tools at once rather than stopping at
+ * the first and hiding the rest.
+ */
+public class ToolchainStep implements AdoptionStep {
+
+	private static final Logger log = LogManager.getLogger(ToolchainStep.class);
+
+	static final List<String> DEFAULT_TOOLS = List.of("git", "claude", "gh");
+
+	private final List<String> tools;
+
+	public ToolchainStep() {
+		this(DEFAULT_TOOLS);
+	}
+
+	public ToolchainStep(List<String> tools) {
+		this.tools = List.copyOf(tools);
+	}
+
+	@Override
+	public String name() {
+		return "toolchain";
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		log.info("Checking required tools are available: {}", tools);
+		List<String> missing = missingTools(context, runner);
+		if (!missing.isEmpty()) {
+			throw new AdoptionException(name() + " failed: required tools were not found on the PATH: "
+					+ String.join(", ", missing));
+		}
+	}
+
+	private List<String> missingTools(AdoptionContext context, CommandRunner runner) {
+		List<String> missing = new ArrayList<>();
+		for (String tool : tools) {
+			collectIfMissing(missing, context, runner, tool);
+		}
+		return missing;
+	}
+
+	private void collectIfMissing(List<String> missing, AdoptionContext context, CommandRunner runner, String tool) {
+		if (isAvailable(context, runner, tool)) {
+			log.info("Found required tool: {}", tool);
+		} else {
+			missing.add(tool);
+		}
+	}
+
+	/**
+	 * A tool the runner cannot even start throws an {@link AdoptionException} out
+	 * of {@link CommandRunner#run}; that is exactly the "not installed" case the
+	 * probe is looking for, so it is caught and reported as unavailable rather than
+	 * aborting the whole check on the first absent tool.
+	 */
+	private boolean isAvailable(AdoptionContext context, CommandRunner runner, String tool) {
+		try {
+			CommandResult result = runner.run(context.workspace(), List.of(tool, "--version"));
+			return result.succeeded();
+		} catch (AdoptionException e) {
+			log.warn("Required tool {} could not be run: {}", tool, e.getMessage());
+			return false;
+		}
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
@@ -36,6 +36,24 @@ class AdoptionContextTest {
 	}
 
 	@Test
+	void derivesCheckoutDirectoryFromNestedGroupUrl() {
+		AdoptionContext context = new AdoptionContext("https://gitlab.com/group/subgroup/tools.git", workspace);
+		assertEquals(workspace.resolve("tools"), context.repositoryDirectory());
+	}
+
+	@Test
+	void keepsDotsInRepositoryNameThatAreNotTheGitSuffix() {
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/my.tool.git", workspace);
+		assertEquals(workspace.resolve("my.tool"), context.repositoryDirectory());
+	}
+
+	@Test
+	void exposesTheWorkspaceDirectory() {
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace);
+		assertEquals(workspace, context.workspace());
+	}
+
+	@Test
 	void trimsAndKeepsUrl() {
 		AdoptionContext context = new AdoptionContext("  https://github.com/adamw7/tools.git  ", workspace);
 		assertEquals("https://github.com/adamw7/tools.git", context.repositoryUrl());
@@ -63,6 +81,17 @@ class AdoptionContextTest {
 	@Test
 	void rejectsBlankUrl() {
 		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext("  ", workspace));
+	}
+
+	@Test
+	void rejectsNullUrl() {
+		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext(null, workspace));
+	}
+
+	@Test
+	void rejectsNullBranchName() {
+		assertThrows(IllegalArgumentException.class,
+				() -> new AdoptionContext("https://github.com/adamw7/tools.git", workspace, null));
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -73,7 +73,7 @@ class GitHubRepoAdopterTest {
 	@Test
 	void defaultPipelineBranchesCommitsPushesAndOpensAPullRequest() {
 		List<String> names = GitHubRepoAdopter.defaultSteps().stream().map(AdoptionStep::name).toList();
-		assertEquals(List.of("clone", "branch", "trust", "claude-init", "commit", "enforcer", "commit", "verify",
-				"push", "pull-request"), names);
+		assertEquals(List.of("toolchain", "clone", "branch", "trust", "claude-init", "commit", "enforcer", "commit",
+				"verify", "push", "pull-request"), names);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,5 +46,22 @@ class EnforcerStepTest {
 		AdoptionContext context = context(workspace);
 		assertDoesNotThrow(() -> new EnforcerStep().execute(context, new RecordingCommandRunner()));
 		assertFalse(Files.exists(context.repositoryDirectory().resolve("pom.xml")));
+	}
+
+	@Test
+	void leavesAnAlreadyWiredPomByteForByteUnchanged(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		Path pom = context.repositoryDirectory().resolve("pom.xml");
+		Files.writeString(pom, POM);
+		EnforcerStep step = new EnforcerStep();
+		step.execute(context, new RecordingCommandRunner());
+		String afterFirstWiring = Files.readString(pom);
+		step.execute(context, new RecordingCommandRunner());
+		assertEquals(afterFirstWiring, Files.readString(pom));
+	}
+
+	@Test
+	void isNamedEnforcer() {
+		assertEquals("enforcer", new EnforcerStep().name());
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
@@ -1,0 +1,73 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class ToolchainStepTest {
+
+	private final AdoptionContext context = new AdoptionContext("https://github.com/adamw7/demo.git",
+			Path.of("/tmp/workspace"));
+
+	@Test
+	void probesEveryRequiredToolInTheWorkspace() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new ToolchainStep().execute(context, runner);
+		assertEquals(List.of("git", "--version"), runner.commandAt(0));
+		assertEquals(List.of("claude", "--version"), runner.commandAt(1));
+		assertEquals(List.of("gh", "--version"), runner.commandAt(2));
+		assertEquals(context.workspace(), runner.invocations().get(0).workingDirectory());
+	}
+
+	@Test
+	void probesTheConfiguredTools() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new ToolchainStep(List.of("git")).execute(context, runner);
+		assertEquals(1, runner.count());
+		assertEquals(List.of("git", "--version"), runner.commandAt(0));
+	}
+
+	@Test
+	void aToolThatExitsNonZeroAbortsTheAdoption() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> command.contains("gh") ? new CommandResult(command, 127, "gh: not found")
+						: new CommandResult(command, 0, ""));
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> new ToolchainStep().execute(context, runner));
+		assertTrue(thrown.getMessage().contains("gh"), thrown.getMessage());
+	}
+
+	@Test
+	void aToolThatCannotStartAbortsTheAdoption() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			throw new AdoptionException("Could not start command: " + String.join(" ", command));
+		});
+		assertThrows(AdoptionException.class, () -> new ToolchainStep().execute(context, runner));
+	}
+
+	@Test
+	void reportsEveryMissingToolAtOnce() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> command.contains("git") ? new CommandResult(command, 0, "")
+						: new CommandResult(command, 1, "missing"));
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> new ToolchainStep().execute(context, runner));
+		assertTrue(thrown.getMessage().contains("claude"), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains("gh"), thrown.getMessage());
+	}
+
+	@Test
+	void isNamedToolchain() {
+		assertEquals("toolchain", new ToolchainStep().name());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -64,6 +65,22 @@ class ToolchainStepTest {
 				() -> new ToolchainStep().execute(context, runner));
 		assertTrue(thrown.getMessage().contains("claude"), thrown.getMessage());
 		assertTrue(thrown.getMessage().contains("gh"), thrown.getMessage());
+	}
+
+	@Test
+	void reportsMissingToolsInDeclarationOrder() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 1, "missing"));
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> new ToolchainStep(List.of("git", "gh")).execute(context, runner));
+		assertTrue(thrown.getMessage().contains("git, gh"), thrown.getMessage());
+	}
+
+	@Test
+	void anEmptyToolListIsANoOpThatPasses() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		assertDoesNotThrow(() -> new ToolchainStep(List.of()).execute(context, runner));
+		assertEquals(0, runner.count());
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/TrustStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/TrustStepTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -37,6 +38,17 @@ class TrustStepTest {
 		String key = context.repositoryDirectory().toAbsolutePath().normalize().toString();
 		assertTrue(MAPPER.readTree(config.toFile()).path("projects").path(key)
 				.path("hasTrustDialogAccepted").asBoolean());
+	}
+
+	@Test
+	void leavesConfigUnchangedWhenTheCheckoutIsAlreadyTrusted(@TempDir Path dir) throws IOException {
+		Path config = dir.resolve(".claude.json");
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", dir);
+		TrustStep step = new TrustStep(new ClaudeTrustStore(config));
+		step.execute(context, new RecordingCommandRunner());
+		String afterFirstTrust = Files.readString(config);
+		step.execute(context, new RecordingCommandRunner());
+		assertEquals(afterFirstTrust, Files.readString(config));
 	}
 
 	@Test


### PR DESCRIPTION
The adoption pipeline only touched `gh` at its very last step, so a missing
or unauthenticated tool surfaced late — after a full clone, a `claude init`,
two commits, and a Maven build had already run — as an opaque "could not
start command" error.

Add a `ToolchainStep` that runs first and probes every external tool the
pipeline shells out to (`git`, `claude`, `gh`) with a `--version` check.
Every tool is probed even after one is found missing, so the failure names
all of the absent tools at once. A tool the runner cannot even start throws
out of `run`; that is exactly the not-installed case, so it is caught and
reported as unavailable rather than aborting the check on the first tool.

Wire it as the head of the default pipeline, cover it with unit tests, and
update the pipeline order test and the README/AGENTS.md/CLAUDE.md docs (also
filling in the previously undocumented Trust and Verify steps).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VMzSPfoyCxTMEgVmntLcKy