### PR TITLE
refactor(adopt): splice POM edits as text and drop unused API

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,9 +826,13 @@ derived checkout directory, and the feature-branch name):
 
 ```java
 CommandRunner runner = new ProcessCommandRunner();
-GitHubRepoAdopter.withDefaultPipeline(runner, PullRequestOptions.defaults(), false)
-    .adopt(new AdoptionContext("https://github.com/owner/repo.git", workspace));
+GitHubRepoAdopter.withDefaultPipeline(runner, PullRequestOptions.defaults(), false, Optional.empty())
+    .adopt(new AdoptionContext("https://github.com/owner/repo.git", workspace), new AdoptionReport());
 ```
+
+The report is a parameter rather than a return value alone, so a run that fails
+part-way still leaves the caller holding the steps that did complete and the
+reason it stopped.
 
 `BatchAdoption` wraps that pipeline to work through a list of repositories, one
 `AdoptionContext` at a time, and answers with an `AdoptionRun` (the context and
@@ -837,7 +841,7 @@ allowed to abandon the rest:
 
 ```java
 GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(
-    runner, PullRequestOptions.defaults(), false);
+    runner, PullRequestOptions.defaults(), false, Optional.empty());
 List<AdoptionRun> runs = new BatchAdoption(adopter::adopt).adoptAll(contexts);
 ```
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
@@ -27,21 +27,12 @@ public class AdoptionReportWriter {
 
 	private final ObjectMapper mapper = new ObjectMapper();
 
-	/** Renders a single repository's outcome, the shape nested in a batch document. */
-	public String toJson(AdoptionContext context, AdoptionReport report) {
-		return toJson(List.of(new AdoptionRun(context, report)));
-	}
-
 	public String toJson(List<AdoptionRun> runs) {
 		try {
 			return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(toNode(runs));
 		} catch (JsonProcessingException e) {
 			throw new AdoptionException("Could not serialise the adoption report", e);
 		}
-	}
-
-	public void write(Path file, AdoptionContext context, AdoptionReport report) {
-		write(file, List.of(new AdoptionRun(context, report)));
 	}
 
 	public void write(Path file, List<AdoptionRun> runs) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -92,11 +92,7 @@ public final class CliArguments {
 	}
 
 	public PullRequestOptions pullRequestOptions() {
-		return PullRequestOptions.builder()
-				.reviewers(reviewers).labels(labels).assignees(assignees).draft(draft)
-				.titleIfPresent(title)
-				.bodyIfPresent(body)
-				.build();
+		return new PullRequestOptions(title, body, reviewers, labels, assignees, draft);
 	}
 
 	public boolean includeAssets() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -61,11 +61,6 @@ public class GitHubRepoAdopter {
 		this.steps = List.copyOf(steps);
 	}
 
-	public static GitHubRepoAdopter withDefaultPipeline(CommandRunner runner, PullRequestOptions options,
-			boolean includeAssets) {
-		return withDefaultPipeline(runner, options, includeAssets, Optional.empty());
-	}
-
 	/**
 	 * @param ruleVersion the released {@code claude-code-enforcer} version a Maven
 	 *                    project's POM should pin, or empty to resolve the version of
@@ -76,10 +71,6 @@ public class GitHubRepoAdopter {
 		return new GitHubRepoAdopter(runner, defaultSteps(options, includeAssets, ruleVersion));
 	}
 
-	public static List<AdoptionStep> defaultSteps(PullRequestOptions options, boolean includeAssets) {
-		return defaultSteps(options, includeAssets, Optional.empty());
-	}
-
 	/**
 	 * The three steps that act on the checkout's build system are given the same
 	 * build-system list, so the guard that is wired in is the guard that is verified
@@ -87,7 +78,7 @@ public class GitHubRepoAdopter {
 	 */
 	public static List<AdoptionStep> defaultSteps(PullRequestOptions options, boolean includeAssets,
 			Optional<String> ruleVersion) {
-		List<BuildSystem> buildSystems = BuildSystems.withRuleVersion(ruleVersion);
+		List<BuildSystem> buildSystems = BuildSystems.defaults(ruleVersion);
 		List<AdoptionStep> steps = new ArrayList<>(List.of(
 				new ToolchainStep(),
 				new CloneStep(),
@@ -107,10 +98,6 @@ public class GitHubRepoAdopter {
 		steps.add(new PushStep());
 		steps.add(new PullRequestStep(options));
 		return List.copyOf(steps);
-	}
-
-	public AdoptionReport adopt(AdoptionContext context) {
-		return adopt(context, new AdoptionReport());
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.adopt;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -64,11 +63,7 @@ public class Main {
 
 	/** Every repository of a run is adopted into one workspace, on one branch name. */
 	static List<AdoptionContext> contexts(CliArguments cli) {
-		return Checkouts.forRun(cli.repositoryUrls(), workspace(cli), cli.branchName());
-	}
-
-	static Path workspace(CliArguments cli) {
-		return Workspaces.resolve(cli.workspace());
+		return Checkouts.forRun(cli.repositoryUrls(), Workspaces.resolve(cli.workspace()), cli.branchName());
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrls.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrls.java
@@ -33,11 +33,10 @@ public final class RepositoryUrls {
 	 * @throws AdoptionException when the file cannot be read
 	 */
 	public static List<String> fromFile(Path file) {
-		return fromLines(AdoptionFiles.read(file, "the repository URL list").lines().toList());
-	}
-
-	public static List<String> fromLines(List<String> lines) {
-		return distinct(lines.stream().map(String::strip).filter(RepositoryUrls::isRepository).toList());
+		return distinct(AdoptionFiles.read(file, "the repository URL list").lines()
+				.map(String::strip)
+				.filter(RepositoryUrls::isRepository)
+				.toList());
 	}
 
 	/** @return the URLs stripped of surrounding whitespace, without duplicates, in order */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -183,14 +183,9 @@ public class AdoptTool implements McpTool {
 	}
 
 	private PullRequestOptions optionsFrom(Map<String, Object> arguments) {
-		return PullRequestOptions.builder()
-				.reviewers(commaSeparated(arguments, "reviewers"))
-				.labels(commaSeparated(arguments, "labels"))
-				.assignees(commaSeparated(arguments, "assignees"))
-				.draft(ToolArguments.optionalBoolean(arguments, "draft", false))
-				.titleIfPresent(text(arguments, "title"))
-				.bodyIfPresent(text(arguments, "body"))
-				.build();
+		return new PullRequestOptions(text(arguments, "title"), text(arguments, "body"),
+				commaSeparated(arguments, "reviewers"), commaSeparated(arguments, "labels"),
+				commaSeparated(arguments, "assignees"), ToolArguments.optionalBoolean(arguments, "draft", false));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetInstaller.java
@@ -34,10 +34,6 @@ public class AssetInstaller {
 		this.executable = executable;
 	}
 
-	public String relativePath() {
-		return relativePath;
-	}
-
 	/**
 	 * @return {@code true} when the asset was written, {@code false} when the
 	 *         checkout already carried a file at its path and was left unchanged.

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -33,20 +33,6 @@ public interface BuildSystem {
 	List<String> verifyCommand();
 
 	/**
-	 * The same build system, pinning an explicitly supplied
-	 * {@code claude-code-enforcer} version into whatever it wires in. Only a build
-	 * system that wires in a versioned artifact of its own has anything to pin — the
-	 * Gradle and fallback guards are self-contained — so the default is to answer
-	 * with this build system unchanged, and a new implementation opts in by
-	 * overriding rather than by being named in a check elsewhere.
-	 *
-	 * @param ruleVersion a released rule version
-	 */
-	default BuildSystem withRuleVersion(String ruleVersion) {
-		return this;
-	}
-
-	/**
 	 * The program {@link #verifyCommand()} launches, so {@link BuildToolchainStep}
 	 * can probe it before the pipeline spends a {@code claude init} on a checkout it
 	 * will not be able to verify. The verification launches the first word of its

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystems.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystems.java
@@ -15,33 +15,24 @@ import java.util.stream.Collectors;
  */
 public final class BuildSystems {
 
-	/**
-	 * Maven first, then Gradle, then the catch-all fallback: the order the checkout
-	 * is probed in. The fallback stays last so a real build tool is always preferred
-	 * when its build file is present.
-	 */
-	public static final List<BuildSystem> DEFAULTS = List.of(new MavenBuildSystem(), new GradleBuildSystem(),
-			new FallbackBuildSystem());
+	/** The set every step falls back to, resolving the rule version of the running build. */
+	public static final List<BuildSystem> DEFAULTS = defaults(Optional.empty());
 
 	private BuildSystems() {
 	}
 
 	/**
-	 * The default set, each build system pinning an explicitly supplied
-	 * {@code claude-code-enforcer} version rather than resolving the version of the
-	 * {@code tools} build running the adoption. Which of them that changes is left to
-	 * {@link BuildSystem#withRuleVersion}: in practice only Maven wires a versioned
-	 * artifact in, and the others answer with themselves.
+	 * Maven first, then Gradle, then the catch-all fallback: the order the checkout
+	 * is probed in. The fallback stays last so a real build tool is always preferred
+	 * when its build file is present. Only Maven wires a versioned artifact into the
+	 * adopted project, so it is the only one the rule version reaches.
 	 *
-	 * @param ruleVersion the released rule version to pin, or empty to resolve the
-	 *                    running build's own
+	 * @param ruleVersion the released {@code claude-code-enforcer} version to pin, or
+	 *                    empty to resolve the version of the {@code tools} build
+	 *                    running the adoption
 	 */
-	public static List<BuildSystem> withRuleVersion(Optional<String> ruleVersion) {
-		return ruleVersion.map(BuildSystems::pinnedTo).orElse(DEFAULTS);
-	}
-
-	private static List<BuildSystem> pinnedTo(String ruleVersion) {
-		return DEFAULTS.stream().map(candidate -> candidate.withRuleVersion(ruleVersion)).toList();
+	public static List<BuildSystem> defaults(Optional<String> ruleVersion) {
+		return List.of(new MavenBuildSystem(ruleVersion), new GradleBuildSystem(), new FallbackBuildSystem());
 	}
 
 	public static Optional<BuildSystem> detect(List<BuildSystem> candidates, Path repositoryDirectory) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -57,11 +57,11 @@ public class ClaudeMdConformer {
 	 */
 	public String conform(String content) {
 		List<String> lines = splitLines(content);
-		lines = closeUnterminatedFence(lines);
-		lines = ensureTitle(lines);
-		lines = canonicalizeHeadings(lines);
-		lines = ensureRequiredSections(lines);
-		lines = ensureAgentsReference(lines);
+		closeUnterminatedFence(lines);
+		ensureTitle(lines);
+		canonicalizeHeadings(lines);
+		ensureRequiredSections(lines);
+		ensureAgentsReference(lines);
 		return join(lines);
 	}
 
@@ -75,37 +75,27 @@ public class ClaudeMdConformer {
 	 * opened with — so everything appended below lands outside the block. A document
 	 * whose fences balance is returned untouched, keeping the reshape idempotent.
 	 */
-	private List<String> closeUnterminatedFence(List<String> lines) {
+	private void closeUnterminatedFence(List<String> lines) {
 		String open = scanFences(lines).openAtEnd();
-		if (open == null) {
-			return lines;
+		if (open != null) {
+			lines.add(open);
 		}
-		List<String> result = new ArrayList<>(lines);
-		result.add(open);
-		return result;
 	}
 
-	private List<String> ensureTitle(List<String> lines) {
-		if (TITLE.equals(firstNonBlank(lines))) {
-			return lines;
+	private void ensureTitle(List<String> lines) {
+		if (!TITLE.equals(firstNonBlank(lines))) {
+			lines.addAll(0, List.of(TITLE, ""));
 		}
-		List<String> result = new ArrayList<>(List.of(TITLE, ""));
-		result.addAll(lines);
-		return result;
 	}
 
 	private String firstNonBlank(List<String> lines) {
 		return lines.stream().map(String::strip).filter(line -> !line.isEmpty()).findFirst().orElse("");
 	}
 
-	private List<String> canonicalizeHeadings(List<String> lines) {
-		List<String> result = new ArrayList<>(lines);
-		boolean[] fence = fenceMask(result);
-		Set<Integer> claimed = reservedHeadings(result, fence);
-		for (String required : REQUIRED_SECTIONS) {
-			canonicalize(result, fence, required, claimed);
-		}
-		return result;
+	private void canonicalizeHeadings(List<String> lines) {
+		boolean[] fence = fenceMask(lines);
+		Set<Integer> claimed = reservedHeadings(lines, fence);
+		REQUIRED_SECTIONS.forEach(required -> canonicalize(lines, fence, required, claimed));
 	}
 
 	/**
@@ -155,12 +145,8 @@ public class ClaudeMdConformer {
 	 * near-miss renamed in place above — has one inserted beneath it. The rule fails
 	 * an empty section just as it fails a missing one, so both are settled here.
 	 */
-	private List<String> ensureRequiredSections(List<String> lines) {
-		List<String> result = new ArrayList<>(lines);
-		for (String required : REQUIRED_SECTIONS) {
-			ensureSection(result, required);
-		}
-		return result;
+	private void ensureRequiredSections(List<String> lines) {
+		REQUIRED_SECTIONS.forEach(required -> ensureSection(lines, required));
 	}
 
 	/**
@@ -201,14 +187,11 @@ public class ClaudeMdConformer {
 		return (int) heading.chars().takeWhile(character -> character == '#').count();
 	}
 
-	private List<String> ensureAgentsReference(List<String> lines) {
+	private void ensureAgentsReference(List<String> lines) {
 		boolean[] fence = fenceMask(lines);
-		if (matchesOutsideFences(lines, fence, line -> line.contains(AGENTS_REFERENCE)).findAny().isPresent()) {
-			return lines;
+		if (matchesOutsideFences(lines, fence, line -> line.contains(AGENTS_REFERENCE)).findAny().isEmpty()) {
+			lines.addAll(titleIndex(lines, fence) + 1, List.of("", AGENTS_REFERENCE_LINE, ""));
 		}
-		List<String> result = new ArrayList<>(lines);
-		result.addAll(titleIndex(result, fence) + 1, List.of("", AGENTS_REFERENCE_LINE, ""));
-		return result;
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
@@ -20,15 +20,7 @@ public class FallbackBuildSystem implements BuildSystem {
 
 	static final List<String> VERIFY_COMMAND = List.of("sh", WorkflowGuardInstaller.SCRIPT_FILE);
 
-	private final WorkflowGuardInstaller installer;
-
-	public FallbackBuildSystem() {
-		this(new WorkflowGuardInstaller());
-	}
-
-	public FallbackBuildSystem(WorkflowGuardInstaller installer) {
-		this.installer = installer;
-	}
+	private final WorkflowGuardInstaller installer = new WorkflowGuardInstaller();
 
 	@Override
 	public String name() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
@@ -20,15 +20,7 @@ public class GradleBuildSystem implements BuildSystem {
 	static final String GROOVY_BUILD_FILE = "build.gradle";
 	static final String KOTLIN_BUILD_FILE = "build.gradle.kts";
 
-	private final GradleGuardInstaller installer;
-
-	public GradleBuildSystem() {
-		this(new GradleGuardInstaller());
-	}
-
-	public GradleBuildSystem(GradleGuardInstaller installer) {
-		this.installer = installer;
-	}
+	private final GradleGuardInstaller installer = new GradleGuardInstaller();
 
 	@Override
 	public String name() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.adopt.step;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Maven support for the adoption: detects a {@code pom.xml}, wires the
@@ -21,6 +22,15 @@ public class MavenBuildSystem implements BuildSystem {
 
 	public MavenBuildSystem() {
 		this(new PomEnforcerInstaller());
+	}
+
+	/**
+	 * @param ruleVersion the released {@code claude-code-enforcer} version to pin into
+	 *                    the adopted POM, or empty to resolve the version of the
+	 *                    {@code tools} build running the adoption
+	 */
+	public MavenBuildSystem(Optional<String> ruleVersion) {
+		this(ruleVersion.<PomEnforcerInstaller>map(PomEnforcerInstaller::new).orElseGet(PomEnforcerInstaller::new));
 	}
 
 	public MavenBuildSystem(PomEnforcerInstaller installer) {
@@ -45,14 +55,5 @@ public class MavenBuildSystem implements BuildSystem {
 	@Override
 	public List<String> verifyCommand() {
 		return VERIFY_COMMAND;
-	}
-
-	/**
-	 * Maven is the one build system that wires a versioned artifact into the adopted
-	 * project, so it is the one that has a version to pin.
-	 */
-	@Override
-	public BuildSystem withRuleVersion(String ruleVersion) {
-		return new MavenBuildSystem(new PomEnforcerInstaller(ruleVersion));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -1,7 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -17,12 +16,6 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -35,31 +28,33 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
 import io.github.adamw7.tools.adopt.step.XmlElementSpans.Span;
 
 /**
- * A {@code pom.xml} parsed for editing and written back without reformatting.
- * Callers append elements through {@link #appendElement} and {@link #appendText};
- * everything the file already held — every whitespace node, its XML declaration,
- * its trailing newline, and its line terminator — survives {@link #write()}
- * untouched, so the adoption commit shows only the block that was added rather
- * than a reformat of the whole file.
+ * A {@code pom.xml} read for editing and written back without reformatting.
+ * Callers find the element they want to extend with the query methods and add
+ * markup under it with {@link #insertUnder}; everything the file already held —
+ * every whitespace character, its XML declaration, its trailing newline, and its
+ * line terminator — survives {@link #write()} untouched, so the adoption commit
+ * shows only the block that was added rather than a reformat of the whole file.
  *
- * <p>Only the added elements are serialised, and their text is spliced into the
- * bytes the file already held. Writing the edited DOM out whole cannot keep that
- * promise however carefully the serialiser is configured, because the details it
- * would reformat are not in the DOM to begin with: a start tag spread over several
- * lines and an empty element written {@code <rule />} both come back normalised,
- * turning a fourteen-line addition into a diff that touches the whole file. The
- * source offsets the splice needs come from {@link XmlElementSpans}.
+ * <p>The DOM is only ever read: it answers which elements the POM declares and how
+ * they nest, while the edit itself is text spliced into the bytes the file already
+ * held. Writing an edited DOM out whole cannot keep the promise above however
+ * carefully the serialiser is configured, because the details it would reformat are
+ * not in the DOM to begin with: a start tag spread over several lines and an empty
+ * element written {@code <rule />} both come back normalised, turning a fourteen-line
+ * addition into a diff that touches the whole file. The source offsets the splice
+ * needs come from {@link XmlElementSpans}. Keeping the edit textual also means added
+ * elements simply inherit the POM's default namespace rather than having to be
+ * qualified — and a POM that declares none stays namespace-free.
  *
- * <p>Each appended element is preceded by a newline and an indentation matching
- * the document's own unit (detected from the file, defaulting to two spaces), and
- * is inserted after the parent's last child so the parent's own closing
- * indentation stays put. Every container is attached to its parent before its
- * children are added, so an element's depth — and therefore its indentation — is
- * known as soon as it is appended. The edit runs on the JDK's namespace-aware DOM,
- * so no third-party XML library is needed and new elements join the POM's default
- * namespace.
+ * <p>Added markup arrives one element per line, indented by {@link #FRAGMENT_INDENT}
+ * per nesting level, and is re-indented to the document's own unit (detected from
+ * the file, defaulting to two spaces) at the depth it lands at. It is inserted after
+ * the parent's last child, so the parent's own closing indentation stays put.
  */
 final class PomDocument {
+
+	/** The indentation one nesting level of a caller's fragment is written with. */
+	static final String FRAGMENT_INDENT = "  ";
 
 	private static final String DEFAULT_INDENT_UNIT = "  ";
 	private static final String DESCRIPTION = "POM";
@@ -71,22 +66,22 @@ final class PomDocument {
 	private final Path file;
 	private final String original;
 	private final Document document;
-	private final String namespace;
 	private final String indentUnit;
 
 	/**
-	 * Where each element the file already carried sits in it. An element absent from
-	 * this map is one the caller appended, which is what makes the added subtrees
-	 * identifiable at {@link #write()} time without the callers having to declare
-	 * them.
+	 * Where each element the file carries sits in it, so an edit can be spliced beside
+	 * it. Paired by document order: a pre-order DOM walk and the lexical scan visit the
+	 * same elements in the same sequence.
 	 */
 	private final Map<Element, Span> spans;
+
+	/** The markup to add inside each element, in fragment indentation, awaiting {@link #write()}. */
+	private final Map<Element, String> additions = new IdentityHashMap<>();
 
 	private PomDocument(Path file, String original, Document document) {
 		this.file = file;
 		this.original = original;
 		this.document = document;
-		this.namespace = document.getDocumentElement().getNamespaceURI();
 		this.indentUnit = detectIndentUnit(document.getDocumentElement());
 		this.spans = spansOf(document, original);
 	}
@@ -95,37 +90,20 @@ final class PomDocument {
 		return new PomDocument(file, AdoptionFiles.read(file, DESCRIPTION), parse(file));
 	}
 
-	/** The {@code build/plugins} element, creating either level when the POM lacks it. */
-	Element pluginsElement() {
-		Element build = childOrCreate(document.getDocumentElement(), "build");
-		return childOrCreate(build, "plugins");
+	Element root() {
+		return document.getDocumentElement();
 	}
 
 	/**
 	 * Every {@code plugin} the POM declares, wherever it sits: the build, plugin
-	 * management, or a profile. A project can wire a plugin somewhere other than
-	 * {@link #pluginsElement()} — behind an opt-in profile, most often — and a check
-	 * that only looked there would conclude the plugin is absent and add a second
-	 * declaration of it.
+	 * management, or a profile. A project can wire a plugin somewhere other than its
+	 * build — behind an opt-in profile, most often — and a check that only looked there
+	 * would conclude the plugin is absent and add a second declaration of it.
 	 */
 	List<Element> plugins() {
-		return preOrder(document.getDocumentElement()).stream()
+		return preOrder(root()).stream()
 				.filter(element -> "plugin".equals(element.getLocalName()))
 				.toList();
-	}
-
-	Element childOrCreate(Element parent, String name) {
-		return child(parent, name).orElseGet(() -> appendElement(parent, name));
-	}
-
-	Element appendElement(Element parent, String name) {
-		return appendChild(parent, create(name));
-	}
-
-	void appendText(Element parent, String name, String text) {
-		Element element = create(name);
-		element.setTextContent(text);
-		appendChild(parent, element);
 	}
 
 	static Optional<Element> child(Element parent, String name) {
@@ -139,7 +117,7 @@ final class PomDocument {
 				.toList();
 	}
 
-	/** @return the element's {@code artifactId} text, when it declares one */
+	/** @return whether the element declares exactly this {@code artifactId} */
 	static boolean hasArtifactId(Element element, String artifactId) {
 		return child(element, "artifactId")
 				.map(Element::getTextContent)
@@ -148,58 +126,73 @@ final class PomDocument {
 				.isPresent();
 	}
 
+	/** @return {@code body} wrapped in a {@code name} element, its lines indented one level deeper */
+	static String wrapped(String name, String body) {
+		return "<" + name + ">\n" + indented(body) + "\n</" + name + ">";
+	}
+
 	/**
-	 * Writes the original text back with the added subtrees spliced into it, so
-	 * every byte the file already held — its XML declaration, its attribute layout,
-	 * its empty-element style, its trailing newline — is preserved by construction
-	 * rather than by a serialiser that has to be talked out of reformatting. A POM
-	 * nothing was appended to is written back unchanged.
+	 * Adds {@code fragment} inside {@code parent}'s nested {@code path}, creating
+	 * whichever of those levels the POM does not carry yet — so a POM with no
+	 * {@code build} at all and one that already has {@code build/plugins} are the same
+	 * call. Nothing is written until {@link #write()}.
+	 */
+	void insertUnder(Element parent, List<String> path, String fragment) {
+		if (path.isEmpty()) {
+			additions.merge(parent, fragment, (existing, added) -> existing + "\n" + added);
+			return;
+		}
+		List<String> rest = path.subList(1, path.size());
+		child(parent, path.get(0)).ifPresentOrElse(
+				element -> insertUnder(element, rest, fragment),
+				() -> insertUnder(parent, List.of(), wrap(path, fragment)));
+	}
+
+	/**
+	 * Writes the original text back with the added markup spliced into it, so every
+	 * byte the file already held — its XML declaration, its attribute layout, its
+	 * empty-element style, its trailing newline — is preserved by construction rather
+	 * than by a serialiser that has to be talked out of reformatting. A POM nothing was
+	 * added to is written back unchanged.
 	 *
 	 * <p>The edits are applied last-first so that each one's offsets, taken from the
 	 * unmodified text, are still correct when it is applied.
 	 */
 	void write() {
 		StringBuilder content = new StringBuilder(original);
-		edits().stream()
+		additions.entrySet().stream()
+				.map(addition -> edit(addition.getKey(), addition.getValue()))
 				.sorted(Comparator.comparingInt(Edit::start).reversed())
 				.forEach(edit -> content.replace(edit.start(), edit.end(), edit.replacement()));
 		AdoptionFiles.write(file, content.toString(), DESCRIPTION);
 	}
 
-	/** One edit per element of the original document that was appended to. */
-	private List<Edit> edits() {
-		return preOrder(document.getDocumentElement()).stream()
-				.filter(spans::containsKey)
-				.map(this::editFor)
-				.flatMap(Optional::stream)
-				.toList();
-	}
-
-	private Optional<Edit> editFor(Element parent) {
-		List<Element> added = elementChildren(parent).stream().filter(child -> !spans.containsKey(child)).toList();
-		if (added.isEmpty()) {
-			return Optional.empty();
+	/** @return {@code fragment} wrapped in the named elements, outermost first */
+	private static String wrap(List<String> names, String fragment) {
+		String wrapped = fragment;
+		for (String name : names.reversed()) {
+			wrapped = wrapped(name, wrapped);
 		}
-		return Optional.of(edit(parent, added.stream().map(this::fragmentOf).collect(Collectors.joining())));
+		return wrapped;
 	}
 
-	/** The added subtree's text, indented to its own depth the way the DOM path indented it. */
-	private String fragmentOf(Element added) {
-		return newlineIndent(depthOf(added)) + serialize(added);
+	private static String indented(String fragment) {
+		return fragment.lines().map(line -> FRAGMENT_INDENT + line).collect(Collectors.joining("\n"));
 	}
 
 	/**
-	 * Where the fragment goes. An element that already had children takes it after
-	 * the last of them, leaving the whitespace before the end tag — and so that
-	 * tag's indentation — exactly as it was. An element that was empty or held only
-	 * whitespace has that content replaced instead, because there is no last child
-	 * to follow and its end tag needs indenting onto a line of its own; an element
-	 * written {@code <plugins/>} additionally has to grow an end tag to hold the
-	 * fragment at all.
+	 * Where the markup goes. An element that already had children takes it after the
+	 * last of them, leaving the whitespace before the end tag — and so that tag's
+	 * indentation — exactly as it was. An element that was empty or held only
+	 * whitespace has that content replaced instead, because there is no last child to
+	 * follow and its end tag needs indenting onto a line of its own; an element written
+	 * {@code <plugins/>} additionally has to grow an end tag to hold the markup at all.
 	 */
-	private Edit edit(Element parent, String fragment) {
+	private Edit edit(Element parent, String addition) {
 		Span span = spans.get(parent);
-		String closingIndent = newlineIndent(depthOf(parent));
+		int depth = depthOf(parent);
+		String fragment = fragment(addition, depth + 1);
+		String closingIndent = newlineIndent(depth);
 		if (span.selfClosing()) {
 			return edit(span.tagStart(), span.contentStart(),
 					reopened(span) + fragment + closingIndent + endTag(parent));
@@ -212,9 +205,24 @@ final class PomDocument {
 	}
 
 	/**
-	 * XML parsing normalises {@code \r\n} to {@code \n}, so a serialised fragment is
-	 * always LF; {@link LineTerminators} puts the file's own terminator back rather
-	 * than leaving LF lines in an otherwise CRLF POM.
+	 * The addition's lines, each on a line of its own indented to {@code depth} plus
+	 * its own nesting within the fragment, in the document's indentation unit rather
+	 * than the fragment's.
+	 */
+	private String fragment(String addition, int depth) {
+		return addition.lines()
+				.map(line -> newlineIndent(depth + levelOf(line)) + line.stripLeading())
+				.collect(Collectors.joining());
+	}
+
+	private int levelOf(String line) {
+		return (line.length() - line.stripLeading().length()) / FRAGMENT_INDENT.length();
+	}
+
+	/**
+	 * A fragment is always LF — XML parsing normalises {@code \r\n} to {@code \n} and
+	 * the templates are written with LF — so {@link LineTerminators} puts the file's own
+	 * terminator back rather than leaving LF lines in an otherwise CRLF POM.
 	 */
 	private Edit edit(int start, int end, String replacement) {
 		return new Edit(start, end, LineTerminators.matching(replacement, original));
@@ -238,12 +246,6 @@ final class PomDocument {
 		return end;
 	}
 
-	/**
-	 * Pairs each element the file carried with its place in the text by document
-	 * order: a pre-order DOM walk and the lexical scan visit the same elements in
-	 * the same sequence, so the two lists line up index for index without having to
-	 * match names or attributes.
-	 */
 	private static Map<Element, Span> spansOf(Document document, String original) {
 		List<Element> elements = preOrder(document.getDocumentElement());
 		List<Span> spans = XmlElementSpans.of(original);
@@ -276,31 +278,8 @@ final class PomDocument {
 		return IntStream.range(0, nodes.getLength()).mapToObj(nodes::item);
 	}
 
-	private Element appendChild(Element parent, Element child) {
-		Node closingIndent = trailingWhitespace(parent);
-		Node childIndent = document.createTextNode(newlineIndent(depthOf(parent) + 1));
-		if (closingIndent == null) {
-			parent.appendChild(childIndent);
-			parent.appendChild(child);
-			parent.appendChild(document.createTextNode(newlineIndent(depthOf(parent))));
-		} else {
-			parent.insertBefore(childIndent, closingIndent);
-			parent.insertBefore(child, closingIndent);
-		}
-		return child;
-	}
-
 	private String newlineIndent(int depth) {
 		return "\n" + indentUnit.repeat(depth);
-	}
-
-	private Element create(String name) {
-		return namespace == null ? document.createElement(name) : document.createElementNS(namespace, name);
-	}
-
-	private static Node trailingWhitespace(Element parent) {
-		Node last = parent.getLastChild();
-		return isWhitespaceText(last) ? last : null;
 	}
 
 	private static int depthOf(Node node) {
@@ -361,42 +340,6 @@ final class PomDocument {
 		} catch (ParserConfigurationException e) {
 			throw new AdoptionException("Could not configure XML parser", e);
 		}
-	}
-
-	private String serialize(Element element) {
-		try {
-			StringWriter writer = new StringWriter();
-			transformer().transform(new DOMSource(element), new StreamResult(writer));
-			return withoutRepeatedNamespace(writer.toString());
-		} catch (TransformerException e) {
-			throw new AdoptionException("Could not write POM: " + file, e);
-		}
-	}
-
-	/**
-	 * Serialising a subtree on its own leaves the serialiser no way to know the
-	 * POM's root already declares the default namespace, so it restates it and the
-	 * added block would read {@code <build xmlns="http://maven.apache.org/POM/4.0.0">}.
-	 * The fragment is spliced back under that root, which still carries the
-	 * declaration, so the repeat is dropped. Only the fragment's own root can carry
-	 * it — its descendants inherit it — so only the first occurrence is removed.
-	 */
-	private String withoutRepeatedNamespace(String fragment) {
-		if (namespace == null) {
-			return fragment;
-		}
-		String declaration = " xmlns=\"" + namespace + "\"";
-		int at = fragment.indexOf(declaration);
-		return at < 0 ? fragment : fragment.substring(0, at) + fragment.substring(at + declaration.length());
-	}
-
-	private static Transformer transformer() throws TransformerException {
-		TransformerFactory factory = TransformerFactory.newInstance();
-		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		Transformer transformer = factory.newTransformer();
-		transformer.setOutputProperty(OutputKeys.INDENT, "no");
-		transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-		return transformer;
 	}
 
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt.step;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -16,10 +17,10 @@ import org.w3c.dom.Element;
  * untouched. A POM that already uses the {@code maven-enforcer-plugin} for other
  * rules is augmented in place rather than skipped, so the rule is still wired in.
  *
- * <p>{@link PomDocument} does the reading, appending, and verbatim writing, so
- * the existing document is preserved exactly and only the newly added elements
- * appear in the adoption commit. The rule version comes from
- * {@link EnforcerRuleVersion} and must be a release.
+ * <p>{@link PomDocument} does the reading, splicing, and verbatim writing, so the
+ * existing document is preserved exactly and only the newly added markup appears in
+ * the adoption commit. The rule version comes from {@link EnforcerRuleVersion} and
+ * must be a release.
  */
 public class PomEnforcerInstaller {
 
@@ -29,6 +30,30 @@ public class PomEnforcerInstaller {
 	static final String RULE_ARTIFACT_ID = "tools.claude-code-enforcer";
 	static final String RULE_GROUP_ID = "io.github.adamw7";
 	static final String CLAUDE_MD_FILE = "${project.basedir}/CLAUDE.md";
+
+	/** Where a plugin belongs in a POM that does not declare the enforcer yet. */
+	private static final List<String> BUILD_PLUGINS = List.of("build", "plugins");
+
+	/**
+	 * The execution that runs the rule, bound to {@code validate} and not inherited
+	 * because {@code CLAUDE.md} lives only at the repository root.
+	 */
+	private static final String EXECUTION = """
+			<execution>
+			  <id>enforce-claude-md</id>
+			  <phase>validate</phase>
+			  <inherited>false</inherited>
+			  <goals>
+			    <goal>enforce</goal>
+			  </goals>
+			  <configuration>
+			    <rules>
+			      <claudeMdFormat>
+			        <claudeMdFile>%s</claudeMdFile>
+			      </claudeMdFormat>
+			    </rules>
+			  </configuration>
+			</execution>""".formatted(CLAUDE_MD_FILE);
 
 	private final Supplier<String> ruleVersion;
 
@@ -60,7 +85,9 @@ public class PomEnforcerInstaller {
 		if (declaresClaudeRule(pom)) {
 			return false;
 		}
-		wireEnforcer(pom, pom.pluginsElement());
+		enforcerPlugin(pom).ifPresentOrElse(
+				plugin -> augment(pom, plugin),
+				() -> pom.insertUnder(pom.root(), BUILD_PLUGINS, plugin()));
 		pom.write();
 		return true;
 	}
@@ -81,52 +108,41 @@ public class PomEnforcerInstaller {
 				.anyMatch(dependency -> PomDocument.hasArtifactId(dependency, RULE_ARTIFACT_ID));
 	}
 
-	/**
-	 * Adds the rule dependency and its {@code enforce} execution to the POM's
-	 * {@code maven-enforcer-plugin}, reusing an existing plugin declaration when
-	 * one is present so the project keeps a single enforcer plugin entry.
-	 */
-	private void wireEnforcer(PomDocument pom, Element plugins) {
-		Element plugin = findEnforcerPlugin(plugins).orElseGet(() -> createEnforcerPlugin(pom, plugins));
-		ruleDependency(pom, pom.childOrCreate(plugin, "dependencies"));
-		enforceExecution(pom, pom.childOrCreate(plugin, "executions"));
-	}
-
-	private Optional<Element> findEnforcerPlugin(Element plugins) {
-		return PomDocument.children(plugins, "plugin").stream()
+	private Optional<Element> enforcerPlugin(PomDocument pom) {
+		return pom.plugins().stream()
 				.filter(plugin -> PomDocument.hasArtifactId(plugin, ENFORCER_ARTIFACT_ID))
 				.findFirst();
 	}
 
-	private Element createEnforcerPlugin(PomDocument pom, Element plugins) {
-		Element plugin = pom.appendElement(plugins, "plugin");
-		pom.appendText(plugin, "groupId", ENFORCER_GROUP_ID);
-		pom.appendText(plugin, "artifactId", ENFORCER_ARTIFACT_ID);
-		pom.appendText(plugin, "version", ENFORCER_VERSION);
-		return plugin;
+	/**
+	 * Adds the rule dependency and the execution to a {@code maven-enforcer-plugin}
+	 * the project already declares — reusing its {@code dependencies} and
+	 * {@code executions} when it has them — so the project keeps a single enforcer
+	 * plugin entry and the rules it already ran keep running.
+	 */
+	private void augment(PomDocument pom, Element plugin) {
+		pom.insertUnder(plugin, List.of("dependencies"), ruleDependency());
+		pom.insertUnder(plugin, List.of("executions"), EXECUTION);
 	}
 
-	private void ruleDependency(PomDocument pom, Element dependencies) {
-		Element dependency = pom.appendElement(dependencies, "dependency");
-		pom.appendText(dependency, "groupId", RULE_GROUP_ID);
-		pom.appendText(dependency, "artifactId", RULE_ARTIFACT_ID);
-		pom.appendText(dependency, "version", ruleVersion.get());
+	/** A freshly declared enforcer plugin: pinned to a version, carrying the rule and its execution. */
+	private String plugin() {
+		return PomDocument.wrapped("plugin", String.join("\n",
+				element("groupId", ENFORCER_GROUP_ID),
+				element("artifactId", ENFORCER_ARTIFACT_ID),
+				element("version", ENFORCER_VERSION),
+				PomDocument.wrapped("dependencies", ruleDependency()),
+				PomDocument.wrapped("executions", EXECUTION)));
 	}
 
-	private void enforceExecution(PomDocument pom, Element executions) {
-		Element execution = pom.appendElement(executions, "execution");
-		pom.appendText(execution, "id", "enforce-claude-md");
-		pom.appendText(execution, "phase", "validate");
-		pom.appendText(execution, "inherited", "false");
-		Element goals = pom.appendElement(execution, "goals");
-		pom.appendText(goals, "goal", "enforce");
-		claudeMdConfiguration(pom, execution);
+	private String ruleDependency() {
+		return PomDocument.wrapped("dependency", String.join("\n",
+				element("groupId", RULE_GROUP_ID),
+				element("artifactId", RULE_ARTIFACT_ID),
+				element("version", ruleVersion.get())));
 	}
 
-	private void claudeMdConfiguration(PomDocument pom, Element execution) {
-		Element configuration = pom.appendElement(execution, "configuration");
-		Element rules = pom.appendElement(configuration, "rules");
-		Element claudeMdFormat = pom.appendElement(rules, "claudeMdFormat");
-		pom.appendText(claudeMdFormat, "claudeMdFile", CLAUDE_MD_FILE);
+	private String element(String name, String text) {
+		return "<" + name + ">" + text + "</" + name + ">";
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
@@ -8,8 +8,12 @@ import io.github.adamw7.tools.adopt.Text;
  * The metadata a {@link PullRequestStep} opens its pull request with: the title
  * and body, plus optional reviewers, labels, and assignees to request, and
  * whether the pull request is opened as a draft. Grouping them keeps the step
- * from a telescoping constructor and lets callers set only the fields they care
- * about through {@link #builder()}.
+ * from a telescoping constructor.
+ *
+ * <p>A title or body that is absent or blank falls back to the adoption default —
+ * the rule every optional input of the adoption follows — so the command line and
+ * the MCP tool map their arguments straight in rather than each guarding an
+ * omitted flag for itself, and no {@code null} can reach {@code gh}'s arguments.
  *
  * <p>The lists are defensively copied and never {@code null}, so the step can
  * translate each entry into a repeated {@code gh pr create} flag without
@@ -23,80 +27,19 @@ public record PullRequestOptions(String title, String body, List<String> reviewe
 			+ "into the build so the file keeps being validated.";
 
 	public PullRequestOptions {
-		title = Text.required(title, "title");
-		body = Text.required(body, "body");
+		title = orDefault(title, DEFAULT_TITLE);
+		body = orDefault(body, DEFAULT_BODY);
 		reviewers = List.copyOf(reviewers);
 		labels = List.copyOf(labels);
 		assignees = List.copyOf(assignees);
 	}
 
+	/** The adoption's own title and body, requesting nobody and not a draft. */
 	public static PullRequestOptions defaults() {
-		return builder().build();
+		return new PullRequestOptions(null, null, List.of(), List.of(), List.of(), false);
 	}
 
-	public static Builder builder() {
-		return new Builder();
-	}
-
-	/** Fluent builder that starts from the adoption defaults and no reviewers, labels, or assignees. */
-	public static final class Builder {
-
-		private String title = DEFAULT_TITLE;
-		private String body = DEFAULT_BODY;
-		private List<String> reviewers = List.of();
-		private List<String> labels = List.of();
-		private List<String> assignees = List.of();
-		private boolean draft;
-
-		private Builder() {
-		}
-
-		public Builder title(String title) {
-			this.title = title;
-			return this;
-		}
-
-		public Builder body(String body) {
-			this.body = body;
-			return this;
-		}
-
-		/**
-		 * Overrides the default title only when one was actually supplied, so a caller
-		 * mapping an optional input — an omitted {@code --title} flag, a blank MCP
-		 * argument — does not have to guard the call itself.
-		 */
-		public Builder titleIfPresent(String title) {
-			return Text.isPresent(title) ? title(title) : this;
-		}
-
-		/** Overrides the default body only when one was supplied; see {@link #titleIfPresent(String)}. */
-		public Builder bodyIfPresent(String body) {
-			return Text.isPresent(body) ? body(body) : this;
-		}
-
-		public Builder reviewers(List<String> reviewers) {
-			this.reviewers = reviewers;
-			return this;
-		}
-
-		public Builder labels(List<String> labels) {
-			this.labels = labels;
-			return this;
-		}
-
-		public Builder assignees(List<String> assignees) {
-			this.assignees = assignees;
-			return this;
-		}
-
-		public Builder draft(boolean draft) {
-			this.draft = draft;
-			return this;
-		}
-
-		public PullRequestOptions build() {
-			return new PullRequestOptions(title, body, reviewers, labels, assignees, draft);
-		}
+	private static String orDefault(String value, String fallback) {
+		return Text.isPresent(value) ? value.strip() : fallback;
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportWriterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportWriterTest.java
@@ -31,7 +31,7 @@ class AdoptionReportWriterTest {
 		report.recordStep("clone");
 		report.recordStep("pull-request");
 		report.recordPullRequestUrl(PR_URL);
-		JsonNode node = mapper.readTree(writer.toJson(context, report));
+		JsonNode node = mapper.readTree(writer.toJson(List.of(run(context, report))));
 		assertEquals("https://github.com/owner/repo.git", node.get("repositoryUrl").asText());
 		assertEquals("claude/adopt-claude-code", node.get("branch").asText());
 		assertEquals(PR_URL, node.get("pullRequestUrl").asText());
@@ -41,7 +41,7 @@ class AdoptionReportWriterTest {
 
 	@Test
 	void serialisesAMissingPullRequestUrlAsNull() throws IOException {
-		JsonNode node = mapper.readTree(writer.toJson(context, new AdoptionReport()));
+		JsonNode node = mapper.readTree(writer.toJson(List.of(run(context))));
 		assertTrue(node.get("pullRequestUrl").isNull());
 		assertTrue(node.get("completedSteps").isEmpty());
 	}
@@ -50,7 +50,7 @@ class AdoptionReportWriterTest {
 	void serialisesASuccessfulRunAsSucceededWithNoFailure() throws IOException {
 		AdoptionReport report = new AdoptionReport();
 		report.recordStep("clone");
-		JsonNode node = mapper.readTree(writer.toJson(context, report));
+		JsonNode node = mapper.readTree(writer.toJson(List.of(run(context, report))));
 		assertTrue(node.get("succeeded").asBoolean());
 		assertTrue(node.get("failure").isNull());
 	}
@@ -65,7 +65,7 @@ class AdoptionReportWriterTest {
 		AdoptionReport report = new AdoptionReport();
 		report.recordStep("clone");
 		report.recordFailure("push: the requested URL returned error: 403");
-		JsonNode node = mapper.readTree(writer.toJson(context, report));
+		JsonNode node = mapper.readTree(writer.toJson(List.of(run(context, report))));
 		assertFalse(node.get("succeeded").asBoolean());
 		assertEquals("push: the requested URL returned error: 403", node.get("failure").asText());
 		assertEquals("clone", node.get("completedSteps").get(0).asText());
@@ -117,7 +117,7 @@ class AdoptionReportWriterTest {
 		Path file = dir.resolve("nested/report.json");
 		AdoptionReport report = new AdoptionReport();
 		report.recordPullRequestUrl(PR_URL);
-		writer.write(file, context, report);
+		writer.write(file, List.of(run(context, report)));
 		JsonNode node = mapper.readTree(Files.readString(file));
 		assertEquals(PR_URL, node.get("pullRequestUrl").asText());
 	}
@@ -126,7 +126,7 @@ class AdoptionReportWriterTest {
 	void failsWithAdoptionExceptionWhenTheFileCannotBeWritten(@TempDir Path dir) throws IOException {
 		Path blockingFile = Files.createFile(dir.resolve("not-a-directory"));
 		Path file = blockingFile.resolve("report.json");
-		assertThrows(AdoptionException.class, () -> writer.write(file, context, new AdoptionReport()));
+		assertThrows(AdoptionException.class, () -> writer.write(file, List.of(run(context))));
 	}
 
 	private AdoptionContext other() {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -73,7 +74,7 @@ class GitHubRepoAdopterTest {
 	void runsEveryStepInOrder() {
 		List<String> order = new ArrayList<>();
 		List<AdoptionStep> steps = List.of(new NamingStep("a", order), new NamingStep("b", order));
-		new GitHubRepoAdopter(new RecordingCommandRunner(), steps).adopt(context);
+		new GitHubRepoAdopter(new RecordingCommandRunner(), steps).adopt(context, new AdoptionReport());
 		assertEquals(List.of("a", "b"), order);
 	}
 
@@ -81,7 +82,8 @@ class GitHubRepoAdopterTest {
 	void reportsEveryCompletedStep() {
 		List<String> order = new ArrayList<>();
 		List<AdoptionStep> steps = List.of(new NamingStep("a", order), new NamingStep("b", order));
-		AdoptionReport report = new GitHubRepoAdopter(new RecordingCommandRunner(), steps).adopt(context);
+		AdoptionReport report = new GitHubRepoAdopter(new RecordingCommandRunner(), steps)
+				.adopt(context, new AdoptionReport());
 		assertEquals(List.of("a", "b"), report.completedSteps());
 	}
 
@@ -91,7 +93,7 @@ class GitHubRepoAdopterTest {
 		List<AdoptionStep> steps = List.of(new NamingStep("a", order), new ExplodingStep(),
 				new NamingStep("c", order));
 		GitHubRepoAdopter adopter = new GitHubRepoAdopter(new RecordingCommandRunner(), steps);
-		assertThrows(AdoptionException.class, () -> adopter.adopt(context));
+		assertThrows(AdoptionException.class, () -> adopter.adopt(context, new AdoptionReport()));
 		assertEquals(List.of("a"), order);
 	}
 
@@ -137,14 +139,15 @@ class GitHubRepoAdopterTest {
 	void withDefaultPipelineHonoursPullRequestOptionsAndTheAssetsFlag() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(
 				command -> new CommandResult(command, 1, "missing"));
-		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, PullRequestOptions.defaults(), true);
-		assertThrows(AdoptionException.class, () -> adopter.adopt(context));
+		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, PullRequestOptions.defaults(),
+				true, Optional.empty());
+		assertThrows(AdoptionException.class, () -> adopter.adopt(context, new AdoptionReport()));
 		assertEquals(List.of("git", "--version"), runner.commandAt(0));
 	}
 
 	@Test
 	void defaultPipelineBranchesCommitsPushesAndOpensAPullRequest() {
-		List<String> names = GitHubRepoAdopter.defaultSteps(PullRequestOptions.defaults(), false).stream()
+		List<String> names = GitHubRepoAdopter.defaultSteps(PullRequestOptions.defaults(), false, Optional.empty()).stream()
 				.map(AdoptionStep::name).toList();
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
 				"commit", "enforcer", "commit", "verify", "push", "pull-request"), names);
@@ -152,7 +155,7 @@ class GitHubRepoAdopterTest {
 
 	@Test
 	void defaultPipelineWithAssetsInstallsAndCommitsThemBeforeVerification() {
-		List<String> names = GitHubRepoAdopter.defaultSteps(PullRequestOptions.defaults(), true).stream()
+		List<String> names = GitHubRepoAdopter.defaultSteps(PullRequestOptions.defaults(), true, Optional.empty()).stream()
 				.map(AdoptionStep::name).toList();
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
 				"commit", "enforcer", "commit", "assets", "commit", "verify", "push", "pull-request"), names);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
@@ -47,27 +47,6 @@ class MainTest {
 		assertThrows(IllegalArgumentException.class, () -> Main.main(new String[] { REPO_URL, "--frobnicate" }));
 	}
 
-	@Test
-	void createsSuppliedWorkspaceDirectoryWhenMissing(@TempDir Path dir) {
-		Path workspace = dir.resolve("nested/workspace");
-		Path resolved = Main.workspace(CliArguments.parse(new String[] { REPO_URL, workspace.toString() }));
-		assertEquals(workspace, resolved);
-		assertTrue(Files.isDirectory(workspace));
-	}
-
-	@Test
-	void keepsAnExistingSuppliedWorkspaceDirectory(@TempDir Path dir) {
-		Path resolved = Main.workspace(CliArguments.parse(new String[] { REPO_URL, dir.toString() }));
-		assertEquals(dir, resolved);
-		assertTrue(Files.isDirectory(dir));
-	}
-
-	@Test
-	void createsTemporaryWorkspaceWhenNoneSupplied() {
-		Path resolved = Main.workspace(CliArguments.parse(new String[] { REPO_URL }));
-		assertTrue(Files.isDirectory(resolved));
-	}
-
 	/**
 	 * Every repository of a run shares the workspace and the branch name; only the
 	 * checkout directory, derived from the repository name, differs.

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetInstallerTest.java
@@ -49,11 +49,6 @@ class AssetInstallerTest {
 	}
 
 	@Test
-	void exposesItsRelativePath() {
-		assertEquals("a/file.txt", new AssetInstaller("a/file.txt", "content\n").relativePath());
-	}
-
-	@Test
 	void failsWithAdoptionExceptionWhenTheAssetCannotBeWritten(@TempDir Path checkout) throws IOException {
 		Files.createFile(checkout.resolve("blocking"));
 		AssetInstaller installer = new AssetInstaller("blocking/file.txt", "content\n");

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -1,8 +1,7 @@
 package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -13,6 +12,8 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
 
 class BuildSystemsTest {
 
@@ -95,23 +96,24 @@ class BuildSystemsTest {
 		assertEquals(Optional.of("gradle"), gradle.requiredTool());
 	}
 
+	/**
+	 * Pinning a version changes what Maven wires in, never which build systems are
+	 * probed or in which order.
+	 */
 	@Test
-	void withNoRuleVersionTheDefaultsAreUsedAsIs() {
-		assertEquals(BuildSystems.DEFAULTS, BuildSystems.withRuleVersion(Optional.empty()));
+	void theDetectionOrderIsTheSameWhateverTheRuleVersion() {
+		assertEquals(BuildSystems.names(BuildSystems.DEFAULTS),
+				BuildSystems.names(BuildSystems.defaults(Optional.of("2.6.0"))));
 	}
 
 	/**
-	 * Only Maven wires a versioned artifact into the adopted project, so pinning a
-	 * version changes that entry and leaves the detection order — and the other two
-	 * build systems — as they were.
+	 * A snapshot could not be resolved by the adopted project's CI, so it is refused
+	 * while the pipeline is still being assembled rather than after a clone and a
+	 * {@code claude init}.
 	 */
 	@Test
-	void anExplicitRuleVersionReplacesOnlyTheMavenBuildSystem() {
-		List<BuildSystem> pinned = BuildSystems.withRuleVersion(Optional.of("2.6.0"));
-		assertEquals(BuildSystems.names(BuildSystems.DEFAULTS), BuildSystems.names(pinned));
-		assertNotSame(BuildSystems.DEFAULTS.get(0), pinned.get(0), "Maven must be rebuilt around the pinned version");
-		assertSame(BuildSystems.DEFAULTS.get(1), pinned.get(1), "Gradle needs no version and must be reused");
-		assertSame(BuildSystems.DEFAULTS.get(2), pinned.get(2), "the fallback needs no version and must be reused");
+	void aSnapshotRuleVersionIsRejectedAsTheBuildSystemsAreBuilt() {
+		assertThrows(AdoptionException.class, () -> BuildSystems.defaults(Optional.of("2.6.0-SNAPSHOT")));
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestOptionsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestOptionsTest.java
@@ -2,7 +2,6 @@ package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -24,15 +23,9 @@ class PullRequestOptionsTest {
 	}
 
 	@Test
-	void builderSetsEveryField() {
-		PullRequestOptions options = PullRequestOptions.builder()
-				.title("Title")
-				.body("Body")
-				.reviewers(List.of("octocat"))
-				.labels(List.of("automation"))
-				.assignees(List.of("adamw7"))
-				.draft(true)
-				.build();
+	void carriesEverySuppliedField() {
+		PullRequestOptions options = new PullRequestOptions("Title", "Body", List.of("octocat"),
+				List.of("automation"), List.of("adamw7"), true);
 		assertEquals("Title", options.title());
 		assertEquals("Body", options.body());
 		assertEquals(List.of("octocat"), options.reviewers());
@@ -43,62 +36,33 @@ class PullRequestOptionsTest {
 
 	@Test
 	void trimsTitleAndBody() {
-		PullRequestOptions options = PullRequestOptions.builder().title("  Title  ").body("  Body  ").build();
+		PullRequestOptions options = options("  Title  ", "  Body  ");
 		assertEquals("Title", options.title());
 		assertEquals("Body", options.body());
-	}
-
-	@Test
-	void rejectsBlankTitle() {
-		PullRequestOptions.Builder builder = PullRequestOptions.builder().title(" ");
-		assertThrows(IllegalArgumentException.class, builder::build);
-	}
-
-	@Test
-	void rejectsBlankBody() {
-		PullRequestOptions.Builder builder = PullRequestOptions.builder().body("");
-		assertThrows(IllegalArgumentException.class, builder::build);
-	}
-
-	/** A caller clearing a field rather than leaving the default must not slip a null into gh's arguments. */
-	@Test
-	void rejectsANullTitleOrBody() {
-		PullRequestOptions.Builder withoutTitle = PullRequestOptions.builder().title(null);
-		assertThrows(IllegalArgumentException.class, withoutTitle::build);
-		PullRequestOptions.Builder withoutBody = PullRequestOptions.builder().body(null);
-		assertThrows(IllegalArgumentException.class, withoutBody::build);
 	}
 
 	/**
-	 * The command line and the MCP tool both map an optional input straight into the
-	 * builder, so an omitted title or body has to leave the adoption default in place
-	 * rather than blank out a field the record refuses.
+	 * The command line and the MCP tool both map an optional input straight in, so an
+	 * omitted — or explicitly blanked — title or body has to leave the adoption
+	 * default in place rather than reach {@code gh} as nothing at all.
 	 */
 	@Test
 	void keepsTheDefaultsWhenNoTitleOrBodyWasSupplied() {
-		PullRequestOptions options = PullRequestOptions.builder()
-				.titleIfPresent(null)
-				.bodyIfPresent("   ")
-				.build();
-		assertEquals(PullRequestOptions.DEFAULT_TITLE, options.title());
-		assertEquals(PullRequestOptions.DEFAULT_BODY, options.body());
-	}
-
-	@Test
-	void suppliedTitleAndBodyOverrideTheDefaults() {
-		PullRequestOptions options = PullRequestOptions.builder()
-				.titleIfPresent("Title")
-				.bodyIfPresent("Body")
-				.build();
-		assertEquals("Title", options.title());
-		assertEquals("Body", options.body());
+		assertEquals(PullRequestOptions.DEFAULT_TITLE, options(null, "   ").title());
+		assertEquals(PullRequestOptions.DEFAULT_BODY, options(null, "   ").body());
+		assertEquals(PullRequestOptions.DEFAULT_TITLE, options(" ", null).title());
+		assertEquals(PullRequestOptions.DEFAULT_BODY, options(" ", null).body());
 	}
 
 	@Test
 	void defensivelyCopiesReviewers() {
 		List<String> reviewers = new ArrayList<>(List.of("octocat"));
-		PullRequestOptions options = PullRequestOptions.builder().reviewers(reviewers).build();
+		PullRequestOptions options = new PullRequestOptions(null, null, reviewers, List.of(), List.of(), false);
 		reviewers.add("hubot");
 		assertEquals(List.of("octocat"), options.reviewers());
+	}
+
+	private PullRequestOptions options(String title, String body) {
+		return new PullRequestOptions(title, body, List.of(), List.of(), List.of(), false);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -93,7 +93,7 @@ class PullRequestStepTest {
 	@Test
 	void usesConfiguredTitleAndBody() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
-		new PullRequestStep(PullRequestOptions.builder().title("My title").body("My body").build())
+		new PullRequestStep(new PullRequestOptions("My title", "My body", List.of(), List.of(), List.of(), false))
 				.execute(context, runner);
 		assertEquals(List.of("gh", "pr", "create", "--title", "My title", "--body", "My body", "--head",
 				"claude/adopt-claude-code", "--repo", "adamw7/tools"), runner.commandAt(1));
@@ -102,14 +102,8 @@ class PullRequestStepTest {
 	@Test
 	void requestsReviewersLabelsAssigneesAndOpensAsDraft() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
-		PullRequestOptions options = PullRequestOptions.builder()
-				.title("My title")
-				.body("My body")
-				.reviewers(List.of("octocat", "hubot"))
-				.labels(List.of("automation"))
-				.assignees(List.of("adamw7"))
-				.draft(true)
-				.build();
+		PullRequestOptions options = new PullRequestOptions("My title", "My body", List.of("octocat", "hubot"),
+				List.of("automation"), List.of("adamw7"), true);
 		new PullRequestStep(options).execute(context, runner);
 		assertEquals(List.of("gh", "pr", "create", "--title", "My title", "--body", "My body", "--head",
 				"claude/adopt-claude-code", "--repo", "adamw7/tools", "--draft", "--reviewer", "octocat", "--reviewer",


### PR DESCRIPTION
Simplify the adopt module without changing what it does:

- PomDocument now reads the DOM only for queries and splices the added
  markup in as text, so the fragment serialiser, the namespace fix-up, the
  DOM-mutation helpers and the added-subtree diff walk all go away.
  PomEnforcerInstaller composes the block it wires in from markup templates
  instead of building it element by element.
- Thread the enforcer rule version straight into MavenBuildSystem instead of
  re-mapping the default build systems through a BuildSystem.withRuleVersion
  no-op that only Maven implemented.
- Replace the PullRequestOptions builder with the record's own constructor,
  which now applies the module's "blank means not supplied" rule to the
  title and body.
- Drop API nothing but tests called: the convenience overloads of
  withDefaultPipeline, defaultSteps, adopt, toJson and write,
  RepositoryUrls.fromLines, AssetInstaller.relativePath and Main.workspace,
  whose behaviour WorkspacesTest already covers.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017JZ37xTCyw9c7ND7czU4bw