### PR TITLE
Preserve original line endings when wiring the CLAUDE.md guard

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -82,9 +82,18 @@ public class GradleGuardInstaller {
 
 	private void append(Path buildFile, String existing, String block) {
 		try {
-			Files.writeString(buildFile, existing + block);
+			Files.writeString(buildFile, existing + matchLineTerminator(block, existing));
 		} catch (IOException e) {
 			throw new AdoptionException("Could not write Gradle build file: " + buildFile, e);
 		}
+	}
+
+	/**
+	 * Rewrites the appended block's LF line terminators to match the ones the script
+	 * already uses, so appending the guard to a CRLF build script does not leave the
+	 * new region with LF endings mixed into an otherwise CRLF file.
+	 */
+	private String matchLineTerminator(String block, String existing) {
+		return existing.contains("\r\n") ? block.replace("\n", "\r\n") : block;
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -249,11 +249,35 @@ public class PomEnforcerInstaller {
 	private void write(Document document, Path pomFile, String original) {
 		try {
 			String content = declarationPrefix(original) + transformBody(document);
+			String withTrailingNewline = matchTrailingNewline(content, original);
 			Files.createDirectories(pomFile.toAbsolutePath().getParent());
-			Files.writeString(pomFile, matchTrailingNewline(content, original));
+			Files.writeString(pomFile, applyLineTerminator(withTrailingNewline, lineTerminator(original)));
 		} catch (IOException | TransformerException e) {
 			throw new AdoptionException("Could not write POM: " + pomFile, e);
 		}
+	}
+
+	/**
+	 * The line terminator the original file used. XML parsing normalizes {@code \r\n}
+	 * to {@code \n}, so the DOM the transformer serializes has lost the original
+	 * terminator; capturing it here lets the rewrite keep a CRLF POM on CRLF rather
+	 * than silently flipping every line to LF and reformatting the whole file. A file
+	 * with no {@code \r\n} is treated as LF.
+	 */
+	private String lineTerminator(String original) {
+		return original.contains("\r\n") ? "\r\n" : "\n";
+	}
+
+	/**
+	 * Rewrites every line terminator in {@code content} to {@code terminator}. The
+	 * assembled content mixes the transformer's LF body, the added block's LF
+	 * indentation, and the declaration carried over verbatim from the original, so it
+	 * is first normalized to a single form to avoid double-converting the parts that
+	 * already ended in the target terminator.
+	 */
+	private String applyLineTerminator(String content, String terminator) {
+		String normalized = content.replace("\r\n", "\n").replace("\r", "\n");
+		return terminator.equals("\n") ? normalized : normalized.replace("\n", terminator);
 	}
 
 	private String transformBody(Document document) throws TransformerException {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
@@ -37,6 +37,17 @@ class GradleGuardInstallerTest {
 	}
 
 	@Test
+	void matchesCarriageReturnLineEndingsWhenAppendingTheGuard(@TempDir Path directory) throws IOException {
+		Path buildFile = directory.resolve("build.gradle");
+		Files.writeString(buildFile, "plugins { id 'java' }\r\n");
+		assertTrue(installer.install(buildFile));
+		String content = Files.readString(buildFile);
+		assertTrue(content.contains("tasks.register('enforceClaudeMd')"), "the guard must be appended");
+		assertFalse(content.replace("\r\n", "").contains("\n"),
+				"a CRLF build script must stay CRLF; the appended block must not introduce bare LF endings");
+	}
+
+	@Test
 	void leavesAnAlreadyGuardedBuildUnchanged(@TempDir Path directory) throws IOException {
 		Path buildFile = directory.resolve("build.gradle");
 		Files.writeString(buildFile, "plugins { id 'java' }\n");

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -240,6 +240,28 @@ class PomEnforcerInstallerTest {
 	}
 
 	@Test
+	void preservesCarriageReturnLineEndingsRatherThanReformattingToLf(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_BUILD.replace("\n", "\r\n"));
+		installer.install(pom);
+		String result = Files.readString(pom);
+		assertTrue(result.contains("tools.claude-code-enforcer"), "the rule must still be wired in");
+		assertFalse(stripCrlf(result).contains("\n"),
+				"a CRLF POM must stay CRLF; no line may be left with a bare LF ending");
+		assertTrue(result.contains(
+				"      <plugin>\r\n"
+						+ "        <groupId>org.apache.maven.plugins</groupId>\r\n"
+						+ "        <artifactId>maven-compiler-plugin</artifactId>\r\n"
+						+ "      </plugin>"),
+				"the existing plugin must be preserved verbatim with its CRLF endings");
+		assertTrue(result.contains("\r\n            <artifactId>tools.claude-code-enforcer</artifactId>\r\n"),
+				"the added block must use the file's CRLF endings, not LF");
+	}
+
+	private String stripCrlf(String text) {
+		return text.replace("\r\n", "");
+	}
+
+	@Test
 	void indentsTheAddedBlockToTheDocumentsOwnIndentationUnit(@TempDir Path dir) throws IOException {
 		Path pom = write(dir, POM_FOUR_SPACE_INDENT);
 		installer.install(pom);


### PR DESCRIPTION
PomEnforcerInstaller rewrote pom.xml through the JDK DOM, which normalizes
CRLF to LF on parse; the transformer then re-emitted LF, so a CRLF pom.xml
was silently reformatted to LF on every line. That defeats the installer's
documented promise that the adoption commit shows only the added enforcer
block, producing a whole-file diff on Windows/CRLF repositories.

Capture the original file's line terminator and restore it on write, so a
CRLF POM stays CRLF and an LF POM is byte-identical to before. Apply the same
terminator-matching to GradleGuardInstaller's appended guard block so it does
not leave a bare-LF region inside an otherwise CRLF build script. Add CRLF
regression tests for both.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J5Gqo1h2iF5v96GP4mqiZP