### PR TITLE
feat(claude-code-enforcer): add seven rules for permissions, imports, secrets, budgets, and plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,6 +424,73 @@ profile:
   README is allowed to document a curated subset — so only a value present in both
   files that disagrees fails the build. Both rules share a `DocumentConsistency`
   helper that owns the pattern validation and capture logic.
+- `PermissionsFormatRule` (`permissionsFormat`) validates the entries of the
+  `permissions` lists (`allow`, `deny`, `ask`) in `.claude/settings.json`.
+  Where `settingsJsonValid` asserts policy (which entries must or must not be
+  present), this rule validates the entries themselves: each must be a
+  non-blank string of the form `Tool` or `Tool(specifier)`, because a
+  malformed entry such as `Bash(mvn *` grants nothing and fails silently at
+  runtime. A duplicate within a list is reported, and so is an entry that
+  appears in both `allow` and `deny`, since the contradiction means one of the
+  two is not doing what its author intended. An optional `allowedTools` list
+  rejects a mistyped tool name (entries prefixed `mcp__` are exempt, their
+  names being defined by the project's servers), and optional
+  `forbiddenEntryPatterns` regexes ban an over-broad `allow` grant such as
+  `Bash(*)` by shape rather than exact spelling. A settings file without a
+  `permissions` section passes.
+- `MemoryImportsRule` (`memoryImports`) follows the `@path` memory imports of
+  `CLAUDE.md` recursively and fails for an import that does not resolve on
+  disk, a circular import, or an import nested deeper than `maxDepth` hops
+  (default 5, the loader's limit — deeper imports are silently never loaded).
+  Imports are recognised the way Claude Code evaluates them — preceded by
+  start-of-line or whitespace, outside fenced code blocks and inline code
+  spans — so `` `@claude` `` in prose is not an import; home-relative imports
+  (`@~/...`) point at machine-specific state a build cannot see and are
+  skipped, as is any path listed in `ignoredImports`.
+- `NoSecretsRule` (`noSecrets`) scans the configured `files` and every regular
+  file under the configured `directories` for what looks like a literal
+  credential — Anthropic, AWS, GitHub, and Slack token formats plus private
+  key blocks by default; `secretPatterns` adds custom regexes, or replaces
+  the defaults when `useDefaultPatterns` is off. Each match is reported with
+  its file, line, and credential kind but only the first characters of the
+  match, so the report never republishes the secret it found. An absent
+  target is skipped, because most of these files are optional; the fix is an
+  environment variable expansion such as `${API_KEY}` plus rotating the
+  leaked value.
+- `ContextBudgetRule` (`contextBudget`) keeps agent context files within a
+  size budget, because `CLAUDE.md` is loaded into every session and each
+  definition file whenever it triggers: every configured file (and every
+  `*.md` under the configured `directories`) must fit `maxBytes`, `maxLines`,
+  and `maxTokens` (estimated with the rough four-characters-per-token
+  heuristic). A budget left at zero is disabled; at least one must be
+  configured. The fix is moving detail into `AGENTS.md` or an on-demand skill
+  rather than the always-loaded context.
+- `LocalSettingsIgnoredRule` (`localSettingsIgnored`) parses the configured
+  `.gitignore` and verifies each path in `ignoredPaths` (by default
+  `.claude/settings.local.json`, the per-developer settings file) is covered,
+  honouring negations, anchoring, directory patterns, and `*`/`?`/`**` globs —
+  a path may be covered by the exact entry, a glob, or an ignored ancestor
+  directory. Committing personal settings imposes one developer's choices on
+  the whole team, so the durable guard is the gitignore entry itself.
+- `ModuleMapConsistencyRule` (`moduleMapConsistency`) extracts every
+  `<module>` entry from the configured aggregator `pomFile` (XML comments are
+  ignored, so a commented-out module does not count) and fails when a
+  module's name — the last path segment, for a nested entry such as
+  `code/context` — is not mentioned in each configured doc file, so a module
+  added to the reactor cannot stay undocumented. The check is presence-only
+  by design: how a doc arranges its module map is prose, but every live
+  module must at least be mentioned. `ignoredModules` exempts a deliberately
+  undocumented module; a pom with no `<module>` entries always fails, because
+  pointing the rule at a non-aggregator pom is a build-setup mistake.
+- `PluginFormatRule` (`pluginFormat`) validates a Claude Code plugin manifest
+  (`.claude-plugin/plugin.json`): when present it must be non-empty valid
+  JSON declaring every required key (`name` by default, overridable via
+  `requiredKeys`), the `name` is held to the naming convention (lower-case
+  kebab-case, at most 64 characters), a `version` must be a dotted version
+  number with an optional pre-release suffix, a present `description` must be
+  non-empty, and `allowedKeys` reports unknown keys, catching typos such as
+  `descripton`. An absent manifest is a pass, since not every repository
+  ships a plugin.
 
 The `claudeMdFormat` and `agentsMdFormat` rules share a `MarkdownFormatRule`
 base class that performs the file-existence, BOM, title, and section checks, and

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRule.java
@@ -1,0 +1,149 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import java.io.File;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import javax.inject.Named;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
+import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+import io.github.adamw7.tools.enforcer.text.NameConvention;
+
+/**
+ * Enforcer rule that validates a Claude Code plugin manifest, the
+ * {@code .claude-plugin/plugin.json} of a plugin repository. The manifest names
+ * the plugin in every marketplace listing, so a malformed one breaks
+ * installation rather than the build that produced it. When present, the file
+ * must be non-empty valid JSON declaring every required key ({@code name} by
+ * default, overridable via {@code requiredKeys}); the {@code name} is held to
+ * the Claude Code naming convention (lower-case kebab-case, at most
+ * {@value NameConvention#MAX_LENGTH} characters), a {@code version} must be a
+ * dotted number with an optional pre-release suffix, and a {@code description}
+ * must be non-empty. When {@code allowedKeys} is configured, any key outside
+ * that set is reported, which catches typos such as {@code descripton}.
+ * <p>
+ * Not every repository ships a plugin, so an absent manifest is a pass; the
+ * rule only fails when the file is present and malformed. All problems found
+ * are reported together.
+ */
+@Named("pluginFormat")
+public class PluginFormatRule extends JsonFileRule {
+
+	private static final String NAME_KEY = "name";
+	private static final String VERSION_KEY = "version";
+	private static final String DESCRIPTION_KEY = "description";
+	private static final List<String> DEFAULT_REQUIRED_KEYS = List.of(NAME_KEY);
+	private static final Pattern VERSION = Pattern.compile("\\d+(\\.\\d+){0,2}([-+][A-Za-z0-9.-]+)?");
+
+	/** The {@code .claude-plugin/plugin.json} manifest to validate. Injected from the rule configuration. */
+	private File pluginFile;
+
+	/** Optional override for the required manifest keys. */
+	private List<String> requiredKeys;
+
+	/** Optional whitelist of allowed manifest keys. When set, unknown keys are reported. */
+	private List<String> allowedKeys;
+
+	@Override
+	protected File jsonFile() {
+		return pluginFile;
+	}
+
+	@Override
+	protected String fileParameter() {
+		return "pluginFile";
+	}
+
+	@Override
+	protected String description() {
+		return "plugin.json";
+	}
+
+	@Override
+	protected String header() {
+		return "plugin.json is not well formed:";
+	}
+
+	/** Not every repository ships a plugin, so an absent manifest is a pass. */
+	@Override
+	protected void handleMissingFile(File file) {
+	}
+
+	@Override
+	protected void collectViolations(JsonNode manifest, List<String> violations) {
+		collectMissingKeys(manifest, violations);
+		collectUnknownKeys(manifest, violations);
+		collectNameViolations(manifest, violations);
+		collectVersionViolation(manifest, violations);
+		collectDescriptionViolation(manifest, violations);
+	}
+
+	private void collectMissingKeys(JsonNode manifest, List<String> violations) {
+		for (String key : requiredKeys()) {
+			if (!manifest.has(key)) {
+				violations.add("plugin.json is missing required key '" + key + "' in: " + pluginFile);
+			}
+		}
+	}
+
+	private void collectUnknownKeys(JsonNode manifest, List<String> violations) {
+		if (allowedKeys == null) {
+			return;
+		}
+		for (String key : JsonNodes.fieldNames(manifest)) {
+			addUnknownKeyViolation(key, violations);
+		}
+	}
+
+	private void addUnknownKeyViolation(String key, List<String> violations) {
+		if (!allowedKeys.contains(key)) {
+			violations.add("plugin.json has unknown key '" + key + "' in: " + pluginFile);
+		}
+	}
+
+	/** A plugin name answers to no directory, so the convention check compares it only to itself. */
+	private void collectNameViolations(JsonNode manifest, List<String> violations) {
+		String name = JsonNodes.textAt(manifest, NAME_KEY, null);
+		if (name != null) {
+			NameConvention.collect(name, name, pluginFile.toString(), violations);
+		}
+	}
+
+	private void collectVersionViolation(JsonNode manifest, List<String> violations) {
+		String version = JsonNodes.textAt(manifest, VERSION_KEY, null);
+		if (version != null && !VERSION.matcher(version).matches()) {
+			violations.add("plugin.json version '" + version + "' is not a dotted version number in: " + pluginFile);
+		}
+	}
+
+	private void collectDescriptionViolation(JsonNode manifest, List<String> violations) {
+		String description = JsonNodes.textAt(manifest, DESCRIPTION_KEY, null);
+		if (description != null && description.isBlank()) {
+			violations.add("plugin.json description must not be empty in: " + pluginFile);
+		}
+	}
+
+	private List<String> requiredKeys() {
+		return requiredKeys != null ? requiredKeys : DEFAULT_REQUIRED_KEYS;
+	}
+
+	void setPluginFile(File pluginFile) {
+		this.pluginFile = pluginFile;
+	}
+
+	void setRequiredKeys(List<String> requiredKeys) {
+		this.requiredKeys = requiredKeys;
+	}
+
+	void setAllowedKeys(List<String> allowedKeys) {
+		this.allowedKeys = allowedKeys;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("PluginFormatRule[pluginFile=%s]", pluginFile);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
@@ -1,0 +1,176 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * Enforcer rule that keeps agent context files within a size budget.
+ * {@code CLAUDE.md} is loaded into every Claude Code session, and each skill,
+ * sub-agent, and command definition is loaded whenever it triggers, so an
+ * unbounded file quietly taxes every conversation. The rule measures every
+ * configured file (each must exist) and every {@code *.md} file under the
+ * configured directories (an absent directory is skipped) against up to three
+ * budgets: {@code maxBytes} (on-disk size), {@code maxLines}, and
+ * {@code maxTokens} — the latter estimated with the common four-characters-per-
+ * token heuristic, which is deliberately rough but stable enough for a budget.
+ * <p>
+ * A budget left at zero is disabled; at least one must be configured, because a
+ * rule with no limits is a build-setup mistake. All files over budget are
+ * reported together — the fix is to move detail into AGENTS.md or an
+ * on-demand skill rather than the always-loaded context.
+ */
+@Named("contextBudget")
+public class ContextBudgetRule extends ClaudeCodeEnforcerRule {
+
+	private static final String MARKDOWN_EXTENSION = ".md";
+	private static final int CHARS_PER_TOKEN = 4;
+
+	/** Files that must fit the budget. Each configured file must exist. */
+	private List<File> files;
+
+	/** Directories whose {@code *.md} files must fit the budget. An absent directory is skipped. */
+	private List<File> directories;
+
+	/** Maximum on-disk size in bytes. Zero (default) disables the check. */
+	private long maxBytes;
+
+	/** Maximum number of lines. Zero (default) disables the check. */
+	private int maxLines;
+
+	/** Maximum estimated tokens (characters divided by four). Zero (default) disables the check. */
+	private int maxTokens;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		requireLimitConfigured();
+		requireTargetsConfigured();
+		List<String> violations = new ArrayList<>();
+		for (File file : configuredFiles()) {
+			requireExists(file, file.getName());
+			collectBudgetViolations(file, violations);
+		}
+		for (File directory : configuredDirectories()) {
+			collectDirectoryViolations(directory, violations);
+		}
+		report("Context budget exceeded:", violations);
+	}
+
+	@Override
+	protected List<String> howToFix() {
+		return List.of(
+				"Open each file listed above.",
+				"Move detail that is not needed in every session into AGENTS.md or an on-demand skill.",
+				"Re-run the build to confirm every context file fits its budget.");
+	}
+
+	private void requireLimitConfigured() throws EnforcerRuleException {
+		if (maxBytes <= 0 && maxLines <= 0 && maxTokens <= 0) {
+			throw new EnforcerRuleException("Configure at least one of maxBytes, maxLines, or maxTokens");
+		}
+	}
+
+	private void requireTargetsConfigured() throws EnforcerRuleException {
+		if (configuredFiles().isEmpty() && configuredDirectories().isEmpty()) {
+			throw new EnforcerRuleException("Configure at least one of the files or directories parameters");
+		}
+	}
+
+	private void collectDirectoryViolations(File directory, List<String> violations) {
+		if (!directory.isDirectory()) {
+			return;
+		}
+		for (Path file : markdownFilesIn(directory)) {
+			collectBudgetViolations(file.toFile(), violations);
+		}
+	}
+
+	private List<Path> markdownFilesIn(File directory) {
+		try (Stream<Path> walk = Files.walk(directory.toPath())) {
+			return walk.filter(Files::isRegularFile)
+					.filter(path -> path.getFileName().toString().endsWith(MARKDOWN_EXTENSION))
+					.sorted().toList();
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not scan directory " + directory, e);
+		}
+	}
+
+	private void collectBudgetViolations(File file, List<String> violations) {
+		collectBytesViolation(file, violations);
+		if (maxLines > 0 || maxTokens > 0) {
+			collectContentViolations(file, MarkdownText.read(file, file.getName()), violations);
+		}
+	}
+
+	private void collectBytesViolation(File file, List<String> violations) {
+		if (maxBytes > 0 && file.length() > maxBytes) {
+			violations.add(file + " is " + file.length() + " bytes, over the " + maxBytes + "-byte budget");
+		}
+	}
+
+	private void collectContentViolations(File file, String content, List<String> violations) {
+		long lines = content.lines().count();
+		if (maxLines > 0 && lines > maxLines) {
+			violations.add(file + " has " + lines + " lines, over the " + maxLines + "-line budget");
+		}
+		collectTokensViolation(file, content, violations);
+	}
+
+	private void collectTokensViolation(File file, String content, List<String> violations) {
+		long tokens = estimatedTokens(content);
+		if (maxTokens > 0 && tokens > maxTokens) {
+			violations.add(file + " is an estimated " + tokens + " tokens, over the " + maxTokens
+					+ "-token budget");
+		}
+	}
+
+	/** Rounds up, so a one-character file estimates to one token rather than zero. */
+	private long estimatedTokens(String content) {
+		return (content.length() + CHARS_PER_TOKEN - 1) / CHARS_PER_TOKEN;
+	}
+
+	private List<File> configuredFiles() {
+		return files != null ? files : List.of();
+	}
+
+	private List<File> configuredDirectories() {
+		return directories != null ? directories : List.of();
+	}
+
+	void setFiles(List<File> files) {
+		this.files = files;
+	}
+
+	void setDirectories(List<File> directories) {
+		this.directories = directories;
+	}
+
+	void setMaxBytes(long maxBytes) {
+		this.maxBytes = maxBytes;
+	}
+
+	void setMaxLines(int maxLines) {
+		this.maxLines = maxLines;
+	}
+
+	void setMaxTokens(int maxTokens) {
+		this.maxTokens = maxTokens;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("ContextBudgetRule[files=%s, directories=%s]", files, directories);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -1,0 +1,167 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
+
+/**
+ * Enforcer rule that validates the {@code @path} memory imports of
+ * {@code CLAUDE.md}. Claude Code loads every imported file into the session, so
+ * an import that does not resolve on disk is silently missing context, and an
+ * import cycle or a chain deeper than the loader's five-hop limit means part of
+ * the memory is never loaded at all. The rule follows every import recursively
+ * and reports a target that does not exist, a circular import, and an import
+ * nested deeper than {@code maxDepth} hops.
+ * <p>
+ * Imports are recognised the way Claude Code evaluates them: an {@code @}
+ * preceded by start-of-line or whitespace and followed by a path, outside fenced
+ * code blocks and inline code spans, so {@code `@claude`} in prose is not an
+ * import. A home-relative import ({@code @~/...}) is skipped because it points
+ * at machine-specific state a build cannot see, and any import listed in
+ * {@code ignoredImports} is skipped verbatim. Each file is scanned once; all
+ * problems found are reported together.
+ */
+@Named("memoryImports")
+public class MemoryImportsRule extends ClaudeCodeEnforcerRule {
+
+	private static final Pattern IMPORT = Pattern.compile("(?<=^|\\s)@([A-Za-z0-9_./-]+)");
+	private static final Pattern CODE_SPAN = Pattern.compile("`[^`]*`");
+	private static final int DEFAULT_MAX_DEPTH = 5;
+
+	/** The {@code CLAUDE.md} file whose imports are validated. Injected from the rule configuration. */
+	private File claudeMdFile;
+
+	/** Maximum allowed import nesting, in hops from the root file. */
+	private int maxDepth = DEFAULT_MAX_DEPTH;
+
+	/** Optional import paths to skip verbatim, e.g. a path only present on developer machines. */
+	private List<String> ignoredImports;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		requireConfigured(claudeMdFile, "claudeMdFile");
+		requireExists(claudeMdFile, "CLAUDE.md");
+		List<String> violations = new ArrayList<>();
+		scan(claudeMdFile.getAbsoluteFile(), 0, new ArrayDeque<>(), new LinkedHashSet<>(), violations);
+		report("Memory imports are not well formed:", violations);
+	}
+
+	private void scan(File file, int depth, Deque<Path> stack, Set<Path> visited, List<String> violations) {
+		Path path = normalized(file);
+		visited.add(path);
+		stack.push(path);
+		for (String imported : importsIn(file)) {
+			checkImport(file, imported, depth, stack, visited, violations);
+		}
+		stack.pop();
+	}
+
+	private void checkImport(File file, String imported, int depth, Deque<Path> stack, Set<Path> visited,
+			List<String> violations) {
+		if (isIgnored(imported)) {
+			return;
+		}
+		File target = resolve(file, imported);
+		Path path = normalized(target);
+		if (stack.contains(path)) {
+			violations.add(file + " has a circular import: @" + imported);
+		} else if (!target.isFile()) {
+			violations.add(file + " imports a missing file: @" + imported + " (resolved to " + target + ")");
+		} else if (depth + 1 > maxDepth) {
+			violations.add(file + " import @" + imported + " is nested deeper than " + maxDepth
+					+ " hops and will not be loaded");
+		} else if (!visited.contains(path)) {
+			scan(target, depth + 1, stack, visited, violations);
+		}
+	}
+
+	private boolean isIgnored(String imported) {
+		return ignoredImports != null && ignoredImports.contains(imported);
+	}
+
+	private File resolve(File file, String imported) {
+		if (imported.startsWith("/")) {
+			return new File(imported);
+		}
+		return new File(file.getParentFile(), imported);
+	}
+
+	private Path normalized(File file) {
+		return file.toPath().toAbsolutePath().normalize();
+	}
+
+	private List<String> importsIn(File file) {
+		MarkdownDocument document = MarkdownDocument.parse(readSafely(file));
+		List<String> imports = new ArrayList<>();
+		for (int i = 0; i < document.lineCount(); i++) {
+			collectLineImports(document, i, imports);
+		}
+		return imports;
+	}
+
+	private void collectLineImports(MarkdownDocument document, int index, List<String> imports) {
+		if (document.isInsideFence(index)) {
+			return;
+		}
+		Matcher matcher = IMPORT.matcher(CODE_SPAN.matcher(document.line(index)).replaceAll(" "));
+		while (matcher.find()) {
+			imports.add(withoutTrailingDots(matcher.group(1)));
+		}
+	}
+
+	/** Drops sentence punctuation, so "see @docs/setup.md." imports {@code docs/setup.md}. */
+	private String withoutTrailingDots(String imported) {
+		String path = imported;
+		while (path.endsWith(".")) {
+			path = path.substring(0, path.length() - 1);
+		}
+		return path;
+	}
+
+	/**
+	 * The file's content, or empty when it cannot be read as text. An imported
+	 * file may be any format, so a binary target is treated as a leaf rather than
+	 * a failure — its existence has already been verified.
+	 */
+	private String readSafely(File file) {
+		try {
+			return Files.readString(file.toPath());
+		} catch (IOException e) {
+			getLog().debug("Skipping unreadable import target " + file + ": " + e.getMessage());
+			return "";
+		}
+	}
+
+	void setClaudeMdFile(File claudeMdFile) {
+		this.claudeMdFile = claudeMdFile;
+	}
+
+	void setMaxDepth(int maxDepth) {
+		this.maxDepth = maxDepth;
+	}
+
+	void setIgnoredImports(List<String> ignoredImports) {
+		this.ignoredImports = ignoredImports;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("MemoryImportsRule[claudeMdFile=%s]", claudeMdFile);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRule.java
@@ -1,0 +1,135 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * Enforcer rule that keeps the module map in the agent docs from drifting away
+ * from the real Maven reactor. {@link CrossDocConsistencyRule} pins scalar
+ * facts with regular expressions, but a module added to the root {@code pom.xml}
+ * and never documented is a structural gap no single pattern expresses: an
+ * agent reading the docs simply never learns the module exists. This rule
+ * extracts every {@code <module>} entry from the configured {@code pomFile}
+ * (XML comments are ignored, so a commented-out module does not count) and
+ * fails when a module's name — the last path segment, for a nested entry such
+ * as {@code code/context} — does not appear in each configured doc file.
+ * <p>
+ * The check is presence-only by design: how a doc arranges its module map is
+ * prose, but every live module must at least be mentioned. Modules listed in
+ * {@code ignoredModules} are exempt, e.g. an internal test-only module the docs
+ * deliberately leave out. A pom with no {@code <module>} entries fails, because
+ * pointing this rule at a non-aggregator pom is a build-setup mistake. All
+ * missing mentions are reported together.
+ */
+@Named("moduleMapConsistency")
+public class ModuleMapConsistencyRule extends ClaudeCodeEnforcerRule {
+
+	private static final Pattern XML_COMMENT = Pattern.compile("(?s)<!--.*?-->");
+	private static final Pattern MODULE = Pattern.compile("<module>\\s*([^<]+?)\\s*</module>");
+
+	/** The aggregator {@code pom.xml} whose {@code <module>} entries are the source of truth. */
+	private File pomFile;
+
+	/** The documentation files that must mention every module, e.g. CLAUDE.md and AGENTS.md. */
+	private List<File> docFiles;
+
+	/** Optional module names the docs may leave undocumented. */
+	private List<String> ignoredModules;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		requireConfigured(pomFile, "pomFile");
+		requireExists(pomFile, "pom.xml");
+		requireDocsConfigured();
+		List<String> modules = modules(requireContent(pomFile, "pom.xml"));
+		requireModules(modules);
+		List<String> violations = new ArrayList<>();
+		for (File docFile : docFiles) {
+			collectDocViolations(docFile, modules, violations);
+		}
+		report("Documented module map is out of date:", violations);
+	}
+
+	@Override
+	protected List<String> howToFix() {
+		return List.of(
+				"Open each doc file listed above.",
+				"Add the missing module to its module map, or list the module under ignoredModules if it is deliberately undocumented.",
+				"Re-run the build to confirm the docs cover every reactor module.");
+	}
+
+	private void requireDocsConfigured() throws EnforcerRuleException {
+		requireConfigured(docFiles, "docFiles");
+		if (docFiles.isEmpty()) {
+			throw new EnforcerRuleException("The docFiles parameter must list at least one file");
+		}
+	}
+
+	private void requireModules(List<String> modules) throws EnforcerRuleException {
+		if (modules.isEmpty()) {
+			throw new EnforcerRuleException(pomFile + " declares no <module> entries; point pomFile at the aggregator pom");
+		}
+	}
+
+	private List<String> modules(String pomContent) {
+		Matcher matcher = MODULE.matcher(XML_COMMENT.matcher(pomContent).replaceAll(""));
+		List<String> modules = new ArrayList<>();
+		while (matcher.find()) {
+			modules.add(matcher.group(1));
+		}
+		return modules;
+	}
+
+	private void collectDocViolations(File docFile, List<String> modules, List<String> violations)
+			throws EnforcerRuleException {
+		requireExists(docFile, docFile.getName());
+		String content = requireContent(docFile, docFile.getName());
+		for (String module : modules) {
+			addMissingMention(docFile, module, content, violations);
+		}
+	}
+
+	private void addMissingMention(File docFile, String module, String content, List<String> violations) {
+		String name = moduleName(module);
+		if (!isIgnored(name) && !content.contains(name)) {
+			violations.add(docFile + " does not mention module '" + name + "' declared in " + pomFile);
+		}
+	}
+
+	/** The last path segment, so a nested reactor entry such as {@code code/context} is looked up as {@code context}. */
+	private String moduleName(String module) {
+		int slash = module.lastIndexOf('/');
+		return slash < 0 ? module : module.substring(slash + 1);
+	}
+
+	private boolean isIgnored(String name) {
+		return ignoredModules != null && ignoredModules.contains(name);
+	}
+
+	void setPomFile(File pomFile) {
+		this.pomFile = pomFile;
+	}
+
+	void setDocFiles(List<File> docFiles) {
+		this.docFiles = docFiles;
+	}
+
+	void setIgnoredModules(List<String> ignoredModules) {
+		this.ignoredModules = ignoredModules;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("ModuleMapConsistencyRule[pomFile=%s, docFiles=%s]", pomFile, docFiles);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
@@ -1,0 +1,195 @@
+package io.github.adamw7.tools.enforcer.secret;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.stream.Stream;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+
+/**
+ * Enforcer rule that fails the build when a configured file contains what looks
+ * like a literal credential. Claude Code configuration is a natural place for a
+ * key to leak — an API token pasted into a {@code .mcp.json} {@code env} or
+ * {@code headers} block, a {@code settings.json} environment variable, or a
+ * hook script — and once committed it must be rotated, so the cheapest fix is to
+ * refuse the commit's build. The scanned targets are the configured
+ * {@code files} plus every regular file under the configured
+ * {@code directories}; an absent target is skipped, because most of these files
+ * are optional.
+ * <p>
+ * Each match is reported with its file, line, and the kind of credential it
+ * resembles, but only the first characters of the match itself, so the report
+ * never republishes the secret it found. The default patterns cover common API
+ * token formats (Anthropic, AWS, GitHub, Slack, private key blocks); custom
+ * {@code secretPatterns} regular expressions are scanned in addition, or
+ * instead when {@code useDefaultPatterns} is switched off. A file that cannot
+ * be decoded as text (e.g. a binary asset) is skipped. All problems found are
+ * reported together — the fix is to move the value into an environment variable
+ * expansion such as {@code ${API_KEY}} and rotate the leaked credential.
+ */
+@Named("noSecrets")
+public class NoSecretsRule extends ClaudeCodeEnforcerRule {
+
+	private static final int VISIBLE_PREFIX_LENGTH = 8;
+
+	/** Files to scan. An entry that does not exist is skipped, since most targets are optional. */
+	private List<File> files;
+
+	/** Directories whose regular files are scanned recursively. An absent directory is skipped. */
+	private List<File> directories;
+
+	/** Additional regular expressions to scan for, each reported under its own pattern text. */
+	private List<String> secretPatterns;
+
+	/** When true (default), the built-in credential patterns are scanned as well. */
+	private boolean useDefaultPatterns = true;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		List<SecretPattern> patterns = patterns();
+		requireTargetsConfigured();
+		requirePatterns(patterns);
+		List<String> violations = new ArrayList<>();
+		for (File file : configuredFiles()) {
+			scanIfPresent(file, patterns, violations);
+		}
+		for (File directory : configuredDirectories()) {
+			scanDirectory(directory, patterns, violations);
+		}
+		report("Files contain what look like secrets:", violations);
+	}
+
+	@Override
+	protected List<String> howToFix() {
+		return List.of(
+				"Open each file listed above at the reported line.",
+				"Replace the literal credential with an environment variable expansion such as ${API_KEY}.",
+				"Rotate the leaked credential — a value that reached the working tree may already be compromised.",
+				"Re-run the build to confirm no secrets remain.");
+	}
+
+	private void requireTargetsConfigured() throws EnforcerRuleException {
+		if (configuredFiles().isEmpty() && configuredDirectories().isEmpty()) {
+			throw new EnforcerRuleException("Configure at least one of the files or directories parameters");
+		}
+	}
+
+	private void requirePatterns(List<SecretPattern> patterns) throws EnforcerRuleException {
+		if (patterns.isEmpty()) {
+			throw new EnforcerRuleException(
+					"Configure secretPatterns or leave useDefaultPatterns enabled, so there is something to scan for");
+		}
+	}
+
+	private void scanDirectory(File directory, List<SecretPattern> patterns, List<String> violations) {
+		if (!directory.isDirectory()) {
+			return;
+		}
+		for (Path file : regularFilesIn(directory)) {
+			scanIfPresent(file.toFile(), patterns, violations);
+		}
+	}
+
+	private List<Path> regularFilesIn(File directory) {
+		try (Stream<Path> walk = Files.walk(directory.toPath())) {
+			return walk.filter(Files::isRegularFile).sorted().toList();
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not scan directory " + directory, e);
+		}
+	}
+
+	private void scanIfPresent(File file, List<SecretPattern> patterns, List<String> violations) {
+		if (!file.isFile()) {
+			return;
+		}
+		List<String> lines = readTextLines(file);
+		for (int i = 0; i < lines.size(); i++) {
+			scanLine(file, lines.get(i), i + 1, patterns, violations);
+		}
+	}
+
+	private void scanLine(File file, String line, int lineNumber, List<SecretPattern> patterns,
+			List<String> violations) {
+		for (SecretPattern pattern : patterns) {
+			collectMatches(file, line, lineNumber, pattern, violations);
+		}
+	}
+
+	private void collectMatches(File file, String line, int lineNumber, SecretPattern pattern,
+			List<String> violations) {
+		Matcher matcher = pattern.pattern().matcher(line);
+		while (matcher.find()) {
+			violations.add(file + " line " + lineNumber + " contains what looks like a " + pattern.name()
+					+ ": " + masked(matcher.group()));
+		}
+	}
+
+	/** The first characters of the match followed by an ellipsis, so the report never echoes the full secret. */
+	private String masked(String match) {
+		return match.substring(0, Math.min(VISIBLE_PREFIX_LENGTH, match.length())) + "...";
+	}
+
+	/** The file's lines, or none when it cannot be decoded as text (e.g. a binary asset). */
+	private List<String> readTextLines(File file) {
+		try {
+			return Files.readString(file.toPath()).lines().toList();
+		} catch (IOException e) {
+			getLog().debug("Skipping undecodable file " + file + ": " + e.getMessage());
+			return List.of();
+		}
+	}
+
+	private List<SecretPattern> patterns() {
+		List<SecretPattern> patterns = new ArrayList<>();
+		if (useDefaultPatterns) {
+			patterns.addAll(SecretPattern.defaults());
+		}
+		for (String regex : configuredSecretPatterns()) {
+			patterns.add(SecretPattern.of(regex, regex));
+		}
+		return patterns;
+	}
+
+	private List<File> configuredFiles() {
+		return files != null ? files : List.of();
+	}
+
+	private List<File> configuredDirectories() {
+		return directories != null ? directories : List.of();
+	}
+
+	private List<String> configuredSecretPatterns() {
+		return secretPatterns != null ? secretPatterns : List.of();
+	}
+
+	void setFiles(List<File> files) {
+		this.files = files;
+	}
+
+	void setDirectories(List<File> directories) {
+		this.directories = directories;
+	}
+
+	void setSecretPatterns(List<String> secretPatterns) {
+		this.secretPatterns = secretPatterns;
+	}
+
+	void setUseDefaultPatterns(boolean useDefaultPatterns) {
+		this.useDefaultPatterns = useDefaultPatterns;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("NoSecretsRule[files=%s, directories=%s]", files, directories);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/SecretPattern.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/SecretPattern.java
@@ -1,0 +1,29 @@
+package io.github.adamw7.tools.enforcer.secret;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * A named credential shape the {@link NoSecretsRule} scans for. The default
+ * catalogue covers the token formats most likely to land in Claude Code
+ * configuration — API keys pasted into an {@code env} block or a hook script —
+ * and each carries a human-readable name so a violation says what kind of
+ * secret it looks like without echoing the secret itself.
+ */
+record SecretPattern(String name, Pattern pattern) {
+
+	static SecretPattern of(String name, String regex) {
+		return new SecretPattern(name, Pattern.compile(regex));
+	}
+
+	/** The built-in credential shapes, scanned unless {@code useDefaultPatterns} is switched off. */
+	static List<SecretPattern> defaults() {
+		return List.of(
+				of("Anthropic API key", "sk-ant-[A-Za-z0-9_-]{16,}"),
+				of("AWS access key ID", "(?<![A-Z0-9])AKIA[0-9A-Z]{16}(?![A-Z0-9])"),
+				of("GitHub token", "(?<![A-Za-z0-9])gh[pousr]_[A-Za-z0-9]{36,}"),
+				of("GitHub fine-grained token", "github_pat_[A-Za-z0-9_]{22,}"),
+				of("Slack token", "xox[abpr]-[A-Za-z0-9-]{10,}"),
+				of("private key block", "-----BEGIN [A-Z ]*PRIVATE KEY-----"));
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/Gitignore.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/Gitignore.java
@@ -1,0 +1,134 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * A parsed {@code .gitignore}, able to answer whether a repository-relative
+ * file path is ignored. It implements the subset of gitignore semantics the
+ * {@link LocalSettingsIgnoredRule} needs: comments and blank lines are skipped,
+ * {@code !} negates, a trailing {@code /} restricts a pattern to directories, a
+ * pattern containing a {@code /} is anchored to the gitignore's directory while
+ * one without matches at any depth, and {@code *}, {@code ?}, and {@code **}
+ * glob within and across path segments respectively. Later lines override
+ * earlier ones, and a file is also ignored when any of its ancestor directories
+ * is.
+ * <p>
+ * Paths are matched with {@code /} separators and no leading slash, exactly as
+ * they appear in {@code git status} output.
+ */
+final class Gitignore {
+
+	private final List<Line> lines;
+
+	private Gitignore(List<Line> lines) {
+		this.lines = lines;
+	}
+
+	static Gitignore parse(String content) {
+		List<Line> lines = new ArrayList<>();
+		for (String raw : content.lines().toList()) {
+			parseLine(raw.strip(), lines);
+		}
+		return new Gitignore(lines);
+	}
+
+	private static void parseLine(String line, List<Line> lines) {
+		if (line.isEmpty() || line.startsWith("#")) {
+			return;
+		}
+		boolean negated = line.startsWith("!");
+		String pattern = negated ? line.substring(1) : line;
+		boolean directoryOnly = pattern.endsWith("/");
+		String body = directoryOnly ? pattern.substring(0, pattern.length() - 1) : pattern;
+		lines.add(new Line(negated, directoryOnly, compile(body)));
+	}
+
+	private static Pattern compile(String body) {
+		boolean anchored = body.startsWith("/") || body.indexOf('/') >= 0;
+		String stripped = body.startsWith("/") ? body.substring(1) : body;
+		String prefix = anchored ? "^" : "^(?:.*/)?";
+		return Pattern.compile(prefix + translate(stripped) + "$");
+	}
+
+	/** Translates one gitignore glob into a regular expression body. */
+	private static String translate(String glob) {
+		StringBuilder regex = new StringBuilder();
+		int i = 0;
+		while (i < glob.length()) {
+			i += appendToken(glob, i, regex);
+		}
+		return regex.toString();
+	}
+
+	private static int appendToken(String glob, int i, StringBuilder regex) {
+		if (glob.startsWith("**/", i)) {
+			regex.append("(?:.*/)?");
+			return 3;
+		}
+		if (glob.startsWith("**", i)) {
+			regex.append(".*");
+			return 2;
+		}
+		return appendCharacter(glob.charAt(i), regex);
+	}
+
+	private static int appendCharacter(char c, StringBuilder regex) {
+		if (c == '*') {
+			regex.append("[^/]*");
+		} else if (c == '?') {
+			regex.append("[^/]");
+		} else {
+			regex.append(Pattern.quote(String.valueOf(c)));
+		}
+		return 1;
+	}
+
+	/**
+	 * True when the file at {@code path} is ignored, either directly or because
+	 * one of its ancestor directories is.
+	 */
+	boolean covers(String path) {
+		if (isIgnored(path, false)) {
+			return true;
+		}
+		return ancestorsOf(path).stream().anyMatch(ancestor -> isIgnored(ancestor, true));
+	}
+
+	/** The verdict of the last matching line, honouring negations; directory-only lines match directories alone. */
+	private boolean isIgnored(String path, boolean isDirectory) {
+		boolean ignored = false;
+		for (Line line : lines) {
+			ignored = line.verdict(path, isDirectory, ignored);
+		}
+		return ignored;
+	}
+
+	private List<String> ancestorsOf(String path) {
+		List<String> ancestors = new ArrayList<>();
+		int slash = path.indexOf('/');
+		while (slash >= 0) {
+			ancestors.add(path.substring(0, slash));
+			slash = path.indexOf('/', slash + 1);
+		}
+		return ancestors;
+	}
+
+	private record Line(boolean negated, boolean directoryOnly, Pattern pattern) {
+
+		boolean verdict(String path, boolean isDirectory, boolean current) {
+			if (matches(path, isDirectory)) {
+				return !negated;
+			}
+			return current;
+		}
+
+		private boolean matches(String path, boolean isDirectory) {
+			if (directoryOnly && !isDirectory) {
+				return false;
+			}
+			return pattern.matcher(path).matches();
+		}
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRule.java
@@ -1,0 +1,91 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * Enforcer rule that fails the build when {@code .gitignore} does not cover the
+ * personal Claude Code settings file. {@code .claude/settings.local.json} holds
+ * per-developer overrides — extra permissions, local hooks — and committing it
+ * imposes one developer's choices on the whole team, so the durable guard is a
+ * gitignore entry that keeps it out of the repository in the first place.
+ * <p>
+ * The rule parses the configured {@code gitignoreFile} and verifies each path
+ * in {@code ignoredPaths} (by default just
+ * {@code .claude/settings.local.json}) is matched by it, honouring negations,
+ * anchoring, directory patterns, and {@code *}/{@code ?}/{@code **} globs. A
+ * path can be covered by any equivalent pattern — the exact path, a
+ * {@code *.local.json} glob, or an ignored ancestor directory. All uncovered
+ * paths are reported together.
+ */
+@Named("localSettingsIgnored")
+public class LocalSettingsIgnoredRule extends ClaudeCodeEnforcerRule {
+
+	private static final List<String> DEFAULT_IGNORED_PATHS = List.of(".claude/settings.local.json");
+
+	/** The {@code .gitignore} to check, normally the repository root's. Injected from the rule configuration. */
+	private File gitignoreFile;
+
+	/** Optional override for the repository-relative paths that must be ignored. */
+	private List<String> ignoredPaths;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		requireConfigured(gitignoreFile, "gitignoreFile");
+		requireExists(gitignoreFile, ".gitignore");
+		Gitignore gitignore = Gitignore.parse(MarkdownText.read(gitignoreFile, ".gitignore"));
+		List<String> violations = new ArrayList<>();
+		for (String path : ignoredPaths()) {
+			collectUncoveredPath(gitignore, path, violations);
+		}
+		report("Local settings are not ignored:", violations);
+	}
+
+	@Override
+	protected List<String> howToFix() {
+		return List.of(
+				"Open " + gitignoreFile + ".",
+				"Add a line covering each path listed above, e.g. the path itself verbatim.",
+				"If the file was already committed, remove it from the index with 'git rm --cached <path>'.",
+				"Re-run the build to confirm the local settings stay out of the repository.");
+	}
+
+	private void collectUncoveredPath(Gitignore gitignore, String path, List<String> violations) {
+		String normalized = normalized(path);
+		if (!gitignore.covers(normalized)) {
+			violations.add(gitignoreFile + " does not cover: " + normalized);
+		}
+	}
+
+	/** Normalises a configured path to the {@code /}-separated, unanchored form the matcher expects. */
+	private String normalized(String path) {
+		String slashed = path.replace('\\', '/');
+		String withoutDot = slashed.startsWith("./") ? slashed.substring(2) : slashed;
+		return withoutDot.startsWith("/") ? withoutDot.substring(1) : withoutDot;
+	}
+
+	private List<String> ignoredPaths() {
+		return ignoredPaths != null ? ignoredPaths : DEFAULT_IGNORED_PATHS;
+	}
+
+	void setGitignoreFile(File gitignoreFile) {
+		this.gitignoreFile = gitignoreFile;
+	}
+
+	void setIgnoredPaths(List<String> ignoredPaths) {
+		this.ignoredPaths = ignoredPaths;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("LocalSettingsIgnoredRule[gitignoreFile=%s]", gitignoreFile);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
@@ -1,0 +1,235 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import javax.inject.Named;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
+import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+
+/**
+ * Enforcer rule that validates the entries of the {@code permissions} lists in
+ * {@code .claude/settings.json}. Where {@link SettingsJsonValidRule} asserts
+ * policy (which entries must or must not be present), this rule validates the
+ * entries themselves: every value in {@code allow}, {@code deny}, and
+ * {@code ask} must be a non-blank string of the form {@code Tool} or
+ * {@code Tool(specifier)}, because a malformed entry such as {@code Bash(mvn *}
+ * grants nothing and fails silently at runtime. A duplicated entry within a
+ * list and an entry that appears in both {@code allow} and {@code deny} are
+ * reported too, since the contradiction means one of the two is not doing what
+ * its author intended.
+ * <p>
+ * When {@code allowedTools} is configured, the tool-name part of every entry
+ * must be in that list, so a typo such as {@code Bsah(mvn *)} cannot slip
+ * through; entries naming MCP tools (prefixed {@code mcp__}) are exempt because
+ * their names are defined by the project's servers, not by Claude Code. When
+ * {@code forbiddenEntryPatterns} is configured, an {@code allow} entry matching
+ * any of the regular expressions is reported, so an over-broad grant such as
+ * {@code Bash(*)} can be banned by shape rather than by exact spelling.
+ * <p>
+ * A settings file without a {@code permissions} section passes, since there is
+ * nothing to validate. All problems found are reported together.
+ */
+@Named("permissionsFormat")
+public class PermissionsFormatRule extends JsonFileRule {
+
+	private static final String PERMISSIONS_KEY = "permissions";
+	private static final String ALLOW_KEY = "allow";
+	private static final String DENY_KEY = "deny";
+	private static final List<String> LIST_KEYS = List.of(ALLOW_KEY, DENY_KEY, "ask");
+	private static final Pattern ENTRY_SYNTAX = Pattern.compile("[A-Za-z][A-Za-z0-9_]*(\\(.+\\))?");
+	private static final String MCP_TOOL_PREFIX = "mcp__";
+
+	/** The {@code .claude/settings.json} file to validate. Injected from the rule configuration. */
+	private File settingsFile;
+
+	/** Optional whitelist of tool names an entry may reference. When set, unknown tools are reported. */
+	private List<String> allowedTools;
+
+	/** Optional regular expressions no {@code allow} entry may match, e.g. {@code Bash\(\*\)}. */
+	private List<String> forbiddenEntryPatterns;
+
+	@Override
+	protected File jsonFile() {
+		return settingsFile;
+	}
+
+	@Override
+	protected String fileParameter() {
+		return "settingsFile";
+	}
+
+	@Override
+	protected String description() {
+		return "settings.json";
+	}
+
+	@Override
+	protected String header() {
+		return "settings.json permissions are not well formed:";
+	}
+
+	@Override
+	protected void collectViolations(JsonNode settings, List<String> violations) {
+		if (!settings.has(PERMISSIONS_KEY)) {
+			return;
+		}
+		JsonNode permissions = JsonNodes.objectAt(settings, PERMISSIONS_KEY);
+		if (permissions == null) {
+			violations.add("settings.json 'permissions' must be a JSON object");
+		} else {
+			collectListViolations(permissions, violations);
+		}
+	}
+
+	private void collectListViolations(JsonNode permissions, List<String> violations) {
+		for (String key : LIST_KEYS) {
+			collectSingleListViolations(permissions, key, violations);
+		}
+		collectContradictions(permissions, violations);
+		collectForbiddenEntries(permissions, violations);
+	}
+
+	private void collectSingleListViolations(JsonNode permissions, String key, List<String> violations) {
+		if (!permissions.has(key)) {
+			return;
+		}
+		JsonNode list = JsonNodes.arrayAt(permissions, key);
+		if (list == null) {
+			violations.add("settings.json 'permissions." + key + "' must be an array");
+		} else {
+			collectEntryViolations(list, key, violations);
+		}
+	}
+
+	private void collectEntryViolations(JsonNode list, String key, List<String> violations) {
+		Set<String> seen = new LinkedHashSet<>();
+		for (int i = 0; i < list.size(); i++) {
+			collectEntryViolations(list.get(i), key, i, seen, violations);
+		}
+	}
+
+	private void collectEntryViolations(JsonNode entry, String key, int index, Set<String> seen,
+			List<String> violations) {
+		if (!entry.isTextual()) {
+			violations.add("settings.json 'permissions." + key + "' entry " + (index + 1) + " must be a string");
+			return;
+		}
+		String value = entry.asText();
+		collectSyntaxViolations(value, key, violations);
+		collectDuplicateViolation(value, key, seen, violations);
+		collectUnknownToolViolation(value, key, violations);
+	}
+
+	private void collectSyntaxViolations(String value, String key, List<String> violations) {
+		if (value.isBlank()) {
+			violations.add("settings.json 'permissions." + key + "' contains a blank entry");
+		} else if (!ENTRY_SYNTAX.matcher(value).matches()) {
+			violations.add("settings.json 'permissions." + key + "' entry '" + value
+					+ "' is not of the form Tool or Tool(specifier)");
+		} else if (specifierOf(value).isBlank() && value.contains("(")) {
+			violations.add("settings.json 'permissions." + key + "' entry '" + value + "' has a blank specifier");
+		}
+	}
+
+	private void collectDuplicateViolation(String value, String key, Set<String> seen, List<String> violations) {
+		if (!seen.add(value)) {
+			violations.add("settings.json 'permissions." + key + "' lists '" + value + "' more than once");
+		}
+	}
+
+	private void collectUnknownToolViolation(String value, String key, List<String> violations) {
+		if (allowedTools == null || value.isBlank()) {
+			return;
+		}
+		String tool = toolNameOf(value);
+		if (!tool.startsWith(MCP_TOOL_PREFIX) && !allowedTools.contains(tool)) {
+			violations.add("settings.json 'permissions." + key + "' entry '" + value
+					+ "' references unknown tool '" + tool + "'");
+		}
+	}
+
+	private void collectContradictions(JsonNode permissions, List<String> violations) {
+		Set<String> denied = textEntries(permissions, DENY_KEY);
+		for (String entry : textEntries(permissions, ALLOW_KEY)) {
+			addContradictionViolation(entry, denied, violations);
+		}
+	}
+
+	private void addContradictionViolation(String entry, Set<String> denied, List<String> violations) {
+		if (denied.contains(entry)) {
+			violations.add("settings.json permission '" + entry + "' appears in both 'allow' and 'deny'");
+		}
+	}
+
+	private void collectForbiddenEntries(JsonNode permissions, List<String> violations) {
+		if (forbiddenEntryPatterns == null) {
+			return;
+		}
+		List<Pattern> patterns = forbiddenEntryPatterns.stream().map(Pattern::compile).toList();
+		for (String entry : textEntries(permissions, ALLOW_KEY)) {
+			addForbiddenEntryViolations(entry, patterns, violations);
+		}
+	}
+
+	private void addForbiddenEntryViolations(String entry, List<Pattern> patterns, List<String> violations) {
+		for (Pattern pattern : patterns) {
+			if (pattern.matcher(entry).matches()) {
+				violations.add("settings.json 'permissions.allow' entry '" + entry
+						+ "' matches forbidden pattern '" + pattern + "'");
+			}
+		}
+	}
+
+	private Set<String> textEntries(JsonNode permissions, String key) {
+		JsonNode list = JsonNodes.arrayAt(permissions, key);
+		Set<String> entries = new LinkedHashSet<>();
+		int size = list != null ? list.size() : 0;
+		for (int i = 0; i < size; i++) {
+			addTextEntry(list.get(i), entries);
+		}
+		return entries;
+	}
+
+	private void addTextEntry(JsonNode entry, Set<String> entries) {
+		if (entry.isTextual()) {
+			entries.add(entry.asText());
+		}
+	}
+
+	/** The specifier between the parentheses, or the whole value when there are none. */
+	private String specifierOf(String value) {
+		int open = value.indexOf('(');
+		return open < 0 ? value : value.substring(open + 1, value.length() - 1);
+	}
+
+	/** The tool-name part of an entry: everything before the opening parenthesis. */
+	private String toolNameOf(String value) {
+		int open = value.indexOf('(');
+		return open < 0 ? value : value.substring(0, open);
+	}
+
+	void setSettingsFile(File settingsFile) {
+		this.settingsFile = settingsFile;
+	}
+
+	void setAllowedTools(List<String> allowedTools) {
+		this.allowedTools = allowedTools;
+	}
+
+	void setForbiddenEntryPatterns(List<String> forbiddenEntryPatterns) {
+		this.forbiddenEntryPatterns = forbiddenEntryPatterns;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("PermissionsFormatRule[settingsFile=%s]", settingsFile);
+	}
+}

--- a/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -12,3 +12,10 @@ io.github.adamw7.tools.enforcer.definition.UniqueNamesRule
 io.github.adamw7.tools.enforcer.settings.HooksFormatRule
 io.github.adamw7.tools.enforcer.mcp.McpConfigFormatRule
 io.github.adamw7.tools.enforcer.definition.UniqueDescriptionsRule
+io.github.adamw7.tools.enforcer.settings.PermissionsFormatRule
+io.github.adamw7.tools.enforcer.doc.MemoryImportsRule
+io.github.adamw7.tools.enforcer.secret.NoSecretsRule
+io.github.adamw7.tools.enforcer.doc.ContextBudgetRule
+io.github.adamw7.tools.enforcer.settings.LocalSettingsIgnoredRule
+io.github.adamw7.tools.enforcer.doc.ModuleMapConsistencyRule
+io.github.adamw7.tools.enforcer.definition.PluginFormatRule

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
@@ -40,12 +40,14 @@ public class EnforcerArchitectureTest {
 			.layer("Definition").definedBy("..enforcer.definition..")
 			.layer("Doc").definedBy("..enforcer.doc..")
 			.layer("Mcp").definedBy("..enforcer.mcp..")
+			.layer("Secret").definedBy("..enforcer.secret..")
 			.layer("Settings").definedBy("..enforcer.settings..")
 			.whereLayer("Text").mayNotAccessAnyLayer()
 			.whereLayer("Rule").mayOnlyAccessLayers("Text")
 			.whereLayer("Definition").mayOnlyAccessLayers("Rule", "Text")
 			.whereLayer("Doc").mayOnlyAccessLayers("Rule", "Text")
 			.whereLayer("Mcp").mayOnlyAccessLayers("Rule", "Text")
+			.whereLayer("Secret").mayOnlyAccessLayers("Rule", "Text")
 			.whereLayer("Settings").mayOnlyAccessLayers("Rule", "Text")
 			.as("text is the foundation, rule builds on it, and the feature packages "
 					+ "build on rule without depending on each other");

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRuleTest.java
@@ -1,0 +1,121 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PluginFormatRuleTest {
+
+	private static final String VALID_MANIFEST = """
+			{
+			  "name": "my-plugin",
+			  "version": "1.2.3",
+			  "description": "Does useful things."
+			}
+			""";
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesForAValidManifest() {
+		assertDoesNotThrow(ruleFor(VALID_MANIFEST)::execute);
+	}
+
+	@Test
+	void passesWhenTheManifestIsAbsent() {
+		PluginFormatRule rule = new PluginFormatRule();
+		rule.setPluginFile(tempDir.resolve("absent.json").toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new PluginFormatRule()::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheManifestIsMalformedJson() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("{ \"name\": ")::execute);
+		assertTrue(exception.getMessage().contains("not valid JSON"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenARequiredKeyIsMissing() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"version\": \"1.0.0\" }")::execute);
+		assertTrue(exception.getMessage().contains("missing required key 'name'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheNameBreaksConvention() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"name\": \"My Plugin\" }")::execute);
+		assertTrue(exception.getMessage().contains("lower-case kebab-case"), exception.getMessage());
+	}
+
+	@Test
+	void failsForAMalformedVersion() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"name\": \"my-plugin\", \"version\": \"one\" }")::execute);
+		assertTrue(exception.getMessage().contains("not a dotted version number"), exception.getMessage());
+	}
+
+	@Test
+	void allowsAPreReleaseVersionSuffix() {
+		assertDoesNotThrow(ruleFor("{ \"name\": \"my-plugin\", \"version\": \"1.0.0-beta.1\" }")::execute);
+	}
+
+	@Test
+	void failsForABlankDescription() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"name\": \"my-plugin\", \"description\": \"  \" }")::execute);
+		assertTrue(exception.getMessage().contains("description must not be empty"), exception.getMessage());
+	}
+
+	@Test
+	void reportsUnknownKeysWhenAllowedKeysIsConfigured() {
+		PluginFormatRule rule = ruleFor("{ \"name\": \"my-plugin\", \"descripton\": \"typo\" }");
+		rule.setAllowedKeys(List.of("name", "version", "description", "author"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("unknown key 'descripton'"), exception.getMessage());
+	}
+
+	@Test
+	void supportsCustomRequiredKeys() {
+		PluginFormatRule rule = ruleFor("{ \"name\": \"my-plugin\" }");
+		rule.setRequiredKeys(List.of("name", "description"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing required key 'description'"), exception.getMessage());
+	}
+
+	private PluginFormatRule ruleFor(String content) {
+		Path file = tempDir.resolve("plugin.json");
+		writeString(file, content);
+		PluginFormatRule rule = new PluginFormatRule();
+		rule.setPluginFile(file.toFile());
+		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
@@ -1,0 +1,121 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ContextBudgetRuleTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesWhenTheFileFitsTheBudget() {
+		ContextBudgetRule rule = ruleForFile("# CLAUDE.md\n\nShort.\n");
+		rule.setMaxBytes(1000);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenNoLimitIsConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleForFile("content")::execute);
+		assertTrue(exception.getMessage().contains("maxBytes, maxLines, or maxTokens"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenNoTargetsAreConfigured() {
+		ContextBudgetRule rule = new ContextBudgetRule();
+		rule.setMaxBytes(1000);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("files or directories"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAConfiguredFileIsMissing() {
+		ContextBudgetRule rule = new ContextBudgetRule();
+		rule.setMaxBytes(1000);
+		rule.setFiles(List.of(tempDir.resolve("absent.md").toFile()));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheByteBudgetIsExceeded() {
+		ContextBudgetRule rule = ruleForFile("x".repeat(100));
+		rule.setMaxBytes(50);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("over the 50-byte budget"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheLineBudgetIsExceeded() {
+		ContextBudgetRule rule = ruleForFile("one\ntwo\nthree\n");
+		rule.setMaxLines(2);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("over the 2-line budget"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheTokenBudgetIsExceeded() {
+		ContextBudgetRule rule = ruleForFile("x".repeat(100));
+		rule.setMaxTokens(10);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("estimated 25 tokens, over the 10-token budget"),
+				exception.getMessage());
+	}
+
+	@Test
+	void measuresMarkdownFilesUnderDirectories() {
+		writeString(tempDir.resolve("skills/big/SKILL.md"), "x".repeat(100));
+		ContextBudgetRule rule = new ContextBudgetRule();
+		rule.setDirectories(List.of(tempDir.resolve("skills").toFile()));
+		rule.setMaxBytes(50);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("SKILL.md"), exception.getMessage());
+	}
+
+	@Test
+	void skipsNonMarkdownFilesAndAbsentDirectories() {
+		writeString(tempDir.resolve("skills/big/data.json"), "x".repeat(100));
+		ContextBudgetRule rule = new ContextBudgetRule();
+		rule.setDirectories(List.of(tempDir.resolve("skills").toFile(), tempDir.resolve("absent").toFile()));
+		rule.setMaxBytes(50);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	private ContextBudgetRule ruleForFile(String content) {
+		Path file = tempDir.resolve("CLAUDE.md");
+		writeString(file, content);
+		ContextBudgetRule rule = new ContextBudgetRule();
+		rule.setFiles(List.of(file.toFile()));
+		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
@@ -1,0 +1,141 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MemoryImportsRuleTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesWhenThereAreNoImports() {
+		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nNo imports here.\n")::execute);
+	}
+
+	@Test
+	void passesWhenImportsResolve() {
+		writeString(tempDir.resolve("docs.md"), "# Docs\n");
+		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nSee @docs.md for details.\n")::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new MemoryImportsRule()::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheFileIsMissing() {
+		MemoryImportsRule rule = new MemoryImportsRule();
+		rule.setClaudeMdFile(tempDir.resolve("absent.md").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsForAMissingImportTarget() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("# CLAUDE.md\n\nSee @docs/absent.md\n")::execute);
+		assertTrue(exception.getMessage().contains("imports a missing file: @docs/absent.md"),
+				exception.getMessage());
+	}
+
+	@Test
+	void dropsSentencePunctuationFromTheImportPath() {
+		writeString(tempDir.resolve("docs.md"), "# Docs\n");
+		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nSee @docs.md.\n")::execute);
+	}
+
+	@Test
+	void ignoresImportsInFencedCodeBlocks() {
+		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\n```\n@docs/absent.md\n```\n")::execute);
+	}
+
+	@Test
+	void ignoresImportsInInlineCodeSpans() {
+		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nan `@claude`-mention workflow\n")::execute);
+	}
+
+	@Test
+	void ignoresTokensNotPrecededByWhitespace() {
+		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nMail adam@example.com about it.\n")::execute);
+	}
+
+	@Test
+	void ignoresHomeRelativeImports() {
+		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nAlso @~/personal/prefs.md is loaded.\n")::execute);
+	}
+
+	@Test
+	void skipsExplicitlyIgnoredImports() {
+		MemoryImportsRule rule = ruleFor("# CLAUDE.md\n\nSee @docs/absent.md\n");
+		rule.setIgnoredImports(List.of("docs/absent.md"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void followsImportsRecursively() {
+		writeString(tempDir.resolve("first.md"), "See @second.md\n");
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("# CLAUDE.md\n\nSee @first.md\n")::execute);
+		assertTrue(exception.getMessage().contains("imports a missing file: @second.md"), exception.getMessage());
+	}
+
+	@Test
+	void failsForACircularImport() {
+		writeString(tempDir.resolve("loop.md"), "Back to @CLAUDE.md\n");
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("# CLAUDE.md\n\nSee @loop.md\n")::execute);
+		assertTrue(exception.getMessage().contains("circular import: @CLAUDE.md"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheChainExceedsMaxDepth() {
+		writeString(tempDir.resolve("first.md"), "See @second.md\n");
+		writeString(tempDir.resolve("second.md"), "# Deep\n");
+		MemoryImportsRule rule = ruleFor("# CLAUDE.md\n\nSee @first.md\n");
+		rule.setMaxDepth(1);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("nested deeper than 1 hops"), exception.getMessage());
+	}
+
+	@Test
+	void resolvesImportsRelativeToTheImportingFile() {
+		Path nested = tempDir.resolve("docs");
+		writeString(nested.resolve("inner.md"), "See @sibling.md\n");
+		writeString(nested.resolve("sibling.md"), "# Sibling\n");
+		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nSee @docs/inner.md\n")::execute);
+	}
+
+	private MemoryImportsRule ruleFor(String content) {
+		Path file = tempDir.resolve("CLAUDE.md");
+		writeString(file, content);
+		MemoryImportsRule rule = new MemoryImportsRule();
+		rule.setClaudeMdFile(file.toFile());
+		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRuleTest.java
@@ -1,0 +1,113 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ModuleMapConsistencyRuleTest {
+
+	private static final String POM = """
+			<project>
+			  <modules>
+			    <module>data</module>
+			    <module>code/context</module>
+			    <!-- <module>disabled</module> -->
+			  </modules>
+			</project>
+			""";
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesWhenEveryModuleIsMentioned() {
+		assertDoesNotThrow(ruleFor(POM, "The data module and the context module.\n")::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				new ModuleMapConsistencyRule()::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenDocFilesIsEmpty() {
+		ModuleMapConsistencyRule rule = new ModuleMapConsistencyRule();
+		rule.setPomFile(write("pom.xml", POM).toFile());
+		rule.setDocFiles(List.of());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("at least one file"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenThePomDeclaresNoModules() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("<project></project>", "docs")::execute);
+		assertTrue(exception.getMessage().contains("declares no <module> entries"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAModuleIsNotMentioned() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor(POM, "Only the data module.\n")::execute);
+		assertTrue(exception.getMessage().contains("does not mention module 'context'"), exception.getMessage());
+	}
+
+	@Test
+	void looksUpANestedModuleByItsLastSegment() {
+		assertDoesNotThrow(ruleFor(POM, "data and context are documented.\n")::execute);
+	}
+
+	@Test
+	void ignoresCommentedOutModules() {
+		assertDoesNotThrow(ruleFor(POM, "data and context, but never the disabled one by name.\n")::execute);
+	}
+
+	@Test
+	void skipsIgnoredModules() {
+		ModuleMapConsistencyRule rule = ruleFor(POM, "Only the data module.\n");
+		rule.setIgnoredModules(List.of("context"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void checksEveryConfiguredDoc() {
+		ModuleMapConsistencyRule rule = ruleFor(POM, "The data module and the context module.\n");
+		Path second = write("README.md", "Only data here.\n");
+		rule.setDocFiles(List.of(tempDir.resolve("CLAUDE.md").toFile(), second.toFile()));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("README.md"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("'context'"), exception.getMessage());
+	}
+
+	private ModuleMapConsistencyRule ruleFor(String pomContent, String docContent) {
+		ModuleMapConsistencyRule rule = new ModuleMapConsistencyRule();
+		rule.setPomFile(write("pom.xml", pomContent).toFile());
+		rule.setDocFiles(List.of(write("CLAUDE.md", docContent).toFile()));
+		return rule;
+	}
+
+	private Path write(String name, String content) {
+		Path file = tempDir.resolve(name);
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+		return file;
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRuleTest.java
@@ -1,0 +1,126 @@
+package io.github.adamw7.tools.enforcer.secret;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class NoSecretsRuleTest {
+
+	private static final String ANTHROPIC_KEY = "sk-ant-api03-abcdefghijklmnop";
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesForACleanFile() {
+		assertDoesNotThrow(ruleForFile("{ \"env\": { \"API_KEY\": \"${API_KEY}\" } }")::execute);
+	}
+
+	@Test
+	void passesWhenTheFileIsAbsent() {
+		NoSecretsRule rule = new NoSecretsRule();
+		rule.setFiles(List.of(tempDir.resolve("absent.json").toFile()));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenNoTargetsAreConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new NoSecretsRule()::execute);
+		assertTrue(exception.getMessage().contains("files or directories"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenThereAreNoPatternsToScanFor() {
+		NoSecretsRule rule = ruleForFile("clean");
+		rule.setUseDefaultPatterns(false);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("secretPatterns"), exception.getMessage());
+	}
+
+	@Test
+	void failsForAnAnthropicKey() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleForFile("{ \"env\": { \"KEY\": \"" + ANTHROPIC_KEY + "\" } }")::execute);
+		assertTrue(exception.getMessage().contains("Anthropic API key"), exception.getMessage());
+	}
+
+	@Test
+	void reportsTheLineWithoutEchoingTheSecret() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleForFile("first line\nkey = " + ANTHROPIC_KEY + "\n")::execute);
+		assertTrue(exception.getMessage().contains("line 2"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("sk-ant-a..."), exception.getMessage());
+		assertFalse(exception.getMessage().contains(ANTHROPIC_KEY), exception.getMessage());
+	}
+
+	@Test
+	void failsForAGithubToken() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleForFile("token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij")::execute);
+		assertTrue(exception.getMessage().contains("GitHub token"), exception.getMessage());
+	}
+
+	@Test
+	void failsForAPrivateKeyBlock() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleForFile("-----BEGIN RSA PRIVATE KEY-----")::execute);
+		assertTrue(exception.getMessage().contains("private key block"), exception.getMessage());
+	}
+
+	@Test
+	void scansDirectoriesRecursively() {
+		writeString(tempDir.resolve("hooks/nested/script.sh"), "export KEY=" + ANTHROPIC_KEY + "\n");
+		NoSecretsRule rule = new NoSecretsRule();
+		rule.setDirectories(List.of(tempDir.resolve("hooks").toFile()));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("script.sh"), exception.getMessage());
+	}
+
+	@Test
+	void skipsAnAbsentDirectory() {
+		NoSecretsRule rule = new NoSecretsRule();
+		rule.setDirectories(List.of(tempDir.resolve("absent").toFile()));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void scansCustomPatterns() {
+		NoSecretsRule rule = ruleForFile("password = hunter2");
+		rule.setSecretPatterns(List.of("password\\s*=\\s*\\S+"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("password"), exception.getMessage());
+	}
+
+	private NoSecretsRule ruleForFile(String content) {
+		Path file = tempDir.resolve("settings.json");
+		writeString(file, content);
+		NoSecretsRule rule = new NoSecretsRule();
+		rule.setFiles(List.of(file.toFile()));
+		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/GitignoreTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/GitignoreTest.java
@@ -1,0 +1,84 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class GitignoreTest {
+
+	@Test
+	void matchesAVerbatimPath() {
+		assertTrue(Gitignore.parse(".claude/settings.local.json").covers(".claude/settings.local.json"));
+	}
+
+	@Test
+	void aPatternWithoutASlashMatchesAtAnyDepth() {
+		assertTrue(Gitignore.parse("settings.local.json").covers(".claude/settings.local.json"));
+	}
+
+	@Test
+	void aPatternWithASlashIsAnchoredToTheRoot() {
+		Gitignore gitignore = Gitignore.parse("claude/settings.local.json");
+		assertFalse(gitignore.covers("nested/claude/settings.local.json"));
+		assertTrue(gitignore.covers("claude/settings.local.json"));
+	}
+
+	@Test
+	void aLeadingSlashAnchorsToTheRoot() {
+		Gitignore gitignore = Gitignore.parse("/derby.log");
+		assertTrue(gitignore.covers("derby.log"));
+		assertFalse(gitignore.covers("data/derby.log"));
+	}
+
+	@Test
+	void starDoesNotCrossSegments() {
+		Gitignore gitignore = Gitignore.parse(".claude/*.json");
+		assertTrue(gitignore.covers(".claude/settings.json"));
+		assertFalse(gitignore.covers(".claude/nested/deep.json"));
+	}
+
+	@Test
+	void starMatchesADirectoryAndSoCoversEverythingBeneathIt() {
+		assertTrue(Gitignore.parse(".claude/*").covers(".claude/nested/deep.json"));
+	}
+
+	@Test
+	void doubleStarCrossesSegments() {
+		assertTrue(Gitignore.parse("**/settings.local.json").covers(".claude/settings.local.json"));
+		assertTrue(Gitignore.parse(".claude/**").covers(".claude/nested/deep.json"));
+	}
+
+	@Test
+	void questionMarkMatchesASingleCharacter() {
+		Gitignore gitignore = Gitignore.parse("file?.txt");
+		assertTrue(gitignore.covers("file1.txt"));
+		assertFalse(gitignore.covers("file12.txt"));
+	}
+
+	@Test
+	void aDirectoryPatternCoversFilesBeneathIt() {
+		Gitignore gitignore = Gitignore.parse("target/");
+		assertTrue(gitignore.covers("target/classes/App.class"));
+		assertFalse(gitignore.covers("target"));
+	}
+
+	@Test
+	void commentsAndBlankLinesAreSkipped() {
+		assertFalse(Gitignore.parse("# a comment\n\n").covers("a comment"));
+	}
+
+	@Test
+	void aLaterNegationWins() {
+		Gitignore gitignore = Gitignore.parse(".mvn/*\n!.mvn/maven.config");
+		assertTrue(gitignore.covers(".mvn/extensions.xml"));
+		assertFalse(gitignore.covers(".mvn/maven.config"));
+	}
+
+	@Test
+	void thisRepositoriesGitignoreShapeCoversTheLocalSettings() {
+		Gitignore gitignore = Gitignore.parse("target/\n*.log\n\n.idea/\n\n.claude/settings.local.json");
+		assertTrue(gitignore.covers(".claude/settings.local.json"));
+		assertFalse(gitignore.covers(".claude/settings.json"));
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRuleTest.java
@@ -1,0 +1,92 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LocalSettingsIgnoredRuleTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesForAVerbatimEntry() {
+		assertDoesNotThrow(ruleFor(".claude/settings.local.json\n")::execute);
+	}
+
+	@Test
+	void passesForABasenameGlob() {
+		assertDoesNotThrow(ruleFor("*.local.json\n")::execute);
+	}
+
+	@Test
+	void passesForAnIgnoredAncestorDirectory() {
+		assertDoesNotThrow(ruleFor(".claude/\n")::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				new LocalSettingsIgnoredRule()::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheGitignoreIsMissing() {
+		LocalSettingsIgnoredRule rule = new LocalSettingsIgnoredRule();
+		rule.setGitignoreFile(tempDir.resolve("absent").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenThePathIsNotCovered() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("target/\n*.log\n")::execute);
+		assertTrue(exception.getMessage().contains("does not cover: .claude/settings.local.json"),
+				exception.getMessage());
+	}
+
+	@Test
+	void failsWhenANegationReincludesThePath() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("*.local.json\n!settings.local.json\n")::execute);
+		assertTrue(exception.getMessage().contains("does not cover"), exception.getMessage());
+	}
+
+	@Test
+	void checksEveryConfiguredPath() {
+		LocalSettingsIgnoredRule rule = ruleFor(".claude/settings.local.json\n");
+		rule.setIgnoredPaths(List.of("./.claude/settings.local.json", ".env"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("does not cover: .env"), exception.getMessage());
+	}
+
+	private LocalSettingsIgnoredRule ruleFor(String gitignoreContent) {
+		Path file = tempDir.resolve(".gitignore");
+		writeString(file, gitignoreContent);
+		LocalSettingsIgnoredRule rule = new LocalSettingsIgnoredRule();
+		rule.setGitignoreFile(file.toFile());
+		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRuleTest.java
@@ -1,0 +1,157 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PermissionsFormatRuleTest {
+
+	private static final String VALID_SETTINGS = """
+			{
+			  "permissions": {
+			    "allow": [ "Bash(mvn *)", "Edit" ],
+			    "deny": [ "WebFetch" ],
+			    "ask": [ "Write" ]
+			  }
+			}
+			""";
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesForWellFormedPermissions() {
+		assertDoesNotThrow(ruleFor(VALID_SETTINGS)::execute);
+	}
+
+	@Test
+	void passesWhenPermissionsSectionIsAbsent() {
+		assertDoesNotThrow(ruleFor("{ \"env\": {} }")::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				new PermissionsFormatRule()::execute);
+		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenPermissionsIsNotAnObject() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": [] }")::execute);
+		assertTrue(exception.getMessage().contains("must be a JSON object"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAListIsNotAnArray() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": { \"allow\": \"Edit\" } }")::execute);
+		assertTrue(exception.getMessage().contains("'permissions.allow' must be an array"), exception.getMessage());
+	}
+
+	@Test
+	void failsForANonStringEntry() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": { \"allow\": [ 42 ] } }")::execute);
+		assertTrue(exception.getMessage().contains("entry 1 must be a string"), exception.getMessage());
+	}
+
+	@Test
+	void failsForABlankEntry() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": { \"ask\": [ \"  \" ] } }")::execute);
+		assertTrue(exception.getMessage().contains("blank entry"), exception.getMessage());
+	}
+
+	@Test
+	void failsForMalformedEntrySyntax() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": { \"allow\": [ \"Bash(mvn *\" ] } }")::execute);
+		assertTrue(exception.getMessage().contains("not of the form Tool or Tool(specifier)"),
+				exception.getMessage());
+	}
+
+	@Test
+	void failsForABlankSpecifier() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": { \"allow\": [ \"Bash( )\" ] } }")::execute);
+		assertTrue(exception.getMessage().contains("blank specifier"), exception.getMessage());
+	}
+
+	@Test
+	void failsForADuplicateEntry() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": { \"allow\": [ \"Edit\", \"Edit\" ] } }")::execute);
+		assertTrue(exception.getMessage().contains("lists 'Edit' more than once"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAnEntryIsBothAllowedAndDenied() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": { \"allow\": [ \"Edit\" ], \"deny\": [ \"Edit\" ] } }")::execute);
+		assertTrue(exception.getMessage().contains("appears in both 'allow' and 'deny'"), exception.getMessage());
+	}
+
+	@Test
+	void failsForAnUnknownToolWhenAllowlistIsConfigured() {
+		PermissionsFormatRule rule = ruleFor("{ \"permissions\": { \"allow\": [ \"Bsah(mvn *)\" ] } }");
+		rule.setAllowedTools(List.of("Bash", "Edit"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("unknown tool 'Bsah'"), exception.getMessage());
+	}
+
+	@Test
+	void exemptsMcpToolsFromTheAllowlist() {
+		PermissionsFormatRule rule = ruleFor("{ \"permissions\": { \"allow\": [ \"mcp__github__get_me\" ] } }");
+		rule.setAllowedTools(List.of("Bash"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsForAForbiddenEntryPattern() {
+		PermissionsFormatRule rule = ruleFor("{ \"permissions\": { \"allow\": [ \"Bash(*)\" ] } }");
+		rule.setForbiddenEntryPatterns(List.of("Bash\\(\\*\\)"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("matches forbidden pattern"), exception.getMessage());
+	}
+
+	@Test
+	void reportsAllProblemsTogether() {
+		PermissionsFormatRule rule = ruleFor(
+				"{ \"permissions\": { \"allow\": [ \"Edit\", \"Edit\", \"Bash(mvn *\" ] } }");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("more than once"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("not of the form"), exception.getMessage());
+	}
+
+	private PermissionsFormatRule ruleFor(String content) {
+		Path file = tempDir.resolve("settings.json");
+		writeString(file, content);
+		PermissionsFormatRule rule = new PermissionsFormatRule();
+		rule.setSettingsFile(file.toFile());
+		return rule;
+	}
+
+	private static void writeString(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -642,6 +642,42 @@
 												<consistentPattern>proto(\d)</consistentPattern>
 											</consistentPatterns>
 										</readmeConsistency>
+										<permissionsFormat>
+											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
+										</permissionsFormat>
+										<memoryImports>
+											<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
+										</memoryImports>
+										<noSecrets>
+											<files>
+												<file>${project.basedir}/.claude/settings.json</file>
+												<file>${project.basedir}/.mcp.json</file>
+											</files>
+											<directories>
+												<directory>${project.basedir}/.claude/hooks</directory>
+											</directories>
+										</noSecrets>
+										<contextBudget>
+											<files>
+												<file>${project.basedir}/CLAUDE.md</file>
+											</files>
+											<!-- CLAUDE.md is loaded into every session; keep it a
+											     summary that defers to AGENTS.md rather than a copy. -->
+											<maxBytes>32768</maxBytes>
+										</contextBudget>
+										<localSettingsIgnored>
+											<gitignoreFile>${project.basedir}/.gitignore</gitignoreFile>
+										</localSettingsIgnored>
+										<moduleMapConsistency>
+											<pomFile>${project.basedir}/pom.xml</pomFile>
+											<docFiles>
+												<docFile>${project.basedir}/CLAUDE.md</docFile>
+												<docFile>${project.basedir}/AGENTS.md</docFile>
+											</docFiles>
+										</moduleMapConsistency>
+										<pluginFormat>
+											<pluginFile>${project.basedir}/.claude-plugin/plugin.json</pluginFile>
+										</pluginFormat>
 									</rules>
 								</configuration>
 							</execution>


### PR DESCRIPTION
New rules: permissionsFormat validates permissions.allow/deny/ask entry
syntax, duplicates, and allow/deny contradictions; memoryImports follows
CLAUDE.md @path imports and fails on missing targets, cycles, and chains
past the five-hop limit; noSecrets scans configuration and hook scripts
for credential shapes without echoing the match; contextBudget caps
context files by bytes, lines, or estimated tokens; localSettingsIgnored
verifies .gitignore covers .claude/settings.local.json; moduleMapConsistency
keeps the documented module map in step with the reactor's <module>
entries; pluginFormat validates a .claude-plugin/plugin.json manifest.

All seven are wired into the claude-md-enforce profile and documented in
AGENTS.md; the new secret package is pinned as a layer in the
architecture tests.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FUy4LvAkWkjJxKaAUV2EZe