### PR TITLE
build(data-test): scope junit-jupiter-engine to test

### DIFF
--- a/data-test/pom.xml
+++ b/data-test/pom.xml
@@ -35,6 +35,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
data-test declared junit-jupiter-engine without a scope, so it resolved
to compile — inconsistent with the other eight modules, all of which use
<scope>test</scope>. The module has no src/main/java (test sources only),
so JUnit is a test-only concern here as well. The Spring Boot parent BOM
manages JUnit's version but not its scope, hence the explicit scope is
required.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XtHZ4z5vNGjG94ezVKdMw7