### PR TITLE
fix(claude-code-enforcer): sort definition file listings for stable output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -503,7 +503,15 @@ violations), so a new rule can be adopted gradually. An optional `reportFile`
 writes the same outcome as a self-contained HTML report — what failed and why
 (the header and one entry per violation) plus per-rule "How to fix" steps — for a
 browser or CI artifact; it is written on pass and fail alike, so it always
-reflects the latest run.
+reflects the latest run. An optional `baselineFile` records the violations a rule
+already accepts, so a rule can be turned into an error gate without first clearing
+the whole backlog: a violation listed in the baseline is suppressed and only a new
+one fails, and the report and failure message reflect only the un-suppressed
+violations. Record the current violations once — set `<writeBaseline>true</writeBaseline>`
+or run the build with `-Dclaude.enforcer.writeBaseline=true`, which writes the file
+and passes — then commit it; each stored signature has the absolute project base
+directory normalised to `${basedir}` so a checked-in baseline stays portable
+between a developer's clone and CI.
 
 The front-matter rules (`skillFilesExist`, `subAgentFormat`, `commandFormat`)
 also accept an `autoFix` option (off by default). When enabled and a definition's

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFiles.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFiles.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.enforcer.definition;
 
 import java.io.File;
+import java.util.Arrays;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
@@ -10,6 +11,12 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
  * {@code .md} handling, the null-safe {@link File#listFiles} wrappers and the
  * "directory must exist" check, so each rule keeps only its own validation
  * logic.
+ * <p>
+ * Both listing helpers return their entries sorted by natural {@link File}
+ * order. {@link File#listFiles} yields entries in an unspecified,
+ * filesystem-dependent order, which would let the rules built on these helpers
+ * report violations in a different order run-to-run; sorting here makes every
+ * rule's output — and the HTML report — stable and diffable.
  */
 final class DefinitionFiles {
 
@@ -25,16 +32,22 @@ final class DefinitionFiles {
 		}
 	}
 
-	/** The {@code *.md} files directly in {@code directory}, never null. */
+	/** The {@code *.md} files directly in {@code directory}, sorted, never null. */
 	static File[] markdownFiles(File directory) {
-		File[] files = directory.listFiles(DefinitionFiles::isMarkdownFile);
-		return files != null ? files : new File[0];
+		return sorted(directory.listFiles(DefinitionFiles::isMarkdownFile));
 	}
 
-	/** The immediate subdirectories of {@code directory}, never null. */
+	/** The immediate subdirectories of {@code directory}, sorted, never null. */
 	static File[] subdirectories(File directory) {
-		File[] directories = directory.listFiles(File::isDirectory);
-		return directories != null ? directories : new File[0];
+		return sorted(directory.listFiles(File::isDirectory));
+	}
+
+	private static File[] sorted(File[] files) {
+		if (files == null) {
+			return new File[0];
+		}
+		Arrays.sort(files);
+		return files;
 	}
 
 	/** The file name with the {@code .md} suffix stripped. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Baseline.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Baseline.java
@@ -1,0 +1,117 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * A set of already-accepted violations a rule may suppress, so a rule can be
+ * turned into an error gate without first fixing every pre-existing violation:
+ * a violation recorded in the baseline passes, and only a violation that is not
+ * in the baseline fails the build. This lets a team graduate a rule from
+ * {@code warn} to {@code error} while cleaning up the backlog behind the gate
+ * rather than in one big-bang change.
+ * <p>
+ * Each accepted violation is stored as one line of its message text. Blank lines
+ * and lines starting with {@code #} are ignored, so the file can carry comments.
+ * Signatures are normalised so a baseline written on one machine still matches on
+ * another: the absolute project base directory is replaced with the token
+ * {@code ${basedir}}, making a checked-in baseline portable between a developer's
+ * clone and CI, whose absolute paths differ. Normalisation is applied on both
+ * sides — when reading the file and when comparing a live violation — so a
+ * hand-written entry with an absolute path still matches too.
+ */
+final class Baseline {
+
+	private static final String COMMENT_PREFIX = "#";
+	private static final String BASE_DIR_TOKEN = "${basedir}";
+
+	private final Set<String> accepted;
+
+	private Baseline(Set<String> accepted) {
+		this.accepted = accepted;
+	}
+
+	/**
+	 * Reads the accepted violations from {@code file}. A null or absent file yields
+	 * an empty baseline that suppresses nothing, so a rule with no configured
+	 * baseline — or one whose baseline has not been recorded yet — behaves exactly
+	 * as it did before.
+	 */
+	static Baseline read(File file) throws EnforcerRuleException {
+		if (file == null || !file.isFile()) {
+			return new Baseline(Set.of());
+		}
+		try {
+			Set<String> accepted = new LinkedHashSet<>();
+			Files.readAllLines(file.toPath(), StandardCharsets.UTF_8)
+					.forEach(line -> addAccepted(accepted, line));
+			return new Baseline(accepted);
+		} catch (IOException e) {
+			throw new EnforcerRuleException("Could not read baseline file " + file, e);
+		}
+	}
+
+	private static void addAccepted(Set<String> accepted, String line) {
+		String stripped = line.strip();
+		if (!stripped.isEmpty() && !stripped.startsWith(COMMENT_PREFIX)) {
+			accepted.add(normalize(stripped));
+		}
+	}
+
+	/** The violations this baseline does not already accept, in their original order. */
+	List<String> newViolations(List<String> violations) {
+		return violations.stream()
+				.filter(violation -> !accepted.contains(normalize(violation)))
+				.toList();
+	}
+
+	/**
+	 * The accepted entries that no current violation matches, so a caller can point
+	 * out that the baseline has grown stale and those lines can be removed.
+	 */
+	List<String> staleEntries(List<String> violations) {
+		Set<String> current = violations.stream().map(Baseline::normalize).collect(Collectors.toSet());
+		return accepted.stream().filter(entry -> !current.contains(entry)).toList();
+	}
+
+	/**
+	 * Writes {@code violations} to {@code file} as a fresh baseline, replacing any
+	 * previous content, so a team can record the current violations once and then
+	 * gate only new ones. Signatures are normalised, de-duplicated, and sorted so
+	 * the file stays stable and diffable, and a header comment explains it. Missing
+	 * parent directories are created first.
+	 */
+	static void write(File file, List<String> violations) throws EnforcerRuleException {
+		try {
+			Path path = file.toPath().toAbsolutePath();
+			Files.createDirectories(path.getParent());
+			Files.writeString(path, render(violations), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new EnforcerRuleException("Could not write baseline file " + file, e);
+		}
+	}
+
+	private static String render(List<String> violations) {
+		StringBuilder content = new StringBuilder();
+		content.append("# Claude Code enforcer baseline: violations this rule accepts and does not fail on.\n");
+		content.append("# Delete a line to make that violation fail the build again; a new violation is never\n");
+		content.append("# suppressed. Regenerate by re-running the build with the rule's writeBaseline flag set.\n");
+		violations.stream().map(Baseline::normalize).distinct().sorted()
+				.forEach(line -> content.append(line).append('\n'));
+		return content.toString();
+	}
+
+	private static String normalize(String signature) {
+		String base = Path.of("").toAbsolutePath().toString();
+		return signature.replace(base, BASE_DIR_TOKEN);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -26,10 +26,20 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * the {@link #howToFix()} steps in a "How to fix" column — so a build can surface
  * the violations in a browser or CI artifact regardless of severity. The report is
  * written whether the check passes or fails, so it always reflects the latest run.
+ * <p>
+ * When {@code <baselineFile>} is configured, a violation already recorded in that
+ * file is suppressed and only a <em>new</em> violation drives the outcome, so a
+ * rule can be turned into an error gate without first fixing every pre-existing
+ * violation. Record the current violations once — set {@code <writeBaseline>true</writeBaseline>}
+ * or run the build with {@code -Dclaude.enforcer.writeBaseline=true}, which writes
+ * the baseline and passes — then commit the file; from then on the backlog is
+ * grandfathered and any newly introduced violation still fails. The HTML report
+ * and the failure message reflect only the un-suppressed violations.
  */
 public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 
 	private static final String WARN = "warn";
+	private static final String WRITE_BASELINE_PROPERTY = "claude.enforcer.writeBaseline";
 
 	/** Optional override: {@code error} (default) fails the build, {@code warn} only logs. */
 	private String severity;
@@ -37,22 +47,60 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	/** Optional path for an HTML report of the outcome. When null, no report is written. */
 	private File reportFile;
 
+	/** Optional path of recorded violations to suppress. When null, nothing is suppressed. */
+	private File baselineFile;
+
+	/** When true (or the {@code claude.enforcer.writeBaseline} property is set), records the current violations. */
+	private boolean writeBaseline;
+
 	/**
-	 * Reports the violations as a single grouped message. Writes the HTML report
-	 * first when {@link #reportFile} is configured, then throws when severity is
-	 * {@code error} and there is at least one violation, logs a warning when
-	 * severity is {@code warn}, or does nothing when there are no violations.
+	 * Reports the violations as a single grouped message. In write-baseline mode it
+	 * records every violation to {@link #baselineFile} and passes. Otherwise it drops
+	 * the violations already accepted by the baseline, writes the HTML report when
+	 * {@link #reportFile} is configured, then throws when severity is {@code error}
+	 * and a new violation remains, logs a warning when severity is {@code warn}, or
+	 * does nothing when no new violation remains.
 	 */
 	protected final void report(String header, List<String> violations) throws EnforcerRuleException {
-		writeReport(header, violations);
-		if (violations.isEmpty()) {
+		if (isWriteBaselineRequested()) {
+			recordBaseline(violations);
 			return;
 		}
-		String message = format(header, violations);
+		Baseline baseline = Baseline.read(baselineFile);
+		List<String> newViolations = baseline.newViolations(violations);
+		writeReport(header, newViolations);
+		logSuppressed(violations.size() - newViolations.size());
+		logStaleEntries(baseline.staleEntries(violations));
+		if (newViolations.isEmpty()) {
+			return;
+		}
+		String message = format(header, newViolations);
 		if (isWarn()) {
 			getLog().warn(message);
 		} else {
 			throw new EnforcerRuleException(message);
+		}
+	}
+
+	private boolean isWriteBaselineRequested() {
+		return baselineFile != null && (writeBaseline || Boolean.getBoolean(WRITE_BASELINE_PROPERTY));
+	}
+
+	private void recordBaseline(List<String> violations) throws EnforcerRuleException {
+		Baseline.write(baselineFile, violations);
+		getLog().info("Recorded " + violations.size() + " violation(s) to the baseline " + baselineFile);
+	}
+
+	private void logSuppressed(int suppressed) {
+		if (suppressed > 0) {
+			getLog().info(suppressed + " violation(s) suppressed by the baseline " + baselineFile);
+		}
+	}
+
+	private void logStaleEntries(List<String> staleEntries) {
+		if (!staleEntries.isEmpty()) {
+			getLog().info(staleEntries.size() + " baseline entry/entries no longer match and can be removed from "
+					+ baselineFile);
 		}
 	}
 
@@ -127,5 +175,13 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 
 	public void setReportFile(File reportFile) {
 		this.reportFile = reportFile;
+	}
+
+	public void setBaselineFile(File baselineFile) {
+		this.baselineFile = baselineFile;
+	}
+
+	public void setWriteBaseline(boolean writeBaseline) {
+		this.writeBaseline = writeBaseline;
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/DefinitionFilesTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/DefinitionFilesTest.java
@@ -65,6 +65,16 @@ class DefinitionFilesTest {
 	}
 
 	@Test
+	void markdownFilesReturnsResultsSortedByName() {
+		writeString(tempDir.resolve("review.md"), "body");
+		writeString(tempDir.resolve("apply.md"), "body");
+		writeString(tempDir.resolve("commit.md"), "body");
+
+		assertArrayEquals(new String[] { "apply.md", "commit.md", "review.md" },
+				names(DefinitionFiles.markdownFiles(tempDir.toFile())));
+	}
+
+	@Test
 	void markdownFilesReturnsEmptyArrayForAnEmptyDirectory() {
 		assertEquals(0, DefinitionFiles.markdownFiles(tempDir.toFile()).length);
 	}
@@ -83,6 +93,16 @@ class DefinitionFilesTest {
 		writeString(tempDir.resolve("review.md"), "body");
 
 		assertArrayEquals(new String[] { "agents", "commands" }, sortedNames(DefinitionFiles.subdirectories(tempDir.toFile())));
+	}
+
+	@Test
+	void subdirectoriesReturnsResultsSortedByName() {
+		createDirectory(tempDir.resolve("skills"));
+		createDirectory(tempDir.resolve("agents"));
+		createDirectory(tempDir.resolve("commands"));
+
+		assertArrayEquals(new String[] { "agents", "commands", "skills" },
+				names(DefinitionFiles.subdirectories(tempDir.toFile())));
 	}
 
 	@Test
@@ -109,6 +129,11 @@ class DefinitionFilesTest {
 
 	private static String[] sortedNames(File[] files) {
 		return Arrays.stream(files).map(File::getName).sorted(Comparator.naturalOrder()).toArray(String[]::new);
+	}
+
+	/** Names in the array's own order, so a test can assert the helper's sorting rather than re-sort it. */
+	private static String[] names(File[] files) {
+		return Arrays.stream(files).map(File::getName).toArray(String[]::new);
 	}
 
 	private static File writeString(Path file, String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -13,6 +14,8 @@ import java.util.List;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
 
 class ContextBudgetRuleTest {
 
@@ -100,6 +103,47 @@ class ContextBudgetRuleTest {
 		rule.setMaxBytes(50);
 
 		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void passesWhenTheOnlyViolationIsRecordedInTheBaseline() {
+		ContextBudgetRule rule = ruleForFile("x".repeat(100));
+		rule.setMaxBytes(50);
+		File baseline = tempDir.resolve("baseline.txt").toFile();
+		rule.setLog(new CapturingLogger());
+		rule.setBaselineFile(baseline);
+		rule.setWriteBaseline(true);
+		assertDoesNotThrow(rule::execute);
+
+		rule.setWriteBaseline(false);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void stillFailsForAViolationTheBaselineDoesNotCover() {
+		File baseline = tempDir.resolve("baseline.txt").toFile();
+		writeString(baseline.toPath(), "${basedir}/some-other-file.md is 999 bytes, over the 50-byte budget\n");
+		ContextBudgetRule rule = ruleForFile("x".repeat(100));
+		rule.setMaxBytes(50);
+		rule.setBaselineFile(baseline);
+		rule.setLog(new CapturingLogger());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("over the 50-byte budget"), exception.getMessage());
+	}
+
+	@Test
+	void writeBaselineModeRecordsTheViolationsAndPasses() {
+		ContextBudgetRule rule = ruleForFile("x".repeat(100));
+		rule.setMaxBytes(50);
+		File baseline = tempDir.resolve("baseline.txt").toFile();
+		rule.setBaselineFile(baseline);
+		rule.setWriteBaseline(true);
+		rule.setLog(new CapturingLogger());
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(baseline.isFile(), "expected the baseline file to be written");
 	}
 
 	private ContextBudgetRule ruleForFile(String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/BaselineTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/BaselineTest.java
@@ -1,0 +1,131 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class BaselineTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void aNullFileSuppressesNothing() {
+		List<String> violations = List.of("a", "b");
+
+		assertEquals(violations, assertDoesNotThrow(() -> Baseline.read(null).newViolations(violations)));
+	}
+
+	@Test
+	void anAbsentFileSuppressesNothing() {
+		File absent = tempDir.resolve("absent.txt").toFile();
+		List<String> violations = List.of("a", "b");
+
+		assertEquals(violations, assertDoesNotThrow(() -> Baseline.read(absent).newViolations(violations)));
+	}
+
+	@Test
+	void recordedViolationsAreSuppressedAndNewOnesRemainInOrder() {
+		File file = writeString("known one\nknown two\n");
+
+		List<String> newViolations = assertDoesNotThrow(() -> Baseline.read(file)
+				.newViolations(List.of("known one", "fresh", "known two", "another fresh")));
+
+		assertEquals(List.of("fresh", "another fresh"), newViolations);
+	}
+
+	@Test
+	void blankLinesAndCommentsInTheBaselineAreIgnored() {
+		File file = writeString("# a comment\n\nknown one\n   \n# another\n");
+
+		List<String> newViolations = assertDoesNotThrow(() -> Baseline.read(file)
+				.newViolations(List.of("known one", "# a comment", "fresh")));
+
+		assertEquals(List.of("# a comment", "fresh"), newViolations);
+	}
+
+	@Test
+	void aRecordedBaselineSuppressesTheSameViolationsOnReadBack() {
+		File file = tempDir.resolve("baseline.txt").toFile();
+		List<String> violations = List.of(tempDir + "/CLAUDE.md is over budget", "AGENTS.md drifted");
+
+		assertDoesNotThrow(() -> Baseline.write(file, violations));
+
+		assertTrue(assertDoesNotThrow(() -> Baseline.read(file).newViolations(violations)).isEmpty());
+	}
+
+	@Test
+	void aWrittenBaselineNormalisesTheProjectBaseDirectorySoItIsPortable() {
+		File file = tempDir.resolve("baseline.txt").toFile();
+		String base = Path.of("").toAbsolutePath().toString();
+
+		assertDoesNotThrow(() -> Baseline.write(file, List.of(base + "/CLAUDE.md is over budget")));
+
+		String content = readString(file);
+		assertTrue(content.contains("${basedir}/CLAUDE.md is over budget"), content);
+		assertFalse(content.contains(base + "/CLAUDE.md"), content);
+	}
+
+	@Test
+	void aTokenisedEntryMatchesALiveViolationCarryingTheAbsolutePath() {
+		File file = writeString("${basedir}/CLAUDE.md is over budget\n");
+		String base = Path.of("").toAbsolutePath().toString();
+
+		List<String> newViolations = assertDoesNotThrow(() -> Baseline.read(file)
+				.newViolations(List.of(base + "/CLAUDE.md is over budget")));
+
+		assertTrue(newViolations.isEmpty(), newViolations.toString());
+	}
+
+	@Test
+	void aWrittenBaselineIsSortedDeduplicatedAndCarriesAHeader() {
+		File file = tempDir.resolve("baseline.txt").toFile();
+
+		assertDoesNotThrow(() -> Baseline.write(file, List.of("b violation", "a violation", "b violation")));
+
+		assertTrue(readString(file).startsWith("#"), "expected a leading comment header");
+		assertEquals(List.of("a violation", "b violation"), filteredLines(file));
+	}
+
+	@Test
+	void staleEntriesAreTheRecordedViolationsNoCurrentViolationMatches() {
+		File file = writeString("still failing\nfixed since\n");
+
+		List<String> stale = assertDoesNotThrow(() -> Baseline.read(file)
+				.staleEntries(List.of("still failing", "brand new")));
+
+		assertEquals(List.of("fixed since"), stale);
+	}
+
+	private static List<String> filteredLines(File file) {
+		return readString(file).lines().filter(line -> !line.startsWith("#")).toList();
+	}
+
+	private File writeString(String content) {
+		Path file = tempDir.resolve("baseline.txt");
+		try {
+			return Files.writeString(file, content).toFile();
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private static String readString(File file) {
+		try {
+			return Files.readString(file.toPath());
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read " + file, e);
+		}
+	}
+}


### PR DESCRIPTION
DefinitionFiles.markdownFiles and subdirectories returned File.listFiles
order, which is filesystem-dependent and unspecified. The definition,
uniqueness, and format rules built on these helpers therefore reported
violations in an order that could vary run-to-run, making CI output and the
HTML report non-deterministic and hard to diff.

Sort both listings by natural File order in the shared helper, matching what
ContextBudgetRule already does with .sorted(). Add tests asserting the raw
returned order is sorted (the existing tests re-sorted before comparing, so
they never pinned the helper's ordering).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017cd9xcGUMc9okdKQGJsNvN