### PR TITLE
fix(adopt): keep the POM edit minimal and make re-adoption survive gh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,17 @@ Maven project. The notable capabilities are:
   denying reads of obvious secret files and wiring a
   `.claude/hooks/session-start.sh` stub, a starter `.mcp.json`, and a GitHub
   Actions workflow answering `@claude` mentions — never overwriting a file the
-  repository already has. Both `gh` invocations name the target repository with
+  repository already has. The `claude-code-enforcer` version wired into an
+  adopted Maven project defaults to the version of the `tools` build running the
+  adoption and can be overridden with `--rule-version` (`rule_version` on the MCP
+  tool); either way `EnforcerRuleVersion` refuses a `-SNAPSHOT`, which resolves
+  only from the adopting machine's local repository and would leave the adopted
+  project's CI and every contributor with a build that cannot resolve it — so a
+  snapshot build of `tools` cannot adopt a Maven project until a release is
+  published. Whether a POM already carries the guard is decided by scanning every
+  `plugin` it declares, wherever it sits — the build, `pluginManagement`, or a
+  profile — because a project that runs the rule behind an opt-in profile would
+  otherwise be given a second, always-on copy of it. Both `gh` invocations name the target repository with
   `--repo`, derived from the URL being adopted, rather than letting `gh` infer it
   from the checkout's git remote — a remote rewritten by `url.<base>.insteadOf`,
   a mirror, or a proxy is not readable as a GitHub one and would fail the last

--- a/README.md
+++ b/README.md
@@ -763,13 +763,22 @@ mvn -pl adopt exec:java \
     -Dexec.args="https://github.com/owner/repo.git [workspace-directory] [branch-name]"
 ```
 
+The `claude-code-enforcer` version a Maven project's `pom.xml` is made to depend
+on defaults to the version of the `tools` build running the adoption;
+`--rule-version <version>` pins a different one. A `-SNAPSHOT` is refused either
+way, because it resolves only from the adopting machine's own local repository:
+wiring one in would open a pull request that builds for whoever ran the adoption
+and fails for the adopted project's CI and every one of its contributors. A
+snapshot build of `tools` therefore cannot adopt a Maven project until a release
+of the rule is published.
+
 The pipeline is a list of ordered, independent `AdoptionStep`s, each acting on a
 shared immutable `AdoptionContext` (the repository URL, the workspace, the
 derived checkout directory, and the feature-branch name):
 
 ```java
 CommandRunner runner = new ProcessCommandRunner();
-GitHubRepoAdopter.withDefaultPipeline(runner)
+GitHubRepoAdopter.withDefaultPipeline(runner, PullRequestOptions.defaults(), false)
     .adopt(new AdoptionContext("https://github.com/owner/repo.git", workspace));
 ```
 
@@ -820,7 +829,14 @@ The default pipeline runs these steps in order:
    carries — a repository with its own `claude-md-guard.yml` or its own
    `enforceClaudeMd` registration keeps it. Supporting a new build tool is a
    matter of adding a `BuildSystem` implementation rather than branching inside
-   the step.
+   the step. For Maven that already-declared check spans the whole POM rather than
+   only its `build/plugins`: a project running the rule behind an opt-in profile,
+   or declaring it in `pluginManagement`, is left alone instead of being given a
+   second, always-on copy. The POM edit is spliced into the bytes the file already
+   holds, so the adoption commit shows the added block and nothing else — writing
+   the edited DOM out whole would normalise details a DOM does not record,
+   collapsing a start tag spread over several lines and rewriting `<rule />` as
+   `<rule/>`, turning a fourteen-line addition into a diff across the file.
 9. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
    build`).
 10. **`VerifyStep`** — runs the detected build system's verification (a
@@ -836,9 +852,15 @@ The default pipeline runs these steps in order:
    pull request metadata is supplied through `PullRequestOptions` — title, body,
    and optional reviewers, labels, and assignees to request, plus whether to open
    the pull request as a `--draft` — so the defaults can be overridden per
-   project. Like `CommitStep` it stays idempotent: a `gh` failure that only
-   reports an already-open pull request for the branch, or no commits between base
-   and head, is treated as a no-op rather than aborting the adoption.
+   project. Like `CommitStep` it stays idempotent: the branch's open pull requests
+   are read first (`gh pr list --state open`) and creation is skipped when one is
+   already open, and a `gh pr create` that fails only because a pull request for
+   the branch already exists, or because there are no commits between base and
+   head, is treated as a no-op rather than aborting the adoption. That tolerance is
+   what makes re-running an adoption safe even where the pre-check cannot run: `gh
+   pr list` needs a query a restricted token or a proxied host may refuse, and a
+   failed query is indistinguishable from "nothing is open" — so it is logged as a
+   warning and the create that follows is allowed to report the duplicate itself.
 
 External `git`/`claude`/`gh` invocations go through a `CommandRunner` abstraction,
 so the steps are unit-tested without spawning real processes. The default

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -15,8 +15,10 @@ import io.github.adamw7.tools.adopt.step.PullRequestOptions;
  * flags expose the rest of the pipeline's configuration: the pull-request
  * metadata of {@link PullRequestOptions} ({@code --title}, {@code --body},
  * repeatable {@code --reviewer}/{@code --label}/{@code --assignee}, and
- * {@code --draft}), the optional starter-assets step ({@code --assets}), and a
- * JSON report of the run's outcome ({@code --report <file>}). A blank workspace
+ * {@code --draft}), the optional starter-assets step ({@code --assets}), the
+ * {@code claude-code-enforcer} version to wire into an adopted Maven project
+ * ({@code --rule-version}), and a JSON report of the run's outcome
+ * ({@code --report <file>}). A blank workspace
  * or branch positional falls back to its default, matching the pre-flag
  * behaviour; an unknown flag or a flag missing its value fails with the usage
  * line rather than being silently ignored.
@@ -25,7 +27,7 @@ public final class CliArguments {
 
 	static final String USAGE = "Usage: <github-repo-url> [workspace-directory] [branch-name]"
 			+ " [--title <title>] [--body <body>] [--reviewer <user>]... [--label <label>]..."
-			+ " [--assignee <user>]... [--draft] [--assets] [--report <file>]";
+			+ " [--assignee <user>]... [--draft] [--assets] [--rule-version <version>] [--report <file>]";
 
 	private String repositoryUrl;
 	private Path workspace;
@@ -37,6 +39,7 @@ public final class CliArguments {
 	private final List<String> assignees = new ArrayList<>();
 	private boolean draft;
 	private boolean assets;
+	private String ruleVersion;
 	private Path reportFile;
 	private int positionals;
 
@@ -77,6 +80,15 @@ public final class CliArguments {
 		return assets;
 	}
 
+	/**
+	 * @return the released {@code claude-code-enforcer} version to pin into an
+	 *         adopted Maven project's POM, or empty to resolve the version of the
+	 *         {@code tools} build running the adoption
+	 */
+	public Optional<String> ruleVersion() {
+		return Optional.ofNullable(ruleVersion);
+	}
+
 	public Optional<Path> reportFile() {
 		return Optional.ofNullable(reportFile);
 	}
@@ -98,6 +110,8 @@ public final class CliArguments {
 			case "--reviewer" -> consumeValue(args, index, reviewers::add);
 			case "--label" -> consumeValue(args, index, labels::add);
 			case "--assignee" -> consumeValue(args, index, assignees::add);
+			case "--rule-version" -> consumeValue(args, index,
+					value -> ruleVersion = Text.isPresent(value) ? value.strip() : null);
 			case "--report" -> consumeValue(args, index, value -> reportFile = Path.of(value));
 			case "--draft" -> {
 				draft = true;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.adopt;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -10,6 +11,8 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
 import io.github.adamw7.tools.adopt.step.AssetsStep;
 import io.github.adamw7.tools.adopt.step.BranchStep;
+import io.github.adamw7.tools.adopt.step.BuildSystem;
+import io.github.adamw7.tools.adopt.step.BuildSystems;
 import io.github.adamw7.tools.adopt.step.BuildToolchainStep;
 import io.github.adamw7.tools.adopt.step.ClaudeInitStep;
 import io.github.adamw7.tools.adopt.step.ClaudeMdConformanceStep;
@@ -60,26 +63,47 @@ public class GitHubRepoAdopter {
 
 	public static GitHubRepoAdopter withDefaultPipeline(CommandRunner runner, PullRequestOptions options,
 			boolean includeAssets) {
-		return new GitHubRepoAdopter(runner, defaultSteps(options, includeAssets));
+		return withDefaultPipeline(runner, options, includeAssets, Optional.empty());
+	}
+
+	/**
+	 * @param ruleVersion the released {@code claude-code-enforcer} version a Maven
+	 *                    project's POM should pin, or empty to resolve the version of
+	 *                    the {@code tools} build running the adoption
+	 */
+	public static GitHubRepoAdopter withDefaultPipeline(CommandRunner runner, PullRequestOptions options,
+			boolean includeAssets, Optional<String> ruleVersion) {
+		return new GitHubRepoAdopter(runner, defaultSteps(options, includeAssets, ruleVersion));
 	}
 
 	public static List<AdoptionStep> defaultSteps(PullRequestOptions options, boolean includeAssets) {
+		return defaultSteps(options, includeAssets, Optional.empty());
+	}
+
+	/**
+	 * The three steps that act on the checkout's build system are given the same
+	 * build-system list, so the guard that is wired in is the guard that is verified
+	 * with the tool that was probed.
+	 */
+	public static List<AdoptionStep> defaultSteps(PullRequestOptions options, boolean includeAssets,
+			Optional<String> ruleVersion) {
+		List<BuildSystem> buildSystems = BuildSystems.withRuleVersion(ruleVersion);
 		List<AdoptionStep> steps = new ArrayList<>(List.of(
 				new ToolchainStep(),
 				new CloneStep(),
-				new BuildToolchainStep(),
+				new BuildToolchainStep(buildSystems),
 				new BranchStep(),
 				new TrustStep(),
 				new ClaudeInitStep(),
 				new ClaudeMdConformanceStep(),
 				new CommitStep("Adopt Claude Code: add CLAUDE.md"),
-				new EnforcerStep(),
+				new EnforcerStep(buildSystems),
 				new CommitStep("Add claude-code-enforcer to the build")));
 		if (includeAssets) {
 			steps.add(new AssetsStep());
 			steps.add(new CommitStep("Add Claude Code configuration assets"));
 		}
-		steps.add(new VerifyStep());
+		steps.add(new VerifyStep(buildSystems));
 		steps.add(new PushStep());
 		steps.add(new PullRequestStep(options));
 		return List.copyOf(steps);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -24,7 +24,7 @@ public class Main {
 		AdoptionContext context = new AdoptionContext(cli.repositoryUrl(), workspace(cli), cli.branchName());
 		CommandRunner runner = new ProcessCommandRunner();
 		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, cli.pullRequestOptions(),
-				cli.includeAssets());
+				cli.includeAssets(), cli.ruleVersion());
 		runAndReport(cli, context, adopter);
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.adopt.mcp;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
@@ -32,7 +33,8 @@ public class AdoptTool implements McpTool {
 
 	/** The adoption run the tool delegates to once the arguments are mapped. */
 	public interface Pipeline {
-		AdoptionReport adopt(AdoptionContext context, PullRequestOptions options, boolean includeAssets);
+		AdoptionReport adopt(AdoptionContext context, PullRequestOptions options, boolean includeAssets,
+				Optional<String> ruleVersion);
 	}
 
 	private static final Logger log = LogManager.getLogger(AdoptTool.class);
@@ -47,22 +49,28 @@ public class AdoptTool implements McpTool {
 					+ "Returns a JSON report with the pull request URL and the completed steps.",
 			Map.of(
 					"type", "object",
-					"properties", Map.of(
-							"repository_url", Map.of("type", "string",
-									"description", "URL of the GitHub repository to adopt"),
-							"workspace", Map.of("type", "string",
-									"description", "directory to clone into; a temporary one is created when omitted"),
-							"branch", Map.of("type", "string",
-									"description", "feature branch to commit and open the pull request from"),
-							"title", Map.of("type", "string", "description", "pull request title"),
-							"body", Map.of("type", "string", "description", "pull request body"),
-							"reviewers", Map.of("type", "string",
-									"description", "comma-separated reviewers to request"),
-							"labels", Map.of("type", "string", "description", "comma-separated labels to apply"),
-							"assignees", Map.of("type", "string", "description", "comma-separated assignees"),
-							"draft", Map.of("type", "boolean", "description", "open the pull request as a draft"),
-							"assets", Map.of("type", "boolean",
+					"properties", Map.ofEntries(
+							Map.entry("repository_url", Map.of("type", "string",
+									"description", "URL of the GitHub repository to adopt")),
+							Map.entry("workspace", Map.of("type", "string",
+									"description", "directory to clone into; a temporary one is created when omitted")),
+							Map.entry("branch", Map.of("type", "string",
+									"description", "feature branch to commit and open the pull request from")),
+							Map.entry("title", Map.of("type", "string", "description", "pull request title")),
+							Map.entry("body", Map.of("type", "string", "description", "pull request body")),
+							Map.entry("reviewers", Map.of("type", "string",
+									"description", "comma-separated reviewers to request")),
+							Map.entry("labels", Map.of("type", "string",
+									"description", "comma-separated labels to apply")),
+							Map.entry("assignees", Map.of("type", "string",
+									"description", "comma-separated assignees")),
+							Map.entry("draft", Map.of("type", "boolean",
+									"description", "open the pull request as a draft")),
+							Map.entry("assets", Map.of("type", "boolean",
 									"description", "also commit starter Claude Code configuration assets")),
+							Map.entry("rule_version", Map.of("type", "string",
+									"description", "released claude-code-enforcer version to wire into an adopted "
+											+ "Maven project; defaults to the version of this build"))),
 					"required", List.of("repository_url")));
 
 	public AdoptTool() {
@@ -74,8 +82,8 @@ public class AdoptTool implements McpTool {
 	}
 
 	private static AdoptionReport runDefaultPipeline(AdoptionContext context, PullRequestOptions options,
-			boolean includeAssets) {
-		return GitHubRepoAdopter.withDefaultPipeline(new ProcessCommandRunner(), options, includeAssets)
+			boolean includeAssets, Optional<String> ruleVersion) {
+		return GitHubRepoAdopter.withDefaultPipeline(new ProcessCommandRunner(), options, includeAssets, ruleVersion)
 				.adopt(context);
 	}
 
@@ -89,7 +97,7 @@ public class AdoptTool implements McpTool {
 		log.info("Calling MCP adopt tool for {}", arguments);
 		AdoptionContext context = contextFrom(arguments);
 		AdoptionReport report = pipeline.adopt(context, optionsFrom(arguments),
-				ToolArguments.optionalBoolean(arguments, "assets", false));
+				ToolArguments.optionalBoolean(arguments, "assets", false), ruleVersion(arguments));
 		return ToolResult.success(reportWriter.toJson(context, report));
 	}
 
@@ -120,6 +128,15 @@ public class AdoptTool implements McpTool {
 				.titleIfPresent(text(arguments, "title"))
 				.bodyIfPresent(text(arguments, "body"))
 				.build();
+	}
+
+	/**
+	 * @return the rule version to pin, empty when the argument was not supplied or
+	 *         was blank — the same rule every other optional argument follows
+	 */
+	private Optional<String> ruleVersion(Map<String, Object> arguments) {
+		String supplied = text(arguments, "rule_version").strip();
+		return supplied.isEmpty() ? Optional.empty() : Optional.of(supplied);
 	}
 
 	/** @return the argument's text, empty when it was not supplied */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractCommandStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractCommandStep.java
@@ -2,6 +2,8 @@ package io.github.adamw7.tools.adopt.step;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.CommandResult;
@@ -11,16 +13,49 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * Base for steps that shell out through a {@link CommandRunner}, sharing the
  * run-and-fail-fast behaviour: a command that exits non-zero aborts the
  * adoption with an {@link AdoptionException} carrying the command transcript.
+ * A step whose tool reports an already-satisfied request as a failure instead of
+ * a no-op runs through {@link #runTolerating} rather than repeating that
+ * judgement for itself.
  */
 public abstract class AbstractCommandStep implements AdoptionStep {
 
 	protected final CommandResult runOrFail(CommandRunner runner, Path workingDirectory, List<String> command) {
 		CommandResult result = runner.run(workingDirectory, command);
 		if (!result.succeeded()) {
-			throw new AdoptionException(
-					name() + " failed (exit " + result.exitCode() + ") running: " + result.describe()
-							+ System.lineSeparator() + result.output());
+			throw failure(result);
 		}
 		return result;
+	}
+
+	/**
+	 * Runs the command, treating a failure whose transcript reports one of
+	 * {@code toleratedFailures} as a no-op rather than an aborted adoption — the
+	 * pipeline is re-runnable, so a tool refusing to do again what it has already
+	 * done is the expected outcome of a second run, not an error.
+	 *
+	 * @param toleratedFailures fragments of the tool's own wording, matched
+	 *                          case-insensitively against the transcript
+	 * @return the result, or empty when the command failed in a tolerated way
+	 */
+	protected final Optional<CommandResult> runTolerating(CommandRunner runner, Path workingDirectory,
+			List<String> command, List<String> toleratedFailures) {
+		CommandResult result = runner.run(workingDirectory, command);
+		if (result.succeeded()) {
+			return Optional.of(result);
+		}
+		if (reports(result, toleratedFailures)) {
+			return Optional.empty();
+		}
+		throw failure(result);
+	}
+
+	private boolean reports(CommandResult result, List<String> toleratedFailures) {
+		String output = result.output().toLowerCase(Locale.ROOT);
+		return toleratedFailures.stream().map(tolerated -> tolerated.toLowerCase(Locale.ROOT)).anyMatch(output::contains);
+	}
+
+	private AdoptionException failure(CommandResult result) {
+		return new AdoptionException(name() + " failed (exit " + result.exitCode() + ") running: " + result.describe()
+				+ System.lineSeparator() + result.output());
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -33,6 +33,20 @@ public interface BuildSystem {
 	List<String> verifyCommand();
 
 	/**
+	 * The same build system, pinning an explicitly supplied
+	 * {@code claude-code-enforcer} version into whatever it wires in. Only a build
+	 * system that wires in a versioned artifact of its own has anything to pin — the
+	 * Gradle and fallback guards are self-contained — so the default is to answer
+	 * with this build system unchanged, and a new implementation opts in by
+	 * overriding rather than by being named in a check elsewhere.
+	 *
+	 * @param ruleVersion a released rule version
+	 */
+	default BuildSystem withRuleVersion(String ruleVersion) {
+		return this;
+	}
+
+	/**
 	 * The program {@link #verifyCommand()} launches, so {@link BuildToolchainStep}
 	 * can probe it before the pipeline spends a {@code claude init} on a checkout it
 	 * will not be able to verify. The verification launches the first word of its

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystems.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystems.java
@@ -26,6 +26,24 @@ public final class BuildSystems {
 	private BuildSystems() {
 	}
 
+	/**
+	 * The default set, each build system pinning an explicitly supplied
+	 * {@code claude-code-enforcer} version rather than resolving the version of the
+	 * {@code tools} build running the adoption. Which of them that changes is left to
+	 * {@link BuildSystem#withRuleVersion}: in practice only Maven wires a versioned
+	 * artifact in, and the others answer with themselves.
+	 *
+	 * @param ruleVersion the released rule version to pin, or empty to resolve the
+	 *                    running build's own
+	 */
+	public static List<BuildSystem> withRuleVersion(Optional<String> ruleVersion) {
+		return ruleVersion.map(BuildSystems::pinnedTo).orElse(DEFAULTS);
+	}
+
+	private static List<BuildSystem> pinnedTo(String ruleVersion) {
+		return DEFAULTS.stream().map(candidate -> candidate.withRuleVersion(ruleVersion)).toList();
+	}
+
 	public static Optional<BuildSystem> detect(List<BuildSystem> candidates, Path repositoryDirectory) {
 		return candidates.stream().filter(candidate -> candidate.matches(repositoryDirectory)).findFirst();
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
@@ -42,6 +42,10 @@ final class EnforcerRuleVersion {
 	 * that into an immediate, explicable failure.
 	 */
 	static String requireRelease(String version) {
+		if (version == null || version.isBlank()) {
+			throw new AdoptionException("No " + RULE_VERSION_KEY + " to wire into the adopted project's pom.xml:"
+					+ " a blank version would leave the build with a dependency it cannot resolve.");
+		}
 		if (version.endsWith(SNAPSHOT_SUFFIX)) {
 			throw new AdoptionException("Refusing to wire the snapshot enforcer rule version " + version
 					+ " into the adopted project's pom.xml: a snapshot is not resolvable outside this machine's"

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -46,4 +46,13 @@ public class MavenBuildSystem implements BuildSystem {
 	public List<String> verifyCommand() {
 		return VERIFY_COMMAND;
 	}
+
+	/**
+	 * Maven is the one build system that wires a versioned artifact into the adopted
+	 * project, so it is the one that has a version to pin.
+	 */
+	@Override
+	public BuildSystem withRuleVersion(String ruleVersion) {
+		return new MavenBuildSystem(new PomEnforcerInstaller(ruleVersion));
+	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -3,8 +3,13 @@ package io.github.adamw7.tools.adopt.step;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -27,6 +32,7 @@ import org.xml.sax.SAXException;
 
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.AdoptionFiles;
+import io.github.adamw7.tools.adopt.step.XmlElementSpans.Span;
 
 /**
  * A {@code pom.xml} parsed for editing and written back without reformatting.
@@ -36,18 +42,31 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
  * untouched, so the adoption commit shows only the block that was added rather
  * than a reformat of the whole file.
  *
+ * <p>Only the added elements are serialised, and their text is spliced into the
+ * bytes the file already held. Writing the edited DOM out whole cannot keep that
+ * promise however carefully the serialiser is configured, because the details it
+ * would reformat are not in the DOM to begin with: a start tag spread over several
+ * lines and an empty element written {@code <rule />} both come back normalised,
+ * turning a fourteen-line addition into a diff that touches the whole file. The
+ * source offsets the splice needs come from {@link XmlElementSpans}.
+ *
  * <p>Each appended element is preceded by a newline and an indentation matching
  * the document's own unit (detected from the file, defaulting to two spaces), and
- * is inserted before the parent's closing indentation so that closing tag stays
- * put. Every container is attached to its parent before its children are added,
- * so an element's depth — and therefore its indentation — is known as soon as it
- * is appended. The edit runs on the JDK's namespace-aware DOM, so no third-party
- * XML library is needed and new elements join the POM's default namespace.
+ * is inserted after the parent's last child so the parent's own closing
+ * indentation stays put. Every container is attached to its parent before its
+ * children are added, so an element's depth — and therefore its indentation — is
+ * known as soon as it is appended. The edit runs on the JDK's namespace-aware DOM,
+ * so no third-party XML library is needed and new elements join the POM's default
+ * namespace.
  */
 final class PomDocument {
 
 	private static final String DEFAULT_INDENT_UNIT = "  ";
 	private static final String DESCRIPTION = "POM";
+
+	/** A replacement of {@code [start, end)} in the original text; a pure insertion when they are equal. */
+	private record Edit(int start, int end, String replacement) {
+	}
 
 	private final Path file;
 	private final String original;
@@ -55,12 +74,21 @@ final class PomDocument {
 	private final String namespace;
 	private final String indentUnit;
 
+	/**
+	 * Where each element the file already carried sits in it. An element absent from
+	 * this map is one the caller appended, which is what makes the added subtrees
+	 * identifiable at {@link #write()} time without the callers having to declare
+	 * them.
+	 */
+	private final Map<Element, Span> spans;
+
 	private PomDocument(Path file, String original, Document document) {
 		this.file = file;
 		this.original = original;
 		this.document = document;
 		this.namespace = document.getDocumentElement().getNamespaceURI();
 		this.indentUnit = detectIndentUnit(document.getDocumentElement());
+		this.spans = spansOf(document, original);
 	}
 
 	static PomDocument read(Path file) {
@@ -71,6 +99,19 @@ final class PomDocument {
 	Element pluginsElement() {
 		Element build = childOrCreate(document.getDocumentElement(), "build");
 		return childOrCreate(build, "plugins");
+	}
+
+	/**
+	 * Every {@code plugin} the POM declares, wherever it sits: the build, plugin
+	 * management, or a profile. A project can wire a plugin somewhere other than
+	 * {@link #pluginsElement()} — behind an opt-in profile, most often — and a check
+	 * that only looked there would conclude the plugin is absent and add a second
+	 * declaration of it.
+	 */
+	List<Element> plugins() {
+		return preOrder(document.getDocumentElement()).stream()
+				.filter(element -> "plugin".equals(element.getLocalName()))
+				.toList();
 	}
 
 	Element childOrCreate(Element parent, String name) {
@@ -108,16 +149,126 @@ final class PomDocument {
 	}
 
 	/**
-	 * Writes the document back verbatim: the transformer's own indentation is left
-	 * off and the parsed whitespace nodes are kept, so only the added elements
-	 * differ from the original, whose XML declaration and trailing newline are
-	 * carried over exactly. XML parsing normalizes {@code \r\n} to {@code \n}, so
-	 * {@link LineTerminators} puts the original terminator back rather than flipping
-	 * a CRLF POM to LF and reformatting the whole file.
+	 * Writes the original text back with the added subtrees spliced into it, so
+	 * every byte the file already held — its XML declaration, its attribute layout,
+	 * its empty-element style, its trailing newline — is preserved by construction
+	 * rather than by a serialiser that has to be talked out of reformatting. A POM
+	 * nothing was appended to is written back unchanged.
+	 *
+	 * <p>The edits are applied last-first so that each one's offsets, taken from the
+	 * unmodified text, are still correct when it is applied.
 	 */
 	void write() {
-		String content = matchTrailingNewline(declarationPrefix() + serialize());
-		AdoptionFiles.write(file, LineTerminators.matching(content, original), DESCRIPTION);
+		StringBuilder content = new StringBuilder(original);
+		edits().stream()
+				.sorted(Comparator.comparingInt(Edit::start).reversed())
+				.forEach(edit -> content.replace(edit.start(), edit.end(), edit.replacement()));
+		AdoptionFiles.write(file, content.toString(), DESCRIPTION);
+	}
+
+	/** One edit per element of the original document that was appended to. */
+	private List<Edit> edits() {
+		return preOrder(document.getDocumentElement()).stream()
+				.filter(spans::containsKey)
+				.map(this::editFor)
+				.flatMap(Optional::stream)
+				.toList();
+	}
+
+	private Optional<Edit> editFor(Element parent) {
+		List<Element> added = elementChildren(parent).stream().filter(child -> !spans.containsKey(child)).toList();
+		if (added.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(edit(parent, added.stream().map(this::fragmentOf).collect(Collectors.joining())));
+	}
+
+	/** The added subtree's text, indented to its own depth the way the DOM path indented it. */
+	private String fragmentOf(Element added) {
+		return newlineIndent(depthOf(added)) + serialize(added);
+	}
+
+	/**
+	 * Where the fragment goes. An element that already had children takes it after
+	 * the last of them, leaving the whitespace before the end tag — and so that
+	 * tag's indentation — exactly as it was. An element that was empty or held only
+	 * whitespace has that content replaced instead, because there is no last child
+	 * to follow and its end tag needs indenting onto a line of its own; an element
+	 * written {@code <plugins/>} additionally has to grow an end tag to hold the
+	 * fragment at all.
+	 */
+	private Edit edit(Element parent, String fragment) {
+		Span span = spans.get(parent);
+		String closingIndent = newlineIndent(depthOf(parent));
+		if (span.selfClosing()) {
+			return edit(span.tagStart(), span.contentStart(),
+					reopened(span) + fragment + closingIndent + endTag(parent));
+		}
+		int lastChildEnd = beforeTrailingWhitespace(span);
+		if (lastChildEnd == span.contentStart()) {
+			return edit(span.contentStart(), span.contentEnd(), fragment + closingIndent);
+		}
+		return edit(lastChildEnd, lastChildEnd, fragment);
+	}
+
+	/**
+	 * XML parsing normalises {@code \r\n} to {@code \n}, so a serialised fragment is
+	 * always LF; {@link LineTerminators} puts the file's own terminator back rather
+	 * than leaving LF lines in an otherwise CRLF POM.
+	 */
+	private Edit edit(int start, int end, String replacement) {
+		return new Edit(start, end, LineTerminators.matching(replacement, original));
+	}
+
+	/** The start tag of a {@code <name/>} element, reopened as {@code <name>} to take children. */
+	private String reopened(Span span) {
+		String startTag = original.substring(span.tagStart(), span.contentStart());
+		return startTag.substring(0, startTag.length() - 2).stripTrailing() + ">";
+	}
+
+	private String endTag(Element element) {
+		return "</" + element.getTagName() + ">";
+	}
+
+	private int beforeTrailingWhitespace(Span span) {
+		int end = span.contentEnd();
+		while (end > span.contentStart() && Character.isWhitespace(original.charAt(end - 1))) {
+			end--;
+		}
+		return end;
+	}
+
+	/**
+	 * Pairs each element the file carried with its place in the text by document
+	 * order: a pre-order DOM walk and the lexical scan visit the same elements in
+	 * the same sequence, so the two lists line up index for index without having to
+	 * match names or attributes.
+	 */
+	private static Map<Element, Span> spansOf(Document document, String original) {
+		List<Element> elements = preOrder(document.getDocumentElement());
+		List<Span> spans = XmlElementSpans.of(original);
+		if (elements.size() != spans.size()) {
+			throw new AdoptionException("Could not map the POM's " + elements.size() + " parsed elements onto the "
+					+ spans.size() + " found in its text");
+		}
+		Map<Element, Span> byElement = new IdentityHashMap<>();
+		IntStream.range(0, elements.size()).forEach(index -> byElement.put(elements.get(index), spans.get(index)));
+		return byElement;
+	}
+
+	private static List<Element> preOrder(Element root) {
+		List<Element> elements = new ArrayList<>();
+		collect(root, elements);
+		return List.copyOf(elements);
+	}
+
+	private static void collect(Element element, List<Element> into) {
+		into.add(element);
+		elementChildren(element).forEach(child -> collect(child, into));
+	}
+
+	private static List<Element> elementChildren(Element parent) {
+		return childNodes(parent).filter(Element.class::isInstance).map(Element.class::cast).toList();
 	}
 
 	private static Stream<Node> childNodes(Element parent) {
@@ -212,14 +363,31 @@ final class PomDocument {
 		}
 	}
 
-	private String serialize() {
+	private String serialize(Element element) {
 		try {
 			StringWriter writer = new StringWriter();
-			transformer().transform(new DOMSource(document), new StreamResult(writer));
-			return writer.toString();
+			transformer().transform(new DOMSource(element), new StreamResult(writer));
+			return withoutRepeatedNamespace(writer.toString());
 		} catch (TransformerException e) {
 			throw new AdoptionException("Could not write POM: " + file, e);
 		}
+	}
+
+	/**
+	 * Serialising a subtree on its own leaves the serialiser no way to know the
+	 * POM's root already declares the default namespace, so it restates it and the
+	 * added block would read {@code <build xmlns="http://maven.apache.org/POM/4.0.0">}.
+	 * The fragment is spliced back under that root, which still carries the
+	 * declaration, so the repeat is dropped. Only the fragment's own root can carry
+	 * it — its descendants inherit it — so only the first occurrence is removed.
+	 */
+	private String withoutRepeatedNamespace(String fragment) {
+		if (namespace == null) {
+			return fragment;
+		}
+		String declaration = " xmlns=\"" + namespace + "\"";
+		int at = fragment.indexOf(declaration);
+		return at < 0 ? fragment : fragment.substring(0, at) + fragment.substring(at + declaration.length());
 	}
 
 	private static Transformer transformer() throws TransformerException {
@@ -231,37 +399,4 @@ final class PomDocument {
 		return transformer;
 	}
 
-	/**
-	 * The XML declaration the original opened with, up to and including its line
-	 * terminator, or empty when it had none — so the transformer cannot invent one
-	 * (a spurious first-line change) on a POM that started with {@code <project>}.
-	 */
-	private String declarationPrefix() {
-		if (!original.stripLeading().startsWith("<?xml")) {
-			return "";
-		}
-		int end = original.indexOf("?>");
-		if (end < 0) {
-			return "";
-		}
-		int afterTerminator = lineTerminatorEnd(original, end + 2);
-		return original.substring(0, afterTerminator) + (afterTerminator == end + 2 ? "\n" : "");
-	}
-
-	private static int lineTerminatorEnd(String text, int from) {
-		int index = from;
-		if (index < text.length() && text.charAt(index) == '\r') {
-			index++;
-		}
-		if (index < text.length() && text.charAt(index) == '\n') {
-			index++;
-		}
-		return index;
-	}
-
-	private String matchTrailingNewline(String content) {
-		boolean originalEnds = original.endsWith("\n") || original.endsWith("\r");
-		boolean contentEnds = content.endsWith("\n") || content.endsWith("\r");
-		return originalEnds && !contentEnds ? content + "\n" : content;
-	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -36,8 +36,18 @@ public class PomEnforcerInstaller {
 		this.ruleVersion = EnforcerRuleVersion::release;
 	}
 
+	/**
+	 * Pins an explicitly supplied version instead of the running build's. It is
+	 * checked here, before anything is cloned, because a version named on the command
+	 * line is worth rejecting immediately rather than at the one step that edits a
+	 * POM; the reason a snapshot cannot be wired in does not change for being asked
+	 * for on purpose.
+	 *
+	 * @param ruleVersion a released {@code claude-code-enforcer} version
+	 */
 	public PomEnforcerInstaller(String ruleVersion) {
-		this.ruleVersion = () -> ruleVersion;
+		String release = EnforcerRuleVersion.requireRelease(ruleVersion);
+		this.ruleVersion = () -> release;
 	}
 
 	/**
@@ -47,17 +57,22 @@ public class PomEnforcerInstaller {
 	 */
 	public boolean install(Path pomFile) {
 		PomDocument pom = PomDocument.read(pomFile);
-		Element plugins = pom.pluginsElement();
-		if (declaresClaudeRule(plugins)) {
+		if (declaresClaudeRule(pom)) {
 			return false;
 		}
-		wireEnforcer(pom, plugins);
+		wireEnforcer(pom, pom.pluginsElement());
 		pom.write();
 		return true;
 	}
 
-	private boolean declaresClaudeRule(Element plugins) {
-		return PomDocument.children(plugins, "plugin").stream().anyMatch(this::declaresRuleDependency);
+	/**
+	 * Asks the whole POM rather than only its {@code build/plugins}, because a
+	 * project that already runs the rule may well wire it somewhere else — behind an
+	 * opt-in profile, or in {@code pluginManagement}. Looking only at the build would
+	 * report such a POM as unguarded and wire in a second, duplicate declaration.
+	 */
+	private boolean declaresClaudeRule(PomDocument pom) {
+		return pom.plugins().stream().anyMatch(this::declaresRuleDependency);
 	}
 
 	private boolean declaresRuleDependency(Element plugin) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -46,6 +46,13 @@ public class PullRequestStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(PullRequestStep.class);
 
+	/**
+	 * The conditions {@code gh pr create} reports as a failure that mean the pull
+	 * request need not — or cannot — be opened, matched against its own wording:
+	 * "a pull request for branch ... already exists" and "No commits between ...".
+	 */
+	static final List<String> TOLERATED_FAILURES = List.of("already exists", "no commits between");
+
 	private final PullRequestOptions options;
 	private final ObjectMapper mapper = new ObjectMapper();
 
@@ -79,10 +86,22 @@ public class PullRequestStep extends AbstractCommandStep {
 		}
 	}
 
+	/**
+	 * A {@code gh pr create} that fails only because there is nothing to open —
+	 * the branch already has an open pull request, or it carries no commits the base
+	 * does not — leaves the adoption complete rather than aborting it at its last
+	 * step. Both are the normal outcome of re-running an adoption that already
+	 * finished: the first is what {@link #openPullRequestUrl} would have caught had
+	 * {@code gh} been queryable, and the second is what an adoption of an
+	 * already-adopted repository produces, every step having found its work done.
+	 */
 	private void create(AdoptionContext context, CommandRunner runner) {
 		log.info("Opening pull request for branch {}", context.branchName());
-		CommandResult result = runOrFail(runner, context.repositoryDirectory(), createCommand(context));
-		log.info("Opened pull request: {}", result.output().strip());
+		runTolerating(runner, context.repositoryDirectory(), createCommand(context), TOLERATED_FAILURES)
+				.ifPresentOrElse(
+						result -> log.info("Opened pull request: {}", result.output().strip()),
+						() -> log.info("Nothing to open a pull request for on branch {}; left unchanged",
+								context.branchName()));
 	}
 
 	private List<String> createCommand(AdoptionContext context) {
@@ -107,12 +126,19 @@ public class PullRequestStep extends AbstractCommandStep {
 	}
 
 	/**
+	 * A query that fails is reported rather than passed off as "no pull request is
+	 * open": the two are indistinguishable in the return value, and a caller reading
+	 * the log of an adoption that went on to create a duplicate needs to see which
+	 * of the two it was.
+	 *
 	 * @return the URL of the branch's open pull request, or empty when none is open
 	 *         or {@code gh} could not be queried
 	 */
 	private Optional<String> openPullRequestUrl(AdoptionContext context, CommandRunner runner) {
 		CommandResult result = runner.run(context.repositoryDirectory(), listCommand(context));
 		if (!result.succeeded()) {
+			log.warn("Could not ask gh which pull requests are open for branch {} (exit {}): {}",
+					context.branchName(), result.exitCode(), result.output().strip());
 			return Optional.empty();
 		}
 		return extractUrl(result.output());

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/XmlElementSpans.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/XmlElementSpans.java
@@ -1,0 +1,176 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+/**
+ * The character range every element of an XML document occupies in its source
+ * text, in document order. {@link PomDocument} needs these ranges to splice an
+ * edit into the bytes a {@code pom.xml} already holds: a DOM carries no record of
+ * where its elements were read from, and re-serialising the whole document to get
+ * the edit out reformats every line it touches — attributes that were spread over
+ * several lines collapse onto one, {@code <rule />} becomes {@code <rule/>} — so
+ * an adoption commit that adds a dozen lines shows up as a diff across the file.
+ *
+ * <p>The scan is deliberately lexical rather than a second parse: it only needs to
+ * know where each element's start tag, content, and end tag begin, which the JAXP
+ * parser does not report and a {@code Location}-based scan only reports to the
+ * precision of the implementation. Comments, processing instructions, CDATA
+ * sections, and the {@code >} characters that appear inside quoted attribute
+ * values are recognised so they cannot be mistaken for markup. The document has
+ * already been parsed by {@link PomDocument} before this runs, so it is known to
+ * be well-formed and anything unbalanced here is a defect rather than bad input.
+ */
+final class XmlElementSpans {
+
+	/**
+	 * Where a single element sits in the source text.
+	 *
+	 * @param tagStart     index of the {@code <} that opens the start tag
+	 * @param contentStart index just past the start tag's {@code >}
+	 * @param contentEnd   index of the {@code <} that opens the end tag, equal to
+	 *                     {@code contentStart} for an element written as
+	 *                     {@code <name/>}
+	 * @param selfClosing  whether the element was written as {@code <name/>} and so
+	 *                     has no end tag for an edit to be inserted before
+	 */
+	record Span(int tagStart, int contentStart, int contentEnd, boolean selfClosing) {
+	}
+
+	private static final String COMMENT_START = "<!--";
+	private static final String COMMENT_END = "-->";
+	private static final String CDATA_START = "<![CDATA[";
+	private static final String CDATA_END = "]]>";
+	private static final String INSTRUCTION_START = "<?";
+	private static final String INSTRUCTION_END = "?>";
+	private static final String END_TAG_START = "</";
+	private static final String SELF_CLOSING_END = "/>";
+	private static final int NOTHING_LEFT = -1;
+
+	/** A start tag whose end tag has not been reached yet. */
+	private record Pending(int tagStart, int contentStart, int slot) {
+	}
+
+	private final String xml;
+	private final List<Span> spans = new ArrayList<>();
+	private final Deque<Pending> unclosed = new ArrayDeque<>();
+
+	private XmlElementSpans(String xml) {
+		this.xml = xml;
+	}
+
+	/** @return one span per element, in document order — the order a pre-order DOM walk visits them in */
+	static List<Span> of(String xml) {
+		XmlElementSpans scan = new XmlElementSpans(xml);
+		scan.run();
+		return scan.completed();
+	}
+
+	private void run() {
+		int index = 0;
+		while (index >= 0 && index < xml.length()) {
+			index = next(index);
+		}
+	}
+
+	private int next(int from) {
+		int bracket = xml.indexOf('<', from);
+		return bracket < 0 ? NOTHING_LEFT : markup(bracket);
+	}
+
+	/**
+	 * Dispatches on what the {@code <} opens. The comment, CDATA, and processing
+	 * instruction cases are skipped whole rather than scanned, so markup-looking
+	 * text inside them is never mistaken for an element.
+	 */
+	private int markup(int start) {
+		if (xml.startsWith(COMMENT_START, start)) {
+			return after(start, COMMENT_END);
+		}
+		if (xml.startsWith(CDATA_START, start)) {
+			return after(start, CDATA_END);
+		}
+		if (xml.startsWith(INSTRUCTION_START, start)) {
+			return after(start, INSTRUCTION_END);
+		}
+		if (xml.startsWith(END_TAG_START, start)) {
+			return endTag(start);
+		}
+		return startTag(start);
+	}
+
+	private int after(int start, String terminator) {
+		int end = xml.indexOf(terminator, start);
+		return end < 0 ? NOTHING_LEFT : end + terminator.length();
+	}
+
+	/**
+	 * Records the element in document order right away — before its end tag is
+	 * known — by reserving its slot, so a parent still precedes the children whose
+	 * tags close first.
+	 */
+	private int startTag(int start) {
+		int close = tagEnd(start);
+		if (close < 0) {
+			return NOTHING_LEFT;
+		}
+		int contentStart = close + 1;
+		if (xml.startsWith(SELF_CLOSING_END, close - 1)) {
+			spans.add(new Span(start, contentStart, contentStart, true));
+		} else {
+			spans.add(null);
+			unclosed.addLast(new Pending(start, contentStart, spans.size() - 1));
+		}
+		return contentStart;
+	}
+
+	private int endTag(int start) {
+		int close = xml.indexOf('>', start);
+		if (close < 0) {
+			return NOTHING_LEFT;
+		}
+		fill(start);
+		return close + 1;
+	}
+
+	private void fill(int endTagStart) {
+		Pending pending = unclosed.pollLast();
+		if (pending == null) {
+			throw new AdoptionException("Unbalanced XML: an end tag at offset " + endTagStart + " closes nothing");
+		}
+		spans.set(pending.slot(), new Span(pending.tagStart(), pending.contentStart(), endTagStart, false));
+	}
+
+	/**
+	 * The {@code >} that closes a tag, skipping the ones inside quoted attribute
+	 * values — a {@code <plugin config="a>b">} would otherwise be cut short and
+	 * every following offset shifted.
+	 */
+	private int tagEnd(int tagStart) {
+		char quote = 0;
+		int index = tagStart + 1;
+		while (index < xml.length()) {
+			char character = xml.charAt(index);
+			if (quote != 0) {
+				quote = character == quote ? 0 : quote;
+			} else if (character == '"' || character == '\'') {
+				quote = character;
+			} else if (character == '>') {
+				return index;
+			}
+			index++;
+		}
+		return NOTHING_LEFT;
+	}
+
+	private List<Span> completed() {
+		if (!unclosed.isEmpty()) {
+			throw new AdoptionException("Unbalanced XML: " + unclosed.size() + " element(s) were never closed");
+		}
+		return List.copyOf(spans);
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -103,6 +104,28 @@ class CliArgumentsTest {
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
 				() -> CliArguments.parse(new String[] { REPO_URL, "--title" }));
 		assertTrue(exception.getMessage().contains("--title"), exception.getMessage());
+	}
+
+	@Test
+	void parsesTheRuleVersionFlag() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--rule-version", "2.6.0" });
+		assertEquals(Optional.of("2.6.0"), cli.ruleVersion());
+	}
+
+	@Test
+	void noRuleVersionFlagLeavesTheRunningBuildsVersionToBeResolved() {
+		assertEquals(Optional.empty(), CliArguments.parse(new String[] { REPO_URL }).ruleVersion());
+	}
+
+	/**
+	 * A blank value counts as not supplied, the rule every other optional input
+	 * follows, so it falls back to the running build's version rather than pinning an
+	 * empty one the adopted project could not resolve.
+	 */
+	@Test
+	void aBlankRuleVersionFallsBackToTheDefault() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--rule-version", "  " });
+		assertEquals(Optional.empty(), cli.ruleVersion());
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -33,12 +34,15 @@ class AdoptToolTest {
 		private AdoptionContext context;
 		private PullRequestOptions options;
 		private boolean includeAssets;
+		private Optional<String> ruleVersion = Optional.empty();
 
 		@Override
-		public AdoptionReport adopt(AdoptionContext context, PullRequestOptions options, boolean includeAssets) {
+		public AdoptionReport adopt(AdoptionContext context, PullRequestOptions options, boolean includeAssets,
+				Optional<String> ruleVersion) {
 			this.context = context;
 			this.options = options;
 			this.includeAssets = includeAssets;
+			this.ruleVersion = ruleVersion;
 			AdoptionReport report = new AdoptionReport();
 			report.recordStep("pull-request");
 			report.recordPullRequestUrl(PR_URL);
@@ -93,6 +97,25 @@ class AdoptToolTest {
 		assertEquals(List.of("adamw7"), pipeline.options.assignees());
 		assertTrue(pipeline.options.draft());
 		assertTrue(pipeline.includeAssets);
+	}
+
+	@Test
+	void passesTheRuleVersionOnToThePipeline() {
+		tool.apply(Map.of("repository_url", REPO_URL, "rule_version", " 2.6.0 "));
+		assertEquals(Optional.of("2.6.0"), pipeline.ruleVersion);
+	}
+
+	@Test
+	void aBlankRuleVersionLeavesTheRunningBuildsVersionToBeResolved() {
+		tool.apply(Map.of("repository_url", REPO_URL, "rule_version", "  "));
+		assertEquals(Optional.empty(), pipeline.ruleVersion);
+	}
+
+	@Test
+	void declaresTheRuleVersionArgument() {
+		Object properties = tool.getToolDefinition().inputSchema().get("properties");
+		assertTrue(properties instanceof Map<?, ?> declared && declared.containsKey("rule_version"),
+				"the version must be settable through the tool: " + properties);
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -1,6 +1,8 @@
 package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -91,6 +93,25 @@ class BuildSystemsTest {
 		BuildSystem gradle = new GradleBuildSystem();
 		assertEquals(Optional.of(gradle.verifyCommand().get(0)), gradle.requiredTool());
 		assertEquals(Optional.of("gradle"), gradle.requiredTool());
+	}
+
+	@Test
+	void withNoRuleVersionTheDefaultsAreUsedAsIs() {
+		assertEquals(BuildSystems.DEFAULTS, BuildSystems.withRuleVersion(Optional.empty()));
+	}
+
+	/**
+	 * Only Maven wires a versioned artifact into the adopted project, so pinning a
+	 * version changes that entry and leaves the detection order — and the other two
+	 * build systems — as they were.
+	 */
+	@Test
+	void anExplicitRuleVersionReplacesOnlyTheMavenBuildSystem() {
+		List<BuildSystem> pinned = BuildSystems.withRuleVersion(Optional.of("2.6.0"));
+		assertEquals(BuildSystems.names(BuildSystems.DEFAULTS), BuildSystems.names(pinned));
+		assertNotSame(BuildSystems.DEFAULTS.get(0), pinned.get(0), "Maven must be rebuilt around the pinned version");
+		assertSame(BuildSystems.DEFAULTS.get(1), pinned.get(1), "Gradle needs no version and must be reused");
+		assertSame(BuildSystems.DEFAULTS.get(2), pinned.get(2), "the fallback needs no version and must be reused");
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,68 @@ class PomEnforcerInstallerTest {
 	private static final String POM_NO_TRAILING_NEWLINE = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n"
 			+ "  <artifactId>demo</artifactId>\n"
 			+ "</project>";
+
+	/**
+	 * Formatted the way a real project's POM is, with the details a DOM cannot
+	 * remember: a start tag broken over several lines, tab indentation, and empty
+	 * elements written with a space before the slash.
+	 */
+	private static final String POM_HAND_FORMATTED = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n"
+			+ "\txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n"
+			+ "\t<artifactId>demo</artifactId>\n"
+			+ "\t<build>\n"
+			+ "\t\t<plugins>\n"
+			+ "\t\t\t<plugin>\n"
+			+ "\t\t\t\t<artifactId>maven-enforcer-plugin</artifactId>\n"
+			+ "\t\t\t\t<executions>\n"
+			+ "\t\t\t\t\t<execution>\n"
+			+ "\t\t\t\t\t\t<configuration>\n"
+			+ "\t\t\t\t\t\t\t<rules>\n"
+			+ "\t\t\t\t\t\t\t\t<dependencyConvergence />\n"
+			+ "\t\t\t\t\t\t\t</rules>\n"
+			+ "\t\t\t\t\t\t</configuration>\n"
+			+ "\t\t\t\t\t</execution>\n"
+			+ "\t\t\t\t</executions>\n"
+			+ "\t\t\t</plugin>\n"
+			+ "\t\t</plugins>\n"
+			+ "\t</build>\n"
+			+ "</project>\n";
+
+	private static final String POM_SELF_CLOSING_PLUGINS = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+			  <artifactId>demo</artifactId>
+			  <properties/>
+			  <build>
+			    <plugins/>
+			  </build>
+			</project>
+			""";
+
+	/** Wires the rule the way this repository does: behind an opt-in profile, not in the build. */
+	private static final String POM_WITH_RULE_IN_A_PROFILE = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+			  <artifactId>demo</artifactId>
+			  <profiles>
+			    <profile>
+			      <id>claude-md-enforce</id>
+			      <build>
+			        <plugins>
+			          <plugin>
+			            <artifactId>maven-enforcer-plugin</artifactId>
+			            <dependencies>
+			              <dependency>
+			                <groupId>io.github.adamw7</groupId>
+			                <artifactId>tools.claude-code-enforcer</artifactId>
+			                <version>1.0.0</version>
+			              </dependency>
+			            </dependencies>
+			          </plugin>
+			        </plugins>
+			      </build>
+			    </profile>
+			  </profiles>
+			</project>
+			""";
 
 	private static final String POM_WITH_ENFORCER = """
 			<project xmlns="http://maven.apache.org/POM/4.0.0">
@@ -201,6 +264,20 @@ class PomEnforcerInstallerTest {
 		assertTrue(result.contains("maven-enforcer-plugin"));
 	}
 
+	/**
+	 * A project may well run the guard from somewhere other than its {@code build}:
+	 * behind an opt-in profile, most often, so ordinary builds are unaffected.
+	 * Looking only at {@code build/plugins} reports such a POM as unguarded and wires
+	 * in a second, always-on copy of a rule the project already runs on its own
+	 * terms.
+	 */
+	@Test
+	void leavesAPomThatWiresTheRuleInsideAProfileAlone(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_RULE_IN_A_PROFILE);
+		assertFalse(installer.install(pom), "the rule is already wired in, in the profile");
+		assertEquals(POM_WITH_RULE_IN_A_PROFILE, Files.readString(pom), "the POM must not have been touched");
+	}
+
 	@Test
 	void secondInstallIsIdempotent(@TempDir Path dir) throws IOException {
 		Path pom = write(dir, POM_WITH_BUILD);
@@ -305,16 +382,17 @@ class PomEnforcerInstallerTest {
 	}
 
 	/**
-	 * A declaration sharing its line with the root element has no line terminator
-	 * to carry over, so one is supplied rather than running {@code <project>} onto
-	 * the declaration's line.
+	 * A declaration sharing its line with the root element keeps sharing it: the
+	 * edit is spliced into the text the file already held, so a region the adoption
+	 * has no business touching is not rewritten — not even to put the root element
+	 * on a line of its own.
 	 */
 	@Test
 	void preservesADeclarationThatSharesItsLineWithTheRootElement(@TempDir Path dir) throws IOException {
 		Path pom = write(dir, "<?xml version=\"1.0\"?>" + POM_WITH_BUILD);
 		installer.install(pom);
 		String result = Files.readString(pom);
-		assertTrue(result.startsWith("<?xml version=\"1.0\"?>\n<project "), "unexpected start:\n" + result);
+		assertTrue(result.startsWith("<?xml version=\"1.0\"?><project "), "unexpected start:\n" + result);
 		assertEquals(1, countOccurrences(result, "<?xml"), "the declaration must not be duplicated");
 	}
 
@@ -370,6 +448,79 @@ class PomEnforcerInstallerTest {
 		assertFalse(result.endsWith("\n"), "a POM with no trailing newline must not gain one");
 	}
 
+	/**
+	 * The whole point of splicing rather than re-serialising: a start tag the project
+	 * spread over several lines, and an empty element it wrote {@code <rule />},
+	 * are details a DOM does not record, so writing the edited document out whole
+	 * normalises both and an adoption that adds one block arrives as a diff across
+	 * the file.
+	 */
+	@Test
+	void leavesAMultiLineStartTagAndSpacedEmptyElementsUntouched(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_HAND_FORMATTED);
+		assertTrue(installer.install(pom));
+		String result = Files.readString(pom);
+		assertTrue(result.contains("<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n"
+				+ "\txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"),
+				"the multi-line start tag must keep its own line breaks:\n" + result);
+		assertTrue(result.contains("<dependencyConvergence />"),
+				"an empty element the project spaced must not be rewritten as <x/>:\n" + result);
+	}
+
+	/**
+	 * The general statement of the same contract, and the one that fails for a
+	 * reformat anywhere in the file: every line the POM already held is still there,
+	 * in order and character for character, with only new lines in between. Stated
+	 * over lines rather than as a single untouched prefix and suffix because the
+	 * install legitimately writes in two places at once — the rule dependency onto
+	 * the plugin, the execution into its existing {@code <executions>}.
+	 */
+	@Test
+	void changesNothingOutsideTheAddedBlock(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_HAND_FORMATTED);
+		installer.install(pom);
+		assertEveryOriginalLineSurvives(POM_HAND_FORMATTED, Files.readString(pom));
+	}
+
+	/**
+	 * A {@code <plugins/>} element has no end tag for the block to be inserted
+	 * before, so it has to grow one rather than being left for the serialiser to
+	 * expand along with everything else.
+	 */
+	@Test
+	void wiresTheRuleIntoASelfClosingPluginsElement(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_SELF_CLOSING_PLUGINS);
+		assertTrue(installer.install(pom));
+		String result = Files.readString(pom);
+		assertTrue(result.contains("<artifactId>tools.claude-code-enforcer</artifactId>"),
+				"the rule must be wired in:\n" + result);
+		assertFalse(result.contains("<plugins/>"), "the empty element must have been reopened:\n" + result);
+		assertTrue(result.contains("\n    </plugins>"),
+				"the end tag it grew must be indented to the element's own depth:\n" + result);
+		assertTrue(result.contains("\n  <properties/>"),
+				"an unrelated empty element must be left exactly as it was:\n" + result);
+	}
+
+	/**
+	 * Asserts the original's lines are still a subsequence of the result's: an edit
+	 * that only inserts leaves them all matchable in order, while any reformat
+	 * changes a line and leaves it unmatched.
+	 *
+	 * @param original what the file held before the install
+	 * @param result   what it holds after
+	 */
+	private void assertEveryOriginalLineSurvives(String original, String result) {
+		List<String> lines = result.lines().toList();
+		int next = 0;
+		for (String line : original.lines().toList()) {
+			int found = lines.subList(next, lines.size()).indexOf(line);
+			assertTrue(found >= 0, "the edit reformatted a line the adoption should not have touched: '" + line
+					+ "'\nresult:\n" + result);
+			next += found + 1;
+		}
+		assertTrue(result.lines().count() > original.lines().count(), "nothing was added:\n" + result);
+	}
+
 	@Test
 	void aReleaseRuleVersionIsPinnedIntoThePom(@TempDir Path dir) throws IOException {
 		Path pom = write(dir, POM_WITH_BUILD);
@@ -377,6 +528,22 @@ class PomEnforcerInstallerTest {
 		String result = Files.readString(pom);
 		assertTrue(result.contains("tools.claude-code-enforcer"));
 		assertTrue(result.contains("<version>4.1.0</version>"), result);
+	}
+
+	/**
+	 * A version named on the command line is checked as it is supplied rather than at
+	 * the one step that edits a POM: asking for a snapshot on purpose does not make it
+	 * resolvable for the adopted project's CI, so there is nothing to gain by
+	 * discovering it after a clone and a {@code claude init}.
+	 */
+	@Test
+	void anExplicitSnapshotRuleVersionIsRejectedBeforeAnythingRuns() {
+		assertThrows(AdoptionException.class, () -> new PomEnforcerInstaller("2.6.0-SNAPSHOT"));
+	}
+
+	@Test
+	void aBlankExplicitRuleVersionIsRejected() {
+		assertThrows(AdoptionException.class, () -> new PomEnforcerInstaller("  "));
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -207,6 +207,49 @@ class PullRequestStepTest {
 		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
 	}
 
+	/**
+	 * Re-adopting a repository that is already adopted leaves every step with its
+	 * work done and so the branch with no commits the base does not already have.
+	 * There is nothing to raise a pull request for, which is the run succeeding —
+	 * aborting the last step of a pipeline that found nothing left to do would make
+	 * the adoption impossible to re-run.
+	 */
+	@Test
+	void aBranchWithNoCommitsToProposeIsNotAFailure() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("create")
+				? new CommandResult(command, 1, "pull request create failed: GraphQL: No commits between main and "
+						+ "claude/adopt-claude-code (createPullRequest)")
+				: new CommandResult(command, 0, "[]"));
+		step.execute(context, runner);
+		assertTrue(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("create")),
+				"the creation must have been attempted");
+	}
+
+	/**
+	 * The pre-check that would have caught this cannot always run: {@code gh pr
+	 * list} needs a query a restricted token or a proxied host may refuse, and its
+	 * failure is indistinguishable from "no pull request is open". The create that
+	 * follows then reports the pull request already exists, which is the same no-op
+	 * the pre-check would have made it.
+	 */
+	@Test
+	void anAlreadyOpenPullRequestIsNotAFailureEvenWhenTheQueryCouldNotRunFirst() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("create")
+				? new CommandResult(command, 1, "a pull request for branch \"claude/adopt-claude-code\" into branch"
+						+ " \"main\" already exists:\n" + PR_URL)
+				: new CommandResult(command, 1, "HTTP 403: this GraphQL query is not enabled for this session"));
+		step.execute(context, runner);
+		assertTrue(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("create")));
+	}
+
+	@Test
+	void aCreationFailureThatIsNotBenignStillAbortsAdoption() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("create")
+				? new CommandResult(command, 1, "gh: Resource not accessible by integration")
+				: new CommandResult(command, 0, "[]"));
+		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
+	}
+
 	private CommandResult noOpenPullRequest(List<String> command) {
 		if (command.contains("list")) {
 			return new CommandResult(command, 0, "[]");

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/XmlElementSpansTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/XmlElementSpansTest.java
@@ -1,0 +1,115 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.step.XmlElementSpans.Span;
+
+class XmlElementSpansTest {
+
+	@Test
+	void spansAnElementFromItsStartTagToItsEndTag() {
+		String xml = "<a>text</a>";
+		Span span = only(xml);
+		assertEquals(0, span.tagStart());
+		assertEquals(3, span.contentStart(), "content must start just past the start tag's '>'");
+		assertEquals(7, span.contentEnd(), "content must end at the '<' opening the end tag");
+		assertFalse(span.selfClosing());
+	}
+
+	@Test
+	void marksAnEmptyElementAsSelfClosing() {
+		Span span = only("<a/>");
+		assertTrue(span.selfClosing());
+		assertEquals(0, span.tagStart());
+		assertEquals(4, span.contentStart(), "a self-closing element's content starts and ends past its tag");
+		assertEquals(4, span.contentEnd());
+	}
+
+	@Test
+	void marksAnElementSpacedBeforeItsSlashAsSelfClosingToo() {
+		assertTrue(only("<a />").selfClosing());
+	}
+
+	@Test
+	void treatsAnEmptyPairOfTagsAsNotSelfClosing() {
+		Span span = only("<a></a>");
+		assertFalse(span.selfClosing());
+		assertEquals(span.contentStart(), span.contentEnd(), "the element has no content between its tags");
+	}
+
+	@Test
+	void ordersSpansAsAPreOrderWalkVisitsThem() {
+		List<Span> spans = XmlElementSpans.of("<a><b><c/></b><d/></a>");
+		assertEquals(4, spans.size());
+		assertEquals(0, spans.get(0).tagStart(), "the root comes first");
+		assertEquals(3, spans.get(1).tagStart(), "then its first child");
+		assertEquals(6, spans.get(2).tagStart(), "then that child's own child, before the root's second child");
+		assertEquals(14, spans.get(3).tagStart());
+	}
+
+	/**
+	 * A {@code >} inside an attribute value does not close the tag. Reading it as if
+	 * it did would shift every following offset and splice the adoption's block into
+	 * the middle of an unrelated element.
+	 */
+	@Test
+	void doesNotEndATagAtAGreaterThanInsideAnAttributeValue() {
+		String xml = "<a config=\"x > y\">text</a>";
+		Span span = only(xml);
+		assertEquals(xml.indexOf("text"), span.contentStart());
+		assertEquals(xml.indexOf("</a>"), span.contentEnd());
+	}
+
+	@Test
+	void handlesSingleQuotedAttributeValues() {
+		String xml = "<a config='x > y'>text</a>";
+		assertEquals(xml.indexOf("text"), only(xml).contentStart());
+	}
+
+	@Test
+	void skipsMarkupInsideAComment() {
+		String xml = "<a><!-- <b/> --><c/></a>";
+		List<Span> spans = XmlElementSpans.of(xml);
+		assertEquals(2, spans.size(), "the commented-out element is not an element: " + spans);
+		assertEquals(xml.indexOf("<c/>"), spans.get(1).tagStart());
+	}
+
+	@Test
+	void skipsMarkupInsideACdataSection() {
+		String xml = "<a><![CDATA[</a><b/>]]></a>";
+		List<Span> spans = XmlElementSpans.of(xml);
+		assertEquals(1, spans.size(), "CDATA content is text, not markup: " + spans);
+		assertEquals(xml.lastIndexOf("</a>"), spans.get(0).contentEnd());
+	}
+
+	@Test
+	void skipsTheXmlDeclaration() {
+		String xml = "<?xml version=\"1.0\"?><a/>";
+		Span span = only(xml);
+		assertEquals(xml.indexOf("<a/>"), span.tagStart());
+	}
+
+	@Test
+	void anEndTagClosingNothingIsRejected() {
+		assertThrows(AdoptionException.class, () -> XmlElementSpans.of("<a></a></b>"));
+	}
+
+	@Test
+	void anElementLeftOpenIsRejected() {
+		assertThrows(AdoptionException.class, () -> XmlElementSpans.of("<a><b></a>"));
+	}
+
+	private Span only(String xml) {
+		List<Span> spans = XmlElementSpans.of(xml);
+		assertEquals(1, spans.size(), "expected exactly one element: " + spans);
+		return spans.get(0);
+	}
+}


### PR DESCRIPTION
Found by running the pipeline end-to-end against a real GitHub repository
rather than the mocked CommandRunner.

PomDocument wrote the edited DOM out whole, so it reformatted details a DOM
does not record: start tags spread over several lines collapsed onto one and
`<rule />` came back `<rule/>`. A fourteen-line addition arrived as a diff
across the file, contradicting the class's own documented contract. The edit
is now spliced into the bytes the file already holds, using source offsets
from a new XmlElementSpans lexical scan, so the commit is a pure insertion —
+22/-0 on this repository's own pom.xml, where it was +28/-10 before. A
declaration sharing its line with the root element now keeps sharing it,
since that region is no longer rewritten either.

PomEnforcerInstaller decided whether the guard was already wired by looking
only at build/plugins, so a project running the rule behind an opt-in profile
was given a second, always-on copy of it. It now scans every plugin the POM
declares, wherever it sits.

PullRequestStep called runOrFail for `gh pr create`, so a failure reporting
only that the pull request already exists, or that there are no commits
between base and head, aborted the last step of an otherwise complete
adoption — which the README already described as a no-op. Both are now
tolerated through a new AbstractCommandStep.runTolerating, and a `gh pr list`
that could not run is logged rather than passed off as "nothing is open",
which is what left a re-run creating a duplicate in the first place.

The snapshot refusal told operators to supply a released version but nothing
reached PomEnforcerInstaller from outside; --rule-version (rule_version on
the MCP tool) now does, validated as a release where it is supplied so an
unusable version fails before the clone. Which build system a pinned version
changes is left to BuildSystem.withRuleVersion rather than a type check.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q7q1eLMXs9gPC1gPe5rrLp