### PR TITLE
fix(adopt): handle a pre-existing .claude/CLAUDE.md in claude-init

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -1,7 +1,11 @@
 package io.github.adamw7.tools.adopt.step;
 
+import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -20,6 +24,16 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * {@code /init} command only prints a request to write {@code CLAUDE.md}, exits
  * cleanly, and leaves nothing behind.
  *
+ * <p>A repository that already carries a {@code .claude/CLAUDE.md} steers
+ * headless {@code /init} into <em>updating that file</em> rather than writing the
+ * root {@code CLAUDE.md} the adoption needs — and a write under {@code .claude/}
+ * is refused as a sensitive path in headless mode, so the run exits cleanly
+ * having produced nothing. That existing memory file is therefore moved out of
+ * the checkout before {@code /init} runs, so the CLI takes its fresh-repository
+ * path and writes the root {@code CLAUDE.md}, and restored afterwards; the
+ * adoption commits only the new root file and leaves the project's own
+ * {@code .claude/CLAUDE.md} untouched.
+ *
  * <p>The generated {@code CLAUDE.md} is the whole point of the adoption, so a run
  * that exits cleanly but leaves no {@code CLAUDE.md} behind aborts the adoption
  * rather than letting the pipeline push a branch and open a pull request with
@@ -33,6 +47,7 @@ public class ClaudeInitStep extends AbstractCommandStep {
 			"--permission-mode", "acceptEdits");
 
 	private static final String CLAUDE_MD = "CLAUDE.md";
+	private static final String CLAUDE_DIR = ".claude";
 
 	private final List<String> claudeCommand;
 
@@ -51,9 +66,58 @@ public class ClaudeInitStep extends AbstractCommandStep {
 
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
-		log.info("Running claude init in {}", context.repositoryDirectory());
-		runOrFail(runner, context.repositoryDirectory(), claudeCommand);
+		Path checkout = context.repositoryDirectory();
+		log.info("Running claude init in {}", checkout);
+		Optional<Path> relocated = relocateExistingClaudeDirMemory(checkout);
+		try {
+			runOrFail(runner, checkout, claudeCommand);
+		} finally {
+			relocated.ifPresent(backup -> restore(backup, claudeDirMemory(checkout)));
+		}
 		requireGenerated(context);
+	}
+
+	private Path claudeDirMemory(Path checkout) {
+		return checkout.resolve(CLAUDE_DIR).resolve(CLAUDE_MD);
+	}
+
+	/**
+	 * Moves an existing {@code .claude/CLAUDE.md} out of the checkout so headless
+	 * {@code /init} writes the root {@code CLAUDE.md} instead of trying — and
+	 * failing — to update the sensitive-path memory file. The backup lands in the
+	 * system temp directory rather than the checkout so a later {@code git add -A}
+	 * cannot pick it up.
+	 *
+	 * @return the backup location when a memory file was moved aside, empty when
+	 *         the checkout carried none and nothing had to be relocated
+	 */
+	private Optional<Path> relocateExistingClaudeDirMemory(Path checkout) {
+		Path memory = claudeDirMemory(checkout);
+		if (!Files.isRegularFile(memory)) {
+			return Optional.empty();
+		}
+		return Optional.of(moveAside(memory));
+	}
+
+	private Path moveAside(Path memory) {
+		try {
+			Path backup = Files.createTempFile("adopt-claude-dir-memory-", ".bak");
+			Files.move(memory, backup, StandardCopyOption.REPLACE_EXISTING);
+			log.info("Moved existing {} aside so /init writes the root {}", memory, CLAUDE_MD);
+			return backup;
+		} catch (IOException e) {
+			throw new AdoptionException(name() + " could not move aside existing " + memory, e);
+		}
+	}
+
+	private void restore(Path backup, Path memory) {
+		try {
+			Files.createDirectories(memory.getParent());
+			Files.move(backup, memory, StandardCopyOption.REPLACE_EXISTING);
+			log.info("Restored existing {}", memory);
+		} catch (IOException e) {
+			throw new AdoptionException(name() + " could not restore " + memory + " from " + backup, e);
+		}
 	}
 
 	private void requireGenerated(AdoptionContext context) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
@@ -1,12 +1,16 @@
 package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -26,6 +30,16 @@ class ClaudeInitStepTest {
 
 	private void generateClaudeMd(AdoptionContext context) throws IOException {
 		Files.writeString(context.repositoryDirectory().resolve("CLAUDE.md"), "# CLAUDE.md");
+	}
+
+	private Path claudeDirMemory(AdoptionContext context) {
+		return context.repositoryDirectory().resolve(".claude").resolve("CLAUDE.md");
+	}
+
+	private void writeClaudeDirMemory(AdoptionContext context) throws IOException {
+		Path memory = claudeDirMemory(context);
+		Files.createDirectories(memory.getParent());
+		Files.writeString(memory, "# project memory");
 	}
 
 	@Test
@@ -66,5 +80,47 @@ class ClaudeInitStepTest {
 		AdoptionContext context = context(workspace);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		assertThrows(AdoptionException.class, () -> new ClaudeInitStep().execute(context, runner));
+	}
+
+	@Test
+	void movesExistingClaudeDirMemoryAsideSoHeadlessInitWritesRootFile(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		writeClaudeDirMemory(context);
+		AtomicBoolean memoryHiddenDuringInit = new AtomicBoolean();
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			memoryHiddenDuringInit.set(!Files.exists(claudeDirMemory(context)));
+			writeRootClaudeMd(context);
+			return new CommandResult(command, 0, "");
+		});
+		new ClaudeInitStep().execute(context, runner);
+		assertTrue(memoryHiddenDuringInit.get(), ".claude/CLAUDE.md must be moved aside while /init runs");
+		assertTrue(Files.isRegularFile(context.repositoryDirectory().resolve("CLAUDE.md")));
+		assertEquals("# project memory", Files.readString(claudeDirMemory(context)));
+	}
+
+	@Test
+	void restoresExistingClaudeDirMemoryWhenInitFails(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		writeClaudeDirMemory(context);
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 1, "boom"));
+		assertThrows(AdoptionException.class, () -> new ClaudeInitStep().execute(context, runner));
+		assertEquals("# project memory", Files.readString(claudeDirMemory(context)));
+	}
+
+	@Test
+	void leavesRootClaudeMdUntouchedWhenNoClaudeDirMemoryExists(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		generateClaudeMd(context);
+		new ClaudeInitStep().execute(context, new RecordingCommandRunner());
+		assertFalse(Files.exists(claudeDirMemory(context)));
+	}
+
+	private void writeRootClaudeMd(AdoptionContext context) {
+		try {
+			Files.writeString(context.repositoryDirectory().resolve("CLAUDE.md"), "# CLAUDE.md");
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
 	}
 }


### PR DESCRIPTION
Adopting a repository that already carries a `.claude/CLAUDE.md` failed at
the claude-init step: headless `/init` updates that existing memory file
instead of writing the root `CLAUDE.md` the adoption needs, and a write
under `.claude/` is refused as a sensitive path in headless mode, so the
run exits cleanly having produced nothing and the step aborts with
"claude-init completed but CLAUDE.md was not found".

ClaudeInitStep now moves an existing `.claude/CLAUDE.md` out of the checkout
(into the system temp dir, so `git add -A` cannot pick up the backup) before
running `/init`, so the CLI takes its fresh-repository path and writes the
root `CLAUDE.md`, then restores the file afterwards. The adoption therefore
commits only the new root file and leaves the project's own
`.claude/CLAUDE.md` untouched. Restoration runs in a finally block so the
file is put back even when the init command fails.

Covered by unit tests for the relocate/restore/root-file behaviour and the
failing-init restore path, and validated end-to-end against a real checkout.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015m9GStFP2tFjUT7WqtdHgC