### PR TITLE
feat(context): prefer X25519MLKEM768 hybrid key exchange for HTTPS

### DIFF
--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -184,6 +184,18 @@ server.ssl.key-store-type=PKCS12
 negotiated even if they are requested. The endpoint is then served at
 `https://localhost:8082/mcp`.
 
+It also **prefers the post-quantum `X25519MLKEM768` hybrid key exchange** for the
+TLS 1.3 handshake: it sets `jdk.tls.namedGroups` to
+`X25519MLKEM768,x25519,secp256r1,secp384r1`, listing the hybrid group first so it
+is chosen when both peers support it, with the classical groups kept as a
+fallback. `X25519MLKEM768` pairs classical X25519 with NIST ML-KEM-768, so the
+session key resists a future quantum attacker while remaining secure if either
+primitive is broken. The SunJSSE provider in JDK 25 does not yet ship this group,
+so the handshake falls back to X25519 today; because the fallback groups are
+listed too, the exchange upgrades to the hybrid automatically once the TLS
+provider supports it, with no code change. See
+[ADR 0011](../../../../../../../../../../docs/adr/0011-hybrid-post-quantum-key-exchange.md).
+
 ## Security
 
 The tools read source files from disk, so access is constrained by design:

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/TlsConfiguration.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/TlsConfiguration.java
@@ -9,11 +9,35 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Pins the embedded server's HTTPS to TLS 1.3. When the streamable HTTP
+ * Hardens the embedded server's HTTPS transport. When the streamable HTTP
  * transport is served over HTTPS (SSL enabled through {@code server.ssl.*}), this
- * customiser forces the only enabled protocol to {@code TLSv1.3}, regardless of
- * what the configuration requested, so older, weaker protocols can never be
- * negotiated. Plain HTTP and disabled SSL are left untouched — there is no TLS to
+ * customiser applies two guarantees regardless of what the deployment
+ * configuration requested, so they hold independent of how {@code server.ssl.*}
+ * is set:
+ *
+ * <ol>
+ * <li>the only enabled protocol is pinned to {@code TLSv1.3}, so older, weaker
+ * protocols can never be negotiated; and</li>
+ * <li>the post-quantum {@code X25519MLKEM768} hybrid group is preferred for the
+ * TLS 1.3 key exchange, with classical elliptic-curve groups kept as a fallback
+ * so peers that cannot do the hybrid exchange still connect.</li>
+ * </ol>
+ *
+ * <p>{@code X25519MLKEM768} combines a NIST ML-KEM-768 key encapsulation with the
+ * classical X25519 exchange; the derived secret stays secure as long as
+ * <em>either</em> primitive holds, which defends against "harvest now, decrypt
+ * later" attacks by a future quantum adversary. It is requested through the
+ * JVM-wide {@code jdk.tls.namedGroups} property, which lists the hybrid group
+ * first (so it is preferred) followed by classical groups (so the handshake
+ * degrades gracefully). Because that list also names supported classical groups,
+ * a JDK whose TLS provider does not yet ship {@code X25519MLKEM768} — such as the
+ * SunJSSE provider in JDK 25 — simply ignores the unknown group and negotiates a
+ * classical one; the hybrid exchange then activates automatically once the
+ * provider supports it, with no code change. The property is set only when HTTPS
+ * is enabled, before the connector starts its TLS stack, so SunJSSE reads it when
+ * initialising its supported groups.
+ *
+ * <p>Plain HTTP and disabled SSL are left untouched — there is no TLS to
  * constrain in those cases.
  */
 @Configuration
@@ -21,17 +45,33 @@ public class TlsConfiguration {
 
 	static final String TLS_1_3 = "TLSv1.3";
 
+	static final String HYBRID_KEY_EXCHANGE_GROUP = "X25519MLKEM768";
+
+	static final String NAMED_GROUPS_PROPERTY = "jdk.tls.namedGroups";
+
+	static final String PREFERRED_NAMED_GROUPS = HYBRID_KEY_EXCHANGE_GROUP + ",x25519,secp256r1,secp384r1";
+
 	private static final Logger log = LogManager.getLogger(TlsConfiguration.class.getName());
 
 	@Bean
 	public WebServerFactoryCustomizer<TomcatServletWebServerFactory> enforceTls13() {
-		return factory -> pinToTls13(factory.getSsl());
+		return factory -> hardenHttps(factory.getSsl());
+	}
+
+	private void hardenHttps(Ssl ssl) {
+		if (ssl != null && ssl.isEnabled()) {
+			pinToTls13(ssl);
+			preferHybridKeyExchange();
+		}
 	}
 
 	private void pinToTls13(Ssl ssl) {
-		if (ssl != null && ssl.isEnabled()) {
-			log.info("Pinning HTTPS to {}", TLS_1_3);
-			ssl.setEnabledProtocols(new String[] { TLS_1_3 });
-		}
+		log.info("Pinning HTTPS to {}", TLS_1_3);
+		ssl.setEnabledProtocols(new String[] { TLS_1_3 });
+	}
+
+	private void preferHybridKeyExchange() {
+		log.info("Preferring {} hybrid key exchange for TLS 1.3", HYBRID_KEY_EXCHANGE_GROUP);
+		System.setProperty(NAMED_GROUPS_PROPERTY, PREFERRED_NAMED_GROUPS);
 	}
 }

--- a/code/context/src/main/resources/application.properties
+++ b/code/context/src/main/resources/application.properties
@@ -14,7 +14,9 @@ spring.main.allow-bean-definition-overriding=true
 
 # Streamable HTTP is served over plain HTTP by default. To serve it over HTTPS,
 # point server.ssl.* at a key store and set server.ssl.enabled=true; the
-# TlsConfiguration customiser then pins the connector to TLS 1.3 automatically.
+# TlsConfiguration customiser then pins the connector to TLS 1.3 automatically and
+# prefers the post-quantum X25519MLKEM768 hybrid key exchange (falling back to
+# classical groups until the JDK's TLS provider ships the hybrid group).
 # server.ssl.enabled=true
 # server.ssl.key-store=classpath:keystore.p12
 # server.ssl.key-store-password=changeit

--- a/code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java
@@ -9,6 +9,7 @@ import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.sli
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.Optional;
+import java.util.Properties;
 
 import org.apache.logging.log4j.Logger;
 
@@ -134,6 +135,17 @@ public class ContextArchitectureTest {
 	static final ArchRule contextCoreDoesNotHaltTheJvm = noClasses()
 			.should().callMethod(System.class, "exit", int.class)
 			.because("the context core is a reusable library and must never terminate the host JVM; it should throw instead");
+
+	@ArchTest
+	static final ArchRule onlyTlsConfigurationMutatesJvmWideProperties = noClasses()
+			.that().doNotHaveSimpleName("TlsConfiguration")
+			.should().callMethod(System.class, "setProperty", String.class, String.class)
+			.orShould().callMethod(System.class, "clearProperty", String.class)
+			.orShould().callMethod(System.class, "setProperties", Properties.class)
+			.because("JVM-wide system properties are global mutable state; the TLS hardening customiser is "
+					+ "the one sanctioned place to set them, so a stray setProperty elsewhere cannot clobber "
+					+ "the pinned TLS protocol and key-exchange configuration")
+			.allowEmptyShould(true);
 
 	@ArchTest
 	static final ArchRule noAccessToStandardStreams =

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpsIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpsIT.java
@@ -97,6 +97,12 @@ public class McpStreamableHttpsIT {
 	}
 
 	@Test
+	void prefersHybridKeyExchangeGroup() {
+		assertEquals(TlsConfiguration.PREFERRED_NAMED_GROUPS,
+				System.getProperty(TlsConfiguration.NAMED_GROUPS_PROPERTY));
+	}
+
+	@Test
 	void refusesTls12Handshakes() throws IOException {
 		SSLSocketFactory factory = testTrustContext().getSocketFactory();
 		try (SSLSocket socket = (SSLSocket) factory.createSocket("localhost", port)) {

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/TlsConfigurationTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/TlsConfigurationTest.java
@@ -1,8 +1,12 @@
 package io.github.adamw7.context.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.web.server.Ssl;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
@@ -10,6 +14,22 @@ import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactor
 public class TlsConfigurationTest {
 
 	private final TlsConfiguration config = new TlsConfiguration();
+
+	private String savedNamedGroups;
+
+	@BeforeEach
+	void clearNamedGroups() {
+		savedNamedGroups = System.clearProperty(TlsConfiguration.NAMED_GROUPS_PROPERTY);
+	}
+
+	@AfterEach
+	void restoreNamedGroups() {
+		if (savedNamedGroups == null) {
+			System.clearProperty(TlsConfiguration.NAMED_GROUPS_PROPERTY);
+		} else {
+			System.setProperty(TlsConfiguration.NAMED_GROUPS_PROPERTY, savedNamedGroups);
+		}
+	}
 
 	@Test
 	void pinsEnabledHttpsToTls13() {
@@ -32,12 +52,27 @@ public class TlsConfigurationTest {
 	}
 
 	@Test
+	void prefersHybridKeyExchangeWhenHttpsEnabled() {
+		TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory();
+		factory.setSsl(enabledSsl(new String[] { "TLSv1.3" }));
+
+		config.enforceTls13().customize(factory);
+
+		String namedGroups = System.getProperty(TlsConfiguration.NAMED_GROUPS_PROPERTY);
+		assertEquals(TlsConfiguration.PREFERRED_NAMED_GROUPS, namedGroups);
+		assertTrue(namedGroups.startsWith(TlsConfiguration.HYBRID_KEY_EXCHANGE_GROUP),
+				"the hybrid group must be listed first so it is preferred");
+		assertTrue(namedGroups.contains("x25519"), "a classical fallback group must remain so the handshake degrades gracefully");
+	}
+
+	@Test
 	void leavesPlainHttpUntouched() {
 		TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory();
 
 		config.enforceTls13().customize(factory);
 
 		assertNull(factory.getSsl());
+		assertNull(System.getProperty(TlsConfiguration.NAMED_GROUPS_PROPERTY));
 	}
 
 	@Test
@@ -50,6 +85,7 @@ public class TlsConfigurationTest {
 		config.enforceTls13().customize(factory);
 
 		assertArrayEquals(new String[] { "TLSv1.2" }, factory.getSsl().getEnabledProtocols());
+		assertNull(System.getProperty(TlsConfiguration.NAMED_GROUPS_PROPERTY));
 	}
 
 	private Ssl enabledSsl(String[] protocols) {

--- a/docs/adr/0011-hybrid-post-quantum-key-exchange.md
+++ b/docs/adr/0011-hybrid-post-quantum-key-exchange.md
@@ -1,0 +1,84 @@
+# 11. Prefer the X25519MLKEM768 hybrid key exchange for TLS 1.3
+
+- **Status:** Accepted
+- **Date:** 2026-07-19
+- **Deciders:** Project maintainers
+- **Tags:** security, transport, tls, post-quantum
+- **Supersedes:** —
+- **Superseded by:** —
+
+Refines the TLS 1.3 transport decision in
+[ADR 0003](0003-require-tls-1.3.md).
+
+## Context
+
+[ADR 0003](0003-require-tls-1.3.md) pins the HTTPS transport to TLS 1.3 but says
+nothing about the *key exchange*: left to defaults, the SunJSSE provider
+negotiates a classical elliptic-curve group (X25519, secp256r1, …). Classical
+Diffie-Hellman is vulnerable to a "harvest now, decrypt later" attack — an
+adversary records today's handshake and derives the session key once a
+cryptographically relevant quantum computer exists. TLS 1.3 already supports
+*hybrid* key-exchange groups that pair a classical exchange with a NIST
+post-quantum KEM; `X25519MLKEM768` combines X25519 with ML-KEM-768 (FIPS 203) so
+the derived secret stays secure as long as **either** primitive holds.
+
+## Decision
+
+**When a transport is served over HTTPS, the server prefers the post-quantum
+`X25519MLKEM768` hybrid group for the TLS 1.3 key exchange, keeping classical
+groups as a graceful fallback.** As with the TLS 1.3 pin, this is enforced in
+code, not left to deployment configuration: the same
+`WebServerFactoryCustomizer` (`enforceTls13()`) that pins the protocol also sets
+the JVM-wide `jdk.tls.namedGroups` property to
+`X25519MLKEM768,x25519,secp256r1,secp384r1` whenever SSL is enabled.
+
+- The hybrid group is listed **first**, so it is preferred when both peers
+  support it; the classical groups follow, so a peer that cannot do the hybrid
+  exchange still completes the handshake.
+- Production implementation:
+  [`code/context/src/main/java/io/github/adamw7/context/mcp/TlsConfiguration.java`](../../code/context/src/main/java/io/github/adamw7/context/mcp/TlsConfiguration.java).
+- **Plain HTTP and disabled SSL are left untouched** — the property is set only
+  when SSL is enabled, before the connector starts its TLS stack, so SunJSSE
+  reads it when initialising its supported groups.
+- `TlsConfigurationTest` asserts that an enabled HTTPS factory sets
+  `jdk.tls.namedGroups` to the hybrid-first list and that plain-HTTP /
+  disabled-SSL factories leave it unset; `McpStreamableHttpsIT` asserts the
+  preference is in force against a live HTTPS server that still completes a real
+  TLS 1.3 MCP call.
+
+### JDK support and forward compatibility
+
+`X25519MLKEM768` is not yet shipped by the SunJSSE provider in **JDK 25** (the
+ML-KEM primitives from JEP 496 are present, but the TLS 1.3 named group is not).
+Setting `jdk.tls.namedGroups` to the hybrid group **alone** would throw at
+provider initialisation ("contains no supported named groups") and break all
+HTTPS. Listing supported classical groups alongside it avoids that: SunJSSE
+silently drops the unknown group and negotiates a classical one, so **today the
+handshake falls back to X25519**. The moment the JVM's TLS provider gains
+`X25519MLKEM768` — a newer JDK, or a provider such as BouncyCastle — the group is
+already first in the preference list and the hybrid exchange activates
+automatically, with no code change. This makes the configuration a safe,
+forward-looking default rather than a hard dependency on a specific JDK.
+
+## Consequences
+
+**Positive**
+
+- HTTPS handshakes prefer a post-quantum-secure key exchange as soon as the
+  runtime can provide it, mitigating "harvest now, decrypt later" without
+  waiting for a code change or a new dependency.
+- The preference is executable and regression-tested, not just documented.
+- No new dependency: the change rides on the JDK's own TLS provider and property.
+
+**Negative / trade-offs**
+
+- On JDK 25 the exchange is still classical; the post-quantum benefit is latent
+  until the provider supports the group. The configuration documents intent and
+  removes the future code change, but does not by itself make today's traffic
+  quantum-resistant.
+- `jdk.tls.namedGroups` is JVM-wide, so it also influences any other TLS client
+  or server in the same process. This is acceptable for the single-purpose MCP
+  server and mirrors the process-wide nature of the TLS 1.3 pin's intent.
+- As with ADR 0003, the enforcement currently lives with the context MCP server;
+  a second HTTPS-serving surface must apply the same customiser to inherit the
+  preference (see the follow-up in [ADR 0003](0003-require-tls-1.3.md)).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,6 +61,7 @@ decision, add a new ADR that supersedes it and set both records' `Supersedes` /
 | [0008](0008-log4j2-logging.md) | log4j2 as the logging backend | Accepted | 2026-07-16 |
 | [0009](0009-mcp-servers-on-spring-boot.md) | MCP servers built on Spring Boot | Accepted | 2026-07-16 |
 | [0010](0010-documentation-as-enforced-contract.md) | Documentation as a build-enforced contract | Accepted | 2026-07-16 |
+| [0011](0011-hybrid-post-quantum-key-exchange.md) | Prefer the X25519MLKEM768 hybrid key exchange for TLS 1.3 | Accepted | 2026-07-19 |
 
 ## Related documents
 


### PR DESCRIPTION
Extend the HTTPS-hardening customiser so that, in addition to pinning the
transport to TLS 1.3, it prefers the post-quantum X25519MLKEM768 hybrid
key-exchange group for the TLS 1.3 handshake. It sets jdk.tls.namedGroups to
"X25519MLKEM768,x25519,secp256r1,secp384r1" whenever SSL is enabled, listing
the hybrid group first (preferred) with classical groups as a graceful
fallback.

Because supported classical groups are listed alongside it, a JDK whose TLS
provider does not yet ship X25519MLKEM768 (SunJSSE in JDK 25) drops the unknown
group and negotiates a classical one; the hybrid exchange activates
automatically once the provider supports it, with no code change and no new
dependency.

Cover the new behaviour in TlsConfigurationTest and assert the preference is in
force against a live HTTPS server in McpStreamableHttpsIT. Document the decision
in ADR 0011 (refining ADR 0003) and in MCP_USAGE / application.properties.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lqen2PoXT3Nj57B4XJwV2g