### PR TITLE
fix(claude-code-enforcer): correct six false-verdict bugs across the rules

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRule.java
@@ -21,7 +21,7 @@ import io.github.adamw7.tools.enforcer.text.NameConvention;
  * default, overridable via {@code requiredKeys}); the {@code name} is held to
  * the Claude Code naming convention (lower-case kebab-case, at most
  * {@value NameConvention#MAX_LENGTH} characters), a {@code version} must be a
- * dotted number with an optional pre-release suffix, and a {@code description}
+ * dotted number with optional pre-release and build-metadata suffixes, and a {@code description}
  * must be non-empty. When {@code allowedKeys} is configured, any key outside
  * that set is reported, which catches typos such as {@code descripton}.
  * <p>
@@ -36,7 +36,9 @@ public class PluginFormatRule extends JsonFileRule {
 	private static final String VERSION_KEY = "version";
 	private static final String DESCRIPTION_KEY = "description";
 	private static final List<String> DEFAULT_REQUIRED_KEYS = List.of(NAME_KEY);
-	private static final Pattern VERSION = Pattern.compile("\\d+(\\.\\d+){0,2}([-+][A-Za-z0-9.-]+)?");
+
+	/** A dotted version with the optional semver pre-release and build-metadata suffixes, e.g. {@code 1.0.0-beta.1+build.5}. */
+	private static final Pattern VERSION = Pattern.compile("\\d+(\\.\\d+){0,2}(-[A-Za-z0-9.-]+)?(\\+[A-Za-z0-9.-]+)?");
 
 	/** The {@code .claude-plugin/plugin.json} manifest to validate. Injected from the rule configuration. */
 	private File pluginFile;

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -21,7 +21,9 @@ import io.github.adamw7.tools.enforcer.text.NameConvention;
  * YAML front matter block declaring every required key, and carry a {@code name}
  * that follows the Claude Code naming convention and matches its file name.
  * <p>
- * The required keys default to {@code name} and {@code description}. When
+ * The required keys default to {@code name} and {@code description}, and a
+ * declared {@code description} must be non-empty, because Claude routes to a
+ * sub-agent by matching intent against its description. When
  * {@code allowedModels} is configured and a definition declares a {@code model},
  * that model must be one of the allowed values, so a typo such as
  * {@code claud-opus} cannot slip through. An agents directory with no
@@ -80,6 +82,7 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 	private void collectFrontMatterViolations(File definition, FrontMatter frontMatter, List<String> violations) {
 		collectMissingKeys(definition, frontMatter, violations);
 		collectNameViolations(definition, frontMatter, violations);
+		collectDescriptionViolations(definition, frontMatter, violations);
 		ModelAllowlist.collect(allowedModels, frontMatter, "Sub-agent", definition, violations);
 	}
 
@@ -94,6 +97,17 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 	private void collectNameViolations(File definition, FrontMatter frontMatter, List<String> violations) {
 		frontMatter.value(NAME_KEY).ifPresent(
 				name -> NameConvention.collect(name, DefinitionFiles.baseName(definition), definition.toString(), violations));
+	}
+
+	private void collectDescriptionViolations(File definition, FrontMatter frontMatter, List<String> violations) {
+		frontMatter.value(DESCRIPTION_KEY).ifPresent(
+				description -> addDescriptionViolation(definition, description, violations));
+	}
+
+	private void addDescriptionViolation(File definition, String description, List<String> violations) {
+		if (description.isBlank()) {
+			violations.add("Sub-agent description must not be empty in: " + definition);
+		}
 	}
 
 	private List<String> requiredKeys() {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -34,10 +35,17 @@ final class HtmlReport {
 		this.howToFix = howToFix;
 	}
 
-	/** Writes the rendered report to {@code file}, failing the build if it cannot be written. */
+	/**
+	 * Writes the rendered report to {@code file}, failing the build if it cannot be
+	 * written. Missing parent directories are created first, because a report under
+	 * {@code target/} is typically written at {@code validate}, before any plugin
+	 * has created that directory.
+	 */
 	void writeTo(File file) throws EnforcerRuleException {
 		try {
-			Files.writeString(file.toPath(), render(), StandardCharsets.UTF_8);
+			Path path = file.toPath().toAbsolutePath();
+			Files.createDirectories(path.getParent());
+			Files.writeString(path, render(), StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new EnforcerRuleException("Could not write HTML report to " + file, e);
 		}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
@@ -23,13 +23,24 @@ final class ClaudeProjectDir {
 
 	/** The path {@code token} resolves to when it references the project dir, else null. */
 	String expand(String token) {
-		if (token.contains(BRACED)) {
-			return token.replace(BRACED, resolve().getPath());
+		String bare = withoutQuotes(token);
+		if (bare.contains(BRACED)) {
+			return bare.replace(BRACED, resolve().getPath());
 		}
-		if (token.contains(PLAIN)) {
-			return token.replace(PLAIN, resolve().getPath());
+		if (bare.contains(PLAIN)) {
+			return bare.replace(PLAIN, resolve().getPath());
 		}
 		return null;
+	}
+
+	/**
+	 * The token without shell quote characters, so a quoted
+	 * {@code "$CLAUDE_PROJECT_DIR/hook.sh"} resolves to the same on-disk path as
+	 * its unquoted spelling — the shell removes the quotes after expansion, and a
+	 * hook path never legitimately contains one.
+	 */
+	private String withoutQuotes(String token) {
+		return token.replace("\"", "").replace("'", "");
 	}
 
 	/** The configured override, else the settings file's grandparent, else the current directory. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
@@ -44,7 +44,14 @@ public class PermissionsFormatRule extends JsonFileRule {
 	private static final String ALLOW_KEY = "allow";
 	private static final String DENY_KEY = "deny";
 	private static final List<String> LIST_KEYS = List.of(ALLOW_KEY, DENY_KEY, "ask");
-	private static final Pattern ENTRY_SYNTAX = Pattern.compile("[A-Za-z][A-Za-z0-9_]*(\\(.+\\))?");
+
+	/**
+	 * A built-in tool name, or an {@code mcp__server__tool} name whose server and
+	 * tool parts may contain hyphens (e.g. {@code mcp__claude-code-remote__list_repos}),
+	 * each optionally followed by a parenthesised specifier.
+	 */
+	private static final Pattern ENTRY_SYNTAX = Pattern
+			.compile("(mcp__[A-Za-z0-9_-]+|[A-Za-z][A-Za-z0-9_]*)(\\(.+\\))?");
 	private static final String MCP_TOOL_PREFIX = "mcp__";
 
 	/** The {@code .claude/settings.json} file to validate. Injected from the rule configuration. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -27,19 +27,21 @@ public final class FrontMatter {
 	/**
 	 * Parses the front matter at the start of {@code content}, or returns empty
 	 * when the content does not begin with a closed {@code ---} delimited block.
-	 * A byte-order mark, if any, must already be stripped by the caller.
+	 * Claude Code only recognises a block whose opening delimiter is the very
+	 * first line, so content that reaches its {@code ---} after blank lines has
+	 * no front matter here either. A byte-order mark, if any, must already be
+	 * stripped by the caller.
 	 */
 	public static Optional<FrontMatter> parse(String content) {
 		List<String> allLines = content.lines().toList();
-		if (!MarkdownText.firstNonBlankLine(content).equals(DELIMITER)) {
+		if (allLines.isEmpty() || !allLines.get(0).strip().equals(DELIMITER)) {
 			return Optional.empty();
 		}
-		int start = indexOfDelimiter(allLines, 0);
-		int end = indexOfDelimiter(allLines, start + 1);
+		int end = indexOfDelimiter(allLines, 1);
 		if (end < 0) {
 			return Optional.empty();
 		}
-		return Optional.of(new FrontMatter(allLines.subList(start + 1, end)));
+		return Optional.of(new FrontMatter(allLines.subList(1, end)));
 	}
 
 	/** True when a {@code key:} entry is present, regardless of its value. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
@@ -6,22 +6,24 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 /**
- * Repairs the two unambiguous ways a Claude Code front matter block is commonly
+ * Repairs the unambiguous ways a Claude Code front matter block is commonly
  * malformed, so an auto-fixing rule can rewrite the file rather than only fail
  * the build:
  * <ul>
  * <li>a delimiter written with too many dashes, such as {@code ----}, which
- * {@link FrontMatter} does not recognise as the canonical {@code ---}; and</li>
+ * {@link FrontMatter} does not recognise as the canonical {@code ---};</li>
  * <li>an opening {@code ---} whose closing delimiter is missing, which leaves
- * the block unterminated.</li>
+ * the block unterminated; and</li>
+ * <li>blank lines before the opening delimiter, which Claude Code does not
+ * accept — the block must start on the first line.</li>
  * </ul>
  * <p>
  * The repair is deliberately conservative: it only acts when the document opens
- * with a dashes-only line and the region that would become the block actually
- * contains at least one {@code key: value} entry, so a lone {@code ---} thematic
- * break is never mistaken for front matter. A document whose front matter
- * already parses, or whose problem is not one of the two above, is left
- * untouched and reported by the rule as before.
+ * (past any leading blank lines) with a dashes-only line and the region that
+ * would become the block actually contains at least one {@code key: value}
+ * entry, so a lone {@code ---} thematic break is never mistaken for front
+ * matter. A document whose front matter already parses, or whose problem is not
+ * one of the above, is left untouched and reported by the rule as before.
  */
 public final class FrontMatterFixer {
 
@@ -48,7 +50,13 @@ public final class FrontMatterFixer {
 		if (open < 0 || !isDelimiterLike(lines.get(open))) {
 			return Optional.empty();
 		}
-		return repairFrom(lines, open).map(fixed -> render(fixed, content));
+		return repairFrom(lines, open).map(fixed -> render(withoutLeadingBlanks(fixed), content));
+	}
+
+	/** The lines with any blank lines before the opening delimiter removed, so the block starts on line one. */
+	private static List<String> withoutLeadingBlanks(List<String> lines) {
+		int first = firstNonBlankIndex(lines);
+		return first <= 0 ? lines : lines.subList(first, lines.size());
 	}
 
 	private static Optional<List<String>> repairFrom(List<String> lines, int open) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRuleTest.java
@@ -79,6 +79,11 @@ class PluginFormatRuleTest {
 	}
 
 	@Test
+	void allowsBuildMetadataAfterAPreReleaseSuffix() {
+		assertDoesNotThrow(ruleFor("{ \"name\": \"my-plugin\", \"version\": \"1.0.0-beta.1+build.5\" }")::execute);
+	}
+
+	@Test
 	void failsForABlankDescription() {
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
 				ruleFor("{ \"name\": \"my-plugin\", \"description\": \"  \" }")::execute);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
@@ -94,6 +94,20 @@ class SubAgentFormatRuleTest {
 	}
 
 	@Test
+	void failsWhenADescriptionIsBlank() {
+		writeString(tempDir.resolve("reviewer.md"), """
+				---
+				name: reviewer
+				description:
+				---
+				# Reviewer
+				""");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("description must not be empty"), exception.getMessage());
+	}
+
+	@Test
 	void failsWhenNameDoesNotMatchFileName() {
 		writeString(tempDir.resolve("reviewer.md"), """
 				---

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
@@ -108,8 +108,20 @@ class HtmlReportTest {
 	}
 
 	@Test
-	void failsWhenTheReportCannotBeWritten() {
-		File unwritable = tempDir.resolve("missing-dir").resolve("report.html").toFile();
+	void createsMissingParentDirectories() throws Exception {
+		// A report under target/ is typically written at validate, before any
+		// plugin has created that directory, so the writer must create it.
+		File report = tempDir.resolve("missing-dir").resolve("nested").resolve("report.html").toFile();
+
+		new HtmlReport("header", List.of("boom"), List.of("fix it")).writeTo(report);
+
+		assertTrue(Files.readString(report.toPath()).contains("boom"));
+	}
+
+	@Test
+	void failsWhenTheReportCannotBeWritten() throws Exception {
+		Files.writeString(tempDir.resolve("blocker"), "a file, not a directory");
+		File unwritable = tempDir.resolve("blocker").resolve("report.html").toFile();
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
 				() -> new HtmlReport("header", List.of("boom"), List.of("fix it")).writeTo(unwritable));

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -51,6 +51,27 @@ class HookCommandsValidRuleTest {
 	}
 
 	@Test
+	void passesWhenTheScriptReferenceIsQuoted() {
+		writeString(tempDir.resolve("session-start.sh"), "#!/bin/sh\necho hi\n");
+		HookCommandsValidRule rule = ruleFor(
+				hooksReferencing("\\\"$CLAUDE_PROJECT_DIR/session-start.sh\\\""));
+		rule.setProjectDir(tempDir.toFile());
+
+		// The shell removes the quotes after expansion, so a quoted reference
+		// points at the same existing script as its unquoted spelling.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenAQuotedScriptReferenceIsMissing() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("\\\"$CLAUDE_PROJECT_DIR/gone.sh\\\""));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("references a missing script"), exception.getMessage());
+	}
+
+	@Test
 	void failsWhenNotConfigured() {
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new HookCommandsValidRule()::execute);
 		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRuleTest.java
@@ -121,6 +121,17 @@ class PermissionsFormatRuleTest {
 	}
 
 	@Test
+	void acceptsHyphenatedMcpToolNames() {
+		// MCP server names routinely contain hyphens, so an entry such as
+		// mcp__claude-code-remote__list_repos is valid syntax.
+		PermissionsFormatRule rule = ruleFor(
+				"{ \"permissions\": { \"allow\": [ \"mcp__claude-code-remote__list_repos\", \"mcp__my-server__tool(x)\" ] } }");
+		rule.setAllowedTools(List.of("Bash"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
 	void failsForAForbiddenEntryPattern() {
 		PermissionsFormatRule rule = ruleFor("{ \"permissions\": { \"allow\": [ \"Bash(*)\" ] } }");
 		rule.setForbiddenEntryPatterns(List.of("Bash\\(\\*\\)"));

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
@@ -72,6 +72,17 @@ class FrontMatterFixerTest {
 	}
 
 	@Test
+	void dropsBlankLinesBeforeTheOpeningDelimiter() {
+		String content = "\n\n---\nname: reviewer\ndescription: Reviews code.\n---\nbody\n";
+
+		Optional<String> repaired = FrontMatterFixer.repair(content);
+
+		assertTrue(repaired.isPresent());
+		assertTrue(repaired.get().startsWith("---\n"), repaired.get());
+		assertTrue(FrontMatter.parse(repaired.get()).isPresent(), repaired.get());
+	}
+
+	@Test
 	void doesNotMistakeALoneThematicBreakForFrontMatter() {
 		String content = """
 				---

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -38,6 +38,13 @@ class FrontMatterTest {
 	}
 
 	@Test
+	void requiresTheOpeningDelimiterOnTheFirstLine() {
+		// Claude Code only recognises front matter that starts on line one, so a
+		// block reached after blank lines must not parse here either.
+		assertTrue(FrontMatter.parse("\n\n---\nname: x\n---\n").isEmpty());
+	}
+
+	@Test
 	void detectsDeclaredKeys() {
 		FrontMatter frontMatter = FrontMatter.parse(DOCUMENT).orElseThrow();
 


### PR DESCRIPTION
- permissionsFormat: accept hyphenated MCP tool names such as
  mcp__claude-code-remote__list_repos, which the entry syntax rejected
  even though the allowlist already exempted the mcp__ prefix.
- hook rules: strip shell quotes before expanding $CLAUDE_PROJECT_DIR,
  so a quoted script reference no longer reports an existing hook as
  missing or unreferenced.
- HTML report: create missing parent directories before writing, so a
  reportFile under target/ works at validate on a clean build.
- subAgentFormat: report a blank description, closing the gap
  uniqueDescriptions assumed the format rules covered.
- pluginFormat: accept semver build metadata after a pre-release
  suffix, e.g. 1.0.0-beta.1+build.5.
- FrontMatter: require the opening delimiter on line one, matching
  Claude Code's parser; the auto-fixer now drops leading blank lines.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LvNkyR6kGe9RmkBXbxLpDa