### PR TITLE
fix(adopt): stop three guard bugs from failing or clobbering an adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,8 +806,11 @@ The default pipeline runs these steps in order:
    `check`. A repository with no recognised build file falls back to a
    `FallbackBuildSystem` that installs a GitHub Actions workflow and the portable
    `.github/claude-md-guard.sh` check it runs via `WorkflowGuardInstaller`. All
-   installs are idempotent. Supporting a new build tool is a matter of adding a
-   `BuildSystem` implementation rather than branching inside the step.
+   installs are idempotent and none of them overwrites a file the project already
+   carries — a repository with its own `claude-md-guard.yml` or its own
+   `enforceClaudeMd` registration keeps it. Supporting a new build tool is a
+   matter of adding a `BuildSystem` implementation rather than branching inside
+   the step.
 8. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
    build`).
 9. **`VerifyStep`** — runs the detected build system's verification (a

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -30,6 +30,12 @@ import java.util.stream.IntStream;
  * fenced code blocks are left alone, mirroring how the rule matches, so a
  * {@code ##} line in a code sample is never mistaken for document structure.
  *
+ * <p>A fence the generated document opened but never closed is closed first, so
+ * the sections appended below it are document structure rather than more code.
+ * Without that the rule — which reads fences exactly the same way — sees every
+ * appended heading as part of the unterminated block and reports all of them
+ * missing, and each re-run appends another unreachable copy.
+ *
  * <p>Running the reshape again on an already-conforming document is a no-op
  * (beyond normalising a missing or doubled trailing newline), so re-adopting a
  * repository does not churn the file.
@@ -65,6 +71,7 @@ public class ClaudeMdConformer {
 	 */
 	public String conform(String content) {
 		List<String> lines = splitLines(content);
+		lines = closeUnterminatedFence(lines);
 		lines = ensureTitle(lines);
 		lines = canonicalizeHeadings(lines);
 		lines = appendMissingSections(lines);
@@ -76,6 +83,22 @@ public class ClaudeMdConformer {
 	private List<String> splitLines(String content) {
 		String normalized = content.replace("\r\n", "\n").replace("\r", "\n");
 		return new ArrayList<>(List.of(normalized.split("\n", -1)));
+	}
+
+	/**
+	 * Closes a fence the document opened and never closed, so everything appended
+	 * below it lands outside the block. The closing marker is the one the fence was
+	 * opened with, and a document whose fences already balance is returned untouched,
+	 * so the reshape stays idempotent.
+	 */
+	private List<String> closeUnterminatedFence(List<String> lines) {
+		String open = scanFences(lines).openAtEnd();
+		if (open == null) {
+			return lines;
+		}
+		List<String> result = new ArrayList<>(lines);
+		result.add(open);
+		return result;
 	}
 
 	private List<String> ensureTitle(List<String> lines) {
@@ -306,12 +329,26 @@ public class ClaudeMdConformer {
 	}
 
 	private boolean[] fenceMask(List<String> lines) {
+		return scanFences(lines).mask();
+	}
+
+	/**
+	 * The outcome of reading the document's fences: which lines are code, and the
+	 * marker still open once the last line has been read.
+	 *
+	 * @param openAtEnd the unterminated fence's marker, or {@code null} when the
+	 *                  document's fences balance
+	 */
+	private record Fences(boolean[] mask, String openAtEnd) {
+	}
+
+	private Fences scanFences(List<String> lines) {
 		boolean[] mask = new boolean[lines.size()];
 		String open = null;
 		for (int index = 0; index < lines.size(); index++) {
 			open = applyFence(lines.get(index).strip(), open, mask, index);
 		}
-		return mask;
+		return new Fences(mask, open);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -3,6 +3,8 @@ package io.github.adamw7.tools.adopt.step;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import io.github.adamw7.tools.adopt.AdoptionException;
 
@@ -26,6 +28,15 @@ public class GradleGuardInstaller {
 	static final String GUARD_TASK = "enforceClaudeMd";
 
 	private static final String KOTLIN_SUFFIX = ".kts";
+	private static final String LINE_COMMENT = "//";
+
+	/**
+	 * The shapes that actually register the task in either DSL:
+	 * {@code tasks.register('enforceClaudeMd')}, its {@code create} and
+	 * double-quoted variants, and the legacy {@code task enforceClaudeMd}.
+	 */
+	private static final Pattern DECLARATION = Pattern.compile(
+			"(?:register|create)\\s*\\(\\s*[\"']" + GUARD_TASK + "[\"']|\\btask\\s+" + GUARD_TASK + "\\b");
 
 	private static final String GROOVY_BLOCK = """
 
@@ -61,11 +72,35 @@ public class GradleGuardInstaller {
 	 */
 	public boolean install(Path buildFile) {
 		String existing = read(buildFile);
-		if (existing.contains(GUARD_TASK)) {
+		if (declaresGuard(existing)) {
 			return false;
 		}
 		append(buildFile, existing, blockFor(buildFile));
 		return true;
+	}
+
+	/**
+	 * The task name has to appear in a registration for the script to count as
+	 * guarded, and comment lines are skipped, so a script that merely mentions
+	 * {@value #GUARD_TASK} — in a {@code // TODO} note, or in a declaration someone
+	 * commented out — is still given the task. Matching the bare name anywhere would
+	 * leave such a script without the task {@link GradleBuildSystem#verifyCommand()}
+	 * is about to run, failing the adoption at its verification step.
+	 */
+	private boolean declaresGuard(String script) {
+		return DECLARATION.matcher(withoutCommentLines(script)).find();
+	}
+
+	/**
+	 * The lines are rejoined rather than matched one at a time so a registration
+	 * spread over several lines is still recognised.
+	 */
+	private String withoutCommentLines(String script) {
+		return script.lines().filter(line -> !isCommentLine(line)).collect(Collectors.joining("\n"));
+	}
+
+	private boolean isCommentLine(String line) {
+		return line.strip().startsWith(LINE_COMMENT);
 	}
 
 	private String blockFor(Path buildFile) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import io.github.adamw7.tools.adopt.AdoptionException;
 
 /**
@@ -18,11 +21,19 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  * shared with every contributor rather than living only in the adopter's local
  * checkout. The script is the single source of truth: the workflow invokes it and
  * {@link FallbackBuildSystem#verifyCommand()} runs the same script locally, so the
- * adoption fails before the branch is pushed just as it would in CI. The install
- * is idempotent: a checkout whose workflow already carries the adoption marker is
- * left unchanged.
+ * adoption fails before the branch is pushed just as it would in CI.
+ *
+ * <p>The two files are installed independently and neither is ever overwritten, so
+ * the install is idempotent and a project that already carries a file at one of
+ * these paths keeps its own version — the same rule {@link AssetInstaller} applies
+ * to every other file the adoption writes. Installing them independently also
+ * means a checkout that kept the workflow but lost the script has the script
+ * written back, rather than being left for {@link FallbackBuildSystem}'s
+ * verification to fail on a file that is not there.
  */
 public class WorkflowGuardInstaller {
+
+	private static final Logger log = LogManager.getLogger(WorkflowGuardInstaller.class);
 
 	static final String WORKFLOW_FILE = ".github/workflows/claude-md-guard.yml";
 	static final String SCRIPT_FILE = ".github/claude-md-guard.sh";
@@ -51,38 +62,38 @@ public class WorkflowGuardInstaller {
 			fi
 			""".formatted(MARKER);
 
+	private final AssetInstaller workflowInstaller = new AssetInstaller(WORKFLOW_FILE, WORKFLOW);
+	private final AssetInstaller scriptInstaller = new AssetInstaller(SCRIPT_FILE, SCRIPT);
+
 	/**
-	 * @return {@code true} when the guard was written, {@code false} when the
-	 *         checkout already carried it and was left unchanged.
+	 * @return {@code true} when either guard file was written, {@code false} when the
+	 *         checkout already carried both and was left unchanged.
 	 */
 	public boolean install(Path repositoryDirectory) {
-		Path workflowFile = repositoryDirectory.resolve(WORKFLOW_FILE);
-		if (alreadyGuarded(workflowFile)) {
-			return false;
-		}
-		write(workflowFile, WORKFLOW);
-		write(repositoryDirectory.resolve(SCRIPT_FILE), SCRIPT);
-		return true;
+		boolean workflowWritten = workflowInstaller.install(repositoryDirectory);
+		boolean scriptWritten = scriptInstaller.install(repositoryDirectory);
+		warnIfWorkflowIsNotOurs(repositoryDirectory, workflowWritten);
+		return workflowWritten || scriptWritten;
 	}
 
-	private boolean alreadyGuarded(Path workflowFile) {
-		return Files.isRegularFile(workflowFile) && read(workflowFile).contains(MARKER);
-	}
-
-	private String read(Path file) {
-		try {
-			return Files.readString(file);
-		} catch (IOException e) {
-			throw new AdoptionException("Could not read workflow file: " + file, e);
+	/**
+	 * A workflow the adoption did not write is kept, but it is unlikely to run the
+	 * guard script, so CI may not enforce {@code CLAUDE.md} even though the local
+	 * verification passes. Saying so is more useful than silently overwriting the
+	 * project's own workflow.
+	 */
+	private void warnIfWorkflowIsNotOurs(Path repositoryDirectory, boolean workflowWritten) {
+		if (!workflowWritten && !carriesMarker(repositoryDirectory.resolve(WORKFLOW_FILE))) {
+			log.warn("{} already exists and is not the adoption's workflow; left unchanged, so CI may not run {}",
+					WORKFLOW_FILE, SCRIPT_FILE);
 		}
 	}
 
-	private void write(Path file, String content) {
+	private boolean carriesMarker(Path workflowFile) {
 		try {
-			Files.createDirectories(file.getParent());
-			Files.writeString(file, content);
+			return Files.isRegularFile(workflowFile) && Files.readString(workflowFile).contains(MARKER);
 		} catch (IOException e) {
-			throw new AdoptionException("Could not write guard file: " + file, e);
+			throw new AdoptionException("Could not read workflow file: " + workflowFile, e);
 		}
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -342,5 +343,56 @@ class ClaudeMdConformerTest {
 			builder.append(section).append("\n\nContent.\n\n");
 		}
 		return builder.toString();
+	}
+
+	private static final String UNTERMINATED_FENCE = """
+			# CLAUDE.md
+
+			Intro.
+
+			```java
+			class Foo {}
+			""";
+
+	/**
+	 * A fence the generated document opened and never closed used to swallow every
+	 * appended section: the rule reads fences the same way the conformer does, so it
+	 * saw the headings as code and reported all six sections missing, failing the
+	 * adoption at its own verification step.
+	 */
+	@Test
+	void closesAnUnterminatedFenceSoAppendedSectionsStayDocumentStructure() {
+		String conformed = conformer.conform(UNTERMINATED_FENCE);
+		assertTrue(headingsOutsideFences(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
+				"every appended section must be a heading, not code:\n" + conformed);
+		assertTrue(conformed.contains("class Foo {}"), "the code block keeps its content:\n" + conformed);
+	}
+
+	/**
+	 * The sections appended below an unterminated fence were invisible to the next
+	 * run's own check for them, so re-adopting a repository appended a second — and
+	 * then a third — unreachable copy of the whole skeleton.
+	 */
+	@Test
+	void reshapingADocumentWithAnUnterminatedFenceIsIdempotent() {
+		String once = conformer.conform(UNTERMINATED_FENCE);
+		assertEquals(once, conformer.conform(once), "a second reshape must not append the sections again");
+	}
+
+	/** Mirrors how the rule finds headings: a heading inside a fence is code, not structure. */
+	private List<String> headingsOutsideFences(String content) {
+		List<String> headings = new ArrayList<>();
+		boolean fenced = false;
+		for (String line : content.lines().map(String::strip).toList()) {
+			fenced = collectHeading(headings, line, fenced);
+		}
+		return headings;
+	}
+
+	private boolean collectHeading(List<String> headings, String line, boolean fenced) {
+		if (!fenced && line.startsWith("#")) {
+			headings.add(line);
+		}
+		return line.startsWith("```") != fenced;
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
@@ -66,4 +66,47 @@ class GradleGuardInstallerTest {
 		assertFalse(installer.install(buildFile));
 		assertEquals(afterFirstInstall, Files.readString(buildFile));
 	}
+
+	/**
+	 * Matching the bare task name anywhere in the script let a comment stand in for
+	 * the task itself, so the guard was never installed and the adoption then failed
+	 * running a verification task that did not exist.
+	 */
+	@Test
+	void installsTheGuardWhenTheScriptOnlyMentionsTheTaskInAComment(@TempDir Path directory) throws IOException {
+		Path buildFile = directory.resolve("build.gradle");
+		Files.writeString(buildFile, "// TODO: one day add an enforceClaudeMd task\nplugins { id 'java' }\n");
+		assertTrue(installer.install(buildFile));
+		assertTrue(Files.readString(buildFile).contains("tasks.register('enforceClaudeMd')"));
+	}
+
+	@Test
+	void installsTheGuardWhenAnEarlierDeclarationWasCommentedOut(@TempDir Path directory) throws IOException {
+		Path buildFile = directory.resolve("build.gradle.kts");
+		Files.writeString(buildFile, "// tasks.register(\"enforceClaudeMd\") { }\nplugins { java }\n");
+		assertTrue(installer.install(buildFile));
+		assertTrue(Files.readString(buildFile).contains("tasks.register(\"enforceClaudeMd\")"));
+	}
+
+	/**
+	 * A project that registers the task itself keeps its own version: appending a
+	 * second registration of the same name would fail the Gradle build outright.
+	 */
+	@Test
+	void leavesAScriptThatRegistersTheTaskItselfUnchanged(@TempDir Path directory) throws IOException {
+		Path buildFile = directory.resolve("build.gradle");
+		String own = "tasks.register('enforceClaudeMd') {\n    doLast { }\n}\n";
+		Files.writeString(buildFile, own);
+		assertFalse(installer.install(buildFile));
+		assertEquals(own, Files.readString(buildFile));
+	}
+
+	@Test
+	void recognisesARegistrationSpreadOverSeveralLines(@TempDir Path directory) throws IOException {
+		Path buildFile = directory.resolve("build.gradle");
+		String own = "tasks.register(\n    'enforceClaudeMd'\n) {\n    doLast { }\n}\n";
+		Files.writeString(buildFile, own);
+		assertFalse(installer.install(buildFile));
+		assertEquals(own, Files.readString(buildFile));
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstallerTest.java
@@ -54,4 +54,33 @@ class WorkflowGuardInstallerTest {
 		assertFalse(installer.install(directory));
 		assertEquals(afterFirstInstall, Files.readString(directory.resolve(WorkflowGuardInstaller.WORKFLOW_FILE)));
 	}
+
+	/**
+	 * The project's own file at the guard's path always wins, as it does for every
+	 * other file the adoption writes; overwriting it destroyed a workflow the
+	 * adoption never wrote.
+	 */
+	@Test
+	void keepsAWorkflowTheProjectAlreadyCarries(@TempDir Path directory) throws IOException {
+		Path workflowFile = directory.resolve(WorkflowGuardInstaller.WORKFLOW_FILE);
+		Files.createDirectories(workflowFile.getParent());
+		String own = "name: my own guard\non: [push]\njobs: {}\n";
+		Files.writeString(workflowFile, own);
+		assertTrue(installer.install(directory), "the guard script is still installed alongside it");
+		assertEquals(own, Files.readString(workflowFile));
+	}
+
+	/**
+	 * The script is what {@link FallbackBuildSystem#verifyCommand()} runs, so a
+	 * checkout that kept the workflow but lost the script has to get the script
+	 * back rather than fail the adoption on a file that is not there.
+	 */
+	@Test
+	void writesBackAGuardScriptThatWentMissing(@TempDir Path directory) throws IOException {
+		installer.install(directory);
+		Path scriptFile = directory.resolve(WorkflowGuardInstaller.SCRIPT_FILE);
+		Files.delete(scriptFile);
+		assertTrue(installer.install(directory));
+		assertTrue(Files.isRegularFile(scriptFile));
+	}
 }


### PR DESCRIPTION
Three high-severity bugs in the adoption pipeline, each verified against the
real ClaudeMdFormatRule and the installers themselves:

- ClaudeMdConformer appended the required sections without noticing the
  generated CLAUDE.md had opened a code fence it never closed, so every
  appended heading landed inside that block. The rule reads fences the same
  way, so it reported all six sections missing and VerifyStep aborted the
  adoption after the clone, claude init, and two commits. The reshape was also
  non-idempotent there, appending another unreachable skeleton on each re-run.
  An unterminated fence is now closed before anything is appended.

- WorkflowGuardInstaller overwrote a pre-existing, unrelated
  .github/workflows/claude-md-guard.yml, destroying a file the adoption never
  wrote, and its marker check covered only the workflow, so a checkout that had
  lost the guard script never got it back and VerifyStep then failed on the
  missing file. Both files are now installed independently through
  AssetInstaller, which never overwrites, and a workflow the adoption did not
  write is kept with a warning that CI may not run the guard.

- GradleGuardInstaller decided a script was already guarded from a bare
  substring match on the task name, so a build.gradle that merely mentioned
  enforceClaudeMd in a comment was left without the task VerifyStep runs. The
  check now requires an actual registration and skips comment lines.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KctCvJcz8P951Vgv3m37pF