### PR TITLE
fix(ci): run mutation testing past `package` and skip the executable-bit assertion off POSIX

### DIFF
--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -20,7 +20,14 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Run PIT mutation testing
-      run: mvn -B -ntp test -Ppitest --file pom.xml
+      # `install`, not `test`: the `data` module is a named JPMS module whose
+      # module-info requires `tools.mcp.common`, the automatic module name
+      # derived from the mcp-common *jar* file name. A `test` build stops before
+      # `package`, so the reactor hands javac `mcp-common/target/classes` — an
+      # exploded directory with no module-info.class, whose automatic name is
+      # `classes` — and compiling `data` fails with "module not found". PIT is
+      # bound to the `test` phase, so it still runs on every module.
+      run: mvn -B -ntp install -Ppitest --file pom.xml
     - name: Upload mutation testing reports
       uses: actions/upload-artifact@v4
       with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,9 +313,14 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
   base 5 s), because JaCoCo's bytecode instrumentation slows first-use
   class-loading.
 - **Mutation testing** is the opt-in `pitest` profile (PIT + JUnit 5):
-  `mvn -Ppitest test` writes HTML/XML reports to `**/target/pit-reports/`. It
+  `mvn -Ppitest install` writes HTML/XML reports to `**/target/pit-reports/`. It
   excludes `*IT` integration tests and does not fail when a class has no
-  mutations.
+  mutations. Run it with `install` (or any phase past `package`), not with
+  `test`: PIT is bound to the `test` phase either way, but a `test`-only reactor
+  build never packages `mcp-common`, so the `data` module's `requires
+  tools.mcp.common` — an automatic module name derived from that **jar**'s file
+  name — cannot resolve against the exploded `target/classes` directory and
+  compilation fails.
 
 ## Continuous integration
 
@@ -329,7 +334,7 @@ requests to `main`; the rest run on a schedule (or manually).
 | `codeql.yml` | push, PR → `main`; weekly | CodeQL security/static analysis for Java (autobuild). |
 | `integration-tests.yml` | daily | `mvn -P integration-tests verify` (MCP streamable-HTTP integration tests). |
 | `coverage.yml` | weekly | `mvn verify -Pcoverage`, uploads JaCoCo reports as an artifact. |
-| `pitest.yml` | weekly; manual | `mvn test -Ppitest`, uploads PIT mutation reports as an artifact. |
+| `pitest.yml` | weekly; manual | `mvn install -Ppitest`, uploads PIT mutation reports as an artifact. |
 | `maven-publish.yml` | on GitHub release | Deploys to **GitHub Packages** (`-P github-packages`). See "Releasing". |
 | `central-publish.yml` | on GitHub release; manual dispatch | Deploys to **Maven Central** (`-P release`), or a staged-only dry run on manual dispatch. See "Releasing". |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ mvn install                       # faster incremental build
 mvn -pl data test                 # tests for a single module
 mvn -P integration-tests verify   # MCP integration tests (*IT)
 mvn -Pcoverage verify             # JaCoCo coverage (fails under 80% instruction or branch)
-mvn -Ppitest test                 # PIT mutation testing
+mvn -Ppitest install              # PIT mutation testing
 ```
 
 Use `clean` after removing a code-generation source, so stale generated builders

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetInstallerTest.java
@@ -4,8 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -40,6 +42,7 @@ class AssetInstallerTest {
 
 	@Test
 	void doesNotMarkAnOrdinaryAssetExecutable(@TempDir Path checkout) {
+		assumeTrue(supportsExecutableBit(), "filesystem has no executable bit to leave unset");
 		AssetInstaller installer = new AssetInstaller("plain.txt", "content\n");
 		assertTrue(installer.install(checkout));
 		assertFalse(Files.isExecutable(checkout.resolve("plain.txt")));
@@ -55,5 +58,12 @@ class AssetInstallerTest {
 		Files.createFile(checkout.resolve("blocking"));
 		AssetInstaller installer = new AssetInstaller("blocking/file.txt", "content\n");
 		assertThrows(AdoptionException.class, () -> installer.install(checkout));
+	}
+
+	// Windows has no executable bit to leave unset: every readable file reports
+	// itself as executable there, so only a POSIX filesystem can tell the two
+	// installers apart.
+	private boolean supportsExecutableBit() {
+		return FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
 	}
 }


### PR DESCRIPTION
Two scheduled workflows were failing on main.

`pitest.yml` ran `mvn test -Ppitest`, which can never compile the `data`
module: `data` is a named JPMS module whose module-info requires
`tools.mcp.common`, an automatic module name derived from the mcp-common
*jar* file name. A `test` build stops before `package`, so the reactor
hands javac `mcp-common/target/classes` — an exploded directory with no
`module-info.class`, whose automatic name is `classes` — and the build
fails with "module not found: tools.mcp.common". Run `install` instead;
PIT stays bound to the `test` phase, so it still runs on every module.
CLAUDE.md and AGENTS.md documented the same broken command and are
updated with it.

`maven-windows.yml` failed on
`AssetInstallerTest.doesNotMarkAnOrdinaryAssetExecutable`: Windows has no
executable bit, so `Files.isExecutable` reports true for every readable
file and the test cannot tell an ordinary asset from a hook script. Gate
it on POSIX support, matching the `supportsExecutableBit()` idiom already
used in `HooksFormatRuleTest`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018xL8c65AaWj1NaWR3MxuMD