### PR TITLE
fix(build): scope junit-jupiter to test in modules that leak it

### DIFF
--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -32,6 +32,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.tngtech.archunit</groupId>

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -75,6 +75,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/code/protogen-maven-plugin-test/pom.xml
+++ b/code/protogen-maven-plugin-test/pom.xml
@@ -87,6 +87,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.google.protobuf</groupId>

--- a/code/protogen-maven-plugin/pom.xml
+++ b/code/protogen-maven-plugin/pom.xml
@@ -66,6 +66,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -86,10 +86,12 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -123,6 +123,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Six modules declared junit-jupiter-engine (and junit-jupiter-params in
data) at the default compile scope, unlike mcp-common and adopt which
correctly use test scope. JUnit is only used from test sources — no main
code imports it (verified), and only data-test's main module-info
legitimately `requires org.junit.jupiter.api`, so that module is left
untouched.

Because the root pom flattens published modules with flattenMode=oss,
which strips test-scoped dependencies, the compile-scoped junit was
leaking into the published POMs of data, code.context and
protogen-maven-plugin, imposing JUnit as a transitive compile/runtime
dependency on every Maven Central consumer. Verified the flattened
tools.data POM no longer lists any junit dependency, and all 468 data
module tests still pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015VkHUuFHbMM9RVcEZg6DWq