### PR TITLE
fix(adopt): stop two repositories of a batch sharing one checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,7 +771,12 @@ adopted once. Every repository of the run shares the workspace and the branch
 name — each clone lands in its own directory under the workspace, named after the
 repository — so a batch driven entirely by the flags names them with
 `--workspace` and `--branch`, the first positional argument always being a
-repository URL:
+repository URL; a first positional that names no repository owner while the flags
+named repositories is rejected, since that is the workspace this reading invites.
+Two repositories that would clone into the same directory — `owner/tools` and
+`other-owner/tools`, or one repository named both with and without its `.git`
+suffix — are rejected before anything is cloned rather than adopted on top of each
+other:
 
 ```bash
 mvn -pl adopt exec:java \

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Checkouts.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Checkouts.java
@@ -1,0 +1,61 @@
+package io.github.adamw7.tools.adopt;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Gives every repository of a run its own checkout, as the {@link AdoptionContext}
+ * list the run works through: one workspace, one branch name, in the order the URLs
+ * were given. Both entry points come through here — the way both resolve their
+ * workspace through {@link Workspaces} — so the command line and the MCP tool
+ * cannot drift apart on how a run's contexts are made, or on which lists of
+ * repositories are adoptable at all.
+ *
+ * <p>Two repositories that would clone into the same checkout directory are
+ * rejected rather than adopted. A checkout is named after the repository alone, so
+ * {@code owner/tools} and {@code other-owner/tools} claim one directory, and so do
+ * the same repository's {@code .../repo} and {@code .../repo.git} forms — distinct
+ * URLs, hence not duplicates to {@link RepositoryUrls#distinct(List)}, but one
+ * directory. The second adoption would then run every step against the first
+ * repository's working tree: {@link io.github.adamw7.tools.adopt.step.CloneStep}
+ * reuses an existing checkout by design, so nothing would clone, and the run would
+ * report the first repository's pull request as the second's or fail at {@code gh}
+ * with a message pointing nowhere near the cause. Failing on the input instead says
+ * exactly which two URLs collided while both repositories are still untouched.
+ */
+public final class Checkouts {
+
+	private Checkouts() {
+	}
+
+	/**
+	 * @param repositoryUrls the repositories to adopt, without duplicates
+	 * @param workspace      the directory every clone is created under
+	 * @param branchName     the feature branch every adoption commits on
+	 * @throws IllegalArgumentException when two repositories would clone into the
+	 *                                  same checkout directory
+	 */
+	public static List<AdoptionContext> forRun(List<String> repositoryUrls, Path workspace, String branchName) {
+		List<AdoptionContext> contexts = repositoryUrls.stream()
+				.map(url -> new AdoptionContext(url, workspace, branchName))
+				.toList();
+		requireDistinctCheckouts(contexts);
+		return contexts;
+	}
+
+	private static void requireDistinctCheckouts(List<AdoptionContext> contexts) {
+		Map<Path, String> urlsByCheckout = new HashMap<>();
+		contexts.forEach(context -> requireCheckoutUnclaimed(urlsByCheckout, context));
+	}
+
+	private static void requireCheckoutUnclaimed(Map<Path, String> urlsByCheckout, AdoptionContext context) {
+		String claimedBy = urlsByCheckout.putIfAbsent(context.repositoryDirectory(), context.repositoryUrl());
+		if (claimedBy != null) {
+			throw new IllegalArgumentException("Cannot adopt " + context.repositoryUrl() + " and " + claimedBy
+					+ " in one run: both would clone into " + context.repositoryDirectory()
+					+ ". Adopt them in separate runs, or into separate workspaces.");
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -31,7 +31,10 @@ import io.github.adamw7.tools.adopt.step.PullRequestOptions;
  * driven entirely by {@code --repo}/{@code --repos} names its workspace and
  * branch with {@code --workspace} and {@code --branch} rather than positionally.
  * Both flags write the same value as their positional, so naming one twice is the
- * last one winning rather than an error.
+ * last one winning rather than an error. A first positional that names no
+ * repository owner while those flags named repositories is rejected outright: it is
+ * the workspace the reading above invites, and adopting it as a repository fails
+ * far from the mistake.
  */
 public final class CliArguments {
 
@@ -54,6 +57,8 @@ public final class CliArguments {
 	private String ruleVersion;
 	private Path reportFile;
 	private int positionals;
+	private String positionalUrl;
+	private int flaggedRepositories;
 
 	private CliArguments() {
 	}
@@ -65,6 +70,7 @@ public final class CliArguments {
 			index = cli.consume(args, index);
 		}
 		cli.requireRepositoryUrls();
+		cli.requirePositionalNamesARepository();
 		return cli;
 	}
 
@@ -122,8 +128,8 @@ public final class CliArguments {
 	private int consumeFlag(String[] args, int index) {
 		String flag = args[index];
 		return switch (flag) {
-			case "--repo" -> consumeValue(args, index, this::addRepository);
-			case "--repos" -> consumeValue(args, index, value -> repositoryUrls.addAll(readList(value)));
+			case "--repo" -> consumeValue(args, index, this::addFlaggedRepository);
+			case "--repos" -> consumeValue(args, index, value -> addFlaggedRepositories(readList(value)));
 			case "--workspace" -> consumeValue(args, index, value -> workspace = optionalPath(value));
 			case "--branch" -> consumeValue(args, index, value -> branchName = optionalText(value));
 			case "--title" -> consumeValue(args, index, value -> title = value);
@@ -162,12 +168,28 @@ public final class CliArguments {
 	 */
 	private void consumePositional(String argument) {
 		switch (positionals) {
-			case 0 -> addRepository(argument);
+			case 0 -> addPositionalRepository(argument);
 			case 1 -> workspace = optionalPath(argument);
 			case 2 -> branchName = optionalText(argument);
 			default -> throw new IllegalArgumentException("Unexpected argument " + argument + ". " + USAGE);
 		}
 		positionals++;
+	}
+
+	private void addPositionalRepository(String url) {
+		positionalUrl = optionalText(url);
+		addRepository(url);
+	}
+
+	private void addFlaggedRepositories(List<String> urls) {
+		urls.forEach(this::addFlaggedRepository);
+	}
+
+	private void addFlaggedRepository(String url) {
+		if (Text.isPresent(url)) {
+			flaggedRepositories++;
+		}
+		addRepository(url);
 	}
 
 	private void addRepository(String url) {
@@ -192,5 +214,32 @@ public final class CliArguments {
 		if (repositoryUrls.isEmpty()) {
 			throw new IllegalArgumentException(USAGE);
 		}
+	}
+
+	/**
+	 * Rejects a first positional that names no repository owner when the flags
+	 * already named repositories — {@code --repos list.txt /tmp/workspace}, where the
+	 * operator meant the workspace the flags left unnamed. The positional slot keeps
+	 * its meaning whatever else is on the command line, so that path is read as a
+	 * repository URL and fails several steps later on a clone of a directory that is
+	 * not a repository, or a push to an origin that does not exist. Saying so here
+	 * names the argument and the flag that was meant instead.
+	 *
+	 * <p>The check is only worth making when the flags supplied a repository, since a
+	 * run whose only repository is the positional has nothing else it could be. A
+	 * local path really is adoptable — {@link RepositoryUrl} accepts one, and only a
+	 * URL with a host names an owner — so a batch of local repositories names them all
+	 * with {@code --repo} rather than positionally.
+	 */
+	private void requirePositionalNamesARepository() {
+		if (positionalUrl != null && flaggedRepositories > 0 && namesNoOwner(positionalUrl)) {
+			throw new IllegalArgumentException("The first argument is read as a repository URL, but " + positionalUrl
+					+ " names no repository owner. Name the workspace with --workspace,"
+					+ " or the repository with --repo. " + USAGE);
+		}
+	}
+
+	private boolean namesNoOwner(String url) {
+		return RepositoryUrl.of(url).slug().isEmpty();
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -64,10 +64,7 @@ public class Main {
 
 	/** Every repository of a run is adopted into one workspace, on one branch name. */
 	static List<AdoptionContext> contexts(CliArguments cli) {
-		Path workspace = workspace(cli);
-		return cli.repositoryUrls().stream()
-				.map(url -> new AdoptionContext(url, workspace, cli.branchName()))
-				.toList();
+		return Checkouts.forRun(cli.repositoryUrls(), workspace(cli), cli.branchName());
 	}
 
 	static Path workspace(CliArguments cli) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -15,6 +15,7 @@ import io.github.adamw7.tools.adopt.AdoptionReport;
 import io.github.adamw7.tools.adopt.AdoptionReportWriter;
 import io.github.adamw7.tools.adopt.AdoptionRun;
 import io.github.adamw7.tools.adopt.BatchAdoption;
+import io.github.adamw7.tools.adopt.Checkouts;
 import io.github.adamw7.tools.adopt.GitHubRepoAdopter;
 import io.github.adamw7.tools.adopt.RepositoryUrls;
 import io.github.adamw7.tools.adopt.Workspaces;
@@ -134,11 +135,7 @@ public class AdoptTool implements McpTool {
 
 	/** Every repository of a call is adopted into one workspace, on one branch name. */
 	private List<AdoptionContext> contextsFrom(Map<String, Object> arguments) {
-		Path workspace = workspace(arguments);
-		String branch = branch(arguments);
-		return repositoryUrls(arguments).stream()
-				.map(url -> new AdoptionContext(url, workspace, branch))
-				.toList();
+		return Checkouts.forRun(repositoryUrls(arguments), workspace(arguments), branch(arguments));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
@@ -18,7 +18,9 @@ repository, the branch, the pull request URL, and the completed steps.
 One call can adopt a list of repositories, one after another, sharing the
 workspace and branch name. A repository whose adoption fails does not strand the
 ones behind it: the batch runs to the end and the report says which landed, the
-result being marked as an error when any of them did not.
+result being marked as an error when any of them did not. Two repositories of the
+list that would clone into the same directory under the workspace are refused
+before anything is cloned, so neither is adopted on top of the other.
 
 Because the pipeline shells out to `git`, `claude`, and `gh`, those tools must
 be installed and authenticated on the machine running the MCP server.
@@ -60,7 +62,8 @@ This creates an executable JAR in `adopt/target/tools.adopt-{version}.jar`.
   each
 - `workspace` (string, optional): directory to clone into, shared by every
   repository of the call — each clone lands in its own directory under it, named
-  after the repository; a temporary directory is created when omitted
+  after the repository, and two repositories of one call may not share that
+  directory; a temporary directory is created when omitted
 - `branch` (string, optional): feature branch name; defaults to
   `claude/adopt-claude-code`
 - `title` / `body` (string, optional): pull request title and body

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CheckoutsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CheckoutsTest.java
@@ -1,0 +1,92 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class CheckoutsTest {
+
+	private static final String REPO_URL = "https://github.com/owner/repo.git";
+	private static final String OTHER_URL = "https://github.com/owner/other.git";
+	private static final String BRANCH = "feature/x";
+	private static final Path WORKSPACE = Path.of("/tmp/workspace");
+
+	@Test
+	void buildsOneContextPerRepositoryInOrder() {
+		List<AdoptionContext> contexts = Checkouts.forRun(List.of(REPO_URL, OTHER_URL), WORKSPACE, BRANCH);
+		assertEquals(List.of(REPO_URL, OTHER_URL), contexts.stream().map(AdoptionContext::repositoryUrl).toList());
+	}
+
+	@Test
+	void adoptsEveryRepositoryIntoOneWorkspaceOnOneBranch() {
+		List<AdoptionContext> contexts = Checkouts.forRun(List.of(REPO_URL, OTHER_URL), WORKSPACE, BRANCH);
+		assertEquals(List.of(WORKSPACE, WORKSPACE), contexts.stream().map(AdoptionContext::workspace).toList());
+		assertEquals(List.of(BRANCH, BRANCH), contexts.stream().map(AdoptionContext::branchName).toList());
+	}
+
+	@Test
+	void givesEachRepositoryItsOwnCheckoutDirectory() {
+		List<AdoptionContext> contexts = Checkouts.forRun(List.of(REPO_URL, OTHER_URL), WORKSPACE, BRANCH);
+		assertEquals(List.of(WORKSPACE.resolve("repo"), WORKSPACE.resolve("other")),
+				contexts.stream().map(AdoptionContext::repositoryDirectory).toList());
+	}
+
+	/**
+	 * A checkout is named after the repository alone, so two owners' repositories of
+	 * the same name claim one directory. The second adoption would reuse the first's
+	 * checkout — the clone step skips a checkout that exists — and report a pull
+	 * request the second repository never got.
+	 */
+	@Test
+	void rejectsTwoOwnersRepositoriesOfTheSameName() {
+		List<String> urls = List.of("https://github.com/owner/tools.git", "https://github.com/other-owner/tools.git");
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> Checkouts.forRun(urls, WORKSPACE, BRANCH));
+		assertTrue(exception.getMessage().contains("other-owner/tools"), exception.getMessage());
+		assertTrue(exception.getMessage().contains(WORKSPACE.resolve("tools").toString()), exception.getMessage());
+	}
+
+	/**
+	 * The two clone URLs of one repository are not duplicates as text, so the list
+	 * input keeps both — and they name the same checkout, which is what makes them one
+	 * adoption rather than two.
+	 */
+	@Test
+	void rejectsTheSameRepositoryNamedWithAndWithoutTheGitSuffix() {
+		List<String> urls = List.of("https://github.com/owner/repo", REPO_URL);
+		assertThrows(IllegalArgumentException.class, () -> Checkouts.forRun(urls, WORKSPACE, BRANCH));
+	}
+
+	@Test
+	void rejectsTheSameRepositoryNamedWithAndWithoutATrailingSlash() {
+		List<String> urls = List.of("https://github.com/owner/repo/", "https://github.com/owner/repo");
+		assertThrows(IllegalArgumentException.class, () -> Checkouts.forRun(urls, WORKSPACE, BRANCH));
+	}
+
+	/** The collision is named while both repositories are still untouched. */
+	@Test
+	void namesBothCollidingRepositories() {
+		List<String> urls = List.of(REPO_URL, "https://github.com/other-owner/repo.git");
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> Checkouts.forRun(urls, WORKSPACE, BRANCH));
+		assertTrue(exception.getMessage().contains(REPO_URL), exception.getMessage());
+		assertTrue(exception.getMessage().contains("other-owner/repo.git"), exception.getMessage());
+	}
+
+	@Test
+	void adoptsASingleRepository() {
+		List<AdoptionContext> contexts = Checkouts.forRun(List.of(REPO_URL), WORKSPACE, BRANCH);
+		assertEquals(1, contexts.size());
+		assertEquals(WORKSPACE.resolve("repo"), contexts.get(0).repositoryDirectory());
+	}
+
+	@Test
+	void buildsNoContextsForNoRepositories() {
+		assertTrue(Checkouts.forRun(List.of(), WORKSPACE, BRANCH).isEmpty());
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -264,6 +264,51 @@ class CliArgumentsTest {
 				() -> CliArguments.parse(new String[] { REPO_URL, "/tmp/ws", "branch", "surplus" }));
 	}
 
+	/**
+	 * The workspace an operator meant to name positionally is read as a repository
+	 * URL, so the run would clone a directory that is not a repository. Rejecting it
+	 * names the flag that was meant instead of failing at the clone.
+	 */
+	@Test
+	void rejectsAWorkspacePositionalAlongsideTheRepositoryFlags(@TempDir Path dir) throws IOException {
+		Path list = Files.writeString(dir.resolve("repos.txt"), REPO_URL + "\n");
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { "/tmp/ws", "--repos", list.toString() }));
+		assertTrue(exception.getMessage().contains("--workspace"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("/tmp/ws"), exception.getMessage());
+	}
+
+	@Test
+	void rejectsAWorkspacePositionalWhateverOrderTheRepositoryFlagCameIn() {
+		assertThrows(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { "--repo", REPO_URL, "/tmp/ws" }));
+	}
+
+	/** A positional URL beside the flags is the documented way to name the first repository. */
+	@Test
+	void acceptsARepositoryPositionalAlongsideTheRepositoryFlags() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL });
+		assertEquals(List.of(REPO_URL, OTHER_URL), cli.repositoryUrls());
+	}
+
+	/**
+	 * A local path names no owner but is adoptable, so a run whose only repository is
+	 * the positional keeps working — the check only fires when the flags named one too.
+	 */
+	@Test
+	void acceptsALocalRepositoryPathAsTheOnlyRepository() {
+		CliArguments cli = CliArguments.parse(new String[] { "/tmp/checkouts/repo", "/tmp/ws" });
+		assertEquals(List.of("/tmp/checkouts/repo"), cli.repositoryUrls());
+		assertEquals(Path.of("/tmp/ws"), cli.workspace().orElseThrow());
+	}
+
+	/** A blank repository flag names nothing, so it cannot turn the positional into a workspace. */
+	@Test
+	void aBlankRepositoryFlagDoesNotRejectALocalRepositoryPositional() {
+		CliArguments cli = CliArguments.parse(new String[] { "/tmp/checkouts/repo", "--repo", "  " });
+		assertEquals(List.of("/tmp/checkouts/repo"), cli.repositoryUrls());
+	}
+
 	private void assertUsageFailure(String[] args) {
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
 				() -> CliArguments.parse(args));

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
@@ -90,6 +90,17 @@ class MainTest {
 		assertEquals(List.of(REPO_URL), contexts.stream().map(AdoptionContext::repositoryUrl).toList());
 	}
 
+	/**
+	 * Two owners' repositories of the same name would clone into one checkout, so the
+	 * run fails on its arguments rather than adopting the first repository twice.
+	 */
+	@Test
+	void rejectsARunWhoseRepositoriesShareACheckoutDirectory(@TempDir Path dir) {
+		CliArguments cli = CliArguments.parse(new String[] { "https://github.com/owner/tools.git",
+				"--repo", "https://github.com/other-owner/tools.git", "--workspace", dir.toString() });
+		assertThrows(IllegalArgumentException.class, () -> Main.contexts(cli));
+	}
+
 	@Test
 	void adoptsTheRepositoriesAListFileNames(@TempDir Path dir) throws IOException {
 		Path list = Files.writeString(dir.resolve("repos.txt"), REPO_URL + "\n" + OTHER_URL + "\n");

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
@@ -206,6 +206,18 @@ class AdoptToolTest {
 		assertThrows(IllegalArgumentException.class, () -> tool.apply(Map.of()));
 	}
 
+	/**
+	 * The collision is refused before anything is cloned, so no repository of the call
+	 * is adopted on the strength of another one's checkout.
+	 */
+	@Test
+	void rejectsAListWhoseRepositoriesShareACheckoutDirectory() {
+		Map<String, Object> arguments = Map.of("repository_urls",
+				List.of("https://github.com/owner/tools.git", "https://github.com/other-owner/tools.git"));
+		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
+		assertTrue(pipeline.contexts.isEmpty());
+	}
+
 	@Test
 	void ignoresBlankEntriesInTheRepositoryList() {
 		tool.apply(Map.of("repository_urls", List.of("  ", REPO_URL, "")));


### PR DESCRIPTION
A checkout is named after the repository alone, so two repositories of one run
could claim the same directory under the shared workspace while remaining
distinct URLs to the list input's de-duplication: `owner/tools` beside
`other-owner/tools`, or one repository named both with and without its `.git`
suffix or a trailing slash. The clone step reuses a checkout that already
exists, by design, so the second adoption ran every step against the first
repository's working tree — reporting the first's pull request as the second's,
or failing at `gh` with a message pointing nowhere near the cause.

`Checkouts` now builds the context list both entry points work through and
rejects a collision before anything is cloned, naming the two URLs and the
directory they share. Failing on the input leaves both repositories untouched,
and routing `Main` and `AdoptTool` through one builder keeps the command line
and the MCP tool from drifting apart on which lists are adoptable.

The command line also rejects a first positional that names no repository owner
while `--repo`/`--repos` named repositories: the positional slot is always a
repository URL, so `--repos list.txt /tmp/workspace` adopted the workspace and
failed several steps later at the clone or the push. A run whose only repository
is the positional is unaffected, so a local path stays adoptable.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cobzc1L82aHjx8jAKCsjcv