### PR TITLE
feat(adopt): adopt a list of repositories in one run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,18 @@ Maven project. The notable capabilities are:
   `PullRequestOptions`, exposed on the command line as `--title`, `--body`,
   repeatable `--reviewer`/`--label`/`--assignee`, and `--draft` (parsed by
   `CliArguments` alongside the positional URL, workspace, and branch arguments).
+  One run adopts a **list of repositories**: repeatable `--repo <url>` and
+  `--repos <file>` (one URL per line, `#` comments and blank lines skipped, read
+  by `RepositoryUrls`) add to the positional URL, duplicates are dropped, and
+  `--workspace`/`--branch` name the shared workspace and branch for a run with no
+  positional arguments — the first positional is always a repository URL, never a
+  workspace. `BatchAdoption` runs the pipeline once per repository with a report
+  each and does *not* stop at the first failure: the adoptions are independent, so
+  a failed one is recorded and the batch runs to the end, with `Main` raising the
+  failures together afterwards so the process still exits non-zero. The MCP tool
+  takes the same list as `repository_urls` (a JSON array, or a comma-separated
+  string) beside `repository_url`, and answers with an error result carrying the
+  report — not a bare exception — when a repository fails.
   An optional `--assets` flag adds an `AssetsStep` that commits starter Claude
   Code configuration assets — an `AGENTS.md` pointer, a `.claude/settings.json`
   denying reads of obvious secret files and wiring a
@@ -85,7 +97,11 @@ Maven project. The notable capabilities are:
   (completed steps, the pull request URL read back with `gh pr list --json url`,
   and whether the run succeeded plus the failing step's message when it did not);
   `--report <file>` writes it as JSON for scripting, on the failure path too, so
-  an abandoned run still records how far it got. An **MCP server** (in the
+  an abandoned run still records how far it got. A run over several repositories
+  writes the batch document instead — an overall `succeeded` and a `repositories`
+  array of those same per-repository documents — while a single-repository run
+  keeps writing its document unwrapped, so the shape existing consumers parse is
+  unchanged. An **MCP server** (in the
   `io.github.adamw7.tools.adopt.mcp` package) exposes the same pipeline as an
   `adopt_repo` tool that answers with that JSON report. External
   `git`/`claude`/`gh` invocations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,9 @@ run `mvn install` from the repository root. The main capabilities are:
   generated file, then push the branch and open a pull request (`gh pr create`)
   with metadata from `PullRequestOptions` (exposed as CLI flags such as
   `--title`, `--reviewer`, and `--draft`); the default branch is never written to
-  directly. An optional `--assets` flag commits starter Claude Code
+  directly. One run adopts a list of repositories — repeatable `--repo <url>` or
+  `--repos <file>` on the command line, `repository_urls` on the MCP tool — each
+  with its own report, and a repository that fails does not stop the rest. An optional `--assets` flag commits starter Claude Code
   configuration assets (an `AGENTS.md` pointer, `.claude/settings.json`, a
   session-start hook stub, `.mcp.json`, and an `@claude`-mention workflow); each
   run returns an `AdoptionReport` with the pull request URL, written as JSON via

--- a/README.md
+++ b/README.md
@@ -763,6 +763,49 @@ mvn -pl adopt exec:java \
     -Dexec.args="https://github.com/owner/repo.git [workspace-directory] [branch-name]"
 ```
 
+One run can adopt **a list of repositories** rather than a single one: repeat
+`--repo <url>` for each, or point `--repos <file>` at a file naming one
+repository per line (blank lines are skipped and a `#` line is a comment, so a
+batch can be annotated and a repository commented out for a run). Duplicates are
+adopted once. Every repository of the run shares the workspace and the branch
+name — each clone lands in its own directory under the workspace, named after the
+repository — so a batch driven entirely by the flags names them with
+`--workspace` and `--branch`, the first positional argument always being a
+repository URL:
+
+```bash
+mvn -pl adopt exec:java \
+    -Dexec.args="--repos repos.txt --workspace /tmp/adoptions --report report.json"
+```
+
+A repository whose adoption fails does not strand the ones behind it: the batch
+runs to the end, and the failures are raised together afterwards so the command
+still exits non-zero. The `--report` file says which repositories landed — a run
+over several repositories writes an overall `succeeded` (true only when every one
+was adopted) and a `repositories` array of exactly the per-repository documents a
+single-repository run writes unwrapped:
+
+```json
+{
+  "succeeded" : false,
+  "repositories" : [ {
+    "repositoryUrl" : "https://github.com/owner/repo.git",
+    "branch" : "claude/adopt-claude-code",
+    "pullRequestUrl" : "https://github.com/owner/repo/pull/42",
+    "succeeded" : true,
+    "failure" : null,
+    "completedSteps" : [ "toolchain", "clone", "…", "pull-request" ]
+  }, {
+    "repositoryUrl" : "https://github.com/owner/other.git",
+    "branch" : "claude/adopt-claude-code",
+    "pullRequestUrl" : null,
+    "succeeded" : false,
+    "failure" : "clone: repository not found",
+    "completedSteps" : [ "toolchain" ]
+  } ]
+}
+```
+
 The `claude-code-enforcer` version a Maven project's `pom.xml` is made to depend
 on defaults to the version of the `tools` build running the adoption;
 `--rule-version <version>` pins a different one. A `-SNAPSHOT` is refused either
@@ -780,6 +823,17 @@ derived checkout directory, and the feature-branch name):
 CommandRunner runner = new ProcessCommandRunner();
 GitHubRepoAdopter.withDefaultPipeline(runner, PullRequestOptions.defaults(), false)
     .adopt(new AdoptionContext("https://github.com/owner/repo.git", workspace));
+```
+
+`BatchAdoption` wraps that pipeline to work through a list of repositories, one
+`AdoptionContext` at a time, and answers with an `AdoptionRun` (the context and
+its report) per repository — a failing repository is recorded rather than
+allowed to abandon the rest:
+
+```java
+GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(
+    runner, PullRequestOptions.defaults(), false);
+List<AdoptionRun> runs = new BatchAdoption(adopter::adopt).adoptAll(contexts);
 ```
 
 The default pipeline runs these steps in order:

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt;
 
 import java.nio.file.Path;
+import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -8,39 +9,66 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
- * Renders an {@link AdoptionReport} as JSON, either to a string or to a file, so
- * the adoption's outcome — repository, branch, pull-request URL, whether the run
- * succeeded, and the steps that completed — is consumable by scripts and other
- * tools rather than only readable in the logs. A report without a pull-request
- * URL serialises the {@code pullRequestUrl} field as JSON {@code null}, and so
- * does a successful run's {@code failure}, keeping the document's shape stable
- * for consumers.
+ * Renders the outcome of an adoption run as JSON, either to a string or to a
+ * file, so it — repository, branch, pull-request URL, whether the run succeeded,
+ * and the steps that completed — is consumable by scripts and other tools rather
+ * than only readable in the logs. A report without a pull-request URL serialises
+ * the {@code pullRequestUrl} field as JSON {@code null}, and so does a successful
+ * run's {@code failure}, keeping the document's shape stable for consumers.
+ *
+ * <p>A run over several repositories is written as a batch document instead: an
+ * overall {@code succeeded} — true only when every repository was adopted — and a
+ * {@code repositories} array of exactly the per-repository documents above.
+ * Adopting a single repository keeps writing that per-repository document
+ * unwrapped, so the shape a consumer of a one-repository run already parses is
+ * unchanged by the list input.
  */
 public class AdoptionReportWriter {
 
 	private final ObjectMapper mapper = new ObjectMapper();
 
+	/** Renders a single repository's outcome, the shape nested in a batch document. */
 	public String toJson(AdoptionContext context, AdoptionReport report) {
+		return toJson(List.of(new AdoptionRun(context, report)));
+	}
+
+	public String toJson(List<AdoptionRun> runs) {
 		try {
-			return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(toNode(context, report));
+			return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(toNode(runs));
 		} catch (JsonProcessingException e) {
 			throw new AdoptionException("Could not serialise the adoption report", e);
 		}
 	}
 
 	public void write(Path file, AdoptionContext context, AdoptionReport report) {
-		AdoptionFiles.write(file, toJson(context, report), "the adoption report");
+		write(file, List.of(new AdoptionRun(context, report)));
 	}
 
-	private ObjectNode toNode(AdoptionContext context, AdoptionReport report) {
+	public void write(Path file, List<AdoptionRun> runs) {
+		AdoptionFiles.write(file, toJson(runs), "the adoption report");
+	}
+
+	private ObjectNode toNode(List<AdoptionRun> runs) {
+		return runs.size() == 1 ? toNode(runs.get(0)) : toBatchNode(runs);
+	}
+
+	private ObjectNode toBatchNode(List<AdoptionRun> runs) {
 		ObjectNode node = mapper.createObjectNode();
-		node.put("repositoryUrl", context.repositoryUrl());
-		node.put("branch", context.branchName());
-		node.put("pullRequestUrl", report.pullRequestUrl().orElse(null));
-		node.put("succeeded", report.succeeded());
-		node.put("failure", report.failure().orElse(null));
+		node.put("succeeded", runs.stream().allMatch(AdoptionRun::succeeded));
+		ArrayNode repositories = node.putArray("repositories");
+		runs.stream().map(this::toNode).forEach(repositories::add);
+		return node;
+	}
+
+	private ObjectNode toNode(AdoptionRun run) {
+		ObjectNode node = mapper.createObjectNode();
+		node.put("repositoryUrl", run.repositoryUrl());
+		node.put("branch", run.context().branchName());
+		node.put("pullRequestUrl", run.report().pullRequestUrl().orElse(null));
+		node.put("succeeded", run.succeeded());
+		node.put("failure", run.failure().orElse(null));
 		ArrayNode steps = node.putArray("completedSteps");
-		report.completedSteps().forEach(steps::add);
+		run.report().completedSteps().forEach(steps::add);
 		return node;
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionRun.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionRun.java
@@ -1,0 +1,28 @@
+package io.github.adamw7.tools.adopt;
+
+import java.util.Optional;
+
+/**
+ * One repository's adoption within a run: the inputs it was given and the report
+ * it produced. A batch answers with a list of these rather than a list of bare
+ * reports, because a report on its own does not say which repository it belongs
+ * to — and a run over several repositories is read repository by repository.
+ *
+ * @param context the inputs the adoption was run with
+ * @param report  what the adoption achieved, and why it stopped when it did
+ */
+public record AdoptionRun(AdoptionContext context, AdoptionReport report) {
+
+	public String repositoryUrl() {
+		return context.repositoryUrl();
+	}
+
+	public boolean succeeded() {
+		return report.succeeded();
+	}
+
+	/** @return why this repository's adoption stopped, or empty when it completed */
+	public Optional<String> failure() {
+		return report.failure();
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
@@ -1,0 +1,76 @@
+package io.github.adamw7.tools.adopt;
+
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Adopts a list of repositories, one after another, with a fresh
+ * {@link AdoptionReport} for each. A batch is why the adoption takes a list of
+ * URLs at all: a team adopts Claude Code across its repositories in one run
+ * rather than invoking the pipeline once per repository by hand.
+ *
+ * <p>A repository whose adoption fails does not stop the batch. Failing fast
+ * would leave the repositories behind it untried, and their adoptions are
+ * independent — a {@code gh} login that expired for one organisation, or a project
+ * whose build tool is missing, says nothing about the next repository on the
+ * list. The failure is recorded in that repository's report and the run moves on,
+ * so the caller can see exactly which repositories were adopted and which were
+ * not; deciding what a partly failed batch means — a non-zero exit, an error
+ * result — is the caller's, not the batch's.
+ *
+ * <p>Repositories are adopted sequentially rather than in parallel: every
+ * adoption shells out to {@code git}, {@code claude}, and {@code gh}, and a
+ * parallel batch would interleave their output and multiply the load a single
+ * {@code claude init} already puts on the machine.
+ */
+public final class BatchAdoption {
+
+	/**
+	 * A single repository's adoption, filling in the report it is handed. The report
+	 * is a parameter rather than a return value so a failed adoption still yields one:
+	 * a report only handed back on the return path is lost the moment the adoption
+	 * throws, which is when the batch most needs to know how far that repository got.
+	 */
+	public interface Adoption {
+		void adopt(AdoptionContext context, AdoptionReport report);
+	}
+
+	private static final Logger log = LogManager.getLogger(BatchAdoption.class);
+
+	private final Adoption adoption;
+
+	public BatchAdoption(Adoption adoption) {
+		this.adoption = adoption;
+	}
+
+	/** @return one run per repository, in the order the repositories were given */
+	public List<AdoptionRun> adoptAll(List<AdoptionContext> contexts) {
+		log.info("Adopting Claude Code into {} repositories", contexts.size());
+		return contexts.stream().map(this::adoptOne).toList();
+	}
+
+	private AdoptionRun adoptOne(AdoptionContext context) {
+		AdoptionReport report = new AdoptionReport();
+		try {
+			adoption.adopt(context, report);
+		} catch (RuntimeException e) {
+			recordFailure(context, report, e);
+		}
+		return new AdoptionRun(context, report);
+	}
+
+	/**
+	 * The failure is logged with its stack trace here because it is not rethrown:
+	 * swallowing it to keep the batch going would otherwise be the last that is seen
+	 * of it. A failure the pipeline already described — naming the step that raised
+	 * it — is left alone, since that reads better than the bare message.
+	 */
+	private void recordFailure(AdoptionContext context, AdoptionReport report, RuntimeException failure) {
+		log.error("Adoption failed for {}", context.repositoryUrl(), failure);
+		if (report.failure().isEmpty()) {
+			report.recordFailure(Failures.describe(failure));
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -12,24 +12,36 @@ import io.github.adamw7.tools.adopt.step.PullRequestOptions;
  * Parses the adoption command line. The first three non-flag arguments are the
  * positional repository URL, workspace directory, and feature-branch name the
  * entry point has always accepted, so existing invocations keep working; the
- * flags expose the rest of the pipeline's configuration: the pull-request
- * metadata of {@link PullRequestOptions} ({@code --title}, {@code --body},
- * repeatable {@code --reviewer}/{@code --label}/{@code --assignee}, and
- * {@code --draft}), the optional starter-assets step ({@code --assets}), the
+ * flags expose the rest of the pipeline's configuration: further repositories to
+ * adopt in the same run (repeatable {@code --repo}, or {@code --repos <file>} for
+ * a file naming one per line), the workspace and branch under their own names
+ * ({@code --workspace}, {@code --branch}), the pull-request metadata of
+ * {@link PullRequestOptions} ({@code --title}, {@code --body}, repeatable
+ * {@code --reviewer}/{@code --label}/{@code --assignee}, and {@code --draft}),
+ * the optional starter-assets step ({@code --assets}), the
  * {@code claude-code-enforcer} version to wire into an adopted Maven project
  * ({@code --rule-version}), and a JSON report of the run's outcome
  * ({@code --report <file>}). A blank workspace
  * or branch positional falls back to its default, matching the pre-flag
  * behaviour; an unknown flag or a flag missing its value fails with the usage
  * line rather than being silently ignored.
+ *
+ * <p>The positional slots keep their meaning whatever else is on the command
+ * line — the first is always a repository URL, never a workspace — so a run
+ * driven entirely by {@code --repo}/{@code --repos} names its workspace and
+ * branch with {@code --workspace} and {@code --branch} rather than positionally.
+ * Both flags write the same value as their positional, so naming one twice is the
+ * last one winning rather than an error.
  */
 public final class CliArguments {
 
-	static final String USAGE = "Usage: <github-repo-url> [workspace-directory] [branch-name]"
+	static final String USAGE = "Usage: [<github-repo-url>] [workspace-directory] [branch-name]"
+			+ " [--repo <github-repo-url>]... [--repos <file>]"
+			+ " [--workspace <directory>] [--branch <name>]"
 			+ " [--title <title>] [--body <body>] [--reviewer <user>]... [--label <label>]..."
 			+ " [--assignee <user>]... [--draft] [--assets] [--rule-version <version>] [--report <file>]";
 
-	private String repositoryUrl;
+	private final List<String> repositoryUrls = new ArrayList<>();
 	private Path workspace;
 	private String branchName;
 	private String title;
@@ -52,12 +64,17 @@ public final class CliArguments {
 		while (args != null && index < args.length) {
 			index = cli.consume(args, index);
 		}
-		cli.requireRepositoryUrl();
+		cli.requireRepositoryUrls();
 		return cli;
 	}
 
-	public String repositoryUrl() {
-		return repositoryUrl;
+	/**
+	 * @return every repository to adopt in this run — the positional URL first, then
+	 *         the ones the flags added — without duplicates, since the same
+	 *         repository twice would adopt one checkout a second time
+	 */
+	public List<String> repositoryUrls() {
+		return RepositoryUrls.distinct(repositoryUrls);
 	}
 
 	public Optional<Path> workspace() {
@@ -105,13 +122,16 @@ public final class CliArguments {
 	private int consumeFlag(String[] args, int index) {
 		String flag = args[index];
 		return switch (flag) {
+			case "--repo" -> consumeValue(args, index, this::addRepository);
+			case "--repos" -> consumeValue(args, index, value -> repositoryUrls.addAll(readList(value)));
+			case "--workspace" -> consumeValue(args, index, value -> workspace = optionalPath(value));
+			case "--branch" -> consumeValue(args, index, value -> branchName = optionalText(value));
 			case "--title" -> consumeValue(args, index, value -> title = value);
 			case "--body" -> consumeValue(args, index, value -> body = value);
 			case "--reviewer" -> consumeValue(args, index, reviewers::add);
 			case "--label" -> consumeValue(args, index, labels::add);
 			case "--assignee" -> consumeValue(args, index, assignees::add);
-			case "--rule-version" -> consumeValue(args, index,
-					value -> ruleVersion = Text.isPresent(value) ? value.strip() : null);
+			case "--rule-version" -> consumeValue(args, index, value -> ruleVersion = optionalText(value));
 			case "--report" -> consumeValue(args, index, value -> reportFile = Path.of(value));
 			case "--draft" -> {
 				draft = true;
@@ -137,20 +157,39 @@ public final class CliArguments {
 	 * A blank workspace or branch positional counts as not supplied — the rule
 	 * {@link Text} defines for every optional input — so it falls back to its
 	 * default rather than resolving the empty path or being rejected as an invalid
-	 * branch.
+	 * branch. A blank repository positional is dropped the same way, leaving the run
+	 * with whatever the {@code --repo} and {@code --repos} flags named.
 	 */
 	private void consumePositional(String argument) {
 		switch (positionals) {
-			case 0 -> repositoryUrl = argument;
-			case 1 -> workspace = Text.isPresent(argument) ? Path.of(argument.strip()) : null;
-			case 2 -> branchName = Text.isPresent(argument) ? argument : null;
+			case 0 -> addRepository(argument);
+			case 1 -> workspace = optionalPath(argument);
+			case 2 -> branchName = optionalText(argument);
 			default -> throw new IllegalArgumentException("Unexpected argument " + argument + ". " + USAGE);
 		}
 		positionals++;
 	}
 
-	private void requireRepositoryUrl() {
-		if (repositoryUrl == null || repositoryUrl.isBlank()) {
+	private void addRepository(String url) {
+		if (Text.isPresent(url)) {
+			repositoryUrls.add(url.strip());
+		}
+	}
+
+	private List<String> readList(String file) {
+		return RepositoryUrls.fromFile(Path.of(Text.required(file, "--repos")));
+	}
+
+	private Path optionalPath(String value) {
+		return Text.isPresent(value) ? Path.of(value.strip()) : null;
+	}
+
+	private String optionalText(String value) {
+		return Text.isPresent(value) ? value.strip() : null;
+	}
+
+	private void requireRepositoryUrls() {
+		if (repositoryUrls.isEmpty()) {
 			throw new IllegalArgumentException(USAGE);
 		}
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Failures.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Failures.java
@@ -28,4 +28,14 @@ public final class Failures {
 			failure.addSuppressed(e);
 		}
 	}
+
+	/**
+	 * @return the failure's message, falling back to its type when it carries none,
+	 *         so a report never records a bare {@code null} as the reason a run
+	 *         stopped
+	 */
+	public static String describe(RuntimeException failure) {
+		String message = failure.getMessage();
+		return message == null || message.isBlank() ? failure.getClass().getSimpleName() : message;
+	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -146,13 +146,9 @@ public class GitHubRepoAdopter {
 	/**
 	 * Names the failing step alongside the failure, because a message alone —
 	 * {@code "The requested URL returned error: 403"} — does not say which stage
-	 * produced it. An exception with no message falls back to its type, so the
-	 * report never records a bare {@code null}.
+	 * produced it.
 	 */
 	private String describe(AdoptionStep step, RuntimeException failure) {
-		String message = failure.getMessage();
-		return step.name() + ": " + (message == null || message.isBlank()
-				? failure.getClass().getSimpleName()
-				: message);
+		return step.name() + ": " + Failures.describe(failure);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -1,57 +1,100 @@
 package io.github.adamw7.tools.adopt;
 
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
 
 /**
  * Command-line entry point: parses the arguments with {@link CliArguments} —
- * the positional GitHub repository URL, optional workspace directory, and
- * optional feature-branch name, plus the flags for pull-request metadata, the
- * starter-assets step, and the JSON report — and runs the default adoption
- * pipeline against a real {@code git}/{@code claude}/{@code gh} toolchain. A
- * supplied workspace directory is created when it does not yet exist; when
- * omitted, a temporary one is created instead. When {@code --report} names a
- * file, the run's {@link AdoptionReport} is written there as JSON — for a failed
- * run as well as a successful one, so the report can say how far the adoption got
- * and why it stopped.
+ * the repositories to adopt (the positional GitHub repository URL, plus any
+ * named with {@code --repo} or listed in a {@code --repos} file), the optional
+ * workspace directory, and optional feature-branch name, plus the flags for
+ * pull-request metadata, the starter-assets step, and the JSON report — and runs
+ * the default adoption pipeline against a real {@code git}/{@code claude}/{@code gh}
+ * toolchain. A supplied workspace directory is created when it does not yet
+ * exist; when omitted, a temporary one is created instead. Every repository of a
+ * run shares that workspace and branch name: each clone lands in its own
+ * directory under the workspace, named after the repository.
+ *
+ * <p>When {@code --report} names a file, the run's {@link AdoptionReport} is
+ * written there as JSON — for a failed run as well as a successful one, so the
+ * report can say how far the adoption got and why it stopped. A run that adopted
+ * several repositories writes the batch document {@link AdoptionReportWriter}
+ * describes, one entry per repository.
+ *
+ * <p>A repository whose adoption fails does not stop the ones behind it: the
+ * batch runs to the end and the failures are raised together afterwards, so the
+ * process still exits non-zero while the repositories that could be adopted have
+ * been.
  */
 public class Main {
 
 	public static void main(String[] args) {
 		CliArguments cli = CliArguments.parse(args);
-		AdoptionContext context = new AdoptionContext(cli.repositoryUrl(), workspace(cli), cli.branchName());
 		CommandRunner runner = new ProcessCommandRunner();
 		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, cli.pullRequestOptions(),
 				cli.includeAssets(), cli.ruleVersion());
-		runAndReport(cli, context, adopter);
+		runAndReport(cli, contexts(cli), adopter);
 	}
 
 	/**
-	 * Runs the adoption and writes the report on both paths, so a run that fails
-	 * part-way still leaves the {@code --report} file behind rather than nothing at
-	 * all.
+	 * Runs the adoption of every requested repository and writes the report on both
+	 * paths, so a run that fails part-way still leaves the {@code --report} file
+	 * behind rather than nothing at all.
 	 *
-	 * @return the run's report, once the adoption has completed
+	 * @return the runs, once every repository has been attempted
+	 * @throws AdoptionException when any repository's adoption failed, naming each
+	 *                           one and why it stopped
 	 */
-	static AdoptionReport runAndReport(CliArguments cli, AdoptionContext context, GitHubRepoAdopter adopter) {
-		AdoptionReport report = new AdoptionReport();
+	static List<AdoptionRun> runAndReport(CliArguments cli, List<AdoptionContext> contexts,
+			GitHubRepoAdopter adopter) {
+		List<AdoptionRun> runs = new BatchAdoption(adopter::adopt).adoptAll(contexts);
 		try {
-			adopter.adopt(context, report);
+			requireEveryAdoptionSucceeded(runs);
 		} catch (RuntimeException e) {
-			Failures.alsoRun(e, () -> writeReport(cli, context, report));
+			Failures.alsoRun(e, () -> writeReport(cli, runs));
 			throw e;
 		}
-		writeReport(cli, context, report);
-		return report;
+		writeReport(cli, runs);
+		return runs;
+	}
+
+	/** Every repository of a run is adopted into one workspace, on one branch name. */
+	static List<AdoptionContext> contexts(CliArguments cli) {
+		Path workspace = workspace(cli);
+		return cli.repositoryUrls().stream()
+				.map(url -> new AdoptionContext(url, workspace, cli.branchName()))
+				.toList();
 	}
 
 	static Path workspace(CliArguments cli) {
 		return Workspaces.resolve(cli.workspace());
 	}
 
-	private static void writeReport(CliArguments cli, AdoptionContext context, AdoptionReport report) {
-		cli.reportFile().ifPresent(file -> new AdoptionReportWriter().write(file, context, report));
+	/**
+	 * Fails the run when any repository's adoption did, naming every failure rather
+	 * than only the first: an operator who started a batch needs to know which
+	 * repositories to re-run, and the count says at a glance how much of the batch
+	 * landed.
+	 */
+	private static void requireEveryAdoptionSucceeded(List<AdoptionRun> runs) {
+		List<AdoptionRun> failed = runs.stream().filter(run -> !run.succeeded()).toList();
+		if (!failed.isEmpty()) {
+			throw new AdoptionException("Adoption failed for " + failed.size() + " of " + runs.size()
+					+ " repositories: " + describe(failed));
+		}
+	}
+
+	private static String describe(List<AdoptionRun> failed) {
+		return failed.stream()
+				.map(run -> run.repositoryUrl() + ": " + run.failure().orElse("unknown failure"))
+				.collect(Collectors.joining("; "));
+	}
+
+	private static void writeReport(CliArguments cli, List<AdoptionRun> runs) {
+		cli.reportFile().ifPresent(file -> new AdoptionReportWriter().write(file, runs));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrls.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrls.java
@@ -1,0 +1,51 @@
+package io.github.adamw7.tools.adopt;
+
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Reads the list of repository URLs an adoption run works through, from the two
+ * forms the entry points offer: a file naming one repository per line, and a list
+ * already collected in memory (repeated command-line flags, or an MCP argument).
+ * Both end in {@link #distinct(List)}, so the two cannot drift apart on what
+ * counts as a repository worth adopting.
+ *
+ * <p>A list file is written for people: blank lines are skipped and a line whose
+ * first non-blank character is {@code #} is a comment, so a batch can be annotated
+ * with why a repository is on it, and a repository can be commented out for a run
+ * rather than deleted from the file.
+ *
+ * <p>Duplicates are dropped, keeping the order the URLs were given in. The same
+ * URL twice would clone into one checkout directory and adopt it a second time,
+ * which at best repeats the work and at worst pushes a branch built on a
+ * half-adopted tree.
+ */
+public final class RepositoryUrls {
+
+	private static final String COMMENT = "#";
+
+	private RepositoryUrls() {
+	}
+
+	/**
+	 * @param file a text file naming one repository URL per line
+	 * @throws AdoptionException when the file cannot be read
+	 */
+	public static List<String> fromFile(Path file) {
+		return fromLines(AdoptionFiles.read(file, "the repository URL list").lines().toList());
+	}
+
+	public static List<String> fromLines(List<String> lines) {
+		return distinct(lines.stream().map(String::strip).filter(RepositoryUrls::isRepository).toList());
+	}
+
+	/** @return the URLs stripped of surrounding whitespace, without duplicates, in order */
+	public static List<String> distinct(List<String> urls) {
+		return List.copyOf(new LinkedHashSet<>(urls.stream().filter(Text::isPresent).map(String::strip).toList()));
+	}
+
+	private static boolean isRepository(String line) {
+		return Text.isPresent(line) && !line.startsWith(COMMENT);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt.mcp;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -12,7 +13,10 @@ import org.apache.logging.log4j.Logger;
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionReport;
 import io.github.adamw7.tools.adopt.AdoptionReportWriter;
+import io.github.adamw7.tools.adopt.AdoptionRun;
+import io.github.adamw7.tools.adopt.BatchAdoption;
 import io.github.adamw7.tools.adopt.GitHubRepoAdopter;
+import io.github.adamw7.tools.adopt.RepositoryUrls;
 import io.github.adamw7.tools.adopt.Workspaces;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
@@ -22,18 +26,28 @@ import io.github.adamw7.tools.mcp.ToolDefinition;
 import io.github.adamw7.tools.mcp.ToolResult;
 
 /**
- * The MCP tool that runs the adoption pipeline: given a GitHub repository URL —
- * plus optional workspace, branch, pull-request metadata, and the starter-assets
- * flag — it adopts Claude Code exactly as the command line does and answers with
- * the run's JSON {@link AdoptionReport}. The pipeline is injected behind the
- * {@link Pipeline} seam so tests exercise the argument mapping without cloning
- * anything; the default wiring runs it against a {@link ProcessCommandRunner}.
+ * The MCP tool that runs the adoption pipeline: given one GitHub repository URL
+ * or a list of them — plus optional workspace, branch, pull-request metadata, and
+ * the starter-assets flag — it adopts Claude Code exactly as the command line
+ * does and answers with the run's JSON {@link AdoptionReport}. The pipeline is
+ * injected behind the {@link Pipeline} seam so tests exercise the argument
+ * mapping without cloning anything; the default wiring runs it against a
+ * {@link ProcessCommandRunner}.
+ *
+ * <p>A repository whose adoption fails does not strand the rest of the list: the
+ * batch runs to the end and the result carries every repository's report, marked
+ * as an error result when any of them failed. That report is the answer even on
+ * the failure path — a client that asked for five repositories needs to know
+ * which two did not land, not only that something threw.
  */
 public class AdoptTool implements McpTool {
 
-	/** The adoption run the tool delegates to once the arguments are mapped. */
+	/**
+	 * The adoption run the tool delegates to once the arguments are mapped, filling
+	 * in the report it is handed so a failed repository still reports how far it got.
+	 */
 	public interface Pipeline {
-		AdoptionReport adopt(AdoptionContext context, PullRequestOptions options, boolean includeAssets,
+		void adopt(AdoptionContext context, AdoptionReport report, PullRequestOptions options, boolean includeAssets,
 				Optional<String> ruleVersion);
 	}
 
@@ -43,15 +57,20 @@ public class AdoptTool implements McpTool {
 	private final AdoptionReportWriter reportWriter = new AdoptionReportWriter();
 
 	private final ToolDefinition toolDefinition = new ToolDefinition("adopt_repo",
-			"Adopt Claude Code into a GitHub repository: clone it, create a feature branch, generate CLAUDE.md, "
-					+ "wire a CLAUDE.md guard into the build, then push the branch and open a pull request. "
-					+ "Requires git, claude and gh on the server's PATH. "
+			"Adopt Claude Code into one or more GitHub repositories: clone each, create a feature branch, "
+					+ "generate CLAUDE.md, wire a CLAUDE.md guard into the build, then push the branch and open a "
+					+ "pull request. Name the repositories with repository_url, repository_urls, or both — at least "
+					+ "one is required. Requires git, claude and gh on the server's PATH. "
 					+ "Returns a JSON report with the pull request URL and the completed steps.",
 			Map.of(
 					"type", "object",
 					"properties", Map.ofEntries(
 							Map.entry("repository_url", Map.of("type", "string",
 									"description", "URL of the GitHub repository to adopt")),
+							Map.entry("repository_urls", Map.of("type", "array",
+									"items", Map.of("type", "string"),
+									"description", "URLs of the repositories to adopt, one after another; "
+											+ "a comma-separated string is accepted too")),
 							Map.entry("workspace", Map.of("type", "string",
 									"description", "directory to clone into; a temporary one is created when omitted")),
 							Map.entry("branch", Map.of("type", "string",
@@ -71,7 +90,7 @@ public class AdoptTool implements McpTool {
 							Map.entry("rule_version", Map.of("type", "string",
 									"description", "released claude-code-enforcer version to wire into an adopted "
 											+ "Maven project; defaults to the version of this build"))),
-					"required", List.of("repository_url")));
+					"required", List.of()));
 
 	public AdoptTool() {
 		this(AdoptTool::runDefaultPipeline);
@@ -81,10 +100,10 @@ public class AdoptTool implements McpTool {
 		this.pipeline = pipeline;
 	}
 
-	private static AdoptionReport runDefaultPipeline(AdoptionContext context, PullRequestOptions options,
+	private static void runDefaultPipeline(AdoptionContext context, AdoptionReport report, PullRequestOptions options,
 			boolean includeAssets, Optional<String> ruleVersion) {
-		return GitHubRepoAdopter.withDefaultPipeline(new ProcessCommandRunner(), options, includeAssets, ruleVersion)
-				.adopt(context);
+		GitHubRepoAdopter.withDefaultPipeline(new ProcessCommandRunner(), options, includeAssets, ruleVersion)
+				.adopt(context, report);
 	}
 
 	@Override
@@ -95,15 +114,62 @@ public class AdoptTool implements McpTool {
 	@Override
 	public ToolResult apply(Map<String, Object> arguments) {
 		log.info("Calling MCP adopt tool for {}", arguments);
-		AdoptionContext context = contextFrom(arguments);
-		AdoptionReport report = pipeline.adopt(context, optionsFrom(arguments),
-				ToolArguments.optionalBoolean(arguments, "assets", false), ruleVersion(arguments));
-		return ToolResult.success(reportWriter.toJson(context, report));
+		PullRequestOptions options = optionsFrom(arguments);
+		boolean includeAssets = ToolArguments.optionalBoolean(arguments, "assets", false);
+		Optional<String> ruleVersion = ruleVersion(arguments);
+		BatchAdoption batch = new BatchAdoption(
+				(context, report) -> pipeline.adopt(context, report, options, includeAssets, ruleVersion));
+		return result(batch.adoptAll(contextsFrom(arguments)));
 	}
 
-	private AdoptionContext contextFrom(Map<String, Object> arguments) {
-		String repositoryUrl = ToolArguments.requiredString(arguments, "repository_url");
-		return new AdoptionContext(repositoryUrl, workspace(arguments), branch(arguments));
+	/**
+	 * A batch in which anything failed is an error result, so a client is not told
+	 * an adoption that stopped at the push went through; the payload stays the report
+	 * either way, since that is what says which repositories landed.
+	 */
+	private ToolResult result(List<AdoptionRun> runs) {
+		String report = reportWriter.toJson(runs);
+		return runs.stream().allMatch(AdoptionRun::succeeded) ? ToolResult.success(report) : ToolResult.error(report);
+	}
+
+	/** Every repository of a call is adopted into one workspace, on one branch name. */
+	private List<AdoptionContext> contextsFrom(Map<String, Object> arguments) {
+		Path workspace = workspace(arguments);
+		String branch = branch(arguments);
+		return repositoryUrls(arguments).stream()
+				.map(url -> new AdoptionContext(url, workspace, branch))
+				.toList();
+	}
+
+	/**
+	 * Reads the repositories from either argument, so a client with one repository
+	 * keeps sending {@code repository_url} and one with a list sends
+	 * {@code repository_urls}; supplying both simply adopts them all.
+	 *
+	 * @throws IllegalArgumentException when neither argument names a repository, the
+	 *                                  one requirement the schema cannot express as a
+	 *                                  required field
+	 */
+	private List<String> repositoryUrls(Map<String, Object> arguments) {
+		List<String> urls = RepositoryUrls.distinct(Stream
+				.concat(Stream.of(text(arguments, "repository_url")), textList(arguments, "repository_urls").stream())
+				.toList());
+		if (urls.isEmpty()) {
+			throw new IllegalArgumentException("Missing required argument: repository_url or repository_urls");
+		}
+		return urls;
+	}
+
+	/**
+	 * @return a list argument's entries, read from a real JSON array or from the
+	 *         comma-separated string a loosely-typed client sends instead
+	 */
+	private List<String> textList(Map<String, Object> arguments, String key) {
+		Object value = arguments.get(key);
+		if (value instanceof Collection<?> entries) {
+			return entries.stream().map(String::valueOf).toList();
+		}
+		return commaSeparated(arguments, key);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
@@ -15,6 +15,11 @@ verifies it, pushes the branch, and opens a pull request. The default branch is
 never written to. The tool answers with a JSON report of the run: the
 repository, the branch, the pull request URL, and the completed steps.
 
+One call can adopt a list of repositories, one after another, sharing the
+workspace and branch name. A repository whose adoption fails does not strand the
+ones behind it: the batch runs to the end and the report says which landed, the
+result being marked as an error when any of them did not.
+
 Because the pipeline shells out to `git`, `claude`, and `gh`, those tools must
 be installed and authenticated on the machine running the MCP server.
 
@@ -48,9 +53,14 @@ This creates an executable JAR in `adopt/target/tools.adopt-{version}.jar`.
 ### adopt_repo
 
 **Parameters:**
-- `repository_url` (string, required): URL of the GitHub repository to adopt
-- `workspace` (string, optional): directory to clone into; a temporary
-  directory is created when omitted
+- `repository_url` (string): URL of the GitHub repository to adopt
+- `repository_urls` (array of strings, or a comma-separated string): the
+  repositories to adopt in one call. At least one of `repository_url` and
+  `repository_urls` must name a repository; supplying both adopts them all, once
+  each
+- `workspace` (string, optional): directory to clone into, shared by every
+  repository of the call — each clone lands in its own directory under it, named
+  after the repository; a temporary directory is created when omitted
 - `branch` (string, optional): feature branch name; defaults to
   `claude/adopt-claude-code`
 - `title` / `body` (string, optional): pull request title and body
@@ -68,8 +78,31 @@ This creates an executable JAR in `adopt/target/tools.adopt-{version}.jar`.
   "repositoryUrl" : "https://github.com/owner/repo.git",
   "branch" : "claude/adopt-claude-code",
   "pullRequestUrl" : "https://github.com/owner/repo/pull/42",
+  "succeeded" : true,
+  "failure" : null,
   "completedSteps" : [ "toolchain", "clone", "branch", "trust", "claude-init",
     "commit", "enforcer", "commit", "verify", "push", "pull-request" ]
+}
+```
+
+A call that adopted several repositories answers with the batch document
+instead — an overall `succeeded`, true only when every repository was adopted,
+and a `repositories` array of exactly the documents above:
+
+```json
+{
+  "succeeded" : false,
+  "repositories" : [ {
+    "repositoryUrl" : "https://github.com/owner/repo.git",
+    "succeeded" : true,
+    "failure" : null,
+    "…" : "…"
+  }, {
+    "repositoryUrl" : "https://github.com/owner/other.git",
+    "succeeded" : false,
+    "failure" : "clone: repository not found",
+    "…" : "…"
+  } ]
 }
 ```
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportWriterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportWriterTest.java
@@ -71,6 +71,47 @@ class AdoptionReportWriterTest {
 		assertEquals("clone", node.get("completedSteps").get(0).asText());
 	}
 
+	/**
+	 * A batch is read repository by repository, so each keeps the document a
+	 * single-repository run produces and the wrapper only adds the run's verdict.
+	 */
+	@Test
+	void serialisesABatchAsOneEntryPerRepository() throws IOException {
+		AdoptionReport failed = new AdoptionReport();
+		failed.recordFailure("clone: repository not found");
+		JsonNode node = mapper.readTree(writer.toJson(List.of(run(context), run(other(), failed))));
+		assertFalse(node.get("succeeded").asBoolean());
+		assertEquals(2, node.get("repositories").size());
+		assertEquals("https://github.com/owner/repo.git", node.get("repositories").get(0).get("repositoryUrl").asText());
+		assertTrue(node.get("repositories").get(0).get("succeeded").asBoolean());
+		assertEquals("clone: repository not found", node.get("repositories").get(1).get("failure").asText());
+	}
+
+	@Test
+	void serialisesABatchInWhichEveryRepositoryLandedAsSucceeded() throws IOException {
+		JsonNode node = mapper.readTree(writer.toJson(List.of(run(context), run(other()))));
+		assertTrue(node.get("succeeded").asBoolean());
+	}
+
+	/**
+	 * A one-repository run keeps the unwrapped document consumers already parse, so
+	 * taking a list of URLs did not change the shape of the runs they were written for.
+	 */
+	@Test
+	void serialisesASingleRunUnwrapped() throws IOException {
+		JsonNode node = mapper.readTree(writer.toJson(List.of(run(context))));
+		assertEquals("https://github.com/owner/repo.git", node.get("repositoryUrl").asText());
+		assertTrue(node.get("repositories") == null);
+	}
+
+	@Test
+	void writesABatchReportToAFile(@TempDir Path dir) throws IOException {
+		Path file = dir.resolve("report.json");
+		writer.write(file, List.of(run(context), run(other())));
+		JsonNode node = mapper.readTree(Files.readString(file));
+		assertEquals(2, node.get("repositories").size());
+	}
+
 	@Test
 	void writesTheReportToAFile(@TempDir Path dir) throws IOException {
 		Path file = dir.resolve("nested/report.json");
@@ -86,5 +127,18 @@ class AdoptionReportWriterTest {
 		Path blockingFile = Files.createFile(dir.resolve("not-a-directory"));
 		Path file = blockingFile.resolve("report.json");
 		assertThrows(AdoptionException.class, () -> writer.write(file, context, new AdoptionReport()));
+	}
+
+	private AdoptionContext other() {
+		return new AdoptionContext("https://github.com/owner/other.git", Path.of("/tmp/workspace"),
+				"claude/adopt-claude-code");
+	}
+
+	private AdoptionRun run(AdoptionContext context) {
+		return run(context, new AdoptionReport());
+	}
+
+	private AdoptionRun run(AdoptionContext context, AdoptionReport report) {
+		return new AdoptionRun(context, report);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionRunTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionRunTest.java
@@ -1,0 +1,49 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+class AdoptionRunTest {
+
+	private static final String REPO_URL = "https://github.com/owner/repo.git";
+
+	private final AdoptionContext context = new AdoptionContext(REPO_URL, Path.of("/tmp/workspace"));
+	private final AdoptionReport report = new AdoptionReport();
+
+	/**
+	 * A report on its own does not say which repository it belongs to, which is the
+	 * whole reason a batch answers with runs rather than bare reports.
+	 */
+	@Test
+	void namesTheRepositoryItsReportBelongsTo() {
+		assertEquals(REPO_URL, new AdoptionRun(context, report).repositoryUrl());
+	}
+
+	@Test
+	void keepsTheContextAndReportItWasGiven() {
+		AdoptionRun run = new AdoptionRun(context, report);
+		assertEquals(context, run.context());
+		assertEquals(report, run.report());
+	}
+
+	@Test
+	void succeedsWhileItsReportRecordsNoFailure() {
+		AdoptionRun run = new AdoptionRun(context, report);
+		assertTrue(run.succeeded());
+		assertEquals(Optional.empty(), run.failure());
+	}
+
+	@Test
+	void failsWithTheReasonItsReportRecorded() {
+		report.recordFailure("clone: repository not found");
+		AdoptionRun run = new AdoptionRun(context, report);
+		assertFalse(run.succeeded());
+		assertEquals("clone: repository not found", run.failure().orElseThrow());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/BatchAdoptionTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/BatchAdoptionTest.java
@@ -1,0 +1,87 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+class BatchAdoptionTest {
+
+	private static final String REPO_URL = "https://github.com/owner/repo.git";
+	private static final String OTHER_URL = "https://github.com/owner/other.git";
+
+	private final List<String> adopted = new ArrayList<>();
+
+	@Test
+	void adoptsEveryRepositoryInOrder() {
+		List<AdoptionRun> runs = new BatchAdoption(this::record).adoptAll(contexts(REPO_URL, OTHER_URL));
+		assertEquals(List.of(REPO_URL, OTHER_URL), adopted);
+		assertEquals(List.of(REPO_URL, OTHER_URL), runs.stream().map(AdoptionRun::repositoryUrl).toList());
+		assertTrue(runs.stream().allMatch(AdoptionRun::succeeded));
+	}
+
+	@Test
+	void givesEachRepositoryItsOwnReport() {
+		List<AdoptionRun> runs = new BatchAdoption((context, report) -> report.recordStep(context.repositoryUrl()))
+				.adoptAll(contexts(REPO_URL, OTHER_URL));
+		assertEquals(List.of(REPO_URL), runs.get(0).report().completedSteps());
+		assertEquals(List.of(OTHER_URL), runs.get(1).report().completedSteps());
+	}
+
+	/**
+	 * The adoptions are independent, so a repository nobody can clone must not strand
+	 * the ones behind it on the list.
+	 */
+	@Test
+	void keepsGoingAfterARepositoryFails() {
+		List<AdoptionRun> runs = new BatchAdoption(this::failFirst).adoptAll(contexts(REPO_URL, OTHER_URL));
+		assertEquals(List.of(REPO_URL, OTHER_URL), adopted);
+		assertFalse(runs.get(0).succeeded());
+		assertEquals("boom", runs.get(0).failure().orElseThrow());
+		assertTrue(runs.get(1).succeeded());
+	}
+
+	@Test
+	void keepsTheStepThePipelineAlreadyBlamed() {
+		List<AdoptionRun> runs = new BatchAdoption((context, report) -> {
+			report.recordFailure("push: rejected");
+			throw new AdoptionException("boom");
+		}).adoptAll(contexts(REPO_URL));
+		assertEquals("push: rejected", runs.get(0).failure().orElseThrow());
+	}
+
+	/** A failure with no message would otherwise record a bare null as the reason. */
+	@Test
+	void fallsBackToTheFailuresTypeWhenItCarriesNoMessage() {
+		List<AdoptionRun> runs = new BatchAdoption((context, report) -> {
+			throw new IllegalStateException();
+		}).adoptAll(contexts(REPO_URL));
+		assertEquals("IllegalStateException", runs.get(0).failure().orElseThrow());
+	}
+
+	@Test
+	void adoptsNothingWhenGivenNoRepositories() {
+		assertTrue(new BatchAdoption(this::record).adoptAll(List.of()).isEmpty());
+	}
+
+	private void record(AdoptionContext context, AdoptionReport report) {
+		adopted.add(context.repositoryUrl());
+	}
+
+	private void failFirst(AdoptionContext context, AdoptionReport report) {
+		record(context, report);
+		if (REPO_URL.equals(context.repositoryUrl())) {
+			throw new AdoptionException("boom");
+		}
+	}
+
+	private List<AdoptionContext> contexts(String... urls) {
+		return Stream.of(urls).map(url -> new AdoptionContext(url, Path.of("/tmp/workspace"))).toList();
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/BatchAdoptionTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/BatchAdoptionTest.java
@@ -65,6 +65,40 @@ class BatchAdoptionTest {
 		assertEquals("IllegalStateException", runs.get(0).failure().orElseThrow());
 	}
 
+	/**
+	 * How far a failed repository got is the report's most useful line, so the steps
+	 * it did complete must survive the failure that stopped it.
+	 */
+	@Test
+	void keepsTheStepsARepositoryCompletedBeforeItFailed() {
+		List<AdoptionRun> runs = new BatchAdoption((context, report) -> {
+			report.recordStep("clone");
+			throw new AdoptionException("boom");
+		}).adoptAll(contexts(REPO_URL));
+		assertEquals(List.of("clone"), runs.get(0).report().completedSteps());
+	}
+
+	@Test
+	void answersWithTheContextEachRepositoryWasAdoptedWith() {
+		List<AdoptionContext> contexts = contexts(REPO_URL, OTHER_URL);
+		List<AdoptionRun> runs = new BatchAdoption(this::record).adoptAll(contexts);
+		assertEquals(contexts, runs.stream().map(AdoptionRun::context).toList());
+	}
+
+	/**
+	 * A failure raised outside the pipeline — an argument the steps never saw, an
+	 * adoption that threw before recording anything — must still be reported as this
+	 * repository's, not swallowed with the batch carrying on silently.
+	 */
+	@Test
+	void recordsAFailureThePipelineNeverDescribed() {
+		List<AdoptionRun> runs = new BatchAdoption((context, report) -> {
+			throw new IllegalArgumentException("workspace must not be null");
+		}).adoptAll(contexts(REPO_URL));
+		assertFalse(runs.get(0).succeeded());
+		assertEquals("workspace must not be null", runs.get(0).failure().orElseThrow());
+	}
+
 	@Test
 	void adoptsNothingWhenGivenNoRepositories() {
 		assertTrue(new BatchAdoption(this::record).adoptAll(List.of()).isEmpty());

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -21,6 +21,7 @@ class CliArgumentsTest {
 	private static final String REPO_URL = "https://github.com/owner/repo.git";
 	private static final String OTHER_URL = "https://github.com/owner/other.git";
 	private static final String THIRD_URL = "https://github.com/owner/third.git";
+	private static final String FOURTH_URL = "https://github.com/owner/fourth.git";
 
 	@Test
 	void parsesPositionalArguments() {
@@ -68,6 +69,76 @@ class CliArgumentsTest {
 	void ignoresABlankRepositoryFlag() {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", "  " });
 		assertEquals(List.of(REPO_URL), cli.repositoryUrls());
+	}
+
+	/**
+	 * The list is read in the order the operator wrote it — the positional first,
+	 * then each flag as it was met — so the run's report reads in the order they
+	 * expect.
+	 */
+	@Test
+	void keepsTheOrderTheRepositoriesWereNamedIn(@TempDir Path dir) throws IOException {
+		Path list = Files.writeString(dir.resolve("repos.txt"), THIRD_URL + "\n");
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL, "--repos", list.toString(),
+				"--repo", FOURTH_URL });
+		assertEquals(List.of(REPO_URL, OTHER_URL, THIRD_URL, FOURTH_URL), cli.repositoryUrls());
+	}
+
+	@Test
+	void adoptsARepositoryListedInAFileAndNamedOnTheCommandLineOnlyOnce(@TempDir Path dir) throws IOException {
+		Path list = Files.writeString(dir.resolve("repos.txt"), REPO_URL + "\n" + OTHER_URL + "\n");
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repos", list.toString() });
+		assertEquals(List.of(REPO_URL, OTHER_URL), cli.repositoryUrls());
+	}
+
+	/**
+	 * A file of nothing but comments names no repository, so a run with no other URL
+	 * fails on its arguments rather than adopting nothing and reporting success.
+	 */
+	@Test
+	void rejectsARepositoryListThatNamesNoRepository(@TempDir Path dir) throws IOException {
+		Path list = Files.writeString(dir.resolve("repos.txt"), "# nothing to adopt yet\n\n");
+		assertUsageFailure(new String[] { "--repos", list.toString() });
+	}
+
+	@Test
+	void rejectsABlankRepositoryListFileName() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { REPO_URL, "--repos", "  " }));
+		assertTrue(exception.getMessage().contains("--repos"), exception.getMessage());
+	}
+
+	@Test
+	void rejectsTheRepositoryFlagsMissingTheirValue() {
+		assertThrows(IllegalArgumentException.class, () -> CliArguments.parse(new String[] { REPO_URL, "--repo" }));
+		assertThrows(IllegalArgumentException.class, () -> CliArguments.parse(new String[] { REPO_URL, "--repos" }));
+	}
+
+	/**
+	 * The flags write the same value as their positionals, so an operator who names
+	 * one twice gets the last one rather than an error they have to decode.
+	 */
+	@Test
+	void theLastWorkspaceAndBranchNamedWins() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "/tmp/ws", "feature/x",
+				"--workspace", "/tmp/other", "--branch", "feature/y" });
+		assertEquals(Path.of("/tmp/other"), cli.workspace().orElseThrow());
+		assertEquals("feature/y", cli.branchName());
+	}
+
+	@Test
+	void stripsSurroundingWhitespaceFromTheWorkspaceAndBranchFlags() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--workspace", " /tmp/ws ",
+				"--branch", " feature/x " });
+		assertEquals(Path.of("/tmp/ws"), cli.workspace().orElseThrow());
+		assertEquals("feature/x", cli.branchName());
+	}
+
+	/** A positional after the branch is still a surplus argument, whatever the flags named. */
+	@Test
+	void rejectsExtraPositionalArgumentAlongsideTheRepositoryFlags() {
+		assertThrows(IllegalArgumentException.class, () -> CliArguments
+				.parse(new String[] { REPO_URL, "--repo", OTHER_URL, "/tmp/ws", "branch", "surplus" }));
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -5,24 +5,76 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 
 class CliArgumentsTest {
 
 	private static final String REPO_URL = "https://github.com/owner/repo.git";
+	private static final String OTHER_URL = "https://github.com/owner/other.git";
+	private static final String THIRD_URL = "https://github.com/owner/third.git";
 
 	@Test
 	void parsesPositionalArguments() {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "/tmp/ws", "feature/x" });
-		assertEquals(REPO_URL, cli.repositoryUrl());
+		assertEquals(List.of(REPO_URL), cli.repositoryUrls());
 		assertEquals(Path.of("/tmp/ws"), cli.workspace().orElseThrow());
 		assertEquals("feature/x", cli.branchName());
+	}
+
+	@Test
+	void collectsRepeatedRepositoryFlagsAfterThePositionalUrl() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL, "--repo", THIRD_URL });
+		assertEquals(List.of(REPO_URL, OTHER_URL, THIRD_URL), cli.repositoryUrls());
+	}
+
+	@Test
+	void adoptsTheFlaggedRepositoriesWhenNoPositionalUrlIsGiven() {
+		CliArguments cli = CliArguments.parse(new String[] { "--repo", OTHER_URL, "--workspace", "/tmp/ws",
+				"--branch", "feature/x" });
+		assertEquals(List.of(OTHER_URL), cli.repositoryUrls());
+		assertEquals(Path.of("/tmp/ws"), cli.workspace().orElseThrow());
+		assertEquals("feature/x", cli.branchName());
+	}
+
+	@Test
+	void readsARepositoryListFromAFile(@TempDir Path dir) throws IOException {
+		Path list = Files.writeString(dir.resolve("repos.txt"),
+				"# the team's repositories\n" + OTHER_URL + "\n\n  " + THIRD_URL + "  \n");
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repos", list.toString() });
+		assertEquals(List.of(REPO_URL, OTHER_URL, THIRD_URL), cli.repositoryUrls());
+	}
+
+	/**
+	 * The same repository twice would clone into one checkout directory and adopt it
+	 * a second time, so a URL listed in a file and named on the command line is one
+	 * adoption, not two.
+	 */
+	@Test
+	void adoptsARepositoryNamedTwiceOnlyOnce() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", " " + REPO_URL + " " });
+		assertEquals(List.of(REPO_URL), cli.repositoryUrls());
+	}
+
+	@Test
+	void ignoresABlankRepositoryFlag() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", "  " });
+		assertEquals(List.of(REPO_URL), cli.repositoryUrls());
+	}
+
+	@Test
+	void failsWhenTheRepositoryListFileCannotBeRead(@TempDir Path dir) {
+		String missing = dir.resolve("absent.txt").toString();
+		assertThrows(AdoptionException.class,
+				() -> CliArguments.parse(new String[] { "--repos", missing }));
 	}
 
 	@Test
@@ -35,6 +87,13 @@ class CliArgumentsTest {
 	@Test
 	void defaultsWorkspaceAndBranchWhenSuppliedBlank() {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "  ", "  " });
+		assertTrue(cli.workspace().isEmpty());
+		assertEquals(AdoptionContext.DEFAULT_BRANCH, cli.branchName());
+	}
+
+	@Test
+	void defaultsWorkspaceAndBranchWhenTheirFlagsAreBlank() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--workspace", "  ", "--branch", "  " });
 		assertTrue(cli.workspace().isEmpty());
 		assertEquals(AdoptionContext.DEFAULT_BRANCH, cli.branchName());
 	}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/FailuresTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/FailuresTest.java
@@ -1,0 +1,59 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import org.junit.jupiter.api.Test;
+
+class FailuresTest {
+
+	@Test
+	void runsTheCleanUp() {
+		StringBuilder cleanedUp = new StringBuilder();
+		Failures.alsoRun(new AdoptionException("boom"), () -> cleanedUp.append("done"));
+		assertEquals("done", cleanedUp.toString());
+	}
+
+	/**
+	 * The adoption failure carries the diagnostic the operator needs, so a clean-up
+	 * that fails on its way out must be attached to it rather than thrown over it.
+	 */
+	@Test
+	void attachesACleanUpFailureToTheOneBeingReported() {
+		AdoptionException failure = new AdoptionException("boom");
+		Failures.alsoRun(failure, () -> {
+			throw new IllegalStateException("could not write the report");
+		});
+		assertEquals(1, failure.getSuppressed().length);
+		assertEquals("could not write the report", failure.getSuppressed()[0].getMessage());
+	}
+
+	@Test
+	void describesAFailureByItsMessage() {
+		assertEquals("boom", Failures.describe(new AdoptionException("boom")));
+	}
+
+	/**
+	 * A report that recorded the empty string as the reason a run stopped would say
+	 * the run failed without saying anything about why.
+	 */
+	@Test
+	void describesAFailureWithABlankMessageByItsType() {
+		assertEquals("AdoptionException", Failures.describe(new AdoptionException("   ")));
+	}
+
+	@Test
+	void describesAFailureWithNoMessageByItsType() {
+		assertEquals("IllegalStateException", Failures.describe(new IllegalStateException()));
+	}
+
+	@Test
+	void isAUtilityClassNobodyInstantiates() throws NoSuchMethodException {
+		Constructor<Failures> constructor = Failures.class.getDeclaredConstructor();
+		assertTrue(Modifier.isPrivate(constructor.getModifiers()),
+				"a class of static helpers must not be instantiable");
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
@@ -23,6 +23,7 @@ import io.github.adamw7.tools.adopt.step.AdoptionStep;
 class MainTest {
 
 	private static final String REPO_URL = "https://github.com/owner/repo.git";
+	private static final String OTHER_URL = "https://github.com/owner/other.git";
 
 	@Test
 	void rejectsMissingArguments() {
@@ -68,6 +69,21 @@ class MainTest {
 	}
 
 	/**
+	 * Every repository of a run shares the workspace and the branch name; only the
+	 * checkout directory, derived from the repository name, differs.
+	 */
+	@Test
+	void buildsAContextPerRepository(@TempDir Path dir) {
+		List<AdoptionContext> contexts = Main.contexts(CliArguments.parse(
+				new String[] { REPO_URL, "--repo", OTHER_URL, "--workspace", dir.toString(), "--branch", "feature/x" }));
+		assertEquals(List.of(REPO_URL, OTHER_URL), contexts.stream().map(AdoptionContext::repositoryUrl).toList());
+		assertEquals(List.of(dir, dir), contexts.stream().map(AdoptionContext::workspace).toList());
+		assertEquals(List.of(dir.resolve("repo"), dir.resolve("other")),
+				contexts.stream().map(AdoptionContext::repositoryDirectory).toList());
+		assertEquals(List.of("feature/x", "feature/x"), contexts.stream().map(AdoptionContext::branchName).toList());
+	}
+
+	/**
 	 * A run that stops part-way is the one whose report matters most — it records
 	 * which steps completed and why the adoption stopped — so writing it only on the
 	 * success path leaves nothing behind exactly when the operator needs it.
@@ -76,8 +92,8 @@ class MainTest {
 	void writesTheReportWhenTheAdoptionFails(@TempDir Path dir) throws IOException {
 		Path file = dir.resolve("report.json");
 		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> Main.runAndReport(cli(dir, file), context(dir), failingAdopter()));
-		assertEquals("boom", thrown.getMessage());
+				() -> Main.runAndReport(cli(dir, file), contexts(dir), failingAdopter()));
+		assertTrue(thrown.getMessage().contains(REPO_URL + ": explode: boom"), thrown.getMessage());
 		JsonNode node = new ObjectMapper().readTree(Files.readString(file));
 		assertFalse(node.get("succeeded").asBoolean());
 		assertEquals("explode: boom", node.get("failure").asText());
@@ -86,10 +102,37 @@ class MainTest {
 	@Test
 	void writesTheReportWhenTheAdoptionSucceeds(@TempDir Path dir) throws IOException {
 		Path file = dir.resolve("report.json");
-		Main.runAndReport(cli(dir, file), context(dir), new GitHubRepoAdopter(new RecordingCommandRunner(), List.of()));
+		Main.runAndReport(cli(dir, file), contexts(dir), new GitHubRepoAdopter(new RecordingCommandRunner(), List.of()));
 		JsonNode node = new ObjectMapper().readTree(Files.readString(file));
 		assertTrue(node.get("succeeded").asBoolean());
 		assertTrue(node.get("failure").isNull());
+	}
+
+	/**
+	 * The repositories behind a failing one are adopted rather than stranded by it,
+	 * and the batch report says which was which — the whole point of taking a list.
+	 */
+	@Test
+	void adoptsEveryRepositoryEvenWhenOneFails(@TempDir Path dir) throws IOException {
+		Path file = dir.resolve("report.json");
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL,
+				"--workspace", dir.toString(), "--report", file.toString() });
+		assertThrows(AdoptionException.class,
+				() -> Main.runAndReport(cli, Main.contexts(cli), failingFor(REPO_URL)));
+		JsonNode node = new ObjectMapper().readTree(Files.readString(file));
+		assertFalse(node.get("succeeded").asBoolean());
+		assertEquals(REPO_URL, node.get("repositories").get(0).get("repositoryUrl").asText());
+		assertFalse(node.get("repositories").get(0).get("succeeded").asBoolean());
+		assertTrue(node.get("repositories").get(1).get("succeeded").asBoolean());
+	}
+
+	@Test
+	void reportsHowManyRepositoriesOfTheBatchFailed(@TempDir Path dir) {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL, "--workspace",
+				dir.toString() });
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> Main.runAndReport(cli, Main.contexts(cli), failingFor(REPO_URL)));
+		assertTrue(thrown.getMessage().startsWith("Adoption failed for 1 of 2 repositories"), thrown.getMessage());
 	}
 
 	/**
@@ -100,15 +143,15 @@ class MainTest {
 	void anUnwritableReportDoesNotReplaceTheAdoptionFailure(@TempDir Path dir) throws IOException {
 		Path blockingFile = Files.createFile(dir.resolve("not-a-directory"));
 		AdoptionException thrown = assertThrows(AdoptionException.class, () -> Main
-				.runAndReport(cli(dir, blockingFile.resolve("report.json")), context(dir), failingAdopter()));
-		assertEquals("boom", thrown.getMessage());
+				.runAndReport(cli(dir, blockingFile.resolve("report.json")), contexts(dir), failingAdopter()));
+		assertTrue(thrown.getMessage().contains("explode: boom"), thrown.getMessage());
 		assertEquals(1, thrown.getSuppressed().length);
 	}
 
 	@Test
 	void writesNoReportWhenNoneWasRequested(@TempDir Path dir) {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, dir.toString() });
-		Main.runAndReport(cli, context(dir), new GitHubRepoAdopter(new RecordingCommandRunner(), List.of()));
+		Main.runAndReport(cli, contexts(dir), new GitHubRepoAdopter(new RecordingCommandRunner(), List.of()));
 		assertTrue(cli.reportFile().isEmpty());
 	}
 
@@ -116,11 +159,16 @@ class MainTest {
 		return CliArguments.parse(new String[] { REPO_URL, workspace.toString(), "--report", reportFile.toString() });
 	}
 
-	private AdoptionContext context(Path workspace) {
-		return new AdoptionContext(REPO_URL, workspace);
+	private List<AdoptionContext> contexts(Path workspace) {
+		return List.of(new AdoptionContext(REPO_URL, workspace));
 	}
 
 	private GitHubRepoAdopter failingAdopter() {
+		return failingFor(REPO_URL);
+	}
+
+	/** An adopter whose only step explodes for the named repository and passes for the rest. */
+	private GitHubRepoAdopter failingFor(String repositoryUrl) {
 		return new GitHubRepoAdopter(new RecordingCommandRunner(), List.of(new AdoptionStep() {
 
 			@Override
@@ -130,7 +178,9 @@ class MainTest {
 
 			@Override
 			public void execute(AdoptionContext context, CommandRunner runner) {
-				throw new AdoptionException("boom");
+				if (repositoryUrl.equals(context.repositoryUrl())) {
+					throw new AdoptionException("boom");
+				}
 			}
 		}));
 	}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
@@ -83,6 +83,46 @@ class MainTest {
 		assertEquals(List.of("feature/x", "feature/x"), contexts.stream().map(AdoptionContext::branchName).toList());
 	}
 
+	@Test
+	void adoptsARepositoryNamedTwiceOnlyOnce(@TempDir Path dir) {
+		List<AdoptionContext> contexts = Main.contexts(CliArguments
+				.parse(new String[] { REPO_URL, "--repo", REPO_URL, "--workspace", dir.toString() }));
+		assertEquals(List.of(REPO_URL), contexts.stream().map(AdoptionContext::repositoryUrl).toList());
+	}
+
+	@Test
+	void adoptsTheRepositoriesAListFileNames(@TempDir Path dir) throws IOException {
+		Path list = Files.writeString(dir.resolve("repos.txt"), REPO_URL + "\n" + OTHER_URL + "\n");
+		List<AdoptionContext> contexts = Main.contexts(CliArguments
+				.parse(new String[] { "--repos", list.toString(), "--workspace", dir.toString() }));
+		assertEquals(List.of(REPO_URL, OTHER_URL), contexts.stream().map(AdoptionContext::repositoryUrl).toList());
+	}
+
+	/**
+	 * The workspace is resolved once for the run, so every repository is cloned under
+	 * the same directory rather than each landing in a temporary one of its own.
+	 */
+	@Test
+	void createsOneTemporaryWorkspaceForTheWholeBatch() {
+		List<AdoptionContext> contexts = Main
+				.contexts(CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL }));
+		assertEquals(contexts.get(0).workspace(), contexts.get(1).workspace());
+		assertTrue(Files.isDirectory(contexts.get(0).workspace()));
+	}
+
+	@Test
+	void adoptsEveryRepositoryOfASucceedingBatch(@TempDir Path dir) throws IOException {
+		Path file = dir.resolve("report.json");
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL,
+				"--workspace", dir.toString(), "--report", file.toString() });
+		List<AdoptionRun> runs = Main.runAndReport(cli, Main.contexts(cli),
+				new GitHubRepoAdopter(new RecordingCommandRunner(), List.of()));
+		assertEquals(List.of(REPO_URL, OTHER_URL), runs.stream().map(AdoptionRun::repositoryUrl).toList());
+		JsonNode node = new ObjectMapper().readTree(Files.readString(file));
+		assertTrue(node.get("succeeded").asBoolean());
+		assertEquals(2, node.get("repositories").size());
+	}
+
 	/**
 	 * A run that stops part-way is the one whose report matters most — it records
 	 * which steps completed and why the adoption stopped — so writing it only on the

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlsTest.java
@@ -1,0 +1,66 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RepositoryUrlsTest {
+
+	private static final String REPO_URL = "https://github.com/owner/repo.git";
+	private static final String OTHER_URL = "https://github.com/owner/other.git";
+
+	@Test
+	void readsOneRepositoryPerLine(@TempDir Path dir) throws IOException {
+		assertEquals(List.of(REPO_URL, OTHER_URL), RepositoryUrls.fromFile(listFile(dir, REPO_URL + "\n" + OTHER_URL)));
+	}
+
+	/**
+	 * A list file is maintained by hand, so it carries the notes and the commented-out
+	 * repository a hand-maintained file always grows.
+	 */
+	@Test
+	void skipsBlankLinesAndComments(@TempDir Path dir) throws IOException {
+		String content = "# the team's repositories\n\n" + REPO_URL + "\n   \n  # " + OTHER_URL + "\n";
+		assertEquals(List.of(REPO_URL), RepositoryUrls.fromFile(listFile(dir, content)));
+	}
+
+	@Test
+	void stripsSurroundingWhitespace(@TempDir Path dir) throws IOException {
+		assertEquals(List.of(REPO_URL), RepositoryUrls.fromFile(listFile(dir, "  " + REPO_URL + "  \n")));
+	}
+
+	@Test
+	void dropsDuplicatesKeepingTheOrderTheyWereGivenIn() {
+		assertEquals(List.of(REPO_URL, OTHER_URL),
+				RepositoryUrls.distinct(List.of(REPO_URL, OTHER_URL, " " + REPO_URL + " ")));
+	}
+
+	@Test
+	void dropsBlankEntries() {
+		assertEquals(List.of(REPO_URL), RepositoryUrls.distinct(List.of("  ", REPO_URL, "")));
+	}
+
+	@Test
+	void readsAnEmptyFileAsNoRepositories(@TempDir Path dir) throws IOException {
+		assertTrue(RepositoryUrls.fromFile(listFile(dir, "\n# nothing here\n")).isEmpty());
+	}
+
+	@Test
+	void failsWithAdoptionExceptionWhenTheFileCannotBeRead(@TempDir Path dir) {
+		Path missing = dir.resolve("absent.txt");
+		AdoptionException thrown = assertThrows(AdoptionException.class, () -> RepositoryUrls.fromFile(missing));
+		assertTrue(thrown.getMessage().contains("the repository URL list"), thrown.getMessage());
+	}
+
+	private Path listFile(Path dir, String content) throws IOException {
+		return Files.writeString(dir.resolve("repos.txt"), content);
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
@@ -35,6 +35,7 @@ class AdoptToolTest {
 	private static final class RecordingPipeline implements AdoptTool.Pipeline {
 
 		private final List<AdoptionContext> contexts = new ArrayList<>();
+		private final List<PullRequestOptions> optionsPerRepository = new ArrayList<>();
 		private AdoptionContext context;
 		private PullRequestOptions options;
 		private boolean includeAssets;
@@ -44,6 +45,7 @@ class AdoptToolTest {
 		public void adopt(AdoptionContext context, AdoptionReport report, PullRequestOptions options,
 				boolean includeAssets, Optional<String> ruleVersion) {
 			this.contexts.add(context);
+			this.optionsPerRepository.add(options);
 			this.context = context;
 			this.options = options;
 			this.includeAssets = includeAssets;
@@ -202,6 +204,52 @@ class AdoptToolTest {
 	@Test
 	void requiresTheRepositoryUrl() {
 		assertThrows(IllegalArgumentException.class, () -> tool.apply(Map.of()));
+	}
+
+	@Test
+	void ignoresBlankEntriesInTheRepositoryList() {
+		tool.apply(Map.of("repository_urls", List.of("  ", REPO_URL, "")));
+		assertEquals(List.of(REPO_URL), pipeline.contexts.stream().map(AdoptionContext::repositoryUrl).toList());
+	}
+
+	/**
+	 * A list of one is one repository's adoption, so it answers with the unwrapped
+	 * document a client that never sends a list already parses.
+	 */
+	@Test
+	void answersWithTheUnwrappedReportForAListOfOne() throws IOException {
+		JsonNode node = new ObjectMapper().readTree(tool.apply(Map.of("repository_urls", List.of(REPO_URL))).text());
+		assertEquals(REPO_URL, node.get("repositoryUrl").asText());
+		assertEquals(PR_URL, node.get("pullRequestUrl").asText());
+	}
+
+	/**
+	 * The repositories behind a failing one are adopted rather than stranded by it,
+	 * and the batch's report says which was which.
+	 */
+	@Test
+	void adoptsTheRestOfTheListAfterARepositoryFails() throws IOException {
+		AdoptTool failing = new AdoptTool((context, report, options, includeAssets, ruleVersion) -> {
+			if (REPO_URL.equals(context.repositoryUrl())) {
+				throw new AdoptionException("boom");
+			}
+			report.recordPullRequestUrl(PR_URL);
+		});
+		ToolResult result = failing.apply(Map.of("repository_urls", List.of(REPO_URL, OTHER_URL)));
+		assertTrue(result.isError());
+		JsonNode node = new ObjectMapper().readTree(result.text());
+		assertEquals("boom", node.get("repositories").get(0).get("failure").asText());
+		assertTrue(node.get("repositories").get(1).get("succeeded").asBoolean());
+		assertEquals(PR_URL, node.get("repositories").get(1).get("pullRequestUrl").asText());
+	}
+
+	/** The metadata is the call's, not the first repository's: every adoption gets it. */
+	@Test
+	void passesThePullRequestMetadataOnToEveryRepositoryOfAList() {
+		tool.apply(Map.of("repository_urls", List.of(REPO_URL, OTHER_URL), "title", "My title", "assets", true));
+		assertEquals(List.of("My title", "My title"),
+				pipeline.optionsPerRepository.stream().map(PullRequestOptions::title).toList());
+		assertTrue(pipeline.includeAssets);
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -19,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.AdoptionReport;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 import io.github.adamw7.tools.mcp.ToolResult;
@@ -26,37 +28,100 @@ import io.github.adamw7.tools.mcp.ToolResult;
 class AdoptToolTest {
 
 	private static final String REPO_URL = "https://github.com/owner/repo.git";
+	private static final String OTHER_URL = "https://github.com/owner/other.git";
 	private static final String PR_URL = "https://github.com/owner/repo/pull/1";
 
 	/** Records what the tool asked the pipeline to run and answers with a fixed report. */
 	private static final class RecordingPipeline implements AdoptTool.Pipeline {
 
+		private final List<AdoptionContext> contexts = new ArrayList<>();
 		private AdoptionContext context;
 		private PullRequestOptions options;
 		private boolean includeAssets;
 		private Optional<String> ruleVersion = Optional.empty();
 
 		@Override
-		public AdoptionReport adopt(AdoptionContext context, PullRequestOptions options, boolean includeAssets,
-				Optional<String> ruleVersion) {
+		public void adopt(AdoptionContext context, AdoptionReport report, PullRequestOptions options,
+				boolean includeAssets, Optional<String> ruleVersion) {
+			this.contexts.add(context);
 			this.context = context;
 			this.options = options;
 			this.includeAssets = includeAssets;
 			this.ruleVersion = ruleVersion;
-			AdoptionReport report = new AdoptionReport();
 			report.recordStep("pull-request");
 			report.recordPullRequestUrl(PR_URL);
-			return report;
 		}
 	}
 
 	private final RecordingPipeline pipeline = new RecordingPipeline();
 	private final AdoptTool tool = new AdoptTool(pipeline);
 
+	/**
+	 * Neither URL argument is required on its own — either names the repositories —
+	 * so the requirement is the one the tool checks itself rather than a schema field.
+	 */
 	@Test
 	void definesTheAdoptRepoTool() {
 		assertEquals("adopt_repo", tool.getToolDefinition().name());
-		assertEquals(List.of("repository_url"), tool.getToolDefinition().inputSchema().get("required"));
+		assertEquals(List.of(), tool.getToolDefinition().inputSchema().get("required"));
+	}
+
+	@Test
+	void adoptsEveryRepositoryOfAList() {
+		tool.apply(Map.of("repository_urls", List.of(REPO_URL, OTHER_URL)));
+		assertEquals(List.of(REPO_URL, OTHER_URL),
+				pipeline.contexts.stream().map(AdoptionContext::repositoryUrl).toList());
+	}
+
+	@Test
+	void acceptsACommaSeparatedListOfRepositories() {
+		tool.apply(Map.of("repository_urls", REPO_URL + " , " + OTHER_URL));
+		assertEquals(List.of(REPO_URL, OTHER_URL),
+				pipeline.contexts.stream().map(AdoptionContext::repositoryUrl).toList());
+	}
+
+	@Test
+	void adoptsTheSingleUrlAndTheListTogetherWithoutRepeatingOne() {
+		tool.apply(Map.of("repository_url", REPO_URL, "repository_urls", List.of(OTHER_URL, REPO_URL)));
+		assertEquals(List.of(REPO_URL, OTHER_URL),
+				pipeline.contexts.stream().map(AdoptionContext::repositoryUrl).toList());
+	}
+
+	@Test
+	void adoptsEveryRepositoryOfAListIntoTheSameWorkspaceAndBranch(@TempDir Path dir) {
+		tool.apply(Map.of("repository_urls", List.of(REPO_URL, OTHER_URL), "workspace", dir.toString(),
+				"branch", "feature/x"));
+		assertEquals(List.of(dir, dir), pipeline.contexts.stream().map(AdoptionContext::workspace).toList());
+		assertEquals(List.of("feature/x", "feature/x"),
+				pipeline.contexts.stream().map(AdoptionContext::branchName).toList());
+	}
+
+	@Test
+	void answersWithAnEntryPerRepositoryOfABatch() throws IOException {
+		ToolResult result = tool.apply(Map.of("repository_urls", List.of(REPO_URL, OTHER_URL)));
+		assertFalse(result.isError());
+		JsonNode node = new ObjectMapper().readTree(result.text());
+		assertTrue(node.get("succeeded").asBoolean());
+		assertEquals(2, node.get("repositories").size());
+		assertEquals(OTHER_URL, node.get("repositories").get(1).get("repositoryUrl").asText());
+	}
+
+	/**
+	 * A failed repository is answered with the report rather than an exception,
+	 * because the report is what says which of the batch landed and which did not.
+	 */
+	@Test
+	void answersWithAnErrorResultCarryingTheReportWhenARepositoryFails() throws IOException {
+		AdoptTool failing = new AdoptTool((context, report, options, includeAssets, ruleVersion) -> {
+			report.recordStep("clone");
+			throw new AdoptionException("boom");
+		});
+		ToolResult result = failing.apply(Map.of("repository_url", REPO_URL));
+		assertTrue(result.isError());
+		JsonNode node = new ObjectMapper().readTree(result.text());
+		assertFalse(node.get("succeeded").asBoolean());
+		assertEquals("boom", node.get("failure").asText());
+		assertEquals("clone", node.get("completedSteps").get(0).asText());
 	}
 
 	@Test
@@ -137,5 +202,18 @@ class AdoptToolTest {
 	@Test
 	void requiresTheRepositoryUrl() {
 		assertThrows(IllegalArgumentException.class, () -> tool.apply(Map.of()));
+	}
+
+	@Test
+	void requiresAtLeastOneRepositoryWhenBothArgumentsAreBlank() {
+		assertThrows(IllegalArgumentException.class,
+				() -> tool.apply(Map.of("repository_url", "  ", "repository_urls", " , ")));
+	}
+
+	@Test
+	void declaresTheRepositoryListArgument() {
+		Object properties = tool.getToolDefinition().inputSchema().get("properties");
+		assertTrue(properties instanceof Map<?, ?> declared && declared.containsKey("repository_urls"),
+				"a list of repositories must be settable through the tool: " + properties);
 	}
 }


### PR DESCRIPTION
The adoption took a single repository URL, so adopting Claude Code across a
team's repositories meant invoking the pipeline once per repository by hand.

The command line now collects a list: repeatable `--repo <url>` and
`--repos <file>` (one URL per line, `#` comments and blank lines skipped, read
by `RepositoryUrls`) add to the positional URL, duplicates are dropped, and
`--workspace`/`--branch` name the shared workspace and branch for a run with no
positionals — the first positional stays a repository URL, never a workspace.
The MCP tool takes the same list as `repository_urls`, a JSON array or a
comma-separated string, beside `repository_url`.

`BatchAdoption` runs the pipeline once per repository with its own report and
does not stop at the first failure: the adoptions are independent, so a failed
one is recorded, the batch runs to the end, and `Main` raises the failures
together afterwards so the process still exits non-zero. The MCP tool answers
with an error result carrying the report rather than a bare exception, since
the report is what says which repositories landed.

A run over several repositories writes the batch report — an overall
`succeeded` and a `repositories` array of per-repository documents — while a
single-repository run keeps writing its document unwrapped, so the shape
existing consumers parse is unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TXYJ7R3pUCL58vVPEVZdG2