### PR TITLE
docs(skills): align java-code-review, solid-principles, git-commit with repo rules

### DIFF
--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: git-commit
-description: Generate conventional commit messages for Java projects. Use when user says "commit", "create commit", "commit changes", or after completing code changes that need to be committed.
+description: Generate conventional commit messages for the tools repo, using its real module scopes. Use when the user says "commit", "create commit", "commit changes", or after completing code changes that need to be committed.
 ---
 
 # Git Commit Message Skill
 
-Generate conventional, informative commit messages for Java projects.
+Generate conventional, informative commit messages for the `tools` multi-module
+Maven reactor.
 
 ## When to Use
 - After making code changes
 - User says "commit this" / "commit changes" / "create commit"
-- Before creating PRs
+- Before creating a PR
 
-## Format Standard
+## Format
 
-Use Conventional Commits format:
+[Conventional Commits](https://www.conventionalcommits.org/):
+
 ```
 <type>(<scope>): <subject>
 
@@ -23,215 +25,83 @@ Use Conventional Commits format:
 <footer>
 ```
 
-### Types (Java context)
-- **feat**: New feature (new API, new functionality)
-- **fix**: Bug fix
-- **refactor**: Code refactoring (no functional change)
-- **test**: Add/update tests
-- **docs**: Documentation only
-- **perf**: Performance improvement
-- **build**: Maven/Gradle changes
-- **chore**: Maintenance (dependency updates, etc)
+### Types
+| Type | Use for |
+|---|---|
+| `feat` | New API / functionality |
+| `fix` | Bug fix |
+| `refactor` | Restructure, no behavior change |
+| `test` | Add/update tests |
+| `docs` | Docs only (README, AGENTS.md, javadoc) |
+| `perf` | Performance improvement |
+| `build` | Maven / pom / CI changes |
+| `chore` | Maintenance (tooling, dependency bumps) |
 
-### Scope Examples (Java specific)
-- Module name: `core`, `api`, `plugin-loader`
-- Component: `PluginManager`, `ExtensionFactory`
-- Area: `lifecycle`, `dependencies`, `security`
+### Scope — use this repo's real modules/components
+`data`, `code`, `context`, `protogen-maven-plugin`, `adopt`, `mcp-common`,
+`claude-code-enforcer`, `assembly`, `grpc-example`, `data-test`. Narrow to a
+component when it's clearer (e.g. `source.db`, `uniqueness`, `mcp`, `builder`).
 
-### Subject Rules
-- Imperative mood: "Add support" not "Added support"
-- No period at end
-- Max 50 chars
-- Lowercase after type
+### Subject rules
+- Imperative mood: "Add support", not "Added support"
+- Lowercase after the type, no trailing period, ≤ ~50 chars
 
-### Body (optional but recommended)
-- Explain WHAT and WHY, not HOW
-- Wrap at 72 chars
-- Reference issues: "Fixes #123" / "Relates to #456"
+### Body (optional, recommended for non-trivial changes)
+- Explain **what** and **why**, not how; wrap at ~72 chars, 2–3 lines is plenty
+- Reference issues: `Fixes #123` / `Relates to #456`
+- Breaking change: add a `BREAKING CHANGE:` footer (and `!` after the scope)
 
 ## Examples
 
-### Simple fix
 ```
-fix(plugin-loader): prevent NPE when plugin directory is missing
+feat(protogen-maven-plugin): enforce proto3 oneof discriminators at compile time
 
-Check for null before accessing plugin directory to avoid
-NullPointerException during initialization.
-
-Fixes #234
-```
-
-### Feature with breaking change
-```
-feat(api): add support for plugin dependencies versioning
-
-BREAKING CHANGE: PluginDescriptor now requires semantic versioning
-format (x.y.z) instead of free-form version strings.
-
-Closes #567
-```
-
-### Refactoring
-```
-refactor(core): extract plugin validation logic
-
-Move validation logic from PluginManager to separate
-PluginValidator class for better testability and separation
-of concerns.
-```
-
-### Test addition
-```
-test(plugin-loader): add integration tests for plugin loading
-
-Add comprehensive integration tests covering:
-- Loading from directory
-- Loading from JAR
-- Error handling for invalid plugins
-```
-
-### Build/dependency update
-```
-build(deps): upgrade Spring Boot to 3.2.1
-
-Update Spring Boot from 3.1.0 to 3.2.1 for security patches
-and performance improvements.
-```
-
-## Workflow
-
-1. **Analyze changes** using `git diff --staged`
-2. **Identify scope** from modified files
-3. **Determine type** based on change nature
-4. **Generate message** following format
-5. **Execute commit**: `git commit -m "message"`
-
-## Token Optimization
-
-- Read staged changes ONCE: `git diff --staged --stat` + targeted file diffs
-- Don't read entire files unless necessary
-- Use concise body - aim for 2-3 lines max
-- Batch multiple small changes into logical commits
-
-## Anti-patterns
-
-❌ Avoid:
-- "fix stuff" / "update code" / "changes"
-- "WIP" commits (unless explicitly requested)
-- Mixing unrelated changes (use separate commits)
-- Over-detailed technical implementation in message
-
-✅ Good commits:
-- Single logical change
-- Clear, searchable subject
-- References issues when applicable
-- Explains business value
-
-## Integration with GitHub
-
-After commit, suggest next steps:
-- "Push changes?" 
-- "Create PR for issue #X?"
-- "Continue with next task?"
-
-## Common Patterns for Java Projects
-
-### Adding new functionality
-```
-feat(extension): add support for prioritized extensions
-
-Allow extensions to specify priority order for execution.
-Extensions with higher priority run first.
+Generated builders now fail compilation when a required oneof branch is
+left unset, matching the proto2 required-field guarantee.
 
 Closes #123
 ```
 
-### Fixing bugs
 ```
-fix(classloader): resolve resource lookup in nested JARs
+fix(data): close JDBC statement when the result iterator is exhausted
 
-ClassLoader.getResource() was failing for resources in
-JARs loaded from plugin JARs (nested JARs). Fixed by
-implementing proper resource resolution chain.
+IterativeDbSource leaked a Statement when callers stopped before the last
+row. Wrap the cursor in try-with-resources so it closes on every path.
 
 Fixes #456
 ```
 
-### Dependency updates
 ```
-build(deps): bump slf4j from 1.7.30 to 2.0.9
+refactor(context): extract project-tree assembly from the MCP adapter
 
-Updates SLF4J to latest stable version. No API changes
-required as we use only stable APIs.
-```
-
-### Documentation improvements
-```
-docs(readme): add plugin development quickstart guide
-
-Add step-by-step guide for creating first plugin:
-- Project setup
-- Implementing Plugin interface
-- Building and testing
+Keeps the uniqueness/context core free of any MCP dependency, satisfying
+the layering rule pinned by the architecture tests.
 ```
 
-### Performance optimizations
 ```
-perf(plugin-loader): cache plugin descriptors
+test(claude-code-enforcer): cover duplicate skill descriptions
 
-Cache parsed plugin descriptors to avoid repeated I/O
-and parsing. Reduces plugin loading time by ~40%.
-
-Related to #789
+Add cases for UniqueDescriptionsRule when two SKILL.md files share a
+description.
 ```
 
-## Multi-file Changes
-
-When changes span multiple components:
-
 ```
-refactor(core): reorganize plugin lifecycle management
-
-- Extract lifecycle state machine to separate class
-- Move validation logic to validators package
-- Update tests to reflect new structure
-
-This refactoring improves testability and separation
-of concerns without changing external APIs.
-
-Related to #111, #222
+build(deps): add the shellcheck-maven-plugin with embedded binary resolution
 ```
 
-## Breaking Changes
+## Workflow
+1. Inspect staged changes: `git diff --staged --stat`, then targeted diffs.
+2. Pick the scope from the changed module(s); split unrelated changes into
+   separate commits.
+3. Choose the type from the nature of the change.
+4. Write the message; commit with `git commit -m "..."` (or a file for the body).
 
-Always use BREAKING CHANGE footer:
-
-```
-feat(api)!: replace Plugin.start() with Plugin.initialize()
-
-BREAKING CHANGE: The Plugin.start() method has been renamed
-to Plugin.initialize() for better semantic clarity. All
-plugin implementations must update their code.
-
-Migration guide: Replace @Override start() with @Override
-initialize() in all Plugin implementations.
-
-Closes #999
-```
-
-## Quick Reference Card
-
-| Change Type | Type | Example Scope |
-|-------------|------|---------------|
-| New feature | feat | api, core, loader |
-| Bug fix | fix | plugin-loader, lifecycle |
-| Refactoring | refactor | core, utils |
-| Tests | test | integration, unit |
-| Docs | docs | readme, javadoc |
-| Build | build | maven, deps |
-| Performance | perf | classloader, cache |
-| Maintenance | chore | ci, tooling |
+## Anti-patterns
+❌ "fix stuff" / "update code" / "WIP" (unless asked) / mixing unrelated changes
+/ inventing scopes that aren't real modules.
+✅ One logical change · clear searchable subject · real scope · references issues
+when applicable.
 
 ## References
-
-- [Conventional Commits Specification](https://www.conventionalcommits.org/)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- `AGENTS.md` — module map and release process

--- a/.claude/skills/java-code-review/SKILL.md
+++ b/.claude/skills/java-code-review/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: java-code-review
-description: Systematic code review for Java with null safety, exception handling, concurrency, and performance checks. Use when user says "review code", "check this PR", "code review", or before merging changes.
+description: Systematic Java code review for the tools repo — leads with the ArchUnit-enforced rules the build fails on, then null safety, exceptions, concurrency, and performance. Use when the user says "review code", "check this PR", "code review", or before merging changes.
 ---
 
 # Java Code Review Skill
 
-Systematic code review checklist for Java projects.
+Systematic code review for the `tools` multi-module reactor. Start with the
+rules this repo *enforces at build time* — an ArchUnit or Surefire violation
+fails the build, not just review — then work through the general Java checks.
 
 ## When to Use
 - User says "review this code" / "check this PR" / "code review"
@@ -13,10 +15,11 @@ Systematic code review checklist for Java projects.
 - After implementing a feature
 
 ## Review Strategy
-
-1. **Quick scan** - Understand intent, identify scope
-2. **Checklist pass** - Go through each category below
-3. **Summary** - List findings by severity (Critical → Minor)
+1. **Enforced-rules pass first** — anything below fails the build, so flag it as
+   Critical regardless of how the code otherwise reads.
+2. **Checklist pass** — null safety, exceptions, collections, concurrency,
+   idioms, resources, API, performance.
+3. **Summary** — findings by severity (Critical → Minor), with line references.
 
 ## Output Format
 
@@ -24,7 +27,7 @@ Systematic code review checklist for Java projects.
 ## Code Review: [file/feature name]
 
 ### Critical
-- [Issue description + line reference + suggestion]
+- [Issue + line reference + suggestion]
 
 ### Improvements
 - [Suggestion + rationale]
@@ -33,26 +36,43 @@ Systematic code review checklist for Java projects.
 - [Nitpicks, optional improvements]
 
 ### Good Practices Observed
-- [Positive feedback - important for morale]
+- [Positive feedback]
 ```
 
 ---
 
-## Review Checklist
+## 0. Repo rules the build enforces (check these FIRST)
 
-### 1. Null Safety
+These are pinned by the module `.architecture` ArchUnit tests and the root
+Surefire config. Production code is `io.github.adamw7.*` (Java 25). Flag any
+violation as **Critical** — CI will reject it.
 
-**Check for:**
+| Rule | What to flag |
+|---|---|
+| **No `continue` / `break`** | Any use in *any* code (production or test). Refactor the loop. |
+| **No `System.out` / `System.err`** | In production code — log through log4j2 instead. (Also banned in tests.) |
+| **Logging via log4j2 only** | No `java.lang.System.Logger`, no `printStackTrace`, no `System.exit`. Report failures through log4j2. |
+| **Loggers `private static final`** | Any other modifier set on a `Logger` field. |
+| **No `Optional` fields** | A field typed `Optional<…>`. Optional is for possibly-absent *return values*; a field holds the value itself and is null-checked. |
+| **Mutable static state is `volatile`** | A non-final mutable static field without `volatile`. |
+| **`java.time` only** | Any use of legacy `java.util.Date` / `Calendar`. |
+| **No package cycles / layering breaks** | Data-source contracts depending on their impls, uniqueness core depending on its MCP adapter, JDBC outside `source.db`. |
+| **Test conventions** | Tests only in `*Test`/`*IT`; JUnit 5 only; no `@Disabled`; no `Thread.sleep`; no `System.out`/`err`. See `testing-conventions`. |
+| **Surefire 900 ms/unit test** | A unit test doing real work without a justified `@Timeout`. See `testing-conventions`. |
+
+> Prefer a plain `for`/`for-each` loop with a single exit over any construct
+> that would want `continue`/`break`; extract a helper method that `return`s
+> early instead.
+
+---
+
+## 1. Null Safety
+
 ```java
 // ❌ NPE risk
 String name = user.getName().toUpperCase();
 
-// ✅ Safe
-String name = Optional.ofNullable(user.getName())
-    .map(String::toUpperCase)
-    .orElse("");
-
-// ✅ Also safe (early return)
+// ✅ Early return
 if (user.getName() == null) {
     return "";
 }
@@ -61,320 +81,124 @@ return user.getName().toUpperCase();
 
 **Flags:**
 - Chained method calls without null checks
-- Missing `@Nullable` / `@NonNull` annotations on public APIs
-- `Optional.get()` without `isPresent()` check
-- Returning `null` from methods that could return `Optional` or empty collection
+- `Optional.get()` without a presence check
+- Returning `null` where an empty collection reads better
 
 **Suggest:**
-- Use `Optional` for return types that may be absent
-- Use `Objects.requireNonNull()` for constructor/method params
-- Return empty collections instead of null: `Collections.emptyList()`
+- `Objects.requireNonNull(x, "x must not be null")` on constructor/method params
+- Return `Collections.emptyList()` (etc.) instead of `null`
+- `Optional` is fine as a **return type**, never as a **field** (repo rule above)
 
-### 2. Exception Handling
+## 2. Exception Handling
 
-**Check for:**
 ```java
-// ❌ Swallowing exceptions
-try {
-    process();
-} catch (Exception e) {
-    // silently ignored
-}
+// ❌ Swallowing / losing the cause
+try { process(); } catch (Exception e) { /* ignored */ }
+catch (IOException e) { throw new RuntimeException(e.getMessage()); }
 
-// ❌ Catching too broad
-catch (Exception e) { }
-catch (Throwable t) { }
-
-// ❌ Losing stack trace
-catch (IOException e) {
-    throw new RuntimeException(e.getMessage());
-}
-
-// ✅ Proper handling
+// ✅ Log with context AND chain the cause (log4j2)
 catch (IOException e) {
     log.error("Failed to process file: {}", filename, e);
     throw new ProcessingException("File processing failed", e);
 }
 ```
 
-**Flags:**
-- Empty catch blocks
-- Catching `Exception` or `Throwable` broadly
-- Losing original exception (not chaining)
-- Using exceptions for flow control
-- Checked exceptions leaking through API boundaries
+**Flags:** empty catch blocks, catching `Exception`/`Throwable` broadly, dropping
+the original cause, exceptions used for flow control, `printStackTrace` (banned).
 
-**Suggest:**
-- Log with context AND stack trace
-- Use specific exception types
-- Chain exceptions with `cause`
-- Consider custom exceptions for domain errors
+## 3. Collections & Streams
 
-### 3. Collections & Streams
-
-**Check for:**
 ```java
-// ❌ Modifying while iterating
-for (Item item : items) {
-    if (item.isExpired()) {
-        items.remove(item);  // ConcurrentModificationException
-    }
-}
-
-// ✅ Use removeIf
+// ❌ Modifying while iterating → ConcurrentModificationException
+for (Item item : items) { if (item.isExpired()) items.remove(item); }
+// ✅
 items.removeIf(Item::isExpired);
 
-// ❌ Stream for simple operations
-list.stream().forEach(System.out::println);
-
-// ✅ Simple loop is cleaner
-for (Item item : list) {
-    System.out.println(item);
-}
-
-// ❌ Collecting to modify
-List<String> names = users.stream()
-    .map(User::getName)
-    .collect(Collectors.toList());
-names.add("extra");  // Might be immutable!
-
-// ✅ Explicit mutable list
-List<String> names = users.stream()
-    .map(User::getName)
+// ❌ Assuming a mutable result
+List<String> names = users.stream().map(User::getName).collect(Collectors.toList());
+names.add("extra");
+// ✅ Be explicit when you need to mutate
+List<String> names = users.stream().map(User::getName)
     .collect(Collectors.toCollection(ArrayList::new));
 ```
 
-**Flags:**
-- Modifying collections during iteration
-- Overusing streams for simple operations
-- Assuming `Collectors.toList()` returns mutable list
-- Not using `List.of()`, `Set.of()`, `Map.of()` for immutable collections
-- Parallel streams without understanding implications
+**Flags:** modification during iteration, assuming `toList()` is mutable, not
+using `List.of()`/`Set.of()`/`Map.of()` for constants, parallel streams without
+a reason.
 
-**Suggest:**
-- `List.copyOf()` for defensive copies
-- `removeIf()` instead of iterator removal
-- Streams for transformations, loops for side effects
+## 4. Concurrency
 
-### 4. Concurrency
-
-**Check for:**
 ```java
 // ❌ Not thread-safe
 private Map<String, User> cache = new HashMap<>();
+// ✅
+private final Map<String, User> cache = new ConcurrentHashMap<>();
 
-// ✅ Thread-safe
-private Map<String, User> cache = new ConcurrentHashMap<>();
-
-// ❌ Check-then-act race condition
-if (!map.containsKey(key)) {
-    map.put(key, computeValue());
-}
-
-// ✅ Atomic operation
+// ❌ Check-then-act race
+if (!map.containsKey(key)) map.put(key, computeValue());
+// ✅ Atomic
 map.computeIfAbsent(key, k -> computeValue());
-
-// ❌ Double-checked locking (broken without volatile)
-if (instance == null) {
-    synchronized(this) {
-        if (instance == null) {
-            instance = new Instance();
-        }
-    }
-}
 ```
 
-**Flags:**
-- Shared mutable state without synchronization
-- Check-then-act patterns without atomicity
-- Missing `volatile` on shared variables
-- Synchronized on non-final objects
-- Thread-unsafe lazy initialization
+**Flags:** shared mutable state without synchronization, check-then-act without
+atomicity, **missing `volatile` on mutable static state** (repo rule), locking
+on non-final objects.
 
-**Suggest:**
-- Prefer immutable objects
-- Use `java.util.concurrent` classes
-- `AtomicReference`, `AtomicInteger` for simple cases
-- Consider `@ThreadSafe` / `@NotThreadSafe` annotations
+## 5. Java Idioms
 
-### 5. Java Idioms
-
-**equals/hashCode:**
 ```java
-// ❌ Only equals without hashCode
-@Override
-public boolean equals(Object o) { ... }
-// Missing hashCode!
-
-// ❌ Mutable fields in hashCode
-@Override
-public int hashCode() {
-    return Objects.hash(id, mutableField);  // Breaks HashMap
-}
-
-// ✅ Use immutable fields, implement both
-@Override
-public boolean equals(Object o) {
+// ✅ equals + hashCode on immutable fields, both or neither
+@Override public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof User user)) return false;
+    if (!(o instanceof User user)) return false;   // pattern matching (Java 25)
     return Objects.equals(id, user.id);
 }
-
-@Override
-public int hashCode() {
-    return Objects.hash(id);
-}
+@Override public int hashCode() { return Objects.hash(id); }
 ```
 
-**toString:**
+**Flags:** `equals` without `hashCode` (or vice versa), mutable fields in
+`hashCode`, missing `toString` on domain objects, sensitive data in `toString`,
+constructors with > 3–4 params (consider a builder — the repo's
+`protogen-maven-plugin` generates compile-time-safe builders for protobuf).
+
+## 6. Resource Management
+
 ```java
-// ❌ Missing - hard to debug
-// No toString()
-
-// ❌ Including sensitive data
-return "User{password='" + password + "'}";
-
-// ✅ Useful for debugging
-@Override
-public String toString() {
-    return "User{id=" + id + ", name='" + name + "'}";
-}
-```
-
-**Builders:**
-```java
-// ✅ For classes with many optional parameters
-User user = User.builder()
-    .name("John")
-    .email("john@example.com")
-    .build();
-```
-
-**Flags:**
-- `equals` without `hashCode`
-- Mutable fields in `hashCode`
-- Missing `toString` on domain objects
-- Constructors with > 3-4 parameters (suggest builder)
-- Not using `instanceof` pattern matching (Java 16+)
-
-### 6. Resource Management
-
-**Check for:**
-```java
-// ❌ Resource leak
-FileInputStream fis = new FileInputStream(file);
-// ... might throw before close
-
-// ✅ Try-with-resources
-try (FileInputStream fis = new FileInputStream(file)) {
-    // ...
-}
-
-// ❌ Multiple resources, wrong order
-try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
-    // FileWriter might not be closed if BufferedWriter fails
-}
-
-// ✅ Separate declarations
+// ✅ Try-with-resources; separate declarations so both always close
 try (FileWriter fw = new FileWriter(file);
      BufferedWriter writer = new BufferedWriter(fw)) {
-    // Both properly closed
+    // ...
 }
 ```
 
-**Flags:**
-- Not using try-with-resources for `Closeable`/`AutoCloseable`
-- Resources opened but not in try-with-resources
-- Database connections/statements not properly closed
+**Flags:** `Closeable`/`AutoCloseable` opened outside try-with-resources; JDBC
+connections/statements not closed (relevant in `data`'s `source.db`).
 
-### 7. API Design
+## 7. API Design
 
-**Check for:**
 ```java
-// ❌ Boolean parameters
-process(data, true, false);  // What do these mean?
-
-// ✅ Use enums or builder
+// ❌ Boolean params — meaning is lost at the call site
+process(data, true, false);
+// ✅ Enums
 process(data, ProcessMode.ASYNC, ErrorHandling.STRICT);
-
-// ❌ Returning null for "not found"
-public User findById(Long id) {
-    return users.get(id);  // null if not found
-}
-
-// ✅ Return Optional
-public Optional<User> findById(Long id) {
-    return Optional.ofNullable(users.get(id));
-}
-
-// ❌ Accepting null collections
-public void process(List<Item> items) {
-    if (items == null) items = Collections.emptyList();
-}
-
-// ✅ Require non-null, accept empty
-public void process(List<Item> items) {
-    Objects.requireNonNull(items, "items must not be null");
-}
 ```
 
-**Flags:**
-- Boolean parameters (prefer enums)
-- Methods with > 3 parameters (consider parameter object)
-- Inconsistent null handling across similar methods
-- Missing validation on public API inputs
+**Flags:** boolean params (prefer enums), > 3 params (parameter object),
+inconsistent null handling, missing validation on public inputs. Reinforce
+**SRP/DIP** — see `solid-principles`.
 
-### 8. Performance Considerations
+## 8. Performance
 
-**Check for:**
 ```java
-// ❌ String concatenation in loop
-String result = "";
-for (String s : strings) {
-    result += s;  // Creates new String each iteration
-}
-
-// ✅ StringBuilder
+// ❌ String concat in a loop / regex compiled per iteration
+// ✅
 StringBuilder sb = new StringBuilder();
-for (String s : strings) {
-    sb.append(s);
-}
-
-// ❌ Regex compilation in loop
-for (String line : lines) {
-    if (line.matches("pattern.*")) { }  // Compiles regex each time
-}
-
-// ✅ Pre-compiled pattern
 private static final Pattern PATTERN = Pattern.compile("pattern.*");
-for (String line : lines) {
-    if (PATTERN.matcher(line).matches()) { }
-}
-
-// ❌ N+1 in loops
-for (User user : users) {
-    List<Order> orders = orderRepo.findByUserId(user.getId());
-}
-
-// ✅ Batch fetch
-Map<Long, List<Order>> ordersByUser = orderRepo.findByUserIds(userIds);
 ```
 
-**Flags:**
-- String concatenation in loops
-- Regex compilation in loops
-- N+1 query patterns
-- Creating objects in tight loops that could be reused
-- Not using primitive streams (`IntStream`, `LongStream`)
-
-### 9. Testing Hints
-
-**Suggest tests for:**
-- Null inputs
-- Empty collections
-- Boundary values
-- Exception cases
-- Concurrent access (if applicable)
+**Flags:** string concatenation in loops, regex compiled inside loops, N+1
+access patterns, object churn in tight loops, not using primitive streams
+(`IntStream`/`LongStream`) where it matters.
 
 ---
 
@@ -382,27 +206,18 @@ Map<Long, List<Order>> ordersByUser = orderRepo.findByUserIds(userIds);
 
 | Severity | Criteria |
 |----------|----------|
-| **Critical** | Security vulnerability, data loss risk, production crash |
-| **High** | Bug likely, significant performance issue, breaks API contract |
+| **Critical** | Breaks an enforced repo rule (section 0), security/data-loss risk, or a likely crash |
+| **High** | Bug likely, significant perf issue, breaks an API contract |
 | **Medium** | Code smell, maintainability issue, missing best practice |
-| **Low** | Style, minor optimization, suggestion |
+| **Low** | Style, minor optimization |
 
 ## Token Optimization
+- Focus on changed lines (`git diff`); group similar findings.
+- Reference line numbers, don't re-quote whole blocks.
+- Skip generated sources (protogen output under `target/`) and fixtures.
 
-- Focus on changed lines (use `git diff`)
-- Don't repeat obvious issues - group similar findings
-- Reference line numbers, not full code quotes
-- Skip files that are auto-generated or test fixtures
-
-## Quick Reference Card
-
-| Category | Key Checks |
-|----------|------------|
-| Null Safety | Chained calls, Optional misuse, null returns |
-| Exceptions | Empty catch, broad catch, lost stack trace |
-| Collections | Modification during iteration, stream vs loop |
-| Concurrency | Shared mutable state, check-then-act |
-| Idioms | equals/hashCode pair, toString, builders |
-| Resources | try-with-resources, connection leaks |
-| API | Boolean params, null handling, validation |
-| Performance | String concat, regex in loop, N+1 |
+## References
+- `CLAUDE.md` / `AGENTS.md` — source of truth for the enforced rules
+- Module `.architecture` tests (e.g. `ProtogenArchitectureTest`,
+  `ContextArchitectureTest`, `TestConventionsArchitectureTest`)
+- Related skills: `solid-principles`, `testing-conventions`, `maven-conventions`

--- a/.claude/skills/solid-principles/SKILL.md
+++ b/.claude/skills/solid-principles/SKILL.md
@@ -574,37 +574,28 @@ public class InMemoryOrderRepository implements OrderRepository {
 }
 ```
 
-### DIP with Spring
+### DIP in this repo (plain constructor injection — no framework)
+
+`tools` is a plain Maven library: **there is no Spring / CDI here.** Wire
+dependencies by hand through the constructor and pass a test double in tests —
+exactly how the `data` sources and the MCP servers are assembled.
 
 ```java
-// Spring handles dependency injection automatically
+// Production wiring — the caller supplies the concretions
+OrderService service = new OrderService(
+    new MySqlOrderRepository(),
+    new SmtpEmailSender());
 
-@Service
-public class OrderService {
-    private final OrderRepository repository;
-    private final NotificationSender notificationSender;
-
-    // Constructor injection (recommended)
-    public OrderService(OrderRepository repository,
-                        NotificationSender notificationSender) {
-        this.repository = repository;
-        this.notificationSender = notificationSender;
-    }
-}
-
-@Repository
-public class JpaOrderRepository implements OrderRepository {
-    // Spring provides implementation
-}
-
-@Component
-@Profile("production")
-public class SmtpEmailSender implements NotificationSender { }
-
-@Component
-@Profile("test")
-public class MockEmailSender implements NotificationSender { }
+// Test wiring — swap in in-memory / fake implementations, no network needed
+OrderService service = new OrderService(
+    new InMemoryOrderRepository(),
+    recordingNotificationSender);
 ```
+
+> Repo caveat: `Optional` is fine as a **return type** (e.g.
+> `Optional<Order> findById(...)`), but a **field must never be `Optional`** —
+> an ArchUnit rule fails the build on `Optional` fields. Hold the value itself
+> and null-check it.
 
 ### How to Detect DIP Violations
 
@@ -643,6 +634,7 @@ When reviewing code, check:
 
 ## Related Skills
 
-- `design-patterns` - Implementation patterns (Factory, Strategy, Observer, etc.)
-- `clean-code` - Code-level principles (DRY, KISS, naming)
-- `java-code-review` - Comprehensive review checklist
+- `java-code-review` - Comprehensive review checklist (leads with the repo's
+  ArchUnit-enforced rules)
+- `testing-conventions` - Writing the fast, network-off, DI-friendly tests these
+  abstractions make possible


### PR DESCRIPTION
Rework the three generic skills to match this repo the way maven-conventions
and testing-conventions already do:

- java-code-review: lead with the ArchUnit/Surefire rules the build enforces
  (no continue/break, no Optional fields, log4j2 only, no System.out /
  printStackTrace / System.exit, volatile static, java.time); drop the
  System.out.println example that violated those rules; fix Java 16 -> 25.
- solid-principles: replace the Spring-based DIP section (repo has no Spring)
  with plain constructor injection, add the "no Optional fields" caveat, and
  fix dead Related Skills links (design-patterns, clean-code did not exist).
- git-commit: trim the boilerplate and use real module scopes (data, code,
  context, protogen-maven-plugin, adopt, mcp-common, claude-code-enforcer,
  assembly) instead of invented plugin-loader/Spring examples.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UpaA8tyAxEuQK9AkEzezoq