### PR TITLE
feat(data): add @NetworkOff annotation for opting tests into the kill-switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,7 +247,11 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
   for a named JPMS module, the `data` module runs its unit tests from the
   classpath (`<useModulePath>false</useModulePath>` on surefire); the published
   `data` artifact stays a proper module. A `NetworkOffDuringUnitTestsTest`
-  verifies the switch is already engaged by the time a unit test executes.
+  verifies the switch is already engaged by the time a unit test executes. A test
+  can also opt in explicitly with the `@NetworkOff` annotation (a composed
+  `@ExtendWith(NetworkOffExtension.class)`); an explicit `@NetworkOff` engages the
+  kill-switch unconditionally, bypassing the `tools.test.network.off` guard, so the
+  network is off even when that single test is run from an IDE.
 - **Architecture tests** (ArchUnit) run in every module as ordinary JUnit tests,
   under an `...architecture` test package (e.g.
   `io.github.adamw7.tools.data.architecture.DataArchitectureTest`). They analyse

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,9 @@ paths.
 - **Unit tests run with the network off.** The `data` module's
   `NetworkOffExtension` engages the `Switch` kill-switch before any test runs, so
   a unit test can never open an outbound connection; the failsafe `*IT` tests are
-  unaffected. See *Testing* in AGENTS.md.
+  unaffected. A single test can opt in explicitly with the `@NetworkOff`
+  annotation, which engages the kill-switch even without the surefire guard
+  property (e.g. when run from an IDE). See *Testing* in AGENTS.md.
 - **Architecture tests** (ArchUnit) live in each module's `.architecture` test
   package and enforce package layering and coding rules — data-source contracts
   must not depend on their implementations, the uniqueness core must not depend

--- a/README.md
+++ b/README.md
@@ -716,6 +716,20 @@ Auto-detection and the `tools.test.network.off` guard property are set only on
 surefire, so the failsafe integration tests (`*IT`), which need real network, keep
 it. See *Testing* in [AGENTS.md](AGENTS.md) for the details.
 
+A single test can also opt in explicitly with the `@NetworkOff` annotation, which
+registers the same extension via `@ExtendWith`:
+
+```java
+@NetworkOff
+class MyDataSourceTest {
+    // every test here runs with the network off
+}
+```
+
+Unlike the module-wide auto-detection, an explicit `@NetworkOff` engages the
+kill-switch unconditionally — regardless of the `tools.test.network.off`
+property — so the network is off even when the test is run on its own from an IDE.
+
 ## Claude Code adoption
 
 The `adopt` module (`tools.adopt`) is an ordered pipeline that **adopts Claude

--- a/data/src/test/java/io/github/adamw7/tools/data/network/BlockingProxySelectorTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/network/BlockingProxySelectorTest.java
@@ -1,0 +1,66 @@
+package io.github.adamw7.tools.data.network;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.URI;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Exercises the {@link ProxySelector} that {@link Switch#off()} installs as the
+ * JVM default. The switch is process-global and already engaged for the unit-test
+ * run, but {@link #engageKillSwitch()} calls {@link Switch#off()} defensively so
+ * the class also holds when run in isolation — the call is an idempotent no-op
+ * once the network is off. Every outbound-connection attempt routes through
+ * {@code select}, so proving it rejects every scheme proves the network is sealed;
+ * {@code connectFailed} is the callback the JDK invokes when a chosen proxy fails
+ * and must stay a quiet no-op so it never masks the block.
+ */
+public class BlockingProxySelectorTest {
+
+	@BeforeAll
+	static void engageKillSwitch() {
+		Switch.off();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "http://192.0.2.1", "https://192.0.2.1:8443/path",
+			"ftp://192.0.2.1/file", "ws://192.0.2.1/socket", "file:///etc/hosts" })
+	public void selectRejectsEveryScheme(String uri) {
+		UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
+				() -> ProxySelector.getDefault().select(URI.create(uri)),
+				"the blocking selector must refuse proxy selection for " + uri);
+
+		assertEquals("The network is off", thrown.getMessage());
+	}
+
+	@Test
+	public void connectFailedIsASilentNoOp() {
+		// createUnresolved avoids any DNS lookup, so the assertion stays offline.
+		InetSocketAddress unreachable = InetSocketAddress.createUnresolved("192.0.2.1", 80);
+
+		assertDoesNotThrow(() -> ProxySelector.getDefault().connectFailed(URI.create("http://192.0.2.1"),
+				unreachable, new IOException("simulated connect failure")),
+				"connectFailed is a callback, not a gate; it must never throw");
+	}
+
+	@Test
+	public void defaultSelectorStaysTheBlockingOneAcrossCalls() {
+		ProxySelector first = ProxySelector.getDefault();
+		ProxySelector second = ProxySelector.getDefault();
+
+		assertSame(first, second, "the installed blocking selector must remain the JVM default");
+		assertThrows(UnsupportedOperationException.class,
+				() -> first.select(URI.create("https://192.0.2.1")),
+				"the retained selector must still block");
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/network/NetworkOff.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/network/NetworkOff.java
@@ -1,0 +1,39 @@
+package io.github.adamw7.tools.data.network;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Engages the {@link Switch} network kill-switch for the annotated test class, so
+ * the test can never open an outbound connection. Add it to any JUnit 5 test that
+ * must run with the network off:
+ *
+ * <pre>{@code
+ * @NetworkOff
+ * class MyDataSourceTest {
+ *     ...
+ * }
+ * }</pre>
+ *
+ * The annotation is a thin composition over {@link NetworkOffExtension}: applying
+ * it registers the extension, which turns the network off once before the class's
+ * tests run. Unlike the module-wide auto-detected registration — gated on the
+ * {@code tools.test.network.off} system property so failsafe's {@code *IT} tests
+ * keep real network — an explicit {@code @NetworkOff} engages the kill-switch
+ * unconditionally, so it also takes effect when a developer runs the single test
+ * from an IDE without that property set.
+ *
+ * @see NetworkOffExtension
+ * @see Switch
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@ExtendWith(NetworkOffExtension.class)
+public @interface NetworkOff {
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/network/NetworkOffAnnotationTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/network/NetworkOffAnnotationTest.java
@@ -1,0 +1,56 @@
+package io.github.adamw7.tools.data.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.net.ProxySelector;
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+/**
+ * Verifies that {@link NetworkOff} both wires up {@link NetworkOffExtension} and,
+ * once applied, leaves the annotated class running with the network off. The
+ * class annotates itself, so the behavioural assertion exercises the real path a
+ * developer would take.
+ */
+@NetworkOff
+public class NetworkOffAnnotationTest {
+
+	@Test
+	public void annotatedClassRunsWithNetworkOff() {
+		UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
+				() -> ProxySelector.getDefault().select(URI.create("http://192.0.2.1")),
+				"@NetworkOff should have engaged the kill-switch before the test ran");
+
+		assertEquals("The network is off", thrown.getMessage());
+	}
+
+	@Test
+	public void annotationRegistersTheKillSwitchExtension() {
+		ExtendWith extendWith = NetworkOff.class.getAnnotation(ExtendWith.class);
+
+		assertTrue(extendWith != null && extendWith.value().length == 1
+				&& extendWith.value()[0].equals(NetworkOffExtension.class),
+				"@NetworkOff must register NetworkOffExtension via @ExtendWith");
+	}
+
+	@Test
+	public void annotationIsDiscoverableAtRuntimeOnTypes() {
+		Retention retention = NetworkOff.class.getAnnotation(Retention.class);
+		Target target = NetworkOff.class.getAnnotation(Target.class);
+
+		assertEquals(RetentionPolicy.RUNTIME, retention.value(),
+				"@NetworkOff must be retained at runtime for JUnit to read it");
+		assertEquals(ElementType.TYPE, target.value()[0], "@NetworkOff applies to test classes");
+		assertTrue(AnnotationSupport.isAnnotated(NetworkOffAnnotationTest.class, NetworkOff.class),
+				"the annotation must be discoverable on the class that carries it");
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/network/NetworkOffExtension.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/network/NetworkOffExtension.java
@@ -2,16 +2,25 @@ package io.github.adamw7.tools.data.network;
 
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
 
 /**
- * Engages the {@link Switch} network kill-switch before any unit test runs, so a
- * unit test can never open an outbound connection. The extension is discovered
- * automatically (JUnit Jupiter extension auto-detection, registered through
- * {@code META-INF/services}) and enabled only for the surefire unit-test run:
- * failsafe leaves auto-detection off, so the MCP {@code *IT} integration tests
- * that need real network are unaffected. The {@code tools.test.network.off}
- * system property — set by surefire, absent under failsafe — is a second guard
- * so the kill-switch stays off unless the unit-test run explicitly asked for it.
+ * Engages the {@link Switch} network kill-switch before a test runs, so the test
+ * can never open an outbound connection. There are two ways it activates:
+ *
+ * <ul>
+ * <li><b>Module-wide.</b> The extension is discovered automatically (JUnit Jupiter
+ * extension auto-detection, registered through {@code META-INF/services}) and
+ * enabled only for the surefire unit-test run: failsafe leaves auto-detection off,
+ * so the MCP {@code *IT} integration tests that need real network are unaffected.
+ * The {@code tools.test.network.off} system property — set by surefire, absent
+ * under failsafe — is a second guard so the kill-switch stays off unless the
+ * unit-test run explicitly asked for it.</li>
+ * <li><b>Per test.</b> Annotating a test class with {@link NetworkOff} registers
+ * this extension explicitly. An explicit request engages the kill-switch
+ * unconditionally — the property guard is bypassed — so the network is off even
+ * when a developer runs that single test from an IDE.</li>
+ * </ul>
  */
 public class NetworkOffExtension implements BeforeAllCallback {
 
@@ -26,9 +35,18 @@ public class NetworkOffExtension implements BeforeAllCallback {
 	 */
 	@Override
 	public void beforeAll(ExtensionContext context) {
-		if (!engaged && Boolean.getBoolean(NETWORK_OFF_PROPERTY)) {
+		if (!engaged && (explicitlyRequested(context) || Boolean.getBoolean(NETWORK_OFF_PROPERTY))) {
 			Switch.off();
 			engaged = true;
 		}
+	}
+
+	/**
+	 * True when the test class opted in with {@link NetworkOff}, as opposed to the
+	 * module-wide auto-detected registration. An explicit opt-in engages the
+	 * kill-switch regardless of the {@code tools.test.network.off} property.
+	 */
+	private boolean explicitlyRequested(ExtensionContext context) {
+		return AnnotationSupport.isAnnotated(context.getElement(), NetworkOff.class);
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/network/SwitchTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/network/SwitchTest.java
@@ -3,9 +3,12 @@ package io.github.adamw7.tools.data.network;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
@@ -17,17 +20,28 @@ public class SwitchTest {
 	@Test
 	public void happyPath() {
 		Switch.off();
-		
+
 		RuntimeException thrown = assertThrows(RuntimeException.class, this::connectToInternet, "Expected connectToInternet() method to throw, but it didn't");
 
 		assertEquals("java.lang.UnsupportedOperationException: The network is off", thrown.getMessage());
 	}
-	
+
 	@Test
 	public void testMultipleOff() {
 		Switch.off();
 		assertFalse(Switch.off());
 		assertFalse(Switch.off());
+	}
+
+	@Test
+	public void switchIsAStatelessUtilityWithAPrivateConstructor() throws Exception {
+		Constructor<Switch> constructor = Switch.class.getDeclaredConstructor();
+
+		assertTrue(Modifier.isPrivate(constructor.getModifiers()),
+				"Switch exposes only static behaviour, so it must not be instantiable");
+
+		constructor.setAccessible(true);
+		constructor.newInstance(); // exercise the guarded constructor for coverage
 	}
 
 	private void connectToInternet() throws Exception {


### PR DESCRIPTION
Introduce a composed `@NetworkOff` annotation
(`@ExtendWith(NetworkOffExtension.class)`) so any JUnit 5 test can opt into
the network kill-switch explicitly, without relying on the module-wide
auto-detection.

`NetworkOffExtension` now engages `Switch.off()` unconditionally when a test
class carries `@NetworkOff`, bypassing the `tools.test.network.off` guard
property, so the network is off even when the single test is run from an IDE.
The auto-detected, property-gated path is unchanged.

Add `NetworkOffAnnotationTest` covering the behaviour and the `@ExtendWith`
wiring, and document the annotation in README, AGENTS.md, and CLAUDE.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PzqukmmcibVomZUDRAazfn