### PR TITLE
refactor(adopt): remove duplication across steps, installers, and the conformer

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -25,10 +25,10 @@ public final class AdoptionContext {
 	}
 
 	public AdoptionContext(String repositoryUrl, Path workspace, String branchName) {
-		this.repositoryUrl = requireUrl(repositoryUrl);
+		this.repositoryUrl = requireText(repositoryUrl, "repositoryUrl");
 		this.workspace = requireWorkspace(workspace);
 		this.repositoryDirectory = workspace.resolve(repositoryName(this.repositoryUrl));
-		this.branchName = requireBranch(branchName);
+		this.branchName = requireText(branchName, "branchName");
 	}
 
 	public String repositoryUrl() {
@@ -47,11 +47,11 @@ public final class AdoptionContext {
 		return branchName;
 	}
 
-	private static String requireUrl(String repositoryUrl) {
-		if (repositoryUrl == null || repositoryUrl.isBlank()) {
-			throw new IllegalArgumentException("repositoryUrl must not be blank");
+	private static String requireText(String value, String field) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(field + " must not be blank");
 		}
-		return repositoryUrl.strip();
+		return value.strip();
 	}
 
 	private static Path requireWorkspace(Path workspace) {
@@ -59,13 +59,6 @@ public final class AdoptionContext {
 			throw new IllegalArgumentException("workspace must not be null");
 		}
 		return workspace;
-	}
-
-	private static String requireBranch(String branchName) {
-		if (branchName == null || branchName.isBlank()) {
-			throw new IllegalArgumentException("branchName must not be blank");
-		}
-		return branchName.strip();
 	}
 
 	private static String repositoryName(String repositoryUrl) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 
@@ -102,23 +103,24 @@ public final class CliArguments {
 			case "--label" -> consumeValue(args, index, labels::add);
 			case "--assignee" -> consumeValue(args, index, assignees::add);
 			case "--report" -> consumeValue(args, index, value -> reportFile = Path.of(value));
-			case "--draft" -> consumeSwitch(index, () -> draft = true);
-			case "--assets" -> consumeSwitch(index, () -> assets = true);
+			case "--draft" -> {
+				draft = true;
+				yield index + 1;
+			}
+			case "--assets" -> {
+				assets = true;
+				yield index + 1;
+			}
 			default -> throw new IllegalArgumentException("Unknown option " + flag + ". " + USAGE);
 		};
 	}
 
-	private int consumeValue(String[] args, int index, java.util.function.Consumer<String> target) {
+	private int consumeValue(String[] args, int index, Consumer<String> target) {
 		if (index + 1 >= args.length) {
 			throw new IllegalArgumentException(args[index] + " requires a value. " + USAGE);
 		}
 		target.accept(args[index + 1]);
 		return index + 2;
-	}
-
-	private int consumeSwitch(int index, Runnable target) {
-		target.run();
-		return index + 1;
 	}
 
 	private void consumePositional(String argument) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -107,7 +107,7 @@ public class AdoptTool implements McpTool {
 	 * branch overrides it, so an empty string is not rejected as an invalid branch.
 	 */
 	private String branch(Map<String, Object> arguments) {
-		String branch = ToolArguments.optionalString(arguments, "branch", AdoptionContext.DEFAULT_BRANCH);
+		String branch = ToolArguments.optionalString(arguments, "branch", "");
 		return branch.isBlank() ? AdoptionContext.DEFAULT_BRANCH : branch;
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractBuildSystemStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractBuildSystemStep.java
@@ -1,0 +1,46 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Base for the steps that act on the checkout's build system: wiring the
+ * {@code CLAUDE.md} guard into it ({@link EnforcerStep}), running that guard
+ * ({@link VerifyStep}), and checking the build tool it needs is installed
+ * ({@link BuildToolchainStep}). Detecting the build system in one place keeps
+ * all three acting on the same build tool, so the guard that is wired in is the
+ * guard that is verified with the tool that was probed.
+ *
+ * <p>Detection only comes up empty when a step is configured with a build-system
+ * list that has no catch-all fallback — {@link BuildSystems#DEFAULTS} always
+ * matches — in which case the step is skipped with a warning rather than failing
+ * the adoption.
+ */
+public abstract class AbstractBuildSystemStep extends AbstractCommandStep {
+
+	private static final Logger log = LogManager.getLogger(AbstractBuildSystemStep.class);
+
+	private final List<BuildSystem> buildSystems;
+
+	protected AbstractBuildSystemStep(List<BuildSystem> buildSystems) {
+		this.buildSystems = List.copyOf(buildSystems);
+	}
+
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner) {
+		Path repositoryDirectory = context.repositoryDirectory();
+		BuildSystems.detect(buildSystems, repositoryDirectory).ifPresentOrElse(
+				detected -> onDetected(detected, context, runner),
+				() -> log.warn("No supported build system ({}) in {}; skipping the {} step",
+						BuildSystems.names(buildSystems), repositoryDirectory, name()));
+	}
+
+	/** What the step does with the build system detected in the checkout. */
+	protected abstract void onDetected(BuildSystem buildSystem, AdoptionContext context, CommandRunner runner);
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
@@ -12,9 +12,16 @@ import java.util.List;
  * mentions on issues and pull requests. Every asset is a plain committed file,
  * so the configuration is shared with all contributors rather than living only
  * in the adopter's local checkout.
+ *
+ * <p>The repository-relative paths the adoption writes are all named here,
+ * including the generated {@code CLAUDE.md}. That one is not a starter asset —
+ * {@link ClaudeInitStep} generates it and {@link ClaudeMdConformanceStep}
+ * reshapes it — but keeping its name beside the others stops the same literal
+ * being spelled out in every step that refers to it.
  */
 public final class AdoptionAssets {
 
+	static final String CLAUDE_MD_FILE = "CLAUDE.md";
 	static final String AGENTS_MD_FILE = "AGENTS.md";
 	static final String SETTINGS_FILE = ".claude/settings.json";
 	static final String SESSION_START_HOOK_FILE = ".claude/hooks/session-start.sh";

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetInstaller.java
@@ -16,6 +16,11 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  * overwritten — the project's own version always wins over the starter content —
  * so re-running the adoption, or adopting a repository that already configured
  * Claude Code, leaves the checkout untouched.
+ *
+ * <p>Which of the two happened is logged here rather than by each caller, so
+ * every asset the adoption writes — the starter files, the companion
+ * {@code AGENTS.md}, and the fallback guard's workflow and script — is reported
+ * the same way.
  */
 public class AssetInstaller {
 
@@ -46,9 +51,11 @@ public class AssetInstaller {
 	public boolean install(Path repositoryDirectory) {
 		Path file = repositoryDirectory.resolve(relativePath);
 		if (Files.exists(file)) {
+			log.info("{} already exists; left unchanged", relativePath);
 			return false;
 		}
 		write(file);
+		log.info("Installed {}", relativePath);
 		return true;
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetsStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetsStep.java
@@ -1,10 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.nio.file.Path;
 import java.util.List;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
@@ -19,8 +15,6 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * records whatever was added.
  */
 public class AssetsStep implements AdoptionStep {
-
-	private static final Logger log = LogManager.getLogger(AssetsStep.class);
 
 	private final List<AssetInstaller> installers;
 
@@ -39,16 +33,6 @@ public class AssetsStep implements AdoptionStep {
 
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
-		for (AssetInstaller installer : installers) {
-			install(installer, context.repositoryDirectory());
-		}
-	}
-
-	private void install(AssetInstaller installer, Path repositoryDirectory) {
-		if (installer.install(repositoryDirectory)) {
-			log.info("Installed {}", installer.relativePath());
-		} else {
-			log.info("{} already exists; left unchanged", installer.relativePath());
-		}
+		installers.forEach(installer -> installer.install(context.repositoryDirectory()));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -38,8 +38,14 @@ public interface BuildSystem {
 	 * can probe it before the pipeline spends a {@code claude init} on a checkout it
 	 * will not be able to verify.
 	 *
+	 * <p>The verification launches the first word of its own command, so that is
+	 * what the default probes; a build system whose guard needs nothing installed
+	 * overrides this with an empty answer.
+	 *
 	 * @return the program to probe, or empty when the verification needs nothing
 	 *         beyond the POSIX shell every supported platform already provides
 	 */
-	Optional<String> requiredTool();
+	default Optional<String> requiredTool() {
+		return Optional.of(verifyCommand().get(0));
+	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystems.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystems.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.adopt.step;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * The build systems the adoption supports and the detection that picks the one
@@ -30,6 +31,6 @@ public final class BuildSystems {
 	}
 
 	static String names(List<BuildSystem> candidates) {
-		return candidates.stream().map(BuildSystem::name).reduce((a, b) -> a + "/" + b).orElse("");
+		return candidates.stream().map(BuildSystem::name).collect(Collectors.joining("/"));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
@@ -2,7 +2,6 @@ package io.github.adamw7.tools.adopt.step;
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -22,17 +21,16 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * late failure the toolchain check exists to prevent.
  *
  * <p>The step runs directly after {@link CloneStep} and detects the build system
- * the same way {@link EnforcerStep} and {@link VerifyStep} do, so the tool it
- * probes is the tool the verification will actually run. A build system that
- * needs no installed tool — the {@link FallbackBuildSystem}, whose guard runs
- * through {@code sh} — and a checkout no configured build system matches are both
- * a no-op, mirroring how those two steps skip rather than fail.
+ * through {@link AbstractBuildSystemStep} exactly as {@link EnforcerStep} and
+ * {@link VerifyStep} do, so the tool it probes is the tool the verification will
+ * actually run. A build system that needs no installed tool — the
+ * {@link FallbackBuildSystem}, whose guard runs through {@code sh} — is a no-op,
+ * mirroring how the step is skipped when no build system matches at all.
  */
-public class BuildToolchainStep implements AdoptionStep {
+public class BuildToolchainStep extends AbstractBuildSystemStep {
 
 	private static final Logger log = LogManager.getLogger(BuildToolchainStep.class);
 
-	private final List<BuildSystem> buildSystems;
 	private final ToolProbe probe = new ToolProbe();
 
 	public BuildToolchainStep() {
@@ -40,7 +38,7 @@ public class BuildToolchainStep implements AdoptionStep {
 	}
 
 	public BuildToolchainStep(List<BuildSystem> buildSystems) {
-		this.buildSystems = List.copyOf(buildSystems);
+		super(buildSystems);
 	}
 
 	@Override
@@ -49,16 +47,8 @@ public class BuildToolchainStep implements AdoptionStep {
 	}
 
 	@Override
-	public void execute(AdoptionContext context, CommandRunner runner) {
+	protected void onDetected(BuildSystem buildSystem, AdoptionContext context, CommandRunner runner) {
 		Path repositoryDirectory = context.repositoryDirectory();
-		Optional<BuildSystem> buildSystem = BuildSystems.detect(buildSystems, repositoryDirectory);
-		buildSystem.ifPresentOrElse(
-				detected -> requireTool(detected, repositoryDirectory, runner),
-				() -> log.warn("No supported build system ({}) in {}; skipping the build tool check",
-						BuildSystems.names(buildSystems), repositoryDirectory));
-	}
-
-	private void requireTool(BuildSystem buildSystem, Path repositoryDirectory, CommandRunner runner) {
 		buildSystem.requiredTool().ifPresentOrElse(
 				tool -> requireInstalled(tool, buildSystem, repositoryDirectory, runner),
 				() -> log.info("The {} guard needs no build tool of its own in {}", buildSystem.name(),

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -48,7 +48,7 @@ public class ClaudeInitStep extends AbstractCommandStep {
 	static final List<String> DEFAULT_COMMAND = List.of("claude", "-p", "/init",
 			"--permission-mode", "acceptEdits");
 
-	private static final String CLAUDE_MD = "CLAUDE.md";
+	private static final String CLAUDE_MD = AdoptionAssets.CLAUDE_MD_FILE;
 	private static final String CLAUDE_DIR = ".claude";
 
 	private final List<String> claudeCommand;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
@@ -31,7 +31,7 @@ public class ClaudeMdConformanceStep implements AdoptionStep {
 
 	private static final Logger log = LogManager.getLogger(ClaudeMdConformanceStep.class);
 
-	static final String CLAUDE_MD = "CLAUDE.md";
+	static final String CLAUDE_MD = AdoptionAssets.CLAUDE_MD_FILE;
 
 	private final ClaudeMdConformer conformer;
 	private final AssetInstaller agentsMdInstaller;
@@ -53,16 +53,8 @@ public class ClaudeMdConformanceStep implements AdoptionStep {
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
 		Path checkout = context.repositoryDirectory();
-		installAgentsMd(checkout);
+		agentsMdInstaller.install(checkout);
 		conformClaudeMd(checkout);
-	}
-
-	private void installAgentsMd(Path checkout) {
-		if (agentsMdInstaller.install(checkout)) {
-			log.info("Wrote companion {}", agentsMdInstaller.relativePath());
-		} else {
-			log.info("{} already exists; left unchanged", agentsMdInstaller.relativePath());
-		}
 	}
 
 	private void conformClaudeMd(Path checkout) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
@@ -132,17 +134,9 @@ public class ClaudeMdConformer {
 	 * required section.
 	 */
 	private Set<Integer> reservedHeadings(List<String> lines, boolean[] fence) {
-		Set<Integer> reserved = new LinkedHashSet<>();
-		for (int index = 0; index < lines.size(); index++) {
-			addIfReserved(reserved, lines, fence, index);
-		}
-		return reserved;
-	}
-
-	private void addIfReserved(Set<Integer> reserved, List<String> lines, boolean[] fence, int index) {
-		if (!fence[index] && REQUIRED_SECTIONS.contains(lines.get(index).strip())) {
-			reserved.add(index);
-		}
+		return matchesOutsideFences(lines, fence, line -> REQUIRED_SECTIONS.contains(line.strip()))
+				.boxed()
+				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
 	private void canonicalize(List<String> lines, boolean[] fence, String required, Set<Integer> claimed) {
@@ -157,19 +151,14 @@ public class ClaudeMdConformer {
 	}
 
 	private int firstNearMatch(List<String> lines, boolean[] fence, String required, Set<Integer> claimed) {
-		for (int index = 0; index < lines.size(); index++) {
-			if (isNearMatch(lines, fence, claimed, index, required)) {
-				return index;
-			}
-		}
-		return -1;
+		return matchesOutsideFences(lines, fence, line -> isNearMatch(line, required))
+				.filter(index -> !claimed.contains(index))
+				.findFirst()
+				.orElse(-1);
 	}
 
-	private boolean isNearMatch(List<String> lines, boolean[] fence, Set<Integer> claimed, int index, String required) {
-		if (fence[index] || claimed.contains(index)) {
-			return false;
-		}
-		String stripped = lines.get(index).strip();
+	private boolean isNearMatch(String line, String required) {
+		String stripped = line.strip();
 		return isHeading(stripped) && nearMatches(stripped, required);
 	}
 
@@ -287,20 +276,20 @@ public class ClaudeMdConformer {
 			return lines;
 		}
 		List<String> result = new ArrayList<>(lines);
-		int titleIndex = indexOfTitle(result);
+		int titleIndex = indexOfTitle(result, fence);
 		result.add(titleIndex + 1, "");
 		result.add(titleIndex + 2, AGENTS_REFERENCE_LINE);
 		result.add(titleIndex + 3, "");
 		return result;
 	}
 
-	private int indexOfTitle(List<String> lines) {
-		for (int index = 0; index < lines.size(); index++) {
-			if (lines.get(index).strip().equals(TITLE)) {
-				return index;
-			}
-		}
-		return 0;
+	/**
+	 * The title is the first non-blank line by the time this runs, and a fence marker
+	 * would itself be a non-blank line before it, so the title can never be one the
+	 * mask covers. A document with no title line at all falls back to the top.
+	 */
+	private int indexOfTitle(List<String> lines, boolean[] fence) {
+		return Math.max(indexOfHeading(lines, fence, TITLE), 0);
 	}
 
 	private boolean hasHeading(List<String> lines, boolean[] fence, String heading) {
@@ -309,19 +298,16 @@ public class ClaudeMdConformer {
 
 	/** @return the index of the heading outside code fences, or {@code -1} when absent */
 	private int indexOfHeading(List<String> lines, boolean[] fence, String heading) {
-		return IntStream.range(0, lines.size())
-				.filter(index -> !fence[index] && lines.get(index).strip().equals(heading))
-				.findFirst()
-				.orElse(-1);
+		return matchesOutsideFences(lines, fence, line -> line.strip().equals(heading)).findFirst().orElse(-1);
 	}
 
 	private boolean containsOutsideFences(List<String> lines, boolean[] fence, String token) {
-		for (int index = 0; index < lines.size(); index++) {
-			if (!fence[index] && lines.get(index).contains(token)) {
-				return true;
-			}
-		}
-		return false;
+		return matchesOutsideFences(lines, fence, line -> line.contains(token)).findFirst().isPresent();
+	}
+
+	/** The indices of the lines outside code fences whose text matches, in document order. */
+	private IntStream matchesOutsideFences(List<String> lines, boolean[] fence, Predicate<String> match) {
+		return IntStream.range(0, lines.size()).filter(index -> !fence[index] && match.test(lines.get(index)));
 	}
 
 	private boolean isHeading(String stripped) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerStep.java
@@ -2,7 +2,6 @@ package io.github.adamw7.tools.adopt.step;
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -16,23 +15,20 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * wiring depends on the checkout's build tool: a Maven project gets the full
  * {@code claude-code-enforcer} rule, a Gradle project gets a presence guard task,
  * and a project with no recognised build file gets the build-tool-agnostic
- * GitHub Actions guard (see {@link BuildSystem}). Detection only comes up empty
- * when the step is configured with a build-system list that has no catch-all
- * fallback, in which case the wiring is skipped with a warning rather than
- * failing the adoption.
+ * GitHub Actions guard (see {@link BuildSystem}). The build system is detected by
+ * {@link AbstractBuildSystemStep}, which also skips the step with a warning when
+ * none matches, rather than failing the adoption.
  */
-public class EnforcerStep implements AdoptionStep {
+public class EnforcerStep extends AbstractBuildSystemStep {
 
 	private static final Logger log = LogManager.getLogger(EnforcerStep.class);
-
-	private final List<BuildSystem> buildSystems;
 
 	public EnforcerStep() {
 		this(BuildSystems.DEFAULTS);
 	}
 
 	public EnforcerStep(List<BuildSystem> buildSystems) {
-		this.buildSystems = List.copyOf(buildSystems);
+		super(buildSystems);
 	}
 
 	@Override
@@ -41,16 +37,8 @@ public class EnforcerStep implements AdoptionStep {
 	}
 
 	@Override
-	public void execute(AdoptionContext context, CommandRunner runner) {
+	protected void onDetected(BuildSystem buildSystem, AdoptionContext context, CommandRunner runner) {
 		Path repositoryDirectory = context.repositoryDirectory();
-		Optional<BuildSystem> buildSystem = BuildSystems.detect(buildSystems, repositoryDirectory);
-		buildSystem.ifPresentOrElse(
-				detected -> install(detected, repositoryDirectory),
-				() -> log.warn("No supported build system ({}) in {}; skipping enforcer wiring",
-						BuildSystems.names(buildSystems), repositoryDirectory));
-	}
-
-	private void install(BuildSystem buildSystem, Path repositoryDirectory) {
 		if (buildSystem.install(repositoryDirectory)) {
 			log.info("Wired the CLAUDE.md guard into the {} build in {}", buildSystem.name(), repositoryDirectory);
 		} else {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
@@ -52,11 +52,6 @@ public class GradleBuildSystem implements BuildSystem {
 		return VERIFY_COMMAND;
 	}
 
-	@Override
-	public Optional<String> requiredTool() {
-		return Optional.of(VERIFY_COMMAND.get(0));
-	}
-
 	/**
 	 * Prefers the Groovy build file over the Kotlin one when a checkout carries
 	 * both, matching the order most Gradle projects resolve them in.

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -125,20 +125,16 @@ public class GradleGuardInstaller {
 		}
 	}
 
+	/**
+	 * The appended block's LF line terminators are rewritten to match the ones the
+	 * script already uses, so appending the guard to a CRLF build script does not
+	 * leave the new region with LF endings mixed into an otherwise CRLF file.
+	 */
 	private void append(Path buildFile, String existing, String block) {
 		try {
-			Files.writeString(buildFile, existing + matchLineTerminator(block, existing));
+			Files.writeString(buildFile, existing + LineTerminators.matching(block, existing));
 		} catch (IOException e) {
 			throw new AdoptionException("Could not write Gradle build file: " + buildFile, e);
 		}
-	}
-
-	/**
-	 * Rewrites the appended block's LF line terminators to match the ones the script
-	 * already uses, so appending the guard to a CRLF build script does not leave the
-	 * new region with LF endings mixed into an otherwise CRLF file.
-	 */
-	private String matchLineTerminator(String block, String existing) {
-		return existing.contains("\r\n") ? block.replace("\n", "\r\n") : block;
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/LineTerminators.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/LineTerminators.java
@@ -1,0 +1,41 @@
+package io.github.adamw7.tools.adopt.step;
+
+/**
+ * Keeps text the adoption writes into an existing file on the line terminator
+ * that file already uses. Both installers that edit a project file — the POM
+ * rewrite in {@link PomEnforcerInstaller} and the block
+ * {@link GradleGuardInstaller} appends — produce LF text, so writing it into a
+ * CRLF file would leave the new region with terminators mixed into an otherwise
+ * CRLF file, or (for the POM, whose terminators XML parsing has already
+ * normalised) flip every line of it to LF and reformat the whole file.
+ */
+final class LineTerminators {
+
+	private static final String CRLF = "\r\n";
+	private static final String LF = "\n";
+	private static final String CR = "\r";
+
+	private LineTerminators() {
+	}
+
+	/** The terminator the text uses: CRLF when it carries one, LF otherwise. */
+	static String of(String text) {
+		return text.contains(CRLF) ? CRLF : LF;
+	}
+
+	/**
+	 * Rewrites every line terminator in {@code text} to {@code terminator}. The text
+	 * is normalised to LF first, so a text that already mixes terminators — assembled
+	 * from a converted body and a part carried over verbatim — is not
+	 * double-converted where it already ended in the target terminator.
+	 */
+	static String apply(String text, String terminator) {
+		String normalized = text.replace(CRLF, LF).replace(CR, LF);
+		return LF.equals(terminator) ? normalized : normalized.replace(LF, terminator);
+	}
+
+	/** Rewrites {@code text}'s line terminators to the one {@code sample} already uses. */
+	static String matching(String text, String sample) {
+		return apply(text, of(sample));
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -3,7 +3,6 @@ package io.github.adamw7.tools.adopt.step;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Maven support for the adoption: detects a {@code pom.xml}, wires the
@@ -46,10 +45,5 @@ public class MavenBuildSystem implements BuildSystem {
 	@Override
 	public List<String> verifyCommand() {
 		return VERIFY_COMMAND;
-	}
-
-	@Override
-	public Optional<String> requiredTool() {
-		return Optional.of(VERIFY_COMMAND.get(0));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -157,14 +157,14 @@ public class PomEnforcerInstaller {
 	private boolean declaresRuleDependency(Element plugin) {
 		return child(plugin, "dependencies").stream()
 				.flatMap(dependencies -> children(dependencies, "dependency").stream())
-				.anyMatch(this::isRuleDependency);
+				.anyMatch(dependency -> hasArtifactId(dependency, RULE_ARTIFACT_ID));
 	}
 
-	private boolean isRuleDependency(Element dependency) {
-		return child(dependency, "artifactId")
+	private static boolean hasArtifactId(Element element, String artifactId) {
+		return child(element, "artifactId")
 				.map(Element::getTextContent)
 				.map(String::strip)
-				.filter(RULE_ARTIFACT_ID::equals)
+				.filter(artifactId::equals)
 				.isPresent();
 	}
 
@@ -181,16 +181,8 @@ public class PomEnforcerInstaller {
 
 	private Optional<Element> findEnforcerPlugin(Element plugins) {
 		return children(plugins, "plugin").stream()
-				.filter(this::isEnforcerPlugin)
+				.filter(plugin -> hasArtifactId(plugin, ENFORCER_ARTIFACT_ID))
 				.findFirst();
-	}
-
-	private boolean isEnforcerPlugin(Element plugin) {
-		return child(plugin, "artifactId")
-				.map(Element::getTextContent)
-				.map(String::strip)
-				.filter(ENFORCER_ARTIFACT_ID::equals)
-				.isPresent();
 	}
 
 	private Element createEnforcerPlugin(PomEditor editor, Element plugins) {
@@ -225,7 +217,7 @@ public class PomEnforcerInstaller {
 		editor.appendText(claudeMdFormat, "claudeMdFile", CLAUDE_MD_FILE);
 	}
 
-	private Optional<Element> child(Element parent, String name) {
+	private static Optional<Element> child(Element parent, String name) {
 		return children(parent, name).stream().findFirst();
 	}
 
@@ -279,39 +271,21 @@ public class PomEnforcerInstaller {
 	 * added — already indented by {@link PomEditor} — differ from the original. The
 	 * original's XML declaration and trailing newline are carried over exactly so
 	 * the first and last lines are not disturbed either.
+	 *
+	 * <p>XML parsing normalizes {@code \r\n} to {@code \n}, so the DOM the
+	 * transformer serializes has lost the original terminator;
+	 * {@link LineTerminators} puts it back, keeping a CRLF POM on CRLF rather than
+	 * silently flipping every line to LF and reformatting the whole file.
 	 */
 	private void write(Document document, Path pomFile, String original) {
 		try {
 			String content = declarationPrefix(original) + transformBody(document);
 			String withTrailingNewline = matchTrailingNewline(content, original);
 			Files.createDirectories(pomFile.toAbsolutePath().getParent());
-			Files.writeString(pomFile, applyLineTerminator(withTrailingNewline, lineTerminator(original)));
+			Files.writeString(pomFile, LineTerminators.matching(withTrailingNewline, original));
 		} catch (IOException | TransformerException e) {
 			throw new AdoptionException("Could not write POM: " + pomFile, e);
 		}
-	}
-
-	/**
-	 * The line terminator the original file used. XML parsing normalizes {@code \r\n}
-	 * to {@code \n}, so the DOM the transformer serializes has lost the original
-	 * terminator; capturing it here lets the rewrite keep a CRLF POM on CRLF rather
-	 * than silently flipping every line to LF and reformatting the whole file. A file
-	 * with no {@code \r\n} is treated as LF.
-	 */
-	private String lineTerminator(String original) {
-		return original.contains("\r\n") ? "\r\n" : "\n";
-	}
-
-	/**
-	 * Rewrites every line terminator in {@code content} to {@code terminator}. The
-	 * assembled content mixes the transformer's LF body, the added block's LF
-	 * indentation, and the declaration carried over verbatim from the original, so it
-	 * is first normalized to a single form to avoid double-converting the parts that
-	 * already ended in the target terminator.
-	 */
-	private String applyLineTerminator(String content, String terminator) {
-		String normalized = content.replace("\r\n", "\n").replace("\r", "\n");
-		return terminator.equals("\n") ? normalized : normalized.replace("\n", terminator);
 	}
 
 	private String transformBody(Document document) throws TransformerException {
@@ -394,7 +368,7 @@ public class PomEnforcerInstaller {
 		}
 
 		private Element childOrCreate(Element parent, String name) {
-			return firstChild(parent, name).orElseGet(() -> appendElement(parent, name));
+			return child(parent, name).orElseGet(() -> appendElement(parent, name));
 		}
 
 		private Element appendElement(Element parent, String name) {
@@ -427,10 +401,6 @@ public class PomEnforcerInstaller {
 
 		private Element create(String name) {
 			return namespace == null ? document.createElement(name) : document.createElementNS(namespace, name);
-		}
-
-		private Optional<Element> firstChild(Element parent, String name) {
-			return children(parent, name).stream().findFirst();
 		}
 
 		private static Node trailingWhitespace(Element parent) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/VerifyStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/VerifyStep.java
@@ -1,8 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -16,23 +14,20 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * contributor's build after the pull request lands. The command to run is
  * chosen from the checkout's build tool — a non-recursive {@code mvn -N validate}
  * for Maven, the guard task for Gradle, the guard script for a project with no
- * recognised build file (see {@link BuildSystem}). Detection only comes up empty
- * when the step is configured with a build-system list that has no catch-all
- * fallback, in which case there is nothing to verify and the step is skipped,
- * mirroring {@link EnforcerStep}.
+ * recognised build file (see {@link BuildSystem}). The build system is detected
+ * by {@link AbstractBuildSystemStep}, which also skips the step with a warning
+ * when none matches and there is therefore nothing to verify.
  */
-public class VerifyStep extends AbstractCommandStep {
+public class VerifyStep extends AbstractBuildSystemStep {
 
 	private static final Logger log = LogManager.getLogger(VerifyStep.class);
-
-	private final List<BuildSystem> buildSystems;
 
 	public VerifyStep() {
 		this(BuildSystems.DEFAULTS);
 	}
 
 	public VerifyStep(List<BuildSystem> buildSystems) {
-		this.buildSystems = List.copyOf(buildSystems);
+		super(buildSystems);
 	}
 
 	@Override
@@ -41,16 +36,7 @@ public class VerifyStep extends AbstractCommandStep {
 	}
 
 	@Override
-	public void execute(AdoptionContext context, CommandRunner runner) {
-		Path repositoryDirectory = context.repositoryDirectory();
-		Optional<BuildSystem> buildSystem = BuildSystems.detect(buildSystems, repositoryDirectory);
-		buildSystem.ifPresentOrElse(
-				detected -> verify(detected, context, runner),
-				() -> log.warn("No supported build system ({}) in {}; skipping build verification",
-						BuildSystems.names(buildSystems), repositoryDirectory));
-	}
-
-	private void verify(BuildSystem buildSystem, AdoptionContext context, CommandRunner runner) {
+	protected void onDetected(BuildSystem buildSystem, AdoptionContext context, CommandRunner runner) {
 		log.info("Verifying the CLAUDE.md guard passes with {} in {}", buildSystem.name(),
 				context.repositoryDirectory());
 		runOrFail(runner, context.repositoryDirectory(), buildSystem.verifyCommand());


### PR DESCRIPTION
The pipeline had grown four clusters of near-identical code. None of this
changes behaviour; the module keeps every existing test green.

- Extract AbstractBuildSystemStep: EnforcerStep, VerifyStep, and
  BuildToolchainStep each repeated the same field, constructor pair, and
  detect-or-warn preamble. They now supply only what they do with the build
  system they were handed.
- Move the "installed / left unchanged" logging into AssetInstaller, so every
  asset the adoption writes is reported the same way and the two callers that
  branched on the returned boolean no longer have to.
- Share the CRLF-preserving rewrite that PomEnforcerInstaller and
  GradleGuardInstaller had each written for themselves as LineTerminators, and
  collapse the installer's duplicated artifactId and first-child lookups.
- Collapse the four ways ClaudeMdConformer scanned for a line outside the code
  fences into one predicate scan.

Alongside those: BuildSystem.requiredTool() now defaults to the first word of
verifyCommand() (the invariant it already documented), AdoptionContext's two
identical validators become one, BuildSystems.names uses Collectors.joining,
CliArguments drops a Runnable wrapper, and the CLAUDE.md file name is spelled
out once.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CCjq7SVQDqFJKQpQEcwa3j