### PR TITLE
docs: reflect JaCoCo branch-coverage gate and coverage-profile timeouts

### DIFF
--- a/.claude/skills/maven-conventions/SKILL.md
+++ b/.claude/skills/maven-conventions/SKILL.md
@@ -42,7 +42,7 @@ profile, is the most common source of avoidable build friction here.
 | `mvn install` | Faster incremental build |
 | `mvn -pl <module> test` | Tests for a single module |
 | `mvn -P integration-tests verify` | MCP integration tests (`*IT`) |
-| `mvn -Pcoverage verify` | JaCoCo coverage (fails under 80%) |
+| `mvn -Pcoverage verify` | JaCoCo coverage (fails under 80% instruction or branch) |
 | `mvn -Ppitest test` | PIT mutation testing |
 | `mvn install -Dskip.shellcheck=true` | Skip the shellcheck lint |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,8 +280,12 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
   streamable HTTP: `mvn -P integration-tests verify`. Test classes ending in
   `IT` belong to this profile.
 - **Coverage** is the opt-in `coverage` profile (JaCoCo): `mvn -Pcoverage verify`
-  produces reports at `**/target/site/jacoco/` and **fails the build** if bundle
-  instruction coverage drops below **80%** (`COVEREDRATIO >= 0.80`).
+  produces reports at `**/target/site/jacoco/` and **fails the build** if a
+  bundle's instruction **or** branch coverage drops below **80%** (two
+  `COVEREDRATIO >= 0.80` limits, one on the `INSTRUCTION` counter and one on
+  `BRANCH`). The profile also raises the per-test timeout to **8 s** (from the
+  base 5 s), because JaCoCo's bytecode instrumentation slows first-use
+  class-loading.
 - **Mutation testing** is the opt-in `pitest` profile (PIT + JUnit 5):
   `mvn -Ppitest test` writes HTML/XML reports to `**/target/pit-reports/`. It
   excludes `*IT` integration tests and does not fail when a class has no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ mvn clean install                 # full clean build + install to local repo
 mvn install                       # faster incremental build
 mvn -pl data test                 # tests for a single module
 mvn -P integration-tests verify   # MCP integration tests (*IT)
-mvn -Pcoverage verify             # JaCoCo coverage (fails under 80%)
+mvn -Pcoverage verify             # JaCoCo coverage (fails under 80% instruction or branch)
 mvn -Ppitest test                 # PIT mutation testing
 ```
 
@@ -109,9 +109,10 @@ Write unit tests for all new logic. Focus on behavior, edge cases, and error
 paths.
 
 - **Unit tests** run in the normal `test`/`package` lifecycle. Surefire enforces
-  a **5-second per-test timeout** (configured on the surefire plugin in the root
-  `pom.xml`) — above the cold-fork warmup, which stretches under the parallel
-  `-T1C` build's CPU contention, but low enough to catch a test doing real work —
+  a **5-second per-test timeout** (8 s under coverage) configured on the surefire
+  plugin in the root `pom.xml` — above the cold-fork warmup, which stretches under
+  the parallel `-T1C` build's CPU contention, but low enough to catch a test doing
+  real work —
   so keep unit tests fast; a genuinely heavier test opts out with an explicit
   `@Timeout` and a comment explaining why. A looser
   **10-second lifecycle-method timeout** (15 s under coverage) covers heavier


### PR DESCRIPTION
The coverage profile's JaCoCo `check` now enforces two 80% floors — one on
the INSTRUCTION counter and one on BRANCH — and raises the per-test timeout
to 8 s. The agent docs still described only instruction coverage. Update
AGENTS.md, CLAUDE.md, and the maven-conventions skill to match the pom.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AkqBBffLumiuMJyuSNRuQX