### PR TITLE
test(claude-code-enforcer): cover quoted hook-script references

### DIFF
--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -63,6 +63,17 @@ class HookCommandsValidRuleTest {
 	}
 
 	@Test
+	void passesWhenTheScriptReferenceIsSingleQuoted() {
+		writeString(tempDir.resolve("session-start.sh"), "#!/bin/sh\necho hi\n");
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("'$CLAUDE_PROJECT_DIR/session-start.sh'"));
+		rule.setProjectDir(tempDir.toFile());
+
+		// Single quotes are stripped just like double quotes, so the reference
+		// still points at the same existing script.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
 	void failsWhenAQuotedScriptReferenceIsMissing() {
 		HookCommandsValidRule rule = ruleFor(hooksReferencing("\\\"$CLAUDE_PROJECT_DIR/gone.sh\\\""));
 		rule.setProjectDir(tempDir.toFile());

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -126,6 +126,19 @@ class HooksFormatRuleTest {
 	}
 
 	@Test
+	void treatsAQuotedReferenceAsReferencing() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("\\\"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh\\\""));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setReportUnreferencedScripts(true);
+
+		// The quotes are stripped before expansion, so the quoted reference marks
+		// the existing script as referenced rather than leaving it an orphan.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
 	void doesNotTreatASymlinkedScriptPointingOutsideAsInsideTheHooksDirectory() {
 		Path outside = tempDir.resolve("outside.sh");
 		writeString(outside, "#!/bin/sh\n");


### PR DESCRIPTION
Commit 4b06656 taught ClaudeProjectDir.expand to strip shell quotes before
expanding $CLAUDE_PROJECT_DIR, fixing false verdicts in both hook rules, but
the added tests only exercised the "missing script" half with double quotes.

- HooksFormatRuleTest: a quoted reference now marks an existing script as
  referenced rather than reporting it as an unreferenced orphan — the
  "unreferenced" half of the fix, previously untested.
- HookCommandsValidRuleTest: single-quoted references are stripped just like
  double-quoted ones.

Both fail when the quote stripping is reverted.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014eWojhp5MkAWiPQsMMUj5w