### PR TITLE
fix(adopt): make claude-init idempotent, report failed runs, and target gh explicitly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,9 @@ Maven project. The notable capabilities are:
   repo, creates a feature branch,
   marks the checkout trusted in `~/.claude.json` so the headless CLI is not
   blocked by the folder-trust prompt, runs the Claude Code CLI (`claude init`) to
-  generate a `CLAUDE.md` and commits it, then wires a `CLAUDE.md` guard into the
+  generate a `CLAUDE.md` and commits it — skipped for a checkout that already has
+  one, since the CLI's output is not reproducible and regenerating would discard
+  edits made since the adoption — then wires a `CLAUDE.md` guard into the
   project's build and commits that, verifies the guard passes on the generated
   file, and finally pushes the branch and opens a pull request with the GitHub
   CLI (`gh pr create`) — the default branch is never written to directly. The
@@ -65,9 +67,15 @@ Maven project. The notable capabilities are:
   denying reads of obvious secret files and wiring a
   `.claude/hooks/session-start.sh` stub, a starter `.mcp.json`, and a GitHub
   Actions workflow answering `@claude` mentions — never overwriting a file the
-  repository already has. Each run returns an `AdoptionReport` (completed steps
-  plus the pull request URL, read back with `gh pr view --json url`);
-  `--report <file>` writes it as JSON for scripting. An **MCP server** (in the
+  repository already has. Both `gh` invocations name the target repository with
+  `--repo`, derived from the URL being adopted, rather than letting `gh` infer it
+  from the checkout's git remote — a remote rewritten by `url.<base>.insteadOf`,
+  a mirror, or a proxy is not readable as a GitHub one and would fail the last
+  step of an otherwise complete adoption. Each run returns an `AdoptionReport`
+  (completed steps, the pull request URL read back with `gh pr list --json url`,
+  and whether the run succeeded plus the failing step's message when it did not);
+  `--report <file>` writes it as JSON for scripting, on the failure path too, so
+  an abandoned run still records how far it got. An **MCP server** (in the
   `io.github.adamw7.tools.adopt.mcp` package) exposes the same pipeline as an
   `adopt_repo` tool that answers with that JSON report. External
   `git`/`claude`/`gh` invocations

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -1,6 +1,9 @@
 package io.github.adamw7.tools.adopt;
 
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Immutable inputs shared by every adoption step: the GitHub repository URL to
@@ -15,10 +18,15 @@ public final class AdoptionContext {
 	/** Feature branch the adoption commits, pushes, and raises a pull request from. */
 	public static final String DEFAULT_BRANCH = "claude/adopt-claude-code";
 
+	private static final String SCHEME = "^[a-zA-Z][a-zA-Z0-9+.-]*://";
+	private static final String SEGMENT_SEPARATORS = "[/:]";
+	private static final int SEGMENTS_WITH_A_HOST = 3;
+
 	private final String repositoryUrl;
 	private final Path workspace;
 	private final Path repositoryDirectory;
 	private final String branchName;
+	private final String repositorySlug;
 
 	public AdoptionContext(String repositoryUrl, Path workspace) {
 		this(repositoryUrl, workspace, DEFAULT_BRANCH);
@@ -29,10 +37,21 @@ public final class AdoptionContext {
 		this.workspace = requireWorkspace(workspace);
 		this.repositoryDirectory = workspace.resolve(repositoryName(this.repositoryUrl));
 		this.branchName = requireText(branchName, "branchName");
+		this.repositorySlug = repositorySlug(this.repositoryUrl);
 	}
 
 	public String repositoryUrl() {
 		return repositoryUrl;
+	}
+
+	/**
+	 * @return the {@code owner/repository} the URL names, for the steps that must
+	 *         tell a tool which repository to act on rather than let it guess from
+	 *         the checkout's git remote; empty when the URL carries no host and so
+	 *         names no owner
+	 */
+	public Optional<String> repositorySlug() {
+		return Optional.ofNullable(repositorySlug);
 	}
 
 	public Path workspace() {
@@ -81,6 +100,38 @@ public final class AdoptionContext {
 					"repositoryUrl must end in a repository name but was: " + repositoryUrl);
 		}
 		return name;
+	}
+
+	/**
+	 * Derives {@code owner/repository} from the clone URL, covering the forms git
+	 * accepts: {@code https://host/owner/repo.git}, {@code ssh://git@host/owner/repo},
+	 * and the scp-like {@code git@host:owner/repo}. The scheme is dropped and the
+	 * remainder split on both separators, so the scp-like form's {@code ':'} is
+	 * treated as the path separator it is.
+	 *
+	 * <p>A URL is only read as naming an owner when a host segment precedes the last
+	 * two — the segment before the owner must look like a hostname. Without that
+	 * check a plain filesystem path such as {@code /tmp/workspace/repo} would yield
+	 * the nonsense slug {@code workspace/repo}, and a step would confidently point a
+	 * tool at a repository that does not exist; an empty result instead leaves the
+	 * step to fall back to its own inference.
+	 */
+	private static String repositorySlug(String repositoryUrl) {
+		List<String> segments = segments(stripGitSuffix(stripTrailingSlash(repositoryUrl)));
+		if (segments.size() < SEGMENTS_WITH_A_HOST || !isHost(segments.get(segments.size() - 3))) {
+			return null;
+		}
+		return segments.get(segments.size() - 2) + "/" + segments.get(segments.size() - 1);
+	}
+
+	private static List<String> segments(String url) {
+		return Stream.of(url.replaceFirst(SCHEME, "").split(SEGMENT_SEPARATORS))
+				.filter(segment -> !segment.isBlank())
+				.toList();
+	}
+
+	private static boolean isHost(String segment) {
+		return segment.contains(".");
 	}
 
 	private static String stripTrailingSlash(String value) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReport.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReport.java
@@ -11,11 +11,17 @@ import java.util.Optional;
  * command line, the MCP server, or any embedding code — can report what happened
  * without scraping logs. The pull-request URL is absent until a step records it,
  * for example when the pipeline is configured without a pull-request step.
+ *
+ * <p>A report is also filled in for a run that fails part-way: the steps that did
+ * complete stay recorded and the failing step's message is recorded as the run's
+ * failure, so the report distinguishes a completed adoption from an abandoned one
+ * instead of looking like a short but successful run.
  */
 public final class AdoptionReport {
 
 	private final List<String> completedSteps = new ArrayList<>();
 	private String pullRequestUrl;
+	private String failure;
 
 	public void recordStep(String name) {
 		completedSteps.add(name);
@@ -25,11 +31,26 @@ public final class AdoptionReport {
 		this.pullRequestUrl = url;
 	}
 
+	public void recordFailure(String message) {
+		this.failure = message;
+	}
+
 	public List<String> completedSteps() {
 		return List.copyOf(completedSteps);
 	}
 
 	public Optional<String> pullRequestUrl() {
 		return Optional.ofNullable(pullRequestUrl);
+	}
+
+	/**
+	 * @return why the run stopped, or empty when every configured step completed
+	 */
+	public Optional<String> failure() {
+		return Optional.ofNullable(failure);
+	}
+
+	public boolean succeeded() {
+		return failure == null;
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
@@ -11,11 +11,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Renders an {@link AdoptionReport} as JSON, either to a string or to a file, so
- * the adoption's outcome — repository, branch, pull-request URL, and the steps
- * that completed — is consumable by scripts and other tools rather than only
- * readable in the logs. A report without a pull-request URL serialises the
- * {@code pullRequestUrl} field as JSON {@code null}, keeping the document's
- * shape stable for consumers.
+ * the adoption's outcome — repository, branch, pull-request URL, whether the run
+ * succeeded, and the steps that completed — is consumable by scripts and other
+ * tools rather than only readable in the logs. A report without a pull-request
+ * URL serialises the {@code pullRequestUrl} field as JSON {@code null}, and so
+ * does a successful run's {@code failure}, keeping the document's shape stable
+ * for consumers.
  */
 public class AdoptionReportWriter {
 
@@ -50,6 +51,8 @@ public class AdoptionReportWriter {
 		node.put("repositoryUrl", context.repositoryUrl());
 		node.put("branch", context.branchName());
 		node.put("pullRequestUrl", report.pullRequestUrl().orElse(null));
+		node.put("succeeded", report.succeeded());
+		node.put("failure", report.failure().orElse(null));
 		ArrayNode steps = node.putArray("completedSteps");
 		report.completedSteps().forEach(steps::add);
 		return node;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -42,9 +42,12 @@ import io.github.adamw7.tools.adopt.step.VerifyStep;
  *
  * <p>Each run returns an {@link AdoptionReport} of the steps that completed and
  * the pull request's URL, so callers can act on the outcome without scraping
- * logs. The default pipeline can optionally include an {@link AssetsStep} that
- * commits starter Claude Code configuration assets alongside the generated
- * {@code CLAUDE.md}.
+ * logs. A caller that needs the report of a run that <em>fails</em> — the case
+ * where knowing how far the pipeline got matters most — supplies its own report
+ * to {@link #adopt(AdoptionContext, AdoptionReport)} and still holds it after the
+ * failure propagates. The default pipeline can optionally include an
+ * {@link AssetsStep} that commits starter Claude Code configuration assets
+ * alongside the generated {@code CLAUDE.md}.
  */
 public class GitHubRepoAdopter {
 
@@ -94,8 +97,21 @@ public class GitHubRepoAdopter {
 	}
 
 	public AdoptionReport adopt(AdoptionContext context) {
+		return adopt(context, new AdoptionReport());
+	}
+
+	/**
+	 * Runs the pipeline into a report the caller already holds, so the outcome
+	 * survives a failure: a report created here and only handed back on the return
+	 * path is lost the moment a step throws, which is exactly when a caller wants to
+	 * know which steps completed.
+	 *
+	 * @param report filled in as the run progresses, and marked as failed before a
+	 *               failing step's exception propagates
+	 * @return the same report, once every step has completed
+	 */
+	public AdoptionReport adopt(AdoptionContext context, AdoptionReport report) {
 		log.info("Adopting Claude Code into {}", context.repositoryUrl());
-		AdoptionReport report = new AdoptionReport();
 		for (AdoptionStep step : steps) {
 			runStep(step, context, report);
 		}
@@ -105,7 +121,25 @@ public class GitHubRepoAdopter {
 
 	private void runStep(AdoptionStep step, AdoptionContext context, AdoptionReport report) {
 		log.info("Step: {}", step.name());
-		step.execute(context, runner, report);
+		try {
+			step.execute(context, runner, report);
+		} catch (RuntimeException e) {
+			report.recordFailure(describe(step, e));
+			throw e;
+		}
 		report.recordStep(step.name());
+	}
+
+	/**
+	 * Names the failing step alongside the failure, because an exception message
+	 * alone — {@code "The requested URL returned error: 403"} — does not say which
+	 * stage of the adoption produced it. An exception carrying no message at all
+	 * falls back to its type, so the report never records a bare {@code null}.
+	 */
+	private String describe(AdoptionStep step, RuntimeException failure) {
+		String message = failure.getMessage();
+		return step.name() + ": " + (message == null || message.isBlank()
+				? failure.getClass().getSimpleName()
+				: message);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -13,7 +13,9 @@ import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
  * pipeline against a real {@code git}/{@code claude}/{@code gh} toolchain. A
  * supplied workspace directory is created when it does not yet exist; when
  * omitted, a temporary one is created instead. When {@code --report} names a
- * file, the run's {@link AdoptionReport} is written there as JSON.
+ * file, the run's {@link AdoptionReport} is written there as JSON — for a failed
+ * run as well as a successful one, so the report can say how far the adoption got
+ * and why it stopped.
  */
 public class Main {
 
@@ -23,12 +25,45 @@ public class Main {
 		CommandRunner runner = new ProcessCommandRunner();
 		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, cli.pullRequestOptions(),
 				cli.includeAssets());
-		AdoptionReport report = adopter.adopt(context);
+		runAndReport(cli, context, adopter);
+	}
+
+	/**
+	 * Runs the adoption and writes the report on both paths, so a run that fails
+	 * part-way still leaves the {@code --report} file behind rather than nothing at
+	 * all.
+	 *
+	 * @return the run's report, once the adoption has completed
+	 */
+	static AdoptionReport runAndReport(CliArguments cli, AdoptionContext context, GitHubRepoAdopter adopter) {
+		AdoptionReport report = new AdoptionReport();
+		try {
+			adopter.adopt(context, report);
+		} catch (RuntimeException e) {
+			writeReportSuppressing(cli, context, report, e);
+			throw e;
+		}
 		writeReport(cli, context, report);
+		return report;
 	}
 
 	static Path workspace(CliArguments cli) {
 		return cli.workspace().map(Workspaces::createIfMissing).orElseGet(Workspaces::createTemporary);
+	}
+
+	/**
+	 * Writes the report of a failed run without letting an unwritable report file
+	 * replace the adoption failure being reported — that failure is the diagnostic
+	 * the operator needs, so a secondary write error is attached to it rather than
+	 * thrown over it.
+	 */
+	private static void writeReportSuppressing(CliArguments cli, AdoptionContext context, AdoptionReport report,
+			RuntimeException failure) {
+		try {
+			writeReport(cli, context, report);
+		} catch (RuntimeException e) {
+			failure.addSuppressed(e);
+		}
 	}
 
 	private static void writeReport(CliArguments cli, AdoptionContext context, AdoptionReport report) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -40,6 +40,13 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * that exits cleanly but leaves no {@code CLAUDE.md} behind aborts the adoption
  * rather than letting the pipeline push a branch and open a pull request with
  * nothing in it.
+ *
+ * <p>The step is idempotent, like every other step in the pipeline: a checkout
+ * that already carries a root {@code CLAUDE.md} is left alone rather than
+ * regenerated. The CLI's output is not reproducible, so regenerating would
+ * rewrite the file on every re-run — discarding any edit the project made to it
+ * since the adoption and adding a second commit with the same message for a
+ * change nobody asked for.
  */
 public class ClaudeInitStep extends AbstractCommandStep {
 
@@ -69,6 +76,10 @@ public class ClaudeInitStep extends AbstractCommandStep {
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
 		Path checkout = context.repositoryDirectory();
+		if (Files.isRegularFile(checkout.resolve(CLAUDE_MD))) {
+			log.info("{} already carries {}; left unchanged", checkout, CLAUDE_MD);
+			return;
+		}
 		log.info("Running claude init in {}", checkout);
 		Optional<Path> relocated = relocateExistingClaudeDirMemory(checkout);
 		try {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -33,6 +33,16 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * pull request as if it were current and wrongly skip creation. That keeps the
  * decision robust across {@code gh} versions and locales.
  *
+ * <p>Both commands name the target repository with {@code --repo} rather than
+ * letting {@code gh} infer it from the checkout's git remote. The adoption
+ * already knows which repository it is adopting, and the remote is not always
+ * readable as a GitHub one: a {@code url.<base>.insteadOf} rewrite, an
+ * organisation mirror, or a proxied clone leaves {@code gh} reporting that "none
+ * of the git remotes configured for this repository point to a known GitHub
+ * host", which would fail the very last step of an otherwise complete adoption.
+ * A URL that names no owner leaves the flag off, so {@code gh} falls back to its
+ * own inference.
+ *
  * <p>After the pull request is created (or found already open), the step records
  * its URL in the run's {@link AdoptionReport}. The URL is read back with
  * {@code gh pr list --json url} rather than scraped from {@code gh pr create}'s
@@ -89,6 +99,7 @@ public class PullRequestStep extends AbstractCommandStep {
 	private List<String> createCommand(AdoptionContext context) {
 		List<String> command = new ArrayList<>(List.of("gh", "pr", "create", "--title", options.title(), "--body",
 				options.body(), "--head", context.branchName()));
+		addTargetRepository(command, context);
 		if (options.draft()) {
 			command.add("--draft");
 		}
@@ -96,6 +107,13 @@ public class PullRequestStep extends AbstractCommandStep {
 		addRepeated(command, "--label", options.labels());
 		addRepeated(command, "--assignee", options.assignees());
 		return List.copyOf(command);
+	}
+
+	private void addTargetRepository(List<String> command, AdoptionContext context) {
+		context.repositorySlug().ifPresent(slug -> {
+			command.add("--repo");
+			command.add(slug);
+		});
 	}
 
 	private void addRepeated(List<String> command, String flag, List<String> values) {
@@ -120,7 +138,10 @@ public class PullRequestStep extends AbstractCommandStep {
 	}
 
 	private List<String> listCommand(AdoptionContext context) {
-		return List.of("gh", "pr", "list", "--head", context.branchName(), "--state", "open", "--json", "url");
+		List<String> command = new ArrayList<>(List.of("gh", "pr", "list", "--head", context.branchName(), "--state",
+				"open", "--json", "url"));
+		addTargetRepository(command, context);
+		return List.copyOf(command);
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.adopt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 
@@ -117,5 +118,45 @@ class AdoptionContextTest {
 	void rejectsNullWorkspace() {
 		assertThrows(IllegalArgumentException.class,
 				() -> new AdoptionContext("https://github.com/adamw7/tools.git", null));
+	}
+
+	@Test
+	void derivesTheOwnerAndRepositoryFromAnHttpsUrl() {
+		assertEquals("adamw7/tools",
+				new AdoptionContext("https://github.com/adamw7/tools.git", workspace).repositorySlug().orElseThrow());
+		assertEquals("adamw7/tools",
+				new AdoptionContext("https://github.com/adamw7/tools", workspace).repositorySlug().orElseThrow());
+		assertEquals("adamw7/tools",
+				new AdoptionContext("https://github.com/adamw7/tools/", workspace).repositorySlug().orElseThrow());
+	}
+
+	/**
+	 * The scp-like form separates the host from the path with ':', not '/', so a
+	 * naive split on '/' alone would read the host and owner as one segment.
+	 */
+	@Test
+	void derivesTheOwnerAndRepositoryFromSshForms() {
+		assertEquals("adamw7/tools",
+				new AdoptionContext("git@github.com:adamw7/tools.git", workspace).repositorySlug().orElseThrow());
+		assertEquals("adamw7/tools", new AdoptionContext("ssh://git@github.com/adamw7/tools.git", workspace)
+				.repositorySlug().orElseThrow());
+	}
+
+	@Test
+	void derivesTheOwnerAndRepositoryFromAnEnterpriseHost() {
+		assertEquals("adamw7/tools", new AdoptionContext("https://github.example.com/adamw7/tools.git", workspace)
+				.repositorySlug().orElseThrow());
+	}
+
+	/**
+	 * A filesystem path names no owner, so reading its last two segments as one
+	 * would point a tool at a repository that does not exist. Reporting no slug
+	 * leaves the caller to fall back to its own inference.
+	 */
+	@Test
+	void aUrlWithNoHostNamesNoOwner() {
+		assertTrue(new AdoptionContext("/tmp/workspace/tools", workspace).repositorySlug().isEmpty());
+		assertTrue(new AdoptionContext("file:///tmp/tools", workspace).repositorySlug().isEmpty());
+		assertTrue(new AdoptionContext("tools", workspace).repositorySlug().isEmpty());
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -14,6 +15,19 @@ class AdoptionReportTest {
 		AdoptionReport report = new AdoptionReport();
 		assertTrue(report.completedSteps().isEmpty());
 		assertTrue(report.pullRequestUrl().isEmpty());
+		assertTrue(report.failure().isEmpty());
+		assertTrue(report.succeeded());
+	}
+
+	@Test
+	void recordsFailure() {
+		AdoptionReport report = new AdoptionReport();
+		report.recordStep("clone");
+		report.recordFailure("push: the requested URL returned error: 403");
+		assertEquals("push: the requested URL returned error: 403", report.failure().orElseThrow());
+		assertFalse(report.succeeded());
+		assertEquals(List.of("clone"), report.completedSteps(),
+				"a failed run still reports the steps that did complete");
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportWriterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportWriterTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,6 +44,31 @@ class AdoptionReportWriterTest {
 		JsonNode node = mapper.readTree(writer.toJson(context, new AdoptionReport()));
 		assertTrue(node.get("pullRequestUrl").isNull());
 		assertTrue(node.get("completedSteps").isEmpty());
+	}
+
+	@Test
+	void serialisesASuccessfulRunAsSucceededWithNoFailure() throws IOException {
+		AdoptionReport report = new AdoptionReport();
+		report.recordStep("clone");
+		JsonNode node = mapper.readTree(writer.toJson(context, report));
+		assertTrue(node.get("succeeded").asBoolean());
+		assertTrue(node.get("failure").isNull());
+	}
+
+	/**
+	 * Without these fields a run that stopped at "push" would serialise exactly like
+	 * a pipeline configured to end there, so a consumer could not tell an abandoned
+	 * adoption from a complete one.
+	 */
+	@Test
+	void serialisesAFailedRunAsNotSucceededWithTheReason() throws IOException {
+		AdoptionReport report = new AdoptionReport();
+		report.recordStep("clone");
+		report.recordFailure("push: the requested URL returned error: 403");
+		JsonNode node = mapper.readTree(writer.toJson(context, report));
+		assertFalse(node.get("succeeded").asBoolean());
+		assertEquals("push: the requested URL returned error: 403", node.get("failure").asText());
+		assertEquals("clone", node.get("completedSteps").get(0).asText());
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -1,6 +1,8 @@
 package io.github.adamw7.tools.adopt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
@@ -54,6 +56,19 @@ class GitHubRepoAdopterTest {
 		}
 	}
 
+	private static final class SilentlyExplodingStep implements AdoptionStep {
+
+		@Override
+		public String name() {
+			return "quiet";
+		}
+
+		@Override
+		public void execute(AdoptionContext context, CommandRunner runner) {
+			throw new IllegalStateException();
+		}
+	}
+
 	@Test
 	void runsEveryStepInOrder() {
 		List<String> order = new ArrayList<>();
@@ -78,6 +93,39 @@ class GitHubRepoAdopterTest {
 		GitHubRepoAdopter adopter = new GitHubRepoAdopter(new RecordingCommandRunner(), steps);
 		assertThrows(AdoptionException.class, () -> adopter.adopt(context));
 		assertEquals(List.of("a"), order);
+	}
+
+	/**
+	 * A report the adopter creates itself is lost the moment a step throws, which is
+	 * when a caller most wants to know how far the run got. Supplying the report
+	 * keeps it readable after the failure has propagated.
+	 */
+	@Test
+	void fillsInASuppliedReportEvenWhenAStepFails() {
+		List<AdoptionStep> steps = List.of(new NamingStep("a", new ArrayList<>()), new ExplodingStep());
+		GitHubRepoAdopter adopter = new GitHubRepoAdopter(new RecordingCommandRunner(), steps);
+		AdoptionReport report = new AdoptionReport();
+		assertThrows(AdoptionException.class, () -> adopter.adopt(context, report));
+		assertEquals(List.of("a"), report.completedSteps());
+		assertEquals("boom: boom", report.failure().orElseThrow());
+		assertFalse(report.succeeded());
+	}
+
+	@Test
+	void namesTheFailingStepAlongsideTheFailure() {
+		AdoptionReport report = new AdoptionReport();
+		GitHubRepoAdopter adopter = new GitHubRepoAdopter(new RecordingCommandRunner(),
+				List.of(new SilentlyExplodingStep()));
+		assertThrows(IllegalStateException.class, () -> adopter.adopt(context, report));
+		assertEquals("quiet: IllegalStateException", report.failure().orElseThrow(),
+				"an exception with no message must not be reported as a bare null");
+	}
+
+	@Test
+	void aSuppliedReportIsTheOneReturned() {
+		AdoptionReport report = new AdoptionReport();
+		GitHubRepoAdopter adopter = new GitHubRepoAdopter(new RecordingCommandRunner(), List.of());
+		assertSame(report, adopter.adopt(context, report));
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
@@ -1,14 +1,24 @@
 package io.github.adamw7.tools.adopt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+import io.github.adamw7.tools.adopt.step.AdoptionStep;
 
 class MainTest {
 
@@ -55,5 +65,73 @@ class MainTest {
 	void createsTemporaryWorkspaceWhenNoneSupplied() {
 		Path resolved = Main.workspace(CliArguments.parse(new String[] { REPO_URL }));
 		assertTrue(Files.isDirectory(resolved));
+	}
+
+	/**
+	 * A run that stops part-way is the one whose report matters most — it records
+	 * which steps completed and why the adoption stopped — so writing it only on the
+	 * success path leaves nothing behind exactly when the operator needs it.
+	 */
+	@Test
+	void writesTheReportWhenTheAdoptionFails(@TempDir Path dir) throws IOException {
+		Path file = dir.resolve("report.json");
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> Main.runAndReport(cli(dir, file), context(dir), failingAdopter()));
+		assertEquals("boom", thrown.getMessage());
+		JsonNode node = new ObjectMapper().readTree(Files.readString(file));
+		assertFalse(node.get("succeeded").asBoolean());
+		assertEquals("explode: boom", node.get("failure").asText());
+	}
+
+	@Test
+	void writesTheReportWhenTheAdoptionSucceeds(@TempDir Path dir) throws IOException {
+		Path file = dir.resolve("report.json");
+		Main.runAndReport(cli(dir, file), context(dir), new GitHubRepoAdopter(new RecordingCommandRunner(), List.of()));
+		JsonNode node = new ObjectMapper().readTree(Files.readString(file));
+		assertTrue(node.get("succeeded").asBoolean());
+		assertTrue(node.get("failure").isNull());
+	}
+
+	/**
+	 * The adoption failure is the diagnostic the operator needs; an unwritable
+	 * report file must be attached to it rather than thrown over it.
+	 */
+	@Test
+	void anUnwritableReportDoesNotReplaceTheAdoptionFailure(@TempDir Path dir) throws IOException {
+		Path blockingFile = Files.createFile(dir.resolve("not-a-directory"));
+		AdoptionException thrown = assertThrows(AdoptionException.class, () -> Main
+				.runAndReport(cli(dir, blockingFile.resolve("report.json")), context(dir), failingAdopter()));
+		assertEquals("boom", thrown.getMessage());
+		assertEquals(1, thrown.getSuppressed().length);
+	}
+
+	@Test
+	void writesNoReportWhenNoneWasRequested(@TempDir Path dir) {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, dir.toString() });
+		Main.runAndReport(cli, context(dir), new GitHubRepoAdopter(new RecordingCommandRunner(), List.of()));
+		assertTrue(cli.reportFile().isEmpty());
+	}
+
+	private CliArguments cli(Path workspace, Path reportFile) {
+		return CliArguments.parse(new String[] { REPO_URL, workspace.toString(), "--report", reportFile.toString() });
+	}
+
+	private AdoptionContext context(Path workspace) {
+		return new AdoptionContext(REPO_URL, workspace);
+	}
+
+	private GitHubRepoAdopter failingAdopter() {
+		return new GitHubRepoAdopter(new RecordingCommandRunner(), List.of(new AdoptionStep() {
+
+			@Override
+			public String name() {
+				return "explode";
+			}
+
+			@Override
+			public void execute(AdoptionContext context, CommandRunner runner) {
+				throw new AdoptionException("boom");
+			}
+		}));
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
@@ -32,6 +32,18 @@ class ClaudeInitStepTest {
 		Files.writeString(context.repositoryDirectory().resolve("CLAUDE.md"), "# CLAUDE.md");
 	}
 
+	/**
+	 * Stands in for a CLI run that does what the step exists to make happen: writes
+	 * the root CLAUDE.md. The file cannot be put there before the step runs, because
+	 * a checkout that already carries one makes the step skip the CLI entirely.
+	 */
+	private RecordingCommandRunner generatingRunner(AdoptionContext context) {
+		return new RecordingCommandRunner(command -> {
+			writeRootClaudeMd(context);
+			return new CommandResult(command, 0, "");
+		});
+	}
+
 	private Path claudeDirMemory(AdoptionContext context) {
 		return context.repositoryDirectory().resolve(".claude").resolve("CLAUDE.md");
 	}
@@ -79,8 +91,7 @@ class ClaudeInitStepTest {
 	@Test
 	void runsConfiguredClaudeCommandInCheckout(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
-		generateClaudeMd(context);
-		RecordingCommandRunner runner = new RecordingCommandRunner();
+		RecordingCommandRunner runner = generatingRunner(context);
 		new ClaudeInitStep(List.of("claude", "init")).execute(context, runner);
 		assertEquals(List.of("claude", "init"), runner.commandAt(0));
 		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
@@ -89,10 +100,39 @@ class ClaudeInitStepTest {
 	@Test
 	void defaultsToHeadlessInitCommand(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
-		generateClaudeMd(context);
-		RecordingCommandRunner runner = new RecordingCommandRunner();
+		RecordingCommandRunner runner = generatingRunner(context);
 		new ClaudeInitStep().execute(context, runner);
 		assertEquals(ClaudeInitStep.DEFAULT_COMMAND, runner.commandAt(0));
+	}
+
+	/**
+	 * The CLI's output is not reproducible, so re-running an adoption over a
+	 * checkout that already has a CLAUDE.md would rewrite the file — discarding any
+	 * edit made to it since — and produce a second commit with the same message. The
+	 * rest of the pipeline skips work it has already done; this step must too.
+	 */
+	@Test
+	void leavesAnAlreadyAdoptedCheckoutUntouched(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		Files.writeString(context.repositoryDirectory().resolve("CLAUDE.md"), "# CLAUDE.md\n\nHand-edited.");
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new ClaudeInitStep().execute(context, runner);
+		assertEquals(0, runner.count(), "claude must not be re-run over an existing CLAUDE.md");
+		assertEquals("# CLAUDE.md\n\nHand-edited.",
+				Files.readString(context.repositoryDirectory().resolve("CLAUDE.md")));
+	}
+
+	/**
+	 * Skipping happens before the {@code .claude/CLAUDE.md} dance, so the memory
+	 * file is never moved when there is no CLI run to steer.
+	 */
+	@Test
+	void doesNotDisturbClaudeDirMemoryWhenSkipping(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = context(workspace);
+		generateClaudeMd(context);
+		writeClaudeDirMemory(context);
+		new ClaudeInitStep().execute(context, new RecordingCommandRunner());
+		assertEquals("# project memory", Files.readString(claudeDirMemory(context)));
 	}
 
 	@Test
@@ -145,8 +185,7 @@ class ClaudeInitStepTest {
 	@Test
 	void leavesRootClaudeMdUntouchedWhenNoClaudeDirMemoryExists(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = context(workspace);
-		generateClaudeMd(context);
-		new ClaudeInitStep().execute(context, new RecordingCommandRunner());
+		new ClaudeInitStep().execute(context, generatingRunner(context));
 		assertFalse(Files.exists(claudeDirMemory(context)));
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -58,10 +58,36 @@ class PullRequestStepTest {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
 		step.execute(context, runner);
 		assertEquals(List.of("gh", "pr", "list", "--head", "claude/adopt-claude-code", "--state", "open", "--json",
-				"url"), runner.commandAt(0));
+				"url", "--repo", "adamw7/tools"), runner.commandAt(0));
 		assertEquals(List.of("gh", "pr", "create", "--title", PullRequestOptions.DEFAULT_TITLE, "--body",
-				PullRequestOptions.DEFAULT_BODY, "--head", "claude/adopt-claude-code"), runner.commandAt(1));
+				PullRequestOptions.DEFAULT_BODY, "--head", "claude/adopt-claude-code", "--repo", "adamw7/tools"),
+				runner.commandAt(1));
 		assertEquals(context.repositoryDirectory(), runner.invocations().get(1).workingDirectory());
+	}
+
+	/**
+	 * gh infers the repository from the checkout's git remote, which is not always
+	 * readable as a GitHub one — a {@code url.<base>.insteadOf} rewrite, a mirror,
+	 * or a proxied clone all leave it reporting that no remote points at a known
+	 * GitHub host, failing the last step of an otherwise complete adoption. The
+	 * adoption already knows the repository, so it says so.
+	 */
+	@Test
+	void namesTheTargetRepositoryRatherThanLettingGhInferItFromTheRemote() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
+		AdoptionContext proxied = new AdoptionContext("git@github.com:adamw7/tools.git", Path.of("/tmp/workspace"));
+		new PullRequestStep().execute(proxied, runner);
+		assertTrue(runner.commandAt(0).containsAll(List.of("--repo", "adamw7/tools")));
+		assertTrue(runner.commandAt(1).containsAll(List.of("--repo", "adamw7/tools")));
+	}
+
+	@Test
+	void omitsTheRepositoryFlagWhenTheUrlNamesNoOwner() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
+		AdoptionContext local = new AdoptionContext("/srv/mirrors/tools", Path.of("/tmp/workspace"));
+		new PullRequestStep().execute(local, runner);
+		assertFalse(runner.commandAt(0).contains("--repo"), "gh must fall back to its own inference");
+		assertFalse(runner.commandAt(1).contains("--repo"));
 	}
 
 	@Test
@@ -69,7 +95,7 @@ class PullRequestStepTest {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
 		new PullRequestStep("My title", "My body").execute(context, runner);
 		assertEquals(List.of("gh", "pr", "create", "--title", "My title", "--body", "My body", "--head",
-				"claude/adopt-claude-code"), runner.commandAt(1));
+				"claude/adopt-claude-code", "--repo", "adamw7/tools"), runner.commandAt(1));
 	}
 
 	@Test
@@ -85,8 +111,8 @@ class PullRequestStepTest {
 				.build();
 		new PullRequestStep(options).execute(context, runner);
 		assertEquals(List.of("gh", "pr", "create", "--title", "My title", "--body", "My body", "--head",
-				"claude/adopt-claude-code", "--draft", "--reviewer", "octocat", "--reviewer", "hubot", "--label",
-				"automation", "--assignee", "adamw7"), runner.commandAt(1));
+				"claude/adopt-claude-code", "--repo", "adamw7/tools", "--draft", "--reviewer", "octocat", "--reviewer",
+				"hubot", "--label", "automation", "--assignee", "adamw7"), runner.commandAt(1));
 	}
 
 	@Test
@@ -95,7 +121,7 @@ class PullRequestStepTest {
 		step.execute(context, runner);
 		assertEquals(1, runner.count());
 		assertEquals(List.of("gh", "pr", "list", "--head", "claude/adopt-claude-code", "--state", "open", "--json",
-				"url"), runner.commandAt(0));
+				"url", "--repo", "adamw7/tools"), runner.commandAt(0));
 	}
 
 	@Test
@@ -103,7 +129,8 @@ class PullRequestStepTest {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
 		step.execute(context, runner);
 		assertEquals(List.of("gh", "pr", "create", "--title", PullRequestOptions.DEFAULT_TITLE, "--body",
-				PullRequestOptions.DEFAULT_BODY, "--head", "claude/adopt-claude-code"), runner.commandAt(1));
+				PullRequestOptions.DEFAULT_BODY, "--head", "claude/adopt-claude-code", "--repo", "adamw7/tools"),
+				runner.commandAt(1));
 	}
 
 	@Test


### PR DESCRIPTION
An end-to-end run of the pipeline against live GitHub repositories surfaced
three gaps.

claude-init was the only step in the pipeline that was not idempotent. Every
other step detects work it has already done and skips it, but claude-init
re-ran the CLI unconditionally, so re-adopting a checkout rewrote its
CLAUDE.md — the CLI's output is not reproducible — discarding any edit made to
it since and adding a second commit with the same message. A checkout that
already carries a root CLAUDE.md is now left alone.

The --report file was only written on the success path, so a run that stopped
part-way produced no report at all: exactly the case where knowing which steps
completed matters. The report is now written on both paths, and carries the
outcome it needs to be honest about — a succeeded flag and the failing step's
message — so a consumer can tell an abandoned run from a pipeline configured to
end early. Callers that need a failed run's report supply their own to
adopt(context, report) and still hold it after the failure propagates.

Both gh commands let gh infer the repository from the checkout's git remote,
which is not always readable as a GitHub one — a url.<base>.insteadOf rewrite,
a mirror, or a proxied clone leaves gh reporting that no remote points at a
known GitHub host, failing the last step of an otherwise complete adoption. The
adoption already knows the repository, so AdoptionContext derives the
owner/repository slug from the URL and both commands pass it as --repo. A URL
that names no owner leaves the flag off and gh falls back to its own inference.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XegL8hiY6eUHfW33mJF8qF