### PR TITLE
build: enforce 80% branch coverage in JaCoCo check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -696,6 +696,11 @@
 													<value>COVEREDRATIO</value>
 													<minimum>0.80</minimum>
 												</limit>
+												<limit>
+													<counter>BRANCH</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>0.80</minimum>
+												</limit>
 											</limits>
 										</rule>
 									</rules>


### PR DESCRIPTION
Add a BRANCH COVEREDRATIO limit (minimum 0.80) alongside the existing
INSTRUCTION limit on the coverage profile's JaCoCo check rule. The gate
was instruction-only, so untested error/guard branches did not fail the
build. All modules currently clear the threshold (lowest is adopt at
81.2% branch coverage), so the build stays green while preventing branch
coverage from eroding.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AGmvT9L1GG6fkxm5nAv9eh