### PR TITLE
feat(adopt): add Gradle build support and richer pull-request metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,11 +44,17 @@ Maven project. The notable capabilities are:
   repo, creates a feature branch,
   marks the checkout trusted in `~/.claude.json` so the headless CLI is not
   blocked by the folder-trust prompt, runs the Claude Code CLI (`claude init`) to
-  generate a `CLAUDE.md` and commits it, then wires the `claude-code-enforcer`
-  into the project's `pom.xml` and commits that, verifies the enforcer passes on
-  the generated file with a non-recursive `mvn -N validate`, and finally pushes
-  the branch and opens a pull request with the GitHub CLI (`gh pr create`) — the default
-  branch is never written to directly. External `git`/`claude`/`gh` invocations
+  generate a `CLAUDE.md` and commits it, then wires a `CLAUDE.md` guard into the
+  project's build and commits that, verifies the guard passes on the generated
+  file, and finally pushes the branch and opens a pull request with the GitHub
+  CLI (`gh pr create`) — the default branch is never written to directly. The
+  guard is build-tool aware behind a `BuildSystem` abstraction: a Maven project
+  gets the full `claude-code-enforcer` rule wired into its `pom.xml` and verified
+  with a non-recursive `mvn -N validate`; a Gradle project (Groovy or Kotlin DSL)
+  gets an `enforceClaudeMd` presence guard task appended to its build script and
+  verified by running that task. The pull request metadata — title, body,
+  reviewers, labels, assignees, and draft flag — is supplied through
+  `PullRequestOptions`. External `git`/`claude`/`gh` invocations
   go through a `CommandRunner`
   abstraction so the steps are unit-tested without spawning real processes; the
   `ProcessCommandRunner` bounds every command with a configurable timeout so a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,12 @@ run `mvn install` from the repository root. The main capabilities are:
 - **Claude Code adoption** (`adopt`) — a pipeline that adopts Claude Code into a
   GitHub repo: check the required tools (`git`, `claude`, `gh`) are installed,
   clone, create a feature branch, `claude init` to generate
-  `CLAUDE.md` and commit it, wire the `claude-code-enforcer` into the repo's
-  `pom.xml` and commit that, verify the enforcer passes on the generated file,
-  then push the branch and open a pull request (`gh pr create`); the default
-  branch is never written to directly.
+  `CLAUDE.md` and commit it, wire a build-tool-aware `CLAUDE.md` guard into the
+  repo (the `claude-code-enforcer` rule for Maven `pom.xml`, an `enforceClaudeMd`
+  guard task for Gradle) and commit that, verify the guard passes on the
+  generated file, then push the branch and open a pull request (`gh pr create`)
+  with metadata from `PullRequestOptions`; the default branch is never written to
+  directly.
 
 Module map (root reactor: `claude-code-enforcer`, `mcp-common`, `data`, `code`,
 `adopt`, `grpc-example`, `assembly`; `data-test` is built separately):

--- a/README.md
+++ b/README.md
@@ -721,12 +721,15 @@ it. See *Testing* in [AGENTS.md](AGENTS.md) for the details.
 The `adopt` module (`tools.adopt`) is an ordered pipeline that **adopts Claude
 Code into a GitHub repository**. Given a repository URL it clones the repo,
 creates a feature branch, runs the Claude Code CLI (`claude -p /init`) to
-generate a `CLAUDE.md` and commits it, then wires the
-[`claude-code-enforcer`](#claude-code-files-maven-enforcer) into the project's
-`pom.xml` and commits that too — so the freshly generated `CLAUDE.md` keeps
-being validated on every build. Finally it pushes the branch and opens a pull
-request with the GitHub CLI, so the change is reviewed rather than landing
-straight on the default branch, which is never written to.
+generate a `CLAUDE.md` and commits it, then wires a `CLAUDE.md` guard into the
+project's build and commits that too — so the freshly generated `CLAUDE.md` keeps
+being validated on every build. The guard is build-tool aware: a Maven project
+gets the full [`claude-code-enforcer`](#claude-code-files-maven-enforcer) rule in
+its `pom.xml`, while a Gradle project (Groovy `build.gradle` or Kotlin
+`build.gradle.kts`) gets a presence-and-non-empty guard task appended to the
+build script — Gradle has no enforcer-rule equivalent. Finally it pushes the
+branch and opens a pull request with the GitHub CLI, so the change is reviewed
+rather than landing straight on the default branch, which is never written to.
 
 Run it from the command line with a GitHub repository URL, an optional workspace
 directory to clone into (a temporary directory is created when it is omitted),
@@ -772,25 +775,33 @@ The default pipeline runs these steps in order:
    the file did not appear.
 6. **`CommitStep`** — commits the generated `CLAUDE.md` (`Adopt Claude Code: add
    CLAUDE.md`).
-7. **`EnforcerStep`** — wires the `claude-code-enforcer` into the checkout's root
-   `pom.xml` via `PomEnforcerInstaller`. The edit is done on the JDK's DOM (no
-   third-party XML library), is namespace-aware, and is idempotent: a POM that
-   already declares the rule is left unchanged, and a repository that is not a
-   Maven project (no `pom.xml`) is skipped with a warning rather than failing the
-   adoption.
+7. **`EnforcerStep`** — detects the checkout's build system and wires the
+   `CLAUDE.md` guard into it. A Maven project has the `claude-code-enforcer` added
+   to its root `pom.xml` via `PomEnforcerInstaller` (the edit is done on the JDK's
+   DOM — no third-party XML library — is namespace-aware, and is idempotent); a
+   Gradle project has a `enforceClaudeMd` guard task appended to its
+   `build.gradle`/`build.gradle.kts` via `GradleGuardInstaller`, wired into
+   `check`. Both installs are idempotent, and a repository with no supported build
+   file is skipped with a warning rather than failing the adoption. Supporting a
+   new build tool is a matter of adding a `BuildSystem` implementation rather than
+   branching inside the step.
 8. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
    build`).
-9. **`VerifyStep`** — runs a non-recursive `mvn -N validate` so the freshly wired
-   enforcer actually executes against the generated `CLAUDE.md`, failing the
-   adoption locally if the file is missing or malformed rather than after the
-   pull request lands.
+9. **`VerifyStep`** — runs the detected build system's verification (a
+   non-recursive `mvn -N validate` for Maven, the `enforceClaudeMd` task for
+   Gradle) so the freshly wired guard actually executes against the generated
+   `CLAUDE.md`, failing the adoption locally if the file is missing or malformed
+   rather than after the pull request lands.
 10. **`PushStep`** — pushes the feature branch to origin and sets its upstream
     (`git push -u origin <branch>`).
 11. **`PullRequestStep`** — opens a pull request from the branch with
-   `gh pr create`, targeting the repository's default branch as the base. Like
-   `CommitStep` it stays idempotent: a `gh` failure that only reports an
-   already-open pull request for the branch, or no commits between base and head,
-   is treated as a no-op rather than aborting the adoption.
+   `gh pr create`, targeting the repository's default branch as the base. The
+   pull request metadata is supplied through `PullRequestOptions` — title, body,
+   and optional reviewers, labels, and assignees to request, plus whether to open
+   the pull request as a `--draft` — so the defaults can be overridden per
+   project. Like `CommitStep` it stays idempotent: a `gh` failure that only
+   reports an already-open pull request for the branch, or no commits between base
+   and head, is treated as a no-op rather than aborting the adoption.
 
 External `git`/`claude`/`gh` invocations go through a `CommandRunner` abstraction,
 so the steps are unit-tested without spawning real processes. The default

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -1,0 +1,33 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * A build tool the adoption knows how to wire a {@code CLAUDE.md} guard into and
+ * run. Abstracting the build tool keeps {@link EnforcerStep} and
+ * {@link VerifyStep} agnostic: each detects the checkout's build system once and
+ * then installs the guard and runs the verification through this contract, so
+ * supporting a new build tool is a matter of adding an implementation rather than
+ * branching inside the steps.
+ */
+public interface BuildSystem {
+
+	/** Human-readable name, e.g. {@code maven} or {@code gradle}, for logging. */
+	String name();
+
+	/** @return {@code true} when this build system's build file is present in the checkout. */
+	boolean matches(Path repositoryDirectory);
+
+	/**
+	 * Wires the {@code CLAUDE.md} guard into the checkout's build file so the
+	 * generated file keeps being validated on every build.
+	 *
+	 * @return {@code true} when the build file was modified, {@code false} when it
+	 *         already declared the guard and was left unchanged.
+	 */
+	boolean install(Path repositoryDirectory);
+
+	/** Command that runs the wired guard so a missing or malformed {@code CLAUDE.md} fails the build. */
+	List<String> verifyCommand();
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystems.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystems.java
@@ -1,0 +1,28 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The build systems the adoption supports and the detection that picks the one
+ * matching a checkout. The default set is tried in order, so a repository that
+ * happens to carry more than one build file is adopted with the first-listed
+ * build tool.
+ */
+public final class BuildSystems {
+
+	/** Maven first, then Gradle: the order the checkout is probed in. */
+	public static final List<BuildSystem> DEFAULTS = List.of(new MavenBuildSystem(), new GradleBuildSystem());
+
+	private BuildSystems() {
+	}
+
+	public static Optional<BuildSystem> detect(List<BuildSystem> candidates, Path repositoryDirectory) {
+		return candidates.stream().filter(candidate -> candidate.matches(repositoryDirectory)).findFirst();
+	}
+
+	static String names(List<BuildSystem> candidates) {
+		return candidates.stream().map(BuildSystem::name).reduce((a, b) -> a + "/" + b).orElse("");
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerStep.java
@@ -1,7 +1,8 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -10,26 +11,25 @@ import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
- * Wires the {@code claude-code-enforcer} into the adopted project's build so
- * the generated {@code CLAUDE.md} keeps being validated on every build. The
- * step edits the checkout's root {@code pom.xml}; a repository that is not a
- * Maven project (no {@code pom.xml}) is skipped with a warning rather than
- * failing the adoption.
+ * Wires a {@code CLAUDE.md} guard into the adopted project's build so the
+ * generated {@code CLAUDE.md} keeps being validated on every build. The concrete
+ * wiring depends on the checkout's build tool: a Maven project gets the full
+ * {@code claude-code-enforcer} rule, a Gradle project gets a presence guard task
+ * (see {@link BuildSystem}). A repository with no supported build file is skipped
+ * with a warning rather than failing the adoption.
  */
 public class EnforcerStep implements AdoptionStep {
 
 	private static final Logger log = LogManager.getLogger(EnforcerStep.class);
 
-	private static final String POM = "pom.xml";
-
-	private final PomEnforcerInstaller installer;
+	private final List<BuildSystem> buildSystems;
 
 	public EnforcerStep() {
-		this(new PomEnforcerInstaller());
+		this(BuildSystems.DEFAULTS);
 	}
 
-	public EnforcerStep(PomEnforcerInstaller installer) {
-		this.installer = installer;
+	public EnforcerStep(List<BuildSystem> buildSystems) {
+		this.buildSystems = List.copyOf(buildSystems);
 	}
 
 	@Override
@@ -39,19 +39,20 @@ public class EnforcerStep implements AdoptionStep {
 
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
-		Path pomFile = context.repositoryDirectory().resolve(POM);
-		if (Files.isRegularFile(pomFile)) {
-			install(pomFile);
-		} else {
-			log.warn("No {} in {}; skipping enforcer wiring", POM, context.repositoryDirectory());
-		}
+		Path repositoryDirectory = context.repositoryDirectory();
+		Optional<BuildSystem> buildSystem = BuildSystems.detect(buildSystems, repositoryDirectory);
+		buildSystem.ifPresentOrElse(
+				detected -> install(detected, repositoryDirectory),
+				() -> log.warn("No supported build system ({}) in {}; skipping enforcer wiring",
+						BuildSystems.names(buildSystems), repositoryDirectory));
 	}
 
-	private void install(Path pomFile) {
-		if (installer.install(pomFile)) {
-			log.info("Added claude-code-enforcer to {}", pomFile);
+	private void install(BuildSystem buildSystem, Path repositoryDirectory) {
+		if (buildSystem.install(repositoryDirectory)) {
+			log.info("Wired the CLAUDE.md guard into the {} build in {}", buildSystem.name(), repositoryDirectory);
 		} else {
-			log.info("{} already declares the enforcer plugin; left unchanged", pomFile);
+			log.info("The {} build in {} already declares the guard; left unchanged", buildSystem.name(),
+					repositoryDirectory);
 		}
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
@@ -1,0 +1,68 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+/**
+ * Gradle support for the adoption: detects a Groovy ({@code build.gradle}) or
+ * Kotlin ({@code build.gradle.kts}) build script, appends a {@code CLAUDE.md}
+ * guard task with {@link GradleGuardInstaller}, and verifies it by running that
+ * task. Gradle has no {@code claude-code-enforcer} equivalent, so the guard is a
+ * presence-and-non-empty check rather than the full Maven format rule.
+ */
+public class GradleBuildSystem implements BuildSystem {
+
+	static final List<String> VERIFY_COMMAND = List.of("gradle", "-q", GradleGuardInstaller.GUARD_TASK);
+	static final String GROOVY_BUILD_FILE = "build.gradle";
+	static final String KOTLIN_BUILD_FILE = "build.gradle.kts";
+
+	private final GradleGuardInstaller installer;
+
+	public GradleBuildSystem() {
+		this(new GradleGuardInstaller());
+	}
+
+	public GradleBuildSystem(GradleGuardInstaller installer) {
+		this.installer = installer;
+	}
+
+	@Override
+	public String name() {
+		return "gradle";
+	}
+
+	@Override
+	public boolean matches(Path repositoryDirectory) {
+		return locate(repositoryDirectory).isPresent();
+	}
+
+	@Override
+	public boolean install(Path repositoryDirectory) {
+		Path buildFile = locate(repositoryDirectory)
+				.orElseThrow(() -> new AdoptionException("No Gradle build file in " + repositoryDirectory));
+		return installer.install(buildFile);
+	}
+
+	@Override
+	public List<String> verifyCommand() {
+		return VERIFY_COMMAND;
+	}
+
+	/**
+	 * Prefers the Groovy build file over the Kotlin one when a checkout carries
+	 * both, matching the order most Gradle projects resolve them in.
+	 */
+	private Optional<Path> locate(Path repositoryDirectory) {
+		return candidate(repositoryDirectory, GROOVY_BUILD_FILE)
+				.or(() -> candidate(repositoryDirectory, KOTLIN_BUILD_FILE));
+	}
+
+	private Optional<Path> candidate(Path repositoryDirectory, String fileName) {
+		Path candidate = repositoryDirectory.resolve(fileName);
+		return Files.isRegularFile(candidate) ? Optional.of(candidate) : Optional.empty();
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -1,0 +1,90 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+/**
+ * Appends a {@code CLAUDE.md} guard task to a Gradle build script so the adopted
+ * repository fails its build when the generated {@code CLAUDE.md} is missing or
+ * empty. Unlike the Maven path — which wires the full {@code claude-code-enforcer}
+ * format rule — Gradle has no such rule available, so the guard is a
+ * dependency-free presence-and-non-empty check written directly into the build
+ * script.
+ *
+ * <p>The correct syntax is chosen from the script's extension: the Kotlin DSL
+ * ({@code build.gradle.kts}) and the Groovy DSL ({@code build.gradle}) differ.
+ * The block is appended rather than parsed in because Gradle scripts are code,
+ * not data, and a self-contained task needs no structural edit. The install is
+ * idempotent: a script that already declares the {@value #GUARD_TASK} task is
+ * left untouched.
+ */
+public class GradleGuardInstaller {
+
+	static final String GUARD_TASK = "enforceClaudeMd";
+
+	private static final String KOTLIN_SUFFIX = ".kts";
+
+	private static final String GROOVY_BLOCK = """
+
+			// Added by claude-code-adopt: fail the build when CLAUDE.md is missing or empty.
+			tasks.register('%s') {
+			    doLast {
+			        def claudeMd = file("$projectDir/CLAUDE.md")
+			        if (!claudeMd.isFile() || claudeMd.text.trim().isEmpty()) {
+			            throw new GradleException('CLAUDE.md is missing or empty')
+			        }
+			    }
+			}
+			tasks.matching { it.name == 'check' }.configureEach { it.dependsOn('%s') }
+			""".formatted(GUARD_TASK, GUARD_TASK);
+
+	private static final String KOTLIN_BLOCK = """
+
+			// Added by claude-code-adopt: fail the build when CLAUDE.md is missing or empty.
+			tasks.register("%s") {
+			    doLast {
+			        val claudeMd = file("$projectDir/CLAUDE.md")
+			        if (!claudeMd.isFile || claudeMd.readText().trim().isEmpty()) {
+			            throw GradleException("CLAUDE.md is missing or empty")
+			        }
+			    }
+			}
+			tasks.matching { it.name == "check" }.configureEach { dependsOn("%s") }
+			""".formatted(GUARD_TASK, GUARD_TASK);
+
+	/**
+	 * @return {@code true} when the guard was appended, {@code false} when the
+	 *         script already declared it and was left unchanged.
+	 */
+	public boolean install(Path buildFile) {
+		String existing = read(buildFile);
+		if (existing.contains(GUARD_TASK)) {
+			return false;
+		}
+		append(buildFile, existing, blockFor(buildFile));
+		return true;
+	}
+
+	private String blockFor(Path buildFile) {
+		return buildFile.getFileName().toString().endsWith(KOTLIN_SUFFIX) ? KOTLIN_BLOCK : GROOVY_BLOCK;
+	}
+
+	private String read(Path buildFile) {
+		try {
+			return Files.readString(buildFile);
+		} catch (IOException e) {
+			throw new AdoptionException("Could not read Gradle build file: " + buildFile, e);
+		}
+	}
+
+	private void append(Path buildFile, String existing, String block) {
+		try {
+			Files.writeString(buildFile, existing + block);
+		} catch (IOException e) {
+			throw new AdoptionException("Could not write Gradle build file: " + buildFile, e);
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -1,0 +1,49 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Maven support for the adoption: detects a {@code pom.xml}, wires the
+ * {@code claude-code-enforcer} rule into it with {@link PomEnforcerInstaller},
+ * and verifies the rule with a non-recursive {@code mvn -N validate} so the
+ * freshly generated {@code CLAUDE.md} is validated against the full format rule
+ * before the branch is pushed.
+ */
+public class MavenBuildSystem implements BuildSystem {
+
+	static final List<String> VERIFY_COMMAND = List.of("mvn", "-q", "-N", "validate");
+
+	private static final String POM = "pom.xml";
+
+	private final PomEnforcerInstaller installer;
+
+	public MavenBuildSystem() {
+		this(new PomEnforcerInstaller());
+	}
+
+	public MavenBuildSystem(PomEnforcerInstaller installer) {
+		this.installer = installer;
+	}
+
+	@Override
+	public String name() {
+		return "maven";
+	}
+
+	@Override
+	public boolean matches(Path repositoryDirectory) {
+		return Files.isRegularFile(repositoryDirectory.resolve(POM));
+	}
+
+	@Override
+	public boolean install(Path repositoryDirectory) {
+		return installer.install(repositoryDirectory.resolve(POM));
+	}
+
+	@Override
+	public List<String> verifyCommand() {
+		return VERIFY_COMMAND;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
@@ -1,0 +1,93 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.List;
+
+/**
+ * The metadata a {@link PullRequestStep} opens its pull request with: the title
+ * and body, plus optional reviewers, labels, and assignees to request, and
+ * whether the pull request is opened as a draft. Grouping them keeps the step
+ * from a telescoping constructor and lets callers set only the fields they care
+ * about through {@link #builder()}.
+ *
+ * <p>The lists are defensively copied and never {@code null}, so the step can
+ * translate each entry into a repeated {@code gh pr create} flag without
+ * guarding against absence.
+ */
+public record PullRequestOptions(String title, String body, List<String> reviewers, List<String> labels,
+		List<String> assignees, boolean draft) {
+
+	static final String DEFAULT_TITLE = "Adopt Claude Code";
+	static final String DEFAULT_BODY = "Adds a generated CLAUDE.md and wires the CLAUDE.md guard "
+			+ "into the build so the file keeps being validated.";
+
+	public PullRequestOptions {
+		title = requireText(title, "title");
+		body = requireText(body, "body");
+		reviewers = List.copyOf(reviewers);
+		labels = List.copyOf(labels);
+		assignees = List.copyOf(assignees);
+	}
+
+	public static PullRequestOptions defaults() {
+		return builder().build();
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	private static String requireText(String value, String field) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(field + " must not be blank");
+		}
+		return value.strip();
+	}
+
+	/** Fluent builder that starts from the adoption defaults and no reviewers, labels, or assignees. */
+	public static final class Builder {
+
+		private String title = DEFAULT_TITLE;
+		private String body = DEFAULT_BODY;
+		private List<String> reviewers = List.of();
+		private List<String> labels = List.of();
+		private List<String> assignees = List.of();
+		private boolean draft;
+
+		private Builder() {
+		}
+
+		public Builder title(String title) {
+			this.title = title;
+			return this;
+		}
+
+		public Builder body(String body) {
+			this.body = body;
+			return this;
+		}
+
+		public Builder reviewers(List<String> reviewers) {
+			this.reviewers = reviewers;
+			return this;
+		}
+
+		public Builder labels(List<String> labels) {
+			this.labels = labels;
+			return this;
+		}
+
+		public Builder assignees(List<String> assignees) {
+			this.assignees = assignees;
+			return this;
+		}
+
+		public Builder draft(boolean draft) {
+			this.draft = draft;
+			return this;
+		}
+
+		public PullRequestOptions build() {
+			return new PullRequestOptions(title, body, reviewers, labels, assignees, draft);
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -12,8 +13,10 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
 /**
  * Opens a pull request for the adoption feature branch with the GitHub CLI
  * ({@code gh pr create}), targeting the repository's default branch as the base.
- * The title and body are configurable because they differ between projects; the
- * defaults describe the Claude Code adoption.
+ * The pull request metadata — title, body, reviewers, labels, assignees, and
+ * whether it is a draft — is supplied through {@link PullRequestOptions} because
+ * it differs between projects; the defaults describe the Claude Code adoption
+ * and request nobody.
  *
  * <p>The step stays idempotent when re-run: it asks {@code gh pr view} whether a
  * pull request already exists for the branch and skips creation when one does,
@@ -24,20 +27,18 @@ public class PullRequestStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(PullRequestStep.class);
 
-	static final String DEFAULT_TITLE = "Adopt Claude Code";
-	static final String DEFAULT_BODY = "Adds a generated CLAUDE.md and wires the claude-code-enforcer "
-			+ "into the build so the file keeps being validated.";
-
-	private final String title;
-	private final String body;
+	private final PullRequestOptions options;
 
 	public PullRequestStep() {
-		this(DEFAULT_TITLE, DEFAULT_BODY);
+		this(PullRequestOptions.defaults());
 	}
 
 	public PullRequestStep(String title, String body) {
-		this.title = title;
-		this.body = body;
+		this(PullRequestOptions.builder().title(title).body(body).build());
+	}
+
+	public PullRequestStep(PullRequestOptions options) {
+		this.options = options;
 	}
 
 	@Override
@@ -52,10 +53,27 @@ public class PullRequestStep extends AbstractCommandStep {
 			return;
 		}
 		log.info("Opening pull request for branch {}", context.branchName());
-		List<String> command = List.of("gh", "pr", "create", "--title", title, "--body", body,
-				"--head", context.branchName());
-		CommandResult result = runOrFail(runner, context.repositoryDirectory(), command);
+		CommandResult result = runOrFail(runner, context.repositoryDirectory(), createCommand(context));
 		log.info("Opened pull request: {}", result.output().strip());
+	}
+
+	private List<String> createCommand(AdoptionContext context) {
+		List<String> command = new ArrayList<>(List.of("gh", "pr", "create", "--title", options.title(), "--body",
+				options.body(), "--head", context.branchName()));
+		if (options.draft()) {
+			command.add("--draft");
+		}
+		addRepeated(command, "--reviewer", options.reviewers());
+		addRepeated(command, "--label", options.labels());
+		addRepeated(command, "--assignee", options.assignees());
+		return List.copyOf(command);
+	}
+
+	private void addRepeated(List<String> command, String flag, List<String> values) {
+		for (String value : values) {
+			command.add(flag);
+			command.add(value);
+		}
 	}
 
 	private boolean pullRequestExists(AdoptionContext context, CommandRunner runner) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/VerifyStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/VerifyStep.java
@@ -1,8 +1,8 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -11,35 +11,26 @@ import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
- * Runs the adopted project's {@code validate} phase so the freshly wired
- * {@code claude-code-enforcer} actually executes against the generated
- * {@code CLAUDE.md} before the branch is pushed and a pull request is opened. A
- * malformed or missing {@code CLAUDE.md} therefore fails the adoption locally
- * instead of breaking the contributor's build after the pull request lands.
- *
- * <p>The enforcer execution is bound to the root module's {@code validate} phase
- * with {@code inherited=false}, so a non-recursive {@code mvn -N validate} is
- * enough to exercise it. The Maven invocation is configurable because it differs
- * between environments. A repository that is not a Maven project (no
- * {@code pom.xml}) has nothing to verify and is skipped, mirroring
+ * Runs the guard wired in by {@link EnforcerStep} so a missing or malformed
+ * {@code CLAUDE.md} fails the adoption locally instead of breaking the
+ * contributor's build after the pull request lands. The command to run is
+ * chosen from the checkout's build tool — a non-recursive {@code mvn -N validate}
+ * for Maven, the guard task for Gradle (see {@link BuildSystem}). A repository
+ * with no supported build file has nothing to verify and is skipped, mirroring
  * {@link EnforcerStep}.
  */
 public class VerifyStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(VerifyStep.class);
 
-	static final List<String> DEFAULT_COMMAND = List.of("mvn", "-q", "-N", "validate");
-
-	private static final String POM = "pom.xml";
-
-	private final List<String> mavenCommand;
+	private final List<BuildSystem> buildSystems;
 
 	public VerifyStep() {
-		this(DEFAULT_COMMAND);
+		this(BuildSystems.DEFAULTS);
 	}
 
-	public VerifyStep(List<String> mavenCommand) {
-		this.mavenCommand = List.copyOf(mavenCommand);
+	public VerifyStep(List<BuildSystem> buildSystems) {
+		this.buildSystems = List.copyOf(buildSystems);
 	}
 
 	@Override
@@ -49,12 +40,17 @@ public class VerifyStep extends AbstractCommandStep {
 
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
-		Path pomFile = context.repositoryDirectory().resolve(POM);
-		if (Files.isRegularFile(pomFile)) {
-			log.info("Verifying the enforcer passes in {}", context.repositoryDirectory());
-			runOrFail(runner, context.repositoryDirectory(), mavenCommand);
-		} else {
-			log.warn("No {} in {}; skipping build verification", POM, context.repositoryDirectory());
-		}
+		Path repositoryDirectory = context.repositoryDirectory();
+		Optional<BuildSystem> buildSystem = BuildSystems.detect(buildSystems, repositoryDirectory);
+		buildSystem.ifPresentOrElse(
+				detected -> verify(detected, context, runner),
+				() -> log.warn("No supported build system ({}) in {}; skipping build verification",
+						BuildSystems.names(buildSystems), repositoryDirectory));
+	}
+
+	private void verify(BuildSystem buildSystem, AdoptionContext context, CommandRunner runner) {
+		log.info("Verifying the CLAUDE.md guard passes with {} in {}", buildSystem.name(),
+				context.repositoryDirectory());
+		runOrFail(runner, context.repositoryDirectory(), buildSystem.verifyCommand());
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -1,0 +1,65 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class BuildSystemsTest {
+
+	@Test
+	void detectsMavenFromPom(@TempDir Path directory) throws IOException {
+		Files.writeString(directory.resolve("pom.xml"), "<project/>");
+		Optional<BuildSystem> detected = BuildSystems.detect(BuildSystems.DEFAULTS, directory);
+		assertEquals("maven", detected.orElseThrow().name());
+	}
+
+	@Test
+	void detectsGradleFromGroovyBuildFile(@TempDir Path directory) throws IOException {
+		Files.writeString(directory.resolve("build.gradle"), "plugins { id 'java' }\n");
+		Optional<BuildSystem> detected = BuildSystems.detect(BuildSystems.DEFAULTS, directory);
+		assertEquals("gradle", detected.orElseThrow().name());
+	}
+
+	@Test
+	void detectsGradleFromKotlinBuildFile(@TempDir Path directory) throws IOException {
+		Files.writeString(directory.resolve("build.gradle.kts"), "plugins { java }\n");
+		Optional<BuildSystem> detected = BuildSystems.detect(BuildSystems.DEFAULTS, directory);
+		assertEquals("gradle", detected.orElseThrow().name());
+	}
+
+	@Test
+	void prefersMavenWhenBothBuildFilesArePresent(@TempDir Path directory) throws IOException {
+		Files.writeString(directory.resolve("pom.xml"), "<project/>");
+		Files.writeString(directory.resolve("build.gradle"), "plugins { id 'java' }\n");
+		Optional<BuildSystem> detected = BuildSystems.detect(BuildSystems.DEFAULTS, directory);
+		assertEquals("maven", detected.orElseThrow().name());
+	}
+
+	@Test
+	void detectsNothingForAnUnsupportedProject(@TempDir Path directory) {
+		assertTrue(BuildSystems.detect(BuildSystems.DEFAULTS, directory).isEmpty());
+	}
+
+	@Test
+	void listsBuildSystemNames() {
+		assertEquals("maven/gradle", BuildSystems.names(BuildSystems.DEFAULTS));
+	}
+
+	@Test
+	void mavenVerifyCommandIsANonRecursiveValidate() {
+		assertEquals(List.of("mvn", "-q", "-N", "validate"), new MavenBuildSystem().verifyCommand());
+	}
+
+	@Test
+	void gradleVerifyCommandRunsTheGuardTask() {
+		assertEquals(List.of("gradle", "-q", "enforceClaudeMd"), new GradleBuildSystem().verifyCommand());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
@@ -42,7 +42,25 @@ class EnforcerStepTest {
 	}
 
 	@Test
-	void skipsWhenNotAMavenProject(@TempDir Path workspace) throws IOException {
+	void wiresGuardIntoAGroovyGradleBuild(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		Path buildFile = context.repositoryDirectory().resolve("build.gradle");
+		Files.writeString(buildFile, "plugins { id 'java' }\n");
+		new EnforcerStep().execute(context, new RecordingCommandRunner());
+		assertTrue(Files.readString(buildFile).contains("enforceClaudeMd"));
+	}
+
+	@Test
+	void wiresGuardIntoAKotlinGradleBuild(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		Path buildFile = context.repositoryDirectory().resolve("build.gradle.kts");
+		Files.writeString(buildFile, "plugins { java }\n");
+		new EnforcerStep().execute(context, new RecordingCommandRunner());
+		assertTrue(Files.readString(buildFile).contains("enforceClaudeMd"));
+	}
+
+	@Test
+	void skipsWhenNoSupportedBuildFileIsPresent(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
 		assertDoesNotThrow(() -> new EnforcerStep().execute(context, new RecordingCommandRunner()));
 		assertFalse(Files.exists(context.repositoryDirectory().resolve("pom.xml")));

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
@@ -1,0 +1,48 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class GradleGuardInstallerTest {
+
+	private final GradleGuardInstaller installer = new GradleGuardInstaller();
+
+	@Test
+	void appendsGroovyGuardToBuildGradle(@TempDir Path directory) throws IOException {
+		Path buildFile = directory.resolve("build.gradle");
+		Files.writeString(buildFile, "plugins { id 'java' }\n");
+		assertTrue(installer.install(buildFile));
+		String content = Files.readString(buildFile);
+		assertTrue(content.contains("tasks.register('enforceClaudeMd')"));
+		assertTrue(content.contains("throw new GradleException('CLAUDE.md is missing or empty')"));
+		assertTrue(content.startsWith("plugins { id 'java' }"));
+	}
+
+	@Test
+	void appendsKotlinGuardToBuildGradleKts(@TempDir Path directory) throws IOException {
+		Path buildFile = directory.resolve("build.gradle.kts");
+		Files.writeString(buildFile, "plugins { java }\n");
+		assertTrue(installer.install(buildFile));
+		String content = Files.readString(buildFile);
+		assertTrue(content.contains("tasks.register(\"enforceClaudeMd\")"));
+		assertTrue(content.contains("val claudeMd = file(\"$projectDir/CLAUDE.md\")"));
+	}
+
+	@Test
+	void leavesAnAlreadyGuardedBuildUnchanged(@TempDir Path directory) throws IOException {
+		Path buildFile = directory.resolve("build.gradle");
+		Files.writeString(buildFile, "plugins { id 'java' }\n");
+		installer.install(buildFile);
+		String afterFirstInstall = Files.readString(buildFile);
+		assertFalse(installer.install(buildFile));
+		assertEquals(afterFirstInstall, Files.readString(buildFile));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestOptionsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestOptionsTest.java
@@ -1,0 +1,70 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class PullRequestOptionsTest {
+
+	@Test
+	void defaultsCarryTheAdoptionTitleAndRequestNobody() {
+		PullRequestOptions options = PullRequestOptions.defaults();
+		assertEquals(PullRequestOptions.DEFAULT_TITLE, options.title());
+		assertEquals(PullRequestOptions.DEFAULT_BODY, options.body());
+		assertTrue(options.reviewers().isEmpty());
+		assertTrue(options.labels().isEmpty());
+		assertTrue(options.assignees().isEmpty());
+		assertFalse(options.draft());
+	}
+
+	@Test
+	void builderSetsEveryField() {
+		PullRequestOptions options = PullRequestOptions.builder()
+				.title("Title")
+				.body("Body")
+				.reviewers(List.of("octocat"))
+				.labels(List.of("automation"))
+				.assignees(List.of("adamw7"))
+				.draft(true)
+				.build();
+		assertEquals("Title", options.title());
+		assertEquals("Body", options.body());
+		assertEquals(List.of("octocat"), options.reviewers());
+		assertEquals(List.of("automation"), options.labels());
+		assertEquals(List.of("adamw7"), options.assignees());
+		assertTrue(options.draft());
+	}
+
+	@Test
+	void trimsTitleAndBody() {
+		PullRequestOptions options = PullRequestOptions.builder().title("  Title  ").body("  Body  ").build();
+		assertEquals("Title", options.title());
+		assertEquals("Body", options.body());
+	}
+
+	@Test
+	void rejectsBlankTitle() {
+		PullRequestOptions.Builder builder = PullRequestOptions.builder().title(" ");
+		assertThrows(IllegalArgumentException.class, builder::build);
+	}
+
+	@Test
+	void rejectsBlankBody() {
+		PullRequestOptions.Builder builder = PullRequestOptions.builder().body("");
+		assertThrows(IllegalArgumentException.class, builder::build);
+	}
+
+	@Test
+	void defensivelyCopiesReviewers() {
+		List<String> reviewers = new ArrayList<>(List.of("octocat"));
+		PullRequestOptions options = PullRequestOptions.builder().reviewers(reviewers).build();
+		reviewers.add("hubot");
+		assertEquals(List.of("octocat"), options.reviewers());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -25,8 +25,8 @@ class PullRequestStepTest {
 		step.execute(context, runner);
 		assertEquals(List.of("gh", "pr", "view", "claude/adopt-claude-code", "--json", "url"),
 				runner.commandAt(0));
-		assertEquals(List.of("gh", "pr", "create", "--title", PullRequestStep.DEFAULT_TITLE, "--body",
-				PullRequestStep.DEFAULT_BODY, "--head", "claude/adopt-claude-code"), runner.commandAt(1));
+		assertEquals(List.of("gh", "pr", "create", "--title", PullRequestOptions.DEFAULT_TITLE, "--body",
+				PullRequestOptions.DEFAULT_BODY, "--head", "claude/adopt-claude-code"), runner.commandAt(1));
 		assertEquals(context.repositoryDirectory(), runner.invocations().get(1).workingDirectory());
 	}
 
@@ -36,6 +36,23 @@ class PullRequestStepTest {
 		new PullRequestStep("My title", "My body").execute(context, runner);
 		assertEquals(List.of("gh", "pr", "create", "--title", "My title", "--body", "My body", "--head",
 				"claude/adopt-claude-code"), runner.commandAt(1));
+	}
+
+	@Test
+	void requestsReviewersLabelsAssigneesAndOpensAsDraft() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::noExistingPullRequest);
+		PullRequestOptions options = PullRequestOptions.builder()
+				.title("My title")
+				.body("My body")
+				.reviewers(List.of("octocat", "hubot"))
+				.labels(List.of("automation"))
+				.assignees(List.of("adamw7"))
+				.draft(true)
+				.build();
+		new PullRequestStep(options).execute(context, runner);
+		assertEquals(List.of("gh", "pr", "create", "--title", "My title", "--body", "My body", "--head",
+				"claude/adopt-claude-code", "--draft", "--reviewer", "octocat", "--reviewer", "hubot", "--label",
+				"automation", "--assignee", "adamw7"), runner.commandAt(1));
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
@@ -34,17 +34,27 @@ class VerifyStepTest {
 		writePom(context);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new VerifyStep().execute(context, runner);
-		assertEquals(VerifyStep.DEFAULT_COMMAND, runner.commandAt(0));
+		assertEquals(MavenBuildSystem.VERIFY_COMMAND, runner.commandAt(0));
 		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
 	}
 
 	@Test
-	void runsConfiguredMavenCommand(@TempDir Path workspace) throws IOException {
+	void runsGradleGuardTaskForAGradleCheckout(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		Files.writeString(context.repositoryDirectory().resolve("build.gradle"), "plugins { id 'java' }\n");
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new VerifyStep().execute(context, runner);
+		assertEquals(GradleBuildSystem.VERIFY_COMMAND, runner.commandAt(0));
+	}
+
+	@Test
+	void runsTheDetectedBuildSystemsVerifyCommand(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
 		writePom(context);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
-		new VerifyStep(List.of("mvn", "verify")).execute(context, runner);
-		assertEquals(List.of("mvn", "verify"), runner.commandAt(0));
+		BuildSystem custom = new FakeBuildSystem(List.of("just", "verify"));
+		new VerifyStep(List.of(custom)).execute(context, runner);
+		assertEquals(List.of("just", "verify"), runner.commandAt(0));
 	}
 
 	@Test
@@ -57,7 +67,7 @@ class VerifyStepTest {
 	}
 
 	@Test
-	void skipsWhenNotAMavenProject(@TempDir Path workspace) throws IOException {
+	void skipsWhenNoSupportedBuildFileIsPresent(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new VerifyStep().execute(context, runner);
@@ -67,5 +77,34 @@ class VerifyStepTest {
 	@Test
 	void isNamedVerify() {
 		assertEquals("verify", new VerifyStep().name());
+	}
+
+	private static final class FakeBuildSystem implements BuildSystem {
+
+		private final List<String> verifyCommand;
+
+		private FakeBuildSystem(List<String> verifyCommand) {
+			this.verifyCommand = verifyCommand;
+		}
+
+		@Override
+		public String name() {
+			return "fake";
+		}
+
+		@Override
+		public boolean matches(Path repositoryDirectory) {
+			return true;
+		}
+
+		@Override
+		public boolean install(Path repositoryDirectory) {
+			return true;
+		}
+
+		@Override
+		public List<String> verifyCommand() {
+			return verifyCommand;
+		}
 	}
 }


### PR DESCRIPTION
Introduce a BuildSystem abstraction so EnforcerStep and VerifyStep detect
the checkout's build tool instead of assuming Maven. Maven keeps the full
claude-code-enforcer rule wired into pom.xml; Gradle projects (Groovy or
Kotlin DSL) get an idempotent enforceClaudeMd presence guard task appended
to the build script and verified by running that task. A repository with no
supported build file is still skipped with a warning.

Add PullRequestOptions so PullRequestStep can request reviewers, labels, and
assignees and open the pull request as a draft, replacing the title/body-only
configuration while keeping the existing constructors.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PDsmxiQWbMGxCZrmyBcwPs