### PR TITLE
fix(adopt): wire the CLAUDE.md guard generically so verification passes on any repo

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -31,8 +31,11 @@ import io.github.adamw7.tools.adopt.AdoptionException;
 /**
  * Adds the {@code claude-code-enforcer} to a Maven project's {@code pom.xml} by
  * wiring the {@code maven-enforcer-plugin} with the {@code claudeMdFormat} rule,
- * so the adopted repository fails its build if the freshly generated
- * {@code CLAUDE.md} is missing or malformed.
+ * so the adopted repository fails its build if the generated {@code CLAUDE.md}
+ * is missing, empty, or loses its {@code # CLAUDE.md} title. The rule is
+ * configured generically — its project-specific section and {@code AGENTS.md}
+ * checks are switched off (see {@link #claudeMdConfiguration}) — so the guard
+ * fits any adopted repository rather than only one shaped like this project.
  *
  * <p>The edit is performed on the JDK's DOM so no third-party XML library is
  * needed, is namespace-aware so the new elements join the POM's default
@@ -186,11 +189,23 @@ public class PomEnforcerInstaller {
 		return execution;
 	}
 
+	/**
+	 * Wires the rule to guard only the structure that is predictable for a
+	 * {@code CLAUDE.md} generated afresh in an arbitrary repository: it exists, is
+	 * non-empty, and starts with the {@code # CLAUDE.md} title. The rule's
+	 * project-specific defaults — this project's required section headings and its
+	 * {@code AGENTS.md} reference — are switched off, because the file
+	 * {@code claude init} produces for the adopted repository will not carry them,
+	 * so leaving them on would fail the verification the adoption runs before it
+	 * ever pushes a branch.
+	 */
 	private Element claudeMdConfiguration(Document document) {
 		Element configuration = create(document, "configuration");
 		Element rules = create(document, "rules");
 		Element claudeMdFormat = create(document, "claudeMdFormat");
 		appendText(document, claudeMdFormat, "claudeMdFile", CLAUDE_MD_FILE);
+		appendText(document, claudeMdFormat, "enforceRequiredSections", "false");
+		appendText(document, claudeMdFormat, "requireAgentsReference", "false");
 		rules.appendChild(claudeMdFormat);
 		configuration.appendChild(rules);
 		return configuration;

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -138,6 +138,17 @@ class PomEnforcerInstallerTest {
 	}
 
 	@Test
+	void configuresTheRuleGenericallyForAnArbitraryRepository(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_BUILD);
+		installer.install(pom);
+		String result = Files.readString(pom);
+		assertTrue(result.contains("<enforceRequiredSections>false</enforceRequiredSections>"),
+				"the adopted repo's CLAUDE.md will not carry this project's section headings");
+		assertTrue(result.contains("<requireAgentsReference>false</requireAgentsReference>"),
+				"the adopted repo's CLAUDE.md will not reference AGENTS.md");
+	}
+
+	@Test
 	void augmentsExistingEnforcerPluginInsteadOfSkipping(@TempDir Path dir) throws IOException {
 		Path pom = write(dir, POM_WITH_ENFORCER);
 		assertTrue(installer.install(pom));

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
@@ -13,6 +13,14 @@ import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
  * not follow the expected structure: it must start with the {@code # CLAUDE.md}
  * title, reference {@code AGENTS.md}, and contain every required section
  * heading.
+ *
+ * <p>The {@code AGENTS.md} reference requirement is on by default but can be
+ * switched off with {@code requireAgentsReference}, and the required-section
+ * check can be switched off with the inherited {@code enforceRequiredSections}
+ * (see {@link io.github.adamw7.tools.enforcer.rule.MarkdownFormatRule}). With
+ * both off the rule guards only the mandatory structure — exists, non-empty,
+ * {@code # CLAUDE.md} title — which is all that is predictable for a
+ * {@code CLAUDE.md} generated afresh for an arbitrary adopted repository.
  */
 @Named("claudeMdFormat")
 public class ClaudeMdFormatRule extends MarkdownFormatRule {
@@ -30,6 +38,9 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 
 	/** The {@code CLAUDE.md} file to validate. Injected from the rule configuration. */
 	private File claudeMdFile;
+
+	/** When false, the {@code AGENTS.md} reference requirement is skipped. */
+	private boolean requireAgentsReference = true;
 
 	@Override
 	protected File documentFile() {
@@ -53,13 +64,17 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 
 	@Override
 	protected void collectAdditionalViolations(MarkdownDocument document, List<String> violations) {
-		if (!document.containsOutsideFences(AGENTS_REFERENCE)) {
+		if (requireAgentsReference && !document.containsOutsideFences(AGENTS_REFERENCE)) {
 			violations.add("CLAUDE.md must reference " + AGENTS_REFERENCE + " as the source of truth");
 		}
 	}
 
 	void setClaudeMdFile(File claudeMdFile) {
 		this.claudeMdFile = claudeMdFile;
+	}
+
+	public void setRequireAgentsReference(boolean requireAgentsReference) {
+		this.requireAgentsReference = requireAgentsReference;
 	}
 
 	@Override

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -31,6 +31,12 @@ import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
  * resolve to something on disk. Each is disabled by default, so existing
  * configurations are unaffected.
  * <p>
+ * The required-section check can also be switched off entirely with
+ * {@code enforceRequiredSections}, leaving only the mandatory structure (exists,
+ * non-empty, title heading). That lets the rule guard a document whose section
+ * layout is not fixed — for example a {@code CLAUDE.md} generated afresh for an
+ * arbitrary adopted repository, where only the title is predictable.
+ * <p>
  * The title and required sections default to the subclass-provided values but
  * can be overridden from the rule configuration, so the rule is reusable across
  * projects without a recompile. Subclasses contribute the file, its name, the
@@ -46,6 +52,9 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 
 	/** Optional override for the required sections. Falls back to the subclass default. */
 	private List<String> requiredSections;
+
+	/** When false, the required-section check is skipped and only the title structure is enforced. */
+	private boolean enforceRequiredSections = true;
 
 	/** Optional tokens that must not appear outside fenced code blocks. */
 	private List<String> forbiddenTokens;
@@ -117,6 +126,10 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 		this.requiredSections = requiredSections;
 	}
 
+	public void setEnforceRequiredSections(boolean enforceRequiredSections) {
+		this.enforceRequiredSections = enforceRequiredSections;
+	}
+
 	public void setForbiddenTokens(List<String> forbiddenTokens) {
 		this.forbiddenTokens = forbiddenTokens;
 	}
@@ -151,6 +164,9 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private void collectSectionViolations(MarkdownDocument document, List<String> violations) {
+		if (!enforceRequiredSections) {
+			return;
+		}
 		for (String section : requiredSections()) {
 			addSectionViolation(document, section, violations);
 		}
@@ -170,7 +186,7 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	 * reported by the section check, so only the present ones are compared here.
 	 */
 	private void collectOrderViolations(MarkdownDocument document, List<String> violations) {
-		if (!enforceSectionOrder) {
+		if (!enforceSectionOrder || !enforceRequiredSections) {
 			return;
 		}
 		List<String> expected = presentRequiredSections(document);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -101,6 +101,49 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
+	void passesGenericFileWhenSectionsAndAgentsReferenceDisabled() {
+		String generic = """
+				# CLAUDE.md
+
+				This file guides Claude Code when working in this repository.
+
+				## Build
+				Run the project's build to compile and test.
+				""";
+		ClaudeMdFormatRule rule = ruleFor(generic);
+		rule.setEnforceRequiredSections(false);
+		rule.setRequireAgentsReference(false);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void stillEnforcesTitleWhenSectionsAndAgentsReferenceDisabled() {
+		ClaudeMdFormatRule rule = ruleFor("# Not the title\n\nSome content.\n");
+		rule.setEnforceRequiredSections(false);
+		rule.setRequireAgentsReference(false);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("title heading"), exception.getMessage());
+	}
+
+	@Test
+	void skipsAgentsReferenceCheckWhenDisabled() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("AGENTS.md", "OTHER.md"));
+		rule.setRequireAgentsReference(false);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void skipsMissingSectionWhenRequiredSectionsDisabled() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "## Quality"));
+		rule.setEnforceRequiredSections(false);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
 	void failsWhenARequiredSectionIsMissing() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "## Quality"));
 


### PR DESCRIPTION
The adoption wired the claudeMdFormat rule with only claudeMdFile, so it fell
back to this project's defaults: the tools-specific required section headings
(## Project, ## Java version, ## Maven, ...) and a mandatory AGENTS.md
reference. A CLAUDE.md generated by `claude init` for an arbitrary adopted repo
carries neither, so VerifyStep's `mvn -N validate` failed and aborted the
adoption before it could push a branch or open a pull request — defeating the
module's purpose of adopting Claude Code into any GitHub repository.

Make the two project-specific checks switchable:
- MarkdownFormatRule gains enforceRequiredSections (default true) to skip the
  required-section (and dependent order) check.
- ClaudeMdFormatRule gains requireAgentsReference (default true) to skip the
  AGENTS.md reference check.

Both default to true, so this repo's own strict enforcement is unchanged.
PomEnforcerInstaller now wires both off, so the adopted repo's guard checks only
the universal structure: CLAUDE.md exists, is non-empty, and starts with the
`# CLAUDE.md` title (which `claude init` always produces).

Verified end-to-end: a generic CLAUDE.md passes `mvn -N validate` with the
toggles off and fails with them on.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EGo7dA76NyU2CfmeKZfBSf