### PR TITLE
fix: contract and lifecycle bugs in data structures, sources, uniqueness and protogen

### DIFF
--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Utils.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Utils.java
@@ -18,10 +18,16 @@ public class Utils {
 	}
 
 	public static String firstToLower(String string) {
+		if (string.isEmpty()) {
+			return string;
+		}
 		return (String.valueOf(string.charAt(0)).toLowerCase() + string.substring(1));
 	}
 
 	public static String firstToUpper(String string) {
+		if (string.isEmpty()) {
+			return string;
+		}
 		return (firstUpper(string) + string.substring(1));
 	}
 
@@ -39,6 +45,11 @@ public class Utils {
 	}
 
 	static String toProperCase(String s) {
+		if (s.isEmpty()) {
+			// A leading, trailing or doubled underscore in a proto name yields an
+			// empty split part; it contributes nothing to the camel-case name.
+			return s;
+		}
 		return s.substring(0, 1).toUpperCase() + s.substring(1).toLowerCase();
 	}
 	

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/gen/UtilsTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/gen/UtilsTest.java
@@ -21,12 +21,26 @@ public class UtilsTest {
 	}
 
 	@Test
+	public void toUpperCamelCaseSurvivesConsecutiveAndEdgeUnderscores() {
+		assertEquals("ExternalId", Utils.toUpperCamelCase("external__id"));
+		assertEquals("External", Utils.toUpperCamelCase("_external"));
+		assertEquals("External", Utils.toUpperCamelCase("external_"));
+		assertEquals("", Utils.toUpperCamelCase("_"));
+	}
+
+	@Test
 	public void firstToLower() {
 		String firstToLower = Utils.firstToLower("Builder");
 		assertEquals("builder", firstToLower);
 
 		String shouldNotChange = Utils.firstToLower("builder");
 		assertEquals("builder", shouldNotChange);
+	}
+
+	@Test
+	public void firstToLowerAndUpperAcceptEmptyInput() {
+		assertEquals("", Utils.firstToLower(""));
+		assertEquals("", Utils.firstToUpper(""));
 	}
 
 	@Test

--- a/data/src/main/java/io/github/adamw7/tools/data/network/Switch.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/network/Switch.java
@@ -1,15 +1,30 @@
 package io.github.adamw7.tools.data.network;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.Proxy;
 import java.net.ProxySelector;
+import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.SocketImpl;
+import java.net.SocketImplFactory;
 import java.net.URI;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * A one-way, process-global network kill-switch. {@link #off()} seals the
+ * network on two layers: a {@link ProxySelector} that rejects every selection
+ * (stopping proxy-aware clients such as {@code HttpURLConnection} and
+ * {@code HttpClient}) and a {@link SocketImplFactory} that refuses to create
+ * any client {@link Socket} (stopping code that bypasses proxy selection by
+ * dialling directly). NIO {@code SocketChannel}s obtained straight from a
+ * {@code SelectorProvider} are the one remaining gap: the provider cannot be
+ * replaced once the JVM has loaded it, so a library that opens raw channels is
+ * not blocked by this switch.
+ */
 public class Switch {
 
 	private static final Logger log = LogManager.getLogger(Switch.class.getName());
@@ -30,6 +45,13 @@ public class Switch {
 		}
 	}
 
+	private static class BlockingSocketImplFactory implements SocketImplFactory {
+		@Override
+		public SocketImpl createSocketImpl() {
+			throw new UnsupportedOperationException("The network is off");
+		}
+	}
+
 	/**
 	 *
 	 * @return true if this execution has turned off the network
@@ -40,8 +62,23 @@ public class Switch {
 			return false;
 		}
 		ProxySelector.setDefault(new BlockingProxySelector());
+		blockClientSockets();
 		isOff = true;
 		log.info("Network is off now");
 		return true;
+	}
+
+	/**
+	 * The factory mechanism is deprecated, but it is the only post-startup hook
+	 * that covers every {@code new Socket(...)} in the JVM; the {@code isOff}
+	 * guard ensures the one-shot {@code setSocketImplFactory} is called once.
+	 */
+	@SuppressWarnings({ "deprecation", "removal" })
+	private static void blockClientSockets() {
+		try {
+			Socket.setSocketImplFactory(new BlockingSocketImplFactory());
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not install the socket-blocking factory", e);
+		}
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -52,10 +52,17 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 
 	@Override
 	public String[] getColumnNames() {
+		checkIfOpen();
 		try {
 			return getColumnsFrom(resultSet);
 		} catch (SQLException e) {
 			throw new UncheckedIOException(new IOException(e));
+		}
+	}
+
+	private void checkIfOpen() {
+		if (resultSet == null) {
+			throw new IllegalStateException("DataSource is not open");
 		}
 	}
 
@@ -73,6 +80,7 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 
 	@Override
 	public String[] nextRow() {
+		checkIfOpen();
 		try {
 			hasMoreData = resultSet.next();
 			return hasMoreData ? getNextFrom(resultSet) : null;
@@ -96,6 +104,7 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 		if (batchSize <= 0) {
 			return;
 		}
+		checkIfOpen();
 		try {
 			resultSet.setFetchSize(batchSize);
 		} catch (SQLException e) {

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractFileSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractFileSource.java
@@ -22,10 +22,13 @@ public abstract class AbstractFileSource implements IterableDataSource {
 	
 	@Override
 	public void close() throws IOException {
-		if (opened) {
+		if (scanner != null) {
+			// Closed regardless of the opened flag: the constructor already
+			// opened the underlying file, so a source that is closed before
+			// open() must still release its handle.
 			scanner.close();
-			opened = false;
 		}
+		opened = false;
 	}
 	
 	protected AbstractFileSource(String fileName) {
@@ -66,6 +69,9 @@ public abstract class AbstractFileSource implements IterableDataSource {
 	}
 	
 	public String getFileName() {
+		if (fileName == null) {
+			throw new IllegalStateException("Source is backed by a raw input stream, not a file");
+		}
 		return Paths.get(fileName).getFileName().toString();
 	}
 	

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
@@ -4,6 +4,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,14 +43,14 @@ public class CSVDataSource extends AbstractFileSource implements ColumnarDataSou
 		scanner = createScanner(inputStream);
 		this.delimiter = delimiter;
 		this.columnsRow = columnsRow;
-		regex = delimiter + REGEX_SUFFIX;
+		regex = Pattern.quote(delimiter) + REGEX_SUFFIX;
 	}
 
 	public CSVDataSource(String fileName, String delimiter, int columnsRow) throws FileNotFoundException {
 		super(fileName);
 		this.delimiter = delimiter;
 		this.columnsRow = columnsRow;
-		regex = delimiter + REGEX_SUFFIX;
+		regex = Pattern.quote(delimiter) + REGEX_SUFFIX;
 	}
 
 	@Override
@@ -87,7 +88,9 @@ public class CSVDataSource extends AbstractFileSource implements ColumnarDataSou
 			if (line.trim().startsWith("#")) {
 				return null;
 			} else {
-				return line.split(regex);
+				// The -1 limit keeps trailing empty columns, so every row of a
+				// well-formed file has the same arity as its header.
+				return line.split(regex, -1);
 			}
 		} else {
 			hasMoreData = false;
@@ -97,6 +100,9 @@ public class CSVDataSource extends AbstractFileSource implements ColumnarDataSou
 
 	@Override
 	public void reset() {
+		if (fileName == null) {
+			throw new IllegalStateException("Cannot reset a source backed by a raw input stream");
+		}
 		try {
 			close();
 			scanner = createScanner();

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
@@ -19,7 +19,7 @@ import io.github.adamw7.tools.data.structure.internal.Primes;
  * the boxing this class exists to avoid. The API mirrors the relevant map
  * operations with primitive {@code int} keys instead.
  *
- * <p>Unlike {@link OpenAddressingMap}, {@code null} values are stored faithfully
+ * <p>Like {@link OpenAddressingMap}, {@code null} values are stored faithfully
  * and reported by {@link #containsKey(int)}; only {@link #get(int)} cannot tell a
  * stored {@code null} from an absent key. The class is not thread-safe.
  */

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -1,11 +1,13 @@
 package io.github.adamw7.tools.data.structure;
 
-import java.util.Arrays;
+import java.util.AbstractCollection;
+import java.util.AbstractSet;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.function.Function;
 
 import io.github.adamw7.tools.data.structure.internal.DoubleHashing;
 import io.github.adamw7.tools.data.structure.internal.Primes;
@@ -46,7 +48,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 
 	@Override
 	public boolean containsKey(Object key) {
-		return get(key) != null;
+		return find(key) != null;
 	}
 
 	@Override
@@ -165,25 +167,117 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 
 	@Override
 	public Set<K> keySet() {
-		return validWrappers().map(wrapper -> wrapper.getKey()).collect(Collectors.toSet());
+		return new KeySetView();
 	}
 
 	@Override
 	public Collection<V> values() {
-		return validWrappers().map(wrapper -> wrapper.getValue()).collect(Collectors.toList());
+		return new ValuesView();
 	}
 
 	@Override
 	public Set<Entry<K, V>> entrySet() {
-		return validWrappers().<Entry<K, V>>map(wrapper -> wrapper).collect(Collectors.toSet());
-	}
-
-	private Stream<Wrapper<K, V>> validWrappers() {
-		return Arrays.stream(array).filter(this::valid);
+		return new EntrySetView();
 	}
 
 	private boolean valid(Wrapper<K, V> wrapper) {
 		return wrapper != null && !wrapper.isRemoved();
+	}
+
+	private final class KeySetView extends AbstractSet<K> {
+
+		@Override
+		public Iterator<K> iterator() {
+			return new LiveEntryIterator<>(Wrapper::getKey);
+		}
+
+		@Override
+		public int size() {
+			return OpenAddressingMap.this.size();
+		}
+
+		@Override
+		public boolean contains(Object key) {
+			return containsKey(key);
+		}
+	}
+
+	private final class ValuesView extends AbstractCollection<V> {
+
+		@Override
+		public Iterator<V> iterator() {
+			return new LiveEntryIterator<>(Wrapper::getValue);
+		}
+
+		@Override
+		public int size() {
+			return OpenAddressingMap.this.size();
+		}
+	}
+
+	private final class EntrySetView extends AbstractSet<Entry<K, V>> {
+
+		@Override
+		public Iterator<Entry<K, V>> iterator() {
+			return new LiveEntryIterator<>(wrapper -> wrapper);
+		}
+
+		@Override
+		public int size() {
+			return OpenAddressingMap.this.size();
+		}
+	}
+
+	/**
+	 * Walks the live entries of the backing array, mapping each wrapper to the
+	 * view's element type. {@code remove()} retires the entry returned last, so
+	 * the views are writable and the bulk operations inherited from
+	 * {@code AbstractCollection} (removeAll, retainAll, removeIf) really mutate
+	 * the map instead of a throwaway copy.
+	 */
+	private final class LiveEntryIterator<T> implements Iterator<T> {
+
+		private final Function<Wrapper<K, V>, T> mapper;
+		private int nextIndex;
+		private Wrapper<K, V> lastReturned;
+
+		private LiveEntryIterator(Function<Wrapper<K, V>, T> mapper) {
+			this.mapper = mapper;
+			this.nextIndex = nextValidFrom(0);
+		}
+
+		@Override
+		public boolean hasNext() {
+			return nextIndex < array.length;
+		}
+
+		@Override
+		public T next() {
+			if (!hasNext()) {
+				throw new NoSuchElementException();
+			}
+			lastReturned = array[nextIndex];
+			nextIndex = nextValidFrom(nextIndex + 1);
+			return mapper.apply(lastReturned);
+		}
+
+		@Override
+		public void remove() {
+			if (lastReturned == null) {
+				throw new IllegalStateException("next() has not been called since the last remove()");
+			}
+			lastReturned.markRemoved();
+			size--;
+			lastReturned = null;
+		}
+
+		private int nextValidFrom(int index) {
+			int i = index;
+			while (i < array.length && !valid(array[i])) {
+				++i;
+			}
+			return i;
+		}
 	}
 
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/internal/Wrapper.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/internal/Wrapper.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.data.structure.internal;
 
 import java.util.Map.Entry;
+import java.util.Objects;
 
 public class Wrapper<K, V> implements Entry<K, V>{
 
@@ -26,8 +27,9 @@ public class Wrapper<K, V> implements Entry<K, V>{
 
 	@Override
 	public V setValue(V value) {
+		V previous = this.value;
 		this.value = value;
-		return value;
+		return previous;
 	}
 
 	public boolean isRemoved() {
@@ -36,6 +38,22 @@ public class Wrapper<K, V> implements Entry<K, V>{
 
 	public void markRemoved() {
 		this.removed = true;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (this == other) {
+			return true;
+		}
+		if (!(other instanceof Entry<?, ?> entry)) {
+			return false;
+		}
+		return Objects.equals(key, entry.getKey()) && Objects.equals(value, entry.getValue());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(key) ^ Objects.hashCode(value);
 	}
 
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
@@ -132,14 +132,24 @@ public abstract class AbstractUniqueness<T extends ColumnarDataSource> implement
 	 * opens the source to read its column names and then reuses that same open source,
 	 * so neither entry point opens the source twice &mdash; which the open-once
 	 * map-backed in-memory sources reject with {@code DataSource is already open}.
+	 *
+	 * <p>Implementations must not close the source: the subset search that follows a
+	 * successful check {@link IterableDataSource#reset() resets} it between passes,
+	 * and a source that owns its connection (the Parquet ones) cannot be reopened
+	 * once closed. The public entry points close the source exactly once, after the
+	 * whole check &mdash; subsets included &mdash; has finished.
 	 */
 	protected abstract Result execOnOpenSource(String[] keyCandidates);
 
 	@Override
 	public Result execForAllColumns() {
 		dataSource.open();
-		String[] keyCandidates = dataSource.getColumnNames();
-		check(keyCandidates);
-		return execOnOpenSource(keyCandidates);
+		try {
+			String[] keyCandidates = dataSource.getColumnNames();
+			check(keyCandidates);
+			return execOnOpenSource(keyCandidates);
+		} finally {
+			close(dataSource);
+		}
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/InMemoryUniquenessCheck.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/InMemoryUniquenessCheck.java
@@ -14,7 +14,11 @@ public class InMemoryUniquenessCheck extends AbstractUniqueness<InMemoryDataSour
 	public Result exec(String... keyCandidates) {
 		check(keyCandidates);
 		dataSource.open();
-		return execOnOpenSource(keyCandidates);
+		try {
+			return execOnOpenSource(keyCandidates);
+		} finally {
+			close(dataSource);
+		}
 	}
 
 	@Override
@@ -28,7 +32,6 @@ public class InMemoryUniquenessCheck extends AbstractUniqueness<InMemoryDataSour
 	private Result findUnique(int[] indices, String... keyCandidates) {
 		dataSource.reset();
 		List<String[]> data = dataSource.readAll();
-		close(dataSource);
 		KeyFinder finder = new KeyFinder(indices);
 		for (String[] row : data) {
 			if (finder.found(row)) {

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
@@ -12,7 +12,11 @@ public class NoMemoryUniquenessCheck extends AbstractUniqueness<ColumnarDataSour
 	public Result exec(String... keyCandidates) {
 		check(keyCandidates);
 		dataSource.open();
-		return execOnOpenSource(keyCandidates);
+		try {
+			return execOnOpenSource(keyCandidates);
+		} finally {
+			close(dataSource);
+		}
 	}
 
 	@Override
@@ -23,18 +27,18 @@ public class NoMemoryUniquenessCheck extends AbstractUniqueness<ColumnarDataSour
 		while (dataSource.hasMoreData()) {
 			String[] row = dataSource.nextRow();
 			if (finder.found(row)) {
-				close(dataSource);
 				return new Result(false, keyCandidates, row);
 			}
 		}
 
-		Result result = handleSuccessfulCheck(keyCandidates);
-		close(dataSource);
-		return result;
+		return handleSuccessfulCheck(keyCandidates);
 	}
 
 	@Override
 	protected Result checkSubset(String[] newCandidates) {
-		return exec(newCandidates);
+		// The caller has just reset() the source, so it is open again; going
+		// through exec() would close it after this subset and leave nothing for
+		// the next one to reset.
+		return execOnOpenSource(newCandidates);
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/network/SwitchTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/network/SwitchTest.java
@@ -10,6 +10,7 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.net.HttpURLConnection;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URL;
 
@@ -24,6 +25,19 @@ public class SwitchTest {
 		RuntimeException thrown = assertThrows(RuntimeException.class, this::connectToInternet, "Expected connectToInternet() method to throw, but it didn't");
 
 		assertEquals("java.lang.UnsupportedOperationException: The network is off", thrown.getMessage());
+	}
+
+	@Test
+	public void directSocketConnectionsAreBlocked() {
+		Switch.off();
+
+		// A plain client socket never consults the ProxySelector, so the switch's
+		// SocketImplFactory must refuse it. The literal TEST-NET-1 address needs no
+		// DNS lookup and would never be routable even if the block failed.
+		UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
+				() -> new Socket("192.0.2.1", 80), "Expected the socket factory to block the connection");
+
+		assertEquals("The network is off", thrown.getMessage());
 	}
 
 	@Test

--- a/data/src/test/java/io/github/adamw7/tools/data/source/db/SQLDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/db/SQLDataSourceTest.java
@@ -93,6 +93,16 @@ public class SQLDataSourceTest extends DBTest {
 		Utils.close(source);
 	}
 
+	@Test
+	public void readBeforeOpenFailsFast() {
+		IterableSQLDataSource source = new IterableSQLDataSource(connection, query);
+		// Before open() there is no result set; the source must say so instead of
+		// failing with a raw NullPointerException.
+		assertThrows(IllegalStateException.class, source::getColumnNames);
+		assertThrows(IllegalStateException.class, source::nextRow);
+		assertThrows(IllegalStateException.class, () -> source.nextRows(10));
+	}
+
 	@ParameterizedTest
 	@MethodSource("wrongQuerySources")
 	public void wrongQuery(IterableSQLDataSource source) {

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/CSVDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/CSVDataSourceTest.java
@@ -6,10 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -192,6 +194,57 @@ public class CSVDataSourceTest {
 		assertEquals(firstPass, secondPass);
 		assertEquals(15, source.getColumnNames().length);
 		assertEquals("hlpi_name", source.getColumnNames()[0]);
+	}
+
+	@Test
+	public void regexSpecialDelimiterIsTreatedLiterally() throws IOException {
+		try (InputStream stream = streamOf("id|name\n1|Adam\n")) {
+			CSVDataSource source = new CSVDataSource(stream, "|", COLUMNS_ROW);
+			source.open();
+			// An unquoted "|" would be an empty regex alternation that splits between
+			// every character; the delimiter must be matched literally.
+			assertArrayEquals(new String[] { "id", "name" }, source.getColumnNames());
+			assertArrayEquals(new String[] { "1", "Adam" }, source.nextRow());
+			source.close();
+		}
+	}
+
+	@Test
+	public void trailingEmptyColumnsAreKept() throws IOException {
+		try (InputStream stream = streamOf("id,name,comment\n1,Adam,\n")) {
+			CSVDataSource source = new CSVDataSource(stream, ",", COLUMNS_ROW);
+			source.open();
+			assertArrayEquals(new String[] { "1", "Adam", "" }, source.nextRow());
+			source.close();
+		}
+	}
+
+	@Test
+	public void resetOnStreamBackedSourceFailsFast() {
+		CSVDataSource source = new CSVDataSource(streamOf("a,b\n"));
+		source.open();
+		// The consumed stream cannot be reopened, so reset() must fail loudly
+		// instead of silently producing an empty source.
+		assertThrows(IllegalStateException.class, source::reset);
+	}
+
+	@Test
+	public void getFileNameOnStreamBackedSourceFailsFast() {
+		CSVDataSource source = new CSVDataSource(streamOf("a,b\n"));
+		assertThrows(IllegalStateException.class, source::getFileName);
+	}
+
+	@Test
+	public void closeBeforeOpenReleasesTheScanner() throws IOException {
+		InMemoryCSVDataSource source = Utils.createInMemoryDataSource(Utils.getHouseholdFile(), COLUMNS_ROW);
+		source.close();
+		// The constructor already opened the file, so an immediate close must release
+		// it; a genuinely closed scanner then fails fast on any read attempt.
+		assertThrows(IllegalStateException.class, source::nextRow);
+	}
+
+	private static InputStream streamOf(String csv) {
+		return new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8));
 	}
 
 	@Test

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
@@ -353,6 +353,57 @@ public class MapTest {
 	
 	@ParameterizedTest
 	@MethodSource("allImplementations")
+	public void containsKeyWhenValueIsNull(Map<Integer, String> map) {
+		map.put(1, null);
+		assertTrue(map.containsKey(1));
+		assertNull(map.get(1));
+		assertTrue(map.containsValue(null));
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void keySetIsALiveViewOfTheMap(Map<Integer, String> map) {
+		map.put(1, "A");
+		map.put(2, "B");
+		Set<Integer> keySet = map.keySet();
+		assertTrue(keySet.remove(1));
+		assertFalse(map.containsKey(1));
+		assertEquals(1, map.size());
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void removeIfOnValuesWritesThroughToTheMap(Map<Integer, String> map) {
+		for (int i = 0; i < 10; ++i) {
+			map.put(i, i % 2 == 0 ? "even" : "odd");
+		}
+		assertTrue(map.values().removeIf("odd"::equals));
+		assertEquals(5, map.size());
+		assertFalse(map.containsValue("odd"));
+		assertTrue(map.containsValue("even"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void entrySetSetValueReturnsPreviousValueAndWritesThrough(Map<Integer, String> map) {
+		map.put(1, "A");
+		Entry<Integer, String> entry = map.entrySet().iterator().next();
+		assertEquals("A", entry.setValue("B"));
+		assertEquals("B", map.get(1));
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void entrySetEqualsAnotherMapsEntrySet(Map<Integer, String> map) {
+		map.put(1, "A");
+		map.put(2, "B");
+		Map<Integer, String> expected = Map.of(1, "A", 2, "B");
+		assertEquals(expected.entrySet(), map.entrySet());
+		assertEquals(map.entrySet(), expected.entrySet());
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
 	public void empty(Map<Integer, String> map) {
 		assertTrue(map.isEmpty());
 	}

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/OpenAddressingSetTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/OpenAddressingSetTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -119,6 +121,49 @@ public class OpenAddressingSetTest {
 		assertTrue(set.addAll(source));
 		assertTrue(set.containsAll(source));
 		assertEquals(50, set.size());
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void removeAllWithLargerCollectionUsesTheIterator(Set<Integer> set) {
+		set.add(1);
+		set.add(2);
+		set.add(3);
+		// The collection is larger than the set, so AbstractSet.removeAll walks the
+		// set's own iterator and relies on its remove() writing through.
+		assertTrue(set.removeAll(List.of(0, 1, 2, 8, 9)));
+		assertEquals(Set.of(3), set);
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void retainAllKeepsOnlyGivenElements(Set<Integer> set) {
+		for (int i = 0; i < 10; ++i) {
+			set.add(i);
+		}
+		assertTrue(set.retainAll(List.of(1, 3, 5)));
+		assertEquals(Set.of(1, 3, 5), set);
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void removeIfRemovesMatchingElements(Set<Integer> set) {
+		for (int i = 0; i < 10; ++i) {
+			set.add(i);
+		}
+		assertTrue(set.removeIf(element -> element % 2 == 0));
+		assertEquals(Set.of(1, 3, 5, 7, 9), set);
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void iteratorRemoveWritesThroughToTheSet(Set<Integer> set) {
+		set.add(1);
+		set.add(2);
+		Iterator<Integer> iterator = set.iterator();
+		iterator.next();
+		iterator.remove();
+		assertEquals(1, set.size());
 	}
 
 	@Test

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/ParquetUniquenessCheckTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/ParquetUniquenessCheckTest.java
@@ -1,0 +1,73 @@
+package io.github.adamw7.tools.data.uniqueness;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.data.source.db.InMemoryParquetDataSource;
+import io.github.adamw7.tools.data.source.db.IterableParquetDataSource;
+
+/**
+ * Regression tests for running the uniqueness checks against the Parquet
+ * sources, which own their DuckDB connection. The subset search that follows a
+ * successful check {@code reset()}s the source between passes; these used to
+ * crash with a closed-connection error because the check closed the source
+ * mid-search, and a connection-owning source cannot be reopened once closed.
+ */
+public class ParquetUniquenessCheckTest {
+
+	private static Path parquetFile;
+
+	@BeforeAll
+	public static void createParquetFixture() throws Exception {
+		parquetFile = Paths.get("target", "uniqueness-people.parquet").toAbsolutePath();
+		Files.deleteIfExists(parquetFile);
+		try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+				Statement statement = connection.createStatement()) {
+			statement.execute("CREATE TABLE people (id INTEGER, name VARCHAR, city VARCHAR)");
+			statement.execute("INSERT INTO people VALUES (1, 'Adam', 'A'), (2, 'Ewa', 'A'), (3, 'Jan', 'B')");
+			statement.execute("COPY people TO '" + parquetFile + "' (FORMAT PARQUET)");
+		}
+	}
+
+	@Test
+	public void inMemoryUniqueCandidatesSurviveTheSubsetSearch() {
+		InMemoryUniquenessCheck check = new InMemoryUniquenessCheck(
+				new InMemoryParquetDataSource(parquetFile.toString()));
+
+		Result result = check.exec("id", "name");
+
+		assertTrue(result.isUnique());
+		assertTrue(result.getBetterOptions().contains(new Result(true, new String[] { "id" })));
+		assertTrue(result.getBetterOptions().contains(new Result(true, new String[] { "name" })));
+	}
+
+	@Test
+	public void noMemoryUniqueCandidatesSurviveTheSubsetSearch() {
+		NoMemoryUniquenessCheck check = new NoMemoryUniquenessCheck(
+				new IterableParquetDataSource(parquetFile.toString()));
+
+		Result result = check.exec("id", "name");
+
+		assertTrue(result.isUnique());
+		assertTrue(result.getBetterOptions().contains(new Result(true, new String[] { "id" })));
+		assertTrue(result.getBetterOptions().contains(new Result(true, new String[] { "name" })));
+	}
+
+	@Test
+	public void notUniqueColumnIsStillReported() {
+		NoMemoryUniquenessCheck check = new NoMemoryUniquenessCheck(
+				new IterableParquetDataSource(parquetFile.toString()));
+
+		assertFalse(check.exec("city").isUnique());
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the Critical/High/Medium findings from a repo-wide Java bug hunt, each with regression tests:

- **`OpenAddressingMap`/`OpenAddressingSet`**: `keySet()`/`values()`/`entrySet()` are now live, write-through views instead of snapshots, so `removeAll`/`retainAll`/`removeIf` and `iterator().remove()` genuinely mutate the map/set (they previously mutated a throwaway copy while reporting success). `containsKey` now reports keys mapped to `null`, and `Wrapper.setValue` returns the previous value with spec-compliant `Map.Entry` `equals`/`hashCode`.
- **CSV source**: the delimiter is `Pattern.quote`d (a `|` delimiter previously split every character), rows keep trailing empty columns (`split(regex, -1)`), and stream-backed sources fail fast on `reset()`/`getFileName()` instead of silently yielding nothing. `close()` releases the scanner even before `open()`, fixing a file-handle leak.
- **Uniqueness checks**: the source is closed exactly once, after the whole subset search. Previously the checks closed it mid-search and then `reset()` it, which crashed the connection-owning Parquet sources on any successful multi-column check.
- **`IterableSQLDataSource`**: reads before `open()` throw `IllegalStateException` instead of raw NPEs.
- **Network kill-switch**: `Switch.off()` now also blocks plain `new Socket(...)` via a `SocketImplFactory`; the remaining NIO `SelectorProvider` gap is documented.
- **protogen**: `Utils.toUpperCamelCase` no longer crashes on legal proto names with doubled/leading/trailing underscores.

Deliberately left unchanged: TOON's trailing-empty-field drop and `field -> field` header emission — both are pinned by intent-named tests (`trailingCommaDropsTrailingEmptyValue`, `emitTabularHeaderEmitsCountThenFields`), so they are format decisions, not bugs.

## Test plan

- Full `mvn install` from the root: **1389 tests, 0 failures, 0 errors**
- 20 new regression tests, including a new `ParquetUniquenessCheckTest` covering the closed-connection crash and a `SwitchTest` case proving direct sockets are refused
- `MapTest`/`OpenAddressingSetTest` additions run side-by-side against `HashMap`/`HashSet` to validate contract behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)