### PR TITLE
feat(skills): add testing-conventions and maven-conventions skills

### DIFF
--- a/.claude/skills/maven-conventions/README.md
+++ b/.claude/skills/maven-conventions/README.md
@@ -1,0 +1,35 @@
+# Maven Conventions
+
+**Load**: `view .claude/skills/maven-conventions/SKILL.md`
+
+---
+
+## Description
+
+Helps Claude edit `pom.xml` files and run builds the way this repo expects:
+versions only in the root pom, version-free module poms, the right profiles, and
+clean-after-codegen.
+
+---
+
+## Use Cases
+
+- "Add a dependency to the data module"
+- "Bump the version of X"
+- "Which command runs the integration tests?"
+
+---
+
+## Examples
+
+```
+> view .claude/skills/maven-conventions/SKILL.md
+> "Bump the log4j2 version"
+→ Change it in root <dependencyManagement>; module poms stay version-free
+```
+
+---
+
+## Notes / Tips
+
+- Always ask before adding a brand-new dependency.

--- a/.claude/skills/maven-conventions/SKILL.md
+++ b/.claude/skills/maven-conventions/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: maven-conventions
+description: Follow this repo's Maven rules — versions only in the root pom, module poms version-free, the build profiles, and clean-after-codegen. Use when editing a pom.xml, adding a dependency or plugin, choosing a build command, or when the user says "add a dependency", "bump a version", or "the build fails".
+---
+
+# Maven Conventions Skill
+
+Keep `pom.xml` edits and build commands consistent with how the `tools`
+multi-module reactor is wired. Getting versions in the wrong place, or missing a
+profile, is the most common source of avoidable build friction here.
+
+## When to Use
+- Editing any `pom.xml`
+- Adding or upgrading a dependency or a Maven plugin
+- Choosing which `mvn` command / profile to run
+- The user says "add a dependency" / "bump a version" / "the build fails"
+
+## Hard rules
+
+### Versions live in exactly one place
+- **Dependency versions and scopes**: only in the **root** `pom.xml` under
+  `<dependencyManagement>`.
+- **Plugin versions**: only in the **root** `pom.xml` under
+  `<pluginManagement>`.
+- **Module poms reference dependencies and plugins WITHOUT versions.** Never add
+  a `<version>` to a module pom — add or change it in the root instead.
+
+### Ask before adding a dependency
+- Use the existing Maven dependencies. **Always ask the user before adding a new
+  one.** If approved, declare it (with version) in root `<dependencyManagement>`,
+  then reference it version-free in the module.
+
+### Clean after removing a code-generation source
+- Run `clean` after deleting a codegen input, so stale generated builders in
+  `target/` cannot mask the change.
+
+## Build commands (run from the repo root)
+
+| Command | Purpose |
+|---|---|
+| `mvn clean install` | Full clean build + install to local repo |
+| `mvn install` | Faster incremental build |
+| `mvn -pl <module> test` | Tests for a single module |
+| `mvn -P integration-tests verify` | MCP integration tests (`*IT`) |
+| `mvn -Pcoverage verify` | JaCoCo coverage (fails under 80%) |
+| `mvn -Ppitest test` | PIT mutation testing |
+| `mvn install -Dskip.shellcheck=true` | Skip the shellcheck lint |
+
+## Notes that save time
+- **Shellcheck runs embedded.** `dev.dimlight:shellcheck-maven-plugin` uses
+  `<binaryResolutionMethod>embedded</binaryResolutionMethod>` — the binary ships
+  in the plugin jar (from Maven Central), so the build needs no installed
+  `shellcheck` and works offline. Skip it with `-Dskip.shellcheck=true` when you
+  just want a fast loop.
+- **Java 25** is required: JDK 25 on `PATH` with `JAVA_HOME` set.
+- The root reactor modules are: `claude-code-enforcer`, `mcp-common`, `data`,
+  `code`, `adopt`, `grpc-example`, `assembly`. `data-test` is built separately
+  (not in the root `<modules>`).
+
+## Workflow for a dependency/plugin change
+1. Confirm it isn't already managed in the root pom.
+2. If it's a *new* dependency, **ask the user first**.
+3. Add/adjust the version in root `<dependencyManagement>` or
+   `<pluginManagement>`.
+4. Reference it version-free in the module pom.
+5. Build: `mvn install` (add `clean` if you removed a codegen source).
+
+## References
+- `CLAUDE.md` / `AGENTS.md` — *Maven* section (source of truth)
+- Root `pom.xml` — `<dependencyManagement>`, `<pluginManagement>`

--- a/.claude/skills/testing-conventions/README.md
+++ b/.claude/skills/testing-conventions/README.md
@@ -1,0 +1,35 @@
+# Testing Conventions
+
+**Load**: `view .claude/skills/testing-conventions/SKILL.md`
+
+---
+
+## Description
+
+Helps Claude write tests that satisfy the `tools` repo's enforced testing rules:
+the 900 ms Surefire per-test timeout, network-off unit tests, ArchUnit test
+conventions, and JUnit 5 only.
+
+---
+
+## Use Cases
+
+- "Write a unit test for this class"
+- "Why is this test timing out?"
+- "This test needs the network — where does it go?"
+
+---
+
+## Examples
+
+```
+> view .claude/skills/testing-conventions/SKILL.md
+> "Add a test for the uniqueness checker"
+→ Fast *Test in the right package, no network, under 900 ms
+```
+
+---
+
+## Notes / Tips
+
+- Anything touching the network is an `*IT`, not a unit test.

--- a/.claude/skills/testing-conventions/SKILL.md
+++ b/.claude/skills/testing-conventions/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: testing-conventions
+description: Write tests that pass this repo's enforced testing rules (Surefire 900ms timeout, network-off unit tests, ArchUnit conventions, JUnit 5 only). Use when adding or changing tests, when a test times out or opens a network connection, or when the user says "write a test", "add tests", or "fix the failing test".
+---
+
+# Testing Conventions Skill
+
+Write unit and integration tests that satisfy the `tools` repo's enforced
+testing rules the first time. These rules are enforced by Surefire config,
+JUnit extensions, and ArchUnit architecture tests — a test that ignores them
+fails the build, not just review.
+
+## When to Use
+- Adding a unit test for new logic (all new logic needs one)
+- A test fails with a timeout, or a unit test tries to open a socket
+- The user says "write a test" / "add tests" / "fix the failing test"
+- Reviewing tests before a commit or PR
+
+## Hard rules (build fails otherwise)
+
+### Timeouts
+- **900 ms per unit test.** Surefire enforces a 900-millisecond per-test
+  timeout (root `pom.xml`). Keep unit tests fast — no real I/O, no sleeps, no
+  heavy loops. A genuinely heavier test opts out with an explicit `@Timeout`
+  **and a comment explaining why**.
+- Heavy shared setup (`@BeforeAll` etc.) has a looser 10-second limit (15 s
+  under coverage). A fork that hangs outright is killed at 300 s
+  (`forkedProcessTimeoutInSeconds`).
+
+### Network is off for unit tests
+- The `data` module's `NetworkOffExtension` engages the `Switch` kill-switch
+  before any test runs, so a unit test **cannot** open an outbound connection.
+- Anything needing the network is an integration test (`*IT`), gated behind the
+  `integration-tests` profile and run by Failsafe — not Surefire.
+
+### Test conventions pinned by `TestConventionsArchitectureTest`
+- Test methods live only in `*Test` / `*IT` classes.
+- **JUnit 5 only** (`org.junit.jupiter`). No JUnit 4.
+- No `@Disabled`.
+- No `System.out` / `System.err` in tests.
+- No `Thread.sleep` in tests.
+
+### Coding rules that also apply to tests
+- **No `continue` or `break`** statements.
+- Loggers, when present, are `private static final`.
+- Date/time uses `java.time`, never `Date` / `Calendar`.
+
+## Naming
+- Unit test class: `SomethingTest` (runs in `test` / `package` lifecycle).
+- Integration test class: `SomethingIT` (runs under `-P integration-tests verify`).
+- Architecture tests live in each module's `.architecture` test package.
+
+## Workflow
+1. Decide unit vs. integration: does it touch the network or a live resource?
+   If yes → `*IT`. If no → `*Test`.
+2. Put the class in the right package (`.architecture` for ArchUnit rules).
+3. Write focused, fast assertions — behavior, edge cases, and error paths.
+4. Run it: `mvn -pl <module> test` (unit) or
+   `mvn -P integration-tests verify` (integration).
+5. If a unit test legitimately needs more than 900 ms, add `@Timeout(...)`
+   with a one-line comment justifying it.
+
+## Quick reference
+
+| Concern | Rule |
+|---|---|
+| Per-unit-test time | 900 ms (opt out with commented `@Timeout`) |
+| `@BeforeAll` etc. | 10 s (15 s under coverage) |
+| Network in unit test | Blocked by `NetworkOffExtension` — use `*IT` |
+| Test framework | JUnit 5 only |
+| Disabled tests | Not allowed (`@Disabled` banned) |
+| `Thread.sleep` in test | Banned |
+| `System.out`/`err` in test | Banned |
+| `continue` / `break` | Banned (all code) |
+
+## References
+- `CLAUDE.md` / `AGENTS.md` — *Testing* section (source of truth)
+- `data` module `NetworkOffExtension`, `Switch`
+- `TestConventionsArchitectureTest`


### PR DESCRIPTION
Fill the two highest-friction gaps in .claude/skills coverage. The existing
skills (git-commit, java-code-review, solid-principles) leave the repo's
enforced testing and Maven conventions undocumented for agents.

- testing-conventions: Surefire 900ms per-test timeout, network-off unit
  tests (NetworkOffExtension), ArchUnit test rules, JUnit 5 only, unit vs
  *IT split.
- maven-conventions: versions only in root pom (dependencyManagement /
  pluginManagement), version-free module poms, build profiles, embedded
  shellcheck, clean-after-codegen.

Both pass the claude-code-enforcer rules (skillFilesExist, uniqueNames,
uniqueDescriptions).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QKss56QVHBvBAYQBX8DcCu