### PR TITLE
refactor(adopt): simplify the adoption pipeline without changing behaviour

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionFiles.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionFiles.java
@@ -12,13 +12,11 @@ import java.nio.file.Path;
  * has to wrap for itself.
  *
  * <p>Every write creates the file's parent directories first, so an asset nested
- * in a directory the checkout does not carry yet ({@code .claude/hooks/}) and a
- * report named under a path that does not exist are both written rather than
- * failing on the missing parent.
- *
- * <p>The {@code description} names the file in the failure message the way the
- * operator thinks of it — "POM", "CLAUDE.md", "the adoption report" — because a
- * bare path does not say what the adoption was trying to do with it.
+ * in a directory the checkout does not carry yet ({@code .claude/hooks/}) is
+ * written rather than failing on the missing parent. The {@code description} names
+ * the file in the failure message the way the operator thinks of it — "POM",
+ * "CLAUDE.md", "the adoption report" — because a bare path does not say what the
+ * adoption was trying to do with it.
  */
 public final class AdoptionFiles {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReport.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReport.java
@@ -7,15 +7,13 @@ import java.util.Optional;
 /**
  * The machine-readable outcome of an adoption run: the steps that completed, in
  * order, and the URL of the pull request the run opened (or found already open).
- * {@link GitHubRepoAdopter#adopt} fills one in and returns it, so callers — the
- * command line, the MCP server, or any embedding code — can report what happened
- * without scraping logs. The pull-request URL is absent until a step records it,
- * for example when the pipeline is configured without a pull-request step.
+ * {@link GitHubRepoAdopter#adopt} fills one in and returns it, so callers can
+ * report what happened without scraping logs. The pull-request URL is absent until
+ * a step records it.
  *
- * <p>A report is also filled in for a run that fails part-way: the steps that did
- * complete stay recorded and the failing step's message is recorded as the run's
- * failure, so the report distinguishes a completed adoption from an abandoned one
- * instead of looking like a short but successful run.
+ * <p>A run that fails part-way is reported too: the steps that did complete stay
+ * recorded and the failing step's message becomes the run's failure, so an
+ * abandoned adoption cannot look like a short but successful one.
  */
 public final class AdoptionReport {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -26,28 +26,25 @@ import io.github.adamw7.tools.adopt.step.VerifyStep;
 /**
  * Runs the ordered pipeline that adopts Claude Code into a GitHub repository:
  * check the required tools are installed, clone, check the cloned project's own
- * build tool is installed too, create a feature branch, mark
- * the checkout trusted for Claude Code, generate {@code CLAUDE.md} with
- * {@code claude init}, normalise that file and add a companion {@code AGENTS.md}
- * so it satisfies the guard the adoption is about to wire in, and commit it, wire
- * in the {@code claude-code-enforcer} and
- * commit that, verify the enforcer passes on the generated file, then push the
- * branch and open a pull request. The toolchain check runs first so a missing
- * {@code git}, {@code claude}, or {@code gh} fails the adoption before any
- * expensive work, and the build-tool check follows the clone — the first moment
- * the project's build system is known — so a missing {@code mvn} or {@code gradle}
- * fails before the {@code claude init} rather than at the verification.
- * The adoption never writes to the default branch. Steps and the
- * command runner are injected so the pipeline is easy to reconfigure and to test.
+ * build tool is installed too, create a feature branch, mark the checkout trusted
+ * for Claude Code, generate {@code CLAUDE.md} with {@code claude init}, normalise
+ * it and add a companion {@code AGENTS.md} so it satisfies the guard the adoption
+ * is about to wire in, commit it, wire in the {@code claude-code-enforcer} and
+ * commit that, verify the guard passes, then push the branch and open a pull
+ * request. The toolchain check runs first so a missing {@code git},
+ * {@code claude}, or {@code gh} fails before any expensive work, and the
+ * build-tool check follows the clone — the first moment the project's build system
+ * is known — so a missing {@code mvn} or {@code gradle} fails before the
+ * {@code claude init} rather than at the verification. The adoption never writes
+ * to the default branch. Steps and the command runner are injected so the pipeline
+ * is easy to reconfigure and to test.
  *
  * <p>Each run returns an {@link AdoptionReport} of the steps that completed and
- * the pull request's URL, so callers can act on the outcome without scraping
- * logs. A caller that needs the report of a run that <em>fails</em> — the case
- * where knowing how far the pipeline got matters most — supplies its own report
- * to {@link #adopt(AdoptionContext, AdoptionReport)} and still holds it after the
- * failure propagates. The default pipeline can optionally include an
- * {@link AssetsStep} that commits starter Claude Code configuration assets
- * alongside the generated {@code CLAUDE.md}.
+ * the pull request's URL, so callers can act on the outcome without scraping logs.
+ * A caller that needs the report of a run that <em>fails</em> supplies its own to
+ * {@link #adopt(AdoptionContext, AdoptionReport)} and still holds it after the
+ * failure propagates. The default pipeline optionally includes an
+ * {@link AssetsStep} that commits starter Claude Code configuration assets.
  */
 public class GitHubRepoAdopter {
 
@@ -123,10 +120,10 @@ public class GitHubRepoAdopter {
 	}
 
 	/**
-	 * Names the failing step alongside the failure, because an exception message
-	 * alone — {@code "The requested URL returned error: 403"} — does not say which
-	 * stage of the adoption produced it. An exception carrying no message at all
-	 * falls back to its type, so the report never records a bare {@code null}.
+	 * Names the failing step alongside the failure, because a message alone —
+	 * {@code "The requested URL returned error: 403"} — does not say which stage
+	 * produced it. An exception with no message falls back to its type, so the
+	 * report never records a bare {@code null}.
 	 */
 	private String describe(AdoptionStep step, RuntimeException failure) {
 		String message = failure.getMessage();

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -7,12 +7,10 @@ import java.util.stream.Stream;
 /**
  * A repository clone URL, parsed once into the two facts the adoption needs from
  * it: the repository name the checkout directory is created under, and the
- * {@code owner/repository} slug the steps name their target repository with.
- *
- * <p>Both are derived up front so a malformed URL fails on the adoption's input
- * rather than several steps later, and so {@link AdoptionContext} can stay what
- * its name says it is — the inputs the pipeline shares — instead of also being a
- * git-URL parser.
+ * {@code owner/repository} slug the steps name their target repository with. Both
+ * are derived up front so a malformed URL fails on the adoption's input rather
+ * than several steps later, and so {@link AdoptionContext} can stay the inputs the
+ * pipeline shares instead of also being a git-URL parser.
  */
 public final class RepositoryUrl {
 
@@ -50,10 +48,9 @@ public final class RepositoryUrl {
 	}
 
 	/**
-	 * @return the {@code owner/repository} the URL names, for the steps that must
-	 *         tell a tool which repository to act on rather than let it guess from
-	 *         the checkout's git remote; empty when the URL carries no host and so
-	 *         names no owner
+	 * @return the {@code owner/repository} the URL names, for the steps that tell a
+	 *         tool which repository to act on rather than let it guess from the
+	 *         checkout's git remote; empty when the URL names no owner
 	 */
 	public Optional<String> slug() {
 		return Optional.ofNullable(slug);
@@ -67,11 +64,10 @@ public final class RepositoryUrl {
 
 	/**
 	 * A URL whose last segment is empty or a directory alias — {@code .../repo//},
-	 * {@code .../.git}, or a bare {@code ..} — would otherwise resolve the checkout
-	 * onto the workspace itself or above it, so the clone would land beside the
-	 * other repositories the workspace holds instead of in its own directory.
-	 * Rejecting it here fails the adoption on its input rather than several steps
-	 * later on a checkout directory nobody intended.
+	 * {@code .../.git}, or a bare {@code ..} — would resolve the checkout onto the
+	 * workspace itself or above it, so the clone would land beside the other
+	 * repositories the workspace holds. Rejecting it fails the adoption on its input
+	 * rather than several steps later on a checkout directory nobody intended.
 	 */
 	private static String requireName(String name, String repositoryUrl) {
 		if (name.isEmpty() || ".".equals(name) || "..".equals(name)) {
@@ -84,16 +80,13 @@ public final class RepositoryUrl {
 	/**
 	 * Derives {@code owner/repository} from the clone URL, covering the forms git
 	 * accepts: {@code https://host/owner/repo.git}, {@code ssh://git@host/owner/repo},
-	 * and the scp-like {@code git@host:owner/repo}. The scheme is dropped and the
-	 * remainder split on both separators, so the scp-like form's {@code ':'} is
-	 * treated as the path separator it is.
+	 * and the scp-like {@code git@host:owner/repo} — hence splitting on both
+	 * separators, so that form's {@code ':'} is the path separator it is.
 	 *
-	 * <p>A URL is only read as naming an owner when a host segment precedes the last
-	 * two — the segment before the owner must look like a hostname. Without that
-	 * check a plain filesystem path such as {@code /tmp/workspace/repo} would yield
-	 * the nonsense slug {@code workspace/repo}, and a step would confidently point a
-	 * tool at a repository that does not exist; an empty result instead leaves the
-	 * step to fall back to its own inference.
+	 * <p>A URL only names an owner when a host-looking segment precedes the last two.
+	 * Without that check a plain filesystem path such as {@code /tmp/workspace/repo}
+	 * would yield the nonsense slug {@code workspace/repo} and point a tool at a
+	 * repository that does not exist; an empty result leaves the step to infer.
 	 *
 	 * @return the slug, or {@code null} when the URL names no owner
 	 */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
@@ -12,19 +12,15 @@ import java.util.Optional;
  * left the choice open. Shared by the command-line entry point and the MCP
  * server, so both resolve workspaces identically.
  *
- * <p>A workspace that cannot be created — the caller named a path that is already
- * a regular file, or one the process may not write — fails with an
- * {@link AdoptionException} like every other adoption failure, rather than
- * surfacing a raw {@link java.io.UncheckedIOException} through the command line
- * and the MCP tool.
+ * <p>A workspace that cannot be created — an existing regular file, or a path the
+ * process may not write — fails with an {@link AdoptionException} like every other
+ * adoption failure rather than a raw {@link java.io.UncheckedIOException}.
  *
  * <p>The returned path is always absolute. The clone step runs {@code git clone}
- * with the workspace as its working directory and the checkout directory
- * ({@code workspace/name}) as the clone target, so a relative workspace would
- * make git resolve that target against the working directory a second time and
- * nest the checkout under {@code workspace/workspace/name}, leaving every later
- * step unable to find it. Absolutising the workspace up front — the temporary
- * directory already is — keeps both entry points on the same, unambiguous path.
+ * with the workspace as its working directory and {@code workspace/name} as the
+ * clone target, so a relative workspace would make git resolve that target against
+ * the working directory a second time and nest the checkout under
+ * {@code workspace/workspace/name}, leaving every later step unable to find it.
  */
 public final class Workspaces {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
@@ -20,19 +20,16 @@ import java.util.stream.Stream;
  * such as {@code mvn} or {@code claude} routinely resolves to a {@code .cmd} or
  * {@code .bat} shim, which the underlying {@code CreateProcess} call cannot
  * start: it appends {@code .exe} to an extensionless name and refuses to run a
- * batch script directly, so a bare {@code mvn} fails with "Cannot run program".
- * This resolver searches the {@code PATH} using {@code PATHEXT} and, when the
- * program is a batch script, rewrites the command to run through
- * {@code cmd.exe /c}; a real executable is rewritten to its resolved absolute
- * path. A program that cannot be located is returned unchanged, so the caller
- * still fails with its usual "could not start" error rather than being masked
- * here.
+ * batch script, so a bare {@code mvn} fails with "Cannot run program". This
+ * resolver searches the {@code PATH} using {@code PATHEXT} and rewrites a batch
+ * script to run through {@code cmd.exe /c}, a real executable to its resolved
+ * absolute path. A program that cannot be located is returned unchanged, so the
+ * caller still fails with its usual "could not start" error.
  *
  * <p>Only the program name is ever routed through {@code cmd.exe}; the arguments
- * are handed to {@link ProcessBuilder} unchanged. Free-form arguments such as a
- * pull-request title or body therefore never reach the command interpreter,
- * because {@code git} and {@code gh} resolve to real {@code .exe} files rather
- * than to batch scripts.
+ * reach {@link ProcessBuilder} unchanged. Free-form arguments such as a
+ * pull-request title therefore never reach the command interpreter, because
+ * {@code git} and {@code gh} resolve to real {@code .exe} files.
  */
 final class ExecutableResolver {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -10,17 +10,15 @@ import io.github.adamw7.tools.adopt.AdoptionException;
 
 /**
  * {@link CommandRunner} backed by {@link ProcessBuilder}. Standard error is
- * merged into standard output so a caller gets a single, ordered transcript of
- * what the command printed. Every command is bounded by a timeout so a hung
- * child — a stalled {@code git clone} or a stuck {@code claude} invocation —
- * cannot block the adoption forever: on expiry the whole process tree is
- * destroyed and the failure is reported with whatever output was captured so
- * far.
+ * merged into standard output so a caller gets a single, ordered transcript.
+ * Every command is bounded by a timeout so a hung child — a stalled
+ * {@code git clone}, a stuck {@code claude} — cannot block the adoption forever:
+ * on expiry the whole process tree is destroyed and the failure is reported with
+ * whatever output was captured.
  *
  * <p>The child's standard input is closed as soon as it starts, so a tool that
- * reads from it — a {@code git} credential prompt, a {@code gh} authentication
- * prompt — sees end-of-stream and fails fast instead of blocking on an input
- * that never arrives until the timeout kills it.
+ * reads from it — a {@code git} or {@code gh} credential prompt — sees
+ * end-of-stream and fails fast instead of blocking until the timeout kills it.
  */
 public class ProcessCommandRunner implements CommandRunner {
 
@@ -50,14 +48,9 @@ public class ProcessCommandRunner implements CommandRunner {
 		ProcessBuilder builder = new ProcessBuilder(resolver.resolve(command))
 				.directory(workingDirectory.toFile())
 				.redirectErrorStream(true);
-		return execute(builder, command);
-	}
-
-	private CommandResult execute(ProcessBuilder builder, List<String> command) {
 		Process process = start(builder, command);
 		closeStandardInput(process, command);
-		StreamGobbler output = StreamGobbler.consuming(process.getInputStream());
-		return await(process, command, output);
+		return await(process, command, StreamGobbler.consuming(process.getInputStream()));
 	}
 
 	private Process start(ProcessBuilder builder, List<String> command) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -15,14 +16,12 @@ import java.time.Duration;
  * the background lets {@link ProcessCommandRunner} time out and destroy the
  * child while its partial output is still recovered.
  *
- * <p>The stream is copied verbatim as it is read — every byte the child emits is
- * preserved, including its own line terminators and any trailing newline — so the
- * captured transcript reflects exactly what the command printed rather than a
- * re-joined approximation. {@link #output()} bounds its wait for the reader
- * thread: a direct child can exit while a descendant it spawned keeps the output
- * pipe open, in which case the stream never reaches end-of-stream; the bounded
- * join stops that from hanging the caller forever and still returns whatever was
- * captured before the wait elapsed.
+ * <p>The stream is copied verbatim as it is read — the child's own line
+ * terminators and any trailing newline survive — so the transcript is what the
+ * command printed rather than a re-joined approximation. {@link #output()} bounds
+ * its wait for the reader thread: a direct child can exit while a descendant it
+ * spawned keeps the pipe open, and the bounded join returns what was captured
+ * instead of hanging the caller forever.
  */
 final class StreamGobbler {
 
@@ -34,7 +33,9 @@ final class StreamGobbler {
 	static final Duration JOIN_TIMEOUT = Duration.ofSeconds(5);
 
 	private final Thread thread;
-	private final StringBuilder output = new StringBuilder();
+
+	/** Written by the reader thread and read by {@link #output()}, so its buffer must be synchronized. */
+	private final StringWriter output = new StringWriter();
 
 	private StreamGobbler(InputStream stream) {
 		this.thread = new Thread(() -> drain(stream), "adopt-stream-gobbler");
@@ -49,16 +50,13 @@ final class StreamGobbler {
 
 	/**
 	 * @return everything the stream produced, waiting up to {@link #JOIN_TIMEOUT}
-	 *         for it to reach end-of-stream. Destroying the process closes the
-	 *         stream, so this returns promptly once a timed-out child has been
-	 *         killed; a descendant that keeps the pipe open only delays it by the
-	 *         bounded wait rather than blocking forever.
+	 *         for end-of-stream. Destroying the process closes the stream, so a
+	 *         killed child returns promptly and a descendant holding the pipe open
+	 *         only costs the bounded wait.
 	 */
 	String output() {
 		join();
-		synchronized (output) {
-			return output.toString();
-		}
+		return output.toString();
 	}
 
 	private void join() {
@@ -71,24 +69,9 @@ final class StreamGobbler {
 
 	private void drain(InputStream stream) {
 		try (Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
-			copy(reader);
+			reader.transferTo(output);
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
-		}
-	}
-
-	private void copy(Reader reader) throws IOException {
-		char[] buffer = new char[8192];
-		int read = reader.read(buffer);
-		while (read != -1) {
-			append(buffer, read);
-			read = reader.read(buffer);
-		}
-	}
-
-	private void append(char[] buffer, int length) {
-		synchronized (output) {
-			output.append(buffer, 0, length);
 		}
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -22,13 +22,11 @@ import io.github.adamw7.tools.mcp.ToolResult;
 
 /**
  * The MCP tool that runs the adoption pipeline: given a GitHub repository URL —
- * plus optional workspace, branch, pull-request metadata, and the flag for the
- * starter-assets step — it adopts Claude Code into the repository exactly as the
- * command line does and answers with the run's JSON {@link AdoptionReport},
- * including the opened pull request's URL. The pipeline itself is injected
- * behind the {@link Pipeline} seam, so tests exercise the argument mapping and
- * the result shape without cloning anything; the default wiring runs the real
- * default pipeline against a {@link ProcessCommandRunner}.
+ * plus optional workspace, branch, pull-request metadata, and the starter-assets
+ * flag — it adopts Claude Code exactly as the command line does and answers with
+ * the run's JSON {@link AdoptionReport}. The pipeline is injected behind the
+ * {@link Pipeline} seam so tests exercise the argument mapping without cloning
+ * anything; the default wiring runs it against a {@link ProcessCommandRunner}.
  */
 public class AdoptTool implements McpTool {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractBuildSystemStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractBuildSystemStep.java
@@ -17,10 +17,9 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * all three acting on the same build tool, so the guard that is wired in is the
  * guard that is verified with the tool that was probed.
  *
- * <p>Detection only comes up empty when a step is configured with a build-system
- * list that has no catch-all fallback — {@link BuildSystems#DEFAULTS} always
- * matches — in which case the step is skipped with a warning rather than failing
- * the adoption.
+ * <p>Detection only comes up empty for a step configured with a build-system list
+ * that has no catch-all fallback ({@link BuildSystems#DEFAULTS} always matches),
+ * in which case the step is skipped with a warning rather than failing the run.
  */
 public abstract class AbstractBuildSystemStep extends AbstractCommandStep {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
@@ -13,11 +13,9 @@ import java.util.List;
  * so the configuration is shared with all contributors rather than living only
  * in the adopter's local checkout.
  *
- * <p>The repository-relative paths the adoption writes are all named here,
- * including the generated {@code CLAUDE.md}. That one is not a starter asset —
- * {@link ClaudeInitStep} generates it and {@link ClaudeMdConformanceStep}
- * reshapes it — but keeping its name beside the others stops the same literal
- * being spelled out in every step that refers to it.
+ * <p>Every repository-relative path the adoption writes is named here, including
+ * the generated {@code CLAUDE.md} — not a starter asset, but keeping its name
+ * beside the others stops the literal being spelled out in every step.
  */
 public final class AdoptionAssets {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetInstaller.java
@@ -11,15 +11,10 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
 /**
  * Writes one starter asset file into a checkout: the file's repository-relative
  * path, its content, and whether it must be executable (for hook scripts).
- * Installation is deliberately conservative: a file that already exists is never
- * overwritten — the project's own version always wins over the starter content —
- * so re-running the adoption, or adopting a repository that already configured
- * Claude Code, leaves the checkout untouched.
- *
- * <p>Which of the two happened is logged here rather than by each caller, so
- * every asset the adoption writes — the starter files, the companion
- * {@code AGENTS.md}, and the fallback guard's workflow and script — is reported
- * the same way.
+ * Installation is deliberately conservative: an existing file is never
+ * overwritten — the project's own version always wins — so re-adopting a
+ * repository leaves the checkout untouched. Which of the two happened is logged
+ * here rather than by each caller, so every asset is reported the same way.
  */
 public class AssetInstaller {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
@@ -17,19 +17,16 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * branch and opens a pull request from it, leaving the default branch untouched.
  *
  * <p>{@code -B} resets the branch to the current {@code HEAD} whether or not it
- * already exists, so re-running the adoption against a checkout that already
- * carries the branch starts the feature branch afresh rather than aborting on an
- * "already exists" failure.
+ * already exists, so re-running the adoption starts the feature branch afresh
+ * rather than aborting on an "already exists" failure.
  *
- * <p>A checkout that carries no local branch yet but whose {@code origin} already
- * publishes one — a fresh clone re-adopting a repository an earlier run already
- * pushed, which is what the default temporary workspace produces on every run —
- * starts the branch from that published tip instead of from {@code HEAD}. Without
- * it the branch would restart at the default branch, and {@link PushStep} would
- * be rejected as a non-fast-forward, so a second adoption could never get past
- * the push even though every other step is idempotent. A local branch that
- * already exists is left to the plain {@code -B} above, so unpushed work in a
- * reused workspace is never reset onto the remote.
+ * <p>A checkout with no local branch yet but whose {@code origin} already
+ * publishes one — a fresh clone re-adopting a repository an earlier run pushed,
+ * which the default temporary workspace produces on every run — starts from that
+ * published tip instead of {@code HEAD}. Otherwise the branch would restart at the
+ * default branch and {@link PushStep} would be rejected as a non-fast-forward, so
+ * a second adoption could never get past the push. An existing local branch is
+ * left to the plain {@code -B}, so unpushed work is never reset onto the remote.
  */
 public class BranchStep extends AbstractCommandStep {
 
@@ -57,7 +54,7 @@ public class BranchStep extends AbstractCommandStep {
 	/**
 	 * @return the published branch to start from, or empty when the checkout
 	 *         already carries the branch locally or {@code origin} does not publish
-	 *         it yet — in both cases the branch starts from {@code HEAD} as before.
+	 *         it yet — in both cases the branch starts from {@code HEAD}
 	 */
 	private Optional<String> startPoint(AdoptionContext context, CommandRunner runner) {
 		if (hasLocalBranch(context, runner) || !hasRemoteBranch(context, runner)) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -33,14 +33,10 @@ public interface BuildSystem {
 	List<String> verifyCommand();
 
 	/**
-	 * The program {@link #verifyCommand()} launches and that must therefore be
-	 * installed for the verification to run at all, so {@link BuildToolchainStep}
+	 * The program {@link #verifyCommand()} launches, so {@link BuildToolchainStep}
 	 * can probe it before the pipeline spends a {@code claude init} on a checkout it
-	 * will not be able to verify.
-	 *
-	 * <p>The verification launches the first word of its own command, so that is
-	 * what the default probes; a build system whose guard needs nothing installed
-	 * overrides this with an empty answer.
+	 * will not be able to verify. The verification launches the first word of its
+	 * own command, so that is what the default probes.
 	 *
 	 * @return the program to probe, or empty when the verification needs nothing
 	 *         beyond the POSIX shell every supported platform already provides

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
@@ -15,17 +15,14 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * clone has revealed which one it is. {@link ToolchainStep} can only probe the
  * pipeline's own {@code git}/{@code claude}/{@code gh} because the checkout does
  * not exist yet, but {@link VerifyStep} later shells out to {@code mvn} or
- * {@code gradle} — so without this step a machine without the adopted project's
- * build tool fails at verification, after a full {@code claude init}, a reshaped
- * {@code CLAUDE.md}, and two commits have already been made. That is exactly the
- * late failure the toolchain check exists to prevent.
+ * {@code gradle} — so without this step a machine missing that build tool fails at
+ * verification, after a full {@code claude init} and two commits: exactly the late
+ * failure the toolchain check exists to prevent.
  *
- * <p>The step runs directly after {@link CloneStep} and detects the build system
- * through {@link AbstractBuildSystemStep} exactly as {@link EnforcerStep} and
- * {@link VerifyStep} do, so the tool it probes is the tool the verification will
- * actually run. A build system that needs no installed tool — the
- * {@link FallbackBuildSystem}, whose guard runs through {@code sh} — is a no-op,
- * mirroring how the step is skipped when no build system matches at all.
+ * <p>The build system is detected through {@link AbstractBuildSystemStep} just as
+ * {@link EnforcerStep} and {@link VerifyStep} detect it, so the tool probed is the
+ * tool the verification runs. A build system that needs none — the
+ * {@link FallbackBuildSystem}, whose guard runs through {@code sh} — is a no-op.
  */
 public class BuildToolchainStep extends AbstractBuildSystemStep {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -28,26 +28,15 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * <p>A repository that already carries a {@code .claude/CLAUDE.md} steers
  * headless {@code /init} into <em>updating that file</em> rather than writing the
  * root {@code CLAUDE.md} the adoption needs — and a write under {@code .claude/}
- * is refused as a sensitive path in headless mode, so the run exits cleanly
- * having produced nothing. That existing memory file is therefore moved out of
- * the checkout before {@code /init} runs, so the CLI takes its fresh-repository
- * path and writes the root {@code CLAUDE.md}, and restored afterwards; the
- * adoption commits only the new root file and leaves the project's own
- * {@code .claude/CLAUDE.md} untouched. The file is put back whether the CLI
- * succeeded or failed, and a restore that fails on the failure path is attached to
- * the original failure rather than replacing it.
+ * is refused as a sensitive path in headless mode, so the run produces nothing.
+ * That memory file is therefore moved aside before {@code /init} runs and
+ * restored afterwards, on the failure path too, so the project's own copy is left
+ * untouched. A run that exits cleanly but leaves no {@code CLAUDE.md} behind
+ * aborts the adoption rather than pushing an empty pull request.
  *
- * <p>The generated {@code CLAUDE.md} is the whole point of the adoption, so a run
- * that exits cleanly but leaves no {@code CLAUDE.md} behind aborts the adoption
- * rather than letting the pipeline push a branch and open a pull request with
- * nothing in it.
- *
- * <p>The step is idempotent, like every other step in the pipeline: a checkout
- * that already carries a root {@code CLAUDE.md} is left alone rather than
- * regenerated. The CLI's output is not reproducible, so regenerating would
- * rewrite the file on every re-run — discarding any edit the project made to it
- * since the adoption and adding a second commit with the same message for a
- * change nobody asked for.
+ * <p>The step is idempotent: a checkout that already carries a root
+ * {@code CLAUDE.md} is left alone, because the CLI's output is not reproducible
+ * and regenerating would discard whatever the project has edited since.
  */
 public class ClaudeInitStep extends AbstractCommandStep {
 
@@ -102,14 +91,10 @@ public class ClaudeInitStep extends AbstractCommandStep {
 	}
 
 	/**
-	 * Moves an existing {@code .claude/CLAUDE.md} out of the checkout so headless
-	 * {@code /init} writes the root {@code CLAUDE.md} instead of trying — and
-	 * failing — to update the sensitive-path memory file. The backup lands in the
-	 * system temp directory rather than the checkout so a later {@code git add -A}
-	 * cannot pick it up.
+	 * Moves an existing {@code .claude/CLAUDE.md} out of the checkout, into the
+	 * system temp directory so a later {@code git add -A} cannot pick it up.
 	 *
-	 * @return the backup location when a memory file was moved aside, empty when
-	 *         the checkout carried none and nothing had to be relocated
+	 * @return the backup location, or empty when the checkout carried no such file
 	 */
 	private Optional<Path> relocateExistingClaudeDirMemory(Path checkout) {
 		Path memory = claudeDirMemory(checkout);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
@@ -17,15 +17,12 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * satisfies the {@code claudeMdFormat} rule {@link EnforcerStep} wires into the
  * build, and writes a companion {@code AGENTS.md} so the reference the rule
  * expects resolves to a real file. Without it the adoption fails its own
- * {@link VerifyStep}, because a generic {@code claude init} produces natural,
- * project-specific headings and no {@code AGENTS.md} reference while the rule
- * demands a fixed set of headings plus that reference.
+ * {@link VerifyStep}.
  *
- * <p>The step runs before the first commit so the normalised {@code CLAUDE.md}
- * and its companion {@code AGENTS.md} are committed together. It never overwrites
- * an {@code AGENTS.md} the project already carries, and reshaping an already
- * conforming {@code CLAUDE.md} leaves it unchanged, so the step is idempotent on
- * re-adoption.
+ * <p>The step runs before the first commit so both files are committed together.
+ * It never overwrites an {@code AGENTS.md} the project already carries, and
+ * reshaping an already conforming {@code CLAUDE.md} leaves it unchanged, so the
+ * step is idempotent on re-adoption.
  */
 public class ClaudeMdConformanceStep implements AdoptionStep {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -14,32 +13,17 @@ import java.util.stream.IntStream;
  * Reshapes the {@code CLAUDE.md} that {@link ClaudeInitStep} generated so it
  * satisfies the {@code claudeMdFormat} rule {@link EnforcerStep} wires into the
  * build. A generic {@code claude init} writes natural, project-specific headings
- * ({@code ## Project purpose}, {@code ## Maven module structure}) and no
- * {@code AGENTS.md} reference, but the rule demands a fixed set of whole-line
- * headings plus that reference — so without this reshape the adoption fails its
- * own {@link VerifyStep}.
+ * ({@code ## Project purpose}) and no {@code AGENTS.md} reference, but the rule
+ * demands a fixed set of whole-line headings plus that reference — so without
+ * this reshape the adoption fails its own {@link VerifyStep}.
  *
- * <p>The reshape is deterministic and conservative. It guarantees the
- * {@code # CLAUDE.md} title is the first non-blank line, that {@code AGENTS.md}
- * is referenced, and that every required section heading is present with a body.
- * A heading that is a near-miss of a required one — the required heading followed
- * by extra words, or the same text in a different case — is <em>renamed</em> in
- * place, preserving the content beneath it; only a required heading with no such
- * near-miss is appended as a fresh stub. A required heading that ends up with an
- * empty section — a renamed near-miss the generated document left bare, or a
- * heading immediately followed by its sibling — gets a stub body, because the
- * rule fails an empty section just as it fails a missing one. Headings inside
- * fenced code blocks are left alone, mirroring how the rule matches, so a
- * {@code ##} line in a code sample is never mistaken for document structure.
- *
- * <p>A fence the generated document opened but never closed is closed first, so
- * the sections appended below it are document structure rather than more code.
- * Without that the rule — which reads fences exactly the same way — sees every
- * appended heading as part of the unterminated block and reports all of them
- * missing, and each re-run appends another unreachable copy.
- *
- * <p>Running the reshape again on an already-conforming document is a no-op
- * (beyond normalising a missing or doubled trailing newline), so re-adopting a
+ * <p>The reshape is deterministic and conservative: a near-miss heading is
+ * <em>renamed</em> in place so its body survives, only a genuinely absent section
+ * is appended, and a required section left empty gets a stub body because the
+ * rule fails an empty section just as it fails a missing one. Fenced code is left
+ * alone, mirroring how the rule matches, and an unterminated fence is closed
+ * first so appended sections are document structure rather than more code.
+ * Reshaping an already-conforming document is a no-op, so re-adopting a
  * repository does not churn the file.
  */
 public class ClaudeMdConformer {
@@ -87,10 +71,9 @@ public class ClaudeMdConformer {
 	}
 
 	/**
-	 * Closes a fence the document opened and never closed, so everything appended
-	 * below it lands outside the block. The closing marker is the one the fence was
-	 * opened with, and a document whose fences already balance is returned untouched,
-	 * so the reshape stays idempotent.
+	 * Closes a fence the document opened and never closed — with the marker it was
+	 * opened with — so everything appended below lands outside the block. A document
+	 * whose fences balance is returned untouched, keeping the reshape idempotent.
 	 */
 	private List<String> closeUnterminatedFence(List<String> lines) {
 		String open = scanFences(lines).openAtEnd();
@@ -106,9 +89,7 @@ public class ClaudeMdConformer {
 		if (TITLE.equals(firstNonBlank(lines))) {
 			return lines;
 		}
-		List<String> result = new ArrayList<>();
-		result.add(TITLE);
-		result.add("");
+		List<String> result = new ArrayList<>(List.of(TITLE, ""));
 		result.addAll(lines);
 		return result;
 	}
@@ -139,7 +120,7 @@ public class ClaudeMdConformer {
 	}
 
 	private void canonicalize(List<String> lines, boolean[] fence, String required, Set<Integer> claimed) {
-		if (hasHeading(lines, fence, required)) {
+		if (indexOfHeading(lines, fence, required) >= 0) {
 			return;
 		}
 		int index = firstNearMatch(lines, fence, required, claimed);
@@ -150,38 +131,29 @@ public class ClaudeMdConformer {
 	}
 
 	private int firstNearMatch(List<String> lines, boolean[] fence, String required, Set<Integer> claimed) {
-		return matchesOutsideFences(lines, fence, line -> isNearMatch(line, required))
+		return matchesOutsideFences(lines, fence, line -> isNearMatch(line.strip(), required))
 				.filter(index -> !claimed.contains(index))
 				.findFirst()
 				.orElse(-1);
 	}
 
-	private boolean isNearMatch(String line, String required) {
-		String stripped = line.strip();
-		return isHeading(stripped) && nearMatches(stripped, required);
-	}
-
 	/**
-	 * A heading is a near-miss of a required one when it is the required heading in
-	 * a different case, or the required heading followed by a space and extra words
-	 * — the two shapes {@code claude init} actually produces ({@code ## Project
-	 * purpose} for {@code ## Project}, {@code ## Principles for Java development}
-	 * for {@code ## Principles for Java Development}). The trailing space keeps
+	 * A near-miss is the required heading in a different case, or followed by a
+	 * space and extra words — the two shapes {@code claude init} produces
+	 * ({@code ## Project purpose} for {@code ## Project}). The trailing space keeps
 	 * {@code ## Maven} from matching an unrelated {@code ## Mavenish} heading.
 	 */
-	private boolean nearMatches(String heading, String required) {
-		String actual = heading.toLowerCase(Locale.ROOT);
+	private boolean isNearMatch(String stripped, String required) {
+		String actual = stripped.toLowerCase(Locale.ROOT);
 		String wanted = required.toLowerCase(Locale.ROOT);
-		return actual.equals(wanted) || actual.startsWith(wanted + " ");
+		return isHeading(stripped) && (actual.equals(wanted) || actual.startsWith(wanted + " "));
 	}
 
 	/**
-	 * Gives every required section both a heading and a body. A section the
-	 * document does not carry at all is appended with a stub body; one whose
-	 * heading the document supplied but left bare — typically a near-miss renamed
-	 * in place above — has a stub inserted beneath it. The rule fails an empty
-	 * section just as it fails a missing one, so the two cases are settled together
-	 * rather than in separate passes.
+	 * Gives every required section both a heading and a body: an absent section is
+	 * appended with a stub, and a heading the document left bare — typically a
+	 * near-miss renamed in place above — has one inserted beneath it. The rule fails
+	 * an empty section just as it fails a missing one, so both are settled here.
 	 */
 	private List<String> ensureRequiredSections(List<String> lines) {
 		List<String> result = new ArrayList<>(lines);
@@ -200,51 +172,29 @@ public class ClaudeMdConformer {
 		boolean[] fence = fenceMask(lines);
 		int index = indexOfHeading(lines, fence, required);
 		if (index < 0) {
-			appendSection(lines, required);
+			lines.addAll(List.of("", required, "", STUB_BODY));
 		} else if (!hasBody(lines, fence, index)) {
-			insertStubBody(lines, index);
+			lines.addAll(index + 1, List.of("", STUB_BODY));
 		}
-	}
-
-	private void appendSection(List<String> lines, String section) {
-		lines.add("");
-		lines.add(section);
-		lines.add("");
-		lines.add(STUB_BODY);
-	}
-
-	private void insertStubBody(List<String> lines, int headingIndex) {
-		lines.add(headingIndex + 1, "");
-		lines.add(headingIndex + 2, STUB_BODY);
 	}
 
 	/**
 	 * Mirrors how the rule decides a section is non-empty: before the next heading
 	 * at its own level or shallower, the section must carry prose, a code block, or
-	 * a deeper sub-heading. Blank lines are neither, so the scan looks past them.
+	 * a deeper sub-heading. Blank lines are neither, so the scan looks past them and
+	 * the first line that decides settles the section.
 	 */
 	private boolean hasBody(List<String> lines, boolean[] fence, int headingIndex) {
 		int level = headingLevel(lines.get(headingIndex).strip());
 		return IntStream.range(headingIndex + 1, lines.size())
-				.mapToObj(index -> classifyBodyLine(lines, fence, index, level))
-				.flatMap(Optional::stream)
-				.findFirst()
-				.orElse(false);
+				.filter(index -> fence[index] || !lines.get(index).isBlank())
+				.limit(1)
+				.anyMatch(index -> fence[index] || isBodyLine(lines.get(index).strip(), level));
 	}
 
-	/**
-	 * @return whether the line is the section's body ({@code true}) or ends it
-	 *         ({@code false}), or empty when it is blank and so decides neither
-	 */
-	private Optional<Boolean> classifyBodyLine(List<String> lines, boolean[] fence, int index, int level) {
-		if (fence[index]) {
-			return Optional.of(true);
-		}
-		String line = lines.get(index).strip();
-		if (isHeading(line)) {
-			return Optional.of(headingLevel(line) > level);
-		}
-		return line.isEmpty() ? Optional.empty() : Optional.of(true);
+	/** A deeper sub-heading continues the section; one at its level or shallower ends it. */
+	private boolean isBodyLine(String line, int level) {
+		return !isHeading(line) || headingLevel(line) > level;
 	}
 
 	private int headingLevel(String heading) {
@@ -253,14 +203,11 @@ public class ClaudeMdConformer {
 
 	private List<String> ensureAgentsReference(List<String> lines) {
 		boolean[] fence = fenceMask(lines);
-		if (containsOutsideFences(lines, fence, AGENTS_REFERENCE)) {
+		if (matchesOutsideFences(lines, fence, line -> line.contains(AGENTS_REFERENCE)).findAny().isPresent()) {
 			return lines;
 		}
 		List<String> result = new ArrayList<>(lines);
-		int titleIndex = indexOfTitle(result, fence);
-		result.add(titleIndex + 1, "");
-		result.add(titleIndex + 2, AGENTS_REFERENCE_LINE);
-		result.add(titleIndex + 3, "");
+		result.addAll(titleIndex(result, fence) + 1, List.of("", AGENTS_REFERENCE_LINE, ""));
 		return result;
 	}
 
@@ -269,21 +216,13 @@ public class ClaudeMdConformer {
 	 * would itself be a non-blank line before it, so the title can never be one the
 	 * mask covers. A document with no title line at all falls back to the top.
 	 */
-	private int indexOfTitle(List<String> lines, boolean[] fence) {
+	private int titleIndex(List<String> lines, boolean[] fence) {
 		return Math.max(indexOfHeading(lines, fence, TITLE), 0);
-	}
-
-	private boolean hasHeading(List<String> lines, boolean[] fence, String heading) {
-		return indexOfHeading(lines, fence, heading) >= 0;
 	}
 
 	/** @return the index of the heading outside code fences, or {@code -1} when absent */
 	private int indexOfHeading(List<String> lines, boolean[] fence, String heading) {
 		return matchesOutsideFences(lines, fence, line -> line.strip().equals(heading)).findFirst().orElse(-1);
-	}
-
-	private boolean containsOutsideFences(List<String> lines, boolean[] fence, String token) {
-		return matchesOutsideFences(lines, fence, line -> line.contains(token)).findFirst().isPresent();
 	}
 
 	/** The indices of the lines outside code fences whose text matches, in document order. */
@@ -330,11 +269,7 @@ public class ClaudeMdConformer {
 			return marker;
 		}
 		mask[index] = true;
-		return sameMarker(marker, open) ? null : open;
-	}
-
-	private boolean sameMarker(String marker, String open) {
-		return marker != null && marker.charAt(0) == open.charAt(0);
+		return open.equals(marker) ? null : open;
 	}
 
 	private String fenceMarker(String line) {
@@ -347,15 +282,8 @@ public class ClaudeMdConformer {
 		return null;
 	}
 
+	/** Joins the lines under a single trailing newline, dropping any blank lines the reshape left at the end. */
 	private String join(List<String> lines) {
-		return String.join("\n", withoutTrailingBlanks(lines)) + "\n";
-	}
-
-	private List<String> withoutTrailingBlanks(List<String> lines) {
-		int end = lines.size();
-		while (end > 0 && lines.get(end - 1).isBlank()) {
-			end--;
-		}
-		return lines.subList(0, end);
+		return String.join("\n", lines).replaceAll("\\n\\s*+\\z", "") + "\n";
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
@@ -18,11 +18,10 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * git's locale or version and the pipeline stays idempotent when re-run.
  *
  * <p>The adoption runs headless — on a CI runner or an MCP server — where git may
- * have no configured {@code user.name}/{@code user.email}, in which case
- * {@code git commit} aborts with "Author identity unknown". Each identity git is
- * missing is supplied for the commit alone with a {@code -c} override, so the
- * commit succeeds on a bare host while any identity the checkout already
- * configures is left in force rather than overridden.
+ * have no configured {@code user.name}/{@code user.email} and {@code git commit}
+ * aborts with "Author identity unknown". Each missing identity is supplied for the
+ * commit alone with a {@code -c} override, so the commit succeeds on a bare host
+ * while an identity the checkout already configures stays in force.
  */
 public class CommitStep extends AbstractCommandStep {
 
@@ -64,27 +63,17 @@ public class CommitStep extends AbstractCommandStep {
 	}
 
 	private List<String> commitCommand(AdoptionContext context, CommandRunner runner) {
-		List<String> command = new ArrayList<>();
-		command.add("git");
-		command.addAll(identityOverrides(context, runner));
-		command.add("commit");
-		command.add("-m");
-		command.add(message);
+		List<String> command = new ArrayList<>(List.of("git"));
+		addOverrideIfMissing(command, context, runner, "user.name", FALLBACK_NAME);
+		addOverrideIfMissing(command, context, runner, "user.email", FALLBACK_EMAIL);
+		command.addAll(List.of("commit", "-m", message));
 		return command;
 	}
 
-	private List<String> identityOverrides(AdoptionContext context, CommandRunner runner) {
-		List<String> overrides = new ArrayList<>();
-		addOverrideIfMissing(overrides, context, runner, "user.name", FALLBACK_NAME);
-		addOverrideIfMissing(overrides, context, runner, "user.email", FALLBACK_EMAIL);
-		return overrides;
-	}
-
-	private void addOverrideIfMissing(List<String> overrides, AdoptionContext context, CommandRunner runner,
+	private void addOverrideIfMissing(List<String> command, AdoptionContext context, CommandRunner runner,
 			String key, String fallback) {
 		if (!hasConfig(context, runner, key)) {
-			overrides.add("-c");
-			overrides.add(key + "=" + fallback);
+			command.addAll(List.of("-c", key + "=" + fallback));
 		}
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
@@ -35,12 +35,11 @@ final class EnforcerRuleVersion {
 	}
 
 	/**
-	 * A snapshot resolves from the adopter's own local repository but from nowhere
-	 * else, so wiring one in would open a pull request that builds on this machine
-	 * and fails for the adopted project's CI and every one of its contributors —
-	 * and {@link VerifyStep} could not catch it, because it too resolves against the
-	 * local repository. Refusing here turns that into an immediate, explicable
-	 * failure for the person running the adoption.
+	 * A snapshot resolves from the adopter's own local repository and nowhere else,
+	 * so wiring one in would open a pull request that builds here and fails for the
+	 * adopted project's CI and every contributor — and {@link VerifyStep} could not
+	 * catch it, resolving against the same local repository. Refusing here turns
+	 * that into an immediate, explicable failure.
 	 */
 	static String requireRelease(String version) {
 		if (version.endsWith(SNAPSHOT_SUFFIX)) {
@@ -54,12 +53,10 @@ final class EnforcerRuleVersion {
 	}
 
 	/**
-	 * Reads the enforcer rule version wired into adopted POMs from the build
-	 * metadata that Maven filters into {@value #BUILD_PROPERTIES} at build time, so
-	 * the dependency is pinned to the exact {@code tools} release running the
-	 * adoption — and is therefore resolvable from the same repository that
-	 * published it — rather than to a hardcoded literal that silently drifts as the
-	 * project is versioned.
+	 * Reads the rule version from the metadata Maven filters into
+	 * {@value #BUILD_PROPERTIES} at build time, so the dependency is pinned to the
+	 * exact {@code tools} release running the adoption — resolvable from the
+	 * repository that published it — rather than to a literal that silently drifts.
 	 */
 	static String fromBuildMetadata() {
 		try (InputStream stream = EnforcerRuleVersion.class.getResourceAsStream(BUILD_PROPERTIES)) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
@@ -13,8 +13,8 @@ import java.util.Optional;
  *
  * <p>The guard is a GitHub Actions workflow and the portable shell script it runs,
  * installed with {@link WorkflowGuardInstaller}; the verification runs that same
- * script locally so a missing or empty {@code CLAUDE.md} fails the adoption before
- * the branch is pushed, exactly as it would in CI afterwards.
+ * script locally, so a missing or empty {@code CLAUDE.md} fails the adoption
+ * before the branch is pushed, exactly as it would in CI afterwards.
  */
 public class FallbackBuildSystem implements BuildSystem {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -9,26 +9,22 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
 /**
  * Appends a {@code CLAUDE.md} guard task to a Gradle build script so the adopted
  * repository fails its build when the generated {@code CLAUDE.md} is missing or
- * empty. Unlike the Maven path — which wires the full {@code claude-code-enforcer}
- * format rule — Gradle has no such rule available, so the guard is a
- * dependency-free presence-and-non-empty check written directly into the build
- * script.
+ * empty. Gradle has no {@code claude-code-enforcer} equivalent, so the guard is a
+ * dependency-free presence-and-non-empty check rather than the full format rule
+ * the Maven path wires in.
  *
- * <p>The correct syntax is chosen from the script's extension: the Kotlin DSL
- * ({@code build.gradle.kts}) and the Groovy DSL ({@code build.gradle}) differ.
- * The block is appended rather than parsed in because Gradle scripts are code,
- * not data, and a self-contained task needs no structural edit. The install is
- * idempotent: a script that already declares the {@value #GUARD_TASK} task is
- * left untouched.
+ * <p>The syntax is chosen from the script's extension, since the Kotlin
+ * ({@code build.gradle.kts}) and Groovy ({@code build.gradle}) DSLs differ. The
+ * block is appended rather than parsed in because Gradle scripts are code, not
+ * data. The install is idempotent: a script that already declares the
+ * {@value #GUARD_TASK} task is left untouched.
  *
  * <p>The file to check is resolved while the task is being <em>configured</em> and
  * only read inside {@code doLast}, so the task body captures a plain
  * {@link java.io.File} rather than reaching back into the {@code Project} at
- * execution time. Gradle's configuration cache — on by default from Gradle 9, and
- * widely opted into before that — rejects a task that holds a script or
- * {@code Project} reference, and would otherwise fail the guard task in the Groovy
- * DSL and the whole build in the Kotlin one, aborting the adoption at
- * {@link GradleBuildSystem#verifyCommand()} and breaking {@code check} for every
+ * execution time. Gradle's configuration cache rejects a task that holds a script
+ * or {@code Project} reference, which would abort the adoption at
+ * {@link GradleBuildSystem#verifyCommand()} and break {@code check} for every
  * contributor afterwards.
  */
 public class GradleGuardInstaller {
@@ -89,12 +85,10 @@ public class GradleGuardInstaller {
 	}
 
 	/**
-	 * The task name has to appear in a registration for the script to count as
-	 * guarded, and comment lines are skipped, so a script that merely mentions
-	 * {@value #GUARD_TASK} — in a {@code // TODO} note, or in a declaration someone
-	 * commented out — is still given the task. Matching the bare name anywhere would
-	 * leave such a script without the task {@link GradleBuildSystem#verifyCommand()}
-	 * is about to run, failing the adoption at its verification step.
+	 * The task name only counts when it appears in a registration outside a comment,
+	 * so a script that merely mentions {@value #GUARD_TASK} — in a {@code // TODO},
+	 * or in a declaration someone commented out — is still given the task rather
+	 * than left without the one {@link GradleBuildSystem#verifyCommand()} runs.
 	 */
 	private boolean declaresGuard(String script) {
 		return DECLARATION.matcher(withoutCommentLines(script)).find();
@@ -105,22 +99,14 @@ public class GradleGuardInstaller {
 	 * spread over several lines is still recognised.
 	 */
 	private String withoutCommentLines(String script) {
-		return script.lines().filter(line -> !isCommentLine(line)).collect(Collectors.joining("\n"));
-	}
-
-	private boolean isCommentLine(String line) {
-		return line.strip().startsWith(LINE_COMMENT);
+		return script.lines().filter(line -> !line.strip().startsWith(LINE_COMMENT)).collect(Collectors.joining("\n"));
 	}
 
 	private String blockFor(Path buildFile) {
 		return buildFile.getFileName().toString().endsWith(KOTLIN_SUFFIX) ? KOTLIN_BLOCK : GROOVY_BLOCK;
 	}
 
-	/**
-	 * The appended block's LF line terminators are rewritten to match the ones the
-	 * script already uses, so appending the guard to a CRLF build script does not
-	 * leave the new region with LF endings mixed into an otherwise CRLF file.
-	 */
+	/** The block's LF terminators are rewritten to the script's own, so a CRLF file stays CRLF throughout. */
 	private void append(Path buildFile, String existing, String block) {
 		AdoptionFiles.write(buildFile, existing + LineTerminators.matching(block, existing), BUILD_FILE_DESCRIPTION);
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/LineTerminators.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/LineTerminators.java
@@ -18,24 +18,14 @@ final class LineTerminators {
 	private LineTerminators() {
 	}
 
-	/** The terminator the text uses: CRLF when it carries one, LF otherwise. */
-	static String of(String text) {
-		return text.contains(CRLF) ? CRLF : LF;
-	}
-
 	/**
-	 * Rewrites every line terminator in {@code text} to {@code terminator}. The text
-	 * is normalised to LF first, so a text that already mixes terminators — assembled
-	 * from a converted body and a part carried over verbatim — is not
-	 * double-converted where it already ended in the target terminator.
+	 * Rewrites {@code text}'s line terminators to the one {@code sample} already
+	 * uses: CRLF when the sample carries one, LF otherwise. The text is normalised
+	 * to LF first, so one that already mixes terminators — assembled from a
+	 * converted body and a part carried over verbatim — is not double-converted.
 	 */
-	static String apply(String text, String terminator) {
-		String normalized = text.replace(CRLF, LF).replace(CR, LF);
-		return LF.equals(terminator) ? normalized : normalized.replace(LF, terminator);
-	}
-
-	/** Rewrites {@code text}'s line terminators to the one {@code sample} already uses. */
 	static String matching(String text, String sample) {
-		return apply(text, of(sample));
+		String normalized = text.replace(CRLF, LF).replace(CR, LF);
+		return sample.contains(CRLF) ? normalized.replace(LF, CRLF) : normalized;
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -3,9 +3,10 @@ package io.github.adamw7.tools.adopt.step;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
@@ -37,14 +38,11 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
  *
  * <p>Each appended element is preceded by a newline and an indentation matching
  * the document's own unit (detected from the file, defaulting to two spaces), and
- * is inserted before the parent's own closing indentation so that closing tag
- * stays put. Every container is attached to its parent before its children are
- * added, so an element's depth — and therefore its indentation — is known as soon
- * as it is appended.
- *
- * <p>The edit is performed on the JDK's DOM so no third-party XML library is
- * needed, and is namespace-aware so new elements join the POM's default
- * namespace.
+ * is inserted before the parent's closing indentation so that closing tag stays
+ * put. Every container is attached to its parent before its children are added,
+ * so an element's depth — and therefore its indentation — is known as soon as it
+ * is appended. The edit runs on the JDK's namespace-aware DOM, so no third-party
+ * XML library is needed and new elements join the POM's default namespace.
  */
 final class PomDocument {
 
@@ -94,12 +92,10 @@ final class PomDocument {
 	}
 
 	static List<Element> children(Element parent, String name) {
-		List<Element> matches = new ArrayList<>();
-		NodeList nodes = parent.getChildNodes();
-		for (int index = 0; index < nodes.getLength(); index++) {
-			addIfMatch(matches, nodes.item(index), name);
-		}
-		return matches;
+		return childNodes(parent)
+				.filter(node -> node instanceof Element element && name.equals(element.getLocalName()))
+				.map(Element.class::cast)
+				.toList();
 	}
 
 	/** @return the element's {@code artifactId} text, when it declares one */
@@ -112,27 +108,21 @@ final class PomDocument {
 	}
 
 	/**
-	 * Writes the document back verbatim. The transformer's own indentation is left
-	 * off and the parsed whitespace nodes are kept, so only the elements the edit
-	 * added differ from the original. The original's XML declaration and trailing
-	 * newline are carried over exactly so the first and last lines are not disturbed
-	 * either.
-	 *
-	 * <p>XML parsing normalizes {@code \r\n} to {@code \n}, so the DOM the
-	 * transformer serializes has lost the original terminator;
-	 * {@link LineTerminators} puts it back, keeping a CRLF POM on CRLF rather than
-	 * silently flipping every line to LF and reformatting the whole file.
+	 * Writes the document back verbatim: the transformer's own indentation is left
+	 * off and the parsed whitespace nodes are kept, so only the added elements
+	 * differ from the original, whose XML declaration and trailing newline are
+	 * carried over exactly. XML parsing normalizes {@code \r\n} to {@code \n}, so
+	 * {@link LineTerminators} puts the original terminator back rather than flipping
+	 * a CRLF POM to LF and reformatting the whole file.
 	 */
 	void write() {
-		String content = declarationPrefix() + serialize();
-		String withTrailingNewline = matchTrailingNewline(content);
-		AdoptionFiles.write(file, LineTerminators.matching(withTrailingNewline, original), DESCRIPTION);
+		String content = matchTrailingNewline(declarationPrefix() + serialize());
+		AdoptionFiles.write(file, LineTerminators.matching(content, original), DESCRIPTION);
 	}
 
-	private static void addIfMatch(List<Element> matches, Node node, String name) {
-		if (node instanceof Element element && name.equals(element.getLocalName())) {
-			matches.add(element);
-		}
+	private static Stream<Node> childNodes(Element parent) {
+		NodeList nodes = parent.getChildNodes();
+		return IntStream.range(0, nodes.getLength()).mapToObj(nodes::item);
 	}
 
 	private Element appendChild(Element parent, Element child) {
@@ -177,14 +167,11 @@ final class PomDocument {
 	 * element's leading whitespace, or two spaces when the POM carries none.
 	 */
 	private static String detectIndentUnit(Element root) {
-		NodeList children = root.getChildNodes();
-		for (int index = 0; index < children.getLength(); index++) {
-			String unit = leadingIndentOf(children.item(index));
-			if (!unit.isEmpty()) {
-				return unit;
-			}
-		}
-		return DEFAULT_INDENT_UNIT;
+		return childNodes(root)
+				.map(PomDocument::leadingIndentOf)
+				.filter(unit -> !unit.isEmpty())
+				.findFirst()
+				.orElse(DEFAULT_INDENT_UNIT);
 	}
 
 	private static String leadingIndentOf(Node node) {
@@ -227,16 +214,12 @@ final class PomDocument {
 
 	private String serialize() {
 		try {
-			return transformBody();
+			StringWriter writer = new StringWriter();
+			transformer().transform(new DOMSource(document), new StreamResult(writer));
+			return writer.toString();
 		} catch (TransformerException e) {
 			throw new AdoptionException("Could not write POM: " + file, e);
 		}
-	}
-
-	private String transformBody() throws TransformerException {
-		StringWriter writer = new StringWriter();
-		transformer().transform(new DOMSource(document), new StreamResult(writer));
-		return writer.toString();
 	}
 
 	private static Transformer transformer() throws TransformerException {
@@ -249,10 +232,9 @@ final class PomDocument {
 	}
 
 	/**
-	 * The XML declaration the original file opened with, up to and including its
-	 * line terminator, or empty when it had none. Carrying it over verbatim keeps
-	 * the transformer from inventing one (and adding a spurious first-line change)
-	 * on a POM that started straight with {@code <project>}.
+	 * The XML declaration the original opened with, up to and including its line
+	 * terminator, or empty when it had none — so the transformer cannot invent one
+	 * (a spurious first-line change) on a POM that started with {@code <project>}.
 	 */
 	private String declarationPrefix() {
 		if (!original.stripLeading().startsWith("<?xml")) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -26,28 +26,21 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  *
  * <p>The step stays idempotent when re-run: it asks {@code gh pr list --state
  * open} whether an <em>open</em> pull request already exists for the branch and
- * skips creation when one does, rather than creating unconditionally and then
- * matching the wording of a failure. Scoping the query to open pull requests
- * matters because a branch whose earlier pull request was closed or merged still
- * needs a fresh one — {@code gh pr view <branch>} would report that stale closed
- * pull request as if it were current and wrongly skip creation. That keeps the
- * decision robust across {@code gh} versions and locales.
+ * skips creation when one does, rather than matching the wording of a failure.
+ * Scoping the query to open pull requests matters because a branch whose earlier
+ * pull request was closed or merged still needs a fresh one.
  *
  * <p>Both commands name the target repository with {@code --repo} rather than
- * letting {@code gh} infer it from the checkout's git remote. The adoption
- * already knows which repository it is adopting, and the remote is not always
- * readable as a GitHub one: a {@code url.<base>.insteadOf} rewrite, an
- * organisation mirror, or a proxied clone leaves {@code gh} reporting that "none
- * of the git remotes configured for this repository point to a known GitHub
- * host", which would fail the very last step of an otherwise complete adoption.
- * A URL that names no owner leaves the flag off, so {@code gh} falls back to its
- * own inference.
+ * letting {@code gh} infer it from the checkout's git remote, which an
+ * {@code insteadOf} rewrite, an organisation mirror, or a proxied clone can leave
+ * unreadable as a GitHub one — failing the very last step of an otherwise
+ * complete adoption. A URL that names no owner leaves the flag off, so {@code gh}
+ * falls back to its own inference.
  *
- * <p>After the pull request is created (or found already open), the step records
- * its URL in the run's {@link AdoptionReport}. The URL is read back with
- * {@code gh pr list --json url} rather than scraped from {@code gh pr create}'s
- * human-oriented output, so the extraction is one structured path for both the
- * fresh and the re-run case.
+ * <p>The pull request's URL is recorded in the run's {@link AdoptionReport}, read
+ * back with {@code gh pr list --json url} rather than scraped from {@code gh pr
+ * create}'s human-oriented output, so both the fresh and the re-run case take one
+ * structured path.
  */
 public class PullRequestStep extends AbstractCommandStep {
 
@@ -106,24 +99,16 @@ public class PullRequestStep extends AbstractCommandStep {
 	}
 
 	private void addTargetRepository(List<String> command, AdoptionContext context) {
-		context.repositorySlug().ifPresent(slug -> {
-			command.add("--repo");
-			command.add(slug);
-		});
+		context.repositorySlug().ifPresent(slug -> command.addAll(List.of("--repo", slug)));
 	}
 
 	private void addRepeated(List<String> command, String flag, List<String> values) {
-		for (String value : values) {
-			command.add(flag);
-			command.add(value);
-		}
+		values.forEach(value -> command.addAll(List.of(flag, value)));
 	}
 
 	/**
 	 * @return the URL of the branch's open pull request, or empty when none is open
-	 *         (or {@code gh} could not be queried). The query is scoped to open pull
-	 *         requests so a stale closed or merged one for the same branch does not
-	 *         count as already open.
+	 *         or {@code gh} could not be queried
 	 */
 	private Optional<String> openPullRequestUrl(AdoptionContext context, CommandRunner runner) {
 		CommandResult result = runner.run(context.repositoryDirectory(), listCommand(context));
@@ -158,15 +143,15 @@ public class PullRequestStep extends AbstractCommandStep {
 
 	/**
 	 * {@code gh pr list --json} writes a JSON array to stdout, but the captured
-	 * output may carry surrounding noise (for example update notices merged in from
-	 * stderr), so parsing starts at an opening bracket instead of assuming a pure
-	 * JSON payload. Every bracket is tried in turn rather than only the first,
-	 * because a diagnostic printed <em>before</em> the payload can itself contain
-	 * one; stopping at the first would parse the noise, conclude no pull request is
-	 * open, and make the step create a duplicate — which {@code gh} rejects, failing
-	 * an adoption that was only being re-run. The first element's {@code url} is
-	 * returned, or empty when no bracket starts a JSON array, the array is empty, or
-	 * it carries no textual URL.
+	 * output may carry surrounding noise (update notices merged in from stderr), so
+	 * parsing starts at an opening bracket. Every bracket is tried rather than only
+	 * the first, because a diagnostic printed <em>before</em> the payload can itself
+	 * contain one; stopping there would parse the noise, conclude no pull request is
+	 * open, and make the step create a duplicate {@code gh} rejects — failing an
+	 * adoption that was only being re-run.
+	 *
+	 * @return the first element's {@code url}, or empty when no bracket starts a
+	 *         JSON array, the array is empty, or it carries no textual URL
 	 */
 	private Optional<String> extractUrl(String output) {
 		for (int start = output.indexOf('['); start >= 0; start = output.indexOf('[', start + 1)) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
@@ -1,7 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -28,31 +27,25 @@ final class ToolProbe {
 	/**
 	 * @return the tools whose {@code --version} probe could not be run or exited
 	 *         non-zero, in the order they were given. Every tool is probed even
-	 *         after one is found missing, so a single failure can name all of the
-	 *         absent tools at once rather than stopping at the first and hiding the
-	 *         rest.
+	 *         after one is found missing, so a single failure names all of the
+	 *         absent tools at once.
 	 */
 	List<String> missingFrom(List<String> tools, Path directory, CommandRunner runner) {
-		List<String> missing = new ArrayList<>();
-		for (String tool : tools) {
-			collectIfMissing(missing, tool, directory, runner);
-		}
-		return missing;
+		return tools.stream().filter(tool -> !found(tool, directory, runner)).toList();
 	}
 
-	private void collectIfMissing(List<String> missing, String tool, Path directory, CommandRunner runner) {
-		if (isInstalled(tool, directory, runner)) {
+	private boolean found(String tool, Path directory, CommandRunner runner) {
+		boolean installed = isInstalled(tool, directory, runner);
+		if (installed) {
 			log.info("Found required tool: {}", tool);
-		} else {
-			missing.add(tool);
 		}
+		return installed;
 	}
 
 	/**
 	 * @return whether the tool's {@code --version} probe runs and exits zero. The
-	 *         probe's shape lives here rather than at each caller, so
-	 *         {@link ToolchainStep} and {@link BuildToolchainStep} cannot drift apart
-	 *         on how a tool is checked for.
+	 *         probe's shape lives here so {@link ToolchainStep} and
+	 *         {@link BuildToolchainStep} cannot drift apart on it.
 	 */
 	boolean isInstalled(String tool, Path directory, CommandRunner runner) {
 		return succeeds(List.of(tool, VERSION_FLAG), directory, runner);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
@@ -20,16 +20,13 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  *
  * <p>A tool counts as available when its {@code --version} probe starts and exits
  * zero. Every required tool is probed even after one is found missing, so a
- * single failure can name all of the absent tools at once rather than stopping at
- * the first and hiding the rest.
+ * single failure names all of the absent tools at once.
  *
  * <p>Being installed is not enough for {@code gh}: {@code gh --version} succeeds
- * for a GitHub CLI nobody is logged in to, and the adoption would only discover
- * that at {@link PullRequestStep}, its very last step. The login is therefore
- * probed here too, so an unauthenticated {@code gh} fails just as early as an
- * absent one. The adopted project's own build tool is not this step's concern —
- * which one it is only becomes known once the repository is cloned, so
- * {@link BuildToolchainStep} probes it there.
+ * for a GitHub CLI nobody is logged in to, which the adoption would only discover
+ * at {@link PullRequestStep}, its very last step. The login is therefore probed
+ * here too. The adopted project's own build tool only becomes known once the
+ * repository is cloned, so {@link BuildToolchainStep} probes it there.
  */
 public class ToolchainStep implements AdoptionStep {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
@@ -16,19 +16,15 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
  * adoption already targets GitHub repositories, a workflow is a guard every
  * adopted repository can run without introducing a build tool.
  *
- * <p>The workflow and the script it runs are both committed, so the guard is
- * shared with every contributor rather than living only in the adopter's local
- * checkout. The script is the single source of truth: the workflow invokes it and
+ * <p>Both files are committed, so the guard is shared with every contributor. The
+ * script is the single source of truth: the workflow invokes it and
  * {@link FallbackBuildSystem#verifyCommand()} runs the same script locally, so the
  * adoption fails before the branch is pushed just as it would in CI.
  *
- * <p>The two files are installed independently and neither is ever overwritten, so
- * the install is idempotent and a project that already carries a file at one of
- * these paths keeps its own version — the same rule {@link AssetInstaller} applies
- * to every other file the adoption writes. Installing them independently also
- * means a checkout that kept the workflow but lost the script has the script
- * written back, rather than being left for {@link FallbackBuildSystem}'s
- * verification to fail on a file that is not there.
+ * <p>The two are installed independently and neither is ever overwritten — the
+ * rule {@link AssetInstaller} applies to every file the adoption writes — so the
+ * install is idempotent and a checkout that kept the workflow but lost the script
+ * has the script written back rather than failing verification on a missing file.
  */
 public class WorkflowGuardInstaller {
 
@@ -82,14 +78,11 @@ public class WorkflowGuardInstaller {
 	 * project's own workflow.
 	 */
 	private void warnIfWorkflowIsNotOurs(Path repositoryDirectory, boolean workflowWritten) {
-		if (!workflowWritten && !carriesMarker(repositoryDirectory.resolve(WORKFLOW_FILE))) {
+		Path workflowFile = repositoryDirectory.resolve(WORKFLOW_FILE);
+		if (!workflowWritten && !(Files.isRegularFile(workflowFile)
+				&& AdoptionFiles.read(workflowFile, "workflow file").contains(MARKER))) {
 			log.warn("{} already exists and is not the adoption's workflow; left unchanged, so CI may not run {}",
 					WORKFLOW_FILE, SCRIPT_FILE);
 		}
-	}
-
-	private boolean carriesMarker(Path workflowFile) {
-		return Files.isRegularFile(workflowFile)
-				&& AdoptionFiles.read(workflowFile, "workflow file").contains(MARKER);
 	}
 }


### PR DESCRIPTION
Collapse indirection and condense the doc comments across the adopt module,
leaving every rationale that explains a decision but dropping the parts that
restate the code. Net 243 lines lighter with the full test suite unchanged.

Code:
- ClaudeMdConformer: fold the Optional<Boolean> body classifier into a single
  predicate, merge the near-match pair, drop the hasHeading and
  containsOutsideFences wrappers, inline the section append/insert helpers, and
  replace the trailing-blank loop with a regex.
- PomDocument: stream the child nodes instead of two index loops, and merge the
  transformer's serialise pair.
- LineTerminators: collapse of/apply/matching into the one method both callers use.
- ToolProbe, CommitStep, PullRequestStep, GradleGuardInstaller,
  WorkflowGuardInstaller, ProcessCommandRunner: replace accumulator loops and
  single-use helpers with the stream or List.of call they were spelling out.
- StreamGobbler: drain through Reader.transferTo into a StringWriter, dropping
  the hand-rolled buffer copy and its synchronized appends.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T1EG7g8oubqqxix1wNiNxv