### PR TITLE
feat(adopt): add PR CLI flags, JSON run report, starter assets, and an MCP server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,20 @@ Maven project. The notable capabilities are:
   check it runs, verified by running that script — so a build-less repository
   still keeps the guard. The pull request metadata — title, body,
   reviewers, labels, assignees, and draft flag — is supplied through
-  `PullRequestOptions`. External `git`/`claude`/`gh` invocations
+  `PullRequestOptions`, exposed on the command line as `--title`, `--body`,
+  repeatable `--reviewer`/`--label`/`--assignee`, and `--draft` (parsed by
+  `CliArguments` alongside the positional URL, workspace, and branch arguments).
+  An optional `--assets` flag adds an `AssetsStep` that commits starter Claude
+  Code configuration assets — an `AGENTS.md` pointer, a `.claude/settings.json`
+  denying reads of obvious secret files and wiring a
+  `.claude/hooks/session-start.sh` stub, a starter `.mcp.json`, and a GitHub
+  Actions workflow answering `@claude` mentions — never overwriting a file the
+  repository already has. Each run returns an `AdoptionReport` (completed steps
+  plus the pull request URL, read back with `gh pr view --json url`);
+  `--report <file>` writes it as JSON for scripting. An **MCP server** (in the
+  `io.github.adamw7.tools.adopt.mcp` package) exposes the same pipeline as an
+  `adopt_repo` tool that answers with that JSON report. External
+  `git`/`claude`/`gh` invocations
   go through a `CommandRunner`
   abstraction so the steps are unit-tested without spawning real processes; the
   `ProcessCommandRunner` bounds every command with a configurable timeout so a
@@ -97,7 +110,7 @@ list).
 Base Java package: `io.github.adamw7` (`io.github.adamw7.context` for the
 context module, `io.github.adamw7.tools.*` elsewhere).
 
-The repository ships two MCP servers, each a Spring Boot app whose entry point
+The repository ships three MCP servers, each a Spring Boot app whose entry point
 is `Main.java` and which supports stdio (default), streamable HTTP
 (`--transport.mode=streamable-http`, served at `/mcp`), stateless HTTP
 (`--transport.mode=stateless-http`, session-less, also served at `/mcp`), or the
@@ -111,6 +124,11 @@ messages at `/mcp/message`):
   `code/context/src/main/java/io/github/adamw7/context/mcp/`, exposing the
   `project_tree`, `find_context` and `estimate_tokens` tools; see its
   [MCP_USAGE.md](code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md).
+- The adoption server in
+  `adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/`, exposing the
+  `adopt_repo` tool that runs the adoption pipeline and answers with its JSON
+  report; see its
+  [MCP_USAGE.md](adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md).
 
 ## Environment & toolchain
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,14 @@ run `mvn install` from the repository root. The main capabilities are:
   `.github/claude-md-guard.sh` check as the build-tool-agnostic fallback) and
   commit that, verify the guard passes on the
   generated file, then push the branch and open a pull request (`gh pr create`)
-  with metadata from `PullRequestOptions`; the default branch is never written to
-  directly.
+  with metadata from `PullRequestOptions` (exposed as CLI flags such as
+  `--title`, `--reviewer`, and `--draft`); the default branch is never written to
+  directly. An optional `--assets` flag commits starter Claude Code
+  configuration assets (an `AGENTS.md` pointer, `.claude/settings.json`, a
+  session-start hook stub, `.mcp.json`, and an `@claude`-mention workflow); each
+  run returns an `AdoptionReport` with the pull request URL, written as JSON via
+  `--report <file>`, and an MCP server exposes the pipeline as an `adopt_repo`
+  tool.
 
 Module map (root reactor: `claude-code-enforcer`, `mcp-common`, `data`, `code`,
 `adopt`, `grpc-example`, `assembly`; `data-test` is built separately):

--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -43,9 +43,35 @@
 					<mainClass>io.github.adamw7.tools.adopt.Main</mainClass>
 				</configuration>
 			</plugin>
+			<!-- Repackages the module jar as the executable adoption MCP server,
+			     mirroring the data and context modules; the release profile skips
+			     the repackaging so Maven Central still gets a plain library jar.
+			     The pipeline CLI stays reachable through exec:java above. -->
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<mainClass>io.github.adamw7.tools.adopt.mcp.Main</mainClass>
+					<executable>true</executable>
+					<layout>JAR</layout>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencies>
+		<dependency>
+			<groupId>io.github.adamw7</groupId>
+			<artifactId>tools.mcp-common</artifactId>
+			<version>${revision}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp-json-jackson2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReport.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReport.java
@@ -1,0 +1,35 @@
+package io.github.adamw7.tools.adopt;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The machine-readable outcome of an adoption run: the steps that completed, in
+ * order, and the URL of the pull request the run opened (or found already open).
+ * {@link GitHubRepoAdopter#adopt} fills one in and returns it, so callers — the
+ * command line, the MCP server, or any embedding code — can report what happened
+ * without scraping logs. The pull-request URL is absent until a step records it,
+ * for example when the pipeline is configured without a pull-request step.
+ */
+public final class AdoptionReport {
+
+	private final List<String> completedSteps = new ArrayList<>();
+	private String pullRequestUrl;
+
+	public void recordStep(String name) {
+		completedSteps.add(name);
+	}
+
+	public void recordPullRequestUrl(String url) {
+		this.pullRequestUrl = url;
+	}
+
+	public List<String> completedSteps() {
+		return List.copyOf(completedSteps);
+	}
+
+	public Optional<String> pullRequestUrl() {
+		return Optional.ofNullable(pullRequestUrl);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
@@ -1,0 +1,57 @@
+package io.github.adamw7.tools.adopt;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Renders an {@link AdoptionReport} as JSON, either to a string or to a file, so
+ * the adoption's outcome — repository, branch, pull-request URL, and the steps
+ * that completed — is consumable by scripts and other tools rather than only
+ * readable in the logs. A report without a pull-request URL serialises the
+ * {@code pullRequestUrl} field as JSON {@code null}, keeping the document's
+ * shape stable for consumers.
+ */
+public class AdoptionReportWriter {
+
+	private final ObjectMapper mapper = new ObjectMapper();
+
+	public String toJson(AdoptionContext context, AdoptionReport report) {
+		try {
+			return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(toNode(context, report));
+		} catch (JsonProcessingException e) {
+			throw new AdoptionException("Could not serialise the adoption report", e);
+		}
+	}
+
+	public void write(Path file, AdoptionContext context, AdoptionReport report) {
+		try {
+			createParentDirectories(file);
+			Files.writeString(file, toJson(context, report));
+		} catch (IOException e) {
+			throw new AdoptionException("Could not write the adoption report to " + file, e);
+		}
+	}
+
+	private void createParentDirectories(Path file) throws IOException {
+		Path parent = file.toAbsolutePath().getParent();
+		if (parent != null) {
+			Files.createDirectories(parent);
+		}
+	}
+
+	private ObjectNode toNode(AdoptionContext context, AdoptionReport report) {
+		ObjectNode node = mapper.createObjectNode();
+		node.put("repositoryUrl", context.repositoryUrl());
+		node.put("branch", context.branchName());
+		node.put("pullRequestUrl", report.pullRequestUrl().orElse(null));
+		ArrayNode steps = node.putArray("completedSteps");
+		report.completedSteps().forEach(steps::add);
+		return node;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -1,0 +1,143 @@
+package io.github.adamw7.tools.adopt;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import io.github.adamw7.tools.adopt.step.PullRequestOptions;
+
+/**
+ * Parses the adoption command line. The first three non-flag arguments are the
+ * positional repository URL, workspace directory, and feature-branch name the
+ * entry point has always accepted, so existing invocations keep working; the
+ * flags expose the rest of the pipeline's configuration: the pull-request
+ * metadata of {@link PullRequestOptions} ({@code --title}, {@code --body},
+ * repeatable {@code --reviewer}/{@code --label}/{@code --assignee}, and
+ * {@code --draft}), the optional starter-assets step ({@code --assets}), and a
+ * JSON report of the run's outcome ({@code --report <file>}). A blank workspace
+ * or branch positional falls back to its default, matching the pre-flag
+ * behaviour; an unknown flag or a flag missing its value fails with the usage
+ * line rather than being silently ignored.
+ */
+public final class CliArguments {
+
+	static final String USAGE = "Usage: <github-repo-url> [workspace-directory] [branch-name]"
+			+ " [--title <title>] [--body <body>] [--reviewer <user>]... [--label <label>]..."
+			+ " [--assignee <user>]... [--draft] [--assets] [--report <file>]";
+
+	private String repositoryUrl;
+	private Path workspace;
+	private String branchName;
+	private String title;
+	private String body;
+	private final List<String> reviewers = new ArrayList<>();
+	private final List<String> labels = new ArrayList<>();
+	private final List<String> assignees = new ArrayList<>();
+	private boolean draft;
+	private boolean assets;
+	private Path reportFile;
+	private int positionals;
+
+	private CliArguments() {
+	}
+
+	public static CliArguments parse(String[] args) {
+		CliArguments cli = new CliArguments();
+		int index = 0;
+		while (args != null && index < args.length) {
+			index = cli.consume(args, index);
+		}
+		cli.requireRepositoryUrl();
+		return cli;
+	}
+
+	public String repositoryUrl() {
+		return repositoryUrl;
+	}
+
+	public Optional<Path> workspace() {
+		return Optional.ofNullable(workspace);
+	}
+
+	public String branchName() {
+		return branchName == null ? AdoptionContext.DEFAULT_BRANCH : branchName;
+	}
+
+	public PullRequestOptions pullRequestOptions() {
+		PullRequestOptions.Builder builder = PullRequestOptions.builder()
+				.reviewers(reviewers).labels(labels).assignees(assignees).draft(draft);
+		if (title != null) {
+			builder.title(title);
+		}
+		if (body != null) {
+			builder.body(body);
+		}
+		return builder.build();
+	}
+
+	public boolean includeAssets() {
+		return assets;
+	}
+
+	public Optional<Path> reportFile() {
+		return Optional.ofNullable(reportFile);
+	}
+
+	private int consume(String[] args, int index) {
+		String argument = args[index];
+		if (argument.startsWith("--")) {
+			return consumeFlag(args, index);
+		}
+		consumePositional(argument);
+		return index + 1;
+	}
+
+	private int consumeFlag(String[] args, int index) {
+		String flag = args[index];
+		return switch (flag) {
+			case "--title" -> consumeValue(args, index, value -> title = value);
+			case "--body" -> consumeValue(args, index, value -> body = value);
+			case "--reviewer" -> consumeValue(args, index, reviewers::add);
+			case "--label" -> consumeValue(args, index, labels::add);
+			case "--assignee" -> consumeValue(args, index, assignees::add);
+			case "--report" -> consumeValue(args, index, value -> reportFile = Path.of(value));
+			case "--draft" -> consumeSwitch(index, () -> draft = true);
+			case "--assets" -> consumeSwitch(index, () -> assets = true);
+			default -> throw new IllegalArgumentException("Unknown option " + flag + ". " + USAGE);
+		};
+	}
+
+	private int consumeValue(String[] args, int index, java.util.function.Consumer<String> target) {
+		if (index + 1 >= args.length) {
+			throw new IllegalArgumentException(args[index] + " requires a value. " + USAGE);
+		}
+		target.accept(args[index + 1]);
+		return index + 2;
+	}
+
+	private int consumeSwitch(int index, Runnable target) {
+		target.run();
+		return index + 1;
+	}
+
+	private void consumePositional(String argument) {
+		assignPositional(positionals, argument);
+		positionals++;
+	}
+
+	private void assignPositional(int position, String argument) {
+		switch (position) {
+			case 0 -> repositoryUrl = argument;
+			case 1 -> workspace = argument.isBlank() ? null : Path.of(argument);
+			case 2 -> branchName = argument.isBlank() ? null : argument;
+			default -> throw new IllegalArgumentException("Unexpected argument " + argument + ". " + USAGE);
+		}
+	}
+
+	private void requireRepositoryUrl() {
+		if (repositoryUrl == null || repositoryUrl.isBlank()) {
+			throw new IllegalArgumentException(USAGE);
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -7,11 +8,13 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
+import io.github.adamw7.tools.adopt.step.AssetsStep;
 import io.github.adamw7.tools.adopt.step.BranchStep;
 import io.github.adamw7.tools.adopt.step.ClaudeInitStep;
 import io.github.adamw7.tools.adopt.step.CloneStep;
 import io.github.adamw7.tools.adopt.step.CommitStep;
 import io.github.adamw7.tools.adopt.step.EnforcerStep;
+import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 import io.github.adamw7.tools.adopt.step.PullRequestStep;
 import io.github.adamw7.tools.adopt.step.PushStep;
 import io.github.adamw7.tools.adopt.step.ToolchainStep;
@@ -28,6 +31,12 @@ import io.github.adamw7.tools.adopt.step.VerifyStep;
  * {@code git}, {@code claude}, or {@code gh} fails the adoption before any
  * expensive work. The adoption never writes to the default branch. Steps and the
  * command runner are injected so the pipeline is easy to reconfigure and to test.
+ *
+ * <p>Each run returns an {@link AdoptionReport} of the steps that completed and
+ * the pull request's URL, so callers can act on the outcome without scraping
+ * logs. The default pipeline can optionally include an {@link AssetsStep} that
+ * commits starter Claude Code configuration assets alongside the generated
+ * {@code CLAUDE.md}.
  */
 public class GitHubRepoAdopter {
 
@@ -45,8 +54,17 @@ public class GitHubRepoAdopter {
 		return new GitHubRepoAdopter(runner, defaultSteps());
 	}
 
+	public static GitHubRepoAdopter withDefaultPipeline(CommandRunner runner, PullRequestOptions options,
+			boolean includeAssets) {
+		return new GitHubRepoAdopter(runner, defaultSteps(options, includeAssets));
+	}
+
 	public static List<AdoptionStep> defaultSteps() {
-		return List.of(
+		return defaultSteps(PullRequestOptions.defaults(), false);
+	}
+
+	public static List<AdoptionStep> defaultSteps(PullRequestOptions options, boolean includeAssets) {
+		List<AdoptionStep> steps = new ArrayList<>(List.of(
 				new ToolchainStep(),
 				new CloneStep(),
 				new BranchStep(),
@@ -54,22 +72,30 @@ public class GitHubRepoAdopter {
 				new ClaudeInitStep(),
 				new CommitStep("Adopt Claude Code: add CLAUDE.md"),
 				new EnforcerStep(),
-				new CommitStep("Add claude-code-enforcer to the build"),
-				new VerifyStep(),
-				new PushStep(),
-				new PullRequestStep());
+				new CommitStep("Add claude-code-enforcer to the build")));
+		if (includeAssets) {
+			steps.add(new AssetsStep());
+			steps.add(new CommitStep("Add Claude Code configuration assets"));
+		}
+		steps.add(new VerifyStep());
+		steps.add(new PushStep());
+		steps.add(new PullRequestStep(options));
+		return List.copyOf(steps);
 	}
 
-	public void adopt(AdoptionContext context) {
+	public AdoptionReport adopt(AdoptionContext context) {
 		log.info("Adopting Claude Code into {}", context.repositoryUrl());
+		AdoptionReport report = new AdoptionReport();
 		for (AdoptionStep step : steps) {
-			runStep(step, context);
+			runStep(step, context, report);
 		}
 		log.info("Adoption complete for {}", context.repositoryUrl());
+		return report;
 	}
 
-	private void runStep(AdoptionStep step, AdoptionContext context) {
+	private void runStep(AdoptionStep step, AdoptionContext context, AdoptionReport report) {
 		log.info("Step: {}", step.name());
-		step.execute(context, runner);
+		step.execute(context, runner, report);
+		report.recordStep(step.name());
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -1,67 +1,37 @@
 package io.github.adamw7.tools.adopt;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
 
 /**
- * Command-line entry point: given a GitHub repository URL (and an optional
- * workspace directory to clone into and an optional feature-branch name), runs
- * the default adoption pipeline against a real {@code git}/{@code claude}/
- * {@code gh} toolchain. A supplied workspace directory is created when it does
- * not yet exist, so the clone step always has a directory to run in; when
- * omitted, a temporary one is created instead. When no branch name is supplied,
- * {@link AdoptionContext#DEFAULT_BRANCH} is used.
+ * Command-line entry point: parses the arguments with {@link CliArguments} —
+ * the positional GitHub repository URL, optional workspace directory, and
+ * optional feature-branch name, plus the flags for pull-request metadata, the
+ * starter-assets step, and the JSON report — and runs the default adoption
+ * pipeline against a real {@code git}/{@code claude}/{@code gh} toolchain. A
+ * supplied workspace directory is created when it does not yet exist; when
+ * omitted, a temporary one is created instead. When {@code --report} names a
+ * file, the run's {@link AdoptionReport} is written there as JSON.
  */
 public class Main {
 
 	public static void main(String[] args) {
-		String repositoryUrl = repositoryUrl(args);
-		Path workspace = workspace(args);
-		String branchName = branchName(args);
+		CliArguments cli = CliArguments.parse(args);
+		AdoptionContext context = new AdoptionContext(cli.repositoryUrl(), workspace(cli), cli.branchName());
 		CommandRunner runner = new ProcessCommandRunner();
-		GitHubRepoAdopter.withDefaultPipeline(runner)
-				.adopt(new AdoptionContext(repositoryUrl, workspace, branchName));
+		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, cli.pullRequestOptions(),
+				cli.includeAssets());
+		AdoptionReport report = adopter.adopt(context);
+		writeReport(cli, context, report);
 	}
 
-	private static String repositoryUrl(String[] args) {
-		if (args == null || args.length < 1 || args[0].isBlank()) {
-			throw new IllegalArgumentException("Usage: <github-repo-url> [workspace-directory] [branch-name]");
-		}
-		return args[0];
+	static Path workspace(CliArguments cli) {
+		return cli.workspace().map(Workspaces::createIfMissing).orElseGet(Workspaces::createTemporary);
 	}
 
-	static String branchName(String[] args) {
-		if (args.length >= 3 && !args[2].isBlank()) {
-			return args[2];
-		}
-		return AdoptionContext.DEFAULT_BRANCH;
-	}
-
-	static Path workspace(String[] args) {
-		if (args.length >= 2 && !args[1].isBlank()) {
-			return createIfMissing(Path.of(args[1]));
-		}
-		return createTemporaryWorkspace();
-	}
-
-	private static Path createIfMissing(Path workspace) {
-		try {
-			return Files.createDirectories(workspace);
-		} catch (IOException e) {
-			throw new UncheckedIOException(e);
-		}
-	}
-
-	private static Path createTemporaryWorkspace() {
-		try {
-			return Files.createTempDirectory("claude-adopt-");
-		} catch (IOException e) {
-			throw new UncheckedIOException(e);
-		}
+	private static void writeReport(CliArguments cli, AdoptionContext context, AdoptionReport report) {
+		cli.reportFile().ifPresent(file -> new AdoptionReportWriter().write(file, context, report));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
@@ -1,0 +1,35 @@
+package io.github.adamw7.tools.adopt;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Creates the workspace directory an adoption clones into: either the directory
+ * the caller named — created when it does not yet exist, so the clone step
+ * always has a directory to run in — or a fresh temporary one when the caller
+ * left the choice open. Shared by the command-line entry point and the MCP
+ * server, so both resolve workspaces identically.
+ */
+public final class Workspaces {
+
+	private Workspaces() {
+	}
+
+	public static Path createIfMissing(Path workspace) {
+		try {
+			return Files.createDirectories(workspace);
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	public static Path createTemporary() {
+		try {
+			return Files.createTempDirectory("claude-adopt-");
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -1,0 +1,132 @@
+package io.github.adamw7.tools.adopt.mcp;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionReport;
+import io.github.adamw7.tools.adopt.AdoptionReportWriter;
+import io.github.adamw7.tools.adopt.GitHubRepoAdopter;
+import io.github.adamw7.tools.adopt.Workspaces;
+import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
+import io.github.adamw7.tools.adopt.step.PullRequestOptions;
+import io.github.adamw7.tools.mcp.McpTool;
+import io.github.adamw7.tools.mcp.ToolArguments;
+import io.github.adamw7.tools.mcp.ToolDefinition;
+import io.github.adamw7.tools.mcp.ToolResult;
+
+/**
+ * The MCP tool that runs the adoption pipeline: given a GitHub repository URL —
+ * plus optional workspace, branch, pull-request metadata, and the flag for the
+ * starter-assets step — it adopts Claude Code into the repository exactly as the
+ * command line does and answers with the run's JSON {@link AdoptionReport},
+ * including the opened pull request's URL. The pipeline itself is injected
+ * behind the {@link Pipeline} seam, so tests exercise the argument mapping and
+ * the result shape without cloning anything; the default wiring runs the real
+ * default pipeline against a {@link ProcessCommandRunner}.
+ */
+public class AdoptTool implements McpTool {
+
+	/** The adoption run the tool delegates to once the arguments are mapped. */
+	public interface Pipeline {
+		AdoptionReport adopt(AdoptionContext context, PullRequestOptions options, boolean includeAssets);
+	}
+
+	private static final Logger log = LogManager.getLogger(AdoptTool.class);
+
+	private final Pipeline pipeline;
+	private final AdoptionReportWriter reportWriter = new AdoptionReportWriter();
+
+	private final ToolDefinition toolDefinition = new ToolDefinition("adopt_repo",
+			"Adopt Claude Code into a GitHub repository: clone it, create a feature branch, generate CLAUDE.md, "
+					+ "wire a CLAUDE.md guard into the build, then push the branch and open a pull request. "
+					+ "Requires git, claude and gh on the server's PATH. "
+					+ "Returns a JSON report with the pull request URL and the completed steps.",
+			Map.of(
+					"type", "object",
+					"properties", Map.of(
+							"repository_url", Map.of("type", "string",
+									"description", "URL of the GitHub repository to adopt"),
+							"workspace", Map.of("type", "string",
+									"description", "directory to clone into; a temporary one is created when omitted"),
+							"branch", Map.of("type", "string",
+									"description", "feature branch to commit and open the pull request from"),
+							"title", Map.of("type", "string", "description", "pull request title"),
+							"body", Map.of("type", "string", "description", "pull request body"),
+							"reviewers", Map.of("type", "string",
+									"description", "comma-separated reviewers to request"),
+							"labels", Map.of("type", "string", "description", "comma-separated labels to apply"),
+							"assignees", Map.of("type", "string", "description", "comma-separated assignees"),
+							"draft", Map.of("type", "boolean", "description", "open the pull request as a draft"),
+							"assets", Map.of("type", "boolean",
+									"description", "also commit starter Claude Code configuration assets")),
+					"required", List.of("repository_url")));
+
+	public AdoptTool() {
+		this(AdoptTool::runDefaultPipeline);
+	}
+
+	public AdoptTool(Pipeline pipeline) {
+		this.pipeline = pipeline;
+	}
+
+	private static AdoptionReport runDefaultPipeline(AdoptionContext context, PullRequestOptions options,
+			boolean includeAssets) {
+		return GitHubRepoAdopter.withDefaultPipeline(new ProcessCommandRunner(), options, includeAssets)
+				.adopt(context);
+	}
+
+	@Override
+	public ToolDefinition getToolDefinition() {
+		return toolDefinition;
+	}
+
+	@Override
+	public ToolResult apply(Map<String, Object> arguments) {
+		log.info("Calling MCP adopt tool for {}", arguments);
+		AdoptionContext context = contextFrom(arguments);
+		AdoptionReport report = pipeline.adopt(context, optionsFrom(arguments),
+				ToolArguments.optionalBoolean(arguments, "assets", false));
+		return ToolResult.success(reportWriter.toJson(context, report));
+	}
+
+	private AdoptionContext contextFrom(Map<String, Object> arguments) {
+		String repositoryUrl = ToolArguments.requiredString(arguments, "repository_url");
+		String branch = ToolArguments.optionalString(arguments, "branch", AdoptionContext.DEFAULT_BRANCH);
+		return new AdoptionContext(repositoryUrl, workspace(arguments), branch);
+	}
+
+	private Path workspace(Map<String, Object> arguments) {
+		String workspace = ToolArguments.optionalString(arguments, "workspace", "");
+		return workspace.isBlank() ? Workspaces.createTemporary() : Workspaces.createIfMissing(Path.of(workspace));
+	}
+
+	private PullRequestOptions optionsFrom(Map<String, Object> arguments) {
+		PullRequestOptions.Builder builder = PullRequestOptions.builder()
+				.reviewers(commaSeparated(arguments, "reviewers"))
+				.labels(commaSeparated(arguments, "labels"))
+				.assignees(commaSeparated(arguments, "assignees"))
+				.draft(ToolArguments.optionalBoolean(arguments, "draft", false));
+		applyText(arguments, "title", builder::title);
+		applyText(arguments, "body", builder::body);
+		return builder.build();
+	}
+
+	private void applyText(Map<String, Object> arguments, String key, Consumer<String> target) {
+		String value = ToolArguments.optionalString(arguments, key, "");
+		if (!value.isBlank()) {
+			target.accept(value);
+		}
+	}
+
+	private List<String> commaSeparated(Map<String, Object> arguments, String key) {
+		String value = ToolArguments.optionalString(arguments, key, "");
+		return Stream.of(value.split(",")).map(String::strip).filter(entry -> !entry.isEmpty()).toList();
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
@@ -1,0 +1,97 @@
+# MCP Server for Claude Code Adoption
+
+This directory contains a Model Context Protocol (MCP) server that exposes the
+`adopt` module's pipeline as an `adopt_repo` tool, so MCP clients such as Claude
+Desktop or Claude Code can adopt Claude Code into a GitHub repository on
+request.
+
+## Overview
+
+The `adopt_repo` tool runs the same default pipeline as the command-line entry
+point: it checks the required tools (`git`, `claude`, `gh`) are installed,
+clones the repository, creates a feature branch, generates `CLAUDE.md` with
+`claude init`, wires a build-tool-aware `CLAUDE.md` guard into the build,
+verifies it, pushes the branch, and opens a pull request. The default branch is
+never written to. The tool answers with a JSON report of the run: the
+repository, the branch, the pull request URL, and the completed steps.
+
+Because the pipeline shells out to `git`, `claude`, and `gh`, those tools must
+be installed and authenticated on the machine running the MCP server.
+
+## Architecture
+
+1. **Main.java** — Spring Boot entry point that selects the transport
+   (stdio by default)
+2. **McpConfiguration.java** — registers the tool against the shared
+   `mcp-common` scaffolding
+3. **AdoptTool.java** — maps the tool arguments onto the adoption pipeline and
+   renders the resulting `AdoptionReport` as JSON
+
+The server supports the same transports as the repository's other MCP servers:
+stdio (default), streamable HTTP (`--transport.mode=streamable-http`, served at
+`/mcp`), stateless HTTP (`--transport.mode=stateless-http`, also at `/mcp`), and
+the legacy HTTP+SSE transport (`--transport.mode=sse`, event stream at `/sse`,
+messages at `/mcp/message`).
+
+## Building the Server
+
+From the root of the repository:
+
+```bash
+mvn clean install
+```
+
+This creates an executable JAR in `adopt/target/tools.adopt-{version}.jar`.
+
+## Tool Specification
+
+### adopt_repo
+
+**Parameters:**
+- `repository_url` (string, required): URL of the GitHub repository to adopt
+- `workspace` (string, optional): directory to clone into; a temporary
+  directory is created when omitted
+- `branch` (string, optional): feature branch name; defaults to
+  `claude/adopt-claude-code`
+- `title` / `body` (string, optional): pull request title and body
+- `reviewers` / `labels` / `assignees` (string, optional): comma-separated
+  values applied to the pull request
+- `draft` (boolean, optional): open the pull request as a draft
+- `assets` (boolean, optional): also commit starter Claude Code configuration
+  assets (`AGENTS.md`, `.claude/settings.json`, a session-start hook,
+  `.mcp.json`, and an `@claude`-mention GitHub Actions workflow)
+
+**Returns** a JSON report:
+
+```json
+{
+  "repositoryUrl" : "https://github.com/owner/repo.git",
+  "branch" : "claude/adopt-claude-code",
+  "pullRequestUrl" : "https://github.com/owner/repo/pull/42",
+  "completedSteps" : [ "toolchain", "clone", "branch", "trust", "claude-init",
+    "commit", "enforcer", "commit", "verify", "push", "pull-request" ]
+}
+```
+
+## Configuring MCP Clients
+
+For any MCP client that supports stdio transport:
+
+```json
+{
+  "mcpServers": {
+    "claude-code-adopt": {
+      "command": "java",
+      "args": [
+        "-jar",
+        "/absolute/path/to/tools/adopt/target/tools.adopt-{version}.jar"
+      ]
+    }
+  }
+}
+```
+
+## Related Documentation
+
+- [Uniqueness-checker MCP server](../../../../../../../../../../data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md)
+- [Context module MCP server](../../../../../../../../../../code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md)

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/Main.java
@@ -1,0 +1,21 @@
+package io.github.adamw7.tools.adopt.mcp;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import io.github.adamw7.tools.mcp.TransportConfigurer;
+
+/**
+ * Entry point of the adoption MCP server. It selects the transport from
+ * {@code --transport.mode} (defaulting to stdio) before starting Spring so that
+ * stdio mode runs without a web server and never prints a banner that would
+ * corrupt the stdio JSON-RPC channel.
+ */
+@SpringBootApplication
+public class Main {
+
+	public static void main(String[] args) {
+		TransportConfigurer.configure(args);
+		SpringApplication.run(Main.class, args);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/McpConfiguration.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/McpConfiguration.java
@@ -1,0 +1,28 @@
+package io.github.adamw7.tools.adopt.mcp;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+
+import io.github.adamw7.tools.mcp.AbstractMcpConfiguration;
+import io.github.adamw7.tools.mcp.McpTool;
+
+/**
+ * Wires the adoption MCP server. It exposes a single {@code adopt_repo} tool
+ * that runs the adoption pipeline against the server's own
+ * {@code git}/{@code claude}/{@code gh} toolchain; all transport wiring is
+ * inherited from {@link AbstractMcpConfiguration}.
+ */
+@Configuration
+public class McpConfiguration extends AbstractMcpConfiguration {
+
+	@Override
+	protected String serverName() {
+		return "adopt-server";
+	}
+
+	@Override
+	protected List<McpTool> tools() {
+		return List.of(new AdoptTool());
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
@@ -1,0 +1,106 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.List;
+
+/**
+ * The starter Claude Code configuration assets an {@link AssetsStep} installs
+ * beyond the generated {@code CLAUDE.md}: an {@code AGENTS.md} pointer for
+ * agents that read the cross-tool convention, a {@code .claude/settings.json}
+ * that denies reading obvious secret files and wires the session-start hook, the
+ * {@code .claude/hooks/session-start.sh} stub that hook runs, a starter
+ * {@code .mcp.json}, and a GitHub Actions workflow that answers {@code @claude}
+ * mentions on issues and pull requests. Every asset is a plain committed file,
+ * so the configuration is shared with all contributors rather than living only
+ * in the adopter's local checkout.
+ */
+public final class AdoptionAssets {
+
+	static final String AGENTS_MD_FILE = "AGENTS.md";
+	static final String SETTINGS_FILE = ".claude/settings.json";
+	static final String SESSION_START_HOOK_FILE = ".claude/hooks/session-start.sh";
+	static final String MCP_CONFIG_FILE = ".mcp.json";
+	static final String CLAUDE_WORKFLOW_FILE = ".github/workflows/claude.yml";
+
+	private static final String AGENTS_MD = """
+			# Agent guide
+
+			See [CLAUDE.md](CLAUDE.md) for this repository's agent instructions.
+			CLAUDE.md is the source of truth; this file exists so agents that follow
+			the cross-tool AGENTS.md convention find the same guidance.
+			""";
+
+	private static final String SETTINGS = """
+			{
+			  "permissions": {
+			    "deny": [
+			      "Read(./.env)",
+			      "Read(./.env.*)",
+			      "Read(./**/*.pem)",
+			      "Read(./**/id_rsa)"
+			    ]
+			  },
+			  "hooks": {
+			    "SessionStart": [
+			      {
+			        "hooks": [
+			          {
+			            "type": "command",
+			            "command": ".claude/hooks/session-start.sh"
+			          }
+			        ]
+			      }
+			    ]
+			  }
+			}
+			""";
+
+	private static final String SESSION_START_HOOK = """
+			#!/bin/sh
+			# Runs when a Claude Code session starts (wired via .claude/settings.json).
+			# Add project setup here — install the toolchain, export environment
+			# variables, or pre-fetch dependencies — so web and remote sessions can
+			# build and test out of the box.
+			exit 0
+			""";
+
+	private static final String MCP_CONFIG = """
+			{
+			  "mcpServers": {}
+			}
+			""";
+
+	private static final String CLAUDE_WORKFLOW = """
+			# Runs Claude Code when @claude is mentioned on an issue or pull request.
+			# Requires the ANTHROPIC_API_KEY repository secret to be configured.
+			name: Claude Code
+			on:
+			  issue_comment:
+			    types: [created]
+			  pull_request_review_comment:
+			    types: [created]
+			jobs:
+			  claude:
+			    if: contains(github.event.comment.body, '@claude')
+			    runs-on: ubuntu-latest
+			    permissions:
+			      contents: write
+			      pull-requests: write
+			      issues: write
+			      id-token: write
+			    steps:
+			      - uses: actions/checkout@v4
+			      - uses: anthropics/claude-code-action@v1
+			        with:
+			          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+			""";
+
+	public static final List<AssetInstaller> DEFAULTS = List.of(
+			new AssetInstaller(AGENTS_MD_FILE, AGENTS_MD),
+			new AssetInstaller(SETTINGS_FILE, SETTINGS),
+			new AssetInstaller(SESSION_START_HOOK_FILE, SESSION_START_HOOK, true),
+			new AssetInstaller(MCP_CONFIG_FILE, MCP_CONFIG),
+			new AssetInstaller(CLAUDE_WORKFLOW_FILE, CLAUDE_WORKFLOW));
+
+	private AdoptionAssets() {
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionStep.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt.step;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionReport;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
@@ -8,10 +9,20 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * and independent: each acts on the shared {@link AdoptionContext} and runs its
  * external commands through the injected {@link CommandRunner}, so the pipeline
  * can be assembled, reordered, or tested one step at a time.
+ *
+ * <p>The pipeline invokes the three-argument {@link #execute(AdoptionContext,
+ * CommandRunner, AdoptionReport)} so a step can contribute facts — such as the
+ * opened pull request's URL — to the run's {@link AdoptionReport}. Most steps
+ * have nothing to report and only implement the two-argument variant; the
+ * default delegation keeps them unaware of the report.
  */
 public interface AdoptionStep {
 
 	String name();
 
 	void execute(AdoptionContext context, CommandRunner runner);
+
+	default void execute(AdoptionContext context, CommandRunner runner, AdoptionReport report) {
+		execute(context, runner);
+	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetInstaller.java
@@ -1,0 +1,70 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+/**
+ * Writes one starter asset file into a checkout: the file's repository-relative
+ * path, its content, and whether it must be executable (for hook scripts).
+ * Installation is deliberately conservative: a file that already exists is never
+ * overwritten — the project's own version always wins over the starter content —
+ * so re-running the adoption, or adopting a repository that already configured
+ * Claude Code, leaves the checkout untouched.
+ */
+public class AssetInstaller {
+
+	private static final Logger log = LogManager.getLogger(AssetInstaller.class);
+
+	private final String relativePath;
+	private final String content;
+	private final boolean executable;
+
+	public AssetInstaller(String relativePath, String content) {
+		this(relativePath, content, false);
+	}
+
+	public AssetInstaller(String relativePath, String content, boolean executable) {
+		this.relativePath = relativePath;
+		this.content = content;
+		this.executable = executable;
+	}
+
+	public String relativePath() {
+		return relativePath;
+	}
+
+	/**
+	 * @return {@code true} when the asset was written, {@code false} when the
+	 *         checkout already carried a file at its path and was left unchanged.
+	 */
+	public boolean install(Path repositoryDirectory) {
+		Path file = repositoryDirectory.resolve(relativePath);
+		if (Files.exists(file)) {
+			return false;
+		}
+		write(file);
+		return true;
+	}
+
+	private void write(Path file) {
+		try {
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new AdoptionException("Could not write asset file: " + file, e);
+		}
+		markExecutable(file);
+	}
+
+	private void markExecutable(Path file) {
+		if (executable && !file.toFile().setExecutable(true, false)) {
+			log.warn("Could not mark {} executable; the filesystem does not support it", file);
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetsStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetsStep.java
@@ -1,0 +1,54 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Installs the starter Claude Code configuration assets (see
+ * {@link AdoptionAssets}) into the checkout, so an adopted repository gets a
+ * working agent setup beyond the generated {@code CLAUDE.md}. Each asset is
+ * installed independently and never overwrites an existing file, so the step is
+ * idempotent and safe on repositories that already configured some of the
+ * files. The step only writes into the checkout; the following commit step
+ * records whatever was added.
+ */
+public class AssetsStep implements AdoptionStep {
+
+	private static final Logger log = LogManager.getLogger(AssetsStep.class);
+
+	private final List<AssetInstaller> installers;
+
+	public AssetsStep() {
+		this(AdoptionAssets.DEFAULTS);
+	}
+
+	public AssetsStep(List<AssetInstaller> installers) {
+		this.installers = List.copyOf(installers);
+	}
+
+	@Override
+	public String name() {
+		return "assets";
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		for (AssetInstaller installer : installers) {
+			install(installer, context.repositoryDirectory());
+		}
+	}
+
+	private void install(AssetInstaller installer, Path repositoryDirectory) {
+		if (installer.install(repositoryDirectory)) {
+			log.info("Installed {}", installer.relativePath());
+		} else {
+			log.info("{} already exists; left unchanged", installer.relativePath());
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -6,7 +6,12 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionReport;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
@@ -22,12 +27,19 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * pull request already exists for the branch and skips creation when one does,
  * rather than creating unconditionally and then matching the wording of a
  * failure. That keeps the decision robust across {@code gh} versions and locales.
+ *
+ * <p>After the pull request is created (or found already open), the step records
+ * its URL in the run's {@link AdoptionReport}. The URL is read back with
+ * {@code gh pr view --json url} rather than scraped from {@code gh pr create}'s
+ * human-oriented output, so the extraction is one structured path for both the
+ * fresh and the re-run case.
  */
 public class PullRequestStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(PullRequestStep.class);
 
 	private final PullRequestOptions options;
+	private final ObjectMapper mapper = new ObjectMapper();
 
 	public PullRequestStep() {
 		this(PullRequestOptions.defaults());
@@ -48,10 +60,20 @@ public class PullRequestStep extends AbstractCommandStep {
 
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
+		execute(context, runner, new AdoptionReport());
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner, AdoptionReport report) {
 		if (pullRequestExists(context, runner)) {
 			log.info("Pull request already open for branch {}; left unchanged", context.branchName());
-			return;
+		} else {
+			create(context, runner);
 		}
+		recordUrl(context, runner, report);
+	}
+
+	private void create(AdoptionContext context, CommandRunner runner) {
 		log.info("Opening pull request for branch {}", context.branchName());
 		CommandResult result = runOrFail(runner, context.repositoryDirectory(), createCommand(context));
 		log.info("Opened pull request: {}", result.output().strip());
@@ -77,7 +99,57 @@ public class PullRequestStep extends AbstractCommandStep {
 	}
 
 	private boolean pullRequestExists(AdoptionContext context, CommandRunner runner) {
-		List<String> command = List.of("gh", "pr", "view", context.branchName(), "--json", "url");
-		return runner.run(context.repositoryDirectory(), command).succeeded();
+		return runner.run(context.repositoryDirectory(), viewCommand(context)).succeeded();
+	}
+
+	private List<String> viewCommand(AdoptionContext context) {
+		return List.of("gh", "pr", "view", context.branchName(), "--json", "url");
+	}
+
+	/**
+	 * A pull request that was just created must be viewable, so a failing view is a
+	 * warning rather than an aborted adoption: the pull request itself exists and
+	 * only its URL is missing from the report.
+	 */
+	private void recordUrl(AdoptionContext context, CommandRunner runner, AdoptionReport report) {
+		CommandResult result = runner.run(context.repositoryDirectory(), viewCommand(context));
+		if (result.succeeded()) {
+			recordUrlFrom(result.output(), report);
+		} else {
+			log.warn("Could not read back the pull request URL for branch {}", context.branchName());
+		}
+	}
+
+	private void recordUrlFrom(String output, AdoptionReport report) {
+		String url = extractUrl(output);
+		if (url == null) {
+			log.warn("gh pr view returned no URL in: {}", output.strip());
+		} else {
+			log.info("Pull request URL: {}", url);
+			report.recordPullRequestUrl(url);
+		}
+	}
+
+	/**
+	 * {@code gh} writes the JSON document to stdout but the captured output may
+	 * carry surrounding noise (for example update notices on stderr), so parsing
+	 * starts at the first opening brace instead of assuming a pure JSON payload.
+	 */
+	private String extractUrl(String output) {
+		int start = output.indexOf('{');
+		if (start < 0) {
+			return null;
+		}
+		return urlField(output.substring(start));
+	}
+
+	private String urlField(String json) {
+		try {
+			JsonNode url = mapper.readTree(json).path("url");
+			return url.isTextual() ? url.asText() : null;
+		} catch (JsonProcessingException e) {
+			log.warn("Could not parse gh pr view output as JSON", e);
+			return null;
+		}
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportTest.java
@@ -1,0 +1,42 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class AdoptionReportTest {
+
+	@Test
+	void startsEmpty() {
+		AdoptionReport report = new AdoptionReport();
+		assertTrue(report.completedSteps().isEmpty());
+		assertTrue(report.pullRequestUrl().isEmpty());
+	}
+
+	@Test
+	void recordsStepsInOrder() {
+		AdoptionReport report = new AdoptionReport();
+		report.recordStep("clone");
+		report.recordStep("branch");
+		assertEquals(List.of("clone", "branch"), report.completedSteps());
+	}
+
+	@Test
+	void recordsPullRequestUrl() {
+		AdoptionReport report = new AdoptionReport();
+		report.recordPullRequestUrl("https://github.com/owner/repo/pull/1");
+		assertEquals("https://github.com/owner/repo/pull/1", report.pullRequestUrl().orElseThrow());
+	}
+
+	@Test
+	void completedStepsAreACopy() {
+		AdoptionReport report = new AdoptionReport();
+		report.recordStep("clone");
+		List<String> steps = report.completedSteps();
+		report.recordStep("branch");
+		assertEquals(List.of("clone"), steps);
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportWriterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportWriterTest.java
@@ -1,0 +1,64 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class AdoptionReportWriterTest {
+
+	private static final String PR_URL = "https://github.com/owner/repo/pull/1";
+
+	private final AdoptionContext context = new AdoptionContext("https://github.com/owner/repo.git",
+			Path.of("/tmp/workspace"), "claude/adopt-claude-code");
+	private final AdoptionReportWriter writer = new AdoptionReportWriter();
+	private final ObjectMapper mapper = new ObjectMapper();
+
+	@Test
+	void serialisesTheRunOutcome() throws IOException {
+		AdoptionReport report = new AdoptionReport();
+		report.recordStep("clone");
+		report.recordStep("pull-request");
+		report.recordPullRequestUrl(PR_URL);
+		JsonNode node = mapper.readTree(writer.toJson(context, report));
+		assertEquals("https://github.com/owner/repo.git", node.get("repositoryUrl").asText());
+		assertEquals("claude/adopt-claude-code", node.get("branch").asText());
+		assertEquals(PR_URL, node.get("pullRequestUrl").asText());
+		assertEquals(List.of("clone", "pull-request"), List.of(node.get("completedSteps").get(0).asText(),
+				node.get("completedSteps").get(1).asText()));
+	}
+
+	@Test
+	void serialisesAMissingPullRequestUrlAsNull() throws IOException {
+		JsonNode node = mapper.readTree(writer.toJson(context, new AdoptionReport()));
+		assertTrue(node.get("pullRequestUrl").isNull());
+		assertTrue(node.get("completedSteps").isEmpty());
+	}
+
+	@Test
+	void writesTheReportToAFile(@TempDir Path dir) throws IOException {
+		Path file = dir.resolve("nested/report.json");
+		AdoptionReport report = new AdoptionReport();
+		report.recordPullRequestUrl(PR_URL);
+		writer.write(file, context, report);
+		JsonNode node = mapper.readTree(Files.readString(file));
+		assertEquals(PR_URL, node.get("pullRequestUrl").asText());
+	}
+
+	@Test
+	void failsWithAdoptionExceptionWhenTheFileCannotBeWritten(@TempDir Path dir) throws IOException {
+		Path blockingFile = Files.createFile(dir.resolve("not-a-directory"));
+		Path file = blockingFile.resolve("report.json");
+		assertThrows(AdoptionException.class, () -> writer.write(file, context, new AdoptionReport()));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -1,0 +1,119 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.step.PullRequestOptions;
+
+class CliArgumentsTest {
+
+	private static final String REPO_URL = "https://github.com/owner/repo.git";
+
+	@Test
+	void parsesPositionalArguments() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "/tmp/ws", "feature/x" });
+		assertEquals(REPO_URL, cli.repositoryUrl());
+		assertEquals(Path.of("/tmp/ws"), cli.workspace().orElseThrow());
+		assertEquals("feature/x", cli.branchName());
+	}
+
+	@Test
+	void defaultsWorkspaceAndBranchWhenOmitted() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL });
+		assertTrue(cli.workspace().isEmpty());
+		assertEquals(AdoptionContext.DEFAULT_BRANCH, cli.branchName());
+	}
+
+	@Test
+	void defaultsWorkspaceAndBranchWhenSuppliedBlank() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "  ", "  " });
+		assertTrue(cli.workspace().isEmpty());
+		assertEquals(AdoptionContext.DEFAULT_BRANCH, cli.branchName());
+	}
+
+	@Test
+	void defaultsPullRequestOptionsWhenNoFlagsGiven() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL });
+		assertEquals(PullRequestOptions.defaults(), cli.pullRequestOptions());
+		assertFalse(cli.includeAssets());
+		assertTrue(cli.reportFile().isEmpty());
+	}
+
+	@Test
+	void parsesPullRequestMetadataFlags() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL,
+				"--title", "My title", "--body", "My body",
+				"--reviewer", "octocat", "--reviewer", "hubot",
+				"--label", "automation", "--assignee", "adamw7", "--draft" });
+		PullRequestOptions options = cli.pullRequestOptions();
+		assertEquals("My title", options.title());
+		assertEquals("My body", options.body());
+		assertEquals(List.of("octocat", "hubot"), options.reviewers());
+		assertEquals(List.of("automation"), options.labels());
+		assertEquals(List.of("adamw7"), options.assignees());
+		assertTrue(options.draft());
+	}
+
+	@Test
+	void parsesAssetsAndReportFlags() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--assets", "--report", "/tmp/report.json" });
+		assertTrue(cli.includeAssets());
+		assertEquals(Path.of("/tmp/report.json"), cli.reportFile().orElseThrow());
+	}
+
+	@Test
+	void mixesFlagsAndPositionals() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--draft", "/tmp/ws", "feature/x" });
+		assertEquals(Path.of("/tmp/ws"), cli.workspace().orElseThrow());
+		assertEquals("feature/x", cli.branchName());
+		assertTrue(cli.pullRequestOptions().draft());
+	}
+
+	@Test
+	void rejectsNullArguments() {
+		assertUsageFailure(null);
+	}
+
+	@Test
+	void rejectsEmptyArguments() {
+		assertUsageFailure(new String[0]);
+	}
+
+	@Test
+	void rejectsBlankRepositoryUrl() {
+		assertUsageFailure(new String[] { "   " });
+	}
+
+	@Test
+	void rejectsUnknownOption() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { REPO_URL, "--frobnicate" }));
+		assertTrue(exception.getMessage().contains("--frobnicate"), exception.getMessage());
+	}
+
+	@Test
+	void rejectsFlagMissingItsValue() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { REPO_URL, "--title" }));
+		assertTrue(exception.getMessage().contains("--title"), exception.getMessage());
+	}
+
+	@Test
+	void rejectsExtraPositionalArgument() {
+		assertThrows(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { REPO_URL, "/tmp/ws", "branch", "surplus" }));
+	}
+
+	private void assertUsageFailure(String[] args) {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> CliArguments.parse(args));
+		assertTrue(exception.getMessage().contains("Usage"), exception.getMessage());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
+import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 
 class GitHubRepoAdopterTest {
 
@@ -61,6 +62,14 @@ class GitHubRepoAdopterTest {
 	}
 
 	@Test
+	void reportsEveryCompletedStep() {
+		List<String> order = new ArrayList<>();
+		List<AdoptionStep> steps = List.of(new NamingStep("a", order), new NamingStep("b", order));
+		AdoptionReport report = new GitHubRepoAdopter(new RecordingCommandRunner(), steps).adopt(context);
+		assertEquals(List.of("a", "b"), report.completedSteps());
+	}
+
+	@Test
 	void stopsAtFirstFailingStep() {
 		List<String> order = new ArrayList<>();
 		List<AdoptionStep> steps = List.of(new NamingStep("a", order), new ExplodingStep(),
@@ -75,5 +84,13 @@ class GitHubRepoAdopterTest {
 		List<String> names = GitHubRepoAdopter.defaultSteps().stream().map(AdoptionStep::name).toList();
 		assertEquals(List.of("toolchain", "clone", "branch", "trust", "claude-init", "commit", "enforcer", "commit",
 				"verify", "push", "pull-request"), names);
+	}
+
+	@Test
+	void defaultPipelineWithAssetsInstallsAndCommitsThemBeforeVerification() {
+		List<String> names = GitHubRepoAdopter.defaultSteps(PullRequestOptions.defaults(), true).stream()
+				.map(AdoptionStep::name).toList();
+		assertEquals(List.of("toolchain", "clone", "branch", "trust", "claude-init", "commit", "enforcer", "commit",
+				"assets", "commit", "verify", "push", "pull-request"), names);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
@@ -32,38 +32,28 @@ class MainTest {
 	}
 
 	@Test
+	void rejectsUnknownOptionBeforeAnyWorkStarts() {
+		assertThrows(IllegalArgumentException.class, () -> Main.main(new String[] { REPO_URL, "--frobnicate" }));
+	}
+
+	@Test
 	void createsSuppliedWorkspaceDirectoryWhenMissing(@TempDir Path dir) {
 		Path workspace = dir.resolve("nested/workspace");
-		Path resolved = Main.workspace(new String[] { REPO_URL, workspace.toString() });
+		Path resolved = Main.workspace(CliArguments.parse(new String[] { REPO_URL, workspace.toString() }));
 		assertEquals(workspace, resolved);
 		assertTrue(Files.isDirectory(workspace));
 	}
 
 	@Test
 	void keepsAnExistingSuppliedWorkspaceDirectory(@TempDir Path dir) {
-		Path resolved = Main.workspace(new String[] { REPO_URL, dir.toString() });
+		Path resolved = Main.workspace(CliArguments.parse(new String[] { REPO_URL, dir.toString() }));
 		assertEquals(dir, resolved);
 		assertTrue(Files.isDirectory(dir));
 	}
 
 	@Test
 	void createsTemporaryWorkspaceWhenNoneSupplied() {
-		Path resolved = Main.workspace(new String[] { REPO_URL });
+		Path resolved = Main.workspace(CliArguments.parse(new String[] { REPO_URL }));
 		assertTrue(Files.isDirectory(resolved));
-	}
-
-	@Test
-	void defaultsBranchNameWhenNoneSupplied() {
-		assertEquals(AdoptionContext.DEFAULT_BRANCH, Main.branchName(new String[] { REPO_URL, "/tmp/ws" }));
-	}
-
-	@Test
-	void usesSuppliedBranchName() {
-		assertEquals("feature/x", Main.branchName(new String[] { REPO_URL, "/tmp/ws", "feature/x" }));
-	}
-
-	@Test
-	void defaultsBranchNameWhenSuppliedBlank() {
-		assertEquals(AdoptionContext.DEFAULT_BRANCH, Main.branchName(new String[] { REPO_URL, "/tmp/ws", "  " }));
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/WorkspacesTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/WorkspacesTest.java
@@ -1,0 +1,33 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WorkspacesTest {
+
+	@Test
+	void createsAMissingDirectoryIncludingParents(@TempDir Path dir) {
+		Path workspace = dir.resolve("a/b/c");
+		assertEquals(workspace, Workspaces.createIfMissing(workspace));
+		assertTrue(Files.isDirectory(workspace));
+	}
+
+	@Test
+	void keepsAnExistingDirectory(@TempDir Path dir) {
+		assertEquals(dir, Workspaces.createIfMissing(dir));
+		assertTrue(Files.isDirectory(dir));
+	}
+
+	@Test
+	void createsATemporaryDirectory() {
+		Path workspace = Workspaces.createTemporary();
+		assertTrue(Files.isDirectory(workspace));
+		assertTrue(workspace.getFileName().toString().startsWith("claude-adopt-"));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
@@ -1,0 +1,112 @@
+package io.github.adamw7.tools.adopt.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionReport;
+import io.github.adamw7.tools.adopt.step.PullRequestOptions;
+import io.github.adamw7.tools.mcp.ToolResult;
+
+class AdoptToolTest {
+
+	private static final String REPO_URL = "https://github.com/owner/repo.git";
+	private static final String PR_URL = "https://github.com/owner/repo/pull/1";
+
+	/** Records what the tool asked the pipeline to run and answers with a fixed report. */
+	private static final class RecordingPipeline implements AdoptTool.Pipeline {
+
+		private AdoptionContext context;
+		private PullRequestOptions options;
+		private boolean includeAssets;
+
+		@Override
+		public AdoptionReport adopt(AdoptionContext context, PullRequestOptions options, boolean includeAssets) {
+			this.context = context;
+			this.options = options;
+			this.includeAssets = includeAssets;
+			AdoptionReport report = new AdoptionReport();
+			report.recordStep("pull-request");
+			report.recordPullRequestUrl(PR_URL);
+			return report;
+		}
+	}
+
+	private final RecordingPipeline pipeline = new RecordingPipeline();
+	private final AdoptTool tool = new AdoptTool(pipeline);
+
+	@Test
+	void definesTheAdoptRepoTool() {
+		assertEquals("adopt_repo", tool.getToolDefinition().name());
+		assertEquals(List.of("repository_url"), tool.getToolDefinition().inputSchema().get("required"));
+	}
+
+	@Test
+	void adoptsWithDefaultsWhenOnlyTheUrlIsGiven() {
+		tool.apply(Map.of("repository_url", REPO_URL));
+		assertEquals(REPO_URL, pipeline.context.repositoryUrl());
+		assertEquals(AdoptionContext.DEFAULT_BRANCH, pipeline.context.branchName());
+		assertEquals(PullRequestOptions.defaults(), pipeline.options);
+		assertFalse(pipeline.includeAssets);
+		assertTrue(Files.isDirectory(pipeline.context.workspace()));
+	}
+
+	@Test
+	void usesTheSuppliedWorkspaceAndBranch(@TempDir Path dir) {
+		Path workspace = dir.resolve("workspace");
+		tool.apply(Map.of("repository_url", REPO_URL, "workspace", workspace.toString(), "branch", "feature/x"));
+		assertEquals(workspace, pipeline.context.workspace());
+		assertTrue(Files.isDirectory(workspace));
+		assertEquals("feature/x", pipeline.context.branchName());
+	}
+
+	@Test
+	void mapsPullRequestMetadataOntoTheOptions() {
+		tool.apply(Map.of("repository_url", REPO_URL,
+				"title", "My title", "body", "My body",
+				"reviewers", "octocat, hubot", "labels", "automation", "assignees", "adamw7",
+				"draft", true, "assets", true));
+		assertEquals("My title", pipeline.options.title());
+		assertEquals("My body", pipeline.options.body());
+		assertEquals(List.of("octocat", "hubot"), pipeline.options.reviewers());
+		assertEquals(List.of("automation"), pipeline.options.labels());
+		assertEquals(List.of("adamw7"), pipeline.options.assignees());
+		assertTrue(pipeline.options.draft());
+		assertTrue(pipeline.includeAssets);
+	}
+
+	@Test
+	void ignoresBlankCommaSeparatedEntries() {
+		tool.apply(Map.of("repository_url", REPO_URL, "reviewers", " , octocat ,, "));
+		assertEquals(List.of("octocat"), pipeline.options.reviewers());
+	}
+
+	@Test
+	void answersWithTheJsonReport() throws IOException {
+		ToolResult result = tool.apply(Map.of("repository_url", REPO_URL));
+		assertFalse(result.isError());
+		JsonNode node = new ObjectMapper().readTree(result.text());
+		assertEquals(REPO_URL, node.get("repositoryUrl").asText());
+		assertEquals(PR_URL, node.get("pullRequestUrl").asText());
+		assertEquals("pull-request", node.get("completedSteps").get(0).asText());
+	}
+
+	@Test
+	void requiresTheRepositoryUrl() {
+		assertThrows(IllegalArgumentException.class, () -> tool.apply(Map.of()));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/McpConfigurationTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/McpConfigurationTest.java
@@ -1,0 +1,49 @@
+package io.github.adamw7.tools.adopt.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
+
+class McpConfigurationTest {
+
+	private final McpConfiguration config = new McpConfiguration();
+
+	@Test
+	void exposesTheAdoptTool() {
+		assertEquals(1, config.tools().size());
+		assertEquals("adopt_repo", config.tools().get(0).getToolDefinition().name());
+	}
+
+	@Test
+	void wiresAServerWithToolCapabilities() throws Exception {
+		// Drive the stdio server from a controllable pipe instead of System.in. The
+		// reader thread is non-daemon and cannot be interrupted while blocked on a
+		// read, so closing the pipe is the only way to let it terminate and avoid
+		// leaking it into the forked test JVM.
+		PipedInputStream input = new PipedInputStream();
+		PipedOutputStream inputWriter = new PipedOutputStream(input);
+		McpSyncServer server = config.mcpSyncServer(new StdioServerTransportProvider(
+				new JacksonMcpJsonMapper(new ObjectMapper()), input, OutputStream.nullOutputStream()));
+		assertNotNull(server.getServerCapabilities().tools());
+		server.close();
+		inputWriter.close();
+	}
+
+	@Test
+	void supportsTheSharedTransports() {
+		assertNotNull(config.stdioServerTransport());
+		assertNotNull(config.streamableServerTransport());
+		assertNotNull(config.sseServerTransport());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetInstallerTest.java
@@ -1,0 +1,59 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+class AssetInstallerTest {
+
+	@Test
+	void writesTheAssetCreatingParentDirectories(@TempDir Path checkout) throws IOException {
+		AssetInstaller installer = new AssetInstaller("a/b/file.txt", "content\n");
+		assertTrue(installer.install(checkout));
+		assertEquals("content\n", Files.readString(checkout.resolve("a/b/file.txt")));
+	}
+
+	@Test
+	void neverOverwritesAnExistingFile(@TempDir Path checkout) throws IOException {
+		Files.writeString(checkout.resolve("file.txt"), "the project's own version\n");
+		AssetInstaller installer = new AssetInstaller("file.txt", "starter content\n");
+		assertFalse(installer.install(checkout));
+		assertEquals("the project's own version\n", Files.readString(checkout.resolve("file.txt")));
+	}
+
+	@Test
+	void marksTheAssetExecutableWhenAsked(@TempDir Path checkout) {
+		AssetInstaller installer = new AssetInstaller("hook.sh", "#!/bin/sh\n", true);
+		assertTrue(installer.install(checkout));
+		assertTrue(Files.isExecutable(checkout.resolve("hook.sh")));
+	}
+
+	@Test
+	void doesNotMarkAnOrdinaryAssetExecutable(@TempDir Path checkout) {
+		AssetInstaller installer = new AssetInstaller("plain.txt", "content\n");
+		assertTrue(installer.install(checkout));
+		assertFalse(Files.isExecutable(checkout.resolve("plain.txt")));
+	}
+
+	@Test
+	void exposesItsRelativePath() {
+		assertEquals("a/file.txt", new AssetInstaller("a/file.txt", "content\n").relativePath());
+	}
+
+	@Test
+	void failsWithAdoptionExceptionWhenTheAssetCannotBeWritten(@TempDir Path checkout) throws IOException {
+		Files.createFile(checkout.resolve("blocking"));
+		AssetInstaller installer = new AssetInstaller("blocking/file.txt", "content\n");
+		assertThrows(AdoptionException.class, () -> installer.install(checkout));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetsStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetsStepTest.java
@@ -1,0 +1,98 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class AssetsStepTest {
+
+	private final AssetsStep step = new AssetsStep();
+
+	@Test
+	void installsEveryDefaultAsset(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = contextFor(workspace);
+		step.execute(context, new RecordingCommandRunner());
+		Path checkout = context.repositoryDirectory();
+		assertTrue(Files.isRegularFile(checkout.resolve(AdoptionAssets.AGENTS_MD_FILE)));
+		assertTrue(Files.isRegularFile(checkout.resolve(AdoptionAssets.SETTINGS_FILE)));
+		assertTrue(Files.isRegularFile(checkout.resolve(AdoptionAssets.SESSION_START_HOOK_FILE)));
+		assertTrue(Files.isRegularFile(checkout.resolve(AdoptionAssets.MCP_CONFIG_FILE)));
+		assertTrue(Files.isRegularFile(checkout.resolve(AdoptionAssets.CLAUDE_WORKFLOW_FILE)));
+	}
+
+	@Test
+	void runsNoExternalCommands(@TempDir Path workspace) throws IOException {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		step.execute(contextFor(workspace), runner);
+		assertEquals(0, runner.count());
+	}
+
+	@Test
+	void installedJsonAssetsAreValidJson(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = contextFor(workspace);
+		step.execute(context, new RecordingCommandRunner());
+		ObjectMapper mapper = new ObjectMapper();
+		Path checkout = context.repositoryDirectory();
+		assertTrue(mapper.readTree(Files.readString(checkout.resolve(AdoptionAssets.SETTINGS_FILE))).isObject());
+		assertTrue(mapper.readTree(Files.readString(checkout.resolve(AdoptionAssets.MCP_CONFIG_FILE)))
+				.get("mcpServers").isObject());
+	}
+
+	@Test
+	void sessionStartHookIsExecutable(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = contextFor(workspace);
+		step.execute(context, new RecordingCommandRunner());
+		assertTrue(Files.isExecutable(context.repositoryDirectory()
+				.resolve(AdoptionAssets.SESSION_START_HOOK_FILE)));
+	}
+
+	@Test
+	void settingsWireTheSessionStartHook(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = contextFor(workspace);
+		step.execute(context, new RecordingCommandRunner());
+		String settings = Files.readString(context.repositoryDirectory().resolve(AdoptionAssets.SETTINGS_FILE));
+		assertTrue(settings.contains(AdoptionAssets.SESSION_START_HOOK_FILE));
+	}
+
+	@Test
+	void isIdempotentAcrossReRuns(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = contextFor(workspace);
+		step.execute(context, new RecordingCommandRunner());
+		Path agentsMd = context.repositoryDirectory().resolve(AdoptionAssets.AGENTS_MD_FILE);
+		Files.writeString(agentsMd, "customised\n");
+		step.execute(context, new RecordingCommandRunner());
+		assertEquals("customised\n", Files.readString(agentsMd));
+	}
+
+	@Test
+	void installsOnlyConfiguredAssets(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = contextFor(workspace);
+		new AssetsStep(List.of(new AssetInstaller("only.txt", "content\n")))
+				.execute(context, new RecordingCommandRunner());
+		assertTrue(Files.isRegularFile(context.repositoryDirectory().resolve("only.txt")));
+		assertTrue(Files.notExists(context.repositoryDirectory().resolve(AdoptionAssets.AGENTS_MD_FILE)));
+	}
+
+	@Test
+	void isNamedAssets() {
+		assertEquals("assets", step.name());
+	}
+
+	private AdoptionContext contextFor(Path workspace) throws IOException {
+		AdoptionContext context = new AdoptionContext("https://github.com/owner/repo.git", workspace);
+		Files.createDirectories(context.repositoryDirectory());
+		return context;
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -10,10 +11,13 @@ import org.junit.jupiter.api.Test;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.AdoptionReport;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class PullRequestStepTest {
+
+	private static final String PR_URL = "https://github.com/adamw7/tools/pull/1";
 
 	private final AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git",
 			Path.of("/tmp/workspace"), "claude/adopt-claude-code");
@@ -57,11 +61,56 @@ class PullRequestStepTest {
 
 	@Test
 	void skipsCreationWhenAPullRequestAlreadyExists() {
-		RecordingCommandRunner runner = new RecordingCommandRunner();
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::existingPullRequest);
 		step.execute(context, runner);
-		assertEquals(1, runner.count());
+		assertEquals(2, runner.count());
 		assertEquals(List.of("gh", "pr", "view", "claude/adopt-claude-code", "--json", "url"),
 				runner.commandAt(0));
+		assertEquals(List.of("gh", "pr", "view", "claude/adopt-claude-code", "--json", "url"),
+				runner.commandAt(1));
+	}
+
+	@Test
+	void recordsCreatedPullRequestUrlInReport() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(new ViewFailsUntilCreated());
+		AdoptionReport report = new AdoptionReport();
+		step.execute(context, runner, report);
+		assertEquals(PR_URL, report.pullRequestUrl().orElseThrow());
+	}
+
+	@Test
+	void recordsExistingPullRequestUrlInReport() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::existingPullRequest);
+		AdoptionReport report = new AdoptionReport();
+		step.execute(context, runner, report);
+		assertEquals(PR_URL, report.pullRequestUrl().orElseThrow());
+	}
+
+	@Test
+	void recordsUrlEvenWhenViewOutputCarriesNoise() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 0, "a new gh release is available\n{\"url\":\"" + PR_URL + "\"}"));
+		AdoptionReport report = new AdoptionReport();
+		step.execute(context, runner, report);
+		assertEquals(PR_URL, report.pullRequestUrl().orElseThrow());
+	}
+
+	@Test
+	void leavesUrlAbsentWhenViewOutputIsNotJson() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 0, "not json at all"));
+		AdoptionReport report = new AdoptionReport();
+		step.execute(context, runner, report);
+		assertTrue(report.pullRequestUrl().isEmpty());
+	}
+
+	@Test
+	void leavesUrlAbsentWhenUrlFieldIsMissing() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 0, "{\"number\": 1}"));
+		AdoptionReport report = new AdoptionReport();
+		step.execute(context, runner, report);
+		assertTrue(report.pullRequestUrl().isEmpty());
 	}
 
 	@Test
@@ -74,7 +123,11 @@ class PullRequestStepTest {
 		if (command.contains("view")) {
 			return new CommandResult(command, 1, "no pull requests found");
 		}
-		return new CommandResult(command, 0, "https://github.com/adamw7/tools/pull/1");
+		return new CommandResult(command, 0, PR_URL);
+	}
+
+	private CommandResult existingPullRequest(List<String> command) {
+		return new CommandResult(command, 0, "{\"url\":\"" + PR_URL + "\"}");
 	}
 
 	private CommandResult createFails(List<String> command) {
@@ -82,6 +135,28 @@ class PullRequestStepTest {
 			return new CommandResult(command, 1, "no pull requests found");
 		}
 		return new CommandResult(command, 1, "gh: could not authenticate");
+	}
+
+	/**
+	 * Mimics the real gh behaviour around creation: the pre-check view finds no
+	 * pull request, and every view after the create succeeds with the URL.
+	 */
+	private static final class ViewFailsUntilCreated
+			implements java.util.function.Function<List<String>, CommandResult> {
+
+		private boolean created;
+
+		@Override
+		public CommandResult apply(List<String> command) {
+			if (command.contains("create")) {
+				created = true;
+				return new CommandResult(command, 0, PR_URL);
+			}
+			if (created) {
+				return new CommandResult(command, 0, "{\"url\":\"" + PR_URL + "\"}");
+			}
+			return new CommandResult(command, 1, "no pull requests found");
+		}
 	}
 
 	@Test

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/ToolArguments.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/ToolArguments.java
@@ -36,6 +36,11 @@ public final class ToolArguments {
 		return value == null ? defaultValue : String.valueOf(value);
 	}
 
+	public static boolean optionalBoolean(Map<String, Object> arguments, String key, boolean defaultValue) {
+		Object value = arguments.get(key);
+		return value == null ? defaultValue : parseBoolean(key, value);
+	}
+
 	public static int optionalInt(Map<String, Object> arguments, String key, int defaultValue) {
 		Object value = arguments.get(key);
 		return value == null ? defaultValue : parseInt(key, value);
@@ -48,6 +53,21 @@ public final class ToolArguments {
 					"Argument " + key + " must be between " + min + " and " + max + " but was " + value);
 		}
 		return value;
+	}
+
+	/**
+	 * Accepts a real JSON boolean or its textual form, since loosely-typed clients
+	 * send either; anything else is an error rather than being coerced to false.
+	 */
+	private static boolean parseBoolean(String key, Object value) {
+		if (value instanceof Boolean bool) {
+			return bool;
+		}
+		String text = String.valueOf(value).trim();
+		if ("true".equalsIgnoreCase(text) || "false".equalsIgnoreCase(text)) {
+			return Boolean.parseBoolean(text);
+		}
+		throw new IllegalArgumentException("Argument " + key + " must be a boolean but was " + value);
 	}
 
 	private static int parseInt(String key, Object value) {

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/ToolArgumentsTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/ToolArgumentsTest.java
@@ -56,6 +56,31 @@ public class ToolArgumentsTest {
 	}
 
 	@Test
+	void optionalBooleanFallsBackToDefault() {
+		assertEquals(true, ToolArguments.optionalBoolean(Map.of(), "draft", true));
+		assertEquals(false, ToolArguments.optionalBoolean(Map.of(), "draft", false));
+	}
+
+	@Test
+	void optionalBooleanAcceptsRealBooleans() {
+		assertEquals(true, ToolArguments.optionalBoolean(Map.of("draft", true), "draft", false));
+		assertEquals(false, ToolArguments.optionalBoolean(Map.of("draft", false), "draft", true));
+	}
+
+	@Test
+	void optionalBooleanParsesTextualBooleans() {
+		assertEquals(true, ToolArguments.optionalBoolean(Map.of("draft", "true"), "draft", false));
+		assertEquals(false, ToolArguments.optionalBoolean(Map.of("draft", "False"), "draft", true));
+	}
+
+	@Test
+	void optionalBooleanRejectsNonBooleanValues() {
+		IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+				() -> ToolArguments.optionalBoolean(Map.of("draft", "yes"), "draft", false));
+		assertEquals("Argument draft must be a boolean but was yes", error.getMessage());
+	}
+
+	@Test
 	void optionalIntFallsBackToDefault() {
 		assertEquals(1, ToolArguments.optionalInt(Map.of(), "depth", 1));
 	}


### PR DESCRIPTION
The entry point now parses --title/--body/--reviewer/--label/--assignee/
--draft into PullRequestOptions, plus --assets and --report <file>
(CliArguments keeps the positional URL/workspace/branch arguments
working). Each run returns an AdoptionReport — the completed steps and
the pull request URL read back with gh pr view --json url — which
--report writes as JSON for scripting.

The optional AssetsStep commits starter Claude Code configuration assets
(an AGENTS.md pointer, .claude/settings.json denying secret-file reads
and wiring a session-start hook stub, a starter .mcp.json, and an
@claude-mention GitHub Actions workflow), never overwriting a file the
repository already has.

A new adopt.mcp Spring Boot server — wired like the data and context
servers through mcp-common — exposes the pipeline as an adopt_repo tool
that answers with the JSON report; mcp-common gains
ToolArguments.optionalBoolean for its draft/assets arguments.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016t3SpNBJGYiz9xSAZLMULk