### PR TITLE
[e2e test] adopt pipeline smoke test — do not merge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -66,9 +64,7 @@
 			<url>https://www.opensource.org/licenses/mit-license.php</url>
 		</license>
 	</licenses>
-	<scm child.scm.connection.inherit.append.path="false"
-		child.scm.developerConnection.inherit.append.path="false"
-		child.scm.url.inherit.append.path="false">
+	<scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
 		<connection>scm:git:git@github.com:adamw7/tools.git</connection>
 		<developerConnection>scm:git:git@github.com:adamw7/tools.git</developerConnection>
 		<url>https://github.com/adamw7/tools</url>
@@ -501,7 +497,7 @@
 						</goals>
 						<configuration>
 							<rules>
-								<banDuplicatePomDependencyVersions />
+								<banDuplicatePomDependencyVersions/>
 								<requireMavenVersion>
 									<version>[3.9,4.0)</version>
 								</requireMavenVersion>
@@ -511,16 +507,38 @@
 								<requireReleaseDeps>
 									<onlyWhenRelease>true</onlyWhenRelease>
 								</requireReleaseDeps>
-								<reactorModuleConvergence />
+								<reactorModuleConvergence/>
 								<requirePluginVersions>
 									<banSnapshots>false</banSnapshots>
 								</requirePluginVersions>
-								<dependencyConvergence />
-								<requireNoRepositories />
+								<dependencyConvergence/>
+								<requireNoRepositories/>
+							</rules>
+						</configuration>
+					</execution>
+					<execution>
+						<id>enforce-claude-md</id>
+						<phase>validate</phase>
+						<inherited>false</inherited>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<claudeMdFormat>
+									<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
+								</claudeMdFormat>
 							</rules>
 						</configuration>
 					</execution>
 				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>io.github.adamw7</groupId>
+						<artifactId>tools.claude-code-enforcer</artifactId>
+						<version>2.6.0</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 			<!-- The root pom uses a CI-friendly ${revision} version, so the
 			     installed/deployed pom of every module would otherwise still


### PR DESCRIPTION
**Test artifact — please close without merging.**

This draft PR is the output of an end-to-end run of the `adopt` module's pipeline against this repository, to verify the adoption works against real GitHub rather than only against the mocked `CommandRunner` in the unit tests.

The commit was produced by `EnforcerStep`/`PomEnforcerInstaller`, not by hand.

**Why it must not be merged:**

- It pins `io.github.adamw7:tools.claude-code-enforcer:2.6.0` — a version that exists only in the test machine's local repository. The run had to be made from a non-snapshot build (`-Drevision=2.6.0`) because `EnforcerRuleVersion` correctly refuses to wire a `-SNAPSHOT`; nothing is published to Maven Central yet, so this dependency does not resolve for CI or for any contributor.
- It wires the `claudeMdFormat` guard into the top-level `<build>`, duplicating the wiring this repo already keeps behind the opt-in `claude-md-enforce` profile.
- The diff carries unrelated whitespace churn from DOM re-serialization (multi-line attributes collapsed, `<x />` rewritten as `<x/>`).

Steps that completed for real: `toolchain`, `clone`, `build-toolchain`, `branch`, `trust`, `claude-init`, `conform`, `commit`, `enforcer`, `commit`, `verify`, `push`. Only `pull-request` failed, because `gh pr create` needs a GraphQL call the test sandbox's proxy does not serve — this PR was opened through the REST API instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7q1eLMXs9gPC1gPe5rrLp)_