### PR TITLE
fix(adopt): correct four pipeline bugs

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
@@ -1,9 +1,9 @@
 package io.github.adamw7.tools.adopt.command;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -15,11 +15,14 @@ import java.time.Duration;
  * the background lets {@link ProcessCommandRunner} time out and destroy the
  * child while its partial output is still recovered.
  *
- * <p>Each line is accumulated as it is read, and {@link #output()} bounds its
- * wait for the reader thread. A direct child can exit while a descendant it
- * spawned keeps the output pipe open, in which case the stream never reaches
- * end-of-stream; the bounded join stops that from hanging the caller forever
- * and still returns whatever was captured before the wait elapsed.
+ * <p>The stream is copied verbatim as it is read — every byte the child emits is
+ * preserved, including its own line terminators and any trailing newline — so the
+ * captured transcript reflects exactly what the command printed rather than a
+ * re-joined approximation. {@link #output()} bounds its wait for the reader
+ * thread: a direct child can exit while a descendant it spawned keeps the output
+ * pipe open, in which case the stream never reaches end-of-stream; the bounded
+ * join stops that from hanging the caller forever and still returns whatever was
+ * captured before the wait elapsed.
  */
 final class StreamGobbler {
 
@@ -32,7 +35,6 @@ final class StreamGobbler {
 
 	private final Thread thread;
 	private final StringBuilder output = new StringBuilder();
-	private boolean firstLine = true;
 
 	private StreamGobbler(InputStream stream) {
 		this.thread = new Thread(() -> drain(stream), "adopt-stream-gobbler");
@@ -68,28 +70,25 @@ final class StreamGobbler {
 	}
 
 	private void drain(InputStream stream) {
-		try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
-			append(reader);
+		try (Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+			copy(reader);
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}
 	}
 
-	private void append(BufferedReader reader) throws IOException {
-		String line = reader.readLine();
-		while (line != null) {
-			appendLine(line);
-			line = reader.readLine();
+	private void copy(Reader reader) throws IOException {
+		char[] buffer = new char[8192];
+		int read = reader.read(buffer);
+		while (read != -1) {
+			append(buffer, read);
+			read = reader.read(buffer);
 		}
 	}
 
-	private void appendLine(String line) {
+	private void append(char[] buffer, int length) {
 		synchronized (output) {
-			if (!firstLine) {
-				output.append(System.lineSeparator());
-			}
-			output.append(line);
-			firstLine = false;
+			output.append(buffer, 0, length);
 		}
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -98,8 +98,17 @@ public class AdoptTool implements McpTool {
 
 	private AdoptionContext contextFrom(Map<String, Object> arguments) {
 		String repositoryUrl = ToolArguments.requiredString(arguments, "repository_url");
+		return new AdoptionContext(repositoryUrl, workspace(arguments), branch(arguments));
+	}
+
+	/**
+	 * A blank {@code branch} argument falls back to the default branch, matching the
+	 * command line's handling of a blank branch positional; only an explicitly named
+	 * branch overrides it, so an empty string is not rejected as an invalid branch.
+	 */
+	private String branch(Map<String, Object> arguments) {
 		String branch = ToolArguments.optionalString(arguments, "branch", AdoptionContext.DEFAULT_BRANCH);
-		return new AdoptionContext(repositoryUrl, workspace(arguments), branch);
+		return branch.isBlank() ? AdoptionContext.DEFAULT_BRANCH : branch;
 	}
 
 	private Path workspace(Map<String, Object> arguments) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -15,10 +16,20 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * ({@code git diff --cached --quiet}) rather than by matching the wording of a
  * failed commit's output, so an empty commit is a harmless no-op regardless of
  * git's locale or version and the pipeline stays idempotent when re-run.
+ *
+ * <p>The adoption runs headless — on a CI runner or an MCP server — where git may
+ * have no configured {@code user.name}/{@code user.email}, in which case
+ * {@code git commit} aborts with "Author identity unknown". Each identity git is
+ * missing is supplied for the commit alone with a {@code -c} override, so the
+ * commit succeeds on a bare host while any identity the checkout already
+ * configures is left in force rather than overridden.
  */
 public class CommitStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(CommitStep.class);
+
+	static final String FALLBACK_NAME = "Claude Code Adopt";
+	static final String FALLBACK_EMAIL = "claude-code-adopt@users.noreply.github.com";
 
 	private final String message;
 
@@ -48,7 +59,36 @@ public class CommitStep extends AbstractCommandStep {
 	}
 
 	private void commit(AdoptionContext context, CommandRunner runner) {
-		runOrFail(runner, context.repositoryDirectory(), List.of("git", "commit", "-m", message));
+		runOrFail(runner, context.repositoryDirectory(), commitCommand(context, runner));
 		log.info("Committed: {}", message);
+	}
+
+	private List<String> commitCommand(AdoptionContext context, CommandRunner runner) {
+		List<String> command = new ArrayList<>();
+		command.add("git");
+		command.addAll(identityOverrides(context, runner));
+		command.add("commit");
+		command.add("-m");
+		command.add(message);
+		return command;
+	}
+
+	private List<String> identityOverrides(AdoptionContext context, CommandRunner runner) {
+		List<String> overrides = new ArrayList<>();
+		addOverrideIfMissing(overrides, context, runner, "user.name", FALLBACK_NAME);
+		addOverrideIfMissing(overrides, context, runner, "user.email", FALLBACK_EMAIL);
+		return overrides;
+	}
+
+	private void addOverrideIfMissing(List<String> overrides, AdoptionContext context, CommandRunner runner,
+			String key, String fallback) {
+		if (!hasConfig(context, runner, key)) {
+			overrides.add("-c");
+			overrides.add(key + "=" + fallback);
+		}
+	}
+
+	private boolean hasConfig(AdoptionContext context, CommandRunner runner, String key) {
+		return runner.run(context.repositoryDirectory(), List.of("git", "config", "--get", key)).succeeded();
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.adopt.step;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -23,14 +24,18 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * it differs between projects; the defaults describe the Claude Code adoption
  * and request nobody.
  *
- * <p>The step stays idempotent when re-run: it asks {@code gh pr view} whether a
- * pull request already exists for the branch and skips creation when one does,
- * rather than creating unconditionally and then matching the wording of a
- * failure. That keeps the decision robust across {@code gh} versions and locales.
+ * <p>The step stays idempotent when re-run: it asks {@code gh pr list --state
+ * open} whether an <em>open</em> pull request already exists for the branch and
+ * skips creation when one does, rather than creating unconditionally and then
+ * matching the wording of a failure. Scoping the query to open pull requests
+ * matters because a branch whose earlier pull request was closed or merged still
+ * needs a fresh one — {@code gh pr view <branch>} would report that stale closed
+ * pull request as if it were current and wrongly skip creation. That keeps the
+ * decision robust across {@code gh} versions and locales.
  *
  * <p>After the pull request is created (or found already open), the step records
  * its URL in the run's {@link AdoptionReport}. The URL is read back with
- * {@code gh pr view --json url} rather than scraped from {@code gh pr create}'s
+ * {@code gh pr list --json url} rather than scraped from {@code gh pr create}'s
  * human-oriented output, so the extraction is one structured path for both the
  * fresh and the re-run case.
  */
@@ -65,12 +70,14 @@ public class PullRequestStep extends AbstractCommandStep {
 
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner, AdoptionReport report) {
-		if (pullRequestExists(context, runner)) {
+		Optional<String> existing = openPullRequestUrl(context, runner);
+		if (existing.isPresent()) {
 			log.info("Pull request already open for branch {}; left unchanged", context.branchName());
+			record(existing.get(), report);
 		} else {
 			create(context, runner);
+			recordUrl(context, runner, report);
 		}
-		recordUrl(context, runner, report);
 	}
 
 	private void create(AdoptionContext context, CommandRunner runner) {
@@ -98,58 +105,66 @@ public class PullRequestStep extends AbstractCommandStep {
 		}
 	}
 
-	private boolean pullRequestExists(AdoptionContext context, CommandRunner runner) {
-		return runner.run(context.repositoryDirectory(), viewCommand(context)).succeeded();
+	/**
+	 * @return the URL of the branch's open pull request, or empty when none is open
+	 *         (or {@code gh} could not be queried). The query is scoped to open pull
+	 *         requests so a stale closed or merged one for the same branch does not
+	 *         count as already open.
+	 */
+	private Optional<String> openPullRequestUrl(AdoptionContext context, CommandRunner runner) {
+		CommandResult result = runner.run(context.repositoryDirectory(), listCommand(context));
+		if (!result.succeeded()) {
+			return Optional.empty();
+		}
+		return extractUrl(result.output());
 	}
 
-	private List<String> viewCommand(AdoptionContext context) {
-		return List.of("gh", "pr", "view", context.branchName(), "--json", "url");
+	private List<String> listCommand(AdoptionContext context) {
+		return List.of("gh", "pr", "list", "--head", context.branchName(), "--state", "open", "--json", "url");
 	}
 
 	/**
-	 * A pull request that was just created must be viewable, so a failing view is a
-	 * warning rather than an aborted adoption: the pull request itself exists and
-	 * only its URL is missing from the report.
+	 * A pull request that was just created must be listable, so a failing read-back
+	 * is a warning rather than an aborted adoption: the pull request itself exists
+	 * and only its URL is missing from the report.
 	 */
 	private void recordUrl(AdoptionContext context, CommandRunner runner, AdoptionReport report) {
-		CommandResult result = runner.run(context.repositoryDirectory(), viewCommand(context));
-		if (result.succeeded()) {
-			recordUrlFrom(result.output(), report);
-		} else {
-			log.warn("Could not read back the pull request URL for branch {}", context.branchName());
-		}
+		openPullRequestUrl(context, runner).ifPresentOrElse(
+				url -> record(url, report),
+				() -> log.warn("Could not read back the pull request URL for branch {}", context.branchName()));
 	}
 
-	private void recordUrlFrom(String output, AdoptionReport report) {
-		String url = extractUrl(output);
-		if (url == null) {
-			log.warn("gh pr view returned no URL in: {}", output.strip());
-		} else {
-			log.info("Pull request URL: {}", url);
-			report.recordPullRequestUrl(url);
-		}
+	private void record(String url, AdoptionReport report) {
+		log.info("Pull request URL: {}", url);
+		report.recordPullRequestUrl(url);
 	}
 
 	/**
-	 * {@code gh} writes the JSON document to stdout but the captured output may
-	 * carry surrounding noise (for example update notices on stderr), so parsing
-	 * starts at the first opening brace instead of assuming a pure JSON payload.
+	 * {@code gh pr list --json} writes a JSON array to stdout, but the captured
+	 * output may carry surrounding noise (for example update notices merged in from
+	 * stderr), so parsing starts at the first opening bracket instead of assuming a
+	 * pure JSON payload. The first element's {@code url} is returned, or empty when
+	 * the array is empty or carries no textual URL.
 	 */
-	private String extractUrl(String output) {
-		int start = output.indexOf('{');
+	private Optional<String> extractUrl(String output) {
+		int start = output.indexOf('[');
 		if (start < 0) {
-			return null;
+			return Optional.empty();
 		}
-		return urlField(output.substring(start));
+		return firstUrl(output.substring(start));
 	}
 
-	private String urlField(String json) {
+	private Optional<String> firstUrl(String json) {
 		try {
-			JsonNode url = mapper.readTree(json).path("url");
-			return url.isTextual() ? url.asText() : null;
+			JsonNode array = mapper.readTree(json);
+			if (!array.isArray() || array.isEmpty()) {
+				return Optional.empty();
+			}
+			JsonNode url = array.get(0).path("url");
+			return url.isTextual() ? Optional.of(url.asText()) : Optional.empty();
 		} catch (JsonProcessingException e) {
-			log.warn("Could not parse gh pr view output as JSON", e);
-			return null;
+			log.warn("Could not parse gh pr list output as JSON", e);
+			return Optional.empty();
 		}
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunnerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunnerTest.java
@@ -20,7 +20,7 @@ class ProcessCommandRunnerTest {
 	void capturesExitCodeAndOutput() {
 		CommandResult result = runner.run(Path.of("."), PlatformCommands.printing("hello"));
 		assertEquals(0, result.exitCode());
-		assertEquals("hello", result.output());
+		assertEquals("hello" + System.lineSeparator(), result.output());
 	}
 
 	@Test
@@ -54,7 +54,7 @@ class ProcessCommandRunnerTest {
 		ProcessCommandRunner patient = new ProcessCommandRunner(Duration.ofSeconds(30));
 		CommandResult result = patient.run(Path.of("."), PlatformCommands.printing("quick"));
 		assertEquals(0, result.exitCode());
-		assertEquals("quick", result.output());
+		assertEquals("quick" + System.lineSeparator(), result.output());
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/StreamGobblerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/StreamGobblerTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Timeout;
 class StreamGobblerTest {
 
 	@Test
-	void joinsMultipleLinesWithTheLineSeparator() {
+	void preservesMultipleLinesVerbatim() {
 		String text = "first" + System.lineSeparator() + "second" + System.lineSeparator() + "third";
 		StreamGobbler gobbler = StreamGobbler.consuming(
 				new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)));
@@ -26,6 +26,19 @@ class StreamGobblerTest {
 	@Test
 	void keepsAnEmptyLeadingLine() {
 		String text = System.lineSeparator() + "second";
+		StreamGobbler gobbler = StreamGobbler.consuming(
+				new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)));
+		assertEquals(text, gobbler.output());
+	}
+
+	/**
+	 * The stream is copied byte-for-byte rather than split into lines and re-joined,
+	 * so the child's own {@code \n} terminators and its trailing newline survive
+	 * unchanged regardless of the host's {@link System#lineSeparator()}.
+	 */
+	@Test
+	void preservesLineTerminatorsAndTrailingNewlineVerbatim() {
+		String text = "first\nsecond\n";
 		StreamGobbler gobbler = StreamGobbler.consuming(
 				new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)));
 		assertEquals(text, gobbler.output());

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
@@ -75,6 +75,12 @@ class AdoptToolTest {
 	}
 
 	@Test
+	void fallsBackToTheDefaultBranchWhenBlank() {
+		tool.apply(Map.of("repository_url", REPO_URL, "branch", "  "));
+		assertEquals(AdoptionContext.DEFAULT_BRANCH, pipeline.context.branchName());
+	}
+
+	@Test
 	void mapsPullRequestMetadataOntoTheOptions() {
 		tool.apply(Map.of("repository_url", REPO_URL,
 				"title", "My title", "body", "My body",

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
@@ -24,7 +24,24 @@ class CommitStepTest {
 		new CommitStep("my message").execute(context, runner);
 		assertEquals(List.of("git", "add", "-A"), runner.commandAt(0));
 		assertEquals(List.of("git", "diff", "--cached", "--quiet"), runner.commandAt(1));
-		assertEquals(List.of("git", "commit", "-m", "my message"), runner.commandAt(2));
+		assertEquals(List.of("git", "config", "--get", "user.name"), runner.commandAt(2));
+		assertEquals(List.of("git", "config", "--get", "user.email"), runner.commandAt(3));
+		assertEquals(List.of("git", "commit", "-m", "my message"), runner.commandAt(4));
+	}
+
+	@Test
+	void suppliesAFallbackIdentityWhenGitHasNone() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::stagedChangesWithoutIdentity);
+		new CommitStep("my message").execute(context, runner);
+		assertEquals(List.of("git", "-c", "user.name=" + CommitStep.FALLBACK_NAME, "-c",
+				"user.email=" + CommitStep.FALLBACK_EMAIL, "commit", "-m", "my message"), runner.commandAt(4));
+	}
+
+	@Test
+	void leavesAConfiguredIdentityInForce() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::stagedChanges);
+		new CommitStep("my message").execute(context, runner);
+		assertEquals(List.of("git", "commit", "-m", "my message"), runner.commandAt(4));
 	}
 
 	@Test
@@ -43,6 +60,16 @@ class CommitStepTest {
 
 	private CommandResult stagedChanges(List<String> command) {
 		if (command.contains("diff")) {
+			return new CommandResult(command, 1, "");
+		}
+		return new CommandResult(command, 0, "");
+	}
+
+	private CommandResult stagedChangesWithoutIdentity(List<String> command) {
+		if (command.contains("diff")) {
+			return new CommandResult(command, 1, "");
+		}
+		if (command.contains("config")) {
 			return new CommandResult(command, 1, "");
 		}
 		return new CommandResult(command, 0, "");

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -25,10 +25,10 @@ class PullRequestStepTest {
 
 	@Test
 	void opensPullRequestForFeatureBranch() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(this::noExistingPullRequest);
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
 		step.execute(context, runner);
-		assertEquals(List.of("gh", "pr", "view", "claude/adopt-claude-code", "--json", "url"),
-				runner.commandAt(0));
+		assertEquals(List.of("gh", "pr", "list", "--head", "claude/adopt-claude-code", "--state", "open", "--json",
+				"url"), runner.commandAt(0));
 		assertEquals(List.of("gh", "pr", "create", "--title", PullRequestOptions.DEFAULT_TITLE, "--body",
 				PullRequestOptions.DEFAULT_BODY, "--head", "claude/adopt-claude-code"), runner.commandAt(1));
 		assertEquals(context.repositoryDirectory(), runner.invocations().get(1).workingDirectory());
@@ -36,7 +36,7 @@ class PullRequestStepTest {
 
 	@Test
 	void usesConfiguredTitleAndBody() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(this::noExistingPullRequest);
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
 		new PullRequestStep("My title", "My body").execute(context, runner);
 		assertEquals(List.of("gh", "pr", "create", "--title", "My title", "--body", "My body", "--head",
 				"claude/adopt-claude-code"), runner.commandAt(1));
@@ -44,7 +44,7 @@ class PullRequestStepTest {
 
 	@Test
 	void requestsReviewersLabelsAssigneesAndOpensAsDraft() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(this::noExistingPullRequest);
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
 		PullRequestOptions options = PullRequestOptions.builder()
 				.title("My title")
 				.body("My body")
@@ -60,14 +60,20 @@ class PullRequestStepTest {
 	}
 
 	@Test
-	void skipsCreationWhenAPullRequestAlreadyExists() {
+	void skipsCreationWhenAnOpenPullRequestAlreadyExists() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::existingPullRequest);
 		step.execute(context, runner);
-		assertEquals(2, runner.count());
-		assertEquals(List.of("gh", "pr", "view", "claude/adopt-claude-code", "--json", "url"),
-				runner.commandAt(0));
-		assertEquals(List.of("gh", "pr", "view", "claude/adopt-claude-code", "--json", "url"),
-				runner.commandAt(1));
+		assertEquals(1, runner.count());
+		assertEquals(List.of("gh", "pr", "list", "--head", "claude/adopt-claude-code", "--state", "open", "--json",
+				"url"), runner.commandAt(0));
+	}
+
+	@Test
+	void createsAFreshPullRequestWhenOnlyAClosedOneExists() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
+		step.execute(context, runner);
+		assertEquals(List.of("gh", "pr", "create", "--title", PullRequestOptions.DEFAULT_TITLE, "--body",
+				PullRequestOptions.DEFAULT_BODY, "--head", "claude/adopt-claude-code"), runner.commandAt(1));
 	}
 
 	@Test
@@ -87,16 +93,17 @@ class PullRequestStepTest {
 	}
 
 	@Test
-	void recordsUrlEvenWhenViewOutputCarriesNoise() {
+	void recordsUrlEvenWhenListOutputCarriesNoise() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 0, "a new gh release is available\n{\"url\":\"" + PR_URL + "\"}"));
+				command -> new CommandResult(command, 0,
+						"a new gh release is available\n[{\"url\":\"" + PR_URL + "\"}]"));
 		AdoptionReport report = new AdoptionReport();
 		step.execute(context, runner, report);
 		assertEquals(PR_URL, report.pullRequestUrl().orElseThrow());
 	}
 
 	@Test
-	void leavesUrlAbsentWhenViewOutputIsNotJson() {
+	void leavesUrlAbsentWhenListOutputIsNotJson() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(
 				command -> new CommandResult(command, 0, "not json at all"));
 		AdoptionReport report = new AdoptionReport();
@@ -107,7 +114,7 @@ class PullRequestStepTest {
 	@Test
 	void leavesUrlAbsentWhenUrlFieldIsMissing() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 0, "{\"number\": 1}"));
+				command -> new CommandResult(command, 0, "[{\"number\": 1}]"));
 		AdoptionReport report = new AdoptionReport();
 		step.execute(context, runner, report);
 		assertTrue(report.pullRequestUrl().isEmpty());
@@ -119,27 +126,27 @@ class PullRequestStepTest {
 		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
 	}
 
-	private CommandResult noExistingPullRequest(List<String> command) {
-		if (command.contains("view")) {
-			return new CommandResult(command, 1, "no pull requests found");
+	private CommandResult noOpenPullRequest(List<String> command) {
+		if (command.contains("list")) {
+			return new CommandResult(command, 0, "[]");
 		}
 		return new CommandResult(command, 0, PR_URL);
 	}
 
 	private CommandResult existingPullRequest(List<String> command) {
-		return new CommandResult(command, 0, "{\"url\":\"" + PR_URL + "\"}");
+		return new CommandResult(command, 0, "[{\"url\":\"" + PR_URL + "\"}]");
 	}
 
 	private CommandResult createFails(List<String> command) {
-		if (command.contains("view")) {
-			return new CommandResult(command, 1, "no pull requests found");
+		if (command.contains("list")) {
+			return new CommandResult(command, 0, "[]");
 		}
 		return new CommandResult(command, 1, "gh: could not authenticate");
 	}
 
 	/**
-	 * Mimics the real gh behaviour around creation: the pre-check view finds no
-	 * pull request, and every view after the create succeeds with the URL.
+	 * Mimics the real gh behaviour around creation: the pre-check list finds no open
+	 * pull request, and every list after the create returns the branch's open one.
 	 */
 	private static final class ViewFailsUntilCreated
 			implements java.util.function.Function<List<String>, CommandResult> {
@@ -153,9 +160,9 @@ class PullRequestStepTest {
 				return new CommandResult(command, 0, PR_URL);
 			}
 			if (created) {
-				return new CommandResult(command, 0, "{\"url\":\"" + PR_URL + "\"}");
+				return new CommandResult(command, 0, "[{\"url\":\"" + PR_URL + "\"}]");
 			}
-			return new CommandResult(command, 1, "no pull requests found");
+			return new CommandResult(command, 0, "[]");
 		}
 	}
 


### PR DESCRIPTION
- PullRequestStep: scope the existence check to open PRs via
  `gh pr list --head <branch> --state open` instead of
  `gh pr view <branch>`, which reports a stale closed/merged PR for the
  branch and wrongly skips creating a fresh one on re-adoption.
- CommitStep: supply a fallback git author identity with `-c` overrides
  when the checkout has no user.name/user.email, so the commit succeeds
  on a bare CI runner or MCP server instead of aborting with "Author
  identity unknown"; a configured identity is left in force.
- AdoptTool: coalesce a blank `branch` argument to the default branch,
  matching the CLI's handling of a blank branch positional instead of
  rejecting it as an invalid branch.
- StreamGobbler: copy process output verbatim rather than splitting into
  lines and re-joining with the platform separator, preserving the
  child's own line terminators and trailing newline.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017DxkKWLks2D4CGyNKowtz8