### PR TITLE
Fix adopt clone nesting for relative workspace paths

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
@@ -11,6 +11,14 @@ import java.nio.file.Path;
  * always has a directory to run in — or a fresh temporary one when the caller
  * left the choice open. Shared by the command-line entry point and the MCP
  * server, so both resolve workspaces identically.
+ *
+ * <p>The returned path is always absolute. The clone step runs {@code git clone}
+ * with the workspace as its working directory and the checkout directory
+ * ({@code workspace/name}) as the clone target, so a relative workspace would
+ * make git resolve that target against the working directory a second time and
+ * nest the checkout under {@code workspace/workspace/name}, leaving every later
+ * step unable to find it. Absolutising the workspace up front — the temporary
+ * directory already is — keeps both entry points on the same, unambiguous path.
  */
 public final class Workspaces {
 
@@ -19,7 +27,7 @@ public final class Workspaces {
 
 	public static Path createIfMissing(Path workspace) {
 		try {
-			return Files.createDirectories(workspace);
+			return Files.createDirectories(workspace).toAbsolutePath();
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/WorkspacesTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/WorkspacesTest.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.adopt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -22,6 +23,27 @@ class WorkspacesTest {
 	void keepsAnExistingDirectory(@TempDir Path dir) {
 		assertEquals(dir, Workspaces.createIfMissing(dir));
 		assertTrue(Files.isDirectory(dir));
+	}
+
+	@Test
+	void absolutisesARelativeWorkspaceSoTheCloneTargetIsNotNested(@TempDir Path dir) {
+		Path relative = dir.getFileSystem().getPath("relative-workspace-" + System.nanoTime());
+		try {
+			Path created = Workspaces.createIfMissing(relative);
+			assertTrue(created.isAbsolute());
+			assertEquals(relative.toAbsolutePath(), created);
+			assertTrue(Files.isDirectory(created));
+		} finally {
+			deleteQuietly(relative);
+		}
+	}
+
+	private void deleteQuietly(Path path) {
+		try {
+			Files.deleteIfExists(path);
+		} catch (IOException ignored) {
+			path.toFile().deleteOnExit();
+		}
 	}
 
 	@Test


### PR DESCRIPTION
The e2e adopter mislocated the checkout when given a relative workspace
directory. CloneStep runs `git clone <url> <workspace>/<name>` with the
workspace as the process working directory, so a relative workspace made
git resolve the clone target against that working directory a second time,
nesting the checkout under `<workspace>/<workspace>/<name>`. Every later
step then looked for the checkout at `<workspace>/<name>` and failed with
"Cannot run program git ... No such file or directory".

Absolutise the workspace at the single choke point (Workspaces.createIfMissing,
shared by the CLI entry point and the MCP adopt tool); the temporary-workspace
path already returns an absolute path. Add a regression test that a relative
workspace is returned absolute.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016GanvqHAN3ZL7cHhTRRRzt