### PR TITLE
refactor(mcp): drop ALL-UNNAMED workaround by decoupling tools from the MCP SDK

### DIFF
--- a/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractClassContextTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractClassContextTool.java
@@ -1,7 +1,6 @@
 package io.github.adamw7.context.mcp;
 
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -12,8 +11,7 @@ import io.github.adamw7.context.ClassContainer;
 import io.github.adamw7.context.Language;
 import io.github.adamw7.context.ProjectSources;
 import io.github.adamw7.tools.mcp.ToolArguments;
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.github.adamw7.tools.mcp.ToolResult;
 
 /**
  * Shared skeleton for the MCP tools that operate on a single class within a
@@ -38,7 +36,7 @@ abstract class AbstractClassContextTool implements ContextTool {
 	}
 
 	@Override
-	public CallToolResult apply(Map<String, Object> arguments) {
+	public ToolResult apply(Map<String, Object> arguments) {
 		log.info("Calling MCP {} tool for {}", getToolDefinition().name(), arguments);
 		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
 		Language language = LanguageArguments.optionalLanguage(arguments, "language", Language.JAVA);
@@ -47,9 +45,9 @@ abstract class AbstractClassContextTool implements ContextTool {
 
 		ClassContainer target = findTarget(containers, arguments, language);
 		if (target == null) {
-			return error("Class not found: " + ToolArguments.requiredString(arguments, "class_name"));
+			return ToolResult.error("Class not found: " + ToolArguments.requiredString(arguments, "class_name"));
 		}
-		return success(result(containers, target, language, depth));
+		return ToolResult.success(result(containers, target, language, depth));
 	}
 
 	/** Computes the tool's textual result from the located class within its project. */
@@ -70,19 +68,5 @@ abstract class AbstractClassContextTool implements ContextTool {
 			return className;
 		}
 		return className + language.extension();
-	}
-
-	private CallToolResult success(String text) {
-		return CallToolResult.builder()
-				.content(List.of(TextContent.builder(text).build()))
-				.isError(false)
-				.build();
-	}
-
-	private CallToolResult error(String message) {
-		return CallToolResult.builder()
-				.content(List.of(TextContent.builder(message).build()))
-				.isError(true)
-				.build();
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.github.adamw7.context.ClassContainer;
 import io.github.adamw7.context.Language;
 import io.github.adamw7.context.PackageAwareFinder;
-import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.github.adamw7.tools.mcp.ToolDefinition;
 
 /**
  * MCP tool that resolves the classes a single source file depends on. It loads
@@ -29,7 +29,8 @@ public class ContextFinderTool extends AbstractClassContextTool {
 		super(pathPolicy);
 	}
 
-	private final Tool toolDefinition = Tool.builder("find_context",
+	private final ToolDefinition toolDefinition = new ToolDefinition("find_context",
+			"Find the classes a given class depends on, within a Java, Kotlin or Scala project",
 			Map.of(
 					"type", "object",
 					"properties", Map.of(
@@ -41,12 +42,10 @@ public class ContextFinderTool extends AbstractClassContextTool {
 									"description", "source language: java (default), kotlin or scala"),
 							"depth", Map.of("type", "integer",
 									"description", "how many levels of transitive dependencies to resolve (default 1)")),
-					"required", List.of("path", "class_name")))
-			.description("Find the classes a given class depends on, within a Java, Kotlin or Scala project")
-			.build();
+					"required", List.of("path", "class_name")));
 
 	@Override
-	public Tool getToolDefinition() {
+	public ToolDefinition getToolDefinition() {
 		return toolDefinition;
 	}
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/EstimateTokensTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/EstimateTokensTool.java
@@ -14,7 +14,7 @@ import io.github.adamw7.context.Language;
 import io.github.adamw7.context.PackageAwareFinder;
 import io.github.adamw7.context.SubwordTokenEstimator;
 import io.github.adamw7.context.TokenEstimator;
-import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.github.adamw7.tools.mcp.ToolDefinition;
 
 /**
  * MCP tool that estimates the LLM token cost of the context assembled for a
@@ -39,7 +39,8 @@ public class EstimateTokensTool extends AbstractClassContextTool {
 		this.estimator = estimator;
 	}
 
-	private final Tool toolDefinition = Tool.builder("estimate_tokens",
+	private final ToolDefinition toolDefinition = new ToolDefinition("estimate_tokens",
+			"Estimate the LLM token cost of the context assembled for a class and its dependencies",
 			Map.of(
 					"type", "object",
 					"properties", Map.of(
@@ -51,12 +52,10 @@ public class EstimateTokensTool extends AbstractClassContextTool {
 									"description", "source language: java (default), kotlin or scala"),
 							"depth", Map.of("type", "integer",
 									"description", "how many levels of transitive dependencies to include (default 1)")),
-					"required", List.of("path", "class_name")))
-			.description("Estimate the LLM token cost of the context assembled for a class and its dependencies")
-			.build();
+					"required", List.of("path", "class_name")));
 
 	@Override
-	public Tool getToolDefinition() {
+	public ToolDefinition getToolDefinition() {
 		return toolDefinition;
 	}
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
@@ -17,9 +17,8 @@ import io.github.adamw7.context.tree.ProjectTreeNode;
 import io.github.adamw7.context.tree.ProjectTreePrinter;
 import io.github.adamw7.context.tree.ProjectTreeSerializer;
 import io.github.adamw7.tools.mcp.ToolArguments;
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.TextContent;
-import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.github.adamw7.tools.mcp.ToolDefinition;
+import io.github.adamw7.tools.mcp.ToolResult;
 
 /**
  * MCP tool that scans a Java, Kotlin or Scala project into a tree of folders,
@@ -43,7 +42,8 @@ public class ProjectTreeTool implements ContextTool {
 		this.pathPolicy = pathPolicy;
 	}
 
-	private final Tool toolDefinition = Tool.builder("project_tree",
+	private final ToolDefinition toolDefinition = new ToolDefinition("project_tree",
+			"Scan a Java, Kotlin or Scala project into a tree of folders, files and class dependencies",
 			Map.of(
 					"type", "object",
 					"properties", Map.of(
@@ -55,20 +55,18 @@ public class ProjectTreeTool implements ContextTool {
 									"description", "how many levels of transitive dependencies to resolve (default 1)"),
 							"format", Map.of("type", "string",
 									"description", "output format: json (default), markdown, text, dot or mermaid")),
-					"required", List.of("path")))
-			.description("Scan a Java, Kotlin or Scala project into a tree of folders, files and class dependencies")
-			.build();
+					"required", List.of("path")));
 
 	@Override
-	public Tool getToolDefinition() {
+	public ToolDefinition getToolDefinition() {
 		return toolDefinition;
 	}
 
 	@Override
-	public CallToolResult apply(Map<String, Object> arguments) {
+	public ToolResult apply(Map<String, Object> arguments) {
 		log.info("Calling MCP project_tree tool for {}", arguments);
 		String rendered = buildTree(arguments);
-		return CallToolResult.builder().content(List.of(TextContent.builder(rendered).build())).isError(false).build();
+		return ToolResult.success(rendered);
 	}
 
 	private String buildTree(Map<String, Object> arguments) {

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ContextFinderToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ContextFinderToolTest.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.github.adamw7.tools.mcp.ToolResult;
 
 public class ContextFinderToolTest {
 
@@ -91,7 +90,7 @@ public class ContextFinderToolTest {
 	void unknownClassYieldsAnErrorResult() throws IOException {
 		writeJava("A", "public class A {}");
 
-		CallToolResult result = tool.apply(arguments("Missing"));
+		ToolResult result = tool.apply(arguments("Missing"));
 
 		assertTrue(result.isError());
 		assertTrue(text(result).contains("Class not found: Missing"));
@@ -101,7 +100,7 @@ public class ContextFinderToolTest {
 	void aClassWithoutDependenciesReturnsAnEmptyArray() throws IOException {
 		writeJava("A", "public class A {}");
 
-		CallToolResult result = tool.apply(arguments("A"));
+		ToolResult result = tool.apply(arguments("A"));
 
 		assertFalse(result.isError());
 		assertTrue(dependencies(result).isEmpty());
@@ -140,7 +139,7 @@ public class ContextFinderToolTest {
 		Files.writeString(projectRoot.resolve(className + ".java"), body);
 	}
 
-	private List<String> dependencies(CallToolResult result) {
+	private List<String> dependencies(ToolResult result) {
 		try {
 			JsonNode array = MAPPER.readTree(text(result));
 			List<String> values = new ArrayList<>();
@@ -151,7 +150,7 @@ public class ContextFinderToolTest {
 		}
 	}
 
-	private String text(CallToolResult result) {
-		return ((TextContent) result.content().getFirst()).text();
+	private String text(ToolResult result) {
+		return result.text();
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/EstimateTokensToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/EstimateTokensToolTest.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.context.TokenEstimator;
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.github.adamw7.tools.mcp.ToolResult;
 
 public class EstimateTokensToolTest {
 
@@ -82,7 +81,7 @@ public class EstimateTokensToolTest {
 	void unknownClassYieldsAnErrorResult() throws IOException {
 		writeJava("A", "A");
 
-		CallToolResult result = tool.apply(arguments("Missing"));
+		ToolResult result = tool.apply(arguments("Missing"));
 
 		assertTrue(result.isError());
 		assertTrue(text(result).contains("Class not found: Missing"));
@@ -181,7 +180,7 @@ public class EstimateTokensToolTest {
 		Files.writeString(projectRoot.resolve(className + ".java"), body);
 	}
 
-	private JsonNode report(CallToolResult result) {
+	private JsonNode report(ToolResult result) {
 		try {
 			return MAPPER.readTree(text(result));
 		} catch (JsonProcessingException e) {
@@ -189,7 +188,7 @@ public class EstimateTokensToolTest {
 		}
 	}
 
-	private String text(CallToolResult result) {
-		return ((TextContent) result.content().getFirst()).text();
+	private String text(ToolResult result) {
+		return result.text();
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
@@ -18,8 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.github.adamw7.tools.mcp.ToolResult;
 
 public class ProjectTreeToolTest {
 
@@ -148,7 +147,7 @@ public class ProjectTreeToolTest {
 		Files.writeString(projectRoot.resolve(className + ".java"), body);
 	}
 
-	private String text(CallToolResult result) {
-		return ((TextContent) result.content().getFirst()).text();
+	private String text(ToolResult result) {
+		return result.text();
 	}
 }

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -16,22 +16,6 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<compilerArgs>
-						<!-- The MCP SDK jars declare hyphenated Automatic-Module-Names
-						     (e.g. io.modelcontextprotocol.sdk.mcp-core), which are not
-						     legal module names and so cannot appear in a `requires`
-						     directive. Let this module read the unnamed module (classpath)
-						     to reach the SDK's io.modelcontextprotocol.spec types and
-						     mcp-common instead. -->
-						<arg>--add-reads</arg>
-						<arg>io.github.adamw7.tools.data=ALL-UNNAMED</arg>
-					</compilerArgs>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<!-- Run unit tests from the classpath, not the module path, so the
@@ -39,7 +23,9 @@
 					     discovered by JUnit's extension auto-detection. ServiceLoader
 					     ignores META-INF/services for a named module, and surefire
 					     otherwise patches the test classes into the
-					     io.github.adamw7.tools.data module. -->
+					     io.github.adamw7.tools.data module. Running from the classpath
+					     also lets the tests reach the MCP client/SDK types (which live in
+					     the unnamed module) without patching the module open. -->
 					<argLine>@{argLine}</argLine>
 					<useModulePath>false</useModulePath>
 				</configuration>
@@ -73,7 +59,11 @@
 							</execution>
 						</executions>
 						<configuration>
-							<argLine>--add-reads io.github.adamw7.tools.data=ALL-UNNAMED</argLine>
+							<!-- Run the *IT tests from the classpath, so their MCP
+							     client/SDK types (in the unnamed module) resolve without
+							     patching the module open, and the server runs exactly as it
+							     does in production (a classpath Spring Boot app). -->
+							<useModulePath>false</useModulePath>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
@@ -15,15 +15,15 @@ import io.github.adamw7.tools.data.uniqueness.Result;
 import io.github.adamw7.tools.data.uniqueness.Uniqueness;
 import io.github.adamw7.tools.mcp.McpTool;
 import io.github.adamw7.tools.mcp.ToolArguments;
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.TextContent;
-import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.github.adamw7.tools.mcp.ToolDefinition;
+import io.github.adamw7.tools.mcp.ToolResult;
 
 public class UniquenessTool implements McpTool {
-	
+
 	private static final Logger log = LogManager.getLogger(UniquenessTool.class.getName());
 
-    private final Tool toolDefinition = Tool.builder("uniqueness_check",
+    private final ToolDefinition toolDefinition = new ToolDefinition("uniqueness_check",
+            "Check if a given set of columns is unique in a given data set",
                     Map.of(
                         "type", "object",
                         "properties", Map.of(
@@ -32,22 +32,21 @@ public class UniquenessTool implements McpTool {
                             "columns_name", Map.of("type", "string", "description", "name of the column to check")
                         ),
                         "required", List.of("file", "columns_row", "columns_name")
-                    )).description(
-            "Check if a given set of columns is unique in a given data set").build();
+                    ));
 
 	public UniquenessTool() {
     }
 
-	public Tool getToolDefinition() {
+	public ToolDefinition getToolDefinition() {
 		return toolDefinition;
 	}
 
 	@Override
-	public CallToolResult apply(Map<String, Object> arguments) {
+	public ToolResult apply(Map<String, Object> arguments) {
 		log.info("Calling MCP uniqueness tool for {}", arguments);
 		String result = runUniqueness(arguments);
 
-		return CallToolResult.builder().content(List.of(TextContent.builder(result).build())).isError(false).build();
+		return ToolResult.success(result);
 	}
 
 	private String runUniqueness(Map<String, Object> arguments) {

--- a/data/src/main/java/module-info.java
+++ b/data/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module io.github.adamw7.tools.data {
+	requires tools.mcp.common;
 	requires org.apache.logging.log4j;
 	requires java.sql;
 	requires duckdb.jdbc;
@@ -6,6 +7,7 @@ module io.github.adamw7.tools.data {
 	requires com.fasterxml.jackson.databind;
 	requires com.fasterxml.jackson.dataformat.yaml;
 	requires org.yaml.snakeyaml;
+	requires spring.beans;
 	requires spring.context;
 	requires spring.boot.autoconfigure;
 	requires spring.boot;

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessToolTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessToolTest.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -21,9 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import io.github.adamw7.tools.data.Utils;
 import io.github.adamw7.tools.data.uniqueness.ColumnNotFoundException;
-import io.modelcontextprotocol.spec.McpSchema;
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.Content;
+import io.github.adamw7.tools.mcp.ToolResult;
 
 public class UniquenessToolTest {
 
@@ -35,13 +32,9 @@ public class UniquenessToolTest {
 		input.put("file", Utils.getHouseholdFile());
 		input.put("columns_row", "1");
 		input.put("columns_name", "year1");
-		CallToolResult result = tool.apply(input);
+		ToolResult result = tool.apply(input);
         assertFalse(result.isError());
-        assertEquals(1, result.content().size());
-        Content content = result.content().getFirst();
-        assertTrue(content instanceof McpSchema.TextContent);
-        McpSchema.TextContent textContent = (McpSchema.TextContent) content;
-        assertTrue("false".equals(textContent.text()));
+        assertTrue("false".equals(result.text()));
 	}
 
 	@Test
@@ -51,10 +44,9 @@ public class UniquenessToolTest {
 		input.put("file", Utils.getHouseholdFile());
 		input.put("columns_row", "1");
 		input.put("columns_name", "income");
-		CallToolResult result = tool.apply(input);
+		ToolResult result = tool.apply(input);
 		assertFalse(result.isError());
-		McpSchema.TextContent textContent = (McpSchema.TextContent) result.content().getFirst();
-		assertTrue("true".equals(textContent.text()));
+		assertTrue("true".equals(result.text()));
 	}
 
 	@Test

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
@@ -26,6 +26,7 @@ import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 
@@ -173,8 +174,8 @@ public abstract class AbstractMcpConfiguration {
 
 	private SyncToolSpecification specificationFor(McpTool tool) {
 		return SyncToolSpecification.builder()
-				.tool(tool.getToolDefinition())
-				.callHandler((exchange, request) -> safeApply(tool, request.arguments()))
+				.tool(sdkTool(tool.getToolDefinition()))
+				.callHandler((exchange, request) -> sdkResult(safeApply(tool, request.arguments())))
 				.build();
 	}
 
@@ -184,29 +185,47 @@ public abstract class AbstractMcpConfiguration {
 
 	private McpStatelessServerFeatures.SyncToolSpecification statelessSpecificationFor(McpTool tool) {
 		return McpStatelessServerFeatures.SyncToolSpecification.builder()
-				.tool(tool.getToolDefinition())
-				.callHandler((context, request) -> safeApply(tool, request.arguments()))
+				.tool(sdkTool(tool.getToolDefinition()))
+				.callHandler((context, request) -> sdkResult(safeApply(tool, request.arguments())))
 				.build();
 	}
 
 	/**
-	 * Invokes a tool and turns any thrown exception into an error {@link CallToolResult}
+	 * Invokes a tool and turns any thrown exception into an error {@link ToolResult}
 	 * rather than letting it surface as a protocol-level failure, so a bad argument or a
 	 * denied path reaches the client as a clear, actionable tool error. Package-private so
 	 * the behaviour can be exercised directly in tests.
 	 */
-	CallToolResult safeApply(McpTool tool, Map<String, Object> arguments) {
+	ToolResult safeApply(McpTool tool, Map<String, Object> arguments) {
 		String name = tool.getToolDefinition().name();
 		try {
 			return tool.apply(arguments);
 		} catch (RuntimeException e) {
 			log.warn("MCP tool {} failed for {}", name, arguments, e);
 			String message = e.getMessage() == null ? e.toString() : e.getMessage();
-			return CallToolResult.builder()
-					.content(List.of(TextContent.builder(name + " failed: " + message).build()))
-					.isError(true)
-					.build();
+			return ToolResult.error(name + " failed: " + message);
 		}
+	}
+
+	/**
+	 * Translates the SPI's transport-neutral {@link ToolDefinition} into the SDK's
+	 * {@link Tool}, so tools describe themselves without depending on the SDK.
+	 */
+	private static Tool sdkTool(ToolDefinition definition) {
+		return Tool.builder(definition.name(), definition.inputSchema())
+				.description(definition.description())
+				.build();
+	}
+
+	/**
+	 * Translates the SPI's transport-neutral {@link ToolResult} into the SDK's
+	 * {@link CallToolResult} returned to the client.
+	 */
+	private static CallToolResult sdkResult(ToolResult result) {
+		return CallToolResult.builder()
+				.content(List.of(TextContent.builder(result.text()).build()))
+				.isError(result.isError())
+				.build();
 	}
 
 	/**

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/McpTool.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/McpTool.java
@@ -3,16 +3,16 @@ package io.github.adamw7.tools.mcp;
 import java.util.Map;
 import java.util.function.Function;
 
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.Tool;
-
 /**
- * A tool an MCP server exposes. Each tool carries its own {@link Tool} definition
- * (name and input schema) and maps a call's arguments to a {@link CallToolResult}.
- * Depending on this abstraction lets {@link AbstractMcpConfiguration} register any
- * number of tools without knowing their concrete types.
+ * A tool an MCP server exposes. Each tool carries its own {@link ToolDefinition}
+ * (name, description and input schema) and maps a call's arguments to a
+ * {@link ToolResult}. Both are the SPI's own, transport-neutral types, so a tool
+ * implementation never depends on the MCP SDK; {@link AbstractMcpConfiguration}
+ * adapts them to the SDK when wiring the server. Depending on this abstraction
+ * lets {@link AbstractMcpConfiguration} register any number of tools without
+ * knowing their concrete types.
  */
-public interface McpTool extends Function<Map<String, Object>, CallToolResult> {
+public interface McpTool extends Function<Map<String, Object>, ToolResult> {
 
-	Tool getToolDefinition();
+	ToolDefinition getToolDefinition();
 }

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/ToolDefinition.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/ToolDefinition.java
@@ -1,0 +1,17 @@
+package io.github.adamw7.tools.mcp;
+
+import java.util.Map;
+
+/**
+ * The definition an {@link McpTool} advertises to clients: its name, a human
+ * description and the JSON schema of its input arguments. This is the SPI's own,
+ * transport-neutral definition type, so a tool never mentions the underlying MCP
+ * SDK; {@link AbstractMcpConfiguration} translates it into the SDK's {@code Tool}
+ * when registering the tool with the server.
+ *
+ * @param name        the tool's unique name
+ * @param description a human-readable description of what the tool does
+ * @param inputSchema the JSON schema (as a nested map) describing the arguments
+ */
+public record ToolDefinition(String name, String description, Map<String, Object> inputSchema) {
+}

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/ToolResult.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/ToolResult.java
@@ -1,0 +1,27 @@
+package io.github.adamw7.tools.mcp;
+
+/**
+ * The outcome of an {@link McpTool} call: a single block of text and whether it
+ * represents an error. This is the SPI's own, transport-neutral result type, so a
+ * tool never mentions the underlying MCP SDK; {@link AbstractMcpConfiguration}
+ * translates it into the SDK's {@code CallToolResult} when answering the client.
+ *
+ * @param text    the textual payload returned to the caller
+ * @param isError whether the call failed, so the client can surface it as an error
+ */
+public record ToolResult(String text, boolean isError) {
+
+	/**
+	 * A successful result carrying the given text.
+	 */
+	public static ToolResult success(String text) {
+		return new ToolResult(text, false);
+	}
+
+	/**
+	 * A failed result carrying the given message.
+	 */
+	public static ToolResult error(String message) {
+		return new ToolResult(message, true);
+	}
+}

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/AbstractMcpConfigurationTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/AbstractMcpConfigurationTest.java
@@ -22,9 +22,6 @@ import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportPro
 import io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport;
 import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
-import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.TextContent;
-import io.modelcontextprotocol.spec.McpSchema.Tool;
 
 public class AbstractMcpConfigurationTest {
 
@@ -50,18 +47,17 @@ public class AbstractMcpConfigurationTest {
 
 	private static final class TestTool implements McpTool {
 
-		private final Tool toolDefinition = Tool.builder("test_tool",
-				Map.of("type", "object", "properties", Map.of())).description("A test tool").build();
+		private final ToolDefinition toolDefinition = new ToolDefinition("test_tool", "A test tool",
+				Map.of("type", "object", "properties", Map.of()));
 
 		@Override
-		public Tool getToolDefinition() {
+		public ToolDefinition getToolDefinition() {
 			return toolDefinition;
 		}
 
 		@Override
-		public CallToolResult apply(Map<String, Object> arguments) {
-			return CallToolResult.builder()
-					.content(List.of(TextContent.builder("ok").build())).isError(false).build();
+		public ToolResult apply(Map<String, Object> arguments) {
+			return ToolResult.success("ok");
 		}
 	}
 
@@ -156,30 +152,30 @@ public class AbstractMcpConfigurationTest {
 
 	@Test
 	public void safeApplyReturnsTheToolResultWhenItSucceeds() {
-		CallToolResult result = new TestMcpConfiguration().safeApply(new TestTool(), Map.of());
+		ToolResult result = new TestMcpConfiguration().safeApply(new TestTool(), Map.of());
 		assertFalse(result.isError());
-		assertEquals("ok", ((TextContent) result.content().getFirst()).text());
+		assertEquals("ok", result.text());
 	}
 
 	@Test
 	public void safeApplyTurnsAThrownExceptionIntoAnErrorResult() {
-		CallToolResult result = new TestMcpConfiguration().safeApply(new ThrowingTool(), Map.of());
+		ToolResult result = new TestMcpConfiguration().safeApply(new ThrowingTool(), Map.of());
 		assertTrue(result.isError());
-		assertEquals("boom failed: bad argument", ((TextContent) result.content().getFirst()).text());
+		assertEquals("boom failed: bad argument", result.text());
 	}
 
 	private static final class ThrowingTool implements McpTool {
 
-		private final Tool toolDefinition = Tool.builder("boom",
-				Map.of("type", "object", "properties", Map.of())).description("Always fails").build();
+		private final ToolDefinition toolDefinition = new ToolDefinition("boom", "Always fails",
+				Map.of("type", "object", "properties", Map.of()));
 
 		@Override
-		public Tool getToolDefinition() {
+		public ToolDefinition getToolDefinition() {
 			return toolDefinition;
 		}
 
 		@Override
-		public CallToolResult apply(Map<String, Object> arguments) {
+		public ToolResult apply(Map<String, Object> arguments) {
 			throw new IllegalArgumentException("bad argument");
 		}
 	}


### PR DESCRIPTION
The data module is the repo's only named module, yet its UniquenessTool
imported io.modelcontextprotocol.spec types directly. The SDK jars declare
hyphenated Automatic-Module-Names (e.g. io.modelcontextprotocol.sdk.mcp-core)
that are illegal in a `requires` directive, so the build reached those types by
reading the whole classpath via `--add-reads
io.github.adamw7.tools.data=ALL-UNNAMED` on both the compiler and failsafe.

Introduce transport-neutral ToolResult/ToolDefinition types in mcp-common so
the McpTool SPI no longer exposes SDK types; AbstractMcpConfiguration adapts
them to the SDK's Tool/CallToolResult only at the wiring boundary. The data
module now `requires tools.mcp.common` (plus spring.beans, previously masked by
the classpath read) and needs no add-reads; its unit and *IT tests run from the
classpath. The context module's tools move to the same neutral SPI.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HS2YyxYTMSEx5qas1M2geZ