### PR TITLE
refactor(data): improve module descriptors

### DIFF
--- a/data-test/src/main/java/module-info.java
+++ b/data-test/src/main/java/module-info.java
@@ -1,6 +1,6 @@
-module datatestmodule {
-	requires datamodule;
+module io.github.adamw7.tools.data.test {
+	requires io.github.adamw7.tools.data;
 	requires org.apache.logging.log4j;
-    requires org.junit.jupiter.api;
+	requires org.junit.jupiter.api;
 	requires org.junit.platform.commons;
 }

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -19,8 +19,14 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<compilerArgs>
+						<!-- The MCP SDK jars declare hyphenated Automatic-Module-Names
+						     (e.g. io.modelcontextprotocol.sdk.mcp-core), which are not
+						     legal module names and so cannot appear in a `requires`
+						     directive. Let this module read the unnamed module (classpath)
+						     to reach the SDK's io.modelcontextprotocol.spec types and
+						     mcp-common instead. -->
 						<arg>--add-reads</arg>
-						<arg>datamodule=ALL-UNNAMED</arg>
+						<arg>io.github.adamw7.tools.data=ALL-UNNAMED</arg>
 					</compilerArgs>
 				</configuration>
 			</plugin>
@@ -32,7 +38,8 @@
 					     NetworkOffExtension registered through META-INF/services is
 					     discovered by JUnit's extension auto-detection. ServiceLoader
 					     ignores META-INF/services for a named module, and surefire
-					     otherwise patches the test classes into the datamodule module. -->
+					     otherwise patches the test classes into the
+					     io.github.adamw7.tools.data module. -->
 					<argLine>@{argLine}</argLine>
 					<useModulePath>false</useModulePath>
 				</configuration>
@@ -66,7 +73,7 @@
 							</execution>
 						</executions>
 						<configuration>
-							<argLine>--add-reads datamodule=ALL-UNNAMED</argLine>
+							<argLine>--add-reads io.github.adamw7.tools.data=ALL-UNNAMED</argLine>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/data/src/main/java/module-info.java
+++ b/data/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-open module datamodule {
+module io.github.adamw7.tools.data {
 	requires org.apache.logging.log4j;
 	requires java.sql;
 	requires duckdb.jdbc;
@@ -17,4 +17,9 @@ open module datamodule {
 	exports io.github.adamw7.tools.data.structure;
 	exports io.github.adamw7.tools.data.uniqueness;
 	exports io.github.adamw7.tools.data.network;
+
+	// Spring reflects into the MCP configuration/beans in this package
+	// (component scan, @Value injection); no other package needs deep
+	// reflection, so open just this one instead of the whole module.
+	opens io.github.adamw7.tools.data.uniqueness.mcp;
 }


### PR DESCRIPTION
Rename the JPMS modules to follow the reverse-DNS convention used
throughout the project instead of single-word names:
  datamodule     -> io.github.adamw7.tools.data
  datatestmodule -> io.github.adamw7.tools.data.test

Replace the blanket `open module` on the data module with a targeted
`opens io.github.adamw7.tools.data.uniqueness.mcp` — only that package
needs deep reflection (Spring component scan / @Value injection), so the
internal packages (e.g. structure.internal) stay strongly encapsulated.

Document why `--add-reads ...=ALL-UNNAMED` is required: the MCP SDK jars
declare hyphenated Automatic-Module-Names (e.g.
io.modelcontextprotocol.sdk.mcp-core) which are not legal module names
and therefore cannot appear in a `requires` directive, so the module must
read the unnamed module to reach the SDK's spec types and mcp-common.

Verified with `mvn -pl data -am clean install -P integration-tests`:
469 unit tests + 6 MCP integration tests (Spring server on the module
path) pass, confirming the narrowed `opens` is sufficient.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014DHaFK9pNX4UqJ6rebu8FK