### PR TITLE
refactor: cut boilerplate from context, protogen, data and mcp-common

### DIFF
--- a/code/context/src/main/java/io/github/adamw7/context/AbstractFinder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/AbstractFinder.java
@@ -1,8 +1,13 @@
 package io.github.adamw7.context;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 /**
@@ -16,6 +21,8 @@ import java.util.regex.Pattern;
  * which name-based and package-aware resolution differ.
  */
 public abstract class AbstractFinder implements Context {
+
+	private static final Logger log = LogManager.getLogger(AbstractFinder.class.getName());
 
 	protected static final Pattern CLASS_REFERENCE =
 			Pattern.compile("\\b[A-Z][A-Za-z0-9_]*(\\.[A-Z][A-Za-z0-9_]*)*\\b");
@@ -77,6 +84,27 @@ public abstract class AbstractFinder implements Context {
 	 * base class.
 	 */
 	protected abstract Set<ClassContainer> findDirectDependencies(ClassContainer source);
+
+	/**
+	 * Runs {@code resolver} over every class reference in {@code strippedCode},
+	 * keeping the ones that resolve to a container in encounter order. Both finders
+	 * scan identically and differ only in how a single reference resolves, which is
+	 * exactly what {@code resolver} supplies.
+	 */
+	protected Set<ClassContainer> resolveReferences(ClassContainer source, String strippedCode,
+			Function<String, ClassContainer> resolver) {
+		Set<ClassContainer> dependencies = new LinkedHashSet<>();
+		CLASS_REFERENCE.matcher(strippedCode).results()
+				.map(result -> resolver.apply(result.group()))
+				.filter(Objects::nonNull)
+				.forEach(container -> addResolved(container, source, dependencies));
+		return dependencies;
+	}
+
+	private void addResolved(ClassContainer container, ClassContainer source, Set<ClassContainer> dependencies) {
+		log.info("Resolved {} used in {}", container.className(), source.className());
+		dependencies.add(container);
+	}
 
 	protected String stripCommentsAndLiterals(String code) {
 		return COMMENTS_AND_LITERALS.matcher(code).replaceAll(" ");

--- a/code/context/src/main/java/io/github/adamw7/context/Finder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/Finder.java
@@ -1,12 +1,7 @@
 package io.github.adamw7.context;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
 /**
@@ -26,8 +21,6 @@ import java.util.stream.Collectors;
  * {@link PackageAwareFinder}); the first one encountered while indexing wins.
  */
 public class Finder extends AbstractFinder {
-
-	private static final Logger log = LogManager.getLogger(Finder.class.getName());
 
 	private final Map<String, ClassContainer> containersByName;
 	private final Language language;
@@ -50,20 +43,7 @@ public class Finder extends AbstractFinder {
 
 	@Override
 	protected Set<ClassContainer> findDirectDependencies(ClassContainer source) {
-		Set<ClassContainer> dependencies = new LinkedHashSet<>();
-		Matcher matcher = CLASS_REFERENCE.matcher(stripCommentsAndLiterals(source.originalCode()));
-		while (matcher.find()) {
-			addResolved(matcher.group(), source, dependencies);
-		}
-		return dependencies;
-	}
-
-	private void addResolved(String className, ClassContainer source, Set<ClassContainer> dependencies) {
-		ClassContainer container = findContainer(className);
-		if (container != null) {
-			log.info("Found {} used in {}", container.className(), source.className());
-			dependencies.add(container);
-		}
+		return resolveReferences(source, stripCommentsAndLiterals(source.originalCode()), this::findContainer);
 	}
 
 	private ClassContainer findContainer(String className) {

--- a/code/context/src/main/java/io/github/adamw7/context/PackageAwareFinder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/PackageAwareFinder.java
@@ -1,11 +1,5 @@
 package io.github.adamw7.context;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,8 +27,6 @@ import java.util.stream.Collectors;
  * {@link Language} the finder supports.
  */
 public class PackageAwareFinder extends AbstractFinder {
-
-	private static final Logger log = LogManager.getLogger(PackageAwareFinder.class.getName());
 
 	private static final Pattern PACKAGE = Pattern.compile("(?m)^\\s*package\\s+([\\w.]+)");
 
@@ -78,21 +70,7 @@ public class PackageAwareFinder extends AbstractFinder {
 	protected Set<ClassContainer> findDirectDependencies(ClassContainer source) {
 		String code = stripCommentsAndLiterals(source.originalCode());
 		ResolutionScope scope = scopeOf(code);
-		Set<ClassContainer> dependencies = new LinkedHashSet<>();
-		Matcher matcher = CLASS_REFERENCE.matcher(code);
-		while (matcher.find()) {
-			addResolved(matcher.group(), scope, source, dependencies);
-		}
-		return dependencies;
-	}
-
-	private void addResolved(String reference, ResolutionScope scope, ClassContainer source,
-			Set<ClassContainer> dependencies) {
-		ClassContainer container = resolve(outerSimpleName(reference), scope);
-		if (container != null) {
-			log.info("Resolved {} used in {}", container.className(), source.className());
-			dependencies.add(container);
-		}
+		return resolveReferences(source, code, reference -> resolve(outerSimpleName(reference), scope));
 	}
 
 	private String outerSimpleName(String reference) {
@@ -139,8 +117,8 @@ public class PackageAwareFinder extends AbstractFinder {
 	}
 
 	private ResolutionScope scopeOf(String strippedCode) {
-		return new ResolutionScope(packageOf(strippedCode), explicitImports(strippedCode),
-				wildcardPackages(strippedCode));
+		List<String> imports = IMPORT.matcher(strippedCode).results().map(result -> result.group(1)).toList();
+		return new ResolutionScope(packageOf(strippedCode), explicitImports(imports), wildcardPackages(imports));
 	}
 
 	private String packageOf(String strippedCode) {
@@ -148,34 +126,21 @@ public class PackageAwareFinder extends AbstractFinder {
 		return matcher.find() ? matcher.group(1) : "";
 	}
 
-	private Map<String, String> explicitImports(String strippedCode) {
-		Matcher matcher = IMPORT.matcher(strippedCode);
-		Map<String, String> imports = new HashMap<>();
-		while (matcher.find()) {
-			recordExplicitImport(matcher.group(1), imports);
-		}
-		return imports;
+	private Map<String, String> explicitImports(List<String> imports) {
+		return imports.stream()
+				.filter(imported -> !isWildcard(imported))
+				.collect(Collectors.toMap(this::lastSegment, imported -> imported, (first, second) -> second));
 	}
 
-	private void recordExplicitImport(String imported, Map<String, String> imports) {
-		if (!imported.endsWith(".*")) {
-			imports.put(lastSegment(imported), imported);
-		}
+	private List<String> wildcardPackages(List<String> imports) {
+		return imports.stream()
+				.filter(this::isWildcard)
+				.map(imported -> imported.substring(0, imported.length() - 2))
+				.toList();
 	}
 
-	private List<String> wildcardPackages(String strippedCode) {
-		Matcher matcher = IMPORT.matcher(strippedCode);
-		List<String> packages = new ArrayList<>();
-		while (matcher.find()) {
-			recordWildcard(matcher.group(1), packages);
-		}
-		return packages;
-	}
-
-	private void recordWildcard(String imported, List<String> packages) {
-		if (imported.endsWith(".*")) {
-			packages.add(imported.substring(0, imported.length() - 2));
-		}
+	private boolean isWildcard(String imported) {
+		return imported.endsWith(".*");
 	}
 
 	private String lastSegment(String dotted) {

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/ClassInfo.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/ClassInfo.java
@@ -1,7 +1,7 @@
 package io.github.adamw7.tools.code.gen;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
 import com.google.protobuf.Descriptors;
@@ -17,6 +17,7 @@ public class ClassInfo {
 	private final List<FieldDescriptor> requiredFields;
 	private final List<FieldDescriptor> nonOptionalFields;
 	private final List<FieldDescriptor> groupFields;
+	private final List<FieldDescriptor> pureComplexFields;
 
 	private final Descriptor descriptor;
 	private final String inputPkg;
@@ -28,18 +29,11 @@ public class ClassInfo {
 		repeatedFields = getRepeatedFields(descriptor);
 		requiredFields = getRequiredFields(descriptor);
 		groupFields = getGroupFields(descriptor);
+		pureComplexFields = getPureComplexFields(descriptor);
 		this.descriptor = descriptor;
-		this.nonOptionalFields = union(required(), map(), repeated());
+		this.nonOptionalFields = Stream.of(required(), map(), repeated()).flatMap(List::stream).toList();
 		this.inputPkg = inputPkg;
 		this.outputPkg = outputPkg;
-	}
-
-	protected List<FieldDescriptor> union(@SuppressWarnings("unchecked") List<FieldDescriptor>... fieldsLists) {
-		List<FieldDescriptor> all = new ArrayList<>();
-		for (List<FieldDescriptor> fieldsList : fieldsLists) {
-			all.addAll(fieldsList);
-		}
-		return all;
 	}
 
 	private List<FieldDescriptor> getRepeatedFields(Descriptor descriptor) {
@@ -63,14 +57,7 @@ public class ClassInfo {
 	}
 	
 	private static List<FieldDescriptor> getPureComplexFields(Descriptor descriptor) {
-		List<FieldDescriptor> allComplexFields =  descriptor.getFields().stream().filter(ClassInfo::isComplexType).toList();
-		List<FieldDescriptor> pureComplexFields = new ArrayList<>();
-		for (FieldDescriptor field : allComplexFields ) {
-			if (isPure(field)) {
-				pureComplexFields.add(field);
-			}
-		}
-		return pureComplexFields;
+		return descriptor.getFields().stream().filter(ClassInfo::isComplexType).filter(ClassInfo::isPure).toList();
 	}
 
 	private static boolean isPure(FieldDescriptor field) {
@@ -78,13 +65,7 @@ public class ClassInfo {
 	}
 
 	private static List<FieldDescriptor> getGroupFields(Descriptor descriptor) {
-		List<FieldDescriptor> groups = new ArrayList<>();
-		for (Descriptors.FieldDescriptor fieldDescriptor : descriptor.getFields()) {
-			if (isGroup(fieldDescriptor)) {
-				groups.add(fieldDescriptor);
-			}
-		}
-		return groups;
+		return descriptor.getFields().stream().filter(ClassInfo::isGroup).toList();
 	}
 
 	private static boolean isGroup(Descriptors.FieldDescriptor fieldDescriptor) {
@@ -136,7 +117,7 @@ public class ClassInfo {
 	}
 	
 	public List<FieldDescriptor> getPureComplexFields() {
-		return getPureComplexFields(descriptor);
+		return pureComplexFields;
 	}
 
 	private static boolean isComplexType(Descriptors.FieldDescriptor fieldDescriptor) {

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Code.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Code.java
@@ -7,12 +7,13 @@ import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -52,20 +53,14 @@ public class Code {
 		return dir;
 	}
 
+	/** Deletes depth-first — reverse document order puts every child before its parent. */
 	private void deleteRecursively(Path path) throws IOException {
 		if (Files.notExists(path)) {
 			return;
 		}
-		if (Files.isDirectory(path)) {
-			deleteChildren(path);
-		}
-		Files.delete(path);
-	}
-
-	private void deleteChildren(Path directory) throws IOException {
-		try (DirectoryStream<Path> children = Files.newDirectoryStream(directory)) {
-			for (Path child : children) {
-				deleteRecursively(child);
+		try (Stream<Path> tree = Files.walk(path)) {
+			for (Path entry : tree.sorted(Comparator.reverseOrder()).toList()) {
+				Files.delete(entry);
 			}
 		}
 	}

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Implementations.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Implementations.java
@@ -1,7 +1,7 @@
 package io.github.adamw7.tools.code.gen;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.OneofDescriptor;
@@ -12,14 +12,8 @@ public class Implementations extends AbstractStatements {
 		super(info, typeMappings, header);
 	}
 
-	public List<ClassContainer> generateRequired() {
-		List<ClassContainer> classes = new ArrayList<>();
-		if (info.nonOptional().size() > 1) {
-			for (int i = 1; i < info.nonOptional().size(); ++i) { // skipping first since already handled
-				classes.add(createContainer(i));
-			}
-		}
-		return classes;
+	public List<ClassContainer> generateRequired() { // skipping the first since it is already handled
+		return IntStream.range(1, info.nonOptional().size()).mapToObj(this::createContainer).toList();
 	}
 
 	private ClassContainer createContainer(int requiredFieldNumber) {

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Interfaces.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Interfaces.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.code.gen;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import com.google.protobuf.Descriptors.FieldDescriptor;
@@ -13,12 +12,7 @@ public class Interfaces extends AbstractStatements {
 	}
 
 	public List<ClassContainer> generateRequired() {
-		List<ClassContainer> ifcs = new ArrayList<>();
-		
-		for (FieldDescriptor requiredField : info.nonOptional()) {
-			ifcs.add(generateInterface(requiredField));
-		}
-		return ifcs;
+		return info.nonOptional().stream().map(this::generateInterface).toList();
 	}
 	
 	public ClassContainer generateOptional() {

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Methods.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Methods.java
@@ -53,16 +53,12 @@ public class Methods {
 	}
 
 	public StringBuilder has(String classOrBuilder, FieldDescriptor field) {
-		if (!needsHas(field)) {
+		if (!field.hasPresence()) {
 			return new StringBuilder();
 		}
 		String fieldName = Utils.toUpperCamelCase(field.getName());
 		return override("public boolean has%s() {return %s.has%s();}"
 				.formatted(fieldName, classOrBuilder, fieldName));
-	}
-
-	private boolean needsHas(FieldDescriptor field) {
-		return field.hasPresence();
 	}
 
 	public StringBuilder clear(String classOrBuilder, FieldDescriptor field, String returnType) {
@@ -101,7 +97,7 @@ public class Methods {
 	}
 
 	public StringBuilder declareHas(FieldDescriptor field) {
-		if (!needsHas(field)) {
+		if (!field.hasPresence()) {
 			return new StringBuilder();
 		}
 		return new StringBuilder(

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Utils.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Utils.java
@@ -21,18 +21,14 @@ public class Utils {
 		if (string.isEmpty()) {
 			return string;
 		}
-		return (String.valueOf(string.charAt(0)).toLowerCase() + string.substring(1));
+		return string.substring(0, 1).toLowerCase() + string.substring(1);
 	}
 
 	public static String firstToUpper(String string) {
 		if (string.isEmpty()) {
 			return string;
 		}
-		return (firstUpper(string) + string.substring(1));
-	}
-
-	private static String firstUpper(String string) {
-		return String.valueOf(string.charAt(0)).toUpperCase();
+		return string.substring(0, 1).toUpperCase() + string.substring(1);
 	}
 
 	public static String toUpperCamelCase(String s) {
@@ -72,13 +68,7 @@ public class Utils {
 	
 	public static String getSuffixOf(String type, int howMany, String delimiter) {
 		String[] tokens = type.split(Pattern.quote(delimiter));
-		StringBuilder suffixBuilder = new StringBuilder();
-		for (int i = howMany; i > 0; i--) {
-			suffixBuilder.append(tokens[tokens.length - i]);
-			suffixBuilder.append(delimiter);
-		}
-		String suffix = suffixBuilder.toString();
-		return suffix.substring(0, suffix.length() - 1);
+		return String.join(delimiter, Arrays.copyOfRange(tokens, tokens.length - howMany, tokens.length));
 	}
 
 	public static String getClassName(String fullName) {

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -149,10 +149,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 
 	@Override
 	public void putAll(Map<? extends K, ? extends V> map) {
-		Set<? extends K> keys = map.keySet();
-		for (K key : keys) {
-			put(key, map.get(key));
-		}
+		map.forEach(this::put);
 	}
 
 	@Override

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
@@ -1,10 +1,10 @@
 package io.github.adamw7.tools.data.uniqueness;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,21 +42,11 @@ public abstract class AbstractUniqueness<T extends ColumnarDataSource> implement
 	}
 
 	protected int[] getIndiciesOf(String[] keyCandidates, String[] allColumns) {
-		List<Integer> indicies = new ArrayList<>();
-
-		for (int i = 0; i < allColumns.length; ++i) {
-			for (int j = 0; j < keyCandidates.length; ++j) {
-				if (allColumns[i].equalsIgnoreCase(keyCandidates[j])) {
-					indicies.add(i);
-				}
-			}
-		}
-
-		int[] result = new int[indicies.size()];
-		for (int i = 0; i < result.length; ++i) {
-			result[i] = indicies.get(i);
-		}
-		return result;
+		return IntStream.range(0, allColumns.length)
+				.flatMap(index -> Arrays.stream(keyCandidates)
+						.filter(candidate -> allColumns[index].equalsIgnoreCase(candidate))
+						.mapToInt(candidate -> index))
+				.toArray();
 	}
 	
 	protected void check(String[] keyCandidates) {
@@ -68,10 +58,8 @@ public abstract class AbstractUniqueness<T extends ColumnarDataSource> implement
 		if (keyCandidates == null || keyCandidates.length == 0) {
 			throw new IllegalArgumentException("Wrong input: " + Arrays.toString(keyCandidates));
 		}
-		for (String candidate : keyCandidates) {
-			if (candidate == null) {
-				throw new IllegalArgumentException("Input columns cannot be null");
-			}
+		if (Arrays.stream(keyCandidates).anyMatch(Objects::isNull)) {
+			throw new IllegalArgumentException("Input columns cannot be null");
 		}
 	}
 

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
@@ -8,6 +8,8 @@ import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jakarta.servlet.Servlet;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
@@ -81,10 +83,7 @@ public abstract class AbstractMcpConfiguration {
 	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
 	public ServletRegistrationBean<HttpServletStreamableServerTransportProvider> streamableServletRegistration(
 			HttpServletStreamableServerTransportProvider transport) {
-		ServletRegistrationBean<HttpServletStreamableServerTransportProvider> registration =
-				new ServletRegistrationBean<>(transport, MCP_ENDPOINT);
-		registration.setAsyncSupported(true);
-		return registration;
+		return asyncRegistration(transport, MCP_ENDPOINT);
 	}
 
 	@Bean
@@ -101,10 +100,7 @@ public abstract class AbstractMcpConfiguration {
 	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stateless-http")
 	public ServletRegistrationBean<HttpServletStatelessServerTransport> statelessServletRegistration(
 			HttpServletStatelessServerTransport transport) {
-		ServletRegistrationBean<HttpServletStatelessServerTransport> registration =
-				new ServletRegistrationBean<>(transport, MCP_ENDPOINT);
-		registration.setAsyncSupported(true);
-		return registration;
+		return asyncRegistration(transport, MCP_ENDPOINT);
 	}
 
 	@Bean
@@ -122,8 +118,15 @@ public abstract class AbstractMcpConfiguration {
 	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "sse")
 	public ServletRegistrationBean<HttpServletSseServerTransportProvider> sseServletRegistration(
 			HttpServletSseServerTransportProvider transport) {
-		ServletRegistrationBean<HttpServletSseServerTransportProvider> registration =
-				new ServletRegistrationBean<>(transport, SSE_ENDPOINT, SSE_MESSAGE_ENDPOINT);
+		return asyncRegistration(transport, SSE_ENDPOINT, SSE_MESSAGE_ENDPOINT);
+	}
+
+	/**
+	 * Registers a transport servlet with async support on, which every HTTP transport
+	 * needs so a response can be streamed after the request thread returns.
+	 */
+	private static <T extends Servlet> ServletRegistrationBean<T> asyncRegistration(T transport, String... endpoints) {
+		ServletRegistrationBean<T> registration = new ServletRegistrationBean<>(transport, endpoints);
 		registration.setAsyncSupported(true);
 		return registration;
 	}


### PR DESCRIPTION
Removes ~90 lines of code without changing behaviour, in the four modules
untouched by the recent adopt and enforcer clean-ups.

- context: both finders ran the same scan-and-resolve loop over
  CLASS_REFERENCE, differing only in how one reference resolves. That loop
  (and the near-identical addResolved of each) moves into AbstractFinder as
  resolveReferences, taking the resolver as a function. PackageAwareFinder
  also matched the import pattern twice per file, once for explicit imports
  and once for wildcards; it now matches once and partitions the result,
  dropping four methods.
- protogen: ClassInfo's two hand-rolled filter loops become stream filters
  like their five siblings already were, pure complex fields are computed
  once in the constructor rather than on every call, and the varargs union
  helper gives way to Stream.of(...).flatMap. Both generateRequired loops
  become streams, Code's recursive delete uses Files.walk in reverse order,
  Utils.getSuffixOf uses String.join, and the needsHas one-line delegation
  is inlined.
- data: putAll delegates to Map.forEach, getIndiciesOf drops the
  List<Integer>-to-int[] copy, and a null scan becomes anyMatch.
- mcp-common: the three servlet registration beans shared identical bodies;
  they now call one generic asyncRegistration helper.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0135bHv9jZBj8fyYxPDdpXZQ