### PR TITLE
test(adopt): exercise a multi-repository run against real GitHub URLs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,4 @@
-name: MCP Integration Tests
+name: Integration Tests
 
 on:
   schedule:
@@ -17,5 +17,5 @@ jobs:
         java-version: '25'
         distribution: 'temurin'
         cache: maven
-    - name: Run MCP streamable HTTP integration tests
+    - name: Run the integration tests (MCP over HTTP, adoption against real GitHub URLs)
       run: mvn -B -ntp verify -P integration-tests --file pom.xml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,10 +327,21 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
   `@Disabled`, tests use JUnit 5 only (no JUnit 4 `org.junit` API), no test
   writes to `System.out`/`err` (assert on the value instead), and no test
   calls `Thread.sleep` (sleeping is slow and flaky — wait on a condition).
-- **MCP integration tests** are gated behind the `integration-tests` profile
-  (defined in `data` and `code/context`) and exercise the MCP servers over
-  streamable HTTP: `mvn -P integration-tests verify`. Test classes ending in
-  `IT` belong to this profile.
+- **Integration tests** are gated behind the `integration-tests` profile
+  (defined in `data`, `code/context`, and `adopt`) and are the tests that need
+  something real: `mvn -P integration-tests verify`. Test classes ending in `IT`
+  belong to this profile. `data` and `code/context` exercise their MCP servers
+  over streamable HTTP; `adopt`'s `MultiRepoAdoptionIT` runs a multi-repository
+  adoption against real GitHub URLs, cloning GitHub's `octocat/Hello-World` and
+  `octocat/Spoon-Knife` samples with the real `git`, to prove that a batch gives
+  each repository its own checkout, that a repository which cannot be cloned
+  costs only itself, and that two real URLs for one repository are refused
+  before anything is cloned. That IT stops the pipeline at the branch step, so
+  it stays read-only towards GitHub: it never runs `claude`, never pushes, and
+  never opens a pull request, and it needs no `gh` login. Because it clones
+  over the network, a host with a git `url.<base>.insteadOf` rewrite records the
+  rewritten remote, so the test identifies each checkout by the
+  `owner/repository` its `origin` names rather than by the URL it was given.
 - **Coverage** is the opt-in `coverage` profile (JaCoCo): `mvn -Pcoverage verify`
   produces reports at `**/target/site/jacoco/` and **fails the build** if a
   bundle's instruction **or** branch coverage drops below **80%** (two
@@ -358,7 +369,7 @@ requests to `main`; the rest run on a schedule (or manually).
 | `maven.yml` | push, PR → `main` | Installs the enforcer rule, then `mvn -B package -DenforceClaudeMd` on JDK 25 — the **only** workflow that runs the CLAUDE.md/AGENTS.md checks. |
 | `docker.yml` | push, PR → `main` | `mvn -B package`, then builds the Docker image from `assembly/Dockerfile`. |
 | `codeql.yml` | push, PR → `main`; weekly | CodeQL security/static analysis for Java (autobuild). |
-| `integration-tests.yml` | daily | `mvn -P integration-tests verify` (MCP streamable-HTTP integration tests). |
+| `integration-tests.yml` | daily | `mvn -P integration-tests verify` (MCP streamable-HTTP integration tests, and the `adopt` multi-repository adoption against real GitHub URLs). |
 | `coverage.yml` | weekly | `mvn verify -Pcoverage`, uploads JaCoCo reports as an artifact. |
 | `pitest.yml` | weekly; manual | `mvn install -Ppitest`, uploads PIT mutation reports as an artifact. |
 | `maven-publish.yml` | on GitHub release | Deploys to **GitHub Packages** (`-P github-packages`). See "Releasing". |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ mvn clean install                 # full clean build + install to local repo
 mvn install                       # faster incremental build
 mvn -pl data test                 # tests for a single module
 mvn -B package                    # build without installing (what CI runs)
-mvn -P integration-tests verify   # MCP integration tests (*IT)
+mvn -P integration-tests verify   # integration tests (*IT): MCP servers, real-GitHub adoption
 mvn -Pcoverage verify             # JaCoCo coverage (fails under 80% instruction or branch)
 mvn -Ppitest install              # PIT mutation testing (needs a phase past package)
 ```
@@ -164,8 +164,11 @@ paths.
   conventions on the tests themselves — test methods must sit in `*Test`/`*IT`
   classes, no `@Disabled`, JUnit 5 only, no `System.out`/`err`, and no
   `Thread.sleep`. Keep new code within these rules.
-- **MCP integration tests** (`*IT`) are gated behind the `integration-tests`
-  profile.
+- **Integration tests** (`*IT`) are gated behind the `integration-tests` profile
+  and cover what needs something real: the MCP servers over HTTP, and `adopt`'s
+  `MultiRepoAdoptionIT`, which clones real GitHub sample repositories to prove a
+  batch gives each repository its own checkout. It stops at the branch step, so
+  it never pushes or opens a pull request. See *Testing* in AGENTS.md.
 
 ## Agent configuration
 

--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -58,6 +58,31 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<!-- Gates the *IT tests, which need real network: MultiRepoAdoptionIT
+		     clones real GitHub repositories to prove a batch gives each one its
+		     own checkout. Mirrors the data and code/context modules. -->
+		<profile>
+			<id>integration-tests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<executions>
+							<execution>
+								<goals>
+									<goal>integration-test</goal>
+									<goal>verify</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<dependencies>
 		<dependency>
 			<groupId>io.github.adamw7</groupId>

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MultiRepoAdoptionIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MultiRepoAdoptionIT.java
@@ -1,0 +1,232 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.command.CommandResult;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
+import io.github.adamw7.tools.adopt.step.AdoptionStep;
+import io.github.adamw7.tools.adopt.step.BranchStep;
+import io.github.adamw7.tools.adopt.step.CloneStep;
+import io.github.adamw7.tools.adopt.step.ToolchainStep;
+
+/**
+ * Adopts several repositories in one run against <em>real</em> GitHub URLs, over
+ * the network, with the real {@code git} the pipeline shells out to. The
+ * unit tests drive the batch with a recording stub and synthetic URLs such as
+ * {@code https://github.com/owner/repo.git}, which proves the wiring but cannot
+ * prove that two real repositories end up as two real checkouts — the failure
+ * that {@link Checkouts} exists to prevent is only visible once {@code git clone}
+ * has actually run twice into one workspace.
+ *
+ * <p>The run goes through the command line the same way an operator's does —
+ * {@link CliArguments} parses {@code --repo}/{@code --repos}, {@link Main} builds
+ * the contexts and writes the report — so the multi-repository path is exercised
+ * end to end rather than from {@link BatchAdoption} inwards.
+ *
+ * <p>What the pipeline is <em>not</em> given here is every step: the adoption
+ * ends at {@link BranchStep}, so the run clones and branches for real but never
+ * runs {@code claude}, never marks a checkout trusted, and above all never pushes
+ * or opens a pull request. A test that ran the default pipeline would write to
+ * repositories nobody asked it to write to, and would need a logged-in {@code gh}
+ * to do it; the steps kept here are the ones the repository list actually changes
+ * the behaviour of, and they only read from GitHub.
+ *
+ * <p>The repositories are GitHub's own long-lived samples, which are tiny — a few
+ * hundred kilobytes each — so a clone costs about a second.
+ */
+class MultiRepoAdoptionIT {
+
+	private static final String HELLO_WORLD = "https://github.com/octocat/Hello-World.git";
+	private static final String SPOON_KNIFE = "https://github.com/octocat/Spoon-Knife.git";
+
+	/** A well-formed GitHub URL for a repository that is not there, so the clone fails. */
+	private static final String MISSING = "https://github.com/octocat/no-such-repository-tools-adopt-it.git";
+
+	/** The SSH form of {@link #HELLO_WORLD}: a second real URL for one repository. */
+	private static final String HELLO_WORLD_OVER_SSH = "git@github.com:octocat/Hello-World.git";
+
+	private static final String BRANCH = "claude/adopt-it";
+
+	/**
+	 * Well under the runner's ten-minute default, which is sized for a
+	 * {@code claude init} rather than for cloning a sample repository, so a stalled
+	 * network fails the test in minutes instead of hanging the build.
+	 */
+	private final CommandRunner runner = new ProcessCommandRunner(Duration.ofMinutes(2));
+
+	private final ObjectMapper mapper = new ObjectMapper();
+
+	@TempDir
+	Path workspace;
+
+	@TempDir
+	Path reports;
+
+	/**
+	 * The batch's whole point: two repositories named on one command line become two
+	 * independent checkouts. Asserting each checkout's {@code origin} — rather than
+	 * only that two directories exist — is what catches a second adoption that
+	 * silently reused the first repository's working tree, since the clone step
+	 * reuses an existing checkout by design and would report success either way.
+	 */
+	@Test
+	void adoptsTwoRealRepositoriesIntoTheirOwnCheckouts() throws IOException {
+		Path report = reports.resolve("batch.json");
+		CliArguments cli = parse("--repo", HELLO_WORLD, "--repo", SPOON_KNIFE,
+				"--workspace", workspace.toString(), "--branch", BRANCH, "--report", report.toString());
+
+		List<AdoptionRun> runs = Main.runAndReport(cli, Main.contexts(cli), cloneOnlyAdopter());
+
+		assertEquals(List.of(HELLO_WORLD, SPOON_KNIFE), runs.stream().map(AdoptionRun::repositoryUrl).toList());
+		assertTrue(runs.stream().allMatch(AdoptionRun::succeeded), () -> failures(runs));
+		assertCheckedOut(HELLO_WORLD);
+		assertCheckedOut(SPOON_KNIFE);
+		assertBatchReport(report, true, List.of(HELLO_WORLD, SPOON_KNIFE));
+	}
+
+	/**
+	 * A repository that cannot be cloned is the failure an operator running a long
+	 * list actually hits — a typo, a repository that moved, one they have no access
+	 * to. It must cost them that repository and no other, so the run is driven with
+	 * the missing one in the middle: a batch that stopped at the first failure would
+	 * leave the third repository unadopted.
+	 */
+	@Test
+	void adoptsTheRestOfTheListWhenOneRepositoryIsNotThere() throws IOException {
+		Path report = reports.resolve("partial.json");
+		CliArguments cli = parse("--repos", listFile(HELLO_WORLD, MISSING, SPOON_KNIFE).toString(),
+				"--workspace", workspace.toString(), "--branch", BRANCH, "--report", report.toString());
+		List<AdoptionContext> contexts = Main.contexts(cli);
+
+		AdoptionException failure = assertThrows(AdoptionException.class,
+				() -> Main.runAndReport(cli, contexts, cloneOnlyAdopter()));
+
+		assertTrue(failure.getMessage().contains("1 of 3 repositories"), failure.getMessage());
+		assertTrue(failure.getMessage().contains(MISSING), failure.getMessage());
+		assertCheckedOut(HELLO_WORLD);
+		assertCheckedOut(SPOON_KNIFE);
+		assertFalse(Files.exists(workspace.resolve("no-such-repository-tools-adopt-it")),
+				"the repository that could not be cloned must leave no checkout behind");
+		assertBatchReport(report, false, List.of(HELLO_WORLD, MISSING, SPOON_KNIFE));
+		assertCloneFailedFor(report, MISSING);
+	}
+
+	/**
+	 * GitHub offers a repository's HTTPS and SSH URLs side by side, so a list
+	 * assembled by pasting from both names one repository twice in two forms. They
+	 * are not duplicates as text, and they claim one checkout directory — the run
+	 * must be refused on its input rather than adopt the repository twice, with
+	 * nothing cloned by the time it is.
+	 */
+	@Test
+	void refusesTwoRealUrlsForOneRepositoryBeforeCloningAnything() throws IOException {
+		CliArguments cli = parse("--repo", HELLO_WORLD, "--repo", HELLO_WORLD_OVER_SSH,
+				"--workspace", workspace.toString(), "--branch", BRANCH);
+
+		IllegalArgumentException failure = assertThrows(IllegalArgumentException.class, () -> Main.contexts(cli));
+
+		assertTrue(failure.getMessage().contains(HELLO_WORLD_OVER_SSH), failure.getMessage());
+		assertTrue(failure.getMessage().contains(workspace.resolve("Hello-World").toString()), failure.getMessage());
+		assertTrue(isEmpty(workspace), "nothing may be cloned when the run is refused on its input");
+	}
+
+	/**
+	 * The pipeline stops at the branch step: the adoption stays read-only towards
+	 * GitHub, so this test can be run against real repositories as often as it likes.
+	 * The toolchain step is given {@code git} alone for the same reason — the
+	 * {@code claude} and {@code gh} it normally requires belong to the steps that are
+	 * not here.
+	 */
+	private GitHubRepoAdopter cloneOnlyAdopter() {
+		List<AdoptionStep> steps = List.of(new ToolchainStep(List.of("git")), new CloneStep(), new BranchStep());
+		return new GitHubRepoAdopter(runner, steps);
+	}
+
+	private CliArguments parse(String... arguments) {
+		return CliArguments.parse(arguments);
+	}
+
+	/** A {@code --repos} file as an operator writes one: a comment, then the URLs. */
+	private Path listFile(String... urls) throws IOException {
+		Path file = reports.resolve("repositories.txt");
+		return Files.writeString(file, "# the batch under test\n" + String.join("\n", urls) + "\n");
+	}
+
+	/**
+	 * Identifies the checkout by the {@code owner/repository} its {@code origin}
+	 * names, rather than by the URL the run was given: a host may carry a git
+	 * {@code url.<base>.insteadOf} rewrite — a mirror, a caching proxy — and the
+	 * remote then records the rewritten URL. The slug survives that rewrite and is
+	 * the fact under test anyway, since two checkouts of one repository is exactly
+	 * what would go wrong.
+	 */
+	private void assertCheckedOut(String repositoryUrl) {
+		RepositoryUrl repository = RepositoryUrl.of(repositoryUrl);
+		String slug = repository.slug().orElseThrow();
+		Path checkout = workspace.resolve(repository.name());
+		assertTrue(Files.isDirectory(checkout.resolve(".git")), () -> checkout + " is not a git checkout");
+		String origin = git(checkout, "remote", "get-url", "origin");
+		assertTrue(origin.endsWith(slug) || origin.endsWith(slug + ".git"),
+				() -> checkout + " was cloned from " + origin + ", which is not " + slug);
+		assertEquals(BRANCH, git(checkout, "rev-parse", "--abbrev-ref", "HEAD"));
+	}
+
+	private void assertBatchReport(Path report, boolean succeeded, List<String> repositoryUrls) throws IOException {
+		JsonNode document = mapper.readTree(Files.readString(report));
+		assertEquals(succeeded, document.get("succeeded").asBoolean());
+		assertEquals(repositoryUrls, document.get("repositories").findValuesAsText("repositoryUrl"));
+	}
+
+	/**
+	 * The report must say which repository stopped and where, not merely that the
+	 * batch was not wholly successful, so the entry naming the missing repository is
+	 * the one that has to carry the failure — and it has to blame the clone.
+	 */
+	private void assertCloneFailedFor(Path report, String repositoryUrl) throws IOException {
+		JsonNode repository = repositoryIn(report, repositoryUrl);
+		assertFalse(repository.get("succeeded").asBoolean());
+		assertTrue(repository.get("failure").asText().startsWith("clone: "), repository.get("failure").asText());
+	}
+
+	private JsonNode repositoryIn(Path report, String repositoryUrl) throws IOException {
+		JsonNode repositories = mapper.readTree(Files.readString(report)).get("repositories");
+		return repositories.valueStream()
+				.filter(entry -> repositoryUrl.equals(entry.get("repositoryUrl").asText()))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError(repositoryUrl + " is missing from " + repositories));
+	}
+
+	private String git(Path directory, String... arguments) {
+		List<String> command = Stream.concat(Stream.of("git"), Arrays.stream(arguments)).toList();
+		CommandResult result = runner.run(directory, command);
+		assertTrue(result.succeeded(), () -> result.describe() + " failed: " + result.output());
+		return result.output().strip();
+	}
+
+	private boolean isEmpty(Path directory) throws IOException {
+		try (var entries = Files.list(directory)) {
+			return entries.findAny().isEmpty();
+		}
+	}
+
+	private String failures(List<AdoptionRun> runs) {
+		return runs.stream().map(run -> run.repositoryUrl() + ": " + run.failure().orElse("ok")).toList().toString();
+	}
+}


### PR DESCRIPTION
The batch adoption was only ever driven by a recording stub over synthetic
URLs such as https://github.com/owner/repo.git. That proves the wiring, but
not the thing Checkouts exists to prevent: two repositories of one run
sharing a checkout is only visible once git clone has actually run twice
into one workspace.

MultiRepoAdoptionIT runs the adoption over real GitHub URLs, cloning
GitHub's octocat/Hello-World and octocat/Spoon-Knife samples with the real
git, through the command line an operator uses — CliArguments parses
--repo/--repos, Main builds the contexts and writes the JSON report. It
covers the three behaviours the repository list introduced: each repository
gets its own checkout, a repository that cannot be cloned costs only itself
while the rest of the list is still adopted, and two real URLs for one
repository (its HTTPS and SSH forms, as GitHub offers them side by side)
are refused before anything is cloned.

The pipeline stops at the branch step, so the test stays read-only towards
GitHub: it never runs claude, never marks a checkout trusted, never pushes,
and never opens a pull request, and it needs no gh login. Checkouts are
identified by the owner/repository their origin names rather than by the URL
given, so a host with a git url.<base>.insteadOf rewrite does not fail it.

Gated behind the integration-tests profile, which the adopt module now
defines alongside data and code/context; the daily workflow that runs the
profile is no longer MCP-only, and the docs say so.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ubzhCxPgC9ZXV5VWmJyQC