### PR TITLE
test(arch): add cross-cutting, module-specific, and test-convention ArchUnit rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,16 +241,21 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
   cannot rot: data-source contracts in `source.interfaces` must not depend on
   their `source.db`/`source.file` implementations; the uniqueness core must not
   depend on its MCP adapter; the `structure` collections stay decoupled from data
-  sources; loggers are `private static final`; abstract types carry an `Abstract`
-  prefix; public fields are `final`; and production code logs through log4j2
-  (never `System.out`/`err`, `java.util.logging`, `printStackTrace`, or
-  `System.exit`), with packages kept free of cycles. New code must satisfy these
-  rules or the module's test suite fails. A companion
+  sources; JDBC (`java.sql`) stays confined to the `source.db` package; loggers
+  are `private static final`; abstract types carry an `Abstract` prefix; public
+  fields are `final`; mutable static state is `volatile` (so its updates publish
+  across threads); fields are never `Optional` (Optional models a return value,
+  not a field); date and time handling uses `java.time` (never the legacy
+  `Date`/`Calendar` API); and production code logs through log4j2 (never
+  `System.out`/`err`, `java.util.logging`, `java.lang.System.Logger`,
+  `printStackTrace`, or `System.exit`), with packages kept free of cycles. New
+  code must satisfy these rules or the module's test suite fails. A companion
   `TestConventionsArchitectureTest` in the same `...architecture` package
   analyses only the *test* classes (via `ImportOption.OnlyIncludeTests`) and pins
   conventions on the tests themselves: every `@Testable` method must live in a
   `*Test` or `*IT` class so surefire/failsafe actually runs it, no test is
-  `@Disabled`, tests use JUnit 5 only (no JUnit 4 `org.junit` API), and no test
+  `@Disabled`, tests use JUnit 5 only (no JUnit 4 `org.junit` API), no test
+  writes to `System.out`/`err` (assert on the value instead), and no test
   calls `Thread.sleep` (sleeping is slow and flaky — wait on a condition).
 - **MCP integration tests** are gated behind the `integration-tests` profile
   (defined in `data` and `code/context`) and exercise the MCP servers over

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,12 +116,15 @@ paths.
 - **Architecture tests** (ArchUnit) live in each module's `.architecture` test
   package and enforce package layering and coding rules — data-source contracts
   must not depend on their implementations, the uniqueness core must not depend
-  on its MCP adapter, loggers are `private static final`, production code logs
-  through log4j2 (no `System.out`/`err`, `printStackTrace`, or `System.exit`),
-  and packages stay free of cycles. A companion `TestConventionsArchitectureTest`
-  pins conventions on the tests themselves — test methods must sit in `*Test`/`*IT`
-  classes, no `@Disabled`, JUnit 5 only, and no `Thread.sleep`. Keep new code
-  within these rules.
+  on its MCP adapter, JDBC stays confined to the `source.db` package, loggers are
+  `private static final`, mutable static state is `volatile`, fields are never
+  `Optional`, date/time uses `java.time` (not the legacy `Date`/`Calendar` API),
+  production code logs through log4j2 (no `System.out`/`err`,
+  `java.lang.System.Logger`, `printStackTrace`, or `System.exit`), and packages
+  stay free of cycles. A companion `TestConventionsArchitectureTest` pins
+  conventions on the tests themselves — test methods must sit in `*Test`/`*IT`
+  classes, no `@Disabled`, JUnit 5 only, no `System.out`/`err`, and no
+  `Thread.sleep`. Keep new code within these rules.
 - **MCP integration tests** (`*IT`) are gated behind the `integration-tests`
   profile.
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
@@ -3,10 +3,12 @@ package io.github.adamw7.tools.adopt.architecture;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.util.Optional;
 
 import org.apache.logging.log4j.Logger;
 
@@ -48,6 +50,13 @@ public class AdoptArchitectureTest {
 			.because("every concrete *Step must honour the AdoptionStep contract");
 
 	@ArchTest
+	static final ArchRule adoptionStepsResideInStepPackage = classes()
+			.that().areAssignableTo(AdoptionStep.class)
+			.and().areNotInterfaces()
+			.should().resideInAPackage(STEP_PACKAGE)
+			.because("every adoption step belongs to the step package that defines the pipeline");
+
+	@ArchTest
 	static final ArchRule abstractTypesArePrefixed = classes()
 			.that().haveModifier(JavaModifier.ABSTRACT).and().areNotInterfaces()
 			.should().haveSimpleNameStartingWith("Abstract")
@@ -77,6 +86,38 @@ public class AdoptArchitectureTest {
 			.should().beFinal()
 			.because("a public field is part of the type's API surface and must not be reassignable")
 			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule mutableStaticStateIsVolatile = fields()
+			.that().areStatic()
+			.and().areNotFinal()
+			.should().haveModifier(JavaModifier.VOLATILE)
+			.because("a mutable static field is shared across every thread, so it must be volatile "
+					+ "for its updates to publish safely")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule optionalFieldsAreForbidden = noFields()
+			.should().haveRawType(Optional.class)
+			.because("Optional models a possibly-absent return value, not a field; a field should hold "
+					+ "the value itself and be null-checked, never wrapped in an Optional")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule noLegacyDateTimeApi = noClasses()
+			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
+			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
+			.because("logging must go through log4j2 so configuration stays in one place");
 
 	@ArchTest
 	static final ArchRule noPrintStackTrace = noClasses()

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/TestConventionsArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/TestConventionsArchitectureTest.java
@@ -58,6 +58,13 @@ public class TestConventionsArchitectureTest {
 			.because("a test that sleeps is slow and flaky; wait on a condition instead");
 
 	@ArchTest
+	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
+			.should().accessField(System.class, "out")
+			.orShould().accessField(System.class, "err")
+			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
+			.allowEmptyShould(true);
+
+	@ArchTest
 	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
 			.that().areAnnotatedWith(BeforeAll.class)
 			.or().areAnnotatedWith(AfterAll.class)

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
@@ -3,12 +3,15 @@ package io.github.adamw7.tools.enforcer.architecture;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.util.Optional;
 
+import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -56,7 +59,7 @@ public class EnforcerArchitectureTest {
 	static final ArchRule concreteRulesHonourTheContract = classes()
 			.that().haveSimpleNameEndingWith("Rule")
 			.and().areNotInterfaces()
-			.and().doNotHaveModifier(com.tngtech.archunit.core.domain.JavaModifier.ABSTRACT)
+			.and().doNotHaveModifier(JavaModifier.ABSTRACT)
 			.should().beAssignableTo(ClaudeCodeEnforcerRule.class)
 			.because("every concrete *Rule is an enforcer rule and must extend the shared base");
 
@@ -73,6 +76,38 @@ public class EnforcerArchitectureTest {
 			.should().beFinal()
 			.because("a public field is part of the type's API surface and must not be reassignable")
 			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule mutableStaticStateIsVolatile = fields()
+			.that().areStatic()
+			.and().areNotFinal()
+			.should().haveModifier(JavaModifier.VOLATILE)
+			.because("a mutable static field is shared across every thread, so it must be volatile "
+					+ "for its updates to publish safely")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule optionalFieldsAreForbidden = noFields()
+			.should().haveRawType(Optional.class)
+			.because("Optional models a possibly-absent return value, not a field; a field should hold "
+					+ "the value itself and be null-checked, never wrapped in an Optional")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule noLegacyDateTimeApi = noClasses()
+			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
+			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
+			.because("logging must go through log4j2 so configuration stays in one place");
 
 	@ArchTest
 	static final ArchRule noAccessToStandardStreams =

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/TestConventionsArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/TestConventionsArchitectureTest.java
@@ -59,6 +59,13 @@ public class TestConventionsArchitectureTest {
 			.because("a test that sleeps is slow and flaky; wait on a condition instead");
 
 	@ArchTest
+	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
+			.should().accessField(System.class, "out")
+			.orShould().accessField(System.class, "err")
+			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
+			.allowEmptyShould(true);
+
+	@ArchTest
 	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
 			.that().areAnnotatedWith(BeforeAll.class)
 			.or().areAnnotatedWith(AfterAll.class)

--- a/code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java
@@ -3,10 +3,12 @@ package io.github.adamw7.context.architecture;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.util.Optional;
 
 import org.apache.logging.log4j.Logger;
 
@@ -73,6 +75,38 @@ public class ContextArchitectureTest {
 			.should().beFinal()
 			.because("a public field is part of the type's API surface and must not be reassignable")
 			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule mutableStaticStateIsVolatile = fields()
+			.that().areStatic()
+			.and().areNotFinal()
+			.should().haveModifier(JavaModifier.VOLATILE)
+			.because("a mutable static field is shared across every thread, so it must be volatile "
+					+ "for its updates to publish safely")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule optionalFieldsAreForbidden = noFields()
+			.should().haveRawType(Optional.class)
+			.because("Optional models a possibly-absent return value, not a field; a field should hold "
+					+ "the value itself and be null-checked, never wrapped in an Optional")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule noLegacyDateTimeApi = noClasses()
+			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
+			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
+			.because("logging must go through log4j2 so configuration stays in one place");
 
 	@ArchTest
 	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()

--- a/code/context/src/test/java/io/github/adamw7/context/architecture/TestConventionsArchitectureTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/architecture/TestConventionsArchitectureTest.java
@@ -59,6 +59,13 @@ public class TestConventionsArchitectureTest {
 			.because("a test that sleeps is slow and flaky; wait on a condition instead");
 
 	@ArchTest
+	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
+			.should().accessField(System.class, "out")
+			.orShould().accessField(System.class, "err")
+			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
+			.allowEmptyShould(true);
+
+	@ArchTest
 	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
 			.that().areAnnotatedWith(BeforeAll.class)
 			.or().areAnnotatedWith(AfterAll.class)

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/ProtogenArchitectureTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/ProtogenArchitectureTest.java
@@ -3,10 +3,12 @@ package io.github.adamw7.tools.code.architecture;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.util.Optional;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.maven.plugin.Mojo;
@@ -67,6 +69,38 @@ public class ProtogenArchitectureTest {
 			.should().beFinal()
 			.because("a public field is part of the type's API surface and must not be reassignable")
 			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule mutableStaticStateIsVolatile = fields()
+			.that().areStatic()
+			.and().areNotFinal()
+			.should().haveModifier(JavaModifier.VOLATILE)
+			.because("a mutable static field is shared across every thread, so it must be volatile "
+					+ "for its updates to publish safely")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule optionalFieldsAreForbidden = noFields()
+			.should().haveRawType(Optional.class)
+			.because("Optional models a possibly-absent return value, not a field; a field should hold "
+					+ "the value itself and be null-checked, never wrapped in an Optional")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule noLegacyDateTimeApi = noClasses()
+			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
+			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
+			.because("logging must go through log4j2 so configuration stays in one place");
 
 	@ArchTest
 	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/TestConventionsArchitectureTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/TestConventionsArchitectureTest.java
@@ -59,6 +59,13 @@ public class TestConventionsArchitectureTest {
 			.because("a test that sleeps is slow and flaky; wait on a condition instead");
 
 	@ArchTest
+	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
+			.should().accessField(System.class, "out")
+			.orShould().accessField(System.class, "err")
+			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
+			.allowEmptyShould(true);
+
+	@ArchTest
 	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
 			.that().areAnnotatedWith(BeforeAll.class)
 			.or().areAnnotatedWith(AfterAll.class)

--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
@@ -5,11 +5,13 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.util.Optional;
 
 import org.apache.logging.log4j.Logger;
 
@@ -91,6 +93,38 @@ public class DataArchitectureTest {
 			.that().arePublic()
 			.should().beFinal()
 			.because("a public field is part of the type's API surface and must not be reassignable");
+
+	@ArchTest
+	static final ArchRule mutableStaticStateIsVolatile = fields()
+			.that().areStatic()
+			.and().areNotFinal()
+			.should().haveModifier(JavaModifier.VOLATILE)
+			.because("a mutable static field is shared across every thread, so it must be volatile "
+					+ "for its updates to publish safely — as Switch.isOff and PathValidator.allowedBaseDir already are")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule optionalFieldsAreForbidden = noFields()
+			.should().haveRawType(Optional.class)
+			.because("Optional models a possibly-absent return value, not a field; a field should hold "
+					+ "the value itself and be null-checked, never wrapped in an Optional")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule noLegacyDateTimeApi = noClasses()
+			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
+			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule jdbcStaysInTheDbPackage = noClasses()
+			.that().resideOutsideOfPackage(DB_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage("java.sql..")
+			.because("JDBC is an implementation detail of the db data sources; no other package may touch java.sql");
 
 	@ArchTest
 	static final ArchRule productionCodeDoesNotUseStandardStreams = noClasses()

--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/TestConventionsArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/TestConventionsArchitectureTest.java
@@ -59,6 +59,13 @@ public class TestConventionsArchitectureTest {
 			.because("a test that sleeps is slow and flaky; wait on a condition instead");
 
 	@ArchTest
+	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
+			.should().accessField(System.class, "out")
+			.orShould().accessField(System.class, "err")
+			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
+			.allowEmptyShould(true);
+
+	@ArchTest
 	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
 			.that().areAnnotatedWith(BeforeAll.class)
 			.or().areAnnotatedWith(AfterAll.class)

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/McpCommonArchitectureTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/McpCommonArchitectureTest.java
@@ -3,9 +3,11 @@ package io.github.adamw7.tools.mcp.architecture;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.util.Optional;
 
 import org.apache.logging.log4j.Logger;
 
@@ -59,6 +61,38 @@ public class McpCommonArchitectureTest {
 			.should().beFinal()
 			.because("a public field is part of the type's API surface and must not be reassignable")
 			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule mutableStaticStateIsVolatile = fields()
+			.that().areStatic()
+			.and().areNotFinal()
+			.should().haveModifier(JavaModifier.VOLATILE)
+			.because("a mutable static field is shared across every thread, so it must be volatile "
+					+ "for its updates to publish safely")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule optionalFieldsAreForbidden = noFields()
+			.should().haveRawType(Optional.class)
+			.because("Optional models a possibly-absent return value, not a field; a field should hold "
+					+ "the value itself and be null-checked, never wrapped in an Optional")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule noLegacyDateTimeApi = noClasses()
+			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
+			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
+			.because("logging must go through log4j2 so configuration stays in one place");
 
 	@ArchTest
 	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/TestConventionsArchitectureTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/TestConventionsArchitectureTest.java
@@ -59,6 +59,13 @@ public class TestConventionsArchitectureTest {
 			.because("a test that sleeps is slow and flaky; wait on a condition instead");
 
 	@ArchTest
+	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
+			.should().accessField(System.class, "out")
+			.orShould().accessField(System.class, "err")
+			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
+			.allowEmptyShould(true);
+
+	@ArchTest
 	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
 			.that().areAnnotatedWith(BeforeAll.class)
 			.or().areAnnotatedWith(AfterAll.class)


### PR DESCRIPTION
Broaden the ArchUnit coverage across every module while pinning conventions the
code already follows:

Cross-cutting (all six production architecture tests):
- mutableStaticStateIsVolatile: a non-final static field must be volatile so its
  updates publish across threads (Switch.isOff, PathValidator.allowedBaseDir).
- optionalFieldsAreForbidden: Optional models an absent return value, not a field.
- noLegacyDateTimeApi: date/time must use java.time, not Date/Calendar/DateFormat.
- productionCodeLogsThroughLog4j: propagated the System.Logger + java.util.logging
  ban to the five modules that lacked it (data already had it).

Module-specific:
- data: jdbcStaysInTheDbPackage confines java.sql to the source.db package.
- adopt: adoptionStepsResideInStepPackage keeps every AdoptionStep in step.

Test conventions (all six TestConventionsArchitectureTest):
- testsDoNotAccessStandardStreams: a test must assert, not print to the console.

Also cleaned up the enforcer test's inline JavaModifier reference to use the
import, and updated the ArchUnit descriptions in AGENTS.md and CLAUDE.md to match.

Intentionally skipped rules that would force out-of-scope refactors rather than
pin an existing convention: an Abstract-prefix rule for the enforcer's abstract
*Rule classes, a static-logger requirement for context's deliberately per-subclass
logger, an I-prefix interface ban (IterableDataSource legitimately starts with I),
and an Optional-parameter ban (used in private enforcer helpers).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LXrbgt7saN7vayss9C7Kz9