### PR TITLE
fix(adopt): probe the GitHub login with a call GitHub answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,8 +853,10 @@ The default pipeline runs these steps in order:
    absent one instead of failing minutes later after a clone, a `claude init`,
    and a Maven build have already run. Being installed is not enough for `gh`:
    `gh --version` succeeds for a CLI nobody is logged in to, so the login is
-   probed too (`gh auth status`) and an unauthenticated `gh` fails here rather
-   than at the very last step.
+   probed too and an unauthenticated `gh` fails here rather than at the very last
+   step. The probe is `gh api user` — an authenticated call to GitHub — rather
+   than `gh auth status`, which reports a rejected `GH_TOKEN` as invalid and
+   still exits zero.
 2. **`CloneStep`** — clones the target repository into the workspace with
    `git clone`, giving the remaining steps a working checkout.
 3. **`BuildToolchainStep`** — probes the *adopted project's* build tool, now that

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
@@ -25,8 +25,10 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * <p>Being installed is not enough for {@code gh}: {@code gh --version} succeeds
  * for a GitHub CLI nobody is logged in to, which the adoption would only discover
  * at {@link PullRequestStep}, its very last step. The login is therefore probed
- * here too. The adopted project's own build tool only becomes known once the
- * repository is cloned, so {@link BuildToolchainStep} probes it there.
+ * here too, by asking GitHub who the credentials belong to rather than by asking
+ * {@code gh} what it has stored — see {@link #AUTHENTICATION_PROBE}. The adopted
+ * project's own build tool only becomes known once the repository is cloned, so
+ * {@link BuildToolchainStep} probes it there.
  */
 public class ToolchainStep implements AdoptionStep {
 
@@ -34,7 +36,17 @@ public class ToolchainStep implements AdoptionStep {
 
 	static final String GITHUB_CLI = "gh";
 	static final List<String> DEFAULT_TOOLS = List.of("git", "claude", GITHUB_CLI);
-	static final List<String> AUTHENTICATION_PROBE = List.of(GITHUB_CLI, "auth", "status");
+
+	/**
+	 * The smallest authenticated call to GitHub there is, used in preference to
+	 * {@code gh auth status} because that command reports on credentials it holds
+	 * without its exit code always following: a {@code GH_TOKEN} that GitHub rejects
+	 * makes it print that the token is invalid and still exit zero, so the probe
+	 * passed for a {@code gh} that could not open a pull request — the one thing it
+	 * is here to rule out. Making the call the pull request will need answers the
+	 * question the step is actually asking, and fails when the answer is no.
+	 */
+	static final List<String> AUTHENTICATION_PROBE = List.of(GITHUB_CLI, "api", "user");
 
 	private final List<String> tools;
 	private final ToolProbe probe = new ToolProbe();
@@ -72,7 +84,7 @@ public class ToolchainStep implements AdoptionStep {
 			return;
 		}
 		throw new AdoptionException(name() + " failed: " + GITHUB_CLI
-				+ " is installed but not authenticated, so the pull request could not be opened."
+				+ " is installed but cannot authenticate to GitHub, so the pull request could not be opened."
 				+ " Run 'gh auth login', or set GH_TOKEN for a non-interactive host.");
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,8 +35,21 @@ class ToolchainStepTest {
 	void probesTheGitHubLoginOnceEveryToolIsPresent() {
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new ToolchainStep().execute(context, runner);
-		assertEquals(List.of("gh", "auth", "status"), runner.commandAt(3));
+		assertEquals(List.of("gh", "api", "user"), runner.commandAt(3));
 		assertEquals(context.workspace(), runner.invocations().get(3).workingDirectory());
+	}
+
+	/**
+	 * The probe must call GitHub rather than read what {@code gh} has stored locally:
+	 * {@code gh auth status} prints that a rejected {@code GH_TOKEN} is invalid and
+	 * still exits zero, which passed the check for a CLI that could not open a pull
+	 * request at all.
+	 */
+	@Test
+	void probesTheGitHubLoginWithAnAuthenticatedCallRatherThanTheLocalCredentialState() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new ToolchainStep().execute(context, runner);
+		assertFalse(runner.commandAt(3).contains("auth"), runner.commandAt(3).toString());
 	}
 
 	/**
@@ -46,11 +60,11 @@ class ToolchainStepTest {
 	@Test
 	void anUnauthenticatedGitHubCliAbortsTheAdoption() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> command.contains("auth") ? new CommandResult(command, 1, "not logged in")
+				command -> command.contains("api") ? new CommandResult(command, 1, "HTTP 401")
 						: new CommandResult(command, 0, ""));
 		AdoptionException thrown = assertThrows(AdoptionException.class,
 				() -> new ToolchainStep().execute(context, runner));
-		assertTrue(thrown.getMessage().contains("not authenticated"), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains("cannot authenticate"), thrown.getMessage());
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
@@ -39,17 +39,11 @@ class ToolchainStepTest {
 		assertEquals(context.workspace(), runner.invocations().get(3).workingDirectory());
 	}
 
-	/**
-	 * The probe must call GitHub rather than read what {@code gh} has stored locally:
-	 * {@code gh auth status} prints that a rejected {@code GH_TOKEN} is invalid and
-	 * still exits zero, which passed the check for a CLI that could not open a pull
-	 * request at all.
-	 */
 	@Test
-	void probesTheGitHubLoginWithAnAuthenticatedCallRatherThanTheLocalCredentialState() {
+	void anAuthenticatedGitHubCliCompletesTheStep() {
 		RecordingCommandRunner runner = new RecordingCommandRunner();
-		new ToolchainStep().execute(context, runner);
-		assertFalse(runner.commandAt(3).contains("auth"), runner.commandAt(3).toString());
+		assertDoesNotThrow(() -> new ToolchainStep().execute(context, runner));
+		assertEquals(4, runner.count());
 	}
 
 	/**
@@ -65,6 +59,44 @@ class ToolchainStepTest {
 		AdoptionException thrown = assertThrows(AdoptionException.class,
 				() -> new ToolchainStep().execute(context, runner));
 		assertTrue(thrown.getMessage().contains("cannot authenticate"), thrown.getMessage());
+	}
+
+	/**
+	 * The failure the probe was changed for: a {@code gh} holding a token GitHub
+	 * rejects prints that the token is invalid and still exits <em>zero</em> from
+	 * {@code gh auth status}. A probe that read that stored credential state passed
+	 * for a CLI which could not open a pull request, and an adoption ran a clone, a
+	 * {@code claude init}, a build and a push before failing at {@code pull-request}
+	 * — the very outcome this step exists to prevent.
+	 */
+	@Test
+	void aGitHubCliWhoseTokenGitHubRejectsAbortsTheAdoption() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::rejectedByGitHub);
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> new ToolchainStep().execute(context, runner));
+		assertTrue(thrown.getMessage().contains("cannot authenticate"), thrown.getMessage());
+	}
+
+	/**
+	 * Pins the probe away from {@code gh auth status} by behaviour rather than by
+	 * name, so a change back to any command that only reports what {@code gh} has
+	 * stored fails here instead of at an adoption's last step.
+	 */
+	@Test
+	void neverAsksGhWhatCredentialsItHolds() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new ToolchainStep().execute(context, runner);
+		assertFalse(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("auth")),
+				runner.invocations().toString());
+	}
+
+	/** A {@code gh} that is installed and holds a token GitHub answers 401 to. */
+	private CommandResult rejectedByGitHub(List<String> command) {
+		if (command.contains("auth")) {
+			return new CommandResult(command, 0, "X Failed to log in to github.com using token (GH_TOKEN)");
+		}
+		return command.contains("api") ? new CommandResult(command, 1, "HTTP 401: Bad credentials")
+				: new CommandResult(command, 0, "");
 	}
 
 	@Test


### PR DESCRIPTION
ToolchainStep exists so an unusable `gh` fails before the clone, the
`claude init` and the build, rather than at `pull-request`, the pipeline's
last step. Its login probe was `gh auth status`, which reports on the
credentials it holds without its exit code always following: a `GH_TOKEN`
that GitHub rejects makes it print that the token is invalid and still
exit zero. An end-to-end run over two repositories walked straight past
the check on such a token and failed where the step was written to stop
failing.

Probe with `gh api user` instead — the smallest authenticated call there
is, and the same kind of call the pull request will need — so the step
asks GitHub the question it is actually interested in and fails when the
answer is no.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XKz2bMB9CbiHq3PfeCnC2s