### PR TITLE
build: fix the actionable warnings from mvn install

### DIFF
--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/CodeMojo.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/CodeMojo.java
@@ -20,7 +20,7 @@ import com.google.protobuf.GeneratedMessage;
 
 import io.github.adamw7.tools.code.gen.Code;
 
-@Mojo(name = "code-generator", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = false, requiresDependencyResolution = ResolutionScope.RUNTIME)
+@Mojo(name = "code-generator", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true, requiresDependencyResolution = ResolutionScope.RUNTIME)
 public class CodeMojo extends AbstractMojo {
 
 	private static final Logger log = LogManager.getLogger(CodeMojo.class.getName());
@@ -40,9 +40,17 @@ public class CodeMojo extends AbstractMojo {
 	@Override
 	public void execute() {
 		log.info("Executing {} maven plugin", this);
-		extendClassPath();
-		Set<Class<? extends GeneratedMessage>> allMessages = new MessagesFinder(pkgs).execute();
-		new Code(generatedSourcesDir, outputpackage).genBuilders(allMessages);
+		// The only shared state this goal touches is the thread context classloader
+		// (Reflections scans through it), so restoring it keeps a parallel `-T` build
+		// from leaking one project's classpath into whatever the thread runs next.
+		ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+		try {
+			extendClassPath();
+			Set<Class<? extends GeneratedMessage>> allMessages = new MessagesFinder(pkgs).execute();
+			new Code(generatedSourcesDir, outputpackage).genBuilders(allMessages);
+		} finally {
+			Thread.currentThread().setContextClassLoader(originalClassLoader);
+		}
 	}
 
 	private void extendClassPath() {

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/MojoTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/MojoTest.java
@@ -1,5 +1,7 @@
 package io.github.adamw7.tools.code;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -32,6 +34,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
 // Every test here runs the Mojo end to end: it generates builders and compiles
 // the result with the JDK compiler, which can exceed the global 1-second
@@ -83,6 +86,39 @@ public class MojoTest {
 		assertTrue(dirSet.contains("com"));
 
 		compileSources(GENERATED_SOURCES + File.separator + mojo.outputpackage.replace(".", File.separator));
+	}
+
+	@Test
+	public void restoresContextClassLoader() {
+		CodeMojo mojo = new CodeMojo();
+		mojo.generatedSourcesDir = GENERATED_SOURCES;
+		mojo.pkgs = new String[] { "io.github.adamw7.tools.code.protos" };
+		mojo.outputpackage = "com.sth.generated";
+		mojo.runtimeClasspathElements = List.of();
+
+		ClassLoader beforeExecution = Thread.currentThread().getContextClassLoader();
+		mojo.execute();
+
+		assertSame(beforeExecution, Thread.currentThread().getContextClassLoader(),
+				"The goal is declared thread-safe, so it must not leave its classpath on the build thread");
+	}
+
+	@Test
+	public void restoresContextClassLoaderWhenGenerationFails(@TempDir Path tempDir) throws IOException {
+		// A regular file where the output directory should go makes generation blow up
+		// after the classloader has already been swapped in.
+		Path blockingFile = Files.createFile(tempDir.resolve("not-a-directory"));
+		CodeMojo mojo = new CodeMojo();
+		mojo.generatedSourcesDir = blockingFile.toString();
+		mojo.pkgs = new String[] { "io.github.adamw7.tools.code.protos" };
+		mojo.outputpackage = "com.sth.generated";
+		mojo.runtimeClasspathElements = List.of();
+
+		ClassLoader beforeExecution = Thread.currentThread().getContextClassLoader();
+		assertThrows(UncheckedIOException.class, mojo::execute);
+
+		assertSame(beforeExecution, Thread.currentThread().getContextClassLoader(),
+				"A failing execution must restore the build thread's classloader too");
 	}
 
 	private void compileSources(String dir) {

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/PluginDescriptorTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/PluginDescriptorTest.java
@@ -95,6 +95,12 @@ public class PluginDescriptorTest {
 	}
 
 	@Test
+	public void mojoIsThreadSafe() {
+		assertEquals("true", textOfFirst(singleMojo(), "threadSafe"),
+				"Goal must be declared thread-safe, or every consumer building with -T warns about it");
+	}
+
+	@Test
 	public void allDocumentedParametersAreRequired() {
 		List<Element> parameters = parameters();
 		assertAll(REQUIRED_PARAMETERS.stream()

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -14,6 +14,21 @@
 	<url>https://github.com/adamw7/tools</url>
 	<build>
 		<plugins>
+			<!-- Expose the mockito-core jar path (it arrives transitively through
+			     spring-boot-starter-test) so it can be pre-loaded as a Java agent
+			     below. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>resolve-mockito-agent</id>
+						<goals>
+							<goal>properties</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
@@ -26,7 +41,16 @@
 					     io.github.adamw7.tools.data module. Running from the classpath
 					     also lets the tests reach the MCP client/SDK types (which live in
 					     the unnamed module) without patching the module open. -->
-					<argLine>@{argLine}</argLine>
+					<!-- The enable-native-access flag grants the native access the DuckDB
+					     JDBC driver needs for its System::load call. Without it the JVM
+					     warns on every Parquet test and, as that warning says, will block
+					     the call outright in a future release.
+
+					     Pre-loading Mockito as a Java agent (the Spring Boot test context
+					     mocks beans) replaces its runtime self-attach, which warns today
+					     and stops working once the JDK disallows dynamic agent loading.
+					     @{argLine} keeps the JaCoCo agent (coverage profile) composed in. -->
+					<argLine>@{argLine} --enable-native-access=ALL-UNNAMED -javaagent:${org.mockito:mockito-core:jar}</argLine>
 					<useModulePath>false</useModulePath>
 				</configuration>
 			</plugin>

--- a/mcp-common/pom.xml
+++ b/mcp-common/pom.xml
@@ -12,6 +12,28 @@
 	<name>Shared MCP server scaffolding</name>
 	<description>Shared MCP server scaffolding providing transport wiring and the tool SPI reused by the repository's MCP servers.</description>
 	<url>https://github.com/adamw7/tools</url>
+	<build>
+		<plugins>
+			<!-- This module has no module-info.java, so the JPMS name that
+			     `requires tools.mcp.common` in tools.data resolves against was being
+			     derived from the jar filename. javac warns about publishing such a
+			     filename-based automodule, because renaming the artifact silently
+			     renames the module. Pinning the manifest entry to the name the
+			     filename already produced keeps existing consumers working and makes
+			     the name part of the artifact instead of an accident. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>tools.mcp.common</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<dependencies>
 		<dependency>
 			<groupId>io.modelcontextprotocol.sdk</groupId>


### PR DESCRIPTION
- protogen-maven-plugin: declare the code-generator goal thread-safe and
  restore the build thread's context classloader in a finally block, so the
  parallel-execution warning stops firing in every consuming module.
- mcp-common: pin Automatic-Module-Name to tools.mcp.common, the name the jar
  filename already produced, so javac no longer warns about publishing a
  filename-based automodule that tools.data requires.
- data: add --enable-native-access=ALL-UNNAMED for DuckDB's System::load and
  pre-load Mockito as a Java agent instead of letting the Spring Boot test
  context self-attach it. Both warnings announce a future JDK release that
  turns them into hard failures.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QZjNfBzLfCMWzaD3mxbMGN