### PR TITLE
feat(adopt): fall back to a GitHub Actions guard for build-less repos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,10 @@ Maven project. The notable capabilities are:
   gets the full `claude-code-enforcer` rule wired into its `pom.xml` and verified
   with a non-recursive `mvn -N validate`; a Gradle project (Groovy or Kotlin DSL)
   gets an `enforceClaudeMd` presence guard task appended to its build script and
-  verified by running that task. The pull request metadata — title, body,
+  verified by running that task; a repository with no recognised build file falls
+  back to a GitHub Actions workflow and the portable `.github/claude-md-guard.sh`
+  check it runs, verified by running that script — so a build-less repository
+  still keeps the guard. The pull request metadata — title, body,
   reviewers, labels, assignees, and draft flag — is supplied through
   `PullRequestOptions`. External `git`/`claude`/`gh` invocations
   go through a `CommandRunner`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,9 @@ run `mvn install` from the repository root. The main capabilities are:
   clone, create a feature branch, `claude init` to generate
   `CLAUDE.md` and commit it, wire a build-tool-aware `CLAUDE.md` guard into the
   repo (the `claude-code-enforcer` rule for Maven `pom.xml`, an `enforceClaudeMd`
-  guard task for Gradle) and commit that, verify the guard passes on the
+  guard task for Gradle, and a GitHub Actions workflow plus
+  `.github/claude-md-guard.sh` check as the build-tool-agnostic fallback) and
+  commit that, verify the guard passes on the
   generated file, then push the branch and open a pull request (`gh pr create`)
   with metadata from `PullRequestOptions`; the default branch is never written to
   directly.

--- a/README.md
+++ b/README.md
@@ -727,7 +727,11 @@ being validated on every build. The guard is build-tool aware: a Maven project
 gets the full [`claude-code-enforcer`](#claude-code-files-maven-enforcer) rule in
 its `pom.xml`, while a Gradle project (Groovy `build.gradle` or Kotlin
 `build.gradle.kts`) gets a presence-and-non-empty guard task appended to the
-build script — Gradle has no enforcer-rule equivalent. Finally it pushes the
+build script — Gradle has no enforcer-rule equivalent. A repository with no
+recognised build file falls back to a build-tool-agnostic GitHub Actions
+workflow that runs a portable presence-and-non-empty check script on every push
+and pull request, so even a build-less repository keeps the guard. Finally it
+pushes the
 branch and opens a pull request with the GitHub CLI, so the change is reviewed
 rather than landing straight on the default branch, which is never written to.
 
@@ -781,17 +785,19 @@ The default pipeline runs these steps in order:
    DOM — no third-party XML library — is namespace-aware, and is idempotent); a
    Gradle project has a `enforceClaudeMd` guard task appended to its
    `build.gradle`/`build.gradle.kts` via `GradleGuardInstaller`, wired into
-   `check`. Both installs are idempotent, and a repository with no supported build
-   file is skipped with a warning rather than failing the adoption. Supporting a
-   new build tool is a matter of adding a `BuildSystem` implementation rather than
-   branching inside the step.
+   `check`. A repository with no recognised build file falls back to a
+   `FallbackBuildSystem` that installs a GitHub Actions workflow and the portable
+   `.github/claude-md-guard.sh` check it runs via `WorkflowGuardInstaller`. All
+   installs are idempotent. Supporting a new build tool is a matter of adding a
+   `BuildSystem` implementation rather than branching inside the step.
 8. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
    build`).
 9. **`VerifyStep`** — runs the detected build system's verification (a
    non-recursive `mvn -N validate` for Maven, the `enforceClaudeMd` task for
-   Gradle) so the freshly wired guard actually executes against the generated
-   `CLAUDE.md`, failing the adoption locally if the file is missing or malformed
-   rather than after the pull request lands.
+   Gradle, the `.github/claude-md-guard.sh` script for the fallback) so the
+   freshly wired guard actually executes against the generated `CLAUDE.md`,
+   failing the adoption locally if the file is missing or malformed rather than
+   after the pull request lands.
 10. **`PushStep`** — pushes the feature branch to origin and sets its upstream
     (`git push -u origin <branch>`).
 11. **`PullRequestStep`** — opens a pull request from the branch with

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystems.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystems.java
@@ -8,12 +8,19 @@ import java.util.Optional;
  * The build systems the adoption supports and the detection that picks the one
  * matching a checkout. The default set is tried in order, so a repository that
  * happens to carry more than one build file is adopted with the first-listed
- * build tool.
+ * build tool. The {@link FallbackBuildSystem} is listed last and matches every
+ * checkout, so a repository with no recognised build file still gets a guard
+ * rather than being adopted with none.
  */
 public final class BuildSystems {
 
-	/** Maven first, then Gradle: the order the checkout is probed in. */
-	public static final List<BuildSystem> DEFAULTS = List.of(new MavenBuildSystem(), new GradleBuildSystem());
+	/**
+	 * Maven first, then Gradle, then the catch-all fallback: the order the checkout
+	 * is probed in. The fallback stays last so a real build tool is always preferred
+	 * when its build file is present.
+	 */
+	public static final List<BuildSystem> DEFAULTS = List.of(new MavenBuildSystem(), new GradleBuildSystem(),
+			new FallbackBuildSystem());
 
 	private BuildSystems() {
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerStep.java
@@ -14,9 +14,12 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * Wires a {@code CLAUDE.md} guard into the adopted project's build so the
  * generated {@code CLAUDE.md} keeps being validated on every build. The concrete
  * wiring depends on the checkout's build tool: a Maven project gets the full
- * {@code claude-code-enforcer} rule, a Gradle project gets a presence guard task
- * (see {@link BuildSystem}). A repository with no supported build file is skipped
- * with a warning rather than failing the adoption.
+ * {@code claude-code-enforcer} rule, a Gradle project gets a presence guard task,
+ * and a project with no recognised build file gets the build-tool-agnostic
+ * GitHub Actions guard (see {@link BuildSystem}). Detection only comes up empty
+ * when the step is configured with a build-system list that has no catch-all
+ * fallback, in which case the wiring is skipped with a warning rather than
+ * failing the adoption.
  */
 public class EnforcerStep implements AdoptionStep {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
@@ -1,0 +1,51 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * The catch-all build system for the adoption: it matches every checkout, so a
+ * repository with no Maven or Gradle build file still gets a {@code CLAUDE.md}
+ * guard instead of being adopted with none. Because it matches unconditionally it
+ * is listed last in {@link BuildSystems#DEFAULTS}, after the real build tools, so
+ * it only wins when none of them detected a build file.
+ *
+ * <p>The guard is a GitHub Actions workflow and the portable shell script it runs,
+ * installed with {@link WorkflowGuardInstaller}; the verification runs that same
+ * script locally so a missing or empty {@code CLAUDE.md} fails the adoption before
+ * the branch is pushed, exactly as it would in CI afterwards.
+ */
+public class FallbackBuildSystem implements BuildSystem {
+
+	static final List<String> VERIFY_COMMAND = List.of("sh", WorkflowGuardInstaller.SCRIPT_FILE);
+
+	private final WorkflowGuardInstaller installer;
+
+	public FallbackBuildSystem() {
+		this(new WorkflowGuardInstaller());
+	}
+
+	public FallbackBuildSystem(WorkflowGuardInstaller installer) {
+		this.installer = installer;
+	}
+
+	@Override
+	public String name() {
+		return "github-actions";
+	}
+
+	@Override
+	public boolean matches(Path repositoryDirectory) {
+		return true;
+	}
+
+	@Override
+	public boolean install(Path repositoryDirectory) {
+		return installer.install(repositoryDirectory);
+	}
+
+	@Override
+	public List<String> verifyCommand() {
+		return VERIFY_COMMAND;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/VerifyStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/VerifyStep.java
@@ -15,9 +15,11 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * {@code CLAUDE.md} fails the adoption locally instead of breaking the
  * contributor's build after the pull request lands. The command to run is
  * chosen from the checkout's build tool — a non-recursive {@code mvn -N validate}
- * for Maven, the guard task for Gradle (see {@link BuildSystem}). A repository
- * with no supported build file has nothing to verify and is skipped, mirroring
- * {@link EnforcerStep}.
+ * for Maven, the guard task for Gradle, the guard script for a project with no
+ * recognised build file (see {@link BuildSystem}). Detection only comes up empty
+ * when the step is configured with a build-system list that has no catch-all
+ * fallback, in which case there is nothing to verify and the step is skipped,
+ * mirroring {@link EnforcerStep}.
  */
 public class VerifyStep extends AbstractCommandStep {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
@@ -1,0 +1,88 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+/**
+ * Installs a build-tool-agnostic {@code CLAUDE.md} guard into a checkout that has
+ * no Maven or Gradle build to wire into. The guard is a GitHub Actions workflow
+ * that runs a small portable shell script on every push and pull request, failing
+ * the run when the generated {@code CLAUDE.md} is missing or empty. Because the
+ * adoption already targets GitHub repositories, a workflow is a guard every
+ * adopted repository can run without introducing a build tool.
+ *
+ * <p>The workflow and the script it runs are both committed, so the guard is
+ * shared with every contributor rather than living only in the adopter's local
+ * checkout. The script is the single source of truth: the workflow invokes it and
+ * {@link FallbackBuildSystem#verifyCommand()} runs the same script locally, so the
+ * adoption fails before the branch is pushed just as it would in CI. The install
+ * is idempotent: a checkout whose workflow already carries the adoption marker is
+ * left unchanged.
+ */
+public class WorkflowGuardInstaller {
+
+	static final String WORKFLOW_FILE = ".github/workflows/claude-md-guard.yml";
+	static final String SCRIPT_FILE = ".github/claude-md-guard.sh";
+
+	private static final String MARKER = "Added by claude-code-adopt";
+
+	private static final String WORKFLOW = """
+			# %s: fail CI when CLAUDE.md is missing or empty.
+			name: CLAUDE.md guard
+			on: [push, pull_request]
+			jobs:
+			  claude-md-guard:
+			    runs-on: ubuntu-latest
+			    steps:
+			      - uses: actions/checkout@v4
+			      - name: Enforce CLAUDE.md
+			        run: sh %s
+			""".formatted(MARKER, SCRIPT_FILE);
+
+	private static final String SCRIPT = """
+			#!/bin/sh
+			# %s: fail when CLAUDE.md is missing or empty.
+			if [ ! -f CLAUDE.md ] || ! grep -q '[^[:space:]]' CLAUDE.md; then
+			  echo "CLAUDE.md is missing or empty" >&2
+			  exit 1
+			fi
+			""".formatted(MARKER);
+
+	/**
+	 * @return {@code true} when the guard was written, {@code false} when the
+	 *         checkout already carried it and was left unchanged.
+	 */
+	public boolean install(Path repositoryDirectory) {
+		Path workflowFile = repositoryDirectory.resolve(WORKFLOW_FILE);
+		if (alreadyGuarded(workflowFile)) {
+			return false;
+		}
+		write(workflowFile, WORKFLOW);
+		write(repositoryDirectory.resolve(SCRIPT_FILE), SCRIPT);
+		return true;
+	}
+
+	private boolean alreadyGuarded(Path workflowFile) {
+		return Files.isRegularFile(workflowFile) && read(workflowFile).contains(MARKER);
+	}
+
+	private String read(Path file) {
+		try {
+			return Files.readString(file);
+		} catch (IOException e) {
+			throw new AdoptionException("Could not read workflow file: " + file, e);
+		}
+	}
+
+	private void write(Path file, String content) {
+		try {
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new AdoptionException("Could not write guard file: " + file, e);
+		}
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -44,13 +44,25 @@ class BuildSystemsTest {
 	}
 
 	@Test
-	void detectsNothingForAnUnsupportedProject(@TempDir Path directory) {
-		assertTrue(BuildSystems.detect(BuildSystems.DEFAULTS, directory).isEmpty());
+	void fallsBackToTheGitHubActionsGuardForAnUnsupportedProject(@TempDir Path directory) {
+		Optional<BuildSystem> detected = BuildSystems.detect(BuildSystems.DEFAULTS, directory);
+		assertEquals("github-actions", detected.orElseThrow().name());
+	}
+
+	@Test
+	void detectsNothingWhenNoCandidateMatchesAndThereIsNoFallback(@TempDir Path directory) {
+		List<BuildSystem> withoutFallback = List.of(new MavenBuildSystem(), new GradleBuildSystem());
+		assertTrue(BuildSystems.detect(withoutFallback, directory).isEmpty());
 	}
 
 	@Test
 	void listsBuildSystemNames() {
-		assertEquals("maven/gradle", BuildSystems.names(BuildSystems.DEFAULTS));
+		assertEquals("maven/gradle/github-actions", BuildSystems.names(BuildSystems.DEFAULTS));
+	}
+
+	@Test
+	void fallbackVerifyCommandRunsTheGuardScript() {
+		assertEquals(List.of("sh", ".github/claude-md-guard.sh"), new FallbackBuildSystem().verifyCommand());
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -60,10 +61,19 @@ class EnforcerStepTest {
 	}
 
 	@Test
-	void skipsWhenNoSupportedBuildFileIsPresent(@TempDir Path workspace) throws IOException {
+	void wiresTheFallbackGuardWhenNoBuildFileIsPresent(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
-		assertDoesNotThrow(() -> new EnforcerStep().execute(context, new RecordingCommandRunner()));
+		new EnforcerStep().execute(context, new RecordingCommandRunner());
+		assertTrue(Files.exists(context.repositoryDirectory().resolve(WorkflowGuardInstaller.WORKFLOW_FILE)));
 		assertFalse(Files.exists(context.repositoryDirectory().resolve("pom.xml")));
+	}
+
+	@Test
+	void skipsWhenNoConfiguredBuildSystemMatches(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		EnforcerStep step = new EnforcerStep(List.of(new MavenBuildSystem(), new GradleBuildSystem()));
+		assertDoesNotThrow(() -> step.execute(context, new RecordingCommandRunner()));
+		assertFalse(Files.exists(context.repositoryDirectory().resolve(WorkflowGuardInstaller.WORKFLOW_FILE)));
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystemTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystemTest.java
@@ -1,0 +1,44 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FallbackBuildSystemTest {
+
+	private final FallbackBuildSystem buildSystem = new FallbackBuildSystem();
+
+	@Test
+	void matchesEveryCheckoutSoNothingIsLeftWithoutAGuard(@TempDir Path directory) {
+		assertTrue(buildSystem.matches(directory));
+	}
+
+	@Test
+	void isNamedForItsGitHubActionsGuard() {
+		assertEquals("github-actions", buildSystem.name());
+	}
+
+	@Test
+	void verifyCommandRunsTheGuardScript() {
+		assertEquals(List.of("sh", ".github/claude-md-guard.sh"), buildSystem.verifyCommand());
+	}
+
+	@Test
+	void installWritesTheWorkflowGuard(@TempDir Path directory) {
+		assertTrue(buildSystem.install(directory));
+		assertTrue(Files.isRegularFile(directory.resolve(WorkflowGuardInstaller.WORKFLOW_FILE)));
+	}
+
+	@Test
+	void installIsIdempotent(@TempDir Path directory) {
+		buildSystem.install(directory);
+		assertFalse(buildSystem.install(directory));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
@@ -67,10 +67,18 @@ class VerifyStepTest {
 	}
 
 	@Test
-	void skipsWhenNoSupportedBuildFileIsPresent(@TempDir Path workspace) throws IOException {
+	void runsTheFallbackGuardScriptWhenNoBuildFileIsPresent(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new VerifyStep().execute(context, runner);
+		assertEquals(FallbackBuildSystem.VERIFY_COMMAND, runner.commandAt(0));
+	}
+
+	@Test
+	void skipsWhenNoConfiguredBuildSystemMatches(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new VerifyStep(List.of(new MavenBuildSystem(), new GradleBuildSystem())).execute(context, runner);
 		assertEquals(0, runner.count());
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstallerTest.java
@@ -1,0 +1,42 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WorkflowGuardInstallerTest {
+
+	private final WorkflowGuardInstaller installer = new WorkflowGuardInstaller();
+
+	@Test
+	void writesTheWorkflowThatRunsTheGuardScript(@TempDir Path directory) throws IOException {
+		assertTrue(installer.install(directory));
+		String workflow = Files.readString(directory.resolve(WorkflowGuardInstaller.WORKFLOW_FILE));
+		assertTrue(workflow.contains("uses: actions/checkout@v4"));
+		assertTrue(workflow.contains("run: sh " + WorkflowGuardInstaller.SCRIPT_FILE));
+	}
+
+	@Test
+	void writesTheGuardScriptThatFailsOnAMissingOrEmptyClaudeMd(@TempDir Path directory) throws IOException {
+		assertTrue(installer.install(directory));
+		String script = Files.readString(directory.resolve(WorkflowGuardInstaller.SCRIPT_FILE));
+		assertTrue(script.startsWith("#!/bin/sh"));
+		assertTrue(script.contains("grep -q '[^[:space:]]' CLAUDE.md"));
+		assertTrue(script.contains("CLAUDE.md is missing or empty"));
+	}
+
+	@Test
+	void leavesAnAlreadyGuardedCheckoutUnchanged(@TempDir Path directory) throws IOException {
+		installer.install(directory);
+		String afterFirstInstall = Files.readString(directory.resolve(WorkflowGuardInstaller.WORKFLOW_FILE));
+		assertFalse(installer.install(directory));
+		assertEquals(afterFirstInstall, Files.readString(directory.resolve(WorkflowGuardInstaller.WORKFLOW_FILE)));
+	}
+}


### PR DESCRIPTION
Repositories with no Maven or Gradle build file were adopted with no
CLAUDE.md guard at all: EnforcerStep/VerifyStep detected no BuildSystem
and skipped with a warning. Add a catch-all FallbackBuildSystem, listed
last in BuildSystems.DEFAULTS, that installs a build-tool-agnostic guard
via WorkflowGuardInstaller: a committed GitHub Actions workflow plus a
portable .github/claude-md-guard.sh presence-and-non-empty check it runs
on every push and pull request. The verification runs that same script
locally so a missing or empty CLAUDE.md fails the adoption before the
branch is pushed, exactly as it would in CI afterwards.

Detection now only comes up empty for a custom build-system list without
a fallback, so that skip path stays covered. Updates AGENTS.md, README,
and CLAUDE.md to describe the fallback.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rd4mHL9wb9xwfGqz6xs8R6