### PR TITLE
feat(skills): add protogen and data-sources module skills

### DIFF
--- a/.claude/skills/data-sources/README.md
+++ b/.claude/skills/data-sources/README.md
@@ -1,0 +1,37 @@
+# Data Sources
+
+**Load**: `view .claude/skills/data-sources/SKILL.md`
+
+---
+
+## Description
+
+Helps Claude pick and use the `data` module's data sources (CSV, JDBC,
+Parquet/DuckDB, JSON, YAML, TOON), keep to the `ColumnarDataSource` vs
+forward-only schema contract, and run the uniqueness/key checker.
+
+---
+
+## Use Cases
+
+- "Read this Parquet file" / "load a JDBC query as rows"
+- "Are these columns a key?" / "find a smaller key"
+- "Add a new data source for format X"
+
+---
+
+## Examples
+
+```
+> view .claude/skills/data-sources/SKILL.md
+> "Check if CUSTOMER_ID + ORDER_ID is unique in this CSV"
+→ InMemoryCSVDataSource + InMemoryUniquenessCheck.exec(...); read getBetterOptions()
+```
+
+---
+
+## Notes / Tips
+
+- Pick `InMemory…` when the data fits in heap; `Iterable…` for large/streaming.
+- The uniqueness check needs a `ColumnarDataSource` — forward-only JSON/YAML/TOON
+  iterables can't be used there by design.

--- a/.claude/skills/data-sources/SKILL.md
+++ b/.claude/skills/data-sources/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: data-sources
+description: Choose and use the data module's sources (CSV, JDBC, Parquet via DuckDB, JSON/YAML/TOON), the ColumnarDataSource vs forward-only contract, and the uniqueness/key checker. Use when reading tabular data, adding a new data source, running a uniqueness check, or when the user says "data source", "uniqueness check", or "find a key".
+---
+
+# Data Sources Skill
+
+Pick the right data source in the `data` module, respect the schema contract
+that keeps forward-only sources away from schema-dependent callers, and run the
+uniqueness checker to find whether a set of columns can serve as a key.
+
+## When to Use
+- Reading tabular data from CSV, a JDBC query, Parquet, JSON, YAML, or TOON
+- Adding a brand-new data source
+- Checking whether columns are unique / finding a smaller key
+- The user says "data source" / "uniqueness check" / "find a key"
+
+## In-memory vs iterative — pick first
+Every format ships in two variants:
+- **`InMemory…`** — loads all rows once (`readAll()`), then runs multiple
+  recursive checks cheaply. Use when the data fits in heap.
+- **`Iterable…`** — holds one row at a time (tiny heap), but re-reads the source
+  for each recursive pass. Use for large data or streaming.
+
+## The schema contract (don't fight it)
+- **`IterableDataSource`** — the base forward-only contract: `open()`,
+  `nextRow()`, `hasMoreData()`, `reset()`, `nextRows(int batchSize)`.
+- **`ColumnarDataSource extends IterableDataSource`** — adds `getColumnNames()`
+  for sources whose columns are known up front.
+- Forward-only sources that discover keys as they stream — **iterable JSON, YAML,
+  TOON** — deliberately do **not** implement `ColumnarDataSource`. Callers that
+  need the schema (e.g. the uniqueness check) depend on the narrower
+  `ColumnarDataSource`, so a schema-less source can never be handed in and answer
+  with `null`. Don't widen `IterableDataSource` to "fix" a compile error — reach
+  for a columnar source instead.
+
+## Source picker
+| Format | In-memory | Iterable | Notes |
+|---|---|---|---|
+| CSV | `InMemoryCSVDataSource` | `CSVDataSource` | file path or `InputStream` |
+| JDBC | `InMemorySQLDataSource` | `IterableSQLDataSource` | `batchSize` sets JDBC fetch size |
+| Parquet | `InMemoryParquetDataSource` | `IterableParquetDataSource` | read via in-process DuckDB, JDBC-like |
+| JSON | `InMemoryJSONDataSource` | `IterableJSONDataSource` | nested flattened to dotted paths |
+| YAML | `InMemoryYAMLDataSource` | `IterableYAMLDataSource` | same flattening; no size limit |
+| TOON | `InMemoryTOONDataSource` | `IterableTOONDataSource` | compact, LLM-friendly |
+
+- All file-based sources accept a **file path or an `InputStream`** and
+  transparently **decompress `.gz`** with no extra config.
+- JSON/YAML flatten nested objects to dotted keys, e.g.
+  `people[0].address.city`.
+
+## Uniqueness check
+```java
+AbstractUniqueness check = new InMemoryUniquenessCheck();   // or NoMemoryUniquenessCheck
+check.setDataSource(new InMemorySQLDataSource(connection, query));
+Result result = check.exec("COLUMN1", "COLUMN2", "COLUMN3");
+if (result.isUnique()) {
+    for (Result better : result.getBetterOptions()) {   // smaller candidate keys
+        log.info(better);
+    }
+}
+```
+The checker consumes a `ColumnarDataSource`, asks whether the given columns form
+a key, and searches for a smaller one. `InMemory…` runs recursive passes over a
+single load; `NoMemory…` re-reads the source per pass for a tiny heap.
+
+## Adding a new source
+Implement `IterableDataSource` (five methods; `nextRows` is a default). If it can
+report its columns, also implement `ColumnarDataSource` so schema-dependent
+callers can use it. Add `readAll()` via `InMemoryDataSource` for an in-memory
+variant. Keep JDBC specifics in `source.db` (ArchUnit enforces this).
+
+## References
+- `README.md` — *Data* (worked uniqueness example, source list, interfaces)
+- `AGENTS.md` — *Data* summary (source of truth)
+- `data/.../uniqueness/mcp/MCP_USAGE.md` — running the uniqueness MCP server

--- a/.claude/skills/protogen/README.md
+++ b/.claude/skills/protogen/README.md
@@ -1,0 +1,38 @@
+# Protogen
+
+**Load**: `view .claude/skills/protogen/SKILL.md`
+
+---
+
+## Description
+
+Helps Claude configure and use the `protogen-maven-plugin` — the plugin that
+generates protobuf builders which catch missing `required` fields at **compile
+time** instead of runtime. Covers the plugin wiring, the generated builder
+chain, and the proto2/proto3/`oneof` handling.
+
+---
+
+## Use Cases
+
+- "Wire protogen into this module's pom"
+- "Why won't my generated builder compile until I set id?"
+- "How is proto3 presence handled?" / "What does a oneof generate?"
+
+---
+
+## Examples
+
+```
+> view .claude/skills/protogen/SKILL.md
+> "Add the protogen plugin to code/context"
+→ Bind the code-generator goal to generate-sources; set generatedSourcesDir,
+  pkgs, and outputpackage; add the output dir as a source root
+```
+
+---
+
+## Notes / Tips
+
+- Generate the protobuf classes first — the plugin scans the compiled messages.
+- `mvn clean` after deleting a `.proto`, so stale builders can't mask the change.

--- a/.claude/skills/protogen/SKILL.md
+++ b/.claude/skills/protogen/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: protogen
+description: Generate compile-time-safe protobuf builders with the protogen-maven-plugin — proto2 required-field enforcement, proto3 presence-aware accessors, and oneof discriminators. Use when configuring the plugin, reasoning about the generated builder chain, or when the user says "generate builders", "protobuf builder", "required field", or "shift-left validation".
+---
+
+# Protogen Skill
+
+Generate and use the compile-time-safe protobuf builders produced by
+`code/protogen-maven-plugin`. The point of this module is **shift-left**: stock
+protobuf builders only detect a missing `required` field at runtime (an
+`UninitializedMessageException` from `build()`), while the generated builder
+chain makes the same mistake **fail to compile**.
+
+## When to Use
+- Wiring `protogen-maven-plugin` into a `pom.xml`
+- Explaining or debugging why generated builders won't compile until every
+  required field is set
+- Questions about proto2 vs proto3 handling, presence accessors, or `oneof`
+- The user says "generate builders" / "protobuf builder" / "required field" /
+  "shift-left validation"
+
+## How the plugin is wired
+The plugin runs **after** protobuf classes exist, so it consumes the compiled
+`*.proto` output and emits builder sources. Bind its `code-generator` goal to a
+generate-sources phase, point it at the packages holding the generated protobuf
+messages, and name an output package for the builders:
+
+```xml
+<plugin>
+    <groupId>io.github.adamw7</groupId>
+    <artifactId>protogen-maven-plugin</artifactId>
+    <!-- Use the latest release: https://github.com/adamw7/tools/releases/latest -->
+    <configuration>
+        <generatedSourcesDir>${project.basedir}/target/generated-sources/</generatedSourcesDir>
+        <pkgs>
+            <param>io.github.adamw7.tools.code.protos</param>
+        </pkgs>
+        <outputpackage>io.github.adamw7.tools.code.builders</outputpackage>
+    </configuration>
+    <executions>
+        <execution>
+            <phase>generate-sources</phase>
+            <goals>
+                <goal>code-generator</goal>
+            </goals>
+        </execution>
+    </executions>
+</plugin>
+```
+
+Mojo goal / parameters (`CodeMojo`, `defaultPhase = GENERATE_SOURCES`):
+
+| Parameter | Property | Meaning |
+|---|---|---|
+| `generatedSourcesDir` | `generatedsourcesdir` | Where the builder sources are written |
+| `pkgs` | `pkgs` | Packages to scan for compiled protobuf messages |
+| `outputpackage` | `outputpackage` | Package the generated builders go into |
+
+Add the output directory as a source root (e.g. `build-helper-maven-plugin`'s
+`add-source` / `add-test-source`) so the builders are compiled with the rest of
+the module.
+
+## What the generated chain guarantees
+For a message with `required` fields, the plugin emits a chain of single-method
+interfaces so each required setter returns the interface exposing only the
+*next* required setter. `build()` appears only after the last required field, so
+you cannot call it early — the missing-field bug is now a compile error:
+
+```java
+// required: id, department  →  both must be set before build() is reachable
+Person person = builder.setId(1).setDepartment("dep")
+                       .setEmail("sth@sth.net").setName("Adam").build();
+```
+
+## proto2 vs proto3 (the rules that trip people up)
+- **proto2**: every `required` field is enforced by the builder chain; every
+  singular field tracks presence, so all get a `hasXxx()` accessor.
+- **proto3**: has no `required` fields, so the builder is all-optional — there is
+  nothing to enforce. `hasXxx()` is generated **only** for message fields and
+  fields declared with the explicit `optional` keyword. Implicit-presence proto3
+  scalars have no `hasXxx()` and are left alone.
+- **`oneof`**: gets a `getXxxCase()` accessor returning protobuf's generated
+  `XxxCase` enum plus a `clearXxx()` that resets the whole group — both reachable
+  through the fluent chain. The synthetic oneofs backing proto3 `optional` fields
+  are **not** treated as groups, so no spurious case accessor is generated.
+
+## Gotchas
+- Run `mvn clean …` after removing a `.proto` source, so stale builders in
+  `target/` cannot mask the change (repo-wide clean-after-codegen rule).
+- The plugin needs the compiled protobuf classes on the runtime classpath
+  (`requiresDependencyResolution = RUNTIME`); generate the `*.proto` first.
+
+## References
+- `README.md` — *Code generation* (worked proto2 example + generated chain)
+- `docs/compile-time-safe-builders.md` — visual walkthrough of the chain
+- `code/protogen-maven-plugin-test/pom.xml` — a working end-to-end configuration
+- `AGENTS.md` — *Code generation* summary (source of truth)


### PR DESCRIPTION
The existing skills all cover cross-cutting workflow (commits, review,
Maven, SOLID, testing); none documented a specific module's domain. Add
two module-capability skills:

- protogen: wiring the protogen-maven-plugin, the compile-time-safe
  builder chain, and proto2/proto3/oneof handling
- data-sources: choosing a data source, the ColumnarDataSource vs
  forward-only schema contract, and the uniqueness/key checker

Each ships a SKILL.md (front matter validated by the skillFilesExist
enforcer rule) and a README.md matching the existing skill layout.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L5gTgSgf15eAjypVkgct71