### PR TITLE
fix(data): reuse a key's own tombstone in IntKeyOpenAddressingMap.put

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
@@ -62,6 +62,11 @@ public class IntKeyOpenAddressingMap<V> {
 		return size == 0;
 	}
 
+	/** The current backing-array length; exposed for tests that assert growth behaviour. */
+	int capacity() {
+		return keys.length;
+	}
+
 	public boolean containsKey(int key) {
 		return indexOf(key) >= 0;
 	}
@@ -104,6 +109,16 @@ public class IntKeyOpenAddressingMap<V> {
 		return DoubleHashing.sequence(Integer.hashCode(key), prime, keys.length);
 	}
 
+	/**
+	 * Probes the double-hashing sequence for {@code key} and stores {@code value}.
+	 * An {@link #EMPTY} slot ends the search and receives a fresh entry. A slot
+	 * already holding {@code key} is reused in place: a {@link #LIVE} one is
+	 * overwritten, a {@link #TOMBSTONE} one is revived. Reviving the key's own
+	 * tombstone rather than probing past it keeps a remove/re-add cycle of the same
+	 * key from leaking a tombstone on every pass, which would otherwise fill the
+	 * probe chain and force needless resizes. Tombstones for a <em>different</em>
+	 * key are skipped, because the sought key may still sit further along the chain.
+	 */
 	public V put(int key, V value) {
 		checkIfResizeNeeded();
 		DoubleHashing.Probe probe = probe(key);
@@ -111,9 +126,9 @@ public class IntKeyOpenAddressingMap<V> {
 			int index = probe.slot(i);
 			if (state[index] == EMPTY) {
 				return insert(index, key, value);
-			} else if (state[index] == LIVE && keys[index] == key) {
-				return overwrite(index, value);
-			} // tombstones are skipped
+			} else if (keys[index] == key) {
+				return state[index] == TOMBSTONE ? insert(index, key, value) : overwrite(index, value);
+			} // slots holding a different key, live or tombstoned, are skipped
 		}
 		resize();
 		return put(key, value);

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMapTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMapTest.java
@@ -108,6 +108,33 @@ public class IntKeyOpenAddressingMapTest {
 	}
 
 	@Test
+	public void reAddingRemovedKeyRevivesItsSlotInPlace() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(7, "first");
+		assertEquals("first", map.remove(7));
+		assertNull(map.put(7, "second")); // reviving a tombstone reports no previous value
+		assertEquals("second", map.get(7));
+		assertEquals(1, map.size());
+	}
+
+	@Test
+	public void repeatedRemoveAndReAddOfSameKeyDoesNotGrowTheTable() {
+		// Removing and re-adding the same key must revive its tombstone rather than
+		// probe past it, otherwise every cycle leaks a tombstone onto the key's probe
+		// chain until the table is forced to resize even though one live entry exists.
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		int initialCapacity = map.capacity();
+		for (int i = 0; i < 10_000; ++i) {
+			map.put(7, "v" + i);
+			map.remove(7);
+		}
+		map.put(7, "final");
+		assertEquals("final", map.get(7));
+		assertEquals(1, map.size());
+		assertEquals(initialCapacity, map.capacity());
+	}
+
+	@Test
 	public void negativeKeysAreSupported() {
 		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
 		map.put(-1, "minus one");


### PR DESCRIPTION
IntKeyOpenAddressingMap.put skipped every tombstone, including the slot
holding the very key being re-inserted, and probed on to a fresh empty
slot. A remove/re-add cycle of the same key therefore leaked one
tombstone per pass onto the key's probe chain until the table was forced
to resize, growing without bound even though only a single live entry
ever existed. Its object-keyed sibling OpenAddressingMap already revives
a same-key tombstone in place; this brings the primitive map to parity.

put now reuses a slot that already holds the key -- overwriting a live
entry, reviving a tombstoned one -- and only skips tombstones belonging
to a different key, matching indexOf's probe semantics.

Add a package-private capacity() accessor and a regression test proving
the table no longer grows across 10k remove/re-add cycles of one key
(previously it ballooned from capacity 64 to several thousand), plus a
test that reviving a tombstone stores the value in place.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J5veDfgLE83zB9Rrk5U7Bx