### PR TITLE
refactor(adopt): remove duplicated file I/O, input mapping, and test fixtures

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -33,10 +33,10 @@ public final class AdoptionContext {
 	}
 
 	public AdoptionContext(String repositoryUrl, Path workspace, String branchName) {
-		this.repositoryUrl = requireText(repositoryUrl, "repositoryUrl");
+		this.repositoryUrl = Text.required(repositoryUrl, "repositoryUrl");
 		this.workspace = requireWorkspace(workspace);
 		this.repositoryDirectory = workspace.resolve(repositoryName(this.repositoryUrl));
-		this.branchName = requireText(branchName, "branchName");
+		this.branchName = Text.required(branchName, "branchName");
 		this.repositorySlug = repositorySlug(this.repositoryUrl);
 	}
 
@@ -66,11 +66,14 @@ public final class AdoptionContext {
 		return branchName;
 	}
 
-	private static String requireText(String value, String field) {
-		if (value == null || value.isBlank()) {
-			throw new IllegalArgumentException(field + " must not be blank");
-		}
-		return value.strip();
+	/**
+	 * @return the branch to adopt on: the one the caller named, or
+	 *         {@link #DEFAULT_BRANCH} when none was. A blank name counts as none, so
+	 *         an omitted command-line positional and an empty MCP argument both fall
+	 *         back to the default instead of being rejected as an invalid branch.
+	 */
+	public static String branchOrDefault(String branchName) {
+		return Text.isPresent(branchName) ? branchName.strip() : DEFAULT_BRANCH;
 	}
 
 	private static Path requireWorkspace(Path workspace) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionFiles.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionFiles.java
@@ -1,0 +1,55 @@
+package io.github.adamw7.tools.adopt;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Reads and writes the text files an adoption touches — the checkout's POM or
+ * Gradle script, the generated {@code CLAUDE.md}, the starter assets, the run's
+ * JSON report — reporting a failure as an {@link AdoptionException} like every
+ * other adoption failure rather than as a raw {@link IOException} each caller
+ * has to wrap for itself.
+ *
+ * <p>Every write creates the file's parent directories first, so an asset nested
+ * in a directory the checkout does not carry yet ({@code .claude/hooks/}) and a
+ * report named under a path that does not exist are both written rather than
+ * failing on the missing parent.
+ *
+ * <p>The {@code description} names the file in the failure message the way the
+ * operator thinks of it — "POM", "CLAUDE.md", "the adoption report" — because a
+ * bare path does not say what the adoption was trying to do with it.
+ */
+public final class AdoptionFiles {
+
+	private AdoptionFiles() {
+	}
+
+	public static String read(Path file, String description) {
+		try {
+			return Files.readString(file);
+		} catch (IOException e) {
+			throw new AdoptionException("Could not read " + description + ": " + file, e);
+		}
+	}
+
+	public static void write(Path file, String content, String description) {
+		try {
+			createParentDirectories(file);
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new AdoptionException("Could not write " + description + ": " + file, e);
+		}
+	}
+
+	/**
+	 * The path is absolutised first so a relative file name — which has no parent
+	 * of its own — still resolves to the directory it will be written into.
+	 */
+	private static void createParentDirectories(Path file) throws IOException {
+		Path parent = file.toAbsolutePath().getParent();
+		if (parent != null) {
+			Files.createDirectories(parent);
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
@@ -1,7 +1,5 @@
 package io.github.adamw7.tools.adopt;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -31,19 +29,7 @@ public class AdoptionReportWriter {
 	}
 
 	public void write(Path file, AdoptionContext context, AdoptionReport report) {
-		try {
-			createParentDirectories(file);
-			Files.writeString(file, toJson(context, report));
-		} catch (IOException e) {
-			throw new AdoptionException("Could not write the adoption report to " + file, e);
-		}
-	}
-
-	private void createParentDirectories(Path file) throws IOException {
-		Path parent = file.toAbsolutePath().getParent();
-		if (parent != null) {
-			Files.createDirectories(parent);
-		}
+		AdoptionFiles.write(file, toJson(context, report), "the adoption report");
 	}
 
 	private ObjectNode toNode(AdoptionContext context, AdoptionReport report) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -62,19 +62,15 @@ public final class CliArguments {
 	}
 
 	public String branchName() {
-		return branchName == null ? AdoptionContext.DEFAULT_BRANCH : branchName;
+		return AdoptionContext.branchOrDefault(branchName);
 	}
 
 	public PullRequestOptions pullRequestOptions() {
-		PullRequestOptions.Builder builder = PullRequestOptions.builder()
-				.reviewers(reviewers).labels(labels).assignees(assignees).draft(draft);
-		if (title != null) {
-			builder.title(title);
-		}
-		if (body != null) {
-			builder.body(body);
-		}
-		return builder.build();
+		return PullRequestOptions.builder()
+				.reviewers(reviewers).labels(labels).assignees(assignees).draft(draft)
+				.titleIfPresent(title)
+				.bodyIfPresent(body)
+				.build();
 	}
 
 	public boolean includeAssets() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -48,7 +48,7 @@ public class Main {
 	}
 
 	static Path workspace(CliArguments cli) {
-		return cli.workspace().map(Workspaces::createIfMissing).orElseGet(Workspaces::createTemporary);
+		return Workspaces.resolve(cli.workspace());
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Text.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Text.java
@@ -1,0 +1,30 @@
+package io.github.adamw7.tools.adopt;
+
+/**
+ * The text checks the adoption's inputs share: rejecting a blank value that must
+ * carry one, and reading an optional value that is absent when blank. Both entry
+ * points — the command line and the MCP tool — treat a blank argument as "not
+ * supplied" rather than as an invalid value, so keeping the rule here stops the
+ * two from drifting apart on what counts as absent.
+ */
+public final class Text {
+
+	private Text() {
+	}
+
+	/**
+	 * @return the value stripped of surrounding whitespace
+	 * @throws IllegalArgumentException when it is {@code null} or blank
+	 */
+	public static String required(String value, String field) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(field + " must not be blank");
+		}
+		return value.strip();
+	}
+
+	/** @return whether the value carries text, so a blank one counts as not supplied */
+	public static boolean isPresent(String value) {
+		return value != null && !value.isBlank();
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.adopt;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * Creates the workspace directory an adoption clones into: either the directory
@@ -28,6 +29,17 @@ import java.nio.file.Path;
 public final class Workspaces {
 
 	private Workspaces() {
+	}
+
+	/**
+	 * The one place the "named workspace or a temporary one" decision is made, so
+	 * the command line and the MCP tool cannot drift apart on it.
+	 *
+	 * @param workspace the directory the caller named, or empty when it left the
+	 *                  choice open
+	 */
+	public static Path resolve(Optional<Path> workspace) {
+		return workspace.map(Workspaces::createIfMissing).orElseGet(Workspaces::createTemporary);
 	}
 
 	public static Path createIfMissing(Path workspace) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandResult.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandResult.java
@@ -15,6 +15,15 @@ public record CommandResult(List<String> command, int exitCode, String output) {
 	}
 
 	public String describe() {
+		return describe(command);
+	}
+
+	/**
+	 * The command as it would be typed, for the failures raised before there is a
+	 * result to describe — a process that could not be started, or one destroyed on
+	 * its timeout — so every report of a command reads the same way.
+	 */
+	public static String describe(List<String> command) {
 		return String.join(" ", command);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -64,7 +64,7 @@ public class ProcessCommandRunner implements CommandRunner {
 		try {
 			return builder.start();
 		} catch (IOException e) {
-			throw new AdoptionException("Could not start command: " + String.join(" ", command), e);
+			throw new AdoptionException("Could not start command: " + CommandResult.describe(command), e);
 		}
 	}
 
@@ -72,7 +72,7 @@ public class ProcessCommandRunner implements CommandRunner {
 		try {
 			process.getOutputStream().close();
 		} catch (IOException e) {
-			throw new AdoptionException("Could not close standard input for: " + String.join(" ", command), e);
+			throw new AdoptionException("Could not close standard input for: " + CommandResult.describe(command), e);
 		}
 	}
 
@@ -85,13 +85,13 @@ public class ProcessCommandRunner implements CommandRunner {
 		} catch (InterruptedException e) {
 			destroyTree(process);
 			Thread.currentThread().interrupt();
-			throw new AdoptionException("Interrupted while running: " + String.join(" ", command), e);
+			throw new AdoptionException("Interrupted while running: " + CommandResult.describe(command), e);
 		}
 	}
 
 	private AdoptionException timedOut(Process process, List<String> command, StreamGobbler output) {
 		destroyTree(process);
-		return new AdoptionException("Timed out after " + timeout + " running: " + String.join(" ", command)
+		return new AdoptionException("Timed out after " + timeout + " running: " + CommandResult.describe(command)
 				+ System.lineSeparator() + output.output());
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -3,7 +3,7 @@ package io.github.adamw7.tools.adopt.mcp;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
@@ -107,35 +107,31 @@ public class AdoptTool implements McpTool {
 	 * branch overrides it, so an empty string is not rejected as an invalid branch.
 	 */
 	private String branch(Map<String, Object> arguments) {
-		String branch = ToolArguments.optionalString(arguments, "branch", "");
-		return branch.isBlank() ? AdoptionContext.DEFAULT_BRANCH : branch;
+		return AdoptionContext.branchOrDefault(text(arguments, "branch"));
 	}
 
 	private Path workspace(Map<String, Object> arguments) {
-		String workspace = ToolArguments.optionalString(arguments, "workspace", "");
-		return workspace.isBlank() ? Workspaces.createTemporary() : Workspaces.createIfMissing(Path.of(workspace));
+		String workspace = text(arguments, "workspace");
+		return Workspaces.resolve(workspace.isBlank() ? Optional.empty() : Optional.of(Path.of(workspace)));
 	}
 
 	private PullRequestOptions optionsFrom(Map<String, Object> arguments) {
-		PullRequestOptions.Builder builder = PullRequestOptions.builder()
+		return PullRequestOptions.builder()
 				.reviewers(commaSeparated(arguments, "reviewers"))
 				.labels(commaSeparated(arguments, "labels"))
 				.assignees(commaSeparated(arguments, "assignees"))
-				.draft(ToolArguments.optionalBoolean(arguments, "draft", false));
-		applyText(arguments, "title", builder::title);
-		applyText(arguments, "body", builder::body);
-		return builder.build();
+				.draft(ToolArguments.optionalBoolean(arguments, "draft", false))
+				.titleIfPresent(text(arguments, "title"))
+				.bodyIfPresent(text(arguments, "body"))
+				.build();
 	}
 
-	private void applyText(Map<String, Object> arguments, String key, Consumer<String> target) {
-		String value = ToolArguments.optionalString(arguments, key, "");
-		if (!value.isBlank()) {
-			target.accept(value);
-		}
+	/** @return the argument's text, empty when it was not supplied */
+	private String text(Map<String, Object> arguments, String key) {
+		return ToolArguments.optionalString(arguments, key, "");
 	}
 
 	private List<String> commaSeparated(Map<String, Object> arguments, String key) {
-		String value = ToolArguments.optionalString(arguments, key, "");
-		return Stream.of(value.split(",")).map(String::strip).filter(entry -> !entry.isEmpty()).toList();
+		return Stream.of(text(arguments, key).split(",")).map(String::strip).filter(entry -> !entry.isEmpty()).toList();
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractBuildSystemStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractBuildSystemStep.java
@@ -28,6 +28,11 @@ public abstract class AbstractBuildSystemStep extends AbstractCommandStep {
 
 	private final List<BuildSystem> buildSystems;
 
+	/** Detects the checkout's build system among {@link BuildSystems#DEFAULTS}. */
+	protected AbstractBuildSystemStep() {
+		this(BuildSystems.DEFAULTS);
+	}
+
 	protected AbstractBuildSystemStep(List<BuildSystem> buildSystems) {
 		this.buildSystems = List.copyOf(buildSystems);
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
@@ -101,8 +101,18 @@ public final class AdoptionAssets {
 			          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 			""";
 
+	/**
+	 * The {@code AGENTS.md} installer, built here rather than by each caller because
+	 * {@link ClaudeMdConformanceStep} also writes the companion file — the guard's
+	 * reference has to resolve whether or not the run installs the starter assets —
+	 * and the two must write the same content to the same path.
+	 */
+	static AssetInstaller agentsMd() {
+		return new AssetInstaller(AGENTS_MD_FILE, AGENTS_MD);
+	}
+
 	public static final List<AssetInstaller> DEFAULTS = List.of(
-			new AssetInstaller(AGENTS_MD_FILE, AGENTS_MD),
+			agentsMd(),
 			new AssetInstaller(SETTINGS_FILE, SETTINGS),
 			new AssetInstaller(SESSION_START_HOOK_FILE, SESSION_START_HOOK, true),
 			new AssetInstaller(MCP_CONFIG_FILE, MCP_CONFIG),

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetInstaller.java
@@ -1,13 +1,12 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.AdoptionFiles;
 
 /**
  * Writes one starter asset file into a checkout: the file's repository-relative
@@ -60,12 +59,7 @@ public class AssetInstaller {
 	}
 
 	private void write(Path file) {
-		try {
-			Files.createDirectories(file.getParent());
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new AdoptionException("Could not write asset file: " + file, e);
-		}
+		AdoptionFiles.write(file, content, "asset file");
 		markExecutable(file);
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
@@ -34,7 +34,6 @@ public class BuildToolchainStep extends AbstractBuildSystemStep {
 	private final ToolProbe probe = new ToolProbe();
 
 	public BuildToolchainStep() {
-		this(BuildSystems.DEFAULTS);
 	}
 
 	public BuildToolchainStep(List<BuildSystem> buildSystems) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -9,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.AdoptionFiles;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
@@ -37,7 +37,7 @@ public class ClaudeMdConformanceStep implements AdoptionStep {
 	private final AssetInstaller agentsMdInstaller;
 
 	public ClaudeMdConformanceStep() {
-		this(new ClaudeMdConformer(), new AssetInstaller(AdoptionAssets.AGENTS_MD_FILE, AdoptionAssets.AGENTS_MD));
+		this(new ClaudeMdConformer(), AdoptionAssets.agentsMd());
 	}
 
 	ClaudeMdConformanceStep(ClaudeMdConformer conformer, AssetInstaller agentsMdInstaller) {
@@ -64,7 +64,7 @@ public class ClaudeMdConformanceStep implements AdoptionStep {
 		if (conformed.equals(original)) {
 			log.info("{} already satisfies the claudeMdFormat rule; left unchanged", CLAUDE_MD);
 		} else {
-			write(claudeMd, conformed);
+			AdoptionFiles.write(claudeMd, conformed, CLAUDE_MD);
 			log.info("Normalised {} to satisfy the claudeMdFormat rule", CLAUDE_MD);
 		}
 	}
@@ -74,18 +74,6 @@ public class ClaudeMdConformanceStep implements AdoptionStep {
 			throw new AdoptionException(name() + " requires " + CLAUDE_MD + " but it was not found in "
 					+ claudeMd.getParent());
 		}
-		try {
-			return Files.readString(claudeMd);
-		} catch (IOException e) {
-			throw new AdoptionException(name() + " could not read " + claudeMd, e);
-		}
-	}
-
-	private void write(Path claudeMd, String content) {
-		try {
-			Files.writeString(claudeMd, content);
-		} catch (IOException e) {
-			throw new AdoptionException(name() + " could not write " + claudeMd, e);
-		}
+		return AdoptionFiles.read(claudeMd, CLAUDE_MD);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerStep.java
@@ -24,7 +24,6 @@ public class EnforcerStep extends AbstractBuildSystemStep {
 	private static final Logger log = LogManager.getLogger(EnforcerStep.class);
 
 	public EnforcerStep() {
-		this(BuildSystems.DEFAULTS);
 	}
 
 	public EnforcerStep(List<BuildSystem> buildSystems) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -1,12 +1,10 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.AdoptionFiles;
 
 /**
  * Appends a {@code CLAUDE.md} guard task to a Gradle build script so the adopted
@@ -37,6 +35,7 @@ public class GradleGuardInstaller {
 
 	static final String GUARD_TASK = "enforceClaudeMd";
 
+	private static final String BUILD_FILE_DESCRIPTION = "Gradle build file";
 	private static final String KOTLIN_SUFFIX = ".kts";
 	private static final String LINE_COMMENT = "//";
 
@@ -81,7 +80,7 @@ public class GradleGuardInstaller {
 	 *         script already declared it and was left unchanged.
 	 */
 	public boolean install(Path buildFile) {
-		String existing = read(buildFile);
+		String existing = AdoptionFiles.read(buildFile, BUILD_FILE_DESCRIPTION);
 		if (declaresGuard(existing)) {
 			return false;
 		}
@@ -117,24 +116,12 @@ public class GradleGuardInstaller {
 		return buildFile.getFileName().toString().endsWith(KOTLIN_SUFFIX) ? KOTLIN_BLOCK : GROOVY_BLOCK;
 	}
 
-	private String read(Path buildFile) {
-		try {
-			return Files.readString(buildFile);
-		} catch (IOException e) {
-			throw new AdoptionException("Could not read Gradle build file: " + buildFile, e);
-		}
-	}
-
 	/**
 	 * The appended block's LF line terminators are rewritten to match the ones the
 	 * script already uses, so appending the guard to a CRLF build script does not
 	 * leave the new region with LF endings mixed into an otherwise CRLF file.
 	 */
 	private void append(Path buildFile, String existing, String block) {
-		try {
-			Files.writeString(buildFile, existing + LineTerminators.matching(block, existing));
-		} catch (IOException e) {
-			throw new AdoptionException("Could not write Gradle build file: " + buildFile, e);
-		}
+		AdoptionFiles.write(buildFile, existing + LineTerminators.matching(block, existing), BUILD_FILE_DESCRIPTION);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -3,7 +3,6 @@ package io.github.adamw7.tools.adopt.step;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +28,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.AdoptionFiles;
 
 /**
  * Adds the {@code claude-code-enforcer} to a Maven project's {@code pom.xml} by
@@ -61,6 +61,8 @@ public class PomEnforcerInstaller {
 	static final String BUILD_PROPERTIES = "/adopt-build.properties";
 	static final String RULE_VERSION_KEY = "enforcer.rule.version";
 	static final String SNAPSHOT_SUFFIX = "-SNAPSHOT";
+
+	private static final String POM_DESCRIPTION = "POM";
 
 	private final Supplier<String> ruleVersion;
 
@@ -138,7 +140,7 @@ public class PomEnforcerInstaller {
 	 *         unchanged.
 	 */
 	public boolean install(Path pomFile) {
-		String original = readText(pomFile);
+		String original = AdoptionFiles.read(pomFile, POM_DESCRIPTION);
 		Document document = parse(pomFile);
 		PomEditor editor = new PomEditor(document);
 		Element plugins = editor.pluginsElement();
@@ -236,14 +238,6 @@ public class PomEnforcerInstaller {
 		}
 	}
 
-	private String readText(Path pomFile) {
-		try {
-			return Files.readString(pomFile);
-		} catch (IOException e) {
-			throw new AdoptionException("Could not read POM: " + pomFile, e);
-		}
-	}
-
 	private Document parse(Path pomFile) {
 		try {
 			return builder().parse(pomFile.toFile());
@@ -278,12 +272,15 @@ public class PomEnforcerInstaller {
 	 * silently flipping every line to LF and reformatting the whole file.
 	 */
 	private void write(Document document, Path pomFile, String original) {
+		String content = declarationPrefix(original) + serialize(document, pomFile);
+		String withTrailingNewline = matchTrailingNewline(content, original);
+		AdoptionFiles.write(pomFile, LineTerminators.matching(withTrailingNewline, original), POM_DESCRIPTION);
+	}
+
+	private String serialize(Document document, Path pomFile) {
 		try {
-			String content = declarationPrefix(original) + transformBody(document);
-			String withTrailingNewline = matchTrailingNewline(content, original);
-			Files.createDirectories(pomFile.toAbsolutePath().getParent());
-			Files.writeString(pomFile, LineTerminators.matching(withTrailingNewline, original));
-		} catch (IOException | TransformerException e) {
+			return transformBody(document);
+		} catch (TransformerException e) {
 			throw new AdoptionException("Could not write POM: " + pomFile, e);
 		}
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
@@ -2,6 +2,8 @@ package io.github.adamw7.tools.adopt.step;
 
 import java.util.List;
 
+import io.github.adamw7.tools.adopt.Text;
+
 /**
  * The metadata a {@link PullRequestStep} opens its pull request with: the title
  * and body, plus optional reviewers, labels, and assignees to request, and
@@ -21,8 +23,8 @@ public record PullRequestOptions(String title, String body, List<String> reviewe
 			+ "into the build so the file keeps being validated.";
 
 	public PullRequestOptions {
-		title = requireText(title, "title");
-		body = requireText(body, "body");
+		title = Text.required(title, "title");
+		body = Text.required(body, "body");
 		reviewers = List.copyOf(reviewers);
 		labels = List.copyOf(labels);
 		assignees = List.copyOf(assignees);
@@ -34,13 +36,6 @@ public record PullRequestOptions(String title, String body, List<String> reviewe
 
 	public static Builder builder() {
 		return new Builder();
-	}
-
-	private static String requireText(String value, String field) {
-		if (value == null || value.isBlank()) {
-			throw new IllegalArgumentException(field + " must not be blank");
-		}
-		return value.strip();
 	}
 
 	/** Fluent builder that starts from the adoption defaults and no reviewers, labels, or assignees. */
@@ -64,6 +59,20 @@ public record PullRequestOptions(String title, String body, List<String> reviewe
 		public Builder body(String body) {
 			this.body = body;
 			return this;
+		}
+
+		/**
+		 * Overrides the default title only when one was actually supplied, so a caller
+		 * mapping an optional input — an omitted {@code --title} flag, a blank MCP
+		 * argument — does not have to guard the call itself.
+		 */
+		public Builder titleIfPresent(String title) {
+			return Text.isPresent(title) ? title(title) : this;
+		}
+
+		/** Overrides the default body only when one was supplied; see {@link #titleIfPresent(String)}. */
+		public Builder bodyIfPresent(String body) {
+			return Text.isPresent(body) ? body(body) : this;
 		}
 
 		public Builder reviewers(List<String> reviewers) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
@@ -57,7 +58,7 @@ final class ToolProbe {
 		try {
 			return runner.run(directory, command).succeeded();
 		} catch (AdoptionException e) {
-			log.warn("Probe {} could not be run: {}", String.join(" ", command), e.getMessage());
+			log.warn("Probe {} could not be run: {}", CommandResult.describe(command), e.getMessage());
 			return false;
 		}
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/VerifyStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/VerifyStep.java
@@ -23,7 +23,6 @@ public class VerifyStep extends AbstractBuildSystemStep {
 	private static final Logger log = LogManager.getLogger(VerifyStep.class);
 
 	public VerifyStep() {
-		this(BuildSystems.DEFAULTS);
 	}
 
 	public VerifyStep(List<BuildSystem> buildSystems) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
@@ -1,13 +1,12 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.AdoptionFiles;
 
 /**
  * Installs a build-tool-agnostic {@code CLAUDE.md} guard into a checkout that has
@@ -90,10 +89,7 @@ public class WorkflowGuardInstaller {
 	}
 
 	private boolean carriesMarker(Path workflowFile) {
-		try {
-			return Files.isRegularFile(workflowFile) && Files.readString(workflowFile).contains(MARKER);
-		} catch (IOException e) {
-			throw new AdoptionException("Could not read workflow file: " + workflowFile, e);
-		}
+		return Files.isRegularFile(workflowFile)
+				&& AdoptionFiles.read(workflowFile, "workflow file").contains(MARKER);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
@@ -159,4 +159,19 @@ class AdoptionContextTest {
 		assertTrue(new AdoptionContext("file:///tmp/tools", workspace).repositorySlug().isEmpty());
 		assertTrue(new AdoptionContext("tools", workspace).repositorySlug().isEmpty());
 	}
+
+	/**
+	 * An omitted command-line positional and an empty MCP argument both mean "adopt
+	 * on the default branch", so neither may be rejected as an invalid branch.
+	 */
+	@Test
+	void aBlankOrAbsentBranchFallsBackToTheDefault() {
+		assertEquals(AdoptionContext.DEFAULT_BRANCH, AdoptionContext.branchOrDefault(null));
+		assertEquals(AdoptionContext.DEFAULT_BRANCH, AdoptionContext.branchOrDefault("   "));
+	}
+
+	@Test
+	void aNamedBranchOverridesTheDefault() {
+		assertEquals("feature/adopt", AdoptionContext.branchOrDefault("  feature/adopt  "));
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContexts.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContexts.java
@@ -1,0 +1,41 @@
+package io.github.adamw7.tools.adopt;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * The checkout fixture the step tests share: an {@link AdoptionContext} whose
+ * repository directory exists, as it would after {@link
+ * io.github.adamw7.tools.adopt.step.CloneStep} has run. Every step from the
+ * clone onwards acts on that directory, so each of their tests needs the same
+ * two lines before it can assert anything — building them here keeps the tests
+ * about the step rather than about its setup.
+ */
+public final class AdoptionContexts {
+
+	private static final String REPOSITORY_URL = "https://github.com/adamw7/demo.git";
+
+	private AdoptionContexts() {
+	}
+
+	/** A context whose checkout directory exists under {@code workspace}, ready for a step to act on. */
+	public static AdoptionContext checkedOutIn(Path workspace) throws IOException {
+		AdoptionContext context = new AdoptionContext(REPOSITORY_URL, workspace);
+		Files.createDirectories(context.repositoryDirectory());
+		return context;
+	}
+
+	/**
+	 * Writes a file into the checkout — a build file for the build-system detection
+	 * to find, or a {@code CLAUDE.md} standing in for one {@code claude init}
+	 * generated.
+	 *
+	 * @return the file that was written
+	 */
+	public static Path write(AdoptionContext context, String relativePath, String content) throws IOException {
+		Path file = context.repositoryDirectory().resolve(relativePath);
+		Files.createDirectories(file.getParent());
+		return Files.writeString(file, content);
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionFilesTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionFilesTest.java
@@ -1,0 +1,58 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AdoptionFilesTest {
+
+	@Test
+	void readsAFilesText(@TempDir Path directory) throws IOException {
+		Path file = Files.writeString(directory.resolve("notes.txt"), "content\n");
+		assertEquals("content\n", AdoptionFiles.read(file, "notes"));
+	}
+
+	@Test
+	void namesTheFileAndItsDescriptionWhenAReadFails(@TempDir Path directory) {
+		Path missing = directory.resolve("absent.txt");
+		AdoptionException thrown = assertThrows(AdoptionException.class, () -> AdoptionFiles.read(missing, "POM"));
+		assertTrue(thrown.getMessage().contains("POM"), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains(missing.toString()), thrown.getMessage());
+	}
+
+	@Test
+	void writesTheContent(@TempDir Path directory) throws IOException {
+		Path file = directory.resolve("report.json");
+		AdoptionFiles.write(file, "{}\n", "the adoption report");
+		assertEquals("{}\n", Files.readString(file));
+	}
+
+	/**
+	 * The starter assets live under directories a checkout need not carry yet
+	 * ({@code .claude/hooks/}), so the write has to create them rather than fail on
+	 * the missing parent.
+	 */
+	@Test
+	void createsMissingParentDirectories(@TempDir Path directory) throws IOException {
+		Path file = directory.resolve("nested/deeper/hook.sh");
+		AdoptionFiles.write(file, "exit 0\n", "asset file");
+		assertEquals("exit 0\n", Files.readString(file));
+	}
+
+	@Test
+	void namesTheFileAndItsDescriptionWhenAWriteFails(@TempDir Path directory) throws IOException {
+		Path file = directory.resolve("occupied");
+		Files.createDirectory(file);
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> AdoptionFiles.write(file, "content", "workflow file"));
+		assertTrue(thrown.getMessage().contains("workflow file"), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains(file.toString()), thrown.getMessage());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/TextTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/TextTest.java
@@ -1,0 +1,41 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class TextTest {
+
+	@Test
+	void stripsARequiredValue() {
+		assertEquals("value", Text.required("  value  ", "field"));
+	}
+
+	@Test
+	void namesTheFieldWhenARequiredValueIsBlank() {
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+				() -> Text.required("   ", "title"));
+		assertEquals("title must not be blank", thrown.getMessage());
+	}
+
+	@Test
+	void rejectsANullRequiredValue() {
+		assertThrows(IllegalArgumentException.class, () -> Text.required(null, "branchName"));
+	}
+
+	@Test
+	void treatsTextAsPresent() {
+		assertTrue(Text.isPresent("value"));
+	}
+
+	/** Both entry points map an omitted argument to a blank string, so blank must count as absent. */
+	@Test
+	void treatsBlankAndNullAsAbsent() {
+		assertFalse(Text.isPresent("   "));
+		assertFalse(Text.isPresent(""));
+		assertFalse(Text.isPresent(null));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/WorkspacesTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/WorkspacesTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -68,6 +69,21 @@ class WorkspacesTest {
 		Path second = Workspaces.createTemporary();
 		assertNotEquals(first, second, "each run must get its own workspace");
 		assertTrue(first.isAbsolute(), "the clone target is resolved against the workspace, so it must be absolute");
+	}
+
+	/** Both entry points resolve their workspace here, so a named one is created and reused. */
+	@Test
+	void resolvesANamedWorkspace(@TempDir Path dir) {
+		Path named = dir.resolve("workspace");
+		assertEquals(named, Workspaces.resolve(Optional.of(named)));
+		assertTrue(Files.isDirectory(named));
+	}
+
+	@Test
+	void resolvesAnUnnamedWorkspaceToATemporaryOne() {
+		Path workspace = Workspaces.resolve(Optional.empty());
+		assertTrue(Files.isDirectory(workspace));
+		assertTrue(workspace.getFileName().toString().startsWith("claude-adopt-"));
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/CommandResultTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/CommandResultTest.java
@@ -27,4 +27,10 @@ class CommandResultTest {
 		CommandResult result = new CommandResult(List.of("git", "commit", "-m", "msg"), 0, "");
 		assertEquals("git commit -m msg", result.describe());
 	}
+
+	/** The failures raised before a result exists describe their command the same way. */
+	@Test
+	void describesACommandWithoutAResult() {
+		assertEquals("gh pr create", CommandResult.describe(List.of("gh", "pr", "create")));
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetsStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetsStepTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.io.TempDir;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionContexts;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class AssetsStepTest {
@@ -22,7 +23,7 @@ class AssetsStepTest {
 
 	@Test
 	void installsEveryDefaultAsset(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = contextFor(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		step.execute(context, new RecordingCommandRunner());
 		Path checkout = context.repositoryDirectory();
 		assertTrue(Files.isRegularFile(checkout.resolve(AdoptionAssets.AGENTS_MD_FILE)));
@@ -35,13 +36,13 @@ class AssetsStepTest {
 	@Test
 	void runsNoExternalCommands(@TempDir Path workspace) throws IOException {
 		RecordingCommandRunner runner = new RecordingCommandRunner();
-		step.execute(contextFor(workspace), runner);
+		step.execute(AdoptionContexts.checkedOutIn(workspace), runner);
 		assertEquals(0, runner.count());
 	}
 
 	@Test
 	void installedJsonAssetsAreValidJson(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = contextFor(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		step.execute(context, new RecordingCommandRunner());
 		ObjectMapper mapper = new ObjectMapper();
 		Path checkout = context.repositoryDirectory();
@@ -52,7 +53,7 @@ class AssetsStepTest {
 
 	@Test
 	void sessionStartHookIsExecutable(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = contextFor(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		step.execute(context, new RecordingCommandRunner());
 		assertTrue(Files.isExecutable(context.repositoryDirectory()
 				.resolve(AdoptionAssets.SESSION_START_HOOK_FILE)));
@@ -60,7 +61,7 @@ class AssetsStepTest {
 
 	@Test
 	void settingsWireTheSessionStartHook(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = contextFor(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		step.execute(context, new RecordingCommandRunner());
 		String settings = Files.readString(context.repositoryDirectory().resolve(AdoptionAssets.SETTINGS_FILE));
 		assertTrue(settings.contains(AdoptionAssets.SESSION_START_HOOK_FILE));
@@ -68,7 +69,7 @@ class AssetsStepTest {
 
 	@Test
 	void isIdempotentAcrossReRuns(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = contextFor(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		step.execute(context, new RecordingCommandRunner());
 		Path agentsMd = context.repositoryDirectory().resolve(AdoptionAssets.AGENTS_MD_FILE);
 		Files.writeString(agentsMd, "customised\n");
@@ -78,7 +79,7 @@ class AssetsStepTest {
 
 	@Test
 	void installsOnlyConfiguredAssets(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = contextFor(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		new AssetsStep(List.of(new AssetInstaller("only.txt", "content\n")))
 				.execute(context, new RecordingCommandRunner());
 		assertTrue(Files.isRegularFile(context.repositoryDirectory().resolve("only.txt")));
@@ -90,9 +91,4 @@ class AssetsStepTest {
 		assertEquals("assets", step.name());
 	}
 
-	private AdoptionContext contextFor(Path workspace) throws IOException {
-		AdoptionContext context = new AdoptionContext("https://github.com/owner/repo.git", workspace);
-		Files.createDirectories(context.repositoryDirectory());
-		return context;
-	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -14,22 +13,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionContexts;
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class BuildToolchainStepTest {
 
-	private AdoptionContext context(Path workspace) throws IOException {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/demo.git", workspace);
-		Files.createDirectories(context.repositoryDirectory());
-		return context;
-	}
-
 	@Test
 	void probesMavenForAMavenCheckout(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
-		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), "<project/>");
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "pom.xml", "<project/>");
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new BuildToolchainStep().execute(context, runner);
 		assertEquals(List.of("mvn", "--version"), runner.commandAt(0));
@@ -38,8 +32,8 @@ class BuildToolchainStepTest {
 
 	@Test
 	void probesGradleForAGradleCheckout(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
-		Files.writeString(context.repositoryDirectory().resolve("build.gradle"), "plugins { id 'java' }\n");
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new BuildToolchainStep().execute(context, runner);
 		assertEquals(List.of("gradle", "--version"), runner.commandAt(0));
@@ -52,8 +46,8 @@ class BuildToolchainStepTest {
 	 */
 	@Test
 	void anAbsentBuildToolAbortsTheAdoption(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
-		Files.writeString(context.repositoryDirectory().resolve("build.gradle"), "plugins { id 'java' }\n");
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
 		RecordingCommandRunner runner = new RecordingCommandRunner(
 				command -> new CommandResult(command, 127, "gradle: not found"));
 		AdoptionException thrown = assertThrows(AdoptionException.class,
@@ -63,8 +57,8 @@ class BuildToolchainStepTest {
 
 	@Test
 	void aBuildToolThatCannotStartAbortsTheAdoption(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
-		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), "<project/>");
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "pom.xml", "<project/>");
 		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
 			throw new AdoptionException("Could not start command: " + String.join(" ", command));
 		});
@@ -73,7 +67,7 @@ class BuildToolchainStepTest {
 
 	@Test
 	void probesNothingForTheFallbackGuardWhichOnlyNeedsAShell(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new BuildToolchainStep().execute(context, runner);
 		assertEquals(0, runner.count());
@@ -81,7 +75,7 @@ class BuildToolchainStepTest {
 
 	@Test
 	void skipsWhenNoConfiguredBuildSystemMatches(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		BuildToolchainStep step = new BuildToolchainStep(List.of(new MavenBuildSystem(), new GradleBuildSystem()));
 		assertDoesNotThrow(() -> step.execute(context, runner));
@@ -90,8 +84,8 @@ class BuildToolchainStepTest {
 
 	@Test
 	void probesTheToolTheVerificationWillActuallyRun(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
-		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), "<project/>");
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "pom.xml", "<project/>");
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new BuildToolchainStep().execute(context, runner);
 		assertEquals(MavenBuildSystem.VERIFY_COMMAND.get(0), runner.commandAt(0).get(0));

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
@@ -16,20 +16,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionContexts;
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class ClaudeInitStepTest {
 
-	private AdoptionContext context(Path workspace) throws IOException {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace);
-		Files.createDirectories(context.repositoryDirectory());
-		return context;
-	}
-
 	private void generateClaudeMd(AdoptionContext context) throws IOException {
-		Files.writeString(context.repositoryDirectory().resolve("CLAUDE.md"), "# CLAUDE.md");
+		AdoptionContexts.write(context, "CLAUDE.md", "# CLAUDE.md");
 	}
 
 	/**
@@ -61,7 +56,7 @@ class ClaudeInitStepTest {
 	 */
 	@Test
 	void aFailedRestoreDoesNotReplaceTheOriginalFailure(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		writeClaudeDirMemory(context);
 		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
 			blockRestore(context);
@@ -90,7 +85,7 @@ class ClaudeInitStepTest {
 
 	@Test
 	void runsConfiguredClaudeCommandInCheckout(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		RecordingCommandRunner runner = generatingRunner(context);
 		new ClaudeInitStep(List.of("claude", "init")).execute(context, runner);
 		assertEquals(List.of("claude", "init"), runner.commandAt(0));
@@ -99,7 +94,7 @@ class ClaudeInitStepTest {
 
 	@Test
 	void defaultsToHeadlessInitCommand(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		RecordingCommandRunner runner = generatingRunner(context);
 		new ClaudeInitStep().execute(context, runner);
 		assertEquals(ClaudeInitStep.DEFAULT_COMMAND, runner.commandAt(0));
@@ -113,8 +108,8 @@ class ClaudeInitStepTest {
 	 */
 	@Test
 	void leavesAnAlreadyAdoptedCheckoutUntouched(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
-		Files.writeString(context.repositoryDirectory().resolve("CLAUDE.md"), "# CLAUDE.md\n\nHand-edited.");
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "CLAUDE.md", "# CLAUDE.md\n\nHand-edited.");
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new ClaudeInitStep().execute(context, runner);
 		assertEquals(0, runner.count(), "claude must not be re-run over an existing CLAUDE.md");
@@ -128,7 +123,7 @@ class ClaudeInitStepTest {
 	 */
 	@Test
 	void doesNotDisturbClaudeDirMemoryWhenSkipping(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		generateClaudeMd(context);
 		writeClaudeDirMemory(context);
 		new ClaudeInitStep().execute(context, new RecordingCommandRunner());
@@ -143,7 +138,7 @@ class ClaudeInitStepTest {
 
 	@Test
 	void failedInitAbortsAdoption(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		RecordingCommandRunner runner = new RecordingCommandRunner(
 				command -> new CommandResult(command, 1, "boom"));
 		assertThrows(AdoptionException.class, () -> new ClaudeInitStep().execute(context, runner));
@@ -151,14 +146,14 @@ class ClaudeInitStepTest {
 
 	@Test
 	void missingClaudeMdAbortsAdoption(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		assertThrows(AdoptionException.class, () -> new ClaudeInitStep().execute(context, runner));
 	}
 
 	@Test
 	void movesExistingClaudeDirMemoryAsideSoHeadlessInitWritesRootFile(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		writeClaudeDirMemory(context);
 		AtomicBoolean memoryHiddenDuringInit = new AtomicBoolean();
 		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
@@ -174,7 +169,7 @@ class ClaudeInitStepTest {
 
 	@Test
 	void restoresExistingClaudeDirMemoryWhenInitFails(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		writeClaudeDirMemory(context);
 		RecordingCommandRunner runner = new RecordingCommandRunner(
 				command -> new CommandResult(command, 1, "boom"));
@@ -184,14 +179,14 @@ class ClaudeInitStepTest {
 
 	@Test
 	void leavesRootClaudeMdUntouchedWhenNoClaudeDirMemoryExists(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		new ClaudeInitStep().execute(context, generatingRunner(context));
 		assertFalse(Files.exists(claudeDirMemory(context)));
 	}
 
 	private void writeRootClaudeMd(AdoptionContext context) {
 		try {
-			Files.writeString(context.repositoryDirectory().resolve("CLAUDE.md"), "# CLAUDE.md");
+			AdoptionContexts.write(context, "CLAUDE.md", "# CLAUDE.md");
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStepTest.java
@@ -12,19 +12,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionContexts;
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class ClaudeMdConformanceStepTest {
 
-	private AdoptionContext context(Path workspace) throws IOException {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/security.git", workspace);
-		Files.createDirectories(context.repositoryDirectory());
-		return context;
-	}
-
 	private void writeClaudeMd(AdoptionContext context, String content) throws IOException {
-		Files.writeString(context.repositoryDirectory().resolve("CLAUDE.md"), content);
+		AdoptionContexts.write(context, "CLAUDE.md", content);
 	}
 
 	private String claudeMd(AdoptionContext context) throws IOException {
@@ -42,7 +37,7 @@ class ClaudeMdConformanceStepTest {
 
 	@Test
 	void writesAgentsMdAndNormalisesClaudeMd(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		writeClaudeMd(context, "# CLAUDE.md\n\n## Project purpose\n\nA repo.\n");
 		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
 		assertTrue(Files.isRegularFile(agentsMd(context)), "a companion AGENTS.md must be written");
@@ -53,7 +48,7 @@ class ClaudeMdConformanceStepTest {
 
 	@Test
 	void doesNotOverwriteAnExistingAgentsMd(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		writeClaudeMd(context, "# CLAUDE.md\n");
 		Files.writeString(agentsMd(context), "# Project's own AGENTS.md\n");
 		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
@@ -67,7 +62,7 @@ class ClaudeMdConformanceStepTest {
 	 */
 	@Test
 	void leavesAnAlreadyConformingClaudeMdByteIdentical(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		writeClaudeMd(context, "# CLAUDE.md\n\nSee AGENTS.md.\n");
 		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
 		String conformed = claudeMd(context);
@@ -77,7 +72,7 @@ class ClaudeMdConformanceStepTest {
 
 	@Test
 	void missingClaudeMdAbortsAdoption(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		ClaudeMdConformanceStep step = new ClaudeMdConformanceStep();
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		assertThrows(AdoptionException.class, () -> step.execute(context, runner));

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionContexts;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class EnforcerStepTest {
@@ -39,16 +40,10 @@ class EnforcerStepTest {
 		return new EnforcerStep(List.of(new MavenBuildSystem(new PomEnforcerInstaller(RULE_VERSION))));
 	}
 
-	private AdoptionContext context(Path workspace) throws IOException {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/demo.git", workspace);
-		Files.createDirectories(context.repositoryDirectory());
-		return context;
-	}
-
 	@Test
 	void wiresEnforcerIntoCheckoutPom(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
-		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), POM);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "pom.xml", POM);
 		mavenStep().execute(context, new RecordingCommandRunner());
 		assertTrue(Files.readString(context.repositoryDirectory().resolve("pom.xml"))
 				.contains("maven-enforcer-plugin"));
@@ -56,7 +51,7 @@ class EnforcerStepTest {
 
 	@Test
 	void wiresGuardIntoAGroovyGradleBuild(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		Path buildFile = context.repositoryDirectory().resolve("build.gradle");
 		Files.writeString(buildFile, "plugins { id 'java' }\n");
 		new EnforcerStep().execute(context, new RecordingCommandRunner());
@@ -65,7 +60,7 @@ class EnforcerStepTest {
 
 	@Test
 	void wiresGuardIntoAKotlinGradleBuild(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		Path buildFile = context.repositoryDirectory().resolve("build.gradle.kts");
 		Files.writeString(buildFile, "plugins { java }\n");
 		new EnforcerStep().execute(context, new RecordingCommandRunner());
@@ -74,7 +69,7 @@ class EnforcerStepTest {
 
 	@Test
 	void wiresTheFallbackGuardWhenNoBuildFileIsPresent(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		new EnforcerStep().execute(context, new RecordingCommandRunner());
 		assertTrue(Files.exists(context.repositoryDirectory().resolve(WorkflowGuardInstaller.WORKFLOW_FILE)));
 		assertFalse(Files.exists(context.repositoryDirectory().resolve("pom.xml")));
@@ -82,7 +77,7 @@ class EnforcerStepTest {
 
 	@Test
 	void skipsWhenNoConfiguredBuildSystemMatches(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		EnforcerStep step = new EnforcerStep(List.of(new MavenBuildSystem(), new GradleBuildSystem()));
 		assertDoesNotThrow(() -> step.execute(context, new RecordingCommandRunner()));
 		assertFalse(Files.exists(context.repositoryDirectory().resolve(WorkflowGuardInstaller.WORKFLOW_FILE)));
@@ -90,7 +85,7 @@ class EnforcerStepTest {
 
 	@Test
 	void leavesAnAlreadyWiredPomByteForByteUnchanged(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		Path pom = context.repositoryDirectory().resolve("pom.xml");
 		Files.writeString(pom, POM);
 		EnforcerStep step = mavenStep();

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestOptionsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestOptionsTest.java
@@ -69,6 +69,31 @@ class PullRequestOptionsTest {
 		assertThrows(IllegalArgumentException.class, withoutBody::build);
 	}
 
+	/**
+	 * The command line and the MCP tool both map an optional input straight into the
+	 * builder, so an omitted title or body has to leave the adoption default in place
+	 * rather than blank out a field the record refuses.
+	 */
+	@Test
+	void keepsTheDefaultsWhenNoTitleOrBodyWasSupplied() {
+		PullRequestOptions options = PullRequestOptions.builder()
+				.titleIfPresent(null)
+				.bodyIfPresent("   ")
+				.build();
+		assertEquals(PullRequestOptions.DEFAULT_TITLE, options.title());
+		assertEquals(PullRequestOptions.DEFAULT_BODY, options.body());
+	}
+
+	@Test
+	void suppliedTitleAndBodyOverrideTheDefaults() {
+		PullRequestOptions options = PullRequestOptions.builder()
+				.titleIfPresent("Title")
+				.bodyIfPresent("Body")
+				.build();
+		assertEquals("Title", options.title());
+		assertEquals("Body", options.body());
+	}
+
 	@Test
 	void defensivelyCopiesReviewers() {
 		List<String> reviewers = new ArrayList<>(List.of("octocat"));

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -13,25 +12,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionContexts;
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class VerifyStepTest {
 
-	private AdoptionContext context(Path workspace) throws IOException {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/demo.git", workspace);
-		Files.createDirectories(context.repositoryDirectory());
-		return context;
-	}
-
 	private void writePom(AdoptionContext context) throws IOException {
-		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), "<project/>");
+		AdoptionContexts.write(context, "pom.xml", "<project/>");
 	}
 
 	@Test
 	void runsMavenValidateInCheckout(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		writePom(context);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new VerifyStep().execute(context, runner);
@@ -41,8 +35,8 @@ class VerifyStepTest {
 
 	@Test
 	void runsGradleGuardTaskForAGradleCheckout(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
-		Files.writeString(context.repositoryDirectory().resolve("build.gradle"), "plugins { id 'java' }\n");
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new VerifyStep().execute(context, runner);
 		assertEquals(GradleBuildSystem.VERIFY_COMMAND, runner.commandAt(0));
@@ -50,7 +44,7 @@ class VerifyStepTest {
 
 	@Test
 	void runsTheDetectedBuildSystemsVerifyCommand(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		writePom(context);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		BuildSystem custom = new FakeBuildSystem(List.of("just", "verify"));
@@ -60,7 +54,7 @@ class VerifyStepTest {
 
 	@Test
 	void failedVerificationAbortsAdoption(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		writePom(context);
 		RecordingCommandRunner runner = new RecordingCommandRunner(
 				command -> new CommandResult(command, 1, "CLAUDE.md is malformed"));
@@ -69,7 +63,7 @@ class VerifyStepTest {
 
 	@Test
 	void runsTheFallbackGuardScriptWhenNoBuildFileIsPresent(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new VerifyStep().execute(context, runner);
 		assertEquals(FallbackBuildSystem.VERIFY_COMMAND, runner.commandAt(0));
@@ -77,7 +71,7 @@ class VerifyStepTest {
 
 	@Test
 	void skipsWhenNoConfiguredBuildSystemMatches(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = context(workspace);
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new VerifyStep(List.of(new MavenBuildSystem(), new GradleBuildSystem())).execute(context, runner);
 		assertEquals(0, runner.count());


### PR DESCRIPTION
The module spelled the same few things out repeatedly. Collapse each to one
place, without changing any behaviour:

- AdoptionFiles now performs every text read and write the adoption does,
  replacing eight near-identical try/catch blocks that each wrapped an
  IOException in an AdoptionException. It also creates the parent directory
  before every write, which the Gradle guard and the CLAUDE.md conformer
  previously did not.
- CommandResult.describe(List) is the single command formatter; the process
  runner and the tool probe no longer re-inline String.join.
- Text holds the blank-value checks AdoptionContext and PullRequestOptions
  had a copy of each.
- The command line and the MCP tool now share their input mapping —
  Workspaces.resolve for "named directory or a temporary one",
  AdoptionContext.branchOrDefault for the branch fallback, and the builder's
  titleIfPresent/bodyIfPresent for optional pull-request metadata — so the
  two entry points cannot drift apart on what an omitted argument means.
- AdoptionAssets.agentsMd() builds the AGENTS.md installer that both the
  assets step and the conformance step write.
- AbstractBuildSystemStep defaults to BuildSystems.DEFAULTS, so its three
  subclasses no longer each repeat that wiring.
- The step tests share the AdoptionContexts fixture instead of carrying six
  copies of the same checkout setup.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qha8cC87hBVSzwwPRbro7P