### PR TITLE
refactor(adopt): split oversized classes into single-purpose collaborators

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -1,15 +1,13 @@
 package io.github.adamw7.tools.adopt;
 
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 /**
  * Immutable inputs shared by every adoption step: the GitHub repository URL to
  * adopt, the workspace directory the clone is created under, the resulting
  * checkout directory, and the feature branch the adoption commits are made on.
- * The repository name is derived from the URL up front so the clone target is
+ * The URL is parsed by {@link RepositoryUrl} up front so the clone target is
  * known before the first step runs. The adoption never pushes to the default
  * branch: it works on {@code branchName} and opens a pull request from it.
  */
@@ -18,40 +16,29 @@ public final class AdoptionContext {
 	/** Feature branch the adoption commits, pushes, and raises a pull request from. */
 	public static final String DEFAULT_BRANCH = "claude/adopt-claude-code";
 
-	private static final String SCHEME = "^[a-zA-Z][a-zA-Z0-9+.-]*://";
-	private static final String SEGMENT_SEPARATORS = "[/:]";
-	private static final int SEGMENTS_WITH_A_HOST = 3;
-
-	private final String repositoryUrl;
+	private final RepositoryUrl repository;
 	private final Path workspace;
 	private final Path repositoryDirectory;
 	private final String branchName;
-	private final String repositorySlug;
 
 	public AdoptionContext(String repositoryUrl, Path workspace) {
 		this(repositoryUrl, workspace, DEFAULT_BRANCH);
 	}
 
 	public AdoptionContext(String repositoryUrl, Path workspace, String branchName) {
-		this.repositoryUrl = Text.required(repositoryUrl, "repositoryUrl");
+		this.repository = RepositoryUrl.of(repositoryUrl);
 		this.workspace = requireWorkspace(workspace);
-		this.repositoryDirectory = workspace.resolve(repositoryName(this.repositoryUrl));
+		this.repositoryDirectory = workspace.resolve(repository.name());
 		this.branchName = Text.required(branchName, "branchName");
-		this.repositorySlug = repositorySlug(this.repositoryUrl);
 	}
 
 	public String repositoryUrl() {
-		return repositoryUrl;
+		return repository.value();
 	}
 
-	/**
-	 * @return the {@code owner/repository} the URL names, for the steps that must
-	 *         tell a tool which repository to act on rather than let it guess from
-	 *         the checkout's git remote; empty when the URL carries no host and so
-	 *         names no owner
-	 */
+	/** @see RepositoryUrl#slug() */
 	public Optional<String> repositorySlug() {
-		return Optional.ofNullable(repositorySlug);
+		return repository.slug();
 	}
 
 	public Path workspace() {
@@ -81,67 +68,5 @@ public final class AdoptionContext {
 			throw new IllegalArgumentException("workspace must not be null");
 		}
 		return workspace;
-	}
-
-	private static String repositoryName(String repositoryUrl) {
-		String withoutTrailingSlash = stripTrailingSlash(repositoryUrl);
-		String lastSegment = withoutTrailingSlash.substring(withoutTrailingSlash.lastIndexOf('/') + 1);
-		return requireName(stripGitSuffix(lastSegment), repositoryUrl);
-	}
-
-	/**
-	 * A URL whose last segment is empty or a directory alias — {@code .../repo//},
-	 * {@code .../.git}, or a bare {@code ..} — would otherwise resolve the checkout
-	 * onto the workspace itself or above it, so the clone would land beside the
-	 * other repositories the workspace holds instead of in its own directory.
-	 * Rejecting it here fails the adoption on its input rather than several steps
-	 * later on a checkout directory nobody intended.
-	 */
-	private static String requireName(String name, String repositoryUrl) {
-		if (name.isEmpty() || ".".equals(name) || "..".equals(name)) {
-			throw new IllegalArgumentException(
-					"repositoryUrl must end in a repository name but was: " + repositoryUrl);
-		}
-		return name;
-	}
-
-	/**
-	 * Derives {@code owner/repository} from the clone URL, covering the forms git
-	 * accepts: {@code https://host/owner/repo.git}, {@code ssh://git@host/owner/repo},
-	 * and the scp-like {@code git@host:owner/repo}. The scheme is dropped and the
-	 * remainder split on both separators, so the scp-like form's {@code ':'} is
-	 * treated as the path separator it is.
-	 *
-	 * <p>A URL is only read as naming an owner when a host segment precedes the last
-	 * two — the segment before the owner must look like a hostname. Without that
-	 * check a plain filesystem path such as {@code /tmp/workspace/repo} would yield
-	 * the nonsense slug {@code workspace/repo}, and a step would confidently point a
-	 * tool at a repository that does not exist; an empty result instead leaves the
-	 * step to fall back to its own inference.
-	 */
-	private static String repositorySlug(String repositoryUrl) {
-		List<String> segments = segments(stripGitSuffix(stripTrailingSlash(repositoryUrl)));
-		if (segments.size() < SEGMENTS_WITH_A_HOST || !isHost(segments.get(segments.size() - 3))) {
-			return null;
-		}
-		return segments.get(segments.size() - 2) + "/" + segments.get(segments.size() - 1);
-	}
-
-	private static List<String> segments(String url) {
-		return Stream.of(url.replaceFirst(SCHEME, "").split(SEGMENT_SEPARATORS))
-				.filter(segment -> !segment.isBlank())
-				.toList();
-	}
-
-	private static boolean isHost(String segment) {
-		return segment.contains(".");
-	}
-
-	private static String stripTrailingSlash(String value) {
-		return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
-	}
-
-	private static String stripGitSuffix(String segment) {
-		return segment.endsWith(".git") ? segment.substring(0, segment.length() - ".git".length()) : segment;
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -119,18 +119,20 @@ public final class CliArguments {
 		return index + 2;
 	}
 
+	/**
+	 * A blank workspace or branch positional counts as not supplied — the rule
+	 * {@link Text} defines for every optional input — so it falls back to its
+	 * default rather than resolving the empty path or being rejected as an invalid
+	 * branch.
+	 */
 	private void consumePositional(String argument) {
-		assignPositional(positionals, argument);
-		positionals++;
-	}
-
-	private void assignPositional(int position, String argument) {
-		switch (position) {
+		switch (positionals) {
 			case 0 -> repositoryUrl = argument;
-			case 1 -> workspace = argument.isBlank() ? null : Path.of(argument);
-			case 2 -> branchName = argument.isBlank() ? null : argument;
+			case 1 -> workspace = Text.isPresent(argument) ? Path.of(argument.strip()) : null;
+			case 2 -> branchName = Text.isPresent(argument) ? argument : null;
 			default -> throw new IllegalArgumentException("Unexpected argument " + argument + ". " + USAGE);
 		}
+		positionals++;
 	}
 
 	private void requireRepositoryUrl() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Failures.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Failures.java
@@ -1,0 +1,31 @@
+package io.github.adamw7.tools.adopt;
+
+/**
+ * Runs the clean-up an adoption owes while a failure is already propagating —
+ * restoring a file that was moved aside, writing the report of a run that did
+ * not finish — without letting the clean-up's own failure replace the one being
+ * reported.
+ *
+ * <p>The original failure is the diagnostic the operator needs: it carries the
+ * {@code claude} transcript, or the step that stopped the pipeline. A clean-up
+ * thrown from a {@code finally} would discard it and leave only the secondary
+ * error behind, so the secondary is attached as a suppressed exception instead
+ * and both survive.
+ */
+public final class Failures {
+
+	private Failures() {
+	}
+
+	/**
+	 * Runs {@code cleanUp}, attaching any failure it raises to {@code failure} as a
+	 * suppressed exception. The caller keeps throwing {@code failure} afterwards.
+	 */
+	public static void alsoRun(RuntimeException failure, Runnable cleanUp) {
+		try {
+			cleanUp.run();
+		} catch (RuntimeException e) {
+			failure.addSuppressed(e);
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -61,17 +61,9 @@ public class GitHubRepoAdopter {
 		this.steps = List.copyOf(steps);
 	}
 
-	public static GitHubRepoAdopter withDefaultPipeline(CommandRunner runner) {
-		return new GitHubRepoAdopter(runner, defaultSteps());
-	}
-
 	public static GitHubRepoAdopter withDefaultPipeline(CommandRunner runner, PullRequestOptions options,
 			boolean includeAssets) {
 		return new GitHubRepoAdopter(runner, defaultSteps(options, includeAssets));
-	}
-
-	public static List<AdoptionStep> defaultSteps() {
-		return defaultSteps(PullRequestOptions.defaults(), false);
 	}
 
 	public static List<AdoptionStep> defaultSteps(PullRequestOptions options, boolean includeAssets) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -40,7 +40,7 @@ public class Main {
 		try {
 			adopter.adopt(context, report);
 		} catch (RuntimeException e) {
-			writeReportSuppressing(cli, context, report, e);
+			Failures.alsoRun(e, () -> writeReport(cli, context, report));
 			throw e;
 		}
 		writeReport(cli, context, report);
@@ -49,21 +49,6 @@ public class Main {
 
 	static Path workspace(CliArguments cli) {
 		return Workspaces.resolve(cli.workspace());
-	}
-
-	/**
-	 * Writes the report of a failed run without letting an unwritable report file
-	 * replace the adoption failure being reported — that failure is the diagnostic
-	 * the operator needs, so a secondary write error is attached to it rather than
-	 * thrown over it.
-	 */
-	private static void writeReportSuppressing(CliArguments cli, AdoptionContext context, AdoptionReport report,
-			RuntimeException failure) {
-		try {
-			writeReport(cli, context, report);
-		} catch (RuntimeException e) {
-			failure.addSuppressed(e);
-		}
 	}
 
 	private static void writeReport(CliArguments cli, AdoptionContext context, AdoptionReport report) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -1,0 +1,125 @@
+package io.github.adamw7.tools.adopt;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * A repository clone URL, parsed once into the two facts the adoption needs from
+ * it: the repository name the checkout directory is created under, and the
+ * {@code owner/repository} slug the steps name their target repository with.
+ *
+ * <p>Both are derived up front so a malformed URL fails on the adoption's input
+ * rather than several steps later, and so {@link AdoptionContext} can stay what
+ * its name says it is — the inputs the pipeline shares — instead of also being a
+ * git-URL parser.
+ */
+public final class RepositoryUrl {
+
+	private static final String SCHEME = "^[a-zA-Z][a-zA-Z0-9+.-]*://";
+	private static final String SEGMENT_SEPARATORS = "[/:]";
+	private static final int SEGMENTS_WITH_A_HOST = 3;
+	private static final String GIT_SUFFIX = ".git";
+
+	private final String value;
+	private final String name;
+	private final String slug;
+
+	private RepositoryUrl(String value) {
+		this.value = value;
+		this.name = repositoryName(value);
+		this.slug = repositorySlug(value);
+	}
+
+	/**
+	 * @param repositoryUrl the clone URL, which must not be blank
+	 * @throws IllegalArgumentException when the URL is blank or names no repository
+	 */
+	public static RepositoryUrl of(String repositoryUrl) {
+		return new RepositoryUrl(Text.required(repositoryUrl, "repositoryUrl"));
+	}
+
+	/** The URL as given, stripped of surrounding whitespace. */
+	public String value() {
+		return value;
+	}
+
+	/** The repository name the checkout directory is created under. */
+	public String name() {
+		return name;
+	}
+
+	/**
+	 * @return the {@code owner/repository} the URL names, for the steps that must
+	 *         tell a tool which repository to act on rather than let it guess from
+	 *         the checkout's git remote; empty when the URL carries no host and so
+	 *         names no owner
+	 */
+	public Optional<String> slug() {
+		return Optional.ofNullable(slug);
+	}
+
+	private static String repositoryName(String repositoryUrl) {
+		String withoutTrailingSlash = stripTrailingSlash(repositoryUrl);
+		String lastSegment = withoutTrailingSlash.substring(withoutTrailingSlash.lastIndexOf('/') + 1);
+		return requireName(stripGitSuffix(lastSegment), repositoryUrl);
+	}
+
+	/**
+	 * A URL whose last segment is empty or a directory alias — {@code .../repo//},
+	 * {@code .../.git}, or a bare {@code ..} — would otherwise resolve the checkout
+	 * onto the workspace itself or above it, so the clone would land beside the
+	 * other repositories the workspace holds instead of in its own directory.
+	 * Rejecting it here fails the adoption on its input rather than several steps
+	 * later on a checkout directory nobody intended.
+	 */
+	private static String requireName(String name, String repositoryUrl) {
+		if (name.isEmpty() || ".".equals(name) || "..".equals(name)) {
+			throw new IllegalArgumentException(
+					"repositoryUrl must end in a repository name but was: " + repositoryUrl);
+		}
+		return name;
+	}
+
+	/**
+	 * Derives {@code owner/repository} from the clone URL, covering the forms git
+	 * accepts: {@code https://host/owner/repo.git}, {@code ssh://git@host/owner/repo},
+	 * and the scp-like {@code git@host:owner/repo}. The scheme is dropped and the
+	 * remainder split on both separators, so the scp-like form's {@code ':'} is
+	 * treated as the path separator it is.
+	 *
+	 * <p>A URL is only read as naming an owner when a host segment precedes the last
+	 * two — the segment before the owner must look like a hostname. Without that
+	 * check a plain filesystem path such as {@code /tmp/workspace/repo} would yield
+	 * the nonsense slug {@code workspace/repo}, and a step would confidently point a
+	 * tool at a repository that does not exist; an empty result instead leaves the
+	 * step to fall back to its own inference.
+	 *
+	 * @return the slug, or {@code null} when the URL names no owner
+	 */
+	private static String repositorySlug(String repositoryUrl) {
+		List<String> segments = segments(stripGitSuffix(stripTrailingSlash(repositoryUrl)));
+		if (segments.size() < SEGMENTS_WITH_A_HOST || !isHost(segments.get(segments.size() - 3))) {
+			return null;
+		}
+		return segments.get(segments.size() - 2) + "/" + segments.get(segments.size() - 1);
+	}
+
+	private static List<String> segments(String url) {
+		return Stream.of(url.replaceFirst(SCHEME, "").split(SEGMENT_SEPARATORS))
+				.filter(segment -> !segment.isBlank())
+				.toList();
+	}
+
+	private static boolean isHost(String segment) {
+		return segment.contains(".");
+	}
+
+	private static String stripTrailingSlash(String value) {
+		return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+	}
+
+	private static String stripGitSuffix(String segment) {
+		return segment.endsWith(GIT_SUFFIX) ? segment.substring(0, segment.length() - GIT_SUFFIX.length()) : segment;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
@@ -42,6 +42,16 @@ public final class Workspaces {
 		return workspace.map(Workspaces::createIfMissing).orElseGet(Workspaces::createTemporary);
 	}
 
+	/**
+	 * Resolves a workspace named as text, treating a blank name as "not supplied"
+	 * the way {@link Text} does everywhere else the adoption reads an optional
+	 * input, so an omitted MCP argument falls back to a temporary workspace instead
+	 * of resolving the empty path.
+	 */
+	public static Path resolveNamed(String workspace) {
+		return resolve(Text.isPresent(workspace) ? Optional.of(Path.of(workspace.strip())) : Optional.empty());
+	}
+
 	public static Path createIfMissing(Path workspace) {
 		try {
 			return Files.createDirectories(workspace).toAbsolutePath();

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -111,8 +111,7 @@ public class AdoptTool implements McpTool {
 	}
 
 	private Path workspace(Map<String, Object> arguments) {
-		String workspace = text(arguments, "workspace");
-		return Workspaces.resolve(workspace.isBlank() ? Optional.empty() : Optional.of(Path.of(workspace)));
+		return Workspaces.resolveNamed(text(arguments, "workspace"));
 	}
 
 	private PullRequestOptions optionsFrom(Map<String, Object> arguments) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -3,7 +3,6 @@ package io.github.adamw7.tools.adopt.mcp;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
@@ -56,7 +56,7 @@ public class BuildToolchainStep extends AbstractBuildSystemStep {
 
 	private void requireInstalled(String tool, BuildSystem buildSystem, Path repositoryDirectory,
 			CommandRunner runner) {
-		if (probe.succeeds(List.of(tool, "--version"), repositoryDirectory, runner)) {
+		if (probe.isInstalled(tool, repositoryDirectory, runner)) {
 			return;
 		}
 		throw new AdoptionException(name() + " failed: " + repositoryDirectory + " builds with "

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.Failures;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
@@ -85,26 +86,15 @@ public class ClaudeInitStep extends AbstractCommandStep {
 		try {
 			runOrFail(runner, checkout, claudeCommand);
 		} catch (RuntimeException e) {
-			restoreSuppressing(relocated, checkout, e);
+			Failures.alsoRun(e, () -> restoreRelocated(relocated, checkout));
 			throw e;
 		}
-		relocated.ifPresent(backup -> restore(backup, claudeDirMemory(checkout)));
+		restoreRelocated(relocated, checkout);
 		requireGenerated(context);
 	}
 
-	/**
-	 * Restores the relocated memory file on the failure path without letting a
-	 * failed restore replace the failure being reported. Thrown from a
-	 * {@code finally} it would do exactly that, discarding the {@code claude}
-	 * transcript that is the only useful diagnostic the run produced; attaching it as
-	 * a suppressed exception keeps both.
-	 */
-	private void restoreSuppressing(Optional<Path> relocated, Path checkout, RuntimeException failure) {
-		try {
-			relocated.ifPresent(backup -> restore(backup, claudeDirMemory(checkout)));
-		} catch (RuntimeException e) {
-			failure.addSuppressed(e);
-		}
+	private void restoreRelocated(Optional<Path> relocated, Path checkout) {
+		relocated.ifPresent(backup -> restore(backup, claudeDirMemory(checkout)));
 	}
 
 	private Path claudeDirMemory(Path checkout) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -76,8 +76,7 @@ public class ClaudeMdConformer {
 		lines = closeUnterminatedFence(lines);
 		lines = ensureTitle(lines);
 		lines = canonicalizeHeadings(lines);
-		lines = appendMissingSections(lines);
-		lines = ensureSectionBodies(lines);
+		lines = ensureRequiredSections(lines);
 		lines = ensureAgentsReference(lines);
 		return join(lines);
 	}
@@ -176,30 +175,34 @@ public class ClaudeMdConformer {
 		return actual.equals(wanted) || actual.startsWith(wanted + " ");
 	}
 
-	private List<String> appendMissingSections(List<String> lines) {
-		boolean[] fence = fenceMask(lines);
-		List<String> missing = missingSections(lines, fence);
-		if (missing.isEmpty()) {
-			return lines;
-		}
+	/**
+	 * Gives every required section both a heading and a body. A section the
+	 * document does not carry at all is appended with a stub body; one whose
+	 * heading the document supplied but left bare — typically a near-miss renamed
+	 * in place above — has a stub inserted beneath it. The rule fails an empty
+	 * section just as it fails a missing one, so the two cases are settled together
+	 * rather than in separate passes.
+	 */
+	private List<String> ensureRequiredSections(List<String> lines) {
 		List<String> result = new ArrayList<>(lines);
-		for (String section : missing) {
-			appendSection(result, section);
+		for (String required : REQUIRED_SECTIONS) {
+			ensureSection(result, required);
 		}
 		return result;
 	}
 
-	private List<String> missingSections(List<String> lines, boolean[] fence) {
-		List<String> missing = new ArrayList<>();
-		for (String required : REQUIRED_SECTIONS) {
-			addIfMissing(missing, lines, fence, required);
-		}
-		return missing;
-	}
-
-	private void addIfMissing(List<String> missing, List<String> lines, boolean[] fence, String required) {
-		if (!hasHeading(lines, fence, required)) {
-			missing.add(required);
+	/**
+	 * The fence mask is rebuilt per section because appending a section or
+	 * inserting a stub shifts the lines the next one is found at, and the sections
+	 * are few enough for that to stay cheap.
+	 */
+	private void ensureSection(List<String> lines, String required) {
+		boolean[] fence = fenceMask(lines);
+		int index = indexOfHeading(lines, fence, required);
+		if (index < 0) {
+			appendSection(lines, required);
+		} else if (!hasBody(lines, fence, index)) {
+			insertStubBody(lines, index);
 		}
 	}
 
@@ -210,31 +213,9 @@ public class ClaudeMdConformer {
 		lines.add(STUB_BODY);
 	}
 
-	/**
-	 * Gives a stub body to every required section that has none. Appended sections
-	 * already carry one, so this only ever fills in a heading the generated document
-	 * supplied — typically a near-miss renamed in place above whose section the
-	 * document left bare.
-	 */
-	private List<String> ensureSectionBodies(List<String> lines) {
-		List<String> result = new ArrayList<>(lines);
-		for (String required : REQUIRED_SECTIONS) {
-			insertStubBodyIfEmpty(result, required);
-		}
-		return result;
-	}
-
-	/**
-	 * The fence mask is rebuilt per section because inserting a stub shifts every
-	 * later line, and the sections are few enough for that to stay cheap.
-	 */
-	private void insertStubBodyIfEmpty(List<String> lines, String required) {
-		boolean[] fence = fenceMask(lines);
-		int index = indexOfHeading(lines, fence, required);
-		if (index >= 0 && !hasBody(lines, fence, index)) {
-			lines.add(index + 1, "");
-			lines.add(index + 2, STUB_BODY);
-		}
+	private void insertStubBody(List<String> lines, int headingIndex) {
+		lines.add(headingIndex + 1, "");
+		lines.add(headingIndex + 2, STUB_BODY);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
@@ -1,0 +1,86 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+/**
+ * Resolves the {@code claude-code-enforcer} rule version that
+ * {@link PomEnforcerInstaller} pins into an adopted project's {@code pom.xml}:
+ * the version of the {@code tools} release running the adoption, refusing a
+ * snapshot.
+ *
+ * <p>Where the version comes from is a question about this build's metadata, not
+ * about editing XML, so it lives here rather than in the installer.
+ */
+final class EnforcerRuleVersion {
+
+	static final String BUILD_PROPERTIES = "/adopt-build.properties";
+	static final String RULE_VERSION_KEY = "enforcer.rule.version";
+	static final String SNAPSHOT_SUFFIX = "-SNAPSHOT";
+
+	private EnforcerRuleVersion() {
+	}
+
+	/**
+	 * The released rule version to wire in. Resolving it lazily — only once a POM is
+	 * actually being edited — keeps merely constructing the default
+	 * {@link BuildSystems#DEFAULTS} list, or adopting a repository that builds with
+	 * something other than Maven, from depending on the running build's version.
+	 */
+	static String release() {
+		return requireRelease(fromBuildMetadata());
+	}
+
+	/**
+	 * A snapshot resolves from the adopter's own local repository but from nowhere
+	 * else, so wiring one in would open a pull request that builds on this machine
+	 * and fails for the adopted project's CI and every one of its contributors —
+	 * and {@link VerifyStep} could not catch it, because it too resolves against the
+	 * local repository. Refusing here turns that into an immediate, explicable
+	 * failure for the person running the adoption.
+	 */
+	static String requireRelease(String version) {
+		if (version.endsWith(SNAPSHOT_SUFFIX)) {
+			throw new AdoptionException("Refusing to wire the snapshot enforcer rule version " + version
+					+ " into the adopted project's pom.xml: a snapshot is not resolvable outside this machine's"
+					+ " local repository, so the pull request would break the adopted project's build."
+					+ " Run the adoption from a released build of tools, or supply a released version to"
+					+ " PomEnforcerInstaller.");
+		}
+		return version;
+	}
+
+	/**
+	 * Reads the enforcer rule version wired into adopted POMs from the build
+	 * metadata that Maven filters into {@value #BUILD_PROPERTIES} at build time, so
+	 * the dependency is pinned to the exact {@code tools} release running the
+	 * adoption — and is therefore resolvable from the same repository that
+	 * published it — rather than to a hardcoded literal that silently drifts as the
+	 * project is versioned.
+	 */
+	static String fromBuildMetadata() {
+		try (InputStream stream = EnforcerRuleVersion.class.getResourceAsStream(BUILD_PROPERTIES)) {
+			return read(stream);
+		} catch (IOException e) {
+			throw new AdoptionException("Could not read build metadata: " + BUILD_PROPERTIES, e);
+		}
+	}
+
+	private static String read(InputStream stream) throws IOException {
+		if (stream == null) {
+			throw new AdoptionException("Build metadata not on the classpath: " + BUILD_PROPERTIES
+					+ " (build the module so its resources are filtered)");
+		}
+		Properties properties = new Properties();
+		properties.load(stream);
+		String version = properties.getProperty(RULE_VERSION_KEY, "").strip();
+		if (version.isEmpty() || version.startsWith("${")) {
+			throw new AdoptionException(
+					RULE_VERSION_KEY + " was not filtered into " + BUILD_PROPERTIES + " (found: '" + version + "')");
+		}
+		return version;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -1,0 +1,285 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.AdoptionFiles;
+
+/**
+ * A {@code pom.xml} parsed for editing and written back without reformatting.
+ * Callers append elements through {@link #appendElement} and {@link #appendText};
+ * everything the file already held — every whitespace node, its XML declaration,
+ * its trailing newline, and its line terminator — survives {@link #write()}
+ * untouched, so the adoption commit shows only the block that was added rather
+ * than a reformat of the whole file.
+ *
+ * <p>Each appended element is preceded by a newline and an indentation matching
+ * the document's own unit (detected from the file, defaulting to two spaces), and
+ * is inserted before the parent's own closing indentation so that closing tag
+ * stays put. Every container is attached to its parent before its children are
+ * added, so an element's depth — and therefore its indentation — is known as soon
+ * as it is appended.
+ *
+ * <p>The edit is performed on the JDK's DOM so no third-party XML library is
+ * needed, and is namespace-aware so new elements join the POM's default
+ * namespace.
+ */
+final class PomDocument {
+
+	private static final String DEFAULT_INDENT_UNIT = "  ";
+	private static final String DESCRIPTION = "POM";
+
+	private final Path file;
+	private final String original;
+	private final Document document;
+	private final String namespace;
+	private final String indentUnit;
+
+	private PomDocument(Path file, String original, Document document) {
+		this.file = file;
+		this.original = original;
+		this.document = document;
+		this.namespace = document.getDocumentElement().getNamespaceURI();
+		this.indentUnit = detectIndentUnit(document.getDocumentElement());
+	}
+
+	static PomDocument read(Path file) {
+		return new PomDocument(file, AdoptionFiles.read(file, DESCRIPTION), parse(file));
+	}
+
+	/** The {@code build/plugins} element, creating either level when the POM lacks it. */
+	Element pluginsElement() {
+		Element build = childOrCreate(document.getDocumentElement(), "build");
+		return childOrCreate(build, "plugins");
+	}
+
+	Element childOrCreate(Element parent, String name) {
+		return child(parent, name).orElseGet(() -> appendElement(parent, name));
+	}
+
+	Element appendElement(Element parent, String name) {
+		return appendChild(parent, create(name));
+	}
+
+	void appendText(Element parent, String name, String text) {
+		Element element = create(name);
+		element.setTextContent(text);
+		appendChild(parent, element);
+	}
+
+	static Optional<Element> child(Element parent, String name) {
+		return children(parent, name).stream().findFirst();
+	}
+
+	static List<Element> children(Element parent, String name) {
+		List<Element> matches = new ArrayList<>();
+		NodeList nodes = parent.getChildNodes();
+		for (int index = 0; index < nodes.getLength(); index++) {
+			addIfMatch(matches, nodes.item(index), name);
+		}
+		return matches;
+	}
+
+	/** @return the element's {@code artifactId} text, when it declares one */
+	static boolean hasArtifactId(Element element, String artifactId) {
+		return child(element, "artifactId")
+				.map(Element::getTextContent)
+				.map(String::strip)
+				.filter(artifactId::equals)
+				.isPresent();
+	}
+
+	/**
+	 * Writes the document back verbatim. The transformer's own indentation is left
+	 * off and the parsed whitespace nodes are kept, so only the elements the edit
+	 * added differ from the original. The original's XML declaration and trailing
+	 * newline are carried over exactly so the first and last lines are not disturbed
+	 * either.
+	 *
+	 * <p>XML parsing normalizes {@code \r\n} to {@code \n}, so the DOM the
+	 * transformer serializes has lost the original terminator;
+	 * {@link LineTerminators} puts it back, keeping a CRLF POM on CRLF rather than
+	 * silently flipping every line to LF and reformatting the whole file.
+	 */
+	void write() {
+		String content = declarationPrefix() + serialize();
+		String withTrailingNewline = matchTrailingNewline(content);
+		AdoptionFiles.write(file, LineTerminators.matching(withTrailingNewline, original), DESCRIPTION);
+	}
+
+	private static void addIfMatch(List<Element> matches, Node node, String name) {
+		if (node instanceof Element element && name.equals(element.getLocalName())) {
+			matches.add(element);
+		}
+	}
+
+	private Element appendChild(Element parent, Element child) {
+		Node closingIndent = trailingWhitespace(parent);
+		Node childIndent = document.createTextNode(newlineIndent(depthOf(parent) + 1));
+		if (closingIndent == null) {
+			parent.appendChild(childIndent);
+			parent.appendChild(child);
+			parent.appendChild(document.createTextNode(newlineIndent(depthOf(parent))));
+		} else {
+			parent.insertBefore(childIndent, closingIndent);
+			parent.insertBefore(child, closingIndent);
+		}
+		return child;
+	}
+
+	private String newlineIndent(int depth) {
+		return "\n" + indentUnit.repeat(depth);
+	}
+
+	private Element create(String name) {
+		return namespace == null ? document.createElement(name) : document.createElementNS(namespace, name);
+	}
+
+	private static Node trailingWhitespace(Element parent) {
+		Node last = parent.getLastChild();
+		return isWhitespaceText(last) ? last : null;
+	}
+
+	private static int depthOf(Node node) {
+		int depth = 0;
+		Node parent = node.getParentNode();
+		while (parent != null && parent.getNodeType() == Node.ELEMENT_NODE) {
+			depth++;
+			parent = parent.getParentNode();
+		}
+		return depth;
+	}
+
+	/**
+	 * The indentation of a single nesting level, read from the first top-level
+	 * element's leading whitespace, or two spaces when the POM carries none.
+	 */
+	private static String detectIndentUnit(Element root) {
+		NodeList children = root.getChildNodes();
+		for (int index = 0; index < children.getLength(); index++) {
+			String unit = leadingIndentOf(children.item(index));
+			if (!unit.isEmpty()) {
+				return unit;
+			}
+		}
+		return DEFAULT_INDENT_UNIT;
+	}
+
+	private static String leadingIndentOf(Node node) {
+		if (node.getNodeType() != Node.ELEMENT_NODE) {
+			return "";
+		}
+		Node previous = node.getPreviousSibling();
+		if (!isWhitespaceText(previous)) {
+			return "";
+		}
+		String text = previous.getTextContent();
+		int newline = text.lastIndexOf('\n');
+		return newline < 0 ? "" : text.substring(newline + 1);
+	}
+
+	private static boolean isWhitespaceText(Node node) {
+		return node != null && node.getNodeType() == Node.TEXT_NODE && node.getTextContent().isBlank();
+	}
+
+	private static Document parse(Path file) {
+		try {
+			return builder().parse(file.toFile());
+		} catch (IOException | SAXException e) {
+			throw new AdoptionException("Could not read POM: " + file, e);
+		}
+	}
+
+	private static DocumentBuilder builder() {
+		try {
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setNamespaceAware(true);
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			factory.setExpandEntityReferences(false);
+			return factory.newDocumentBuilder();
+		} catch (ParserConfigurationException e) {
+			throw new AdoptionException("Could not configure XML parser", e);
+		}
+	}
+
+	private String serialize() {
+		try {
+			return transformBody();
+		} catch (TransformerException e) {
+			throw new AdoptionException("Could not write POM: " + file, e);
+		}
+	}
+
+	private String transformBody() throws TransformerException {
+		StringWriter writer = new StringWriter();
+		transformer().transform(new DOMSource(document), new StreamResult(writer));
+		return writer.toString();
+	}
+
+	private static Transformer transformer() throws TransformerException {
+		TransformerFactory factory = TransformerFactory.newInstance();
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		Transformer transformer = factory.newTransformer();
+		transformer.setOutputProperty(OutputKeys.INDENT, "no");
+		transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+		return transformer;
+	}
+
+	/**
+	 * The XML declaration the original file opened with, up to and including its
+	 * line terminator, or empty when it had none. Carrying it over verbatim keeps
+	 * the transformer from inventing one (and adding a spurious first-line change)
+	 * on a POM that started straight with {@code <project>}.
+	 */
+	private String declarationPrefix() {
+		if (!original.stripLeading().startsWith("<?xml")) {
+			return "";
+		}
+		int end = original.indexOf("?>");
+		if (end < 0) {
+			return "";
+		}
+		int afterTerminator = lineTerminatorEnd(original, end + 2);
+		return original.substring(0, afterTerminator) + (afterTerminator == end + 2 ? "\n" : "");
+	}
+
+	private static int lineTerminatorEnd(String text, int from) {
+		int index = from;
+		if (index < text.length() && text.charAt(index) == '\r') {
+			index++;
+		}
+		if (index < text.length() && text.charAt(index) == '\n') {
+			index++;
+		}
+		return index;
+	}
+
+	private String matchTrailingNewline(String content) {
+		boolean originalEnds = original.endsWith("\n") || original.endsWith("\r");
+		boolean contentEnds = content.endsWith("\n") || content.endsWith("\r");
+		return originalEnds && !contentEnds ? content + "\n" : content;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -1,34 +1,10 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.function.Supplier;
 
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
-
-import io.github.adamw7.tools.adopt.AdoptionException;
-import io.github.adamw7.tools.adopt.AdoptionFiles;
 
 /**
  * Adds the {@code claude-code-enforcer} to a Maven project's {@code pom.xml} by
@@ -36,19 +12,14 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
  * so the adopted repository fails its build if the freshly generated
  * {@code CLAUDE.md} is missing or malformed.
  *
- * <p>The edit is performed on the JDK's DOM so no third-party XML library is
- * needed, is namespace-aware so the new elements join the POM's default
- * namespace, and is idempotent: a POM that already wires the rule is left
+ * <p>The install is idempotent: a POM that already wires the rule is left
  * untouched. A POM that already uses the {@code maven-enforcer-plugin} for other
  * rules is augmented in place rather than skipped, so the rule is still wired in.
  *
- * <p>The existing document is preserved verbatim — every original whitespace and
- * line is left untouched — and only the newly added elements are indented, to the
- * style the POM already uses. The adoption commit therefore shows just the
- * enforcer block being added rather than a reformat of the whole file.
- *
- * <p>The rule version comes from the running build and must be a release: see
- * {@link #requireReleaseVersion(String)}.
+ * <p>{@link PomDocument} does the reading, appending, and verbatim writing, so
+ * the existing document is preserved exactly and only the newly added elements
+ * appear in the adoption commit. The rule version comes from
+ * {@link EnforcerRuleVersion} and must be a release.
  */
 public class PomEnforcerInstaller {
 
@@ -58,80 +29,15 @@ public class PomEnforcerInstaller {
 	static final String RULE_ARTIFACT_ID = "tools.claude-code-enforcer";
 	static final String RULE_GROUP_ID = "io.github.adamw7";
 	static final String CLAUDE_MD_FILE = "${project.basedir}/CLAUDE.md";
-	static final String BUILD_PROPERTIES = "/adopt-build.properties";
-	static final String RULE_VERSION_KEY = "enforcer.rule.version";
-	static final String SNAPSHOT_SUFFIX = "-SNAPSHOT";
-
-	private static final String POM_DESCRIPTION = "POM";
 
 	private final Supplier<String> ruleVersion;
 
 	public PomEnforcerInstaller() {
-		this.ruleVersion = PomEnforcerInstaller::releaseRuleVersion;
+		this.ruleVersion = EnforcerRuleVersion::release;
 	}
 
 	public PomEnforcerInstaller(String ruleVersion) {
 		this.ruleVersion = () -> ruleVersion;
-	}
-
-	/**
-	 * The released rule version to wire in. Resolving it lazily — only once a POM is
-	 * actually being edited — keeps merely constructing the default
-	 * {@link BuildSystems#DEFAULTS} list, or adopting a repository that builds with
-	 * something other than Maven, from depending on the running build's version.
-	 */
-	static String releaseRuleVersion() {
-		return requireReleaseVersion(buildRuleVersion());
-	}
-
-	/**
-	 * A snapshot resolves from the adopter's own local repository but from nowhere
-	 * else, so wiring one in would open a pull request that builds on this machine
-	 * and fails for the adopted project's CI and every one of its contributors —
-	 * and {@link VerifyStep} could not catch it, because it too resolves against the
-	 * local repository. Refusing here turns that into an immediate, explicable
-	 * failure for the person running the adoption.
-	 */
-	static String requireReleaseVersion(String version) {
-		if (version.endsWith(SNAPSHOT_SUFFIX)) {
-			throw new AdoptionException("Refusing to wire the snapshot enforcer rule version " + version
-					+ " into the adopted project's pom.xml: a snapshot is not resolvable outside this machine's"
-					+ " local repository, so the pull request would break the adopted project's build."
-					+ " Run the adoption from a released build of tools, or supply a released version to"
-					+ " PomEnforcerInstaller.");
-		}
-		return version;
-	}
-
-	/**
-	 * Reads the enforcer rule version wired into adopted POMs from the build
-	 * metadata that Maven filters into {@value #BUILD_PROPERTIES} at build time, so
-	 * the dependency is pinned to the exact {@code tools} release running the
-	 * adoption — and is therefore resolvable from the same repository that
-	 * published it — rather than to a hardcoded literal that silently drifts as the
-	 * project is versioned.
-	 */
-	static String buildRuleVersion() {
-		try (InputStream stream = PomEnforcerInstaller.class.getResourceAsStream(BUILD_PROPERTIES)) {
-			return readRuleVersion(stream);
-		} catch (IOException e) {
-			throw new AdoptionException("Could not read build metadata: " + BUILD_PROPERTIES, e);
-		}
-	}
-
-	private static String readRuleVersion(InputStream stream) throws IOException {
-		if (stream == null) {
-			throw new AdoptionException("Build metadata not on the classpath: " + BUILD_PROPERTIES
-					+ " (build the module so its resources are filtered)");
-		}
-		Properties properties = new Properties();
-		properties.load(stream);
-		String version = properties.getProperty(RULE_VERSION_KEY, "").strip();
-		if (version.isEmpty() || version.startsWith("${")) {
-			throw new AdoptionException(
-					RULE_VERSION_KEY + " was not filtered into " + BUILD_PROPERTIES + " (found: '" + version + "')");
-		}
-		return version;
 	}
 
 	/**
@@ -140,34 +46,24 @@ public class PomEnforcerInstaller {
 	 *         unchanged.
 	 */
 	public boolean install(Path pomFile) {
-		String original = AdoptionFiles.read(pomFile, POM_DESCRIPTION);
-		Document document = parse(pomFile);
-		PomEditor editor = new PomEditor(document);
-		Element plugins = editor.pluginsElement();
+		PomDocument pom = PomDocument.read(pomFile);
+		Element plugins = pom.pluginsElement();
 		if (declaresClaudeRule(plugins)) {
 			return false;
 		}
-		wireEnforcer(editor, plugins);
-		write(document, pomFile, original);
+		wireEnforcer(pom, plugins);
+		pom.write();
 		return true;
 	}
 
 	private boolean declaresClaudeRule(Element plugins) {
-		return children(plugins, "plugin").stream().anyMatch(this::declaresRuleDependency);
+		return PomDocument.children(plugins, "plugin").stream().anyMatch(this::declaresRuleDependency);
 	}
 
 	private boolean declaresRuleDependency(Element plugin) {
-		return child(plugin, "dependencies").stream()
-				.flatMap(dependencies -> children(dependencies, "dependency").stream())
-				.anyMatch(dependency -> hasArtifactId(dependency, RULE_ARTIFACT_ID));
-	}
-
-	private static boolean hasArtifactId(Element element, String artifactId) {
-		return child(element, "artifactId")
-				.map(Element::getTextContent)
-				.map(String::strip)
-				.filter(artifactId::equals)
-				.isPresent();
+		return PomDocument.child(plugin, "dependencies").stream()
+				.flatMap(dependencies -> PomDocument.children(dependencies, "dependency").stream())
+				.anyMatch(dependency -> PomDocument.hasArtifactId(dependency, RULE_ARTIFACT_ID));
 	}
 
 	/**
@@ -175,276 +71,47 @@ public class PomEnforcerInstaller {
 	 * {@code maven-enforcer-plugin}, reusing an existing plugin declaration when
 	 * one is present so the project keeps a single enforcer plugin entry.
 	 */
-	private void wireEnforcer(PomEditor editor, Element plugins) {
-		Element plugin = findEnforcerPlugin(plugins).orElseGet(() -> createEnforcerPlugin(editor, plugins));
-		ruleDependency(editor, editor.childOrCreate(plugin, "dependencies"));
-		enforceExecution(editor, editor.childOrCreate(plugin, "executions"));
+	private void wireEnforcer(PomDocument pom, Element plugins) {
+		Element plugin = findEnforcerPlugin(plugins).orElseGet(() -> createEnforcerPlugin(pom, plugins));
+		ruleDependency(pom, pom.childOrCreate(plugin, "dependencies"));
+		enforceExecution(pom, pom.childOrCreate(plugin, "executions"));
 	}
 
 	private Optional<Element> findEnforcerPlugin(Element plugins) {
-		return children(plugins, "plugin").stream()
-				.filter(plugin -> hasArtifactId(plugin, ENFORCER_ARTIFACT_ID))
+		return PomDocument.children(plugins, "plugin").stream()
+				.filter(plugin -> PomDocument.hasArtifactId(plugin, ENFORCER_ARTIFACT_ID))
 				.findFirst();
 	}
 
-	private Element createEnforcerPlugin(PomEditor editor, Element plugins) {
-		Element plugin = editor.appendElement(plugins, "plugin");
-		editor.appendText(plugin, "groupId", ENFORCER_GROUP_ID);
-		editor.appendText(plugin, "artifactId", ENFORCER_ARTIFACT_ID);
-		editor.appendText(plugin, "version", ENFORCER_VERSION);
+	private Element createEnforcerPlugin(PomDocument pom, Element plugins) {
+		Element plugin = pom.appendElement(plugins, "plugin");
+		pom.appendText(plugin, "groupId", ENFORCER_GROUP_ID);
+		pom.appendText(plugin, "artifactId", ENFORCER_ARTIFACT_ID);
+		pom.appendText(plugin, "version", ENFORCER_VERSION);
 		return plugin;
 	}
 
-	private void ruleDependency(PomEditor editor, Element dependencies) {
-		Element dependency = editor.appendElement(dependencies, "dependency");
-		editor.appendText(dependency, "groupId", RULE_GROUP_ID);
-		editor.appendText(dependency, "artifactId", RULE_ARTIFACT_ID);
-		editor.appendText(dependency, "version", ruleVersion.get());
+	private void ruleDependency(PomDocument pom, Element dependencies) {
+		Element dependency = pom.appendElement(dependencies, "dependency");
+		pom.appendText(dependency, "groupId", RULE_GROUP_ID);
+		pom.appendText(dependency, "artifactId", RULE_ARTIFACT_ID);
+		pom.appendText(dependency, "version", ruleVersion.get());
 	}
 
-	private void enforceExecution(PomEditor editor, Element executions) {
-		Element execution = editor.appendElement(executions, "execution");
-		editor.appendText(execution, "id", "enforce-claude-md");
-		editor.appendText(execution, "phase", "validate");
-		editor.appendText(execution, "inherited", "false");
-		Element goals = editor.appendElement(execution, "goals");
-		editor.appendText(goals, "goal", "enforce");
-		claudeMdConfiguration(editor, execution);
+	private void enforceExecution(PomDocument pom, Element executions) {
+		Element execution = pom.appendElement(executions, "execution");
+		pom.appendText(execution, "id", "enforce-claude-md");
+		pom.appendText(execution, "phase", "validate");
+		pom.appendText(execution, "inherited", "false");
+		Element goals = pom.appendElement(execution, "goals");
+		pom.appendText(goals, "goal", "enforce");
+		claudeMdConfiguration(pom, execution);
 	}
 
-	private void claudeMdConfiguration(PomEditor editor, Element execution) {
-		Element configuration = editor.appendElement(execution, "configuration");
-		Element rules = editor.appendElement(configuration, "rules");
-		Element claudeMdFormat = editor.appendElement(rules, "claudeMdFormat");
-		editor.appendText(claudeMdFormat, "claudeMdFile", CLAUDE_MD_FILE);
-	}
-
-	private static Optional<Element> child(Element parent, String name) {
-		return children(parent, name).stream().findFirst();
-	}
-
-	private static List<Element> children(Element parent, String name) {
-		List<Element> matches = new ArrayList<>();
-		NodeList nodes = parent.getChildNodes();
-		for (int index = 0; index < nodes.getLength(); index++) {
-			addIfMatch(matches, nodes.item(index), name);
-		}
-		return matches;
-	}
-
-	private static void addIfMatch(List<Element> matches, Node node, String name) {
-		if (node instanceof Element element && name.equals(element.getLocalName())) {
-			matches.add(element);
-		}
-	}
-
-	private Document parse(Path pomFile) {
-		try {
-			return builder().parse(pomFile.toFile());
-		} catch (IOException | SAXException e) {
-			throw new AdoptionException("Could not read POM: " + pomFile, e);
-		}
-	}
-
-	private DocumentBuilder builder() {
-		try {
-			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-			factory.setNamespaceAware(true);
-			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			factory.setExpandEntityReferences(false);
-			return factory.newDocumentBuilder();
-		} catch (ParserConfigurationException e) {
-			throw new AdoptionException("Could not configure XML parser", e);
-		}
-	}
-
-	/**
-	 * Writes the document back verbatim. The transformer's own indentation is left
-	 * off and the parsed whitespace nodes are kept, so only the elements the edit
-	 * added — already indented by {@link PomEditor} — differ from the original. The
-	 * original's XML declaration and trailing newline are carried over exactly so
-	 * the first and last lines are not disturbed either.
-	 *
-	 * <p>XML parsing normalizes {@code \r\n} to {@code \n}, so the DOM the
-	 * transformer serializes has lost the original terminator;
-	 * {@link LineTerminators} puts it back, keeping a CRLF POM on CRLF rather than
-	 * silently flipping every line to LF and reformatting the whole file.
-	 */
-	private void write(Document document, Path pomFile, String original) {
-		String content = declarationPrefix(original) + serialize(document, pomFile);
-		String withTrailingNewline = matchTrailingNewline(content, original);
-		AdoptionFiles.write(pomFile, LineTerminators.matching(withTrailingNewline, original), POM_DESCRIPTION);
-	}
-
-	private String serialize(Document document, Path pomFile) {
-		try {
-			return transformBody(document);
-		} catch (TransformerException e) {
-			throw new AdoptionException("Could not write POM: " + pomFile, e);
-		}
-	}
-
-	private String transformBody(Document document) throws TransformerException {
-		StringWriter writer = new StringWriter();
-		transformer().transform(new DOMSource(document), new StreamResult(writer));
-		return writer.toString();
-	}
-
-	/**
-	 * The XML declaration the original file opened with, up to and including its
-	 * line terminator, or empty when it had none. Carrying it over verbatim keeps
-	 * the transformer from inventing one (and adding a spurious first-line change)
-	 * on a POM that started straight with {@code <project>}.
-	 */
-	private String declarationPrefix(String original) {
-		if (!original.stripLeading().startsWith("<?xml")) {
-			return "";
-		}
-		int end = original.indexOf("?>");
-		if (end < 0) {
-			return "";
-		}
-		int afterTerminator = lineTerminatorEnd(original, end + 2);
-		return original.substring(0, afterTerminator) + (afterTerminator == end + 2 ? "\n" : "");
-	}
-
-	private int lineTerminatorEnd(String text, int from) {
-		int index = from;
-		if (index < text.length() && text.charAt(index) == '\r') {
-			index++;
-		}
-		if (index < text.length() && text.charAt(index) == '\n') {
-			index++;
-		}
-		return index;
-	}
-
-	private String matchTrailingNewline(String content, String original) {
-		boolean originalEnds = original.endsWith("\n") || original.endsWith("\r");
-		boolean contentEnds = content.endsWith("\n") || content.endsWith("\r");
-		return originalEnds && !contentEnds ? content + "\n" : content;
-	}
-
-	private Transformer transformer() throws TransformerException {
-		TransformerFactory factory = TransformerFactory.newInstance();
-		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		Transformer transformer = factory.newTransformer();
-		transformer.setOutputProperty(OutputKeys.INDENT, "no");
-		transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-		return transformer;
-	}
-
-	/**
-	 * Appends new elements to a parsed POM without disturbing its existing layout.
-	 * Each appended element is preceded by a newline and an indentation matching
-	 * the document's own unit (detected from the file, defaulting to two spaces),
-	 * and is inserted before the parent's own closing indentation so that closing
-	 * tag stays put. Every container is attached to its parent before its children
-	 * are added, so an element's depth — and therefore its indentation — is known
-	 * as soon as it is appended.
-	 */
-	private static final class PomEditor {
-
-		private static final String DEFAULT_INDENT_UNIT = "  ";
-
-		private final Document document;
-		private final String namespace;
-		private final String indentUnit;
-
-		private PomEditor(Document document) {
-			this.document = document;
-			this.namespace = document.getDocumentElement().getNamespaceURI();
-			this.indentUnit = detectIndentUnit(document.getDocumentElement());
-		}
-
-		private Element pluginsElement() {
-			Element project = document.getDocumentElement();
-			Element build = childOrCreate(project, "build");
-			return childOrCreate(build, "plugins");
-		}
-
-		private Element childOrCreate(Element parent, String name) {
-			return child(parent, name).orElseGet(() -> appendElement(parent, name));
-		}
-
-		private Element appendElement(Element parent, String name) {
-			return appendChild(parent, create(name));
-		}
-
-		private void appendText(Element parent, String name, String text) {
-			Element element = create(name);
-			element.setTextContent(text);
-			appendChild(parent, element);
-		}
-
-		private Element appendChild(Element parent, Element child) {
-			Node closingIndent = trailingWhitespace(parent);
-			Node childIndent = document.createTextNode(newlineIndent(depthOf(parent) + 1));
-			if (closingIndent == null) {
-				parent.appendChild(childIndent);
-				parent.appendChild(child);
-				parent.appendChild(document.createTextNode(newlineIndent(depthOf(parent))));
-			} else {
-				parent.insertBefore(childIndent, closingIndent);
-				parent.insertBefore(child, closingIndent);
-			}
-			return child;
-		}
-
-		private String newlineIndent(int depth) {
-			return "\n" + indentUnit.repeat(depth);
-		}
-
-		private Element create(String name) {
-			return namespace == null ? document.createElement(name) : document.createElementNS(namespace, name);
-		}
-
-		private static Node trailingWhitespace(Element parent) {
-			Node last = parent.getLastChild();
-			return isWhitespaceText(last) ? last : null;
-		}
-
-		private static int depthOf(Node node) {
-			int depth = 0;
-			Node parent = node.getParentNode();
-			while (parent != null && parent.getNodeType() == Node.ELEMENT_NODE) {
-				depth++;
-				parent = parent.getParentNode();
-			}
-			return depth;
-		}
-
-		/**
-		 * The indentation of a single nesting level, read from the first top-level
-		 * element's leading whitespace, or two spaces when the POM carries none.
-		 */
-		private static String detectIndentUnit(Element root) {
-			NodeList children = root.getChildNodes();
-			for (int index = 0; index < children.getLength(); index++) {
-				String unit = leadingIndentOf(children.item(index));
-				if (!unit.isEmpty()) {
-					return unit;
-				}
-			}
-			return DEFAULT_INDENT_UNIT;
-		}
-
-		private static String leadingIndentOf(Node node) {
-			if (node.getNodeType() != Node.ELEMENT_NODE) {
-				return "";
-			}
-			Node previous = node.getPreviousSibling();
-			if (!isWhitespaceText(previous)) {
-				return "";
-			}
-			String text = previous.getTextContent();
-			int newline = text.lastIndexOf('\n');
-			return newline < 0 ? "" : text.substring(newline + 1);
-		}
-
-		private static boolean isWhitespaceText(Node node) {
-			return node != null && node.getNodeType() == Node.TEXT_NODE && node.getTextContent().isBlank();
-		}
+	private void claudeMdConfiguration(PomDocument pom, Element execution) {
+		Element configuration = pom.appendElement(execution, "configuration");
+		Element rules = pom.appendElement(configuration, "rules");
+		Element claudeMdFormat = pom.appendElement(rules, "claudeMdFormat");
+		pom.appendText(claudeMdFormat, "claudeMdFile", CLAUDE_MD_FILE);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -60,10 +60,6 @@ public class PullRequestStep extends AbstractCommandStep {
 		this(PullRequestOptions.defaults());
 	}
 
-	public PullRequestStep(String title, String body) {
-		this(PullRequestOptions.builder().title(title).body(body).build());
-	}
-
 	public PullRequestStep(PullRequestOptions options) {
 		this.options = options;
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
@@ -41,11 +41,21 @@ final class ToolProbe {
 	}
 
 	private void collectIfMissing(List<String> missing, String tool, Path directory, CommandRunner runner) {
-		if (succeeds(List.of(tool, VERSION_FLAG), directory, runner)) {
+		if (isInstalled(tool, directory, runner)) {
 			log.info("Found required tool: {}", tool);
 		} else {
 			missing.add(tool);
 		}
+	}
+
+	/**
+	 * @return whether the tool's {@code --version} probe runs and exits zero. The
+	 *         probe's shape lives here rather than at each caller, so
+	 *         {@link ToolchainStep} and {@link BuildToolchainStep} cannot drift apart
+	 *         on how a tool is checked for.
+	 */
+	boolean isInstalled(String tool, Path directory, CommandRunner runner) {
+		return succeeds(List.of(tool, VERSION_FLAG), directory, runner);
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
@@ -2,7 +2,6 @@ package io.github.adamw7.tools.adopt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 
@@ -10,154 +9,60 @@ import org.junit.jupiter.api.Test;
 
 class AdoptionContextTest {
 
+	private static final String REPOSITORY_URL = "https://github.com/adamw7/tools.git";
+
 	private final Path workspace = Path.of("/tmp/workspace");
 
-	/**
-	 * An empty last segment would resolve the checkout onto the workspace itself,
-	 * so the clone would land beside the other repositories the workspace holds
-	 * instead of in its own directory.
-	 */
+	/** The URL itself is parsed by {@link RepositoryUrl}; the context resolves the checkout under the workspace. */
 	@Test
-	void aUrlWithNoRepositoryNameIsRejected() {
-		assertThrows(IllegalArgumentException.class,
-				() -> new AdoptionContext("https://github.com/adamw7//", Path.of("/tmp/workspace")));
-		assertThrows(IllegalArgumentException.class,
-				() -> new AdoptionContext("https://github.com/adamw7/.git", Path.of("/tmp/workspace")));
-	}
-
-	@Test
-	void aUrlWhoseNameIsADirectoryAliasIsRejected() {
-		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext("..", Path.of("/tmp/workspace")));
-		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext(".", Path.of("/tmp/workspace")));
-	}
-
-	@Test
-	void derivesCheckoutDirectoryFromHttpsUrl() {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace);
+	void resolvesTheCheckoutDirectoryUnderTheWorkspace() {
+		AdoptionContext context = new AdoptionContext(REPOSITORY_URL, workspace);
 		assertEquals(workspace.resolve("tools"), context.repositoryDirectory());
 	}
 
 	@Test
-	void derivesCheckoutDirectoryWithoutGitSuffix() {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools", workspace);
-		assertEquals(workspace.resolve("tools"), context.repositoryDirectory());
-	}
-
-	@Test
-	void handlesTrailingSlash() {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools/", workspace);
-		assertEquals(workspace.resolve("tools"), context.repositoryDirectory());
-	}
-
-	@Test
-	void derivesCheckoutDirectoryFromSshUrl() {
-		AdoptionContext context = new AdoptionContext("git@github.com:adamw7/tools.git", workspace);
-		assertEquals(workspace.resolve("tools"), context.repositoryDirectory());
-	}
-
-	@Test
-	void derivesCheckoutDirectoryFromNestedGroupUrl() {
-		AdoptionContext context = new AdoptionContext("https://gitlab.com/group/subgroup/tools.git", workspace);
-		assertEquals(workspace.resolve("tools"), context.repositoryDirectory());
-	}
-
-	@Test
-	void keepsDotsInRepositoryNameThatAreNotTheGitSuffix() {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/my.tool.git", workspace);
-		assertEquals(workspace.resolve("my.tool"), context.repositoryDirectory());
+	void exposesTheUrlAndItsSlug() {
+		AdoptionContext context = new AdoptionContext(REPOSITORY_URL, workspace);
+		assertEquals(REPOSITORY_URL, context.repositoryUrl());
+		assertEquals("adamw7/tools", context.repositorySlug().orElseThrow());
 	}
 
 	@Test
 	void exposesTheWorkspaceDirectory() {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace);
-		assertEquals(workspace, context.workspace());
-	}
-
-	@Test
-	void trimsAndKeepsUrl() {
-		AdoptionContext context = new AdoptionContext("  https://github.com/adamw7/tools.git  ", workspace);
-		assertEquals("https://github.com/adamw7/tools.git", context.repositoryUrl());
+		assertEquals(workspace, new AdoptionContext(REPOSITORY_URL, workspace).workspace());
 	}
 
 	@Test
 	void defaultsToTheAdoptionFeatureBranch() {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace);
+		AdoptionContext context = new AdoptionContext(REPOSITORY_URL, workspace);
 		assertEquals(AdoptionContext.DEFAULT_BRANCH, context.branchName());
 	}
 
 	@Test
 	void keepsAndTrimsSuppliedBranchName() {
-		AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git", workspace,
-				"  feature/x  ");
+		AdoptionContext context = new AdoptionContext(REPOSITORY_URL, workspace, "  feature/x  ");
 		assertEquals("feature/x", context.branchName());
 	}
 
 	@Test
 	void rejectsBlankBranchName() {
-		assertThrows(IllegalArgumentException.class,
-				() -> new AdoptionContext("https://github.com/adamw7/tools.git", workspace, "  "));
-	}
-
-	@Test
-	void rejectsBlankUrl() {
-		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext("  ", workspace));
-	}
-
-	@Test
-	void rejectsNullUrl() {
-		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext(null, workspace));
+		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext(REPOSITORY_URL, workspace, "  "));
 	}
 
 	@Test
 	void rejectsNullBranchName() {
-		assertThrows(IllegalArgumentException.class,
-				() -> new AdoptionContext("https://github.com/adamw7/tools.git", workspace, null));
+		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext(REPOSITORY_URL, workspace, null));
+	}
+
+	@Test
+	void rejectsAUrlThatNamesNoRepository() {
+		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext("  ", workspace));
+		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext(null, workspace));
 	}
 
 	@Test
 	void rejectsNullWorkspace() {
-		assertThrows(IllegalArgumentException.class,
-				() -> new AdoptionContext("https://github.com/adamw7/tools.git", null));
-	}
-
-	@Test
-	void derivesTheOwnerAndRepositoryFromAnHttpsUrl() {
-		assertEquals("adamw7/tools",
-				new AdoptionContext("https://github.com/adamw7/tools.git", workspace).repositorySlug().orElseThrow());
-		assertEquals("adamw7/tools",
-				new AdoptionContext("https://github.com/adamw7/tools", workspace).repositorySlug().orElseThrow());
-		assertEquals("adamw7/tools",
-				new AdoptionContext("https://github.com/adamw7/tools/", workspace).repositorySlug().orElseThrow());
-	}
-
-	/**
-	 * The scp-like form separates the host from the path with ':', not '/', so a
-	 * naive split on '/' alone would read the host and owner as one segment.
-	 */
-	@Test
-	void derivesTheOwnerAndRepositoryFromSshForms() {
-		assertEquals("adamw7/tools",
-				new AdoptionContext("git@github.com:adamw7/tools.git", workspace).repositorySlug().orElseThrow());
-		assertEquals("adamw7/tools", new AdoptionContext("ssh://git@github.com/adamw7/tools.git", workspace)
-				.repositorySlug().orElseThrow());
-	}
-
-	@Test
-	void derivesTheOwnerAndRepositoryFromAnEnterpriseHost() {
-		assertEquals("adamw7/tools", new AdoptionContext("https://github.example.com/adamw7/tools.git", workspace)
-				.repositorySlug().orElseThrow());
-	}
-
-	/**
-	 * A filesystem path names no owner, so reading its last two segments as one
-	 * would point a tool at a repository that does not exist. Reporting no slug
-	 * leaves the caller to fall back to its own inference.
-	 */
-	@Test
-	void aUrlWithNoHostNamesNoOwner() {
-		assertTrue(new AdoptionContext("/tmp/workspace/tools", workspace).repositorySlug().isEmpty());
-		assertTrue(new AdoptionContext("file:///tmp/tools", workspace).repositorySlug().isEmpty());
-		assertTrue(new AdoptionContext("tools", workspace).repositorySlug().isEmpty());
+		assertThrows(IllegalArgumentException.class, () -> new AdoptionContext(REPOSITORY_URL, null));
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -134,15 +134,6 @@ class GitHubRepoAdopterTest {
 	 * TrustStep writes to the real ~/.claude.json — touch anything outside the test.
 	 */
 	@Test
-	void withDefaultPipelineRunsTheDefaultStepsStartingWithTheToolchainCheck() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "missing"));
-		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner);
-		assertThrows(AdoptionException.class, () -> adopter.adopt(context));
-		assertEquals(List.of("git", "--version"), runner.commandAt(0));
-	}
-
-	@Test
 	void withDefaultPipelineHonoursPullRequestOptionsAndTheAssetsFlag() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(
 				command -> new CommandResult(command, 1, "missing"));
@@ -153,7 +144,8 @@ class GitHubRepoAdopterTest {
 
 	@Test
 	void defaultPipelineBranchesCommitsPushesAndOpensAPullRequest() {
-		List<String> names = GitHubRepoAdopter.defaultSteps().stream().map(AdoptionStep::name).toList();
+		List<String> names = GitHubRepoAdopter.defaultSteps(PullRequestOptions.defaults(), false).stream()
+				.map(AdoptionStep::name).toList();
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
 				"commit", "enforcer", "commit", "verify", "push", "pull-request"), names);
 	}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
@@ -1,0 +1,100 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class RepositoryUrlTest {
+
+	/**
+	 * An empty last segment would resolve the checkout onto the workspace itself,
+	 * so the clone would land beside the other repositories the workspace holds
+	 * instead of in its own directory.
+	 */
+	@Test
+	void aUrlWithNoRepositoryNameIsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> RepositoryUrl.of("https://github.com/adamw7//"));
+		assertThrows(IllegalArgumentException.class, () -> RepositoryUrl.of("https://github.com/adamw7/.git"));
+	}
+
+	@Test
+	void aUrlWhoseNameIsADirectoryAliasIsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> RepositoryUrl.of(".."));
+		assertThrows(IllegalArgumentException.class, () -> RepositoryUrl.of("."));
+	}
+
+	@Test
+	void rejectsBlankUrl() {
+		assertThrows(IllegalArgumentException.class, () -> RepositoryUrl.of("  "));
+	}
+
+	@Test
+	void rejectsNullUrl() {
+		assertThrows(IllegalArgumentException.class, () -> RepositoryUrl.of(null));
+	}
+
+	@Test
+	void trimsAndKeepsUrl() {
+		assertEquals("https://github.com/adamw7/tools.git",
+				RepositoryUrl.of("  https://github.com/adamw7/tools.git  ").value());
+	}
+
+	@Test
+	void derivesTheNameFromAnHttpsUrl() {
+		assertEquals("tools", RepositoryUrl.of("https://github.com/adamw7/tools.git").name());
+		assertEquals("tools", RepositoryUrl.of("https://github.com/adamw7/tools").name());
+		assertEquals("tools", RepositoryUrl.of("https://github.com/adamw7/tools/").name());
+	}
+
+	@Test
+	void derivesTheNameFromAnSshUrl() {
+		assertEquals("tools", RepositoryUrl.of("git@github.com:adamw7/tools.git").name());
+	}
+
+	@Test
+	void derivesTheNameFromANestedGroupUrl() {
+		assertEquals("tools", RepositoryUrl.of("https://gitlab.com/group/subgroup/tools.git").name());
+	}
+
+	@Test
+	void keepsDotsInTheNameThatAreNotTheGitSuffix() {
+		assertEquals("my.tool", RepositoryUrl.of("https://github.com/adamw7/my.tool.git").name());
+	}
+
+	@Test
+	void derivesTheOwnerAndRepositoryFromAnHttpsUrl() {
+		assertEquals("adamw7/tools", RepositoryUrl.of("https://github.com/adamw7/tools.git").slug().orElseThrow());
+		assertEquals("adamw7/tools", RepositoryUrl.of("https://github.com/adamw7/tools").slug().orElseThrow());
+		assertEquals("adamw7/tools", RepositoryUrl.of("https://github.com/adamw7/tools/").slug().orElseThrow());
+	}
+
+	/**
+	 * The scp-like form separates the host from the path with ':', not '/', so a
+	 * naive split on '/' alone would read the host and owner as one segment.
+	 */
+	@Test
+	void derivesTheOwnerAndRepositoryFromSshForms() {
+		assertEquals("adamw7/tools", RepositoryUrl.of("git@github.com:adamw7/tools.git").slug().orElseThrow());
+		assertEquals("adamw7/tools", RepositoryUrl.of("ssh://git@github.com/adamw7/tools.git").slug().orElseThrow());
+	}
+
+	@Test
+	void derivesTheOwnerAndRepositoryFromAnEnterpriseHost() {
+		assertEquals("adamw7/tools",
+				RepositoryUrl.of("https://github.example.com/adamw7/tools.git").slug().orElseThrow());
+	}
+
+	/**
+	 * A filesystem path names no owner, so reading its last two segments as one
+	 * would point a tool at a repository that does not exist. Reporting no slug
+	 * leaves the caller to fall back to its own inference.
+	 */
+	@Test
+	void aUrlWithNoHostNamesNoOwner() {
+		assertTrue(RepositoryUrl.of("/tmp/workspace/tools").slug().isEmpty());
+		assertTrue(RepositoryUrl.of("file:///tmp/tools").slug().isEmpty());
+		assertTrue(RepositoryUrl.of("tools").slug().isEmpty());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersionTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersionTest.java
@@ -1,0 +1,78 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+class EnforcerRuleVersionTest {
+
+	/**
+	 * The rule must be pinned to the version Maven filtered into
+	 * {@code adopt-build.properties} — the release actually running the adoption —
+	 * rather than a hardcoded literal that drifts as the project is versioned.
+	 */
+	@Test
+	void readsTheFilteredBuildVersion() throws IOException {
+		assertEquals(filteredRuleVersion(), EnforcerRuleVersion.fromBuildMetadata());
+	}
+
+	/**
+	 * A snapshot resolves from the adopter's local repository and nowhere else, so
+	 * wiring one in would open a pull request that only builds on the machine that
+	 * opened it.
+	 */
+	@Test
+	void aSnapshotRuleVersionIsRefused() {
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> EnforcerRuleVersion.requireRelease("2.6.0-SNAPSHOT"));
+		assertTrue(thrown.getMessage().contains("2.6.0-SNAPSHOT"), thrown.getMessage());
+	}
+
+	@Test
+	void aReleaseRuleVersionIsAccepted() {
+		assertEquals("2.6.0", EnforcerRuleVersion.requireRelease("2.6.0"));
+	}
+
+	/**
+	 * The version the default installer wires in must go through the release guard,
+	 * so a snapshot build cannot put an unresolvable dependency into an adopted POM.
+	 * Whether that refuses or returns depends on how this module was built, so the
+	 * assertion pins the composition rather than one fixed outcome.
+	 */
+	@Test
+	void theDefaultVersionGoesThroughTheReleaseGuard() {
+		assertEquals(outcomeOf(() -> EnforcerRuleVersion.requireRelease(EnforcerRuleVersion.fromBuildMetadata())),
+				outcomeOf(EnforcerRuleVersion::release));
+	}
+
+	private String outcomeOf(Supplier<String> version) {
+		try {
+			return "wired " + version.get();
+		} catch (AdoptionException e) {
+			return "refused: " + e.getMessage();
+		}
+	}
+
+	private String filteredRuleVersion() throws IOException {
+		try (InputStream stream = getClass().getResourceAsStream(EnforcerRuleVersion.BUILD_PROPERTIES)) {
+			assertNotNull(stream, EnforcerRuleVersion.BUILD_PROPERTIES + " must be filtered onto the test classpath");
+			Properties properties = new Properties();
+			properties.load(stream);
+			String version = properties.getProperty(EnforcerRuleVersion.RULE_VERSION_KEY, "").strip();
+			assertFalse(version.isEmpty() || version.startsWith("${"),
+					"enforcer.rule.version must be filtered to a concrete version, was: " + version);
+			return version;
+		}
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -374,16 +374,6 @@ class PomEnforcerInstallerTest {
 		assertFalse(result.endsWith("\n"), "a POM with no trailing newline must not gain one");
 	}
 
-	/**
-	 * The default installer must pin the rule to the version Maven filtered into
-	 * {@code adopt-build.properties} — the release actually running the adoption —
-	 * rather than a hardcoded literal that drifts as the project is versioned.
-	 */
-	@Test
-	void defaultInstallerReadsTheFilteredBuildVersion() throws IOException {
-		assertEquals(filteredRuleVersion(), PomEnforcerInstaller.buildRuleVersion());
-	}
-
 	@Test
 	void aReleaseRuleVersionIsPinnedIntoThePom(@TempDir Path dir) throws IOException {
 		Path pom = write(dir, POM_WITH_BUILD);
@@ -391,43 +381,6 @@ class PomEnforcerInstallerTest {
 		String result = Files.readString(pom);
 		assertTrue(result.contains("tools.claude-code-enforcer"));
 		assertTrue(result.contains("<version>4.1.0</version>"), result);
-	}
-
-	/**
-	 * A snapshot resolves from the adopter's local repository and nowhere else, so
-	 * wiring one in would open a pull request that only builds on the machine that
-	 * opened it.
-	 */
-	@Test
-	void aSnapshotRuleVersionIsRefused() {
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> PomEnforcerInstaller.requireReleaseVersion("2.6.0-SNAPSHOT"));
-		assertTrue(thrown.getMessage().contains("2.6.0-SNAPSHOT"), thrown.getMessage());
-	}
-
-	@Test
-	void aReleaseRuleVersionIsAccepted() {
-		assertEquals("2.6.0", PomEnforcerInstaller.requireReleaseVersion("2.6.0"));
-	}
-
-	/**
-	 * The version the default installer wires in must go through the release guard,
-	 * so a snapshot build cannot put an unresolvable dependency into an adopted POM.
-	 * Whether that refuses or returns depends on how this module was built, so the
-	 * assertion pins the composition rather than one fixed outcome.
-	 */
-	@Test
-	void theDefaultVersionGoesThroughTheReleaseGuard() {
-		assertEquals(outcomeOf(() -> PomEnforcerInstaller.requireReleaseVersion(PomEnforcerInstaller.buildRuleVersion())),
-				outcomeOf(PomEnforcerInstaller::releaseRuleVersion));
-	}
-
-	private String outcomeOf(Supplier<String> version) {
-		try {
-			return "wired " + version.get();
-		} catch (AdoptionException e) {
-			return "refused: " + e.getMessage();
-		}
 	}
 
 	/**
@@ -440,17 +393,5 @@ class PomEnforcerInstallerTest {
 		Path pom = write(dir, POM_WITH_BUILD);
 		installer.install(pom);
 		assertFalse(new PomEnforcerInstaller().install(pom));
-	}
-
-	private String filteredRuleVersion() throws IOException {
-		try (InputStream stream = getClass().getResourceAsStream(PomEnforcerInstaller.BUILD_PROPERTIES)) {
-			assertNotNull(stream, PomEnforcerInstaller.BUILD_PROPERTIES + " must be filtered onto the test classpath");
-			Properties properties = new Properties();
-			properties.load(stream);
-			String version = properties.getProperty(PomEnforcerInstaller.RULE_VERSION_KEY, "").strip();
-			assertFalse(version.isEmpty() || version.startsWith("${"),
-					"enforcer.rule.version must be filtered to a concrete version, was: " + version);
-			return version;
-		}
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -2,16 +2,12 @@ package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Properties;
-import java.util.function.Supplier;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -93,7 +93,8 @@ class PullRequestStepTest {
 	@Test
 	void usesConfiguredTitleAndBody() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
-		new PullRequestStep("My title", "My body").execute(context, runner);
+		new PullRequestStep(PullRequestOptions.builder().title("My title").body("My body").build())
+				.execute(context, runner);
 		assertEquals(List.of("gh", "pr", "create", "--title", "My title", "--body", "My body", "--head",
 				"claude/adopt-claude-code", "--repo", "adamw7/tools"), runner.commandAt(1));
 	}


### PR DESCRIPTION
PomEnforcerInstaller carried three jobs in 450 lines: resolving the enforcer
rule version, reading and writing a POM verbatim, and the actual wiring. The
first two move to EnforcerRuleVersion and PomDocument, leaving an installer
that is only about finding or creating the enforcer plugin and appending the
rule to it.

AdoptionContext was half a git-URL parser. That parsing moves to a
RepositoryUrl value type, so the context is the shared pipeline inputs its
name promises and the URL forms are tested directly.

Also removes duplication the earlier passes left behind:

- ToolProbe.isInstalled owns the --version probe, so BuildToolchainStep no
  longer spells the flag out itself.
- Failures.alsoRun replaces the run-cleanup-without-replacing-the-failure
  idiom that Main and ClaudeInitStep each implemented.
- Workspaces.resolveNamed and CliArguments both read a blank input as absent
  through Text, the one place that rule is defined.
- Drops three public entry points no production code called
  (GitHubRepoAdopter.withDefaultPipeline(runner), defaultSteps(), and
  PullRequestStep(title, body)); their tests use the real overloads.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018EmixNCtXyDWsYY9JByuef