### PR TITLE
fix(adopt): correct seven pipeline and guard bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ tools (root pom, packaging=pom)
 │   ├── protogen-maven-plugin       # the proto2 builder-generating Maven plugin
 │   ├── protogen-maven-plugin-test  # integration tests / use cases for the plugin
 │   └── context                     # regex-based class-usage context finder
-├── adopt                       # adopts Claude Code into a GitHub repo (clone, branch, trust, init, enforcer, verify, push, PR)
+├── adopt                       # adopts Claude Code into a GitHub repo (clone, build-tool check, branch, trust, init, enforcer, verify, push, PR)
 ├── grpc-example                # end-to-end gRPC example with compile-time-safe builders
 ├── assembly                    # builds an executable jar-with-dependencies
 │                               #   (mainClass: io.github.adamw7.tools.data.SampleApp)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,9 @@ run `mvn install` from the repository root. The main capabilities are:
   (`OpenAddressingMap`, `OpenAddressingSet`, primitive-keyed
   `IntKeyOpenAddressingMap`), and an MCP server exposing the uniqueness checker.
 - **Claude Code adoption** (`adopt`) — a pipeline that adopts Claude Code into a
-  GitHub repo: check the required tools (`git`, `claude`, `gh`) are installed,
-  clone, create a feature branch, `claude init` to generate
+  GitHub repo: check the required tools (`git`, `claude`, `gh`) are installed
+  and that `gh` is logged in, clone, check the cloned project's own build tool is
+  installed too, create a feature branch, `claude init` to generate
   `CLAUDE.md` and commit it, wire a build-tool-aware `CLAUDE.md` guard into the
   repo (the `claude-code-enforcer` rule for Maven `pom.xml`, an `enforceClaudeMd`
   guard task for Gradle, and a GitHub Actions workflow plus
@@ -57,7 +58,7 @@ tools (root pom, packaging=pom)
 │   ├── protogen-maven-plugin       # compile-time-safe protobuf builder generator
 │   ├── protogen-maven-plugin-test  # integration tests for the plugin
 │   └── context                     # class-usage context finder + MCP server
-├── adopt                  # adopts Claude Code into a GitHub repo (clone, branch, trust, init, enforcer, verify, push, PR)
+├── adopt                  # adopts Claude Code into a GitHub repo (clone, build-tool check, branch, trust, init, enforcer, verify, push, PR)
 ├── grpc-example           # end-to-end gRPC example
 ├── assembly               # executable jar-with-dependencies (SampleApp)
 └── data-test              # standalone test module (not in root <modules>)

--- a/README.md
+++ b/README.md
@@ -779,25 +779,35 @@ The default pipeline runs these steps in order:
    (`git`, `claude`, `gh`) with a `--version` check before any real work, so a
    missing tool aborts the adoption immediately with a message naming every
    absent one instead of failing minutes later after a clone, a `claude init`,
-   and a Maven build have already run.
+   and a Maven build have already run. Being installed is not enough for `gh`:
+   `gh --version` succeeds for a CLI nobody is logged in to, so the login is
+   probed too (`gh auth status`) and an unauthenticated `gh` fails here rather
+   than at the very last step.
 2. **`CloneStep`** — clones the target repository into the workspace with
    `git clone`, giving the remaining steps a working checkout.
-3. **`BranchStep`** — creates and checks out the adoption feature branch with
+3. **`BuildToolchainStep`** — probes the *adopted project's* build tool, now that
+   the clone has revealed which one it is. `ToolchainStep` cannot: the checkout
+   does not exist yet. Without this a machine without the project's `mvn` or
+   `gradle` only fails at `VerifyStep`, after a full `claude init`, a reshaped
+   `CLAUDE.md`, and two commits have already been spent on a checkout that was
+   never going to be verifiable. A build system needing no tool of its own — the
+   fallback guard runs through `sh` — is a no-op.
+4. **`BranchStep`** — creates and checks out the adoption feature branch with
    `git checkout -B`, so every later commit lands on that branch instead of the
    default branch. A fresh clone whose `origin` already publishes the branch — a
    re-adoption of a repository an earlier run pushed — starts it from that
    published tip, so the later push stays a fast-forward instead of being
    rejected; a branch that already exists locally is left alone, so unpushed work
    in a reused workspace is never reset onto the remote.
-4. **`TrustStep`** — marks the checkout trusted in `~/.claude.json` so the
+5. **`TrustStep`** — marks the checkout trusted in `~/.claude.json` so the
    headless `claude` run is not blocked by the interactive folder-trust prompt.
-5. **`ClaudeInitStep`** — runs the Claude Code CLI in headless mode
+6. **`ClaudeInitStep`** — runs the Claude Code CLI in headless mode
    (`claude -p /init` by default; the invocation is configurable because the
    flags differ between environments) so it generates a `CLAUDE.md`, aborting if
    the file did not appear.
-6. **`CommitStep`** — commits the generated `CLAUDE.md` (`Adopt Claude Code: add
+7. **`CommitStep`** — commits the generated `CLAUDE.md` (`Adopt Claude Code: add
    CLAUDE.md`).
-7. **`EnforcerStep`** — detects the checkout's build system and wires the
+8. **`EnforcerStep`** — detects the checkout's build system and wires the
    `CLAUDE.md` guard into it. A Maven project has the `claude-code-enforcer` added
    to its root `pom.xml` via `PomEnforcerInstaller` (the edit is done on the JDK's
    DOM — no third-party XML library — is namespace-aware, and is idempotent); a
@@ -811,17 +821,17 @@ The default pipeline runs these steps in order:
    `enforceClaudeMd` registration keeps it. Supporting a new build tool is a
    matter of adding a `BuildSystem` implementation rather than branching inside
    the step.
-8. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
+9. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
    build`).
-9. **`VerifyStep`** — runs the detected build system's verification (a
+10. **`VerifyStep`** — runs the detected build system's verification (a
    non-recursive `mvn -N validate` for Maven, the `enforceClaudeMd` task for
    Gradle, the `.github/claude-md-guard.sh` script for the fallback) so the
    freshly wired guard actually executes against the generated `CLAUDE.md`,
    failing the adoption locally if the file is missing or malformed rather than
    after the pull request lands.
-10. **`PushStep`** — pushes the feature branch to origin and sets its upstream
+11. **`PushStep`** — pushes the feature branch to origin and sets its upstream
     (`git push -u origin <branch>`).
-11. **`PullRequestStep`** — opens a pull request from the branch with
+12. **`PullRequestStep`** — opens a pull request from the branch with
    `gh pr create`, targeting the repository's default branch as the base. The
    pull request metadata is supplied through `PullRequestOptions` — title, body,
    and optional reviewers, labels, and assignees to request, plus whether to open

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -71,7 +71,23 @@ public final class AdoptionContext {
 	private static String repositoryName(String repositoryUrl) {
 		String withoutTrailingSlash = stripTrailingSlash(repositoryUrl);
 		String lastSegment = withoutTrailingSlash.substring(withoutTrailingSlash.lastIndexOf('/') + 1);
-		return stripGitSuffix(lastSegment);
+		return requireName(stripGitSuffix(lastSegment), repositoryUrl);
+	}
+
+	/**
+	 * A URL whose last segment is empty or a directory alias — {@code .../repo//},
+	 * {@code .../.git}, or a bare {@code ..} — would otherwise resolve the checkout
+	 * onto the workspace itself or above it, so the clone would land beside the
+	 * other repositories the workspace holds instead of in its own directory.
+	 * Rejecting it here fails the adoption on its input rather than several steps
+	 * later on a checkout directory nobody intended.
+	 */
+	private static String requireName(String name, String repositoryUrl) {
+		if (name.isEmpty() || ".".equals(name) || "..".equals(name)) {
+			throw new IllegalArgumentException(
+					"repositoryUrl must end in a repository name but was: " + repositoryUrl);
+		}
+		return name;
 	}
 
 	private static String stripTrailingSlash(String value) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -10,6 +10,7 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
 import io.github.adamw7.tools.adopt.step.AssetsStep;
 import io.github.adamw7.tools.adopt.step.BranchStep;
+import io.github.adamw7.tools.adopt.step.BuildToolchainStep;
 import io.github.adamw7.tools.adopt.step.ClaudeInitStep;
 import io.github.adamw7.tools.adopt.step.ClaudeMdConformanceStep;
 import io.github.adamw7.tools.adopt.step.CloneStep;
@@ -24,7 +25,8 @@ import io.github.adamw7.tools.adopt.step.VerifyStep;
 
 /**
  * Runs the ordered pipeline that adopts Claude Code into a GitHub repository:
- * check the required tools are installed, clone, create a feature branch, mark
+ * check the required tools are installed, clone, check the cloned project's own
+ * build tool is installed too, create a feature branch, mark
  * the checkout trusted for Claude Code, generate {@code CLAUDE.md} with
  * {@code claude init}, normalise that file and add a companion {@code AGENTS.md}
  * so it satisfies the guard the adoption is about to wire in, and commit it, wire
@@ -32,7 +34,10 @@ import io.github.adamw7.tools.adopt.step.VerifyStep;
  * commit that, verify the enforcer passes on the generated file, then push the
  * branch and open a pull request. The toolchain check runs first so a missing
  * {@code git}, {@code claude}, or {@code gh} fails the adoption before any
- * expensive work. The adoption never writes to the default branch. Steps and the
+ * expensive work, and the build-tool check follows the clone — the first moment
+ * the project's build system is known — so a missing {@code mvn} or {@code gradle}
+ * fails before the {@code claude init} rather than at the verification.
+ * The adoption never writes to the default branch. Steps and the
  * command runner are injected so the pipeline is easy to reconfigure and to test.
  *
  * <p>Each run returns an {@link AdoptionReport} of the steps that completed and
@@ -70,6 +75,7 @@ public class GitHubRepoAdopter {
 		List<AdoptionStep> steps = new ArrayList<>(List.of(
 				new ToolchainStep(),
 				new CloneStep(),
+				new BuildToolchainStep(),
 				new BranchStep(),
 				new TrustStep(),
 				new ClaudeInitStep(),

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
@@ -1,7 +1,6 @@
 package io.github.adamw7.tools.adopt;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -11,6 +10,12 @@ import java.nio.file.Path;
  * always has a directory to run in — or a fresh temporary one when the caller
  * left the choice open. Shared by the command-line entry point and the MCP
  * server, so both resolve workspaces identically.
+ *
+ * <p>A workspace that cannot be created — the caller named a path that is already
+ * a regular file, or one the process may not write — fails with an
+ * {@link AdoptionException} like every other adoption failure, rather than
+ * surfacing a raw {@link java.io.UncheckedIOException} through the command line
+ * and the MCP tool.
  *
  * <p>The returned path is always absolute. The clone step runs {@code git clone}
  * with the workspace as its working directory and the checkout directory
@@ -29,7 +34,7 @@ public final class Workspaces {
 		try {
 			return Files.createDirectories(workspace).toAbsolutePath();
 		} catch (IOException e) {
-			throw new UncheckedIOException(e);
+			throw new AdoptionException("Could not create the workspace directory: " + workspace, e);
 		}
 	}
 
@@ -37,7 +42,7 @@ public final class Workspaces {
 		try {
 			return Files.createTempDirectory("claude-adopt-");
 		} catch (IOException e) {
-			throw new UncheckedIOException(e);
+			throw new AdoptionException("Could not create a temporary workspace directory", e);
 		}
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.adopt.step;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A build tool the adoption knows how to wire a {@code CLAUDE.md} guard into and
@@ -30,4 +31,15 @@ public interface BuildSystem {
 
 	/** Command that runs the wired guard so a missing or malformed {@code CLAUDE.md} fails the build. */
 	List<String> verifyCommand();
+
+	/**
+	 * The program {@link #verifyCommand()} launches and that must therefore be
+	 * installed for the verification to run at all, so {@link BuildToolchainStep}
+	 * can probe it before the pipeline spends a {@code claude init} on a checkout it
+	 * will not be able to verify.
+	 *
+	 * @return the program to probe, or empty when the verification needs nothing
+	 *         beyond the POSIX shell every supported platform already provides
+	 */
+	Optional<String> requiredTool();
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
@@ -1,0 +1,77 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Checks that the adopted project's own build tool is installed, as soon as the
+ * clone has revealed which one it is. {@link ToolchainStep} can only probe the
+ * pipeline's own {@code git}/{@code claude}/{@code gh} because the checkout does
+ * not exist yet, but {@link VerifyStep} later shells out to {@code mvn} or
+ * {@code gradle} — so without this step a machine without the adopted project's
+ * build tool fails at verification, after a full {@code claude init}, a reshaped
+ * {@code CLAUDE.md}, and two commits have already been made. That is exactly the
+ * late failure the toolchain check exists to prevent.
+ *
+ * <p>The step runs directly after {@link CloneStep} and detects the build system
+ * the same way {@link EnforcerStep} and {@link VerifyStep} do, so the tool it
+ * probes is the tool the verification will actually run. A build system that
+ * needs no installed tool — the {@link FallbackBuildSystem}, whose guard runs
+ * through {@code sh} — and a checkout no configured build system matches are both
+ * a no-op, mirroring how those two steps skip rather than fail.
+ */
+public class BuildToolchainStep implements AdoptionStep {
+
+	private static final Logger log = LogManager.getLogger(BuildToolchainStep.class);
+
+	private final List<BuildSystem> buildSystems;
+	private final ToolProbe probe = new ToolProbe();
+
+	public BuildToolchainStep() {
+		this(BuildSystems.DEFAULTS);
+	}
+
+	public BuildToolchainStep(List<BuildSystem> buildSystems) {
+		this.buildSystems = List.copyOf(buildSystems);
+	}
+
+	@Override
+	public String name() {
+		return "build-toolchain";
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		Path repositoryDirectory = context.repositoryDirectory();
+		Optional<BuildSystem> buildSystem = BuildSystems.detect(buildSystems, repositoryDirectory);
+		buildSystem.ifPresentOrElse(
+				detected -> requireTool(detected, repositoryDirectory, runner),
+				() -> log.warn("No supported build system ({}) in {}; skipping the build tool check",
+						BuildSystems.names(buildSystems), repositoryDirectory));
+	}
+
+	private void requireTool(BuildSystem buildSystem, Path repositoryDirectory, CommandRunner runner) {
+		buildSystem.requiredTool().ifPresentOrElse(
+				tool -> requireInstalled(tool, buildSystem, repositoryDirectory, runner),
+				() -> log.info("The {} guard needs no build tool of its own in {}", buildSystem.name(),
+						repositoryDirectory));
+	}
+
+	private void requireInstalled(String tool, BuildSystem buildSystem, Path repositoryDirectory,
+			CommandRunner runner) {
+		if (probe.succeeds(List.of(tool, "--version"), repositoryDirectory, runner)) {
+			return;
+		}
+		throw new AdoptionException(name() + " failed: " + repositoryDirectory + " builds with "
+				+ buildSystem.name() + " but " + tool + " was not found on the PATH, so the CLAUDE.md guard"
+				+ " could not be verified.");
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -32,7 +32,9 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * the checkout before {@code /init} runs, so the CLI takes its fresh-repository
  * path and writes the root {@code CLAUDE.md}, and restored afterwards; the
  * adoption commits only the new root file and leaves the project's own
- * {@code .claude/CLAUDE.md} untouched.
+ * {@code .claude/CLAUDE.md} untouched. The file is put back whether the CLI
+ * succeeded or failed, and a restore that fails on the failure path is attached to
+ * the original failure rather than replacing it.
  *
  * <p>The generated {@code CLAUDE.md} is the whole point of the adoption, so a run
  * that exits cleanly but leaves no {@code CLAUDE.md} behind aborts the adoption
@@ -71,10 +73,27 @@ public class ClaudeInitStep extends AbstractCommandStep {
 		Optional<Path> relocated = relocateExistingClaudeDirMemory(checkout);
 		try {
 			runOrFail(runner, checkout, claudeCommand);
-		} finally {
-			relocated.ifPresent(backup -> restore(backup, claudeDirMemory(checkout)));
+		} catch (RuntimeException e) {
+			restoreSuppressing(relocated, checkout, e);
+			throw e;
 		}
+		relocated.ifPresent(backup -> restore(backup, claudeDirMemory(checkout)));
 		requireGenerated(context);
+	}
+
+	/**
+	 * Restores the relocated memory file on the failure path without letting a
+	 * failed restore replace the failure being reported. Thrown from a
+	 * {@code finally} it would do exactly that, discarding the {@code claude}
+	 * transcript that is the only useful diagnostic the run produced; attaching it as
+	 * a suppressed exception keeps both.
+	 */
+	private void restoreSuppressing(Optional<Path> relocated, Path checkout, RuntimeException failure) {
+		try {
+			relocated.ifPresent(backup -> restore(backup, claudeDirMemory(checkout)));
+		} catch (RuntimeException e) {
+			failure.addSuppressed(e);
+		}
 	}
 
 	private Path claudeDirMemory(Path checkout) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.adopt.step;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The catch-all build system for the adoption: it matches every checkout, so a
@@ -47,5 +48,15 @@ public class FallbackBuildSystem implements BuildSystem {
 	@Override
 	public List<String> verifyCommand() {
 		return VERIFY_COMMAND;
+	}
+
+	/**
+	 * The guard runs through {@code sh}, which every platform the adoption supports
+	 * already provides and which has no portable {@code --version} probe, so there is
+	 * nothing to check ahead of time.
+	 */
+	@Override
+	public Optional<String> requiredTool() {
+		return Optional.empty();
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
@@ -52,6 +52,11 @@ public class GradleBuildSystem implements BuildSystem {
 		return VERIFY_COMMAND;
 	}
 
+	@Override
+	public Optional<String> requiredTool() {
+		return Optional.of(VERIFY_COMMAND.get(0));
+	}
+
 	/**
 	 * Prefers the Groovy build file over the Kotlin one when a checkout carries
 	 * both, matching the order most Gradle projects resolve them in.

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -22,6 +22,16 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  * not data, and a self-contained task needs no structural edit. The install is
  * idempotent: a script that already declares the {@value #GUARD_TASK} task is
  * left untouched.
+ *
+ * <p>The file to check is resolved while the task is being <em>configured</em> and
+ * only read inside {@code doLast}, so the task body captures a plain
+ * {@link java.io.File} rather than reaching back into the {@code Project} at
+ * execution time. Gradle's configuration cache — on by default from Gradle 9, and
+ * widely opted into before that — rejects a task that holds a script or
+ * {@code Project} reference, and would otherwise fail the guard task in the Groovy
+ * DSL and the whole build in the Kotlin one, aborting the adoption at
+ * {@link GradleBuildSystem#verifyCommand()} and breaking {@code check} for every
+ * contributor afterwards.
  */
 public class GradleGuardInstaller {
 
@@ -42,8 +52,8 @@ public class GradleGuardInstaller {
 
 			// Added by claude-code-adopt: fail the build when CLAUDE.md is missing or empty.
 			tasks.register('%s') {
+			    def claudeMd = project.file('CLAUDE.md')
 			    doLast {
-			        def claudeMd = file("$projectDir/CLAUDE.md")
 			        if (!claudeMd.isFile() || claudeMd.text.trim().isEmpty()) {
 			            throw new GradleException('CLAUDE.md is missing or empty')
 			        }
@@ -56,8 +66,8 @@ public class GradleGuardInstaller {
 
 			// Added by claude-code-adopt: fail the build when CLAUDE.md is missing or empty.
 			tasks.register("%s") {
+			    val claudeMd = project.file("CLAUDE.md")
 			    doLast {
-			        val claudeMd = file("$projectDir/CLAUDE.md")
 			        if (!claudeMd.isFile || claudeMd.readText().trim().isEmpty()) {
 			            throw GradleException("CLAUDE.md is missing or empty")
 			        }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.adopt.step;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Maven support for the adoption: detects a {@code pom.xml}, wires the
@@ -45,5 +46,10 @@ public class MavenBuildSystem implements BuildSystem {
 	@Override
 	public List<String> verifyCommand() {
 		return VERIFY_COMMAND;
+	}
+
+	@Override
+	public Optional<String> requiredTool() {
+		return Optional.of(VERIFY_COMMAND.get(0));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Supplier;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
@@ -45,6 +46,9 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  * line is left untouched — and only the newly added elements are indented, to the
  * style the POM already uses. The adoption commit therefore shows just the
  * enforcer block being added rather than a reformat of the whole file.
+ *
+ * <p>The rule version comes from the running build and must be a release: see
+ * {@link #requireReleaseVersion(String)}.
  */
 public class PomEnforcerInstaller {
 
@@ -56,15 +60,45 @@ public class PomEnforcerInstaller {
 	static final String CLAUDE_MD_FILE = "${project.basedir}/CLAUDE.md";
 	static final String BUILD_PROPERTIES = "/adopt-build.properties";
 	static final String RULE_VERSION_KEY = "enforcer.rule.version";
+	static final String SNAPSHOT_SUFFIX = "-SNAPSHOT";
 
-	private final String ruleVersion;
+	private final Supplier<String> ruleVersion;
 
 	public PomEnforcerInstaller() {
-		this(buildRuleVersion());
+		this.ruleVersion = PomEnforcerInstaller::releaseRuleVersion;
 	}
 
 	public PomEnforcerInstaller(String ruleVersion) {
-		this.ruleVersion = ruleVersion;
+		this.ruleVersion = () -> ruleVersion;
+	}
+
+	/**
+	 * The released rule version to wire in. Resolving it lazily — only once a POM is
+	 * actually being edited — keeps merely constructing the default
+	 * {@link BuildSystems#DEFAULTS} list, or adopting a repository that builds with
+	 * something other than Maven, from depending on the running build's version.
+	 */
+	static String releaseRuleVersion() {
+		return requireReleaseVersion(buildRuleVersion());
+	}
+
+	/**
+	 * A snapshot resolves from the adopter's own local repository but from nowhere
+	 * else, so wiring one in would open a pull request that builds on this machine
+	 * and fails for the adopted project's CI and every one of its contributors —
+	 * and {@link VerifyStep} could not catch it, because it too resolves against the
+	 * local repository. Refusing here turns that into an immediate, explicable
+	 * failure for the person running the adoption.
+	 */
+	static String requireReleaseVersion(String version) {
+		if (version.endsWith(SNAPSHOT_SUFFIX)) {
+			throw new AdoptionException("Refusing to wire the snapshot enforcer rule version " + version
+					+ " into the adopted project's pom.xml: a snapshot is not resolvable outside this machine's"
+					+ " local repository, so the pull request would break the adopted project's build."
+					+ " Run the adoption from a released build of tools, or supply a released version to"
+					+ " PomEnforcerInstaller.");
+		}
+		return version;
 	}
 
 	/**
@@ -75,7 +109,7 @@ public class PomEnforcerInstaller {
 	 * published it — rather than to a hardcoded literal that silently drifts as the
 	 * project is versioned.
 	 */
-	private static String buildRuleVersion() {
+	static String buildRuleVersion() {
 		try (InputStream stream = PomEnforcerInstaller.class.getResourceAsStream(BUILD_PROPERTIES)) {
 			return readRuleVersion(stream);
 		} catch (IOException e) {
@@ -171,7 +205,7 @@ public class PomEnforcerInstaller {
 		Element dependency = editor.appendElement(dependencies, "dependency");
 		editor.appendText(dependency, "groupId", RULE_GROUP_ID);
 		editor.appendText(dependency, "artifactId", RULE_ARTIFACT_ID);
-		editor.appendText(dependency, "version", ruleVersion);
+		editor.appendText(dependency, "version", ruleVersion.get());
 	}
 
 	private void enforceExecution(PomEditor editor, Element executions) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -142,16 +142,23 @@ public class PullRequestStep extends AbstractCommandStep {
 	/**
 	 * {@code gh pr list --json} writes a JSON array to stdout, but the captured
 	 * output may carry surrounding noise (for example update notices merged in from
-	 * stderr), so parsing starts at the first opening bracket instead of assuming a
-	 * pure JSON payload. The first element's {@code url} is returned, or empty when
-	 * the array is empty or carries no textual URL.
+	 * stderr), so parsing starts at an opening bracket instead of assuming a pure
+	 * JSON payload. Every bracket is tried in turn rather than only the first,
+	 * because a diagnostic printed <em>before</em> the payload can itself contain
+	 * one; stopping at the first would parse the noise, conclude no pull request is
+	 * open, and make the step create a duplicate — which {@code gh} rejects, failing
+	 * an adoption that was only being re-run. The first element's {@code url} is
+	 * returned, or empty when no bracket starts a JSON array, the array is empty, or
+	 * it carries no textual URL.
 	 */
 	private Optional<String> extractUrl(String output) {
-		int start = output.indexOf('[');
-		if (start < 0) {
-			return Optional.empty();
+		for (int start = output.indexOf('['); start >= 0; start = output.indexOf('[', start + 1)) {
+			Optional<String> url = firstUrl(output.substring(start));
+			if (url.isPresent()) {
+				return url;
+			}
 		}
-		return firstUrl(output.substring(start));
+		return Optional.empty();
 	}
 
 	private Optional<String> firstUrl(String json) {
@@ -163,7 +170,7 @@ public class PullRequestStep extends AbstractCommandStep {
 			JsonNode url = array.get(0).path("url");
 			return url.isTextual() ? Optional.of(url.asText()) : Optional.empty();
 		} catch (JsonProcessingException e) {
-			log.warn("Could not parse gh pr list output as JSON", e);
+			log.debug("Skipping a '[' in the gh pr list output that does not start a JSON array", e);
 			return Optional.empty();
 		}
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
@@ -1,0 +1,64 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Decides whether an external tool can actually be run, by starting a probe
+ * command and reading its exit code. Shared by {@link ToolchainStep}, which
+ * checks the pipeline's own {@code git}/{@code claude}/{@code gh} before any work
+ * begins, and {@link BuildToolchainStep}, which checks the adopted project's
+ * build tool as soon as the clone reveals which one it is — so both report a
+ * missing tool the same way.
+ */
+final class ToolProbe {
+
+	private static final Logger log = LogManager.getLogger(ToolProbe.class);
+
+	private static final String VERSION_FLAG = "--version";
+
+	/**
+	 * @return the tools whose {@code --version} probe could not be run or exited
+	 *         non-zero, in the order they were given. Every tool is probed even
+	 *         after one is found missing, so a single failure can name all of the
+	 *         absent tools at once rather than stopping at the first and hiding the
+	 *         rest.
+	 */
+	List<String> missingFrom(List<String> tools, Path directory, CommandRunner runner) {
+		List<String> missing = new ArrayList<>();
+		for (String tool : tools) {
+			collectIfMissing(missing, tool, directory, runner);
+		}
+		return missing;
+	}
+
+	private void collectIfMissing(List<String> missing, String tool, Path directory, CommandRunner runner) {
+		if (succeeds(List.of(tool, VERSION_FLAG), directory, runner)) {
+			log.info("Found required tool: {}", tool);
+		} else {
+			missing.add(tool);
+		}
+	}
+
+	/**
+	 * A command the runner cannot even start throws an {@link AdoptionException} out
+	 * of {@link CommandRunner#run}; for a probe that is exactly the "not installed"
+	 * answer being looked for, so it is caught and reported as a failed probe rather
+	 * than aborting the whole check on the first absent tool.
+	 */
+	boolean succeeds(List<String> command, Path directory, CommandRunner runner) {
+		try {
+			return runner.run(directory, command).succeeded();
+		} catch (AdoptionException e) {
+			log.warn("Probe {} could not be run: {}", String.join(" ", command), e.getMessage());
+			return false;
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -8,7 +7,6 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
-import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
@@ -24,14 +22,25 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * zero. Every required tool is probed even after one is found missing, so a
  * single failure can name all of the absent tools at once rather than stopping at
  * the first and hiding the rest.
+ *
+ * <p>Being installed is not enough for {@code gh}: {@code gh --version} succeeds
+ * for a GitHub CLI nobody is logged in to, and the adoption would only discover
+ * that at {@link PullRequestStep}, its very last step. The login is therefore
+ * probed here too, so an unauthenticated {@code gh} fails just as early as an
+ * absent one. The adopted project's own build tool is not this step's concern —
+ * which one it is only becomes known once the repository is cloned, so
+ * {@link BuildToolchainStep} probes it there.
  */
 public class ToolchainStep implements AdoptionStep {
 
 	private static final Logger log = LogManager.getLogger(ToolchainStep.class);
 
-	static final List<String> DEFAULT_TOOLS = List.of("git", "claude", "gh");
+	static final String GITHUB_CLI = "gh";
+	static final List<String> DEFAULT_TOOLS = List.of("git", "claude", GITHUB_CLI);
+	static final List<String> AUTHENTICATION_PROBE = List.of(GITHUB_CLI, "auth", "status");
 
 	private final List<String> tools;
+	private final ToolProbe probe = new ToolProbe();
 
 	public ToolchainStep() {
 		this(DEFAULT_TOOLS);
@@ -49,42 +58,24 @@ public class ToolchainStep implements AdoptionStep {
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
 		log.info("Checking required tools are available: {}", tools);
-		List<String> missing = missingTools(context, runner);
+		requireInstalled(context, runner);
+		requireGitHubLogin(context, runner);
+	}
+
+	private void requireInstalled(AdoptionContext context, CommandRunner runner) {
+		List<String> missing = probe.missingFrom(tools, context.workspace(), runner);
 		if (!missing.isEmpty()) {
 			throw new AdoptionException(name() + " failed: required tools were not found on the PATH: "
 					+ String.join(", ", missing));
 		}
 	}
 
-	private List<String> missingTools(AdoptionContext context, CommandRunner runner) {
-		List<String> missing = new ArrayList<>();
-		for (String tool : tools) {
-			collectIfMissing(missing, context, runner, tool);
+	private void requireGitHubLogin(AdoptionContext context, CommandRunner runner) {
+		if (!tools.contains(GITHUB_CLI) || probe.succeeds(AUTHENTICATION_PROBE, context.workspace(), runner)) {
+			return;
 		}
-		return missing;
-	}
-
-	private void collectIfMissing(List<String> missing, AdoptionContext context, CommandRunner runner, String tool) {
-		if (isAvailable(context, runner, tool)) {
-			log.info("Found required tool: {}", tool);
-		} else {
-			missing.add(tool);
-		}
-	}
-
-	/**
-	 * A tool the runner cannot even start throws an {@link AdoptionException} out
-	 * of {@link CommandRunner#run}; that is exactly the "not installed" case the
-	 * probe is looking for, so it is caught and reported as unavailable rather than
-	 * aborting the whole check on the first absent tool.
-	 */
-	private boolean isAvailable(AdoptionContext context, CommandRunner runner, String tool) {
-		try {
-			CommandResult result = runner.run(context.workspace(), List.of(tool, "--version"));
-			return result.succeeded();
-		} catch (AdoptionException e) {
-			log.warn("Required tool {} could not be run: {}", tool, e.getMessage());
-			return false;
-		}
+		throw new AdoptionException(name() + " failed: " + GITHUB_CLI
+				+ " is installed but not authenticated, so the pull request could not be opened."
+				+ " Run 'gh auth login', or set GH_TOKEN for a non-interactive host.");
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
@@ -11,6 +11,25 @@ class AdoptionContextTest {
 
 	private final Path workspace = Path.of("/tmp/workspace");
 
+	/**
+	 * An empty last segment would resolve the checkout onto the workspace itself,
+	 * so the clone would land beside the other repositories the workspace holds
+	 * instead of in its own directory.
+	 */
+	@Test
+	void aUrlWithNoRepositoryNameIsRejected() {
+		assertThrows(IllegalArgumentException.class,
+				() -> new AdoptionContext("https://github.com/adamw7//", Path.of("/tmp/workspace")));
+		assertThrows(IllegalArgumentException.class,
+				() -> new AdoptionContext("https://github.com/adamw7/.git", Path.of("/tmp/workspace")));
+	}
+
+	@Test
+	void aUrlWhoseNameIsADirectoryAliasIsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext("..", Path.of("/tmp/workspace")));
+		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext(".", Path.of("/tmp/workspace")));
+	}
+
 	@Test
 	void derivesCheckoutDirectoryFromHttpsUrl() {
 		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -82,15 +82,15 @@ class GitHubRepoAdopterTest {
 	@Test
 	void defaultPipelineBranchesCommitsPushesAndOpensAPullRequest() {
 		List<String> names = GitHubRepoAdopter.defaultSteps().stream().map(AdoptionStep::name).toList();
-		assertEquals(List.of("toolchain", "clone", "branch", "trust", "claude-init", "conform", "commit", "enforcer",
-				"commit", "verify", "push", "pull-request"), names);
+		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
+				"commit", "enforcer", "commit", "verify", "push", "pull-request"), names);
 	}
 
 	@Test
 	void defaultPipelineWithAssetsInstallsAndCommitsThemBeforeVerification() {
 		List<String> names = GitHubRepoAdopter.defaultSteps(PullRequestOptions.defaults(), true).stream()
 				.map(AdoptionStep::name).toList();
-		assertEquals(List.of("toolchain", "clone", "branch", "trust", "claude-init", "conform", "commit", "enforcer",
-				"commit", "assets", "commit", "verify", "push", "pull-request"), names);
+		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
+				"commit", "enforcer", "commit", "assets", "commit", "verify", "push", "pull-request"), names);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
@@ -77,6 +78,29 @@ class GitHubRepoAdopterTest {
 		GitHubRepoAdopter adopter = new GitHubRepoAdopter(new RecordingCommandRunner(), steps);
 		assertThrows(AdoptionException.class, () -> adopter.adopt(context));
 		assertEquals(List.of("a"), order);
+	}
+
+	/**
+	 * Every tool is reported missing, so the pipeline aborts in its first step. That
+	 * proves the factory wired the default pipeline without letting any later step —
+	 * TrustStep writes to the real ~/.claude.json — touch anything outside the test.
+	 */
+	@Test
+	void withDefaultPipelineRunsTheDefaultStepsStartingWithTheToolchainCheck() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 1, "missing"));
+		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner);
+		assertThrows(AdoptionException.class, () -> adopter.adopt(context));
+		assertEquals(List.of("git", "--version"), runner.commandAt(0));
+	}
+
+	@Test
+	void withDefaultPipelineHonoursPullRequestOptionsAndTheAssetsFlag() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 1, "missing"));
+		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, PullRequestOptions.defaults(), true);
+		assertThrows(AdoptionException.class, () -> adopter.adopt(context));
+		assertEquals(List.of("git", "--version"), runner.commandAt(0));
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/WorkspacesTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/WorkspacesTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -51,13 +50,16 @@ class WorkspacesTest {
 
 	/**
 	 * The clone has nowhere to go if the workspace cannot be created, so the
-	 * failure must surface rather than leaving a later step to fail obscurely.
+	 * failure must surface rather than leaving a later step to fail obscurely — and
+	 * as the module's own exception type, so the command line and the MCP tool
+	 * report it like every other adoption failure instead of leaking a raw
+	 * UncheckedIOException.
 	 */
 	@Test
 	void reportsAWorkspaceThatCannotBeCreated(@TempDir Path dir) throws IOException {
 		Path blocker = dir.resolve("not-a-directory");
 		Files.writeString(blocker, "");
-		assertThrows(UncheckedIOException.class, () -> Workspaces.createIfMissing(blocker.resolve("workspace")));
+		assertThrows(AdoptionException.class, () -> Workspaces.createIfMissing(blocker.resolve("workspace")));
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -74,4 +74,31 @@ class BuildSystemsTest {
 	void gradleVerifyCommandRunsTheGuardTask() {
 		assertEquals(List.of("gradle", "-q", "enforceClaudeMd"), new GradleBuildSystem().verifyCommand());
 	}
+
+	/**
+	 * The tool BuildToolchainStep probes must be the one the verification actually
+	 * launches, or the check passes for a tool the adoption never runs.
+	 */
+	@Test
+	void mavenRequiresTheToolItsVerificationLaunches() {
+		BuildSystem maven = new MavenBuildSystem();
+		assertEquals(Optional.of(maven.verifyCommand().get(0)), maven.requiredTool());
+		assertEquals(Optional.of("mvn"), maven.requiredTool());
+	}
+
+	@Test
+	void gradleRequiresTheToolItsVerificationLaunches() {
+		BuildSystem gradle = new GradleBuildSystem();
+		assertEquals(Optional.of(gradle.verifyCommand().get(0)), gradle.requiredTool());
+		assertEquals(Optional.of("gradle"), gradle.requiredTool());
+	}
+
+	/**
+	 * The fallback guard runs through sh, which every supported platform provides
+	 * and which has no portable --version probe, so there is nothing to check.
+	 */
+	@Test
+	void theFallbackRequiresNoToolOfItsOwn() {
+		assertEquals(Optional.empty(), new FallbackBuildSystem().requiredTool());
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
@@ -1,0 +1,104 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class BuildToolchainStepTest {
+
+	private AdoptionContext context(Path workspace) throws IOException {
+		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/demo.git", workspace);
+		Files.createDirectories(context.repositoryDirectory());
+		return context;
+	}
+
+	@Test
+	void probesMavenForAMavenCheckout(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), "<project/>");
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new BuildToolchainStep().execute(context, runner);
+		assertEquals(List.of("mvn", "--version"), runner.commandAt(0));
+		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
+	}
+
+	@Test
+	void probesGradleForAGradleCheckout(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		Files.writeString(context.repositoryDirectory().resolve("build.gradle"), "plugins { id 'java' }\n");
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new BuildToolchainStep().execute(context, runner);
+		assertEquals(List.of("gradle", "--version"), runner.commandAt(0));
+	}
+
+	/**
+	 * Without this the adoption only finds out at {@link VerifyStep}, once a clone,
+	 * a claude init, a reshaped CLAUDE.md, and two commits have already been spent
+	 * on a checkout it was never going to be able to verify.
+	 */
+	@Test
+	void anAbsentBuildToolAbortsTheAdoption(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		Files.writeString(context.repositoryDirectory().resolve("build.gradle"), "plugins { id 'java' }\n");
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 127, "gradle: not found"));
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> new BuildToolchainStep().execute(context, runner));
+		assertTrue(thrown.getMessage().contains("gradle"), thrown.getMessage());
+	}
+
+	@Test
+	void aBuildToolThatCannotStartAbortsTheAdoption(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), "<project/>");
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			throw new AdoptionException("Could not start command: " + String.join(" ", command));
+		});
+		assertThrows(AdoptionException.class, () -> new BuildToolchainStep().execute(context, runner));
+	}
+
+	@Test
+	void probesNothingForTheFallbackGuardWhichOnlyNeedsAShell(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new BuildToolchainStep().execute(context, runner);
+		assertEquals(0, runner.count());
+	}
+
+	@Test
+	void skipsWhenNoConfiguredBuildSystemMatches(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		BuildToolchainStep step = new BuildToolchainStep(List.of(new MavenBuildSystem(), new GradleBuildSystem()));
+		assertDoesNotThrow(() -> step.execute(context, runner));
+		assertEquals(0, runner.count());
+	}
+
+	@Test
+	void probesTheToolTheVerificationWillActuallyRun(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), "<project/>");
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new BuildToolchainStep().execute(context, runner);
+		assertEquals(MavenBuildSystem.VERIFY_COMMAND.get(0), runner.commandAt(0).get(0));
+	}
+
+	@Test
+	void isNamedBuildToolchain() {
+		assertEquals("build-toolchain", new BuildToolchainStep().name());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
@@ -42,6 +42,40 @@ class ClaudeInitStepTest {
 		Files.writeString(memory, "# project memory");
 	}
 
+	/**
+	 * The claude transcript carried by the original failure is the only useful
+	 * diagnostic a failed run produces, so a restore that also fails must not throw
+	 * over it — which is what a plain finally block would do.
+	 */
+	@Test
+	void aFailedRestoreDoesNotReplaceTheOriginalFailure(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		writeClaudeDirMemory(context);
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			blockRestore(context);
+			return new CommandResult(command, 3, "claude: the underlying failure");
+		});
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> new ClaudeInitStep(List.of("claude")).execute(context, runner));
+		assertTrue(thrown.getMessage().contains("the underlying failure"), thrown.getMessage());
+		assertEquals(1, thrown.getSuppressed().length, "the failed restore must be attached, not thrown");
+	}
+
+	/**
+	 * Puts a regular file where the {@code .claude} directory was, while the CLI is
+	 * notionally running — that is, after the memory file has been moved aside and
+	 * before it is put back — so the restore cannot succeed.
+	 */
+	private void blockRestore(AdoptionContext context) {
+		Path claudeDir = context.repositoryDirectory().resolve(".claude");
+		try {
+			Files.delete(claudeDir);
+			Files.writeString(claudeDir, "not a directory");
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
 	@Test
 	void runsConfiguredClaudeCommandInCheckout(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
@@ -18,6 +18,8 @@ import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class EnforcerStepTest {
 
+	private static final String RULE_VERSION = "1.0.0";
+
 	private static final String POM = """
 			<project xmlns="http://maven.apache.org/POM/4.0.0">
 			  <modelVersion>4.0.0</modelVersion>
@@ -26,6 +28,16 @@ class EnforcerStepTest {
 			  <version>1.0.0</version>
 			</project>
 			""";
+
+	/**
+	 * The Maven path wires a rule dependency whose version comes from the running
+	 * build, and {@link PomEnforcerInstaller} refuses a snapshot. Pinning a released
+	 * version here keeps these tests about the wiring rather than about whichever
+	 * version the module happens to be built at.
+	 */
+	private EnforcerStep mavenStep() {
+		return new EnforcerStep(List.of(new MavenBuildSystem(new PomEnforcerInstaller(RULE_VERSION))));
+	}
 
 	private AdoptionContext context(Path workspace) throws IOException {
 		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/demo.git", workspace);
@@ -37,7 +49,7 @@ class EnforcerStepTest {
 	void wiresEnforcerIntoCheckoutPom(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
 		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), POM);
-		new EnforcerStep().execute(context, new RecordingCommandRunner());
+		mavenStep().execute(context, new RecordingCommandRunner());
 		assertTrue(Files.readString(context.repositoryDirectory().resolve("pom.xml"))
 				.contains("maven-enforcer-plugin"));
 	}
@@ -81,7 +93,7 @@ class EnforcerStepTest {
 		AdoptionContext context = context(workspace);
 		Path pom = context.repositoryDirectory().resolve("pom.xml");
 		Files.writeString(pom, POM);
-		EnforcerStep step = new EnforcerStep();
+		EnforcerStep step = mavenStep();
 		step.execute(context, new RecordingCommandRunner());
 		String afterFirstWiring = Files.readString(pom);
 		step.execute(context, new RecordingCommandRunner());

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
@@ -18,6 +18,41 @@ class GradleGuardInstallerTest {
 
 	private final GradleGuardInstaller installer = new GradleGuardInstaller();
 
+	/**
+	 * Gradle's configuration cache — on by default from Gradle 9 — rejects a task
+	 * whose execution-time body reaches back into the Project, failing the guard
+	 * task in the Groovy DSL and the whole build in the Kotlin one. Resolving the
+	 * file while the task is configured and only reading it in doLast keeps the task
+	 * body holding a plain File.
+	 */
+	@Test
+	void theGroovyGuardResolvesTheFileBeforeDoLast(@TempDir Path dir) throws IOException {
+		Path buildFile = write(dir, "build.gradle", "plugins { id 'java' }\n");
+		new GradleGuardInstaller().install(buildFile);
+		String script = Files.readString(buildFile);
+		assertTrue(script.indexOf("project.file('CLAUDE.md')") < script.indexOf("doLast"),
+				"the file must be resolved at configuration time, before doLast: " + script);
+		assertFalse(script.contains("$projectDir"),
+				"a project reference inside the task body breaks the configuration cache: " + script);
+	}
+
+	@Test
+	void theKotlinGuardResolvesTheFileBeforeDoLast(@TempDir Path dir) throws IOException {
+		Path buildFile = write(dir, "build.gradle.kts", "plugins { java }\n");
+		new GradleGuardInstaller().install(buildFile);
+		String script = Files.readString(buildFile);
+		assertTrue(script.indexOf("project.file(\"CLAUDE.md\")") < script.indexOf("doLast"),
+				"the file must be resolved at configuration time, before doLast: " + script);
+		assertFalse(script.contains("$projectDir"),
+				"a project reference inside the task body breaks the configuration cache: " + script);
+	}
+
+	private Path write(Path directory, String fileName, String content) throws IOException {
+		Path buildFile = directory.resolve(fileName);
+		Files.writeString(buildFile, content);
+		return buildFile;
+	}
+
 	@Test
 	void appendsGroovyGuardToBuildGradle(@TempDir Path directory) throws IOException {
 		Path buildFile = directory.resolve("build.gradle");
@@ -36,7 +71,7 @@ class GradleGuardInstallerTest {
 		assertTrue(installer.install(buildFile));
 		String content = Files.readString(buildFile);
 		assertTrue(content.contains("tasks.register(\"enforceClaudeMd\")"));
-		assertTrue(content.contains("val claudeMd = file(\"$projectDir/CLAUDE.md\")"));
+		assertTrue(content.contains("val claudeMd = project.file(\"CLAUDE.md\")"));
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -342,14 +342,46 @@ class PomEnforcerInstallerTest {
 	 * rather than a hardcoded literal that drifts as the project is versioned.
 	 */
 	@Test
-	void defaultInstallerPinsTheRuleToTheFilteredBuildVersion(@TempDir Path dir) throws IOException {
-		String buildVersion = filteredRuleVersion();
+	void defaultInstallerReadsTheFilteredBuildVersion() throws IOException {
+		assertEquals(filteredRuleVersion(), PomEnforcerInstaller.buildRuleVersion());
+	}
+
+	@Test
+	void aReleaseRuleVersionIsPinnedIntoThePom(@TempDir Path dir) throws IOException {
 		Path pom = write(dir, POM_WITH_BUILD);
-		assertTrue(new PomEnforcerInstaller().install(pom));
+		assertTrue(new PomEnforcerInstaller("4.1.0").install(pom));
 		String result = Files.readString(pom);
 		assertTrue(result.contains("tools.claude-code-enforcer"));
-		assertTrue(result.contains("<version>" + buildVersion + "</version>"),
-				"the rule dependency must be pinned to the filtered build version " + buildVersion);
+		assertTrue(result.contains("<version>4.1.0</version>"), result);
+	}
+
+	/**
+	 * A snapshot resolves from the adopter's local repository and nowhere else, so
+	 * wiring one in would open a pull request that only builds on the machine that
+	 * opened it.
+	 */
+	@Test
+	void aSnapshotRuleVersionIsRefused() {
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> PomEnforcerInstaller.requireReleaseVersion("2.6.0-SNAPSHOT"));
+		assertTrue(thrown.getMessage().contains("2.6.0-SNAPSHOT"), thrown.getMessage());
+	}
+
+	@Test
+	void aReleaseRuleVersionIsAccepted() {
+		assertEquals("2.6.0", PomEnforcerInstaller.requireReleaseVersion("2.6.0"));
+	}
+
+	/**
+	 * Resolving the version only when a POM is actually being edited keeps a
+	 * non-Maven adoption — and merely constructing the default build-system list —
+	 * independent of whichever version the module was built at.
+	 */
+	@Test
+	void theDefaultInstallerResolvesItsVersionOnlyWhenItWiresAPom(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_BUILD);
+		installer.install(pom);
+		assertFalse(new PomEnforcerInstaller().install(pom));
 	}
 
 	private String filteredRuleVersion() throws IOException {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,13 @@ class PomEnforcerInstallerTest {
 			+ "    <artifactId>demo</artifactId>\n"
 			+ "    <version>1.0.0</version>\n"
 			+ "</project>\n";
+
+	private static final String POM_SINGLE_LINE =
+			"<project xmlns=\"http://maven.apache.org/POM/4.0.0\"><artifactId>demo</artifactId></project>\n";
+
+	private static final String POM_NO_TRAILING_NEWLINE = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n"
+			+ "  <artifactId>demo</artifactId>\n"
+			+ "</project>";
 
 	private static final String POM_WITH_ENFORCER = """
 			<project xmlns="http://maven.apache.org/POM/4.0.0">
@@ -337,6 +345,36 @@ class PomEnforcerInstallerTest {
 	}
 
 	/**
+	 * A POM whose elements sit on one line offers no indentation to copy, so the
+	 * editor falls back to two spaces rather than running the added block together.
+	 * The original line is still preserved verbatim.
+	 */
+	@Test
+	void indentsTheAddedBlockByTwoSpacesWhenThePomShowsNoIndentation(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_SINGLE_LINE);
+		assertTrue(installer.install(pom));
+		String result = Files.readString(pom);
+		assertTrue(result.startsWith(POM_SINGLE_LINE.strip().replace("</project>", "")),
+				"the original line must be preserved verbatim: " + result);
+		assertTrue(result.contains("\n  <build>\n"), result);
+		assertTrue(result.contains("\n    <plugins>\n"), result);
+	}
+
+	/**
+	 * The rewrite matches whatever the original ended with, so a POM saved without a
+	 * final newline does not gain one and show a spurious last-line change in the
+	 * adoption commit.
+	 */
+	@Test
+	void leavesAPomThatEndedWithoutANewlineWithoutOne(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_NO_TRAILING_NEWLINE);
+		assertTrue(installer.install(pom));
+		String result = Files.readString(pom);
+		assertTrue(result.contains("tools.claude-code-enforcer"), "the rule must still be wired in");
+		assertFalse(result.endsWith("\n"), "a POM with no trailing newline must not gain one");
+	}
+
+	/**
 	 * The default installer must pin the rule to the version Maven filtered into
 	 * {@code adopt-build.properties} — the release actually running the adoption —
 	 * rather than a hardcoded literal that drifts as the project is versioned.
@@ -370,6 +408,26 @@ class PomEnforcerInstallerTest {
 	@Test
 	void aReleaseRuleVersionIsAccepted() {
 		assertEquals("2.6.0", PomEnforcerInstaller.requireReleaseVersion("2.6.0"));
+	}
+
+	/**
+	 * The version the default installer wires in must go through the release guard,
+	 * so a snapshot build cannot put an unresolvable dependency into an adopted POM.
+	 * Whether that refuses or returns depends on how this module was built, so the
+	 * assertion pins the composition rather than one fixed outcome.
+	 */
+	@Test
+	void theDefaultVersionGoesThroughTheReleaseGuard() {
+		assertEquals(outcomeOf(() -> PomEnforcerInstaller.requireReleaseVersion(PomEnforcerInstaller.buildRuleVersion())),
+				outcomeOf(PomEnforcerInstaller::releaseRuleVersion));
+	}
+
+	private String outcomeOf(Supplier<String> version) {
+		try {
+			return "wired " + version.get();
+		} catch (AdoptionException e) {
+			return "refused: " + e.getMessage();
+		}
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -1,11 +1,13 @@
 package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,6 +24,34 @@ class PullRequestStepTest {
 	private final AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git",
 			Path.of("/tmp/workspace"), "claude/adopt-claude-code");
 	private final PullRequestStep step = new PullRequestStep();
+
+	/**
+	 * gh's diagnostics are merged into the captured output, and one printed before
+	 * the JSON can itself contain a '['. Stopping at the first bracket would parse
+	 * the noise, conclude no pull request is open, and create a duplicate that gh
+	 * rejects — failing an adoption that was only being re-run.
+	 */
+	@Test
+	void findsTheOpenPullRequestDespiteLeadingBracketedNoise() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("list")
+				? new CommandResult(command, 0, "warning: [core] ignoring stale entry\n"
+						+ "[{\"url\":\"https://github.com/adamw7/demo/pull/7\"}]\n")
+				: new CommandResult(command, 0, ""));
+		AdoptionReport report = new AdoptionReport();
+		new PullRequestStep().execute(context, runner, report);
+		assertEquals(Optional.of("https://github.com/adamw7/demo/pull/7"), report.pullRequestUrl());
+		assertFalse(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("create")),
+				"an already-open pull request must not be created a second time");
+	}
+
+	@Test
+	void anEmptyArrayAfterNoiseStillMeansNoOpenPullRequest() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("list")
+				? new CommandResult(command, 0, "warning: [core] ignoring stale entry\n[]\n")
+				: new CommandResult(command, 0, ""));
+		new PullRequestStep().execute(context, runner, new AdoptionReport());
+		assertTrue(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("create")));
+	}
 
 	@Test
 	void opensPullRequestForFeatureBranch() {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolProbeTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolProbeTest.java
@@ -1,0 +1,89 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class ToolProbeTest {
+
+	private final ToolProbe probe = new ToolProbe();
+	private final Path directory = Path.of("/tmp/workspace");
+
+	@Test
+	void probesEachToolWithAVersionFlagInTheGivenDirectory() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		probe.missingFrom(List.of("git", "gh"), directory, runner);
+		assertEquals(List.of("git", "--version"), runner.commandAt(0));
+		assertEquals(List.of("gh", "--version"), runner.commandAt(1));
+		assertEquals(directory, runner.invocations().get(0).workingDirectory());
+	}
+
+	@Test
+	void reportsNothingMissingWhenEveryProbeSucceeds() {
+		assertEquals(List.of(), probe.missingFrom(List.of("git", "gh"), directory, new RecordingCommandRunner()));
+	}
+
+	/**
+	 * Probing every tool even after one is found missing lets a single failure name
+	 * all of the absent ones rather than sending the caller round the loop once per
+	 * tool.
+	 */
+	@Test
+	void reportsEveryMissingToolInDeclarationOrder() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> command.contains("claude") ? new CommandResult(command, 0, "")
+						: new CommandResult(command, 1, "missing"));
+		assertEquals(List.of("git", "gh"), probe.missingFrom(List.of("git", "claude", "gh"), directory, runner));
+		assertEquals(3, runner.count(), "every tool must be probed, not just up to the first missing one");
+	}
+
+	/**
+	 * A tool the runner cannot even start throws out of run(); for a probe that is
+	 * the "not installed" answer, not a reason to abort the whole check.
+	 */
+	@Test
+	void aToolThatCannotStartCountsAsMissingRatherThanPropagating() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			throw new AdoptionException("Could not start command: " + String.join(" ", command));
+		});
+		assertEquals(List.of("git"), probe.missingFrom(List.of("git"), directory, runner));
+	}
+
+	@Test
+	void anEmptyToolListProbesNothing() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		assertEquals(List.of(), probe.missingFrom(List.of(), directory, runner));
+		assertEquals(0, runner.count());
+	}
+
+	@Test
+	void succeedsRunsTheGivenCommandVerbatim() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		assertTrue(probe.succeeds(List.of("gh", "auth", "status"), directory, runner));
+		assertEquals(List.of("gh", "auth", "status"), runner.commandAt(0));
+	}
+
+	@Test
+	void succeedsIsFalseForANonZeroExit() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 1, "not logged in"));
+		assertFalse(probe.succeeds(List.of("gh", "auth", "status"), directory, runner));
+	}
+
+	@Test
+	void succeedsIsFalseForACommandThatCannotStart() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			throw new AdoptionException("Could not start command");
+		});
+		assertFalse(probe.succeeds(List.of("gh", "auth", "status"), directory, runner));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
@@ -31,6 +31,44 @@ class ToolchainStepTest {
 	}
 
 	@Test
+	void probesTheGitHubLoginOnceEveryToolIsPresent() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new ToolchainStep().execute(context, runner);
+		assertEquals(List.of("gh", "auth", "status"), runner.commandAt(3));
+		assertEquals(context.workspace(), runner.invocations().get(3).workingDirectory());
+	}
+
+	/**
+	 * {@code gh --version} succeeds for a GitHub CLI nobody is logged in to, so
+	 * without this the adoption would only find out at its very last step, after a
+	 * clone, a claude init, and a build have already run.
+	 */
+	@Test
+	void anUnauthenticatedGitHubCliAbortsTheAdoption() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> command.contains("auth") ? new CommandResult(command, 1, "not logged in")
+						: new CommandResult(command, 0, ""));
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> new ToolchainStep().execute(context, runner));
+		assertTrue(thrown.getMessage().contains("not authenticated"), thrown.getMessage());
+	}
+
+	@Test
+	void doesNotProbeTheGitHubLoginWhenGhIsNotARequiredTool() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new ToolchainStep(List.of("git")).execute(context, runner);
+		assertEquals(1, runner.count());
+	}
+
+	@Test
+	void reportsAMissingToolWithoutProbingTheGitHubLogin() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 1, "missing"));
+		assertThrows(AdoptionException.class, () -> new ToolchainStep().execute(context, runner));
+		assertEquals(3, runner.count());
+	}
+
+	@Test
 	void probesTheConfiguredTools() {
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new ToolchainStep(List.of("git")).execute(context, runner);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -113,6 +114,11 @@ class VerifyStepTest {
 		@Override
 		public List<String> verifyCommand() {
 			return verifyCommand;
+		}
+
+		@Override
+		public Optional<String> requiredTool() {
+			return Optional.empty();
 		}
 	}
 }


### PR DESCRIPTION
The Gradle guard reached into the Project from inside doLast, which
Gradle's configuration cache rejects: the guard task failed in the Groovy
DSL and the whole build failed in the Kotlin one, aborting the adoption at
VerifyStep and breaking check for every contributor afterwards. The file is
now resolved while the task is configured, verified against Gradle 8.14.3
with the cache on, in both DSLs.

PullRequestStep parsed gh pr list from the first '[' in the captured
output. gh's stderr is merged in, and a diagnostic printed before the JSON
can carry a bracket, so the step parsed noise, concluded no pull request
was open, and created a duplicate that gh rejects - failing an adoption
that was only being re-run. Every bracket is tried now.

AdoptionContext derived an empty repository name from a URL ending in '//'
or '/.git', resolving the checkout onto the workspace itself; such a URL is
rejected up front. Workspaces failed with a raw UncheckedIOException rather
than the module's AdoptionException.

PomEnforcerInstaller wired whatever version the running build carried,
including a snapshot - resolvable from the adopter's local repository and
nowhere else, so the pull request built only on the machine that opened it
and VerifyStep could not catch it. A snapshot is refused, and the version
is resolved lazily so a non-Maven adoption stays independent of it.

ToolchainStep promised fail-fast but probed the wrong set: it never checked
the adopted project's own build tool, so a missing mvn or gradle surfaced
at VerifyStep after a clone, a claude init and two commits, and gh --version
succeeds for a CLI nobody is logged in to. A new BuildToolchainStep probes
the build tool right after the clone, and the gh login is probed up front;
both share a ToolProbe with the existing check.

ClaudeInitStep restored the relocated .claude/CLAUDE.md from a finally
block, so a failing restore threw over the claude transcript that is the
only useful diagnostic of a failed run; it is attached as suppressed now.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ANnAXah93mKpfiKio2qcYF