### PR TITLE
fix(adopt): pre-approve edits so headless claude init writes CLAUDE.md

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -14,7 +14,11 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * Runs the Claude Code CLI in headless mode against the checkout so it
  * generates a {@code CLAUDE.md} for the project. The exact CLI invocation is
  * configurable because the flags differ between environments; the default runs
- * the {@code /init} command non-interactively.
+ * the {@code /init} command non-interactively with {@code --permission-mode
+ * acceptEdits} so the CLI may write the file. Headless {@code -p} mode has no
+ * interactive approver, so without a permission mode that pre-approves edits the
+ * {@code /init} command only prints a request to write {@code CLAUDE.md}, exits
+ * cleanly, and leaves nothing behind.
  *
  * <p>The generated {@code CLAUDE.md} is the whole point of the adoption, so a run
  * that exits cleanly but leaves no {@code CLAUDE.md} behind aborts the adoption
@@ -25,7 +29,8 @@ public class ClaudeInitStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(ClaudeInitStep.class);
 
-	static final List<String> DEFAULT_COMMAND = List.of("claude", "-p", "/init");
+	static final List<String> DEFAULT_COMMAND = List.of("claude", "-p", "/init",
+			"--permission-mode", "acceptEdits");
 
 	private static final String CLAUDE_MD = "CLAUDE.md";
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
@@ -48,6 +48,12 @@ class ClaudeInitStepTest {
 	}
 
 	@Test
+	void defaultCommandPreApprovesEditsSoHeadlessInitCanWriteTheFile() {
+		assertEquals(List.of("claude", "-p", "/init", "--permission-mode", "acceptEdits"),
+				ClaudeInitStep.DEFAULT_COMMAND);
+	}
+
+	@Test
 	void failedInitAbortsAdoption(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
 		RecordingCommandRunner runner = new RecordingCommandRunner(


### PR DESCRIPTION
An e2e run of the adopter against a real repository failed at the
claude-init step: `claude -p /init` exited cleanly but wrote no
CLAUDE.md, so the step aborted the adoption. In headless `-p` mode there
is no interactive approver, so the CLI only prints a request to write
CLAUDE.md instead of writing it.

Add `--permission-mode acceptEdits` to the default init command so the
CLI may create the file non-interactively, and pin the invocation with a
test. Verified end to end: with the flag, `/init` generates a proper
CLAUDE.md for the checkout.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MY1B86q5hsdA6okgQtXffa