### PR TITLE
fix(adopt): wire the guard into the build, never pluginManagement

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -106,6 +106,20 @@ final class PomDocument {
 				.toList();
 	}
 
+	/**
+	 * The element the nested {@code path} names below the root, or empty when the POM
+	 * does not carry every level of it. The counterpart of {@link #insertUnder}: a
+	 * caller asks about the very place it would add to, so what it inspects and what
+	 * it edits cannot drift apart.
+	 */
+	Optional<Element> at(List<String> path) {
+		Optional<Element> element = Optional.of(root());
+		for (String name : path) {
+			element = element.flatMap(parent -> child(parent, name));
+		}
+		return element;
+	}
+
 	static Optional<Element> child(Element parent, String name) {
 		return children(parent, name).stream().findFirst();
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -14,8 +14,10 @@ import org.w3c.dom.Element;
  * {@code CLAUDE.md} is missing or malformed.
  *
  * <p>The install is idempotent: a POM that already wires the rule is left
- * untouched. A POM that already uses the {@code maven-enforcer-plugin} for other
- * rules is augmented in place rather than skipped, so the rule is still wired in.
+ * untouched. A POM whose {@code build} already uses the
+ * {@code maven-enforcer-plugin} for other rules has that declaration augmented in
+ * place rather than skipped, so the rule is still wired in and the project keeps a
+ * single enforcer entry.
  *
  * <p>{@link PomDocument} does the reading, splicing, and verbatim writing, so the
  * existing document is preserved exactly and only the newly added markup appears in
@@ -31,7 +33,7 @@ public class PomEnforcerInstaller {
 	static final String RULE_GROUP_ID = "io.github.adamw7";
 	static final String CLAUDE_MD_FILE = "${project.basedir}/CLAUDE.md";
 
-	/** Where a plugin belongs in a POM that does not declare the enforcer yet. */
+	/** The one place a plugin both runs from and is added to; see {@link #enforcerPluginOfTheBuild}. */
 	private static final List<String> BUILD_PLUGINS = List.of("build", "plugins");
 
 	/**
@@ -85,7 +87,7 @@ public class PomEnforcerInstaller {
 		if (declaresClaudeRule(pom)) {
 			return false;
 		}
-		enforcerPlugin(pom).ifPresentOrElse(
+		enforcerPluginOfTheBuild(pom).ifPresentOrElse(
 				plugin -> augment(pom, plugin),
 				() -> pom.insertUnder(pom.root(), BUILD_PLUGINS, plugin()));
 		pom.write();
@@ -108,15 +110,30 @@ public class PomEnforcerInstaller {
 				.anyMatch(dependency -> PomDocument.hasArtifactId(dependency, RULE_ARTIFACT_ID));
 	}
 
-	private Optional<Element> enforcerPlugin(PomDocument pom) {
-		return pom.plugins().stream()
+	/**
+	 * The {@code maven-enforcer-plugin} of the POM's own {@code build}, and only that
+	 * one. Where the rule is <em>looked for</em> is the whole POM — see
+	 * {@link #declaresClaudeRule} — but where it is <em>added</em> cannot be: an
+	 * execution spliced into {@code pluginManagement} only configures a plugin the
+	 * build never runs, and one spliced into a profile runs only when that profile is
+	 * activated. Neither actually enforces anything, and neither shows up as a
+	 * failure: {@code install} would report the rule wired in, {@link VerifyStep}'s
+	 * {@code mvn -N validate} would pass without the rule ever executing, and the
+	 * adoption would open a pull request advertising a guard the project does not
+	 * have. A POM whose only enforcer sits somewhere else therefore gets its own
+	 * declaration in {@code build/plugins}, exactly as a POM with no enforcer at all
+	 * does.
+	 */
+	private Optional<Element> enforcerPluginOfTheBuild(PomDocument pom) {
+		return pom.at(BUILD_PLUGINS).stream()
+				.flatMap(plugins -> PomDocument.children(plugins, "plugin").stream())
 				.filter(plugin -> PomDocument.hasArtifactId(plugin, ENFORCER_ARTIFACT_ID))
 				.findFirst();
 	}
 
 	/**
-	 * Adds the rule dependency and the execution to a {@code maven-enforcer-plugin}
-	 * the project already declares — reusing its {@code dependencies} and
+	 * Adds the rule dependency and the execution to the {@code maven-enforcer-plugin}
+	 * the build already declares — reusing its {@code dependencies} and
 	 * {@code executions} when it has them — so the project keeps a single enforcer
 	 * plugin entry and the rules it already ran keep running.
 	 */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -94,6 +94,84 @@ class PomEnforcerInstallerTest {
 			</project>
 			""";
 
+	/** An enforcer declaration that only pins a version, as a multi-module build's does. */
+	private static final String MANAGED_ENFORCER = """
+			    <pluginManagement>
+			      <plugins>
+			        <plugin>
+			          <groupId>org.apache.maven.plugins</groupId>
+			          <artifactId>maven-enforcer-plugin</artifactId>
+			          <version>3.5.0</version>
+			        </plugin>
+			      </plugins>
+			    </pluginManagement>""";
+
+	/** An enforcer declaration that runs rules of its own, but only when its profile is activated. */
+	private static final String PROFILED_ENFORCER = """
+			  <profiles>
+			    <profile>
+			      <id>strict</id>
+			      <build>
+			        <plugins>
+			          <plugin>
+			            <artifactId>maven-enforcer-plugin</artifactId>
+			            <executions>
+			              <execution>
+			                <id>converge</id>
+			              </execution>
+			            </executions>
+			          </plugin>
+			        </plugins>
+			      </build>
+			    </profile>
+			  </profiles>""";
+
+	/**
+	 * Pins the enforcer's version in {@code pluginManagement} without running it, as a
+	 * project with several modules does. {@code pluginManagement} configures a plugin;
+	 * it does not activate one.
+	 */
+	private static final String POM_WITH_ENFORCER_IN_PLUGIN_MANAGEMENT = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+			  <artifactId>demo</artifactId>
+			  <build>
+			%s
+			    <plugins>
+			      <plugin>
+			        <artifactId>maven-compiler-plugin</artifactId>
+			      </plugin>
+			    </plugins>
+			  </build>
+			</project>
+			""".formatted(MANAGED_ENFORCER);
+
+	/**
+	 * Runs the enforcer from an opt-in profile — for rules the project does not want on
+	 * every build — and does not run the {@code claude-code-enforcer} rule at all.
+	 */
+	private static final String POM_WITH_ENFORCER_IN_A_PROFILE_ONLY = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+			  <artifactId>demo</artifactId>
+			%s
+			</project>
+			""".formatted(PROFILED_ENFORCER);
+
+	/** The enforcer twice over: managed and profiled ahead of the build that actually runs it. */
+	private static final String POM_WITH_ENFORCER_EVERYWHERE = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+			  <artifactId>demo</artifactId>
+			%s
+			  <build>
+			%s
+			    <plugins>
+			      <plugin>
+			        <artifactId>maven-enforcer-plugin</artifactId>
+			      </plugin>
+			    </plugins>
+			  </build>
+			</project>
+			""".formatted(PROFILED_ENFORCER, MANAGED_ENFORCER);
+
 	/** Wires the rule the way this repository does: behind an opt-in profile, not in the build. */
 	private static final String POM_WITH_RULE_IN_A_PROFILE = """
 			<project xmlns="http://maven.apache.org/POM/4.0.0">
@@ -276,6 +354,55 @@ class PomEnforcerInstallerTest {
 		Path pom = write(dir, POM_WITH_RULE_IN_A_PROFILE);
 		assertFalse(installer.install(pom), "the rule is already wired in, in the profile");
 		assertEquals(POM_WITH_RULE_IN_A_PROFILE, Files.readString(pom), "the POM must not have been touched");
+	}
+
+	/**
+	 * A managed enforcer is not a running one: {@code pluginManagement} says which
+	 * version to use if the plugin is ever bound, and nothing more. Adding the
+	 * execution there would leave the adopted project with no guard at all, and would
+	 * not look like a failure — {@link VerifyStep}'s {@code mvn -N validate} passes
+	 * because the rule never runs — so the pull request would advertise a guard the
+	 * project does not have.
+	 */
+	@Test
+	void wiresItsOwnDeclarationWhenTheEnforcerIsOnlyManaged(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_ENFORCER_IN_PLUGIN_MANAGEMENT);
+		assertTrue(installer.install(pom));
+		String result = Files.readString(pom);
+		assertTrue(result.contains(MANAGED_ENFORCER),
+				"the managed declaration must be left verbatim; an execution there would never run");
+		assertTrue(result.contains("tools.claude-code-enforcer"), "the rule must still be wired in");
+		assertEquals(2, countOccurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
+				"the build needs its own enforcer declaration alongside the managed one");
+	}
+
+	/** A profiled enforcer runs only when its profile is activated, which an ordinary build does not do. */
+	@Test
+	void wiresItsOwnDeclarationWhenTheEnforcerIsOnlyInAProfile(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_ENFORCER_IN_A_PROFILE_ONLY);
+		assertTrue(installer.install(pom));
+		String result = Files.readString(pom);
+		assertTrue(result.contains(PROFILED_ENFORCER),
+				"the profile must be left verbatim; an execution there runs only when the profile is activated");
+		assertTrue(result.contains("<build>"), "the POM had no build of its own and needs one to run the rule from");
+		assertTrue(result.contains("claudeMdFormat"), "the rule must be wired into that build");
+	}
+
+	/**
+	 * With the enforcer declared in three places, the one that runs on every build is
+	 * the one to augment — not whichever a document-order walk reaches first, which is
+	 * the profile's.
+	 */
+	@Test
+	void augmentsTheBuildsEnforcerRatherThanAProfilesOrAManagedOne(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_ENFORCER_EVERYWHERE);
+		assertTrue(installer.install(pom));
+		String result = Files.readString(pom);
+		assertTrue(result.contains(PROFILED_ENFORCER), "the profile must be left verbatim");
+		assertTrue(result.contains(MANAGED_ENFORCER), "the managed declaration must be left verbatim");
+		assertEquals(3, countOccurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
+				"the build's existing declaration must be augmented, not joined by a fourth");
+		assertTrue(result.contains("claudeMdFormat"), "the rule must be wired in");
 	}
 
 	@Test


### PR DESCRIPTION
Since the enforcer lookup moved to the whole POM, PomEnforcerInstaller
augmented whichever maven-enforcer-plugin a pre-order walk reached first —
including one declared in pluginManagement or inside a profile, where the
execution it splices in never runs. pluginManagement configures a plugin
without activating it, and a profile's plugins run only when that profile is
activated, so an adopted project was left with no guard at all.

Nothing reported it, either: install() answered true, EnforcerStep logged the
guard as wired in, and VerifyStep's `mvn -N validate` passed precisely because
the rule never executed — so the adoption pushed a branch and opened a pull
request advertising a guard the project did not have. A re-adoption then found
the rule dependency it had written, skipped, and left the repository
permanently unguardable.

Detection stays deliberately POM-wide: a project that already runs the rule on
its own terms, behind an opt-in profile, must not be given a second always-on
copy. Only placement is scoped, to the build/plugins the run adds to anyway —
PomDocument.at answers about that same path, so the place inspected and the
place edited cannot drift apart.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L1RNzjqEe43VcdEeaEPsPb