### PR TITLE
fix(data): close symlink path-traversal bypass in PathValidator

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/PathValidator.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/PathValidator.java
@@ -1,6 +1,8 @@
 package io.github.adamw7.tools.data.source.file;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
@@ -57,10 +59,10 @@ public final class PathValidator {
 			Path resolved = Path.of(filePath).toAbsolutePath().normalize();
 			Path baseDir = allowedBaseDir;
 			if (baseDir != null) {
-				Path normalizedBase = baseDir.toAbsolutePath().normalize();
-				if (!resolved.startsWith(normalizedBase)) {
+				Path realResolved = toRealPathAllowingMissing(resolved);
+				if (!realResolved.startsWith(baseDir)) {
 					throw new SecurityException(
-							"Access denied: path '" + resolved + "' is outside the allowed base directory '" + normalizedBase + "'");
+							"Access denied: path '" + realResolved + "' is outside the allowed base directory '" + baseDir + "'");
 				}
 			}
 
@@ -68,6 +70,31 @@ public final class PathValidator {
 			return resolved.toString();
 		} catch (InvalidPathException e) {
 			throw new IllegalArgumentException("Invalid file path: " + filePath, e);
+		}
+	}
+
+	/**
+	 * Resolves {@code path} to its real, symlink-followed location so the containment
+	 * check cannot be bypassed by a symlink that lives inside the base directory but
+	 * points outside it. A purely textual {@code normalize()} would collapse {@code ..}
+	 * without ever following the link, letting {@code <base>/link/secret} slip past when
+	 * {@code link} targets {@code /etc}. The nearest existing ancestor is canonicalised
+	 * with {@link Path#toRealPath()} and the not-yet-created remainder re-appended, so the
+	 * check works whether or not the leaf file exists yet.
+	 */
+	private static Path toRealPathAllowingMissing(Path path) {
+		Path existing = path;
+		while (existing != null && !Files.exists(existing)) {
+			existing = existing.getParent();
+		}
+		if (existing == null) {
+			return path;
+		}
+		try {
+			Path realExisting = existing.toRealPath();
+			return realExisting.resolve(existing.relativize(path)).normalize();
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not resolve real path for: " + path, e);
 		}
 	}
 

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/PathValidatorTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/PathValidatorTest.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.data.source.file;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -83,6 +84,27 @@ public class PathValidatorTest {
 
 		Path outside = tempDir.resolve("outside.csv");
 		assertThrows(SecurityException.class, () -> PathValidator.validate(outside.toString()));
+	}
+
+	@Test
+	public void deniesSymlinkInsideBaseDirPointingOutside(@TempDir Path tempDir) throws IOException {
+		Path baseDir = Files.createDirectory(tempDir.resolve("base"));
+		Path secret = Files.writeString(tempDir.resolve("secret.csv"), "top,secret");
+		Path link = baseDir.resolve("link.csv");
+		assumeTrue(canCreateSymbolicLink(link, secret),
+				"platform does not support creating symbolic links");
+		PathValidator.setAllowedBaseDir(baseDir);
+
+		assertThrows(SecurityException.class, () -> PathValidator.validate(link.toString()));
+	}
+
+	private static boolean canCreateSymbolicLink(Path link, Path target) {
+		try {
+			Files.createSymbolicLink(link, target);
+			return true;
+		} catch (UnsupportedOperationException | IOException e) {
+			return false;
+		}
 	}
 
 	@Test


### PR DESCRIPTION
PathValidator.validate() enforced its allowed-base-directory containment
with a purely textual normalize(), which collapses ".." without following
symlinks. A symlink living inside the base directory but pointing outside
it (e.g. "<base>/link" -> "/etc") therefore passed the check while reading
an arbitrary file — defeating the confinement the uniqueness MCP server
relies on to keep a remote client away from files like /etc/passwd
(McpConfiguration.confineFileAccess). The sibling PathPolicy in the context
module already resolves the real path; PathValidator did not.

Resolve the requested path to its real, symlink-followed location (via the
nearest existing ancestor, so not-yet-created leaves still validate) before
the startsWith containment check. Add a regression test that creates a
symlink inside the base dir pointing outside and asserts it is denied.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KHJQUDVquaGPc2MmLCgAk4