### PR TITLE
fix(adopt): make the generated CLAUDE.md pass the guard it wires in

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -11,6 +11,7 @@ import io.github.adamw7.tools.adopt.step.AdoptionStep;
 import io.github.adamw7.tools.adopt.step.AssetsStep;
 import io.github.adamw7.tools.adopt.step.BranchStep;
 import io.github.adamw7.tools.adopt.step.ClaudeInitStep;
+import io.github.adamw7.tools.adopt.step.ClaudeMdConformanceStep;
 import io.github.adamw7.tools.adopt.step.CloneStep;
 import io.github.adamw7.tools.adopt.step.CommitStep;
 import io.github.adamw7.tools.adopt.step.EnforcerStep;
@@ -25,7 +26,9 @@ import io.github.adamw7.tools.adopt.step.VerifyStep;
  * Runs the ordered pipeline that adopts Claude Code into a GitHub repository:
  * check the required tools are installed, clone, create a feature branch, mark
  * the checkout trusted for Claude Code, generate {@code CLAUDE.md} with
- * {@code claude init} and commit it, wire in the {@code claude-code-enforcer} and
+ * {@code claude init}, normalise that file and add a companion {@code AGENTS.md}
+ * so it satisfies the guard the adoption is about to wire in, and commit it, wire
+ * in the {@code claude-code-enforcer} and
  * commit that, verify the enforcer passes on the generated file, then push the
  * branch and open a pull request. The toolchain check runs first so a missing
  * {@code git}, {@code claude}, or {@code gh} fails the adoption before any
@@ -70,6 +73,7 @@ public class GitHubRepoAdopter {
 				new BranchStep(),
 				new TrustStep(),
 				new ClaudeInitStep(),
+				new ClaudeMdConformanceStep(),
 				new CommitStep("Adopt Claude Code: add CLAUDE.md"),
 				new EnforcerStep(),
 				new CommitStep("Add claude-code-enforcer to the build")));

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
@@ -21,7 +21,7 @@ public final class AdoptionAssets {
 	static final String MCP_CONFIG_FILE = ".mcp.json";
 	static final String CLAUDE_WORKFLOW_FILE = ".github/workflows/claude.yml";
 
-	private static final String AGENTS_MD = """
+	static final String AGENTS_MD = """
 			# Agent guide
 
 			See [CLAUDE.md](CLAUDE.md) for this repository's agent instructions.

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
@@ -1,0 +1,99 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Makes the adoption self-consistent: after {@link ClaudeInitStep} generates a
+ * {@code CLAUDE.md}, this reshapes it with a {@link ClaudeMdConformer} so it
+ * satisfies the {@code claudeMdFormat} rule {@link EnforcerStep} wires into the
+ * build, and writes a companion {@code AGENTS.md} so the reference the rule
+ * expects resolves to a real file. Without it the adoption fails its own
+ * {@link VerifyStep}, because a generic {@code claude init} produces natural,
+ * project-specific headings and no {@code AGENTS.md} reference while the rule
+ * demands a fixed set of headings plus that reference.
+ *
+ * <p>The step runs before the first commit so the normalised {@code CLAUDE.md}
+ * and its companion {@code AGENTS.md} are committed together. It never overwrites
+ * an {@code AGENTS.md} the project already carries, and reshaping an already
+ * conforming {@code CLAUDE.md} leaves it unchanged, so the step is idempotent on
+ * re-adoption.
+ */
+public class ClaudeMdConformanceStep implements AdoptionStep {
+
+	private static final Logger log = LogManager.getLogger(ClaudeMdConformanceStep.class);
+
+	static final String CLAUDE_MD = "CLAUDE.md";
+
+	private final ClaudeMdConformer conformer;
+	private final AssetInstaller agentsMdInstaller;
+
+	public ClaudeMdConformanceStep() {
+		this(new ClaudeMdConformer(), new AssetInstaller(AdoptionAssets.AGENTS_MD_FILE, AdoptionAssets.AGENTS_MD));
+	}
+
+	ClaudeMdConformanceStep(ClaudeMdConformer conformer, AssetInstaller agentsMdInstaller) {
+		this.conformer = conformer;
+		this.agentsMdInstaller = agentsMdInstaller;
+	}
+
+	@Override
+	public String name() {
+		return "conform";
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		Path checkout = context.repositoryDirectory();
+		installAgentsMd(checkout);
+		conformClaudeMd(checkout);
+	}
+
+	private void installAgentsMd(Path checkout) {
+		if (agentsMdInstaller.install(checkout)) {
+			log.info("Wrote companion {}", agentsMdInstaller.relativePath());
+		} else {
+			log.info("{} already exists; left unchanged", agentsMdInstaller.relativePath());
+		}
+	}
+
+	private void conformClaudeMd(Path checkout) {
+		Path claudeMd = checkout.resolve(CLAUDE_MD);
+		String original = read(claudeMd);
+		String conformed = conformer.conform(original);
+		if (conformed.equals(original)) {
+			log.info("{} already satisfies the claudeMdFormat rule; left unchanged", CLAUDE_MD);
+		} else {
+			write(claudeMd, conformed);
+			log.info("Normalised {} to satisfy the claudeMdFormat rule", CLAUDE_MD);
+		}
+	}
+
+	private String read(Path claudeMd) {
+		if (!Files.isRegularFile(claudeMd)) {
+			throw new AdoptionException(name() + " requires " + CLAUDE_MD + " but it was not found in "
+					+ claudeMd.getParent());
+		}
+		try {
+			return Files.readString(claudeMd);
+		} catch (IOException e) {
+			throw new AdoptionException(name() + " could not read " + claudeMd, e);
+		}
+	}
+
+	private void write(Path claudeMd, String content) {
+		try {
+			Files.writeString(claudeMd, content);
+		} catch (IOException e) {
+			throw new AdoptionException(name() + " could not write " + claudeMd, e);
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -1,0 +1,288 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Reshapes the {@code CLAUDE.md} that {@link ClaudeInitStep} generated so it
+ * satisfies the {@code claudeMdFormat} rule {@link EnforcerStep} wires into the
+ * build. A generic {@code claude init} writes natural, project-specific headings
+ * ({@code ## Project purpose}, {@code ## Maven module structure}) and no
+ * {@code AGENTS.md} reference, but the rule demands a fixed set of whole-line
+ * headings plus that reference — so without this reshape the adoption fails its
+ * own {@link VerifyStep}.
+ *
+ * <p>The reshape is deterministic and conservative. It guarantees the
+ * {@code # CLAUDE.md} title is the first non-blank line, that {@code AGENTS.md}
+ * is referenced, and that every required section heading is present with a body.
+ * A heading that is a near-miss of a required one — the required heading followed
+ * by extra words, or the same text in a different case — is <em>renamed</em> in
+ * place, preserving the content beneath it; only a required heading with no such
+ * near-miss is appended as a fresh stub. Headings inside fenced code blocks are
+ * left alone, mirroring how the rule matches, so a {@code ##} line in a code
+ * sample is never mistaken for document structure.
+ *
+ * <p>Running the reshape again on an already-conforming document is a no-op
+ * (beyond normalising a missing or doubled trailing newline), so re-adopting a
+ * repository does not churn the file.
+ */
+public class ClaudeMdConformer {
+
+	/*
+	 * These mirror io.github.adamw7.tools.enforcer.doc.ClaudeMdFormatRule in the
+	 * claude-code-enforcer module: the title, the AGENTS.md reference, and the
+	 * required section headings the wired-in claudeMdFormat rule checks for. They
+	 * are duplicated here rather than imported because the adopt module does not
+	 * depend on the enforcer module; keep the two in sync.
+	 */
+	static final String TITLE = "# CLAUDE.md";
+	static final String AGENTS_REFERENCE = "AGENTS.md";
+	static final List<String> REQUIRED_SECTIONS = List.of(
+			"## Project",
+			"## Java version",
+			"## Maven",
+			"## Principles for Java Development",
+			"## Testing",
+			"## Dependencies");
+
+	static final String AGENTS_REFERENCE_LINE = "See [AGENTS.md](AGENTS.md) for the companion agent guide.";
+
+	private static final String BACKTICK_FENCE = "```";
+	private static final String TILDE_FENCE = "~~~";
+	private static final String STUB_BODY = "See [AGENTS.md](AGENTS.md).";
+
+	/**
+	 * @return {@code content} reshaped so the {@code claudeMdFormat} rule passes,
+	 *         with a single trailing newline
+	 */
+	public String conform(String content) {
+		List<String> lines = splitLines(content);
+		lines = ensureTitle(lines);
+		lines = canonicalizeHeadings(lines);
+		lines = appendMissingSections(lines);
+		lines = ensureAgentsReference(lines);
+		return join(lines);
+	}
+
+	private List<String> splitLines(String content) {
+		String normalized = content.replace("\r\n", "\n").replace("\r", "\n");
+		return new ArrayList<>(List.of(normalized.split("\n", -1)));
+	}
+
+	private List<String> ensureTitle(List<String> lines) {
+		if (TITLE.equals(firstNonBlank(lines))) {
+			return lines;
+		}
+		List<String> result = new ArrayList<>();
+		result.add(TITLE);
+		result.add("");
+		result.addAll(lines);
+		return result;
+	}
+
+	private String firstNonBlank(List<String> lines) {
+		return lines.stream().map(String::strip).filter(line -> !line.isEmpty()).findFirst().orElse("");
+	}
+
+	private List<String> canonicalizeHeadings(List<String> lines) {
+		List<String> result = new ArrayList<>(lines);
+		boolean[] fence = fenceMask(result);
+		Set<Integer> claimed = reservedHeadings(result, fence);
+		for (String required : REQUIRED_SECTIONS) {
+			canonicalize(result, fence, required, claimed);
+		}
+		return result;
+	}
+
+	/**
+	 * The indices of lines that already are a required heading exactly, reserved so
+	 * a near-match search never renames a heading that is already serving another
+	 * required section.
+	 */
+	private Set<Integer> reservedHeadings(List<String> lines, boolean[] fence) {
+		Set<Integer> reserved = new LinkedHashSet<>();
+		for (int index = 0; index < lines.size(); index++) {
+			addIfReserved(reserved, lines, fence, index);
+		}
+		return reserved;
+	}
+
+	private void addIfReserved(Set<Integer> reserved, List<String> lines, boolean[] fence, int index) {
+		if (!fence[index] && REQUIRED_SECTIONS.contains(lines.get(index).strip())) {
+			reserved.add(index);
+		}
+	}
+
+	private void canonicalize(List<String> lines, boolean[] fence, String required, Set<Integer> claimed) {
+		if (hasHeading(lines, fence, required)) {
+			return;
+		}
+		int index = firstNearMatch(lines, fence, required, claimed);
+		if (index >= 0) {
+			lines.set(index, required);
+			claimed.add(index);
+		}
+	}
+
+	private int firstNearMatch(List<String> lines, boolean[] fence, String required, Set<Integer> claimed) {
+		for (int index = 0; index < lines.size(); index++) {
+			if (isNearMatch(lines, fence, claimed, index, required)) {
+				return index;
+			}
+		}
+		return -1;
+	}
+
+	private boolean isNearMatch(List<String> lines, boolean[] fence, Set<Integer> claimed, int index, String required) {
+		if (fence[index] || claimed.contains(index)) {
+			return false;
+		}
+		String stripped = lines.get(index).strip();
+		return isHeading(stripped) && nearMatches(stripped, required);
+	}
+
+	/**
+	 * A heading is a near-miss of a required one when it is the required heading in
+	 * a different case, or the required heading followed by a space and extra words
+	 * — the two shapes {@code claude init} actually produces ({@code ## Project
+	 * purpose} for {@code ## Project}, {@code ## Principles for Java development}
+	 * for {@code ## Principles for Java Development}). The trailing space keeps
+	 * {@code ## Maven} from matching an unrelated {@code ## Mavenish} heading.
+	 */
+	private boolean nearMatches(String heading, String required) {
+		String actual = heading.toLowerCase(Locale.ROOT);
+		String wanted = required.toLowerCase(Locale.ROOT);
+		return actual.equals(wanted) || actual.startsWith(wanted + " ");
+	}
+
+	private List<String> appendMissingSections(List<String> lines) {
+		boolean[] fence = fenceMask(lines);
+		List<String> missing = missingSections(lines, fence);
+		if (missing.isEmpty()) {
+			return lines;
+		}
+		List<String> result = new ArrayList<>(lines);
+		for (String section : missing) {
+			appendSection(result, section);
+		}
+		return result;
+	}
+
+	private List<String> missingSections(List<String> lines, boolean[] fence) {
+		List<String> missing = new ArrayList<>();
+		for (String required : REQUIRED_SECTIONS) {
+			addIfMissing(missing, lines, fence, required);
+		}
+		return missing;
+	}
+
+	private void addIfMissing(List<String> missing, List<String> lines, boolean[] fence, String required) {
+		if (!hasHeading(lines, fence, required)) {
+			missing.add(required);
+		}
+	}
+
+	private void appendSection(List<String> lines, String section) {
+		lines.add("");
+		lines.add(section);
+		lines.add("");
+		lines.add(STUB_BODY);
+	}
+
+	private List<String> ensureAgentsReference(List<String> lines) {
+		boolean[] fence = fenceMask(lines);
+		if (containsOutsideFences(lines, fence, AGENTS_REFERENCE)) {
+			return lines;
+		}
+		List<String> result = new ArrayList<>(lines);
+		int titleIndex = indexOfTitle(result);
+		result.add(titleIndex + 1, "");
+		result.add(titleIndex + 2, AGENTS_REFERENCE_LINE);
+		result.add(titleIndex + 3, "");
+		return result;
+	}
+
+	private int indexOfTitle(List<String> lines) {
+		for (int index = 0; index < lines.size(); index++) {
+			if (lines.get(index).strip().equals(TITLE)) {
+				return index;
+			}
+		}
+		return 0;
+	}
+
+	private boolean hasHeading(List<String> lines, boolean[] fence, String heading) {
+		for (int index = 0; index < lines.size(); index++) {
+			if (!fence[index] && lines.get(index).strip().equals(heading)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean containsOutsideFences(List<String> lines, boolean[] fence, String token) {
+		for (int index = 0; index < lines.size(); index++) {
+			if (!fence[index] && lines.get(index).contains(token)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean isHeading(String stripped) {
+		return stripped.startsWith("#");
+	}
+
+	private boolean[] fenceMask(List<String> lines) {
+		boolean[] mask = new boolean[lines.size()];
+		String open = null;
+		for (int index = 0; index < lines.size(); index++) {
+			open = applyFence(lines.get(index).strip(), open, mask, index);
+		}
+		return mask;
+	}
+
+	/**
+	 * Marks whether the line is code and returns the fence marker still open after
+	 * it. A fence is closed only by the marker it was opened with, so a {@code ~~~}
+	 * line inside a {@code ```} block stays content.
+	 */
+	private String applyFence(String line, String open, boolean[] mask, int index) {
+		String marker = fenceMarker(line);
+		if (open == null) {
+			mask[index] = marker != null;
+			return marker;
+		}
+		mask[index] = true;
+		return sameMarker(marker, open) ? null : open;
+	}
+
+	private boolean sameMarker(String marker, String open) {
+		return marker != null && marker.charAt(0) == open.charAt(0);
+	}
+
+	private String fenceMarker(String line) {
+		if (line.startsWith(BACKTICK_FENCE)) {
+			return BACKTICK_FENCE;
+		}
+		if (line.startsWith(TILDE_FENCE)) {
+			return TILDE_FENCE;
+		}
+		return null;
+	}
+
+	private String join(List<String> lines) {
+		return String.join("\n", withoutTrailingBlanks(lines)) + "\n";
+	}
+
+	private List<String> withoutTrailingBlanks(List<String> lines) {
+		int end = lines.size();
+		while (end > 0 && lines.get(end - 1).isBlank()) {
+			end--;
+		}
+		return lines.subList(0, end);
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -82,15 +82,15 @@ class GitHubRepoAdopterTest {
 	@Test
 	void defaultPipelineBranchesCommitsPushesAndOpensAPullRequest() {
 		List<String> names = GitHubRepoAdopter.defaultSteps().stream().map(AdoptionStep::name).toList();
-		assertEquals(List.of("toolchain", "clone", "branch", "trust", "claude-init", "commit", "enforcer", "commit",
-				"verify", "push", "pull-request"), names);
+		assertEquals(List.of("toolchain", "clone", "branch", "trust", "claude-init", "conform", "commit", "enforcer",
+				"commit", "verify", "push", "pull-request"), names);
 	}
 
 	@Test
 	void defaultPipelineWithAssetsInstallsAndCommitsThemBeforeVerification() {
 		List<String> names = GitHubRepoAdopter.defaultSteps(PullRequestOptions.defaults(), true).stream()
 				.map(AdoptionStep::name).toList();
-		assertEquals(List.of("toolchain", "clone", "branch", "trust", "claude-init", "commit", "enforcer", "commit",
-				"assets", "commit", "verify", "push", "pull-request"), names);
+		assertEquals(List.of("toolchain", "clone", "branch", "trust", "claude-init", "conform", "commit", "enforcer",
+				"commit", "assets", "commit", "verify", "push", "pull-request"), names);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStepTest.java
@@ -1,0 +1,71 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class ClaudeMdConformanceStepTest {
+
+	private AdoptionContext context(Path workspace) throws IOException {
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/security.git", workspace);
+		Files.createDirectories(context.repositoryDirectory());
+		return context;
+	}
+
+	private void writeClaudeMd(AdoptionContext context, String content) throws IOException {
+		Files.writeString(context.repositoryDirectory().resolve("CLAUDE.md"), content);
+	}
+
+	private String claudeMd(AdoptionContext context) throws IOException {
+		return Files.readString(context.repositoryDirectory().resolve("CLAUDE.md"));
+	}
+
+	private Path agentsMd(AdoptionContext context) {
+		return context.repositoryDirectory().resolve(AdoptionAssets.AGENTS_MD_FILE);
+	}
+
+	@Test
+	void isNamedConform() {
+		assertEquals("conform", new ClaudeMdConformanceStep().name());
+	}
+
+	@Test
+	void writesAgentsMdAndNormalisesClaudeMd(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		writeClaudeMd(context, "# CLAUDE.md\n\n## Project purpose\n\nA repo.\n");
+		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
+		assertTrue(Files.isRegularFile(agentsMd(context)), "a companion AGENTS.md must be written");
+		String claudeMd = claudeMd(context);
+		assertTrue(claudeMd.contains(ClaudeMdConformer.AGENTS_REFERENCE), "CLAUDE.md must reference AGENTS.md");
+		assertTrue(claudeMd.contains("## Project"), "CLAUDE.md must carry the required heading");
+	}
+
+	@Test
+	void doesNotOverwriteAnExistingAgentsMd(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		writeClaudeMd(context, "# CLAUDE.md\n");
+		Files.writeString(agentsMd(context), "# Project's own AGENTS.md\n");
+		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
+		assertEquals("# Project's own AGENTS.md\n", Files.readString(agentsMd(context)),
+				"the project's own AGENTS.md must win");
+	}
+
+	@Test
+	void missingClaudeMdAbortsAdoption(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		ClaudeMdConformanceStep step = new ClaudeMdConformanceStep();
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -1,0 +1,196 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class ClaudeMdConformerTest {
+
+	private final ClaudeMdConformer conformer = new ClaudeMdConformer();
+
+	private List<String> headings(String content) {
+		return content.lines().map(String::strip).filter(line -> line.startsWith("#")).toList();
+	}
+
+	@Test
+	void canonicalisesNearMissHeadingsInPlacePreservingBody() {
+		String generated = """
+				# CLAUDE.md
+
+				## Project purpose
+
+				A security playground.
+
+				## Java version
+
+				Java 25.
+
+				## Maven module structure
+
+				Root pom is packaging=pom.
+
+				## Principles for Java development
+
+				SOLID.
+
+				## Testing
+
+				JUnit 5.
+
+				## Dependencies
+
+				Existing only.
+				""";
+		String conformed = conformer.conform(generated);
+		List<String> headings = headings(conformed);
+		assertTrue(headings.containsAll(ClaudeMdConformer.REQUIRED_SECTIONS), headings.toString());
+		assertFalse(conformed.contains("## Project purpose"), "the near-miss heading should be renamed, not duplicated");
+		assertFalse(conformed.contains("## Maven module structure"), "the near-miss heading should be renamed");
+		assertTrue(conformed.contains("A security playground."), "the renamed section keeps its body");
+		assertTrue(conformed.contains("Root pom is packaging=pom."), "the renamed section keeps its body");
+	}
+
+	@Test
+	void insertsAgentsReferenceWhenAbsent() {
+		String generated = "# CLAUDE.md\n\n" + requiredSectionsBody();
+		assertFalse(generated.contains(ClaudeMdConformer.AGENTS_REFERENCE));
+		String conformed = conformer.conform(generated);
+		assertTrue(conformed.contains(ClaudeMdConformer.AGENTS_REFERENCE), "an AGENTS.md reference must be added");
+		assertEquals(ClaudeMdConformer.TITLE, conformed.lines().findFirst().orElseThrow(),
+				"the title must stay the first line");
+	}
+
+	@Test
+	void appendsAStubForAGenuinelyMissingSection() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				## Project
+
+				A repo.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Maven.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Dependencies
+
+				Existing only.
+				""";
+		assertFalse(generated.contains("## Testing"));
+		String conformed = conformer.conform(generated);
+		assertTrue(headings(conformed).contains("## Testing"), "the missing section is scaffolded");
+		assertTrue(headings(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS));
+	}
+
+	@Test
+	void addsTheTitleWhenTheDocumentDoesNotStartWithIt() {
+		String generated = "## Project\n\nA repo.\n";
+		String conformed = conformer.conform(generated);
+		assertEquals(ClaudeMdConformer.TITLE, conformed.lines().findFirst().orElseThrow());
+	}
+
+	@Test
+	void ignoresHeadingsInsideCodeFencesWhenCanonicalising() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				```markdown
+				## Project purpose
+				```
+
+				## Project
+
+				A repo.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Maven.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Testing
+
+				JUnit 5.
+
+				## Dependencies
+
+				Existing only.
+				""";
+		String conformed = conformer.conform(generated);
+		assertTrue(conformed.contains("## Project purpose"), "the fenced heading must be left untouched");
+		assertTrue(headings(conformed).contains("## Project"));
+	}
+
+	@Test
+	void leavesAnAlreadyConformingDocumentUnchanged() {
+		String conforming = ("# CLAUDE.md\n\n" + ClaudeMdConformer.AGENTS_REFERENCE_LINE + "\n\n"
+				+ requiredSectionsBody()).stripTrailing() + "\n";
+		String conformed = conformer.conform(conforming);
+		assertEquals(conforming, conformed, "a conforming document must be a no-op");
+	}
+
+	@Test
+	void normalisationIsIdempotent() {
+		String generated = """
+				# CLAUDE.md
+
+				## Project purpose
+
+				A repo.
+
+				## Java version
+
+				Java 25.
+
+				## Maven module structure
+
+				Maven.
+
+				## Principles for Java development
+
+				SOLID.
+
+				## Testing
+
+				JUnit 5.
+
+				## Dependencies
+
+				Existing only.
+				""";
+		String once = conformer.conform(generated);
+		String twice = conformer.conform(once);
+		assertEquals(once, twice, "re-running the conformer must not churn the file");
+	}
+
+	private String requiredSectionsBody() {
+		StringBuilder builder = new StringBuilder();
+		for (String section : ClaudeMdConformer.REQUIRED_SECTIONS) {
+			builder.append(section).append("\n\nContent.\n\n");
+		}
+		return builder.toString();
+	}
+}


### PR DESCRIPTION
The e2e adoption failed its own verify step: `claude init` produces a
CLAUDE.md with natural, project-specific headings (## Project purpose,
## Maven module structure) and no AGENTS.md reference, but the
claudeMdFormat rule the adoption wires into the build demands a fixed set
of whole-line headings plus that reference. So `mvn -N validate` rejected
the freshly generated file and the adoption aborted before pushing.

Add a `conform` step, run after `claude init` and before the first
commit, that reshapes CLAUDE.md to satisfy the rule and writes a
companion AGENTS.md so the reference resolves to a real file:

- ClaudeMdConformer: deterministic, fence-aware normalisation. Ensures
  the `# CLAUDE.md` title and an AGENTS.md reference, canonicalises
  near-miss headings in place (## Project purpose -> ## Project) keeping
  their body, and scaffolds a stub only for a genuinely absent required
  section. Idempotent, so re-adoption does not churn the file.
- ClaudeMdConformanceStep: writes the companion AGENTS.md (reusing the
  starter asset content, never overwriting a project's own) and applies
  the conformer to CLAUDE.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014Z38nu7HhjgVYgybYXyh1p