### PR TITLE
fix(adopt): make a re-adoption push fast-forward and never leave an empty CLAUDE.md section

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,7 +784,11 @@ The default pipeline runs these steps in order:
    `git clone`, giving the remaining steps a working checkout.
 3. **`BranchStep`** — creates and checks out the adoption feature branch with
    `git checkout -B`, so every later commit lands on that branch instead of the
-   default branch.
+   default branch. A fresh clone whose `origin` already publishes the branch — a
+   re-adoption of a repository an earlier run pushed — starts it from that
+   published tip, so the later push stays a fast-forward instead of being
+   rejected; a branch that already exists locally is left alone, so unpushed work
+   in a reused workspace is never reset onto the remote.
 4. **`TrustStep`** — marks the checkout trusted in `~/.claude.json` so the
    headless `claude` run is not blocked by the interactive folder-trust prompt.
 5. **`ClaudeInitStep`** — runs the Claude Code CLI in headless mode

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
@@ -1,6 +1,8 @@
 package io.github.adamw7.tools.adopt.step;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -18,10 +20,22 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * already exists, so re-running the adoption against a checkout that already
  * carries the branch starts the feature branch afresh rather than aborting on an
  * "already exists" failure.
+ *
+ * <p>A checkout that carries no local branch yet but whose {@code origin} already
+ * publishes one — a fresh clone re-adopting a repository an earlier run already
+ * pushed, which is what the default temporary workspace produces on every run —
+ * starts the branch from that published tip instead of from {@code HEAD}. Without
+ * it the branch would restart at the default branch, and {@link PushStep} would
+ * be rejected as a non-fast-forward, so a second adoption could never get past
+ * the push even though every other step is idempotent. A local branch that
+ * already exists is left to the plain {@code -B} above, so unpushed work in a
+ * reused workspace is never reset onto the remote.
  */
 public class BranchStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(BranchStep.class);
+
+	private static final String REMOTE = "origin";
 
 	@Override
 	public String name() {
@@ -31,7 +45,42 @@ public class BranchStep extends AbstractCommandStep {
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
 		log.info("Creating branch {} in {}", context.branchName(), context.repositoryDirectory());
-		List<String> command = List.of("git", "checkout", "-B", context.branchName());
-		runOrFail(runner, context.repositoryDirectory(), command);
+		runOrFail(runner, context.repositoryDirectory(), checkoutCommand(context, runner));
+	}
+
+	private List<String> checkoutCommand(AdoptionContext context, CommandRunner runner) {
+		List<String> command = new ArrayList<>(List.of("git", "checkout", "-B", context.branchName()));
+		startPoint(context, runner).ifPresent(command::add);
+		return List.copyOf(command);
+	}
+
+	/**
+	 * @return the published branch to start from, or empty when the checkout
+	 *         already carries the branch locally or {@code origin} does not publish
+	 *         it yet — in both cases the branch starts from {@code HEAD} as before.
+	 */
+	private Optional<String> startPoint(AdoptionContext context, CommandRunner runner) {
+		if (hasLocalBranch(context, runner) || !hasRemoteBranch(context, runner)) {
+			return Optional.empty();
+		}
+		log.info("Resuming branch {} from {}", context.branchName(), remoteBranch(context));
+		return Optional.of(remoteBranch(context));
+	}
+
+	private boolean hasLocalBranch(AdoptionContext context, CommandRunner runner) {
+		return hasRef(context, runner, "refs/heads/" + context.branchName());
+	}
+
+	private boolean hasRemoteBranch(AdoptionContext context, CommandRunner runner) {
+		return hasRef(context, runner, "refs/remotes/" + remoteBranch(context));
+	}
+
+	private String remoteBranch(AdoptionContext context) {
+		return REMOTE + "/" + context.branchName();
+	}
+
+	private boolean hasRef(AdoptionContext context, CommandRunner runner, String ref) {
+		List<String> command = List.of("git", "rev-parse", "--verify", "--quiet", ref);
+		return runner.run(context.repositoryDirectory(), command).succeeded();
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 /**
  * Reshapes the {@code CLAUDE.md} that {@link ClaudeInitStep} generated so it
@@ -21,9 +23,12 @@ import java.util.Set;
  * A heading that is a near-miss of a required one — the required heading followed
  * by extra words, or the same text in a different case — is <em>renamed</em> in
  * place, preserving the content beneath it; only a required heading with no such
- * near-miss is appended as a fresh stub. Headings inside fenced code blocks are
- * left alone, mirroring how the rule matches, so a {@code ##} line in a code
- * sample is never mistaken for document structure.
+ * near-miss is appended as a fresh stub. A required heading that ends up with an
+ * empty section — a renamed near-miss the generated document left bare, or a
+ * heading immediately followed by its sibling — gets a stub body, because the
+ * rule fails an empty section just as it fails a missing one. Headings inside
+ * fenced code blocks are left alone, mirroring how the rule matches, so a
+ * {@code ##} line in a code sample is never mistaken for document structure.
  *
  * <p>Running the reshape again on an already-conforming document is a no-op
  * (beyond normalising a missing or doubled trailing newline), so re-adopting a
@@ -63,6 +68,7 @@ public class ClaudeMdConformer {
 		lines = ensureTitle(lines);
 		lines = canonicalizeHeadings(lines);
 		lines = appendMissingSections(lines);
+		lines = ensureSectionBodies(lines);
 		lines = ensureAgentsReference(lines);
 		return join(lines);
 	}
@@ -192,6 +198,66 @@ public class ClaudeMdConformer {
 		lines.add(STUB_BODY);
 	}
 
+	/**
+	 * Gives a stub body to every required section that has none. Appended sections
+	 * already carry one, so this only ever fills in a heading the generated document
+	 * supplied — typically a near-miss renamed in place above whose section the
+	 * document left bare.
+	 */
+	private List<String> ensureSectionBodies(List<String> lines) {
+		List<String> result = new ArrayList<>(lines);
+		for (String required : REQUIRED_SECTIONS) {
+			insertStubBodyIfEmpty(result, required);
+		}
+		return result;
+	}
+
+	/**
+	 * The fence mask is rebuilt per section because inserting a stub shifts every
+	 * later line, and the sections are few enough for that to stay cheap.
+	 */
+	private void insertStubBodyIfEmpty(List<String> lines, String required) {
+		boolean[] fence = fenceMask(lines);
+		int index = indexOfHeading(lines, fence, required);
+		if (index >= 0 && !hasBody(lines, fence, index)) {
+			lines.add(index + 1, "");
+			lines.add(index + 2, STUB_BODY);
+		}
+	}
+
+	/**
+	 * Mirrors how the rule decides a section is non-empty: before the next heading
+	 * at its own level or shallower, the section must carry prose, a code block, or
+	 * a deeper sub-heading. Blank lines are neither, so the scan looks past them.
+	 */
+	private boolean hasBody(List<String> lines, boolean[] fence, int headingIndex) {
+		int level = headingLevel(lines.get(headingIndex).strip());
+		return IntStream.range(headingIndex + 1, lines.size())
+				.mapToObj(index -> classifyBodyLine(lines, fence, index, level))
+				.flatMap(Optional::stream)
+				.findFirst()
+				.orElse(false);
+	}
+
+	/**
+	 * @return whether the line is the section's body ({@code true}) or ends it
+	 *         ({@code false}), or empty when it is blank and so decides neither
+	 */
+	private Optional<Boolean> classifyBodyLine(List<String> lines, boolean[] fence, int index, int level) {
+		if (fence[index]) {
+			return Optional.of(true);
+		}
+		String line = lines.get(index).strip();
+		if (isHeading(line)) {
+			return Optional.of(headingLevel(line) > level);
+		}
+		return line.isEmpty() ? Optional.empty() : Optional.of(true);
+	}
+
+	private int headingLevel(String heading) {
+		return (int) heading.chars().takeWhile(character -> character == '#').count();
+	}
+
 	private List<String> ensureAgentsReference(List<String> lines) {
 		boolean[] fence = fenceMask(lines);
 		if (containsOutsideFences(lines, fence, AGENTS_REFERENCE)) {
@@ -215,12 +281,15 @@ public class ClaudeMdConformer {
 	}
 
 	private boolean hasHeading(List<String> lines, boolean[] fence, String heading) {
-		for (int index = 0; index < lines.size(); index++) {
-			if (!fence[index] && lines.get(index).strip().equals(heading)) {
-				return true;
-			}
-		}
-		return false;
+		return indexOfHeading(lines, fence, heading) >= 0;
+	}
+
+	/** @return the index of the heading outside code fences, or {@code -1} when absent */
+	private int indexOfHeading(List<String> lines, boolean[] fence, String heading) {
+		return IntStream.range(0, lines.size())
+				.filter(index -> !fence[index] && lines.get(index).strip().equals(heading))
+				.findFirst()
+				.orElse(-1);
 	}
 
 	private boolean containsOutsideFences(List<String> lines, boolean[] fence, String token) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/WorkspacesTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/WorkspacesTest.java
@@ -1,9 +1,12 @@
 package io.github.adamw7.tools.adopt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -44,6 +47,25 @@ class WorkspacesTest {
 		} catch (IOException ignored) {
 			path.toFile().deleteOnExit();
 		}
+	}
+
+	/**
+	 * The clone has nowhere to go if the workspace cannot be created, so the
+	 * failure must surface rather than leaving a later step to fail obscurely.
+	 */
+	@Test
+	void reportsAWorkspaceThatCannotBeCreated(@TempDir Path dir) throws IOException {
+		Path blocker = dir.resolve("not-a-directory");
+		Files.writeString(blocker, "");
+		assertThrows(UncheckedIOException.class, () -> Workspaces.createIfMissing(blocker.resolve("workspace")));
+	}
+
+	@Test
+	void createsTemporaryDirectoriesThatDoNotCollide() {
+		Path first = Workspaces.createTemporary();
+		Path second = Workspaces.createTemporary();
+		assertNotEquals(first, second, "each run must get its own workspace");
+		assertTrue(first.isAbsolute(), "the clone target is resolved against the workspace, so it must be absolute");
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ExecutableResolverTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ExecutableResolverTest.java
@@ -71,6 +71,14 @@ class ExecutableResolverTest {
 	}
 
 	@Test
+	void windowsLeavesAProgramCarryingABackslashPathUnchanged(@TempDir Path dir) throws IOException {
+		Files.createFile(dir.resolve("mvn.cmd"));
+		ExecutableResolver resolver = new ExecutableResolver(true, List.of(dir), EXTENSIONS);
+		List<String> command = List.of("C:\\tools\\mvn", "-N");
+		assertSame(command, resolver.resolve(command));
+	}
+
+	@Test
 	void anEmptyCommandIsReturnedUnchanged() {
 		ExecutableResolver resolver = new ExecutableResolver(true, List.of(), EXTENSIONS);
 		List<String> command = List.of();

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunnerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunnerTest.java
@@ -36,6 +36,30 @@ class ProcessCommandRunnerTest {
 	}
 
 	@Test
+	void rejectsATimeoutThatIsNotPositive() {
+		assertThrows(IllegalArgumentException.class, () -> new ProcessCommandRunner(Duration.ZERO));
+		assertThrows(IllegalArgumentException.class, () -> new ProcessCommandRunner(Duration.ofSeconds(-1)));
+		assertThrows(IllegalArgumentException.class, () -> new ProcessCommandRunner(null));
+	}
+
+	/**
+	 * An adoption running inside a host that interrupts its worker — an MCP server
+	 * shutting down — must abort rather than swallow the interrupt, and must leave
+	 * the flag set so the caller above still sees it.
+	 */
+	@Test
+	void interruptionAbortsAndRestoresTheInterruptFlag() {
+		Thread.currentThread().interrupt();
+		try {
+			assertThrows(AdoptionException.class,
+					() -> runner.run(Path.of("."), PlatformCommands.sleepingFor(30)));
+			assertTrue(Thread.currentThread().isInterrupted(), "the interrupt flag must be restored");
+		} finally {
+			Thread.interrupted();
+		}
+	}
+
+	@Test
 	void wrapsMissingExecutableInAdoptionException() {
 		assertThrows(AdoptionException.class,
 				() -> runner.run(Path.of("."), List.of("definitely-not-a-real-binary-xyz")));

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/StreamGobblerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/StreamGobblerTest.java
@@ -51,6 +51,27 @@ class StreamGobblerTest {
 	}
 
 	/**
+	 * An interrupted caller must not be left waiting out the join: {@code output()}
+	 * returns what it has and hands the interrupt on, so the runner above can abort
+	 * the adoption instead of losing the signal.
+	 */
+	@Test
+	void interruptedJoinReturnsPromptlyAndRestoresTheInterruptFlag() throws IOException {
+		PipedOutputStream sink = new PipedOutputStream();
+		PipedInputStream source = new PipedInputStream(sink);
+		StreamGobbler gobbler = StreamGobbler.consuming(source);
+
+		Thread.currentThread().interrupt();
+		try {
+			assertEquals("", gobbler.output());
+			assertTrue(Thread.currentThread().isInterrupted(), "the interrupt flag must be restored");
+		} finally {
+			Thread.interrupted();
+			sink.close();
+		}
+	}
+
+	/**
 	 * A descendant of a destroyed child can keep the output pipe open, so the
 	 * stream never reaches end-of-stream. {@link StreamGobbler#output()} must
 	 * still return — with whatever it captured — rather than block forever. This

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BranchStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BranchStepTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,10 +22,49 @@ class BranchStepTest {
 
 	@Test
 	void createsFeatureBranchInCheckout() {
-		RecordingCommandRunner runner = new RecordingCommandRunner();
+		RecordingCommandRunner runner = new RecordingCommandRunner(missingRefs());
 		step.execute(context, runner);
-		assertEquals(List.of("git", "checkout", "-B", "claude/adopt-claude-code"), runner.commandAt(0));
+		assertEquals(List.of("git", "checkout", "-B", "claude/adopt-claude-code"), lastCommand(runner));
 		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
+	}
+
+	/**
+	 * A fresh clone re-adopting a repository an earlier run already pushed carries
+	 * no local branch but does carry origin's. Starting from that published tip is
+	 * what keeps the later push a fast-forward instead of a rejected one.
+	 */
+	@Test
+	void resumesThePublishedBranchWhenTheCheckoutHasNoLocalOne() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				refs(List.of("refs/remotes/origin/claude/adopt-claude-code")));
+		step.execute(context, runner);
+		assertEquals(List.of("git", "checkout", "-B", "claude/adopt-claude-code",
+				"origin/claude/adopt-claude-code"), lastCommand(runner));
+	}
+
+	@Test
+	void keepsALocalBranchRatherThanResettingItOntoTheRemote() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(refs(List.of(
+				"refs/heads/claude/adopt-claude-code", "refs/remotes/origin/claude/adopt-claude-code")));
+		step.execute(context, runner);
+		assertEquals(List.of("git", "checkout", "-B", "claude/adopt-claude-code"), lastCommand(runner));
+	}
+
+	private Function<List<String>, CommandResult> missingRefs() {
+		return refs(List.of());
+	}
+
+	/** Answers {@code git rev-parse --verify} for the named refs only, as git does. */
+	private Function<List<String>, CommandResult> refs(List<String> existing) {
+		return command -> new CommandResult(command, resolves(command, existing) ? 0 : 1, "");
+	}
+
+	private boolean resolves(List<String> command, List<String> existing) {
+		return !command.contains("rev-parse") || existing.contains(command.get(command.size() - 1));
+	}
+
+	private List<String> lastCommand(RecordingCommandRunner runner) {
+		return runner.commandAt(runner.count() - 1);
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStepTest.java
@@ -61,6 +61,20 @@ class ClaudeMdConformanceStepTest {
 				"the project's own AGENTS.md must win");
 	}
 
+	/**
+	 * Re-adopting a repository must not churn a {@code CLAUDE.md} the previous run
+	 * already normalised, so the second commit has nothing to record for it.
+	 */
+	@Test
+	void leavesAnAlreadyConformingClaudeMdByteIdentical(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		writeClaudeMd(context, "# CLAUDE.md\n\nSee AGENTS.md.\n");
+		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
+		String conformed = claudeMd(context);
+		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
+		assertEquals(conformed, claudeMd(context), "a conforming CLAUDE.md must be left untouched");
+	}
+
 	@Test
 	void missingClaudeMdAbortsAdoption(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -54,6 +54,50 @@ class ClaudeMdConformerTest {
 		assertTrue(conformed.contains("Root pom is packaging=pom."), "the renamed section keeps its body");
 	}
 
+	/**
+	 * A heading is only half of what the rule checks: it fails an empty section
+	 * just as it fails a missing one, so a near-miss renamed over a bare section
+	 * has to come out with a body or the adoption fails its own verification.
+	 */
+	@Test
+	void givesARenamedNearMissWithNoContentAStubBody() {
+		String generated = """
+				# CLAUDE.md
+
+				## Project purpose
+
+				## Build commands
+
+				Run `mvn install`.
+				""";
+		String conformed = conformer.conform(generated);
+		assertTrue(conformed.contains("## Project\n\nSee [AGENTS.md](AGENTS.md)."),
+				"the emptied section must be given a body:\n" + conformed);
+		ClaudeMdConformer.REQUIRED_SECTIONS.forEach(section -> assertTrue(hasBody(conformed, section),
+				section + " must have a body:\n" + conformed));
+	}
+
+	@Test
+	void keepsTheBodyOfASectionThatAlreadyHasOne() {
+		String generated = "# CLAUDE.md\n\n" + requiredSectionsBody();
+		String conformed = conformer.conform(generated);
+		assertEquals(ClaudeMdConformer.REQUIRED_SECTIONS.size(), conformed.split("Content\\.", -1).length - 1,
+				"every original body must survive exactly once:\n" + conformed);
+		assertFalse(conformed.contains("Content.\n\nSee [AGENTS.md](AGENTS.md)."),
+				"a section that already has a body must not be given a stub");
+	}
+
+	/**
+	 * Mirrors the enforcer rule's own check: the section must carry something other
+	 * than blank lines before the next heading at its level or shallower.
+	 */
+	private boolean hasBody(String content, String section) {
+		List<String> lines = content.lines().map(String::strip).toList();
+		int start = lines.indexOf(section);
+		return start >= 0 && lines.stream().skip(start + 1L).dropWhile(String::isEmpty).findFirst()
+				.filter(line -> !line.startsWith("## ")).isPresent();
+	}
+
 	@Test
 	void insertsAgentsReferenceWhenAbsent() {
 		String generated = "# CLAUDE.md\n\n" + requiredSectionsBody();

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -230,6 +230,112 @@ class ClaudeMdConformerTest {
 		assertEquals(once, twice, "re-running the conformer must not churn the file");
 	}
 
+	@Test
+	void countsAFencedCodeBlockAsASectionBody() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				## Project
+
+				```bash
+				mvn install
+				```
+
+				## Java version
+
+				Java 25.
+				""";
+		String conformed = conformer.conform(generated);
+		assertFalse(conformed.contains("## Project\n\nSee [AGENTS.md](AGENTS.md)."),
+				"a section whose body is a code block must not be given a stub:\n" + conformed);
+	}
+
+	@Test
+	void countsADeeperSubHeadingAsASectionBody() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				## Testing
+
+				### Unit tests
+
+				JUnit 5.
+				""";
+		String conformed = conformer.conform(generated);
+		assertFalse(conformed.contains("## Testing\n\nSee [AGENTS.md](AGENTS.md)."),
+				"a section carrying a sub-heading must not be given a stub:\n" + conformed);
+	}
+
+	@Test
+	void leavesHeadingsInsideTildeFencesAlone() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				~~~markdown
+				## Project purpose
+				~~~
+
+				## Project
+
+				A repo.
+				""";
+		String conformed = conformer.conform(generated);
+		assertTrue(conformed.contains("## Project purpose"), "the tilde-fenced heading must be left untouched");
+		assertTrue(headings(conformed).contains("## Project"));
+	}
+
+	@Test
+	void addsTheAgentsReferenceWhenTheOnlyMentionIsInsideAFence() {
+		String generated = """
+				# CLAUDE.md
+
+				```markdown
+				See AGENTS.md.
+				```
+
+				## Project
+
+				A repo.
+				""";
+		String conformed = conformer.conform(generated);
+		assertTrue(referencesAgentsMdOutsideFences(conformed),
+				"a mention that only exists as a code sample does not satisfy the rule:\n" + conformed);
+	}
+
+	/** Mirrors how the rule looks for the reference: fenced lines do not count. */
+	private boolean referencesAgentsMdOutsideFences(String content) {
+		boolean fenced = false;
+		boolean found = false;
+		for (String line : content.lines().toList()) {
+			found = found || (!fenced && line.contains(ClaudeMdConformer.AGENTS_REFERENCE));
+			fenced = line.strip().startsWith("```") != fenced;
+		}
+		return found;
+	}
+
+	@Test
+	void buildsAWholeSkeletonFromAnEmptyDocument() {
+		String conformed = conformer.conform("");
+		assertEquals(ClaudeMdConformer.TITLE, conformed.lines().findFirst().orElseThrow());
+		assertTrue(headings(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS), conformed);
+		ClaudeMdConformer.REQUIRED_SECTIONS.forEach(section -> assertTrue(hasBody(conformed, section),
+				section + " must have a body:\n" + conformed));
+	}
+
+	@Test
+	void collapsesTrailingBlankLinesToASingleNewline() {
+		String conforming = ("# CLAUDE.md\n\n" + ClaudeMdConformer.AGENTS_REFERENCE_LINE + "\n\n"
+				+ requiredSectionsBody()).stripTrailing() + "\n";
+		String conformed = conformer.conform(conforming + "\n\n\n");
+		assertEquals(conforming, conformed, "trailing blank lines must be normalised away");
+	}
+
 	private String requiredSectionsBody() {
 		StringBuilder builder = new StringBuilder();
 		for (String section : ClaudeMdConformer.REQUIRED_SECTIONS) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStoreTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStoreTest.java
@@ -109,6 +109,20 @@ class ClaudeTrustStoreTest {
 		assertEquals(original, Files.readString(config));
 	}
 
+	/**
+	 * A half-written or hand-edited config is not something to silently replace:
+	 * the trust flag is worth far less than the user's own Claude Code settings.
+	 */
+	@Test
+	void refusesToOverwriteAConfigThatIsNotValidJson(@TempDir Path dir) throws IOException {
+		Path config = dir.resolve(".claude.json");
+		Files.writeString(config, "{\"projects\": ");
+		ClaudeTrustStore store = new ClaudeTrustStore(config);
+		Path repo = dir.resolve("repo");
+		assertThrows(AdoptionException.class, () -> store.trust(repo));
+		assertEquals("{\"projects\": ", Files.readString(config), "the unreadable config must be left as it was");
+	}
+
 	@Test
 	void treatsAnEmptyConfigFileAsAFreshObject(@TempDir Path dir) throws IOException {
 		Path config = dir.resolve(".claude.json");

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleBuildSystemTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleBuildSystemTest.java
@@ -1,0 +1,77 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+class GradleBuildSystemTest {
+
+	private final GradleBuildSystem buildSystem = new GradleBuildSystem();
+
+	@Test
+	void matchesNothingWithoutABuildScript(@TempDir Path directory) {
+		assertFalse(buildSystem.matches(directory));
+	}
+
+	/**
+	 * Detection and installation are separate calls, so a checkout that lost its
+	 * build script in between must fail with a message naming the directory rather
+	 * than with an empty {@code Optional} unwrapping somewhere deeper.
+	 */
+	@Test
+	void installingWithoutABuildScriptAbortsAdoption(@TempDir Path directory) {
+		assertThrows(AdoptionException.class, () -> buildSystem.install(directory));
+	}
+
+	/**
+	 * Gradle itself prefers the Groovy script when a project carries both, so the
+	 * guard has to land in the file Gradle will actually run.
+	 */
+	@Test
+	void guardsTheGroovyScriptWhenTheCheckoutCarriesBoth(@TempDir Path directory) throws IOException {
+		Path groovy = directory.resolve(GradleBuildSystem.GROOVY_BUILD_FILE);
+		Path kotlin = directory.resolve(GradleBuildSystem.KOTLIN_BUILD_FILE);
+		Files.writeString(groovy, "plugins { id 'java' }\n");
+		Files.writeString(kotlin, "plugins { java }\n");
+
+		assertTrue(buildSystem.install(directory));
+
+		assertTrue(Files.readString(groovy).contains(GradleGuardInstaller.GUARD_TASK),
+				"the guard belongs in the script Gradle resolves first");
+		assertFalse(Files.readString(kotlin).contains(GradleGuardInstaller.GUARD_TASK),
+				"the unused Kotlin script must be left alone");
+	}
+
+	@Test
+	void guardsTheKotlinScriptWhenItIsTheOnlyOne(@TempDir Path directory) throws IOException {
+		Path kotlin = directory.resolve(GradleBuildSystem.KOTLIN_BUILD_FILE);
+		Files.writeString(kotlin, "plugins { java }\n");
+
+		assertTrue(buildSystem.install(directory));
+
+		assertTrue(Files.readString(kotlin).contains("tasks.register(\"" + GradleGuardInstaller.GUARD_TASK + "\")"),
+				"the Kotlin DSL syntax must be used for a .kts script");
+	}
+
+	@Test
+	void reportsAnAlreadyGuardedScriptAsUnchanged(@TempDir Path directory) throws IOException {
+		Files.writeString(directory.resolve(GradleBuildSystem.GROOVY_BUILD_FILE), "plugins { id 'java' }\n");
+		assertTrue(buildSystem.install(directory));
+		assertFalse(buildSystem.install(directory), "a second adoption must leave the script unchanged");
+	}
+
+	@Test
+	void isNamedGradle() {
+		assertEquals("gradle", buildSystem.name());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -10,6 +11,8 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
 
 class GradleGuardInstallerTest {
 
@@ -45,6 +48,13 @@ class GradleGuardInstallerTest {
 		assertTrue(content.contains("tasks.register('enforceClaudeMd')"), "the guard must be appended");
 		assertFalse(content.replace("\r\n", "").contains("\n"),
 				"a CRLF build script must stay CRLF; the appended block must not introduce bare LF endings");
+	}
+
+	@Test
+	void unreadableBuildScriptAbortsAdoption(@TempDir Path directory) throws IOException {
+		Path buildFile = directory.resolve("build.gradle");
+		Files.createDirectory(buildFile);
+		assertThrows(AdoptionException.class, () -> installer.install(buildFile));
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.adopt.step;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -14,6 +15,8 @@ import java.util.Properties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
 
 class PomEnforcerInstallerTest {
 
@@ -272,6 +275,65 @@ class PomEnforcerInstallerTest {
 				"a created element must use the file's four-space unit, not the default two");
 		assertTrue(result.contains("\n        <plugins>\n"),
 				"nesting must scale by the detected four-space unit");
+	}
+
+	/**
+	 * A POM that declares no namespace at all is still valid Maven input, and its
+	 * added elements must stay namespace-less too — qualifying them would leave the
+	 * build with elements Maven no longer recognises.
+	 */
+	@Test
+	void wiresTheRuleIntoAPomThatDeclaresNoNamespace(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_BUILD.replace(" xmlns=\"http://maven.apache.org/POM/4.0.0\"", ""));
+		assertTrue(installer.install(pom));
+		String result = Files.readString(pom);
+		assertTrue(result.contains("<artifactId>tools.claude-code-enforcer</artifactId>"),
+				"the rule must be wired in:\n" + result);
+		assertFalse(result.contains("xmlns"), "no namespace may be invented for a POM that had none:\n" + result);
+	}
+
+	@Test
+	void doesNotAddATrailingNewlineToAPomThatHadNone(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_BUILD.stripTrailing());
+		installer.install(pom);
+		String result = Files.readString(pom);
+		assertTrue(result.endsWith("</project>"), "the file must end exactly as it did:\n" + result);
+	}
+
+	/**
+	 * A declaration sharing its line with the root element has no line terminator
+	 * to carry over, so one is supplied rather than running {@code <project>} onto
+	 * the declaration's line.
+	 */
+	@Test
+	void preservesADeclarationThatSharesItsLineWithTheRootElement(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, "<?xml version=\"1.0\"?>" + POM_WITH_BUILD);
+		installer.install(pom);
+		String result = Files.readString(pom);
+		assertTrue(result.startsWith("<?xml version=\"1.0\"?>\n<project "), "unexpected start:\n" + result);
+		assertEquals(1, countOccurrences(result, "<?xml"), "the declaration must not be duplicated");
+	}
+
+	@Test
+	void fallsBackToATwoSpaceUnitForAPomWithNoIndentation(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITHOUT_BUILD.replace("\n  ", "\n"));
+		installer.install(pom);
+		String result = Files.readString(pom);
+		assertTrue(result.contains("\n  <build>\n"),
+				"a POM carrying no indentation of its own must get the two-space default:\n" + result);
+		assertTrue(result.contains("\n    <plugins>\n"), "nesting must scale by the default unit:\n" + result);
+	}
+
+	@Test
+	void malformedPomAbortsAdoption(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, "<project><build></project>");
+		assertThrows(AdoptionException.class, () -> installer.install(pom));
+	}
+
+	@Test
+	void missingPomAbortsAdoption(@TempDir Path dir) {
+		Path pom = dir.resolve("pom.xml");
+		assertThrows(AdoptionException.class, () -> installer.install(pom));
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestOptionsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestOptionsTest.java
@@ -60,6 +60,15 @@ class PullRequestOptionsTest {
 		assertThrows(IllegalArgumentException.class, builder::build);
 	}
 
+	/** A caller clearing a field rather than leaving the default must not slip a null into gh's arguments. */
+	@Test
+	void rejectsANullTitleOrBody() {
+		PullRequestOptions.Builder withoutTitle = PullRequestOptions.builder().title(null);
+		assertThrows(IllegalArgumentException.class, withoutTitle::build);
+		PullRequestOptions.Builder withoutBody = PullRequestOptions.builder().body(null);
+		assertThrows(IllegalArgumentException.class, withoutBody::build);
+	}
+
 	@Test
 	void defensivelyCopiesReviewers() {
 		List<String> reviewers = new ArrayList<>(List.of("octocat"));

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -120,6 +120,29 @@ class PullRequestStepTest {
 		assertTrue(report.pullRequestUrl().isEmpty());
 	}
 
+	/**
+	 * A list that cannot even be run — an unauthenticated {@code gh}, a remote that
+	 * is not a GitHub repository — must not be read as "a pull request is already
+	 * open", or the adoption would report success having created nothing.
+	 */
+	@Test
+	void createsThePullRequestWhenTheListQueryItselfFails() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::listFails);
+		step.execute(context, runner);
+		assertTrue(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("create")),
+				"creation must still be attempted when the pre-check could not be answered");
+	}
+
+	/** Output cut short mid-document — a killed {@code gh}, a truncated pipe. */
+	@Test
+	void leavesUrlAbsentWhenListOutputIsTruncatedJson() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 0, "[{\"url\": "));
+		AdoptionReport report = new AdoptionReport();
+		step.execute(context, runner, report);
+		assertTrue(report.pullRequestUrl().isEmpty());
+	}
+
 	@Test
 	void failedCreationAbortsAdoption() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::createFails);
@@ -135,6 +158,13 @@ class PullRequestStepTest {
 
 	private CommandResult existingPullRequest(List<String> command) {
 		return new CommandResult(command, 0, "[{\"url\":\"" + PR_URL + "\"}]");
+	}
+
+	private CommandResult listFails(List<String> command) {
+		if (command.contains("list")) {
+			return new CommandResult(command, 1, "gh: not authenticated");
+		}
+		return new CommandResult(command, 0, PR_URL);
 	}
 
 	private CommandResult createFails(List<String> command) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstallerTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -10,6 +11,8 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
 
 class WorkflowGuardInstallerTest {
 
@@ -30,6 +33,18 @@ class WorkflowGuardInstallerTest {
 		assertTrue(script.startsWith("#!/bin/sh"));
 		assertTrue(script.contains("grep -q '[^[:space:]]' CLAUDE.md"));
 		assertTrue(script.contains("CLAUDE.md is missing or empty"));
+	}
+
+	/**
+	 * The fallback guard is the only thing standing between a build-less repository
+	 * and an unchecked CLAUDE.md, so a checkout it cannot be written into must fail
+	 * the adoption rather than pass silently guarded by nothing.
+	 */
+	@Test
+	void aCheckoutTheGuardCannotBeWrittenIntoAbortsAdoption(@TempDir Path directory) throws IOException {
+		Files.createDirectories(directory.resolve(".github"));
+		Files.writeString(directory.resolve(".github/workflows"), "not a directory");
+		assertThrows(AdoptionException.class, () -> installer.install(directory));
 	}
 
 	@Test


### PR DESCRIPTION
Two failures that only surface on the pipeline's own promises.

BranchStep restarted the feature branch at HEAD on every run, so a second
adoption from a fresh workspace — the default, since an omitted workspace is a
new temporary directory each run — branched from the default branch and PushStep
was rejected as a non-fast-forward. Every other step is idempotent, and
PullRequestStep even handles the "the earlier pull request was closed, open a
fresh one" case that can only be reached after a successful re-push. A checkout
with no local branch whose origin already publishes one now starts from that
published tip, so the push fast-forwards; a branch that already exists locally is
left to the plain -B, so unpushed work in a reused workspace is never reset onto
the remote.

ClaudeMdConformer guaranteed only that every required heading exists. The
claudeMdFormat rule it conforms the document for fails an empty section just as
it fails a missing one, so a near-miss heading renamed over a bare section (for
example "## Project purpose" with nothing under it) produced a CLAUDE.md that
failed the adoption's own VerifyStep. Required sections that end up empty now get
the same stub body as an appended one, matching the rule's notion of a body:
prose, a code block, or a deeper sub-heading before the next sibling heading.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tq8omXeJ36rrSB9cm7dX3X