### PR TITLE
fix(adopt): stop the enforcer version drifting and launch .cmd tools on Windows

### DIFF
--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -13,6 +13,23 @@
 	<description>Adopts Claude Code into a GitHub repository: clones it, runs claude init to generate CLAUDE.md, commits and pushes, then wires the claude-code-enforcer into the project build.</description>
 	<url>https://github.com/adamw7/tools</url>
 	<build>
+		<resources>
+			<!-- Default resources copied verbatim: log4j2.properties carries ${...}
+			     tokens that are log4j's own and must survive unfiltered. -->
+			<resource>
+				<directory>src/main/resources</directory>
+			</resource>
+			<!-- A dedicated directory that IS filtered, so the project version is
+			     baked into adopt-build.properties (see PomEnforcerInstaller). The
+			     spring-boot-starter parent filters with the @...@ delimiter, which
+			     that file uses. Kept separate from src/main/resources because
+			     overlapping filtered and unfiltered entries on one directory are
+			     unreliable, and because log4j2.properties must stay unfiltered. -->
+			<resource>
+				<directory>src/main/filtered-resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<plugins>
 			<!-- Lets the pipeline be launched with `mvn -pl adopt exec:java`, which
 			     resolves the full runtime classpath (log4j2 and the rest) from the

--- a/adopt/src/main/filtered-resources/adopt-build.properties
+++ b/adopt/src/main/filtered-resources/adopt-build.properties
@@ -1,0 +1,11 @@
+# Build metadata, filtered by Maven at build time (see the <resources> block in
+# adopt/pom.xml, which filters this directory). Supplies the claude-code-enforcer
+# rule version wired into an adopted project's pom.xml so it always matches the
+# tools release running the adoption -- and is therefore resolvable from the same
+# repository that published that release -- instead of a hardcoded literal that
+# silently drifts as the project is versioned.
+#
+# The @...@ delimiter (rather than ${...}) is deliberate: the spring-boot-starter
+# parent configures resource filtering with useDefaultDelimiters=false and the
+# @ delimiter, so ${...} tokens are left untouched and only @...@ is substituted.
+enforcer.rule.version=@project.version@

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
@@ -1,0 +1,136 @@
+package io.github.adamw7.tools.adopt.command;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Resolves a command's program name to a form {@link ProcessBuilder} can
+ * actually launch on the host operating system.
+ *
+ * <p>On POSIX the command is returned unchanged. On Windows a bare program name
+ * such as {@code mvn} or {@code claude} routinely resolves to a {@code .cmd} or
+ * {@code .bat} shim, which the underlying {@code CreateProcess} call cannot
+ * start: it appends {@code .exe} to an extensionless name and refuses to run a
+ * batch script directly, so a bare {@code mvn} fails with "Cannot run program".
+ * This resolver searches the {@code PATH} using {@code PATHEXT} and, when the
+ * program is a batch script, rewrites the command to run through
+ * {@code cmd.exe /c}; a real executable is rewritten to its resolved absolute
+ * path. A program that cannot be located is returned unchanged, so the caller
+ * still fails with its usual "could not start" error rather than being masked
+ * here.
+ *
+ * <p>Only the program name is ever routed through {@code cmd.exe}; the arguments
+ * are handed to {@link ProcessBuilder} unchanged. Free-form arguments such as a
+ * pull-request title or body therefore never reach the command interpreter,
+ * because {@code git} and {@code gh} resolve to real {@code .exe} files rather
+ * than to batch scripts.
+ */
+final class ExecutableResolver {
+
+	private static final List<String> BATCH_EXTENSIONS = List.of(".cmd", ".bat");
+	private static final List<String> DEFAULT_PATH_EXTENSIONS = List.of(".com", ".exe", ".bat", ".cmd");
+
+	private final boolean windows;
+	private final List<Path> pathDirectories;
+	private final List<String> pathExtensions;
+
+	ExecutableResolver() {
+		this(isWindows(), pathDirectoriesFromEnvironment(), pathExtensionsFromEnvironment());
+	}
+
+	ExecutableResolver(boolean windows, List<Path> pathDirectories, List<String> pathExtensions) {
+		this.windows = windows;
+		this.pathDirectories = List.copyOf(pathDirectories);
+		this.pathExtensions = List.copyOf(pathExtensions);
+	}
+
+	List<String> resolve(List<String> command) {
+		if (!windows || command.isEmpty()) {
+			return command;
+		}
+		return locate(command.get(0))
+				.map(executable -> rewrite(executable, command))
+				.orElse(command);
+	}
+
+	private Optional<Path> locate(String program) {
+		if (hasPathSeparator(program)) {
+			return Optional.empty();
+		}
+		return pathDirectories.stream()
+				.flatMap(directory -> candidates(directory, program))
+				.filter(Files::isRegularFile)
+				.findFirst();
+	}
+
+	private Stream<Path> candidates(Path directory, String program) {
+		Stream<Path> withExtensions = pathExtensions.stream().map(extension -> directory.resolve(program + extension));
+		Stream<Path> bareName = Stream.of(directory.resolve(program));
+		return Stream.concat(withExtensions, bareName);
+	}
+
+	private List<String> rewrite(Path executable, List<String> command) {
+		List<String> rewritten = new ArrayList<>();
+		if (isBatchScript(executable)) {
+			rewritten.add("cmd.exe");
+			rewritten.add("/c");
+		}
+		rewritten.add(executable.toString());
+		rewritten.addAll(command.subList(1, command.size()));
+		return rewritten;
+	}
+
+	private boolean isBatchScript(Path executable) {
+		String name = executable.getFileName().toString().toLowerCase(Locale.ROOT);
+		return BATCH_EXTENSIONS.stream().anyMatch(name::endsWith);
+	}
+
+	private boolean hasPathSeparator(String program) {
+		return program.indexOf('/') >= 0 || program.indexOf('\\') >= 0;
+	}
+
+	private static boolean isWindows() {
+		return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("windows");
+	}
+
+	private static List<Path> pathDirectoriesFromEnvironment() {
+		return splitPathList(System.getenv("PATH")).stream()
+				.map(ExecutableResolver::toPath)
+				.flatMap(Optional::stream)
+				.toList();
+	}
+
+	private static Optional<Path> toPath(String entry) {
+		try {
+			return Optional.of(Path.of(entry));
+		} catch (InvalidPathException e) {
+			return Optional.empty();
+		}
+	}
+
+	private static List<String> pathExtensionsFromEnvironment() {
+		List<String> configured = splitPathList(System.getenv("PATHEXT")).stream()
+				.map(extension -> extension.startsWith(".") ? extension : "." + extension)
+				.map(extension -> extension.toLowerCase(Locale.ROOT))
+				.toList();
+		return configured.isEmpty() ? DEFAULT_PATH_EXTENSIONS : configured;
+	}
+
+	private static List<String> splitPathList(String value) {
+		if (value == null || value.isBlank()) {
+			return List.of();
+		}
+		return Arrays.stream(value.split(Pattern.quote(File.pathSeparator)))
+				.filter(entry -> !entry.isBlank())
+				.toList();
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -27,6 +27,7 @@ public class ProcessCommandRunner implements CommandRunner {
 	static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(10);
 
 	private final Duration timeout;
+	private final ExecutableResolver resolver;
 
 	public ProcessCommandRunner() {
 		this(DEFAULT_TIMEOUT);
@@ -34,6 +35,7 @@ public class ProcessCommandRunner implements CommandRunner {
 
 	public ProcessCommandRunner(Duration timeout) {
 		this.timeout = requirePositive(timeout);
+		this.resolver = new ExecutableResolver();
 	}
 
 	private static Duration requirePositive(Duration timeout) {
@@ -45,7 +47,7 @@ public class ProcessCommandRunner implements CommandRunner {
 
 	@Override
 	public CommandResult run(Path workingDirectory, List<String> command) {
-		ProcessBuilder builder = new ProcessBuilder(command)
+		ProcessBuilder builder = new ProcessBuilder(resolver.resolve(command))
 				.directory(workingDirectory.toFile())
 				.redirectErrorStream(true);
 		return execute(builder, command);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -1,11 +1,13 @@
 package io.github.adamw7.tools.adopt.step;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
@@ -45,17 +47,49 @@ public class PomEnforcerInstaller {
 	static final String ENFORCER_VERSION = "3.6.3";
 	static final String RULE_ARTIFACT_ID = "tools.claude-code-enforcer";
 	static final String RULE_GROUP_ID = "io.github.adamw7";
-	static final String DEFAULT_RULE_VERSION = "2.5.0";
 	static final String CLAUDE_MD_FILE = "${project.basedir}/CLAUDE.md";
+	static final String BUILD_PROPERTIES = "/adopt-build.properties";
+	static final String RULE_VERSION_KEY = "enforcer.rule.version";
 
 	private final String ruleVersion;
 
 	public PomEnforcerInstaller() {
-		this(DEFAULT_RULE_VERSION);
+		this(buildRuleVersion());
 	}
 
 	public PomEnforcerInstaller(String ruleVersion) {
 		this.ruleVersion = ruleVersion;
+	}
+
+	/**
+	 * Reads the enforcer rule version wired into adopted POMs from the build
+	 * metadata that Maven filters into {@value #BUILD_PROPERTIES} at build time, so
+	 * the dependency is pinned to the exact {@code tools} release running the
+	 * adoption — and is therefore resolvable from the same repository that
+	 * published it — rather than to a hardcoded literal that silently drifts as the
+	 * project is versioned.
+	 */
+	private static String buildRuleVersion() {
+		try (InputStream stream = PomEnforcerInstaller.class.getResourceAsStream(BUILD_PROPERTIES)) {
+			return readRuleVersion(stream);
+		} catch (IOException e) {
+			throw new AdoptionException("Could not read build metadata: " + BUILD_PROPERTIES, e);
+		}
+	}
+
+	private static String readRuleVersion(InputStream stream) throws IOException {
+		if (stream == null) {
+			throw new AdoptionException("Build metadata not on the classpath: " + BUILD_PROPERTIES
+					+ " (build the module so its resources are filtered)");
+		}
+		Properties properties = new Properties();
+		properties.load(stream);
+		String version = properties.getProperty(RULE_VERSION_KEY, "").strip();
+		if (version.isEmpty() || version.startsWith("${")) {
+			throw new AdoptionException(
+					RULE_VERSION_KEY + " was not filtered into " + BUILD_PROPERTIES + " (found: '" + version + "')");
+		}
+		return version;
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ExecutableResolverTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ExecutableResolverTest.java
@@ -1,0 +1,79 @@
+package io.github.adamw7.tools.adopt.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ExecutableResolverTest {
+
+	private static final List<String> EXTENSIONS = List.of(".com", ".exe", ".bat", ".cmd");
+
+	@Test
+	void posixReturnsTheCommandUnchanged(@TempDir Path dir) throws IOException {
+		Files.createFile(dir.resolve("mvn.cmd"));
+		ExecutableResolver resolver = new ExecutableResolver(false, List.of(dir), EXTENSIONS);
+		List<String> command = List.of("mvn", "-N", "validate");
+		assertSame(command, resolver.resolve(command));
+	}
+
+	@Test
+	void windowsRewritesABatchScriptThroughCmd(@TempDir Path dir) throws IOException {
+		Path script = Files.createFile(dir.resolve("mvn.cmd"));
+		ExecutableResolver resolver = new ExecutableResolver(true, List.of(dir), EXTENSIONS);
+		assertEquals(List.of("cmd.exe", "/c", script.toString(), "-N", "validate"),
+				resolver.resolve(List.of("mvn", "-N", "validate")));
+	}
+
+	@Test
+	void windowsRewritesARealExecutableToItsAbsolutePath(@TempDir Path dir) throws IOException {
+		Path executable = Files.createFile(dir.resolve("git.exe"));
+		ExecutableResolver resolver = new ExecutableResolver(true, List.of(dir), EXTENSIONS);
+		assertEquals(List.of(executable.toString(), "clone", "https://example.test/repo.git"),
+				resolver.resolve(List.of("git", "clone", "https://example.test/repo.git")));
+	}
+
+	@Test
+	void windowsPrefersAnExecutableExtensionOverABareFileOfTheSameName(@TempDir Path dir) throws IOException {
+		Files.createFile(dir.resolve("tool"));
+		Path executable = Files.createFile(dir.resolve("tool.exe"));
+		ExecutableResolver resolver = new ExecutableResolver(true, List.of(dir), EXTENSIONS);
+		assertEquals(List.of(executable.toString()), resolver.resolve(List.of("tool")));
+	}
+
+	@Test
+	void windowsSearchesPathDirectoriesInOrder(@TempDir Path first, @TempDir Path second) throws IOException {
+		Files.createFile(first.resolve("gh.exe"));
+		Files.createFile(second.resolve("gh.exe"));
+		ExecutableResolver resolver = new ExecutableResolver(true, List.of(first, second), EXTENSIONS);
+		assertEquals(List.of(first.resolve("gh.exe").toString()), resolver.resolve(List.of("gh")));
+	}
+
+	@Test
+	void windowsLeavesAnUnresolvableCommandUnchanged(@TempDir Path dir) {
+		ExecutableResolver resolver = new ExecutableResolver(true, List.of(dir), EXTENSIONS);
+		List<String> command = List.of("definitely-not-installed");
+		assertSame(command, resolver.resolve(command));
+	}
+
+	@Test
+	void windowsLeavesAProgramThatAlreadyCarriesAPathUnchanged(@TempDir Path dir) throws IOException {
+		Files.createFile(dir.resolve("mvn.cmd"));
+		ExecutableResolver resolver = new ExecutableResolver(true, List.of(dir), EXTENSIONS);
+		List<String> command = List.of("some/dir/mvn", "-N");
+		assertSame(command, resolver.resolve(command));
+	}
+
+	@Test
+	void anEmptyCommandIsReturnedUnchanged() {
+		ExecutableResolver resolver = new ExecutableResolver(true, List.of(), EXTENSIONS);
+		List<String> command = List.of();
+		assertSame(command, resolver.resolve(command));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -2,11 +2,14 @@ package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Properties;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -196,5 +199,33 @@ class PomEnforcerInstallerTest {
 		Path pom = write(dir, POM_WITH_BUILD);
 		installer.install(pom);
 		assertTrue(Files.readString(pom).contains("http://maven.apache.org/POM/4.0.0"));
+	}
+
+	/**
+	 * The default installer must pin the rule to the version Maven filtered into
+	 * {@code adopt-build.properties} — the release actually running the adoption —
+	 * rather than a hardcoded literal that drifts as the project is versioned.
+	 */
+	@Test
+	void defaultInstallerPinsTheRuleToTheFilteredBuildVersion(@TempDir Path dir) throws IOException {
+		String buildVersion = filteredRuleVersion();
+		Path pom = write(dir, POM_WITH_BUILD);
+		assertTrue(new PomEnforcerInstaller().install(pom));
+		String result = Files.readString(pom);
+		assertTrue(result.contains("tools.claude-code-enforcer"));
+		assertTrue(result.contains("<version>" + buildVersion + "</version>"),
+				"the rule dependency must be pinned to the filtered build version " + buildVersion);
+	}
+
+	private String filteredRuleVersion() throws IOException {
+		try (InputStream stream = getClass().getResourceAsStream(PomEnforcerInstaller.BUILD_PROPERTIES)) {
+			assertNotNull(stream, PomEnforcerInstaller.BUILD_PROPERTIES + " must be filtered onto the test classpath");
+			Properties properties = new Properties();
+			properties.load(stream);
+			String version = properties.getProperty(PomEnforcerInstaller.RULE_VERSION_KEY, "").strip();
+			assertFalse(version.isEmpty() || version.startsWith("${"),
+					"enforcer.rule.version must be filtered to a concrete version, was: " + version);
+			return version;
+		}
 	}
 }


### PR DESCRIPTION
Two bug fixes in the `adopt` pipeline, found while reviewing the module.

## 1. Enforcer rule version was hardcoded

`PomEnforcerInstaller` wired `io.github.adamw7:tools.claude-code-enforcer` into adopted POMs with a literal `"2.5.0"`. Two problems:

- **Release coupling:** during `2.5.0-SNAPSHOT` development the pinned `2.5.0` isn't on Maven Central yet, so `VerifyStep`'s `mvn -N validate` can't resolve the dependency and **every adoption aborts** — including runs from source (`mvn -pl adopt exec:java`, which the module explicitly supports).
- **Silent drift:** nothing kept the literal in sync with the project version across releases.

The version is now filtered from the reactor version into `adopt-build.properties` and read at construction time, failing loudly if it's missing or unfiltered. It always matches the tools release running the adoption and is resolvable from the same repository that published it.

Notes:
- Uses the `@project.version@` delimiter because the `spring-boot-starter` parent sets `useDefaultDelimiters=false` with the `@…@` delimiter — `${…}` tokens are never filtered here.
- Deliberately keeps `-SNAPSHOT` (no stripping) so a local snapshot build wires a snapshot that resolves from the same `~/.m2` that built it, and a release wires the released version.
- The enforcer *plugin* version (`3.6.3`) is left hardcoded — it lives in the root pom's pluginManagement, isn't tied to the project version, and is always resolvable from Central.

## 2. `.cmd`/`.bat` tools couldn't be launched on Windows

`ProcessBuilder` → `CreateProcess` appends `.exe` to a bare name and can't run a batch script directly, so `mvn`/`claude` (routinely `.cmd` shims on Windows) failed `VerifyStep`/`ClaudeInitStep` with "Cannot run program" — on this repo's primary dev platform.

New `ExecutableResolver`: no-op on POSIX; on Windows it resolves the program against `PATH`/`PATHEXT`, rewrites a real executable to its absolute path, and wraps a batch script in `cmd.exe /c`. An unresolvable program is returned unchanged (never worse than before), and only the program name is routed through `cmd.exe` — `git`/`gh` resolve to real `.exe`s, so free-form args (a PR title/body) never reach the interpreter.

## Testing

`mvn -pl adopt -am test` — **125 tests pass**, including 8 new `ExecutableResolver` tests, a new test pinning the wired version to the filtered build version, and the existing real-process `ProcessCommandRunnerTest` (green on Windows with the resolver engaged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)