### PR TITLE
security(data): bind MCP server to loopback and quiet debug logging

### DIFF
--- a/data/src/main/resources/application.properties
+++ b/data/src/main/resources/application.properties
@@ -1,10 +1,11 @@
 spring.application.name=Application
 server.port=8081
+# Bind the streamable HTTP transport to the loopback interface only. The MCP
+# endpoint has no authentication, so it must not be reachable from the network.
+# Override deliberately (and add authentication) before exposing it more widely.
+server.address=127.0.0.1
 spring.main.allow-bean-definition-overriding=true
 
 logging.level.root=INFO
-logging.level.io.github.innobridge=DEBUG
-logging.level.org.springframework.web=DEBUG
-logging.level.org.springframework.web.reactive=DEBUG
 logging.level.org.springframework.boot.autoconfigure=ERROR
-logging.level.io.modelcontextprotocol=DEBUG
+logging.level.io.modelcontextprotocol=INFO


### PR DESCRIPTION
The data uniqueness MCP server left server.address unset, so under an HTTP
transport (streamable-http/sse/stateless-http) Spring Boot binds all
interfaces, exposing the unauthenticated uniqueness_check file-reading tool
to the network. The context MCP server already pins server.address to
127.0.0.1 for exactly this reason; bring the data server in line.

Also trim verbose DEBUG logging (including a stray non-project logger) that
could leak request details, matching the context server's INFO baseline.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XQXe3W4go23YUtZztDL6vD