### PR TITLE
docs: trim the longest Javadoc blocks across the modules

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionFiles.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionFiles.java
@@ -5,18 +5,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
- * Reads and writes the text files an adoption touches — the checkout's POM or
- * Gradle script, the generated {@code CLAUDE.md}, the starter assets, the run's
- * JSON report — reporting a failure as an {@link AdoptionException} like every
- * other adoption failure rather than as a raw {@link IOException} each caller
- * has to wrap for itself.
- *
- * <p>Every write creates the file's parent directories first, so an asset nested
- * in a directory the checkout does not carry yet ({@code .claude/hooks/}) is
- * written rather than failing on the missing parent. The {@code description} names
- * the file in the failure message the way the operator thinks of it — "POM",
- * "CLAUDE.md", "the adoption report" — because a bare path does not say what the
- * adoption was trying to do with it.
+ * Reads and writes the text files an adoption touches — the checkout's build
+ * script, the generated {@code CLAUDE.md}, the starter assets, the run's JSON
+ * report — failing with an {@link AdoptionException} rather than a raw
+ * {@link IOException} every caller would have to wrap for itself. Writes create
+ * the parent directories first, so an asset under a directory the checkout does
+ * not carry yet ({@code .claude/hooks/}) still lands, and the
+ * {@code description} names the file in the failure message the way the operator
+ * thinks of it.
  */
 public final class AdoptionFiles {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
@@ -9,19 +9,16 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
- * Renders the outcome of an adoption run as JSON, either to a string or to a
- * file, so it — repository, branch, pull-request URL, whether the run succeeded,
- * and the steps that completed — is consumable by scripts and other tools rather
- * than only readable in the logs. A report without a pull-request URL serialises
- * the {@code pullRequestUrl} field as JSON {@code null}, and so does a successful
- * run's {@code failure}, keeping the document's shape stable for consumers.
+ * Renders the outcome of an adoption run as JSON, to a string or to a file:
+ * repository, branch, pull-request URL, whether the run succeeded, and the steps
+ * that completed. An absent pull-request URL, and a successful run's
+ * {@code failure}, are serialised as JSON {@code null} so the document's shape
+ * stays stable for consumers.
  *
- * <p>A run over several repositories is written as a batch document instead: an
- * overall {@code succeeded} — true only when every repository was adopted — and a
- * {@code repositories} array of exactly the per-repository documents above.
- * Adopting a single repository keeps writing that per-repository document
- * unwrapped, so the shape a consumer of a one-repository run already parses is
- * unchanged by the list input.
+ * <p>A run over several repositories is wrapped in a batch document instead: an
+ * overall {@code succeeded}, true only when every repository was adopted, plus a
+ * {@code repositories} array of exactly those per-repository documents. A single
+ * repository is still written unwrapped.
  */
 public class AdoptionReportWriter {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
@@ -6,24 +6,16 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * Adopts a list of repositories, one after another, with a fresh
- * {@link AdoptionReport} for each. A batch is why the adoption takes a list of
- * URLs at all: a team adopts Claude Code across its repositories in one run
- * rather than invoking the pipeline once per repository by hand.
+ * Adopts a list of repositories one after another, with a fresh
+ * {@link AdoptionReport} for each.
  *
- * <p>A repository whose adoption fails does not stop the batch. Failing fast
- * would leave the repositories behind it untried, and their adoptions are
- * independent — a {@code gh} login that expired for one organisation, or a project
- * whose build tool is missing, says nothing about the next repository on the
- * list. The failure is recorded in that repository's report and the run moves on,
- * so the caller can see exactly which repositories were adopted and which were
- * not; deciding what a partly failed batch means — a non-zero exit, an error
- * result — is the caller's, not the batch's.
- *
- * <p>Repositories are adopted sequentially rather than in parallel: every
- * adoption shells out to {@code git}, {@code claude}, and {@code gh}, and a
- * parallel batch would interleave their output and multiply the load a single
- * {@code claude init} already puts on the machine.
+ * <p>A repository whose adoption fails does not stop the batch. The adoptions are
+ * independent — an expired {@code gh} login or a missing build tool says nothing
+ * about the next repository — so the failure is recorded in that repository's
+ * report and the run moves on, leaving the caller to decide what a partly failed
+ * batch means. Repositories are adopted sequentially because every adoption
+ * shells out to {@code git}, {@code claude}, and {@code gh}, whose output a
+ * parallel batch would interleave.
  */
 public final class BatchAdoption {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Checkouts.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Checkouts.java
@@ -7,23 +7,16 @@ import java.util.Map;
 
 /**
  * Gives every repository of a run its own checkout, as the {@link AdoptionContext}
- * list the run works through: one workspace, one branch name, in the order the URLs
- * were given. Both entry points come through here — the way both resolve their
- * workspace through {@link Workspaces} — so the command line and the MCP tool
- * cannot drift apart on how a run's contexts are made, or on which lists of
- * repositories are adoptable at all.
+ * list the run works through: one workspace, one branch name, in the order the
+ * URLs were given. Both entry points come through here, so the command line and
+ * the MCP tool cannot drift apart on how a run's contexts are made.
  *
  * <p>Two repositories that would clone into the same checkout directory are
  * rejected rather than adopted. A checkout is named after the repository alone, so
- * {@code owner/tools} and {@code other-owner/tools} claim one directory, and so do
- * the same repository's {@code .../repo} and {@code .../repo.git} forms — distinct
- * URLs, hence not duplicates to {@link RepositoryUrls#distinct(List)}, but one
- * directory. The second adoption would then run every step against the first
- * repository's working tree: {@link io.github.adamw7.tools.adopt.step.CloneStep}
- * reuses an existing checkout by design, so nothing would clone, and the run would
- * report the first repository's pull request as the second's or fail at {@code gh}
- * with a message pointing nowhere near the cause. Failing on the input instead says
- * exactly which two URLs collided while both repositories are still untouched.
+ * {@code owner/tools} and {@code other-owner/tools} claim one directory, as do a
+ * repository's {@code .../repo} and {@code .../repo.git} forms. The second
+ * adoption would otherwise run every step against the first repository's working
+ * tree and report its pull request as the second's.
  */
 public final class Checkouts {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -11,30 +11,23 @@ import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 /**
  * Parses the adoption command line. The first three non-flag arguments are the
  * positional repository URL, workspace directory, and feature-branch name the
- * entry point has always accepted, so existing invocations keep working; the
- * flags expose the rest of the pipeline's configuration: further repositories to
- * adopt in the same run (repeatable {@code --repo}, or {@code --repos <file>} for
- * a file naming one per line), the workspace and branch under their own names
- * ({@code --workspace}, {@code --branch}), the pull-request metadata of
- * {@link PullRequestOptions} ({@code --title}, {@code --body}, repeatable
- * {@code --reviewer}/{@code --label}/{@code --assignee}, and {@code --draft}),
- * the optional starter-assets step ({@code --assets}), the
- * {@code claude-code-enforcer} version to wire into an adopted Maven project
- * ({@code --rule-version}), and a JSON report of the run's outcome
- * ({@code --report <file>}). A blank workspace
- * or branch positional falls back to its default, matching the pre-flag
- * behaviour; an unknown flag or a flag missing its value fails with the usage
- * line rather than being silently ignored.
+ * entry point has always accepted; the flags expose the rest of the pipeline's
+ * configuration: further repositories for the same run (repeatable
+ * {@code --repo}, or {@code --repos <file>} for a file naming one per line), the
+ * workspace and branch under their own names, the {@link PullRequestOptions}
+ * metadata ({@code --title}, {@code --body}, repeatable
+ * {@code --reviewer}/{@code --label}/{@code --assignee}, {@code --draft}), the
+ * starter-assets step ({@code --assets}), the {@code claude-code-enforcer}
+ * version to wire in ({@code --rule-version}), and a JSON report of the outcome
+ * ({@code --report <file>}). A blank workspace or branch positional falls back to
+ * its default; an unknown flag, or one missing its value, fails with the usage
+ * line rather than being ignored.
  *
- * <p>The positional slots keep their meaning whatever else is on the command
- * line — the first is always a repository URL, never a workspace — so a run
- * driven entirely by {@code --repo}/{@code --repos} names its workspace and
- * branch with {@code --workspace} and {@code --branch} rather than positionally.
- * Both flags write the same value as their positional, so naming one twice is the
- * last one winning rather than an error. A first positional that names no
- * repository owner while those flags named repositories is rejected outright: it is
- * the workspace the reading above invites, and adopting it as a repository fails
- * far from the mistake.
+ * <p>The positional slots keep their meaning whatever else is on the command line
+ * — the first is always a repository URL, never a workspace — so a run driven
+ * entirely by {@code --repo}/{@code --repos} names its workspace and branch with
+ * {@code --workspace} and {@code --branch}. A flag and its positional write the
+ * same value, so naming one twice is the last one winning rather than an error.
  */
 public final class CliArguments {
 
@@ -213,19 +206,17 @@ public final class CliArguments {
 	}
 
 	/**
-	 * Rejects a first positional that names no repository owner when the flags
-	 * already named repositories — {@code --repos list.txt /tmp/workspace}, where the
-	 * operator meant the workspace the flags left unnamed. The positional slot keeps
-	 * its meaning whatever else is on the command line, so that path is read as a
+	 * Rejects a first positional that names no repository owner when the flags already
+	 * named repositories — {@code --repos list.txt /tmp/workspace}, where the operator
+	 * meant the workspace the flags left unnamed. The positional slot keeps its
+	 * meaning whatever else is on the command line, so that path is read as a
 	 * repository URL and fails several steps later on a clone of a directory that is
-	 * not a repository, or a push to an origin that does not exist. Saying so here
-	 * names the argument and the flag that was meant instead.
+	 * not a repository. Saying so here names the argument and the flag meant instead.
 	 *
 	 * <p>The check is only worth making when the flags supplied a repository, since a
 	 * run whose only repository is the positional has nothing else it could be. A
-	 * local path really is adoptable — {@link RepositoryUrl} accepts one, and only a
-	 * URL with a host names an owner — so a batch of local repositories names them all
-	 * with {@code --repo} rather than positionally.
+	 * local path really is adoptable — only a URL with a host names an owner — so a
+	 * batch of local repositories names them all with {@code --repo}.
 	 */
 	private void requirePositionalNamesARepository() {
 		if (positionalUrl != null && flaggedRepositories > 0 && namesNoOwner(positionalUrl)) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -29,25 +29,20 @@ import io.github.adamw7.tools.adopt.step.VerifyStep;
 /**
  * Runs the ordered pipeline that adopts Claude Code into a GitHub repository:
  * check the required tools are installed, clone, check the cloned project's own
- * build tool is installed too, create a feature branch, mark the checkout trusted
- * for Claude Code, generate {@code CLAUDE.md} with {@code claude init}, normalise
- * it and add a companion {@code AGENTS.md} so it satisfies the guard the adoption
- * is about to wire in, commit it, wire in the {@code claude-code-enforcer} and
- * commit that, verify the guard passes, then push the branch and open a pull
- * request. The toolchain check runs first so a missing {@code git},
- * {@code claude}, or {@code gh} fails before any expensive work, and the
- * build-tool check follows the clone — the first moment the project's build system
- * is known — so a missing {@code mvn} or {@code gradle} fails before the
- * {@code claude init} rather than at the verification. The adoption never writes
- * to the default branch. Steps and the command runner are injected so the pipeline
- * is easy to reconfigure and to test.
+ * build tool, create a feature branch, mark the checkout trusted for Claude Code,
+ * generate {@code CLAUDE.md} with {@code claude init}, conform it and commit,
+ * wire in the {@code claude-code-enforcer} and commit that, verify the guard
+ * passes, then push the branch and open a pull request. The default branch is
+ * never written to. Steps and the command runner are injected, so the pipeline is
+ * easy to reconfigure and to test.
  *
- * <p>Each run returns an {@link AdoptionReport} of the steps that completed and
- * the pull request's URL, so callers can act on the outcome without scraping logs.
- * A caller that needs the report of a run that <em>fails</em> supplies its own to
- * {@link #adopt(AdoptionContext, AdoptionReport)} and still holds it after the
- * failure propagates. The default pipeline optionally includes an
- * {@link AssetsStep} that commits starter Claude Code configuration assets.
+ * <p>Both toolchain checks are placed to fail early: the pipeline's own tools
+ * before any expensive work, the project's build tool as soon as the clone
+ * reveals which one it is, rather than at the verification. Each run returns an
+ * {@link AdoptionReport} of the steps that completed and the pull request's URL;
+ * a caller that needs the report of a run that <em>fails</em> supplies its own to
+ * {@link #adopt(AdoptionContext, AdoptionReport)} and still holds it afterwards.
+ * The default pipeline optionally includes an {@link AssetsStep}.
  */
 public class GitHubRepoAdopter {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -7,27 +7,21 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
 
 /**
- * Command-line entry point: parses the arguments with {@link CliArguments} —
- * the repositories to adopt (the positional GitHub repository URL, plus any
- * named with {@code --repo} or listed in a {@code --repos} file), the optional
- * workspace directory, and optional feature-branch name, plus the flags for
- * pull-request metadata, the starter-assets step, and the JSON report — and runs
- * the default adoption pipeline against a real {@code git}/{@code claude}/{@code gh}
- * toolchain. A supplied workspace directory is created when it does not yet
- * exist; when omitted, a temporary one is created instead. Every repository of a
- * run shares that workspace and branch name: each clone lands in its own
- * directory under the workspace, named after the repository.
+ * Command-line entry point: parses the arguments with {@link CliArguments} and
+ * runs the default adoption pipeline against a real
+ * {@code git}/{@code claude}/{@code gh} toolchain. Every repository of a run
+ * shares one workspace — the one supplied, created when it does not exist, or a
+ * temporary one — and one branch name, each clone landing in its own directory
+ * under the workspace, named after the repository.
  *
  * <p>When {@code --report} names a file, the run's {@link AdoptionReport} is
- * written there as JSON — for a failed run as well as a successful one, so the
- * report can say how far the adoption got and why it stopped. A run that adopted
- * several repositories writes the batch document {@link AdoptionReportWriter}
- * describes, one entry per repository.
+ * written there as JSON, for a failed run as well as a successful one, so it can
+ * say how far the adoption got and why it stopped. A run over several
+ * repositories writes the batch document {@link AdoptionReportWriter} describes.
  *
- * <p>A repository whose adoption fails does not stop the ones behind it: the
- * batch runs to the end and the failures are raised together afterwards, so the
- * process still exits non-zero while the repositories that could be adopted have
- * been.
+ * <p>A repository whose adoption fails does not stop the ones behind it: the batch
+ * runs to the end and the failures are raised together afterwards, so the process
+ * still exits non-zero.
  */
 public class Main {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrls.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrls.java
@@ -5,21 +5,16 @@ import java.util.LinkedHashSet;
 import java.util.List;
 
 /**
- * Reads the list of repository URLs an adoption run works through, from the two
+ * Reads the list of repository URLs an adoption run works through, in the two
  * forms the entry points offer: a file naming one repository per line, and a list
- * already collected in memory (repeated command-line flags, or an MCP argument).
- * Both end in {@link #distinct(List)}, so the two cannot drift apart on what
- * counts as a repository worth adopting.
+ * already collected in memory. Both end in {@link #distinct(List)}, so the two
+ * cannot drift apart on what counts as a repository worth adopting.
  *
  * <p>A list file is written for people: blank lines are skipped and a line whose
  * first non-blank character is {@code #} is a comment, so a batch can be annotated
- * with why a repository is on it, and a repository can be commented out for a run
- * rather than deleted from the file.
- *
- * <p>Duplicates are dropped, keeping the order the URLs were given in. The same
- * URL twice would clone into one checkout directory and adopt it a second time,
- * which at best repeats the work and at worst pushes a branch built on a
- * half-adopted tree.
+ * and a repository commented out for a run rather than deleted. Duplicates are
+ * dropped, keeping the order the URLs were given in — the same URL twice would
+ * clone into one checkout directory and adopt it a second time.
  */
 public final class RepositoryUrls {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Workspaces.java
@@ -6,21 +6,15 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 /**
- * Creates the workspace directory an adoption clones into: either the directory
- * the caller named — created when it does not yet exist, so the clone step
- * always has a directory to run in — or a fresh temporary one when the caller
- * left the choice open. Shared by the command-line entry point and the MCP
- * server, so both resolve workspaces identically.
- *
- * <p>A workspace that cannot be created — an existing regular file, or a path the
- * process may not write — fails with an {@link AdoptionException} like every other
- * adoption failure rather than a raw {@link java.io.UncheckedIOException}.
+ * Creates the workspace directory an adoption clones into: the directory the
+ * caller named, created when it does not yet exist, or a fresh temporary one when
+ * the caller left the choice open. Shared by the command line and the MCP server,
+ * and failing with an {@link AdoptionException} like every other adoption failure.
  *
  * <p>The returned path is always absolute. The clone step runs {@code git clone}
  * with the workspace as its working directory and {@code workspace/name} as the
- * clone target, so a relative workspace would make git resolve that target against
- * the working directory a second time and nest the checkout under
- * {@code workspace/workspace/name}, leaving every later step unable to find it.
+ * target, so a relative workspace would be resolved a second time and nest the
+ * checkout under {@code workspace/workspace/name}.
  */
 public final class Workspaces {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
@@ -13,23 +13,20 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
- * Resolves a command's program name to a form {@link ProcessBuilder} can
- * actually launch on the host operating system.
+ * Resolves a command's program name to a form {@link ProcessBuilder} can actually
+ * launch on the host operating system.
  *
  * <p>On POSIX the command is returned unchanged. On Windows a bare program name
  * such as {@code mvn} or {@code claude} routinely resolves to a {@code .cmd} or
- * {@code .bat} shim, which the underlying {@code CreateProcess} call cannot
- * start: it appends {@code .exe} to an extensionless name and refuses to run a
- * batch script, so a bare {@code mvn} fails with "Cannot run program". This
- * resolver searches the {@code PATH} using {@code PATHEXT} and rewrites a batch
- * script to run through {@code cmd.exe /c}, a real executable to its resolved
- * absolute path. A program that cannot be located is returned unchanged, so the
- * caller still fails with its usual "could not start" error.
+ * {@code .bat} shim, which {@code CreateProcess} refuses to start. This resolver
+ * searches the {@code PATH} using {@code PATHEXT} and rewrites a batch script to
+ * run through {@code cmd.exe /c}, a real executable to its absolute path. A
+ * program that cannot be located is returned unchanged, so the caller still fails
+ * with its usual "could not start" error.
  *
  * <p>Only the program name is ever routed through {@code cmd.exe}; the arguments
- * reach {@link ProcessBuilder} unchanged. Free-form arguments such as a
- * pull-request title therefore never reach the command interpreter, because
- * {@code git} and {@code gh} resolve to real {@code .exe} files.
+ * reach {@link ProcessBuilder} unchanged, so free-form arguments such as a
+ * pull-request title never reach the command interpreter.
  */
 final class ExecutableResolver {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
@@ -10,18 +10,16 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 /**
- * Drains a process's output stream on a dedicated daemon thread so the command
- * can be waited for with a timeout. Reading the stream inline would block until
- * the child closes it, which never happens for a hung process; consuming it in
- * the background lets {@link ProcessCommandRunner} time out and destroy the
- * child while its partial output is still recovered.
+ * Drains a process's output stream on a dedicated daemon thread so the command can
+ * be waited for with a timeout. Reading the stream inline would block until the
+ * child closes it, which a hung process never does; consuming it in the background
+ * lets {@link ProcessCommandRunner} destroy the child with its partial output
+ * still recovered.
  *
- * <p>The stream is copied verbatim as it is read — the child's own line
- * terminators and any trailing newline survive — so the transcript is what the
- * command printed rather than a re-joined approximation. {@link #output()} bounds
- * its wait for the reader thread: a direct child can exit while a descendant it
- * spawned keeps the pipe open, and the bounded join returns what was captured
- * instead of hanging the caller forever.
+ * <p>The stream is copied verbatim, so the transcript keeps the child's own line
+ * terminators rather than a re-joined approximation. {@link #output()} bounds its
+ * wait for the reader thread, because a descendant the child spawned can keep the
+ * pipe open after the child itself has exited.
  */
 final class StreamGobbler {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -27,19 +27,17 @@ import io.github.adamw7.tools.mcp.ToolDefinition;
 import io.github.adamw7.tools.mcp.ToolResult;
 
 /**
- * The MCP tool that runs the adoption pipeline: given one GitHub repository URL
- * or a list of them — plus optional workspace, branch, pull-request metadata, and
- * the starter-assets flag — it adopts Claude Code exactly as the command line
- * does and answers with the run's JSON {@link AdoptionReport}. The pipeline is
- * injected behind the {@link Pipeline} seam so tests exercise the argument
- * mapping without cloning anything; the default wiring runs it against a
- * {@link ProcessCommandRunner}.
+ * The MCP tool that runs the adoption pipeline: given one GitHub repository URL or
+ * a list of them — plus optional workspace, branch, pull-request metadata, and the
+ * starter-assets flag — it adopts Claude Code exactly as the command line does and
+ * answers with the run's JSON {@link AdoptionReport}. The pipeline is injected
+ * behind the {@link Pipeline} seam so tests exercise the argument mapping without
+ * cloning anything.
  *
  * <p>A repository whose adoption fails does not strand the rest of the list: the
- * batch runs to the end and the result carries every repository's report, marked
- * as an error result when any of them failed. That report is the answer even on
- * the failure path — a client that asked for five repositories needs to know
- * which two did not land, not only that something threw.
+ * result carries every repository's report, marked as an error result when any of
+ * them failed. A client that asked for five repositories needs to know which two
+ * did not land, not only that something threw.
  */
 public class AdoptTool implements McpTool {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractBuildSystemStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractBuildSystemStep.java
@@ -13,9 +13,8 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * Base for the steps that act on the checkout's build system: wiring the
  * {@code CLAUDE.md} guard into it ({@link EnforcerStep}), running that guard
  * ({@link VerifyStep}), and checking the build tool it needs is installed
- * ({@link BuildToolchainStep}). Detecting the build system in one place keeps
- * all three acting on the same build tool, so the guard that is wired in is the
- * guard that is verified with the tool that was probed.
+ * ({@link BuildToolchainStep}). Detecting the build system in one place keeps all
+ * three acting on the same one.
  *
  * <p>Detection only comes up empty for a step configured with a build-system list
  * that has no catch-all fallback ({@link BuildSystems#DEFAULTS} always matches),

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
@@ -4,14 +4,12 @@ import java.util.List;
 
 /**
  * The starter Claude Code configuration assets an {@link AssetsStep} installs
- * beyond the generated {@code CLAUDE.md}: an {@code AGENTS.md} pointer for
- * agents that read the cross-tool convention, a {@code .claude/settings.json}
- * that denies reading obvious secret files and wires the session-start hook, the
- * {@code .claude/hooks/session-start.sh} stub that hook runs, a starter
- * {@code .mcp.json}, and a GitHub Actions workflow that answers {@code @claude}
- * mentions on issues and pull requests. Every asset is a plain committed file,
- * so the configuration is shared with all contributors rather than living only
- * in the adopter's local checkout.
+ * beyond the generated {@code CLAUDE.md}: an {@code AGENTS.md} pointer, a
+ * {@code .claude/settings.json} that denies reading obvious secret files and wires
+ * the session-start hook, the {@code .claude/hooks/session-start.sh} stub that
+ * hook runs, a starter {@code .mcp.json}, and a GitHub Actions workflow answering
+ * {@code @claude} mentions. Every asset is a plain committed file, so the
+ * configuration is shared with all contributors.
  *
  * <p>Every repository-relative path the adoption writes is named here, including
  * the generated {@code CLAUDE.md} — not a starter asset, but keeping its name

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
@@ -11,22 +11,19 @@ import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
- * Creates and checks out the adoption feature branch in the fresh checkout with
- * {@code git checkout -B}, so every subsequent commit lands on that branch
- * rather than on the repository's default branch. The adoption pushes this
- * branch and opens a pull request from it, leaving the default branch untouched.
- *
- * <p>{@code -B} resets the branch to the current {@code HEAD} whether or not it
- * already exists, so re-running the adoption starts the feature branch afresh
- * rather than aborting on an "already exists" failure.
+ * Creates and checks out the adoption feature branch with
+ * {@code git checkout -B}, so every subsequent commit lands there rather than on
+ * the repository's default branch. {@code -B} resets the branch to the current
+ * {@code HEAD} whether or not it already exists, so re-running the adoption starts
+ * it afresh rather than aborting.
  *
  * <p>A checkout with no local branch yet but whose {@code origin} already
  * publishes one — a fresh clone re-adopting a repository an earlier run pushed,
- * which the default temporary workspace produces on every run — starts from that
- * published tip instead of {@code HEAD}. Otherwise the branch would restart at the
- * default branch and {@link PushStep} would be rejected as a non-fast-forward, so
- * a second adoption could never get past the push. An existing local branch is
- * left to the plain {@code -B}, so unpushed work is never reset onto the remote.
+ * which the default temporary workspace produces every time — starts from that
+ * published tip instead. Otherwise the branch would restart at the default branch
+ * and {@link PushStep} would be rejected as a non-fast-forward. An existing local
+ * branch is left to the plain {@code -B}, so unpushed work is never reset onto the
+ * remote.
  */
 public class BranchStep extends AbstractCommandStep {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
@@ -13,11 +13,10 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
 /**
  * Checks that the adopted project's own build tool is installed, as soon as the
  * clone has revealed which one it is. {@link ToolchainStep} can only probe the
- * pipeline's own {@code git}/{@code claude}/{@code gh} because the checkout does
- * not exist yet, but {@link VerifyStep} later shells out to {@code mvn} or
- * {@code gradle} — so without this step a machine missing that build tool fails at
- * verification, after a full {@code claude init} and two commits: exactly the late
- * failure the toolchain check exists to prevent.
+ * pipeline's own {@code git}/{@code claude}/{@code gh}, but {@link VerifyStep}
+ * later shells out to {@code mvn} or {@code gradle} — so without this step a
+ * machine missing that build tool fails at verification, after a full
+ * {@code claude init} and two commits.
  *
  * <p>The build system is detected through {@link AbstractBuildSystemStep} just as
  * {@link EnforcerStep} and {@link VerifyStep} detect it, so the tool probed is the

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -16,27 +16,24 @@ import io.github.adamw7.tools.adopt.Failures;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
- * Runs the Claude Code CLI in headless mode against the checkout so it
- * generates a {@code CLAUDE.md} for the project. The exact CLI invocation is
- * configurable because the flags differ between environments; the default runs
- * the {@code /init} command non-interactively with {@code --permission-mode
- * acceptEdits} so the CLI may write the file. Headless {@code -p} mode has no
- * interactive approver, so without a permission mode that pre-approves edits the
- * {@code /init} command only prints a request to write {@code CLAUDE.md}, exits
- * cleanly, and leaves nothing behind.
+ * Runs the Claude Code CLI in headless mode against the checkout so it generates a
+ * {@code CLAUDE.md} for the project. The invocation is configurable because the
+ * flags differ between environments; the default runs {@code /init}
+ * non-interactively with {@code --permission-mode acceptEdits}, since headless
+ * {@code -p} mode has no interactive approver and would otherwise only print a
+ * request to write the file, exit cleanly, and leave nothing behind.
  *
- * <p>A repository that already carries a {@code .claude/CLAUDE.md} steers
- * headless {@code /init} into <em>updating that file</em> rather than writing the
- * root {@code CLAUDE.md} the adoption needs — and a write under {@code .claude/}
- * is refused as a sensitive path in headless mode, so the run produces nothing.
- * That memory file is therefore moved aside before {@code /init} runs and
- * restored afterwards, on the failure path too, so the project's own copy is left
- * untouched. A run that exits cleanly but leaves no {@code CLAUDE.md} behind
- * aborts the adoption rather than pushing an empty pull request.
+ * <p>A repository that already carries a {@code .claude/CLAUDE.md} steers headless
+ * {@code /init} into updating <em>that</em> file rather than the root one the
+ * adoption needs — and a write under {@code .claude/} is refused as a sensitive
+ * path — so that memory file is moved aside before the run and restored
+ * afterwards, on the failure path too. A run that exits cleanly but leaves no
+ * {@code CLAUDE.md} behind aborts the adoption rather than pushing an empty pull
+ * request.
  *
  * <p>The step is idempotent: a checkout that already carries a root
  * {@code CLAUDE.md} is left alone, because the CLI's output is not reproducible
- * and regenerating would discard whatever the project has edited since.
+ * and regenerating would discard whatever has been edited since.
  */
 public class ClaudeInitStep extends AbstractCommandStep {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -13,18 +13,16 @@ import java.util.stream.IntStream;
  * Reshapes the {@code CLAUDE.md} that {@link ClaudeInitStep} generated so it
  * satisfies the {@code claudeMdFormat} rule {@link EnforcerStep} wires into the
  * build. A generic {@code claude init} writes natural, project-specific headings
- * ({@code ## Project purpose}) and no {@code AGENTS.md} reference, but the rule
- * demands a fixed set of whole-line headings plus that reference — so without
- * this reshape the adoption fails its own {@link VerifyStep}.
+ * and no {@code AGENTS.md} reference, while the rule demands a fixed set of
+ * whole-line headings plus that reference — so without this reshape the adoption
+ * fails its own {@link VerifyStep}.
  *
  * <p>The reshape is deterministic and conservative: a near-miss heading is
  * <em>renamed</em> in place so its body survives, only a genuinely absent section
- * is appended, and a required section left empty gets a stub body because the
- * rule fails an empty section just as it fails a missing one. Fenced code is left
- * alone, mirroring how the rule matches, and an unterminated fence is closed
- * first so appended sections are document structure rather than more code.
- * Reshaping an already-conforming document is a no-op, so re-adopting a
- * repository does not churn the file.
+ * is appended, and a required section left empty gets a stub body because the rule
+ * fails an empty section just as it fails a missing one. Fenced code is left
+ * alone, mirroring how the rule matches, and reshaping an already-conforming
+ * document is a no-op.
  */
 public class ClaudeMdConformer {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
@@ -11,17 +11,17 @@ import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
- * Stages every change in the checkout and commits it with the configured
- * message. Whether there is anything to commit is decided by asking git
+ * Stages every change in the checkout and commits it with the configured message.
+ * Whether there is anything to commit is decided by asking git
  * ({@code git diff --cached --quiet}) rather than by matching the wording of a
  * failed commit's output, so an empty commit is a harmless no-op regardless of
- * git's locale or version and the pipeline stays idempotent when re-run.
+ * git's locale or version.
  *
  * <p>The adoption runs headless — on a CI runner or an MCP server — where git may
  * have no configured {@code user.name}/{@code user.email} and {@code git commit}
  * aborts with "Author identity unknown". Each missing identity is supplied for the
- * commit alone with a {@code -c} override, so the commit succeeds on a bare host
- * while an identity the checkout already configures stays in force.
+ * commit alone with a {@code -c} override, so an identity the checkout already
+ * configures stays in force.
  */
 public class CommitStep extends AbstractCommandStep {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
@@ -7,9 +7,9 @@ import java.util.Optional;
 /**
  * The catch-all build system for the adoption: it matches every checkout, so a
  * repository with no Maven or Gradle build file still gets a {@code CLAUDE.md}
- * guard instead of being adopted with none. Because it matches unconditionally it
- * is listed last in {@link BuildSystems#DEFAULTS}, after the real build tools, so
- * it only wins when none of them detected a build file.
+ * guard. Because it matches unconditionally it is listed last in
+ * {@link BuildSystems#DEFAULTS}, and only wins when no real build tool detected a
+ * build file.
  *
  * <p>The guard is a GitHub Actions workflow and the portable shell script it runs,
  * installed with {@link WorkflowGuardInstaller}; the verification runs that same

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -7,25 +7,24 @@ import java.util.stream.Collectors;
 import io.github.adamw7.tools.adopt.AdoptionFiles;
 
 /**
- * Appends a {@code CLAUDE.md} guard task to a Gradle build script so the adopted
+ * Appends a {@code CLAUDE.md} guard task to a Gradle build script, so the adopted
  * repository fails its build when the generated {@code CLAUDE.md} is missing or
  * empty. Gradle has no {@code claude-code-enforcer} equivalent, so the guard is a
  * dependency-free presence-and-non-empty check rather than the full format rule
  * the Maven path wires in.
  *
  * <p>The syntax is chosen from the script's extension, since the Kotlin
- * ({@code build.gradle.kts}) and Groovy ({@code build.gradle}) DSLs differ. The
- * block is appended rather than parsed in because Gradle scripts are code, not
- * data. The install is idempotent: a script that already declares the
- * {@value #GUARD_TASK} task is left untouched.
+ * ({@code build.gradle.kts}) and Groovy ({@code build.gradle}) DSLs differ, and
+ * the block is appended rather than parsed in because Gradle scripts are code, not
+ * data. A script that already declares the {@value #GUARD_TASK} task is left
+ * untouched.
  *
  * <p>The file to check is resolved while the task is being <em>configured</em> and
  * only read inside {@code doLast}, so the task body captures a plain
  * {@link java.io.File} rather than reaching back into the {@code Project} at
- * execution time. Gradle's configuration cache rejects a task that holds a script
- * or {@code Project} reference, which would abort the adoption at
- * {@link GradleBuildSystem#verifyCommand()} and break {@code check} for every
- * contributor afterwards.
+ * execution time: Gradle's configuration cache rejects a task holding a script or
+ * {@code Project} reference, which would break {@code check} for every contributor
+ * afterwards.
  */
 public class GradleGuardInstaller {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -30,26 +30,26 @@ import io.github.adamw7.tools.adopt.step.XmlElementSpans.Span;
 /**
  * A {@code pom.xml} read for editing and written back without reformatting.
  * Callers find the element they want to extend with the query methods and add
- * markup under it with {@link #insertUnder}; everything the file already held —
- * every whitespace character, its XML declaration, its trailing newline, and its
- * line terminator — survives {@link #write()} untouched, so the adoption commit
- * shows only the block that was added rather than a reformat of the whole file.
+ * markup under it with {@link #insertUnder}; every whitespace character, the XML
+ * declaration, the trailing newline, and the line terminator survive
+ * {@link #write()} untouched, so the adoption commit shows only the block that was
+ * added.
  *
- * <p>The DOM is only ever read: it answers which elements the POM declares and how
- * they nest, while the edit itself is text spliced into the bytes the file already
- * held. Writing an edited DOM out whole cannot keep the promise above however
- * carefully the serialiser is configured, because the details it would reformat are
- * not in the DOM to begin with: a start tag spread over several lines and an empty
- * element written {@code <rule />} both come back normalised, turning a fourteen-line
- * addition into a diff that touches the whole file. The source offsets the splice
- * needs come from {@link XmlElementSpans}. Keeping the edit textual also means added
- * elements simply inherit the POM's default namespace rather than having to be
- * qualified — and a POM that declares none stays namespace-free.
+ * <p>The DOM is only ever read — it answers which elements the POM declares and
+ * how they nest — while the edit itself is text spliced into the bytes the file
+ * already held, at the source offsets {@link XmlElementSpans} reports. Writing an
+ * edited DOM out whole cannot keep that promise however carefully the serialiser
+ * is configured, because the details it reformats are not in the DOM to begin
+ * with: a start tag spread over several lines and an empty element written
+ * {@code <rule />} both come back normalised. Keeping the edit textual also means
+ * added elements inherit the POM's default namespace rather than having to be
+ * qualified.
  *
- * <p>Added markup arrives one element per line, indented by {@link #FRAGMENT_INDENT}
- * per nesting level, and is re-indented to the document's own unit (detected from
- * the file, defaulting to two spaces) at the depth it lands at. It is inserted after
- * the parent's last child, so the parent's own closing indentation stays put.
+ * <p>Added markup arrives one element per line, indented by
+ * {@link #FRAGMENT_INDENT} per nesting level, and is re-indented to the document's
+ * own unit (detected from the file, defaulting to two spaces) at the depth it
+ * lands at. It is inserted after the parent's last child, so the parent's own
+ * closing indentation stays put.
  */
 final class PomDocument {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -14,15 +14,10 @@ import org.w3c.dom.Element;
  * {@code CLAUDE.md} is missing or malformed.
  *
  * <p>The install is idempotent: a POM that already wires the rule is left
- * untouched. A POM whose {@code build} already uses the
- * {@code maven-enforcer-plugin} for other rules has that declaration augmented in
- * place rather than skipped, so the rule is still wired in and the project keeps a
- * single enforcer entry.
- *
- * <p>{@link PomDocument} does the reading, splicing, and verbatim writing, so the
- * existing document is preserved exactly and only the newly added markup appears in
- * the adoption commit. The rule version comes from {@link EnforcerRuleVersion} and
- * must be a release.
+ * untouched, and one whose {@code build} already uses the plugin for other rules
+ * has that declaration augmented in place, so the project keeps a single enforcer
+ * entry. {@link PomDocument} does the reading, splicing, and verbatim writing, and
+ * the rule version comes from {@link EnforcerRuleVersion} and must be a release.
  */
 public class PomEnforcerInstaller {
 
@@ -116,13 +111,11 @@ public class PomEnforcerInstaller {
 	 * {@link #declaresClaudeRule} — but where it is <em>added</em> cannot be: an
 	 * execution spliced into {@code pluginManagement} only configures a plugin the
 	 * build never runs, and one spliced into a profile runs only when that profile is
-	 * activated. Neither actually enforces anything, and neither shows up as a
-	 * failure: {@code install} would report the rule wired in, {@link VerifyStep}'s
-	 * {@code mvn -N validate} would pass without the rule ever executing, and the
-	 * adoption would open a pull request advertising a guard the project does not
-	 * have. A POM whose only enforcer sits somewhere else therefore gets its own
-	 * declaration in {@code build/plugins}, exactly as a POM with no enforcer at all
-	 * does.
+	 * activated. Neither enforces anything, and neither shows up as a failure —
+	 * {@link VerifyStep}'s {@code mvn -N validate} would pass without the rule ever
+	 * executing and the adoption would advertise a guard the project does not have. A
+	 * POM whose only enforcer sits somewhere else therefore gets its own declaration
+	 * in {@code build/plugins}.
 	 */
 	private Optional<Element> enforcerPluginOfTheBuild(PomDocument pom) {
 		return pom.at(BUILD_PLUGINS).stream()

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
@@ -6,18 +6,14 @@ import io.github.adamw7.tools.adopt.Text;
 
 /**
  * The metadata a {@link PullRequestStep} opens its pull request with: the title
- * and body, plus optional reviewers, labels, and assignees to request, and
- * whether the pull request is opened as a draft. Grouping them keeps the step
- * from a telescoping constructor.
+ * and body, plus optional reviewers, labels, and assignees, and whether the pull
+ * request is opened as a draft. Grouping them keeps the step from a telescoping
+ * constructor.
  *
- * <p>A title or body that is absent or blank falls back to the adoption default —
- * the rule every optional input of the adoption follows — so the command line and
- * the MCP tool map their arguments straight in rather than each guarding an
- * omitted flag for itself, and no {@code null} can reach {@code gh}'s arguments.
- *
- * <p>The lists are defensively copied and never {@code null}, so the step can
- * translate each entry into a repeated {@code gh pr create} flag without
- * guarding against absence.
+ * <p>A title or body that is absent or blank falls back to the adoption default,
+ * and the lists are defensively copied and never {@code null}, so the command line
+ * and the MCP tool map their arguments straight in and no {@code null} can reach
+ * {@code gh}'s arguments.
  */
 public record PullRequestOptions(String title, String body, List<String> reviewers, List<String> labels,
 		List<String> assignees, boolean draft) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -19,26 +19,21 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
 /**
  * Opens a pull request for the adoption feature branch with the GitHub CLI
  * ({@code gh pr create}), targeting the repository's default branch as the base.
- * The pull request metadata — title, body, reviewers, labels, assignees, and
- * whether it is a draft — is supplied through {@link PullRequestOptions} because
- * it differs between projects; the defaults describe the Claude Code adoption
- * and request nobody.
+ * The metadata comes from {@link PullRequestOptions}; the defaults describe the
+ * Claude Code adoption and request nobody.
  *
  * <p>The step stays idempotent when re-run: it asks {@code gh pr list --state
- * open} whether an <em>open</em> pull request already exists for the branch and
- * skips creation when one does, rather than matching the wording of a failure.
- * Scoping the query to open pull requests matters because a branch whose earlier
- * pull request was closed or merged still needs a fresh one.
+ * open} whether an <em>open</em> pull request already exists for the branch rather
+ * than matching the wording of a failure. Scoping the query to open pull requests
+ * matters because a branch whose earlier one was closed or merged still needs a
+ * fresh one.
  *
  * <p>Both commands name the target repository with {@code --repo} rather than
  * letting {@code gh} infer it from the checkout's git remote, which an
  * {@code insteadOf} rewrite, an organisation mirror, or a proxied clone can leave
- * unreadable as a GitHub one — failing the very last step of an otherwise
- * complete adoption. A URL that names no owner leaves the flag off, so {@code gh}
- * falls back to its own inference.
- *
- * <p>The pull request's URL is recorded in the run's {@link AdoptionReport}, read
- * back with {@code gh pr list --json url} rather than scraped from {@code gh pr
+ * unreadable — failing the very last step of an otherwise complete adoption. A URL
+ * that names no owner leaves the flag off. The pull request's URL is read back
+ * with {@code gh pr list --json url} rather than scraped from {@code gh pr
  * create}'s human-oriented output, so both the fresh and the re-run case take one
  * structured path.
  */
@@ -168,13 +163,13 @@ public class PullRequestStep extends AbstractCommandStep {
 	}
 
 	/**
-	 * {@code gh pr list --json} writes a JSON array to stdout, but the captured
-	 * output may carry surrounding noise (update notices merged in from stderr), so
-	 * parsing starts at an opening bracket. Every bracket is tried rather than only
-	 * the first, because a diagnostic printed <em>before</em> the payload can itself
-	 * contain one; stopping there would parse the noise, conclude no pull request is
-	 * open, and make the step create a duplicate {@code gh} rejects — failing an
-	 * adoption that was only being re-run.
+	 * {@code gh pr list --json} writes a JSON array to stdout, but the captured output
+	 * may carry surrounding noise (update notices merged in from stderr), so parsing
+	 * starts at an opening bracket. Every bracket is tried rather than only the first,
+	 * because a diagnostic printed <em>before</em> the payload can itself contain one;
+	 * stopping there would parse the noise, conclude no pull request is open, and
+	 * create a duplicate {@code gh} rejects — failing an adoption that was only being
+	 * re-run.
 	 *
 	 * @return the first element's {@code url}, or empty when no bracket starts a
 	 *         JSON array, the array is empty, or it carries no textual URL

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
@@ -12,23 +12,19 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
 /**
  * Verifies up front that every external tool the pipeline shells out to is
  * available — {@code git} to clone and commit, {@code claude} to generate the
- * {@code CLAUDE.md}, and {@code gh} to open the pull request. Probing the
- * toolchain before any real work begins turns a missing {@code gh} into an
- * immediate, self-explanatory failure instead of one that only surfaces at the
- * very end, after a full clone, a {@code claude init}, and a Maven build have
- * already run.
- *
- * <p>A tool counts as available when its {@code --version} probe starts and exits
- * zero. Every required tool is probed even after one is found missing, so a
- * single failure names all of the absent tools at once.
+ * {@code CLAUDE.md}, {@code gh} to open the pull request — so a missing one fails
+ * immediately instead of at the very end, after a full clone, a
+ * {@code claude init}, and a build have already run. A tool counts as available
+ * when its {@code --version} probe starts and exits zero, and every required tool
+ * is probed even after one is found missing, so a single failure names them all.
  *
  * <p>Being installed is not enough for {@code gh}: {@code gh --version} succeeds
  * for a GitHub CLI nobody is logged in to, which the adoption would only discover
- * at {@link PullRequestStep}, its very last step. The login is therefore probed
- * here too, by asking GitHub who the credentials belong to rather than by asking
- * {@code gh} what it has stored — see {@link #AUTHENTICATION_PROBE}. The adopted
- * project's own build tool only becomes known once the repository is cloned, so
- * {@link BuildToolchainStep} probes it there.
+ * at {@link PullRequestStep}. The login is therefore probed here too, by asking
+ * GitHub who the credentials belong to rather than {@code gh} what it has stored —
+ * see {@link #AUTHENTICATION_PROBE}. The adopted project's own build tool only
+ * becomes known once the repository is cloned, so {@link BuildToolchainStep}
+ * probes it there.
  */
 public class ToolchainStep implements AdoptionStep {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
@@ -10,11 +10,11 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
 
 /**
  * Installs a build-tool-agnostic {@code CLAUDE.md} guard into a checkout that has
- * no Maven or Gradle build to wire into. The guard is a GitHub Actions workflow
- * that runs a small portable shell script on every push and pull request, failing
- * the run when the generated {@code CLAUDE.md} is missing or empty. Because the
- * adoption already targets GitHub repositories, a workflow is a guard every
- * adopted repository can run without introducing a build tool.
+ * no Maven or Gradle build to wire into: a GitHub Actions workflow that runs a
+ * small portable shell script on every push and pull request, failing the run when
+ * the generated {@code CLAUDE.md} is missing or empty. Because the adoption
+ * already targets GitHub repositories, a workflow is a guard every adopted
+ * repository can run without introducing a build tool.
  *
  * <p>Both files are committed, so the guard is shared with every contributor. The
  * script is the single source of truth: the workflow invokes it and
@@ -22,9 +22,8 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
  * adoption fails before the branch is pushed just as it would in CI.
  *
  * <p>The two are installed independently and neither is ever overwritten — the
- * rule {@link AssetInstaller} applies to every file the adoption writes — so the
- * install is idempotent and a checkout that kept the workflow but lost the script
- * has the script written back rather than failing verification on a missing file.
+ * rule {@link AssetInstaller} applies to every file the adoption writes — so a
+ * checkout that kept the workflow but lost the script has it written back.
  */
 public class WorkflowGuardInstaller {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/XmlElementSpans.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/XmlElementSpans.java
@@ -11,19 +11,17 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  * The character range every element of an XML document occupies in its source
  * text, in document order. {@link PomDocument} needs these ranges to splice an
  * edit into the bytes a {@code pom.xml} already holds: a DOM carries no record of
- * where its elements were read from, and re-serialising the whole document to get
- * the edit out reformats every line it touches — attributes that were spread over
- * several lines collapse onto one, {@code <rule />} becomes {@code <rule/>} — so
- * an adoption commit that adds a dozen lines shows up as a diff across the file.
+ * where its elements were read from, and re-serialising the whole document
+ * reformats every line it touches, turning a dozen added lines into a diff across
+ * the file.
  *
  * <p>The scan is deliberately lexical rather than a second parse: it only needs to
  * know where each element's start tag, content, and end tag begin, which the JAXP
- * parser does not report and a {@code Location}-based scan only reports to the
- * precision of the implementation. Comments, processing instructions, CDATA
- * sections, and the {@code >} characters that appear inside quoted attribute
- * values are recognised so they cannot be mistaken for markup. The document has
- * already been parsed by {@link PomDocument} before this runs, so it is known to
- * be well-formed and anything unbalanced here is a defect rather than bad input.
+ * parser does not report. Comments, processing instructions, CDATA sections, and
+ * the {@code >} characters inside quoted attribute values are recognised so they
+ * cannot be mistaken for markup. The document has already been parsed by
+ * {@link PomDocument}, so anything unbalanced here is a defect rather than bad
+ * input.
  */
 final class XmlElementSpans {
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -15,20 +15,17 @@ import io.github.adamw7.tools.enforcer.text.NameConvention;
 
 /**
  * Enforcer rule that fails the build when any custom slash command under the
- * configured commands directory is malformed. Every {@code *.md} file directly
- * in {@code commandsDir} is treated as a slash command: it must be non-empty and
+ * configured commands directory is malformed. Every {@code *.md} file directly in
+ * {@code commandsDir} is treated as a slash command: it must be non-empty and
  * carry a file name that follows the Claude Code naming convention, because the
  * command's name is taken from its file name rather than from front matter.
  * <p>
- * Front matter is optional for a command. When a command does open with a YAML
- * front matter block, the optional checks apply: a present {@code description}
- * must be non-empty; a present {@code model} must be one of {@code allowedModels}
- * when that whitelist is configured; and when {@code allowedFrontMatterKeys} is
- * configured, any key outside that set is reported, which catches typos such as
- * {@code argument-hnt}.
- * <p>
- * A commands directory with no commands is allowed; all problems found are
- * reported together.
+ * Front matter is optional for a command. When one is present, a declared
+ * {@code description} must be non-empty, a declared {@code model} must be one of
+ * {@code allowedModels} when that whitelist is configured, and any key outside a
+ * configured {@code allowedFrontMatterKeys} is reported, which catches typos such
+ * as {@code argument-hnt}. A commands directory with no commands is allowed; all
+ * problems found are reported together.
  */
 @Named("commandFormat")
 public class CommandFormatRule extends ClaudeCodeEnforcerRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/MultiDefinitionRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/MultiDefinitionRule.java
@@ -9,14 +9,14 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 /**
  * Base for the enforcer rules that check a property across <em>every</em> Claude
  * Code definition at once (currently uniqueness of names and of descriptions).
- * They all scan the same three optional directories - {@code commandsDir},
- * {@code agentsDir} and {@code skillsDir} - where a command and a sub-agent are
- * each a {@code *.md} file and a skill is a directory containing a
- * {@code SKILL.md}. This class owns that shared configuration and traversal so a
- * subclass only describes what it does with each definition.
+ * This class owns the shared configuration and traversal of the three optional
+ * directories - {@code commandsDir}, {@code agentsDir} and {@code skillsDir},
+ * where a command and a sub-agent are each a {@code *.md} file and a skill is a
+ * directory containing a {@code SKILL.md} - so a subclass only describes what it
+ * does with each definition.
  * <p>
- * The three directories are independent: each is optional and at least one must
- * be configured. A directory that is configured must exist, because that is a
+ * The directories are independent: each is optional and at least one must be
+ * configured. A directory that is configured must exist, because that is a
  * build-setup mistake rather than a content problem.
  */
 abstract class MultiDefinitionRule extends ClaudeCodeEnforcerRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRule.java
@@ -15,19 +15,18 @@ import io.github.adamw7.tools.enforcer.text.NameConvention;
 /**
  * Enforcer rule that validates a Claude Code plugin manifest, the
  * {@code .claude-plugin/plugin.json} of a plugin repository. The manifest names
- * the plugin in every marketplace listing, so a malformed one breaks
- * installation rather than the build that produced it. When present, the file
- * must be non-empty valid JSON declaring every required key ({@code name} by
- * default, overridable via {@code requiredKeys}); the {@code name} is held to
- * the Claude Code naming convention (lower-case kebab-case, at most
- * {@value NameConvention#MAX_LENGTH} characters), a {@code version} must be a
- * dotted number with optional pre-release and build-metadata suffixes, and a {@code description}
- * must be non-empty. When {@code allowedKeys} is configured, any key outside
- * that set is reported, which catches typos such as {@code descripton}.
+ * the plugin in every marketplace listing, so a malformed one breaks installation
+ * rather than the build that produced it.
  * <p>
- * Not every repository ships a plugin, so an absent manifest is a pass; the
- * rule only fails when the file is present and malformed. All problems found
- * are reported together.
+ * When present, the file must be non-empty valid JSON declaring every required key
+ * ({@code name} by default, overridable via {@code requiredKeys}). The
+ * {@code name} is held to the Claude Code naming convention (lower-case
+ * kebab-case, at most {@value NameConvention#MAX_LENGTH} characters), a
+ * {@code version} must be a dotted number with optional pre-release and
+ * build-metadata suffixes, and a {@code description} must be non-empty; a key
+ * outside a configured {@code allowedKeys} is reported, which catches typos such
+ * as {@code descripton}. Not every repository ships a plugin, so an absent
+ * manifest is a pass.
  */
 @Named("pluginFormat")
 public class PluginFormatRule extends JsonFileRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -17,20 +17,18 @@ import io.github.adamw7.tools.enforcer.text.NameConvention;
 /**
  * Enforcer rule that fails the build when any skill under the configured skills
  * directory is malformed. Every immediate subdirectory of {@code skillsDir} is
- * treated as a skill and must contain a non-empty {@code SKILL.md} that opens
- * with a YAML front matter block declaring every required key.
+ * treated as a skill and must contain a non-empty {@code SKILL.md} that opens with
+ * a YAML front matter block declaring every required key.
  * <p>
  * The required keys default to {@code name} and {@code description} but can be
- * overridden with {@code requiredKeys}. The {@code name} value is held to the
- * Claude Code naming convention: lower-case kebab-case, at most
- * {@value NameConvention#MAX_LENGTH} characters, and equal to the skill's
- * directory name. The {@code description} must be non-empty and within
- * {@code maxDescriptionLength}. When {@code allowedFrontMatterKeys} is
- * configured, any key outside that set is reported, which catches typos such as
- * {@code descripton}.
- * <p>
- * A skills directory with no skills is allowed; all problems found are reported
- * together.
+ * overridden with {@code requiredKeys}. The {@code name} is held to the Claude
+ * Code naming convention — lower-case kebab-case, at most
+ * {@value NameConvention#MAX_LENGTH} characters — and must equal the skill's
+ * directory name; the {@code description} must be non-empty and within
+ * {@code maxDescriptionLength}. A key outside a configured
+ * {@code allowedFrontMatterKeys} is reported, which catches typos such as
+ * {@code descripton}. A skills directory with no skills is allowed; all problems
+ * found are reported together.
  */
 @Named("skillFilesExist")
 public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -22,11 +22,10 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * <p>
  * The required keys default to {@code name} and {@code description}, and a
  * declared {@code description} must be non-empty, because Claude routes to a
- * sub-agent by matching intent against its description. When
- * {@code allowedModels} is configured and a definition declares a {@code model},
- * that model must be one of the allowed values, so a typo such as
- * {@code claud-opus} cannot slip through. An agents directory with no
- * definitions is allowed; all problems found are reported together.
+ * sub-agent by matching intent against it. A declared {@code model} outside a
+ * configured {@code allowedModels} is reported, so a typo such as
+ * {@code claud-opus} cannot slip through. An agents directory with no definitions
+ * is allowed; all problems found are reported together.
  */
 @Named("subAgentFormat")
 public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRule.java
@@ -14,16 +14,15 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * Enforcer rule that fails the build when two Claude Code definitions share the
  * same {@code description}. Claude routes to a skill, sub-agent, or command by
  * matching the user's intent against these descriptions, so two definitions that
- * describe themselves identically are ambiguous and one will shadow the other.
- * The rule reads the {@code description} from the front matter of every
- * sub-agent ({@code *.md}), command ({@code *.md}), and skill ({@code SKILL.md})
- * in the configured directories and reports each description used more than once,
- * naming every file that uses it.
+ * describe themselves identically are ambiguous and one will shadow the other. The
+ * rule reads the {@code description} from the front matter of every sub-agent,
+ * command, and skill in the configured directories and reports each description
+ * used more than once, naming every file that uses it.
  * <p>
  * Comparison ignores case and runs of whitespace, so {@code Reviews code.} and
- * {@code reviews   code.} are treated as the same description. Definitions with
- * no description, or a blank one, are skipped here because the format rules
- * already report those. All clashes are reported together.
+ * {@code reviews   code.} are the same description. Definitions with no
+ * description, or a blank one, are skipped here because the format rules already
+ * report those.
  */
 @Named("uniqueDescriptions")
 public class UniqueDescriptionsRule extends MultiDefinitionRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRule.java
@@ -6,16 +6,15 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 /**
  * Enforcer rule that fails the build when two Claude Code definitions claim the
- * same name. A command's name is its {@code *.md} file name, a sub-agent's name
- * is its {@code *.md} file name, and a skill's name is its directory name, so a
- * command and a sub-agent both called {@code review}, or two skills called
- * {@code commit}, are a real source of confusion. The rule gathers the names
- * from every configured directory and reports each name that is used more than
- * once, naming every file or directory that uses it.
+ * same name. A command's and a sub-agent's name is its {@code *.md} file name and
+ * a skill's name is its directory name, so a command and a sub-agent both called
+ * {@code review}, or two skills called {@code commit}, are a real source of
+ * confusion.
  * <p>
- * Uniqueness is checked across every configured directory at once, so a clash
- * between a command and a skill is caught just like a clash between two commands.
- * All clashes found are reported together.
+ * Names are gathered from every configured directory and checked across all of
+ * them at once, so a clash between a command and a skill is caught just like one
+ * between two commands. Each name used more than once is reported together with
+ * every file or directory that uses it.
  */
 @Named("uniqueNames")
 public class UniqueNamesRule extends MultiDefinitionRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
@@ -17,17 +17,16 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * Enforcer rule that keeps agent context files within a size budget.
  * {@code CLAUDE.md} is loaded into every Claude Code session, and each skill,
  * sub-agent, and command definition is loaded whenever it triggers, so an
- * unbounded file quietly taxes every conversation. The rule measures every
- * configured file (each must exist) and every {@code *.md} file under the
- * configured directories (an absent directory is skipped) against up to three
- * budgets: {@code maxBytes} (on-disk size), {@code maxLines}, and
- * {@code maxTokens} — the latter estimated with the common four-characters-per-
- * token heuristic, which is deliberately rough but stable enough for a budget.
+ * unbounded file quietly taxes every conversation.
  * <p>
- * A budget left at zero is disabled; at least one must be configured, because a
- * rule with no limits is a build-setup mistake. All files over budget are
- * reported together — the fix is to move detail into AGENTS.md or an
- * on-demand skill rather than the always-loaded context.
+ * Every configured file (each must exist) and every {@code *.md} file under the
+ * configured directories (an absent directory is skipped) is measured against up
+ * to three budgets: {@code maxBytes} (on-disk size), {@code maxLines}, and
+ * {@code maxTokens} — estimated with the common four-characters-per-token
+ * heuristic, deliberately rough but stable enough for a budget. A budget left at
+ * zero is disabled, and at least one must be configured. All files over budget are
+ * reported together; the fix is to move detail into AGENTS.md or an on-demand
+ * skill rather than the always-loaded context.
  */
 @Named("contextBudget")
 public class ContextBudgetRule extends ClaudeCodeEnforcerRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRule.java
@@ -11,17 +11,15 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 
 /**
  * Enforcer rule that keeps two documents from contradicting each other. Because
- * {@code CLAUDE.md} defers to {@code AGENTS.md} as the single source of truth,
- * any fact stated in both must agree. Each configured pattern is a regular
- * expression with one capturing group; the rule captures that group from each
- * file and fails when the captured values differ, or when the fact appears in
- * one file but not the other.
+ * {@code CLAUDE.md} defers to {@code AGENTS.md} as the single source of truth, any
+ * fact stated in both must agree.
  * <p>
- * For example the pattern {@code Java (\d+)} pins the Java version: if
- * {@code CLAUDE.md} says {@code Java 25} and {@code AGENTS.md} says
- * {@code Java 24}, the build fails. A pattern that matches in neither file is
- * ignored, so unrelated documents are unaffected. All mismatches are reported
- * together.
+ * Each configured pattern is a regular expression with one capturing group; the
+ * rule captures that group from each file and fails when the captured values
+ * differ, or when the fact appears in one file but not the other. For example the
+ * pattern {@code Java (\d+)} pins the Java version. A pattern that matches in
+ * neither file is ignored, so unrelated documents are unaffected; all mismatches
+ * are reported together.
  */
 @Named("crossDocConsistency")
 public class CrossDocConsistencyRule extends ClaudeCodeEnforcerRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
@@ -15,16 +15,13 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
 /**
  * Compares two documents against a list of single-group regular expressions and
  * reports where a captured value differs. Shared by
- * {@link CrossDocConsistencyRule} and {@link ReadmeConsistencyRule} so the
- * pattern validation and capture logic live in one place.
+ * {@link CrossDocConsistencyRule} and {@link ReadmeConsistencyRule} so the pattern
+ * validation and capture logic live in one place.
  * <p>
- * Each configured pattern must declare one capturing group; the value captured
- * from each document is compared and a mismatch becomes a violation message.
- * The two rules differ only in how they treat a fact that appears in one
- * document but not the other: mirror documents (CLAUDE.md and AGENTS.md) require
- * it in both, while a curated view (README.md against the agent docs) ignores a
- * fact the view simply chose not to repeat. That choice is the
- * {@code requireInBoth} flag.
+ * The two rules differ only in how they treat a fact that appears in one document
+ * but not the other: mirror documents (CLAUDE.md and AGENTS.md) require it in
+ * both, while a curated view (README.md against the agent docs) ignores a fact the
+ * view simply chose not to repeat. That choice is the {@code requireInBoth} flag.
  */
 final class DocumentConsistency {
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -22,20 +22,19 @@ import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
 
 /**
  * Enforcer rule that validates the {@code @path} memory imports of
- * {@code CLAUDE.md}. Claude Code loads every imported file into the session, so
- * an import that does not resolve on disk is silently missing context, and an
- * import cycle or a chain deeper than the loader's five-hop limit means part of
- * the memory is never loaded at all. The rule follows every import recursively
- * and reports a target that does not exist, a circular import, and an import
- * nested deeper than {@code maxDepth} hops.
+ * {@code CLAUDE.md}. Claude Code loads every imported file into the session, so an
+ * import that does not resolve on disk is silently missing context, and an import
+ * cycle or a chain deeper than the loader's five-hop limit means part of the
+ * memory is never loaded at all. The rule follows every import recursively and
+ * reports a target that does not exist, a circular import, and an import nested
+ * deeper than {@code maxDepth} hops.
  * <p>
- * Imports are recognised the way Claude Code evaluates them: an {@code @}
- * preceded by start-of-line or whitespace and followed by a path, outside fenced
- * code blocks and inline code spans, so {@code `@claude`} in prose is not an
- * import. A home-relative import ({@code @~/...}) is skipped because it points
- * at machine-specific state a build cannot see, and any import listed in
- * {@code ignoredImports} is skipped verbatim. Each file is scanned once; all
- * problems found are reported together.
+ * Imports are recognised the way Claude Code evaluates them: an {@code @} preceded
+ * by start-of-line or whitespace and followed by a path, outside fenced code
+ * blocks and inline code spans, so {@code `@claude`} in prose is not an import. A
+ * home-relative import ({@code @~/...}) points at machine-specific state a build
+ * cannot see and is skipped, as is any import listed in {@code ignoredImports}.
+ * Each file is scanned once; all problems found are reported together.
  */
 @Named("memoryImports")
 public class MemoryImportsRule extends ClaudeCodeEnforcerRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRule.java
@@ -14,21 +14,18 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 
 /**
  * Enforcer rule that keeps the module map in the agent docs from drifting away
- * from the real Maven reactor. {@link CrossDocConsistencyRule} pins scalar
- * facts with regular expressions, but a module added to the root {@code pom.xml}
- * and never documented is a structural gap no single pattern expresses: an
- * agent reading the docs simply never learns the module exists. This rule
- * extracts every {@code <module>} entry from the configured {@code pomFile}
- * (XML comments are ignored, so a commented-out module does not count) and
- * fails when a module's name — the last path segment, for a nested entry such
- * as {@code code/context} — does not appear in each configured doc file.
+ * from the real Maven reactor. {@link CrossDocConsistencyRule} pins scalar facts
+ * with regular expressions, but a module added to the root {@code pom.xml} and
+ * never documented is a structural gap no single pattern expresses: an agent
+ * reading the docs simply never learns the module exists.
  * <p>
- * The check is presence-only by design: how a doc arranges its module map is
- * prose, but every live module must at least be mentioned. Modules listed in
- * {@code ignoredModules} are exempt, e.g. an internal test-only module the docs
- * deliberately leave out. A pom with no {@code <module>} entries fails, because
- * pointing this rule at a non-aggregator pom is a build-setup mistake. All
- * missing mentions are reported together.
+ * The rule extracts every {@code <module>} entry from the configured
+ * {@code pomFile} (XML comments are ignored, so a commented-out module does not
+ * count) and fails when a module's name — the last path segment, for a nested
+ * entry such as {@code code/context} — does not appear in each configured doc
+ * file. The check is presence-only by design, since how a doc arranges its module
+ * map is prose. Modules listed in {@code ignoredModules} are exempt, and a pom
+ * with no {@code <module>} entries fails as a build-setup mistake.
  */
 @Named("moduleMapConsistency")
 public class ModuleMapConsistencyRule extends ClaudeCodeEnforcerRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRule.java
@@ -13,17 +13,13 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
  * Enforcer rule that keeps the README from drifting away from the agent docs.
  * {@code README.md} is a curated, example-heavy view of the same project that
  * {@code AGENTS.md} (the single source of truth) describes, so any capability or
- * version it documents must match. Each configured pattern is a regular
- * expression with one capturing group; the rule captures that group from each
- * file and fails when the README's value disagrees with the agent docs.
+ * version it documents must match. Each configured pattern is a regular expression
+ * with one capturing group, captured from each file and compared.
  * <p>
- * Unlike {@link CrossDocConsistencyRule}, a fact the README simply does not
- * repeat is not a violation: the README is allowed to document a subset. Only a
- * value present in both files that disagrees fails the build. For example the
- * pattern {@code proto(\d)} pins the supported protobuf version: if the README
- * claims {@code proto3} support while the agent docs say {@code proto2}, the
- * build fails, but a fact the README omits is ignored. All mismatches are
- * reported together.
+ * Unlike {@link CrossDocConsistencyRule}, a fact the README simply does not repeat
+ * is not a violation: only a value present in both files that disagrees fails the
+ * build. For example the pattern {@code proto(\d)} pins the supported protobuf
+ * version. All mismatches are reported together.
  */
 @Named("readmeConsistency")
 public class ReadmeConsistencyRule extends ClaudeCodeEnforcerRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
@@ -14,10 +14,10 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 
 /**
  * Enforcer rule that fails the build when an {@code .mcp.json} server entry is
- * structurally well formed at the transport level but wrong in its details.
- * Where {@link McpServersValidRule} checks that a server declares the right
+ * structurally well formed at the transport level but wrong in its details. Where
+ * {@link McpServersValidRule} checks that a server declares the right
  * {@code command} or {@code url} for its transport, this rule validates the
- * optional fields around them so a subtle mistake cannot reach Claude Code:
+ * optional fields around them:
  * <ul>
  * <li>{@code args} must be an array of strings;</li>
  * <li>{@code env} and {@code headers} must be objects whose values are all
@@ -28,8 +28,7 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
  * mixes a stdio and a remote transport in one entry.</li>
  * </ul>
  * <p>
- * A project-level {@code .mcp.json} is optional, so an absent file is a pass; the
- * rule only fails when the file is present and a server entry is malformed. All
+ * A project-level {@code .mcp.json} is optional, so an absent file is a pass; all
  * problems found are reported together.
  */
 @Named("mcpConfigFormat")

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
@@ -12,24 +12,19 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 
 /**
  * Enforcer rule that fails the build when the project's {@code .mcp.json} is
- * missing, empty, or not valid JSON. Beyond that baseline it validates the shape
- * of every entry under the {@code mcpServers} object: each server must be a JSON
- * object whose transport is well formed. A {@code stdio} server (the default when
- * no {@code type} is declared) must carry a non-blank {@code command}; an
- * {@code sse} or {@code http} server must carry a non-blank {@code url}. An
- * explicit {@code type} outside the allowed set is reported, which catches a
- * mistyped {@code htttp}.
+ * empty, not valid JSON, or declares a malformed server. Every entry under
+ * {@code mcpServers} must be a JSON object whose transport is well formed: a
+ * {@code stdio} server (the default when no {@code type} is declared) must carry a
+ * non-blank {@code command}, an {@code sse} or {@code http} server a non-blank
+ * {@code url}, and an explicit {@code type} outside {@code allowedTypes} —
+ * {@code stdio}, {@code sse}, and {@code http} by default — is reported, which
+ * catches a mistyped {@code htttp}.
  * <p>
  * A project-level {@code .mcp.json} is optional in Claude Code, so an absent file
- * is treated as a pass; the rule only fails when the file is present and
- * malformed. The rule can also assert policy on the configured servers:
- * {@code requiredServers}
- * must all be present and {@code forbiddenServers} must all be absent, so a project
- * can mandate an MCP server it relies on or ban one it does not want committed. The
- * {@code allowedTypes} whitelist defaults to {@code stdio}, {@code sse}, and
- * {@code http} and can be overridden.
- * <p>
- * All problems found are reported together.
+ * is treated as a pass. The rule can also assert policy on the configured servers:
+ * {@code requiredServers} must all be present and {@code forbiddenServers} all
+ * absent, so a project can mandate an MCP server it relies on or ban one it does
+ * not want committed. All problems found are reported together.
  */
 @Named("mcpServersValid")
 public class McpServersValidRule extends JsonFileRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Baseline.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Baseline.java
@@ -15,19 +15,17 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 /**
  * A set of already-accepted violations a rule may suppress, so a rule can be
  * turned into an error gate without first fixing every pre-existing violation:
- * a violation recorded in the baseline passes, and only a violation that is not
- * in the baseline fails the build. This lets a team graduate a rule from
- * {@code warn} to {@code error} while cleaning up the backlog behind the gate
- * rather than in one big-bang change.
+ * only a violation that is not in the baseline fails the build. This lets a team
+ * graduate a rule from {@code warn} to {@code error} while cleaning up the backlog
+ * behind the gate rather than in one big-bang change.
  * <p>
- * Each accepted violation is stored as one line of its message text. Blank lines
+ * Each accepted violation is stored as one line of its message text; blank lines
  * and lines starting with {@code #} are ignored, so the file can carry comments.
- * Signatures are normalised so a baseline written on one machine still matches on
- * another: the absolute project base directory is replaced with the token
- * {@code ${basedir}}, making a checked-in baseline portable between a developer's
- * clone and CI, whose absolute paths differ. Normalisation is applied on both
- * sides — when reading the file and when comparing a live violation — so a
- * hand-written entry with an absolute path still matches too.
+ * Signatures are normalised — the absolute project base directory is replaced with
+ * the token {@code ${basedir}} — so a checked-in baseline is portable between a
+ * developer's clone and CI. Normalisation is applied both when reading the file
+ * and when comparing a live violation, so a hand-written entry with an absolute
+ * path still matches.
  */
 final class Baseline {
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -13,28 +13,25 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * share: turning a collected list of violations into either a build failure or a
  * build warning, depending on the configured {@link #severity}.
  * <p>
- * The default severity is {@code error}, which fails the build and preserves the
- * original behaviour. Setting {@code <severity>warn</severity>} in the rule
- * configuration downgrades the same violations to a logged warning, so a team can
- * adopt a rule gradually before it is allowed to break the build. Severity only
- * governs collected structural violations; a misconfigured rule (missing file or
- * directory parameter) always fails, because that is a build-setup mistake rather
- * than a document-quality problem.
+ * The default severity is {@code error}. Setting
+ * {@code <severity>warn</severity>} downgrades the same violations to a logged
+ * warning, so a team can adopt a rule gradually before it is allowed to break the
+ * build. Severity only governs collected structural violations; a misconfigured
+ * rule (missing file or directory parameter) always fails, because that is a
+ * build-setup mistake rather than a document-quality problem.
  * <p>
  * When {@code <reportFile>} is configured the same outcome is also written as a
- * self-contained HTML report — a single table pairing what failed and why with
- * the {@link #howToFix()} steps in a "How to fix" column — so a build can surface
- * the violations in a browser or CI artifact regardless of severity. The report is
- * written whether the check passes or fails, so it always reflects the latest run.
+ * self-contained HTML report — a single table pairing what failed and why with the
+ * {@link #howToFix()} steps — so a build can surface the violations in a browser
+ * or CI artifact. It is written whether the check passes or fails, so it always
+ * reflects the latest run.
  * <p>
  * When {@code <baselineFile>} is configured, a violation already recorded in that
- * file is suppressed and only a <em>new</em> violation drives the outcome, so a
- * rule can be turned into an error gate without first fixing every pre-existing
- * violation. Record the current violations once — set {@code <writeBaseline>true</writeBaseline>}
- * or run the build with {@code -Dclaude.enforcer.writeBaseline=true}, which writes
- * the baseline and passes — then commit the file; from then on the backlog is
- * grandfathered and any newly introduced violation still fails. The HTML report
- * and the failure message reflect only the un-suppressed violations.
+ * file is suppressed and only a <em>new</em> one drives the outcome. Record the
+ * current violations once — {@code <writeBaseline>true</writeBaseline>} or
+ * {@code -Dclaude.enforcer.writeBaseline=true}, which writes the baseline and
+ * passes — then commit the file. The HTML report and the failure message reflect
+ * only the un-suppressed violations.
  */
 public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
@@ -11,13 +11,12 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 /**
  * Renders a self-contained HTML report of a rule's outcome and writes it to a
- * file. When there are violations the page shows a single numbered table with the
- * header plus a "What failed and why" column (one collected violation per row) and
- * a "How to fix" column (the remediation steps the rule supplies). The two lists
- * are independent, so rows run to the longer of the two and the shorter column is
- * left blank once it runs out. When there are no violations it renders a short
- * "passed" page, so a configured report file always reflects the latest run rather
- * than leaving a stale failure behind.
+ * file. When there are violations the page shows a single numbered table pairing a
+ * "What failed and why" column (one collected violation per row) with a "How to
+ * fix" column (the remediation steps the rule supplies); the two lists are
+ * independent, so rows run to the longer of the two. When there are none it
+ * renders a short "passed" page, so a configured report file never leaves a stale
+ * failure behind.
  * <p>
  * The document is inlined (styles included, no external assets) so it opens
  * anywhere, and every piece of rule-supplied text is HTML-escaped so a violation

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -9,19 +9,18 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
- * Base for enforcer rules that validate a single JSON configuration file. It
- * owns the scaffolding every such rule repeats: the file parameter must be
- * configured, the file must exist (unless the subclass treats absence as a
- * pass), it must be non-empty, and it must parse as JSON. A parse failure is
- * collected as a violation rather than thrown, so it is reported through the
- * shared {@link #report} path alongside any structural problems.
+ * Base for enforcer rules that validate a single JSON configuration file. It owns
+ * the scaffolding every such rule repeats: the file parameter must be configured,
+ * the file must exist (unless the subclass treats absence as a pass), be non-empty,
+ * and parse as JSON. A parse failure is collected as a violation rather than
+ * thrown, so it is reported through the shared {@link #report} path alongside any
+ * structural problems.
  * <p>
- * Subclasses contribute the file, its parameter name, a human-readable
- * description used in messages, the report header, and the document-specific
- * checks against the parsed {@link JsonNode}. A misconfigured rule (missing
- * file parameter) or a missing or empty file always fails, because that is a
- * build-setup mistake; a rule whose file is optional overrides
- * {@link #handleMissingFile} to pass instead.
+ * Subclasses contribute the file, its parameter name, a human-readable description
+ * used in messages, the report header, and the document-specific checks against
+ * the parsed {@link JsonNode}. A misconfigured rule or a missing or empty file
+ * always fails, because that is a build-setup mistake; a rule whose file is
+ * optional overrides {@link #handleMissingFile} to pass instead.
  */
 public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -13,28 +13,23 @@ import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
 
 /**
  * Base for enforcer rules that validate a Markdown document follows an expected
- * structure: it must exist, be non-empty, start with a required title heading
- * (a leading UTF-8 BOM is tolerated), and contain every required section
- * heading as a real, non-empty heading.
+ * structure: it must exist, be non-empty, start with a required title heading (a
+ * leading UTF-8 BOM is tolerated), and contain every required section heading as a
+ * real, non-empty heading.
  * <p>
  * Headings are matched on whole lines outside fenced code blocks, so a heading
- * mentioned inside a {@code ```} fence or in prose does not satisfy a
- * requirement, and a partial match such as {@code # CLAUDE.md-extended} does
- * not satisfy {@code # CLAUDE.md}. All structural problems are collected and
- * reported together rather than one per build.
+ * mentioned inside a fence or in prose does not satisfy a requirement, and a
+ * partial match such as {@code # CLAUDE.md-extended} does not satisfy
+ * {@code # CLAUDE.md}. All structural problems are collected and reported
+ * together.
  * <p>
- * Beyond the mandatory structure, several optional checks can be switched on
- * from the rule configuration: a list of {@code forbiddenTokens} that must not
- * appear outside code fences, {@code enforceSectionOrder} to require the
- * sections in the configured order, a {@code maxLineLength} cap, and
- * {@code validateFileReferences} to confirm that Markdown links to local files
- * resolve to something on disk. Each is disabled by default, so existing
- * configurations are unaffected.
- * <p>
- * The title and required sections default to the subclass-provided values but
- * can be overridden from the rule configuration, so the rule is reusable across
- * projects without a recompile. Subclasses contribute the file, its name, the
- * required sections, and any document-specific checks.
+ * Several optional checks, each disabled by default, can be switched on from the
+ * rule configuration: {@code forbiddenTokens} that must not appear outside code
+ * fences, {@code enforceSectionOrder}, a {@code maxLineLength} cap, and
+ * {@code validateFileReferences} to confirm that links to local files resolve on
+ * disk. The title and required sections default to the subclass-provided values
+ * but can be overridden, so the rule is reusable across projects without a
+ * recompile.
  */
 public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
@@ -18,22 +18,19 @@ import io.github.adamw7.tools.enforcer.rule.ScanTargets;
  * Enforcer rule that fails the build when a configured file contains what looks
  * like a literal credential. Claude Code configuration is a natural place for a
  * key to leak — an API token pasted into a {@code .mcp.json} {@code env} or
- * {@code headers} block, a {@code settings.json} environment variable, or a
- * hook script — and once committed it must be rotated, so the cheapest fix is to
- * refuse the commit's build. The scanned targets are the configured
- * {@code files} plus every regular file under the configured
- * {@code directories}; an absent target is skipped, because most of these files
- * are optional.
+ * {@code headers} block, a {@code settings.json} environment variable, or a hook
+ * script — and once committed it must be rotated, so the cheapest fix is to refuse
+ * the commit's build.
  * <p>
- * Each match is reported with its file, line, and the kind of credential it
+ * The scanned targets are the configured {@code files} plus every regular file
+ * under the configured {@code directories}; an absent target is skipped, because
+ * most of these files are optional, and so is a file that cannot be decoded as
+ * text. Each match is reported with its file, line, and the kind of credential it
  * resembles, but only the first characters of the match itself, so the report
  * never republishes the secret it found. The default patterns cover common API
  * token formats (Anthropic, AWS, GitHub, Slack, private key blocks); custom
- * {@code secretPatterns} regular expressions are scanned in addition, or
- * instead when {@code useDefaultPatterns} is switched off. A file that cannot
- * be decoded as text (e.g. a binary asset) is skipped. All problems found are
- * reported together — the fix is to move the value into an environment variable
- * expansion such as {@code ${API_KEY}} and rotate the leaked credential.
+ * {@code secretPatterns} are scanned in addition, or instead when
+ * {@code useDefaultPatterns} is switched off.
  */
 @Named("noSecrets")
 public class NoSecretsRule extends ClaudeCodeEnforcerRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/Gitignore.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/Gitignore.java
@@ -5,15 +5,14 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 /**
- * A parsed {@code .gitignore}, able to answer whether a repository-relative
- * file path is ignored. It implements the subset of gitignore semantics the
+ * A parsed {@code .gitignore}, able to answer whether a repository-relative file
+ * path is ignored. It implements the subset of gitignore semantics the
  * {@link LocalSettingsIgnoredRule} needs: comments and blank lines are skipped,
  * {@code !} negates, a trailing {@code /} restricts a pattern to directories, a
  * pattern containing a {@code /} is anchored to the gitignore's directory while
- * one without matches at any depth, and {@code *}, {@code ?}, and {@code **}
- * glob within and across path segments respectively. Later lines override
- * earlier ones, and a file is also ignored when any of its ancestor directories
- * is.
+ * one without matches at any depth, and {@code *}, {@code ?}, and {@code **} glob
+ * within and across path segments respectively. Later lines override earlier ones,
+ * and a file is also ignored when any of its ancestor directories is.
  * <p>
  * Paths are matched with {@code /} separators and no leading slash, exactly as
  * they appear in {@code git status} output.

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -12,24 +12,18 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 
 /**
  * Enforcer rule that fails the build when the {@code hooks} section of
- * {@code .claude/settings.json} is malformed. The file must exist, be non-empty,
- * and parse as JSON. When a {@code hooks} object is present, every event must map
- * to an array of groups, every group must carry a {@code hooks} array, and every
- * hook in it must declare a non-blank {@code type}; a {@code command} hook must
- * also declare a non-blank {@code command}.
+ * {@code .claude/settings.json} is malformed. When a {@code hooks} object is
+ * present, every event must map to an array of groups, every group must carry a
+ * {@code hooks} array, and every hook in it must declare a non-blank {@code type};
+ * a {@code command} hook must also declare a non-blank {@code command}.
  * <p>
  * A command that points at a project-local script through the
- * {@code $CLAUDE_PROJECT_DIR} variable is resolved against {@code projectDir}
- * (the parent of the settings file's directory by default) and must exist on
- * disk, so a renamed or missing hook script such as
- * {@code $CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh} is caught. This
- * check is on by default and can be switched off with
- * {@code validateScriptReferences}. When {@code allowedEvents} is configured, any
- * event name outside that set is reported, which catches a mistyped
- * {@code SessionSart}.
- * <p>
- * A settings file without a {@code hooks} object is allowed; all problems found
- * are reported together.
+ * {@code $CLAUDE_PROJECT_DIR} variable is resolved against {@code projectDir} (the
+ * parent of the settings file's directory by default) and must exist on disk, so a
+ * renamed or missing hook script is caught; the check is on by default and can be
+ * switched off with {@code validateScriptReferences}. An event name outside a
+ * configured {@code allowedEvents} is reported, which catches a mistyped
+ * {@code SessionSart}. A settings file without a {@code hooks} object is allowed.
  */
 @Named("hookCommandsValid")
 public class HookCommandsValidRule extends JsonFileRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -21,28 +21,26 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
 /**
- * Enforcer rule that fails the build when a hook script under {@code .claude/hooks}
- * is not a well-formed executable, or when {@code .claude/settings.json} wires a
- * command hook to a script that should live in that directory but does not.
+ * Enforcer rule that fails the build when a hook script under
+ * {@code .claude/hooks} is not a well-formed executable, or when
+ * {@code .claude/settings.json} wires a command hook to a script that should live
+ * in that directory but does not.
  * <p>
  * Where {@link HookCommandsValidRule} validates the JSON shape of the
- * {@code hooks} section, this rule validates the scripts themselves: every
- * regular file directly under {@code hooksDir} must be non-empty, start with a
- * {@code #!} shebang line, and carry the executable bit, so a hook that Claude
- * Code would try to run cannot be committed broken. Each of the script checks can
- * be switched off ({@code requireShebang}, {@code requireExecutable}), and an
- * optional {@code allowedExtensions} whitelist rejects a stray file such as a
- * {@code .txt} note left in the hooks directory.
+ * {@code hooks} section, this rule validates the scripts themselves: every regular
+ * file directly under {@code hooksDir} must be non-empty, start with a {@code #!}
+ * shebang line, and carry the executable bit, so a hook Claude Code would try to
+ * run cannot be committed broken. Each script check can be switched off
+ * ({@code requireShebang}, {@code requireExecutable}), and an optional
+ * {@code allowedExtensions} whitelist rejects a stray file such as a {@code .txt}
+ * note left in the directory.
  * <p>
- * When {@code settingsFile} is configured, the rule cross-checks the wiring: any
- * command hook whose command resolves a {@code $CLAUDE_PROJECT_DIR} path into the
- * hooks directory must point at a script that exists there, catching a hook
- * renamed on disk but not in settings. With {@code reportUnreferencedScripts} a
- * script in the directory that no hook references is reported too.
- * <p>
- * The {@code hooksDir} parameter must be configured, but an absent directory is a
- * pass because hooks are optional in Claude Code. All problems found are reported
- * together.
+ * When {@code settingsFile} is configured, any command hook whose command resolves
+ * a {@code $CLAUDE_PROJECT_DIR} path into the hooks directory must point at a
+ * script that exists there, catching a hook renamed on disk but not in settings;
+ * {@code reportUnreferencedScripts} also reports a script no hook references. The
+ * {@code hooksDir} parameter must be configured, but an absent directory is a pass
+ * because hooks are optional. All problems found are reported together.
  */
 @Named("hooksFormat")
 public class HooksFormatRule extends ClaudeCodeEnforcerRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRule.java
@@ -16,15 +16,14 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * personal Claude Code settings file. {@code .claude/settings.local.json} holds
  * per-developer overrides — extra permissions, local hooks — and committing it
  * imposes one developer's choices on the whole team, so the durable guard is a
- * gitignore entry that keeps it out of the repository in the first place.
+ * gitignore entry.
  * <p>
- * The rule parses the configured {@code gitignoreFile} and verifies each path
- * in {@code ignoredPaths} (by default just
- * {@code .claude/settings.local.json}) is matched by it, honouring negations,
- * anchoring, directory patterns, and {@code *}/{@code ?}/{@code **} globs. A
- * path can be covered by any equivalent pattern — the exact path, a
- * {@code *.local.json} glob, or an ignored ancestor directory. All uncovered
- * paths are reported together.
+ * The rule parses the configured {@code gitignoreFile} and verifies each path in
+ * {@code ignoredPaths} (by default just {@code .claude/settings.local.json}) is
+ * matched by it, honouring negations, anchoring, directory patterns, and
+ * {@code *}/{@code ?}/{@code **} globs. Any equivalent pattern will do — the exact
+ * path, a {@code *.local.json} glob, or an ignored ancestor directory. All
+ * uncovered paths are reported together.
  */
 @Named("localSettingsIgnored")
 public class LocalSettingsIgnoredRule extends ClaudeCodeEnforcerRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
@@ -18,24 +18,20 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
  * Enforcer rule that validates the entries of the {@code permissions} lists in
  * {@code .claude/settings.json}. Where {@link SettingsJsonValidRule} asserts
  * policy (which entries must or must not be present), this rule validates the
- * entries themselves: every value in {@code allow}, {@code deny}, and
- * {@code ask} must be a non-blank string of the form {@code Tool} or
- * {@code Tool(specifier)}, because a malformed entry such as {@code Bash(mvn *}
- * grants nothing and fails silently at runtime. A duplicated entry within a
- * list and an entry that appears in both {@code allow} and {@code deny} are
- * reported too, since the contradiction means one of the two is not doing what
- * its author intended.
+ * entries themselves: every value in {@code allow}, {@code deny}, and {@code ask}
+ * must be a non-blank string of the form {@code Tool} or {@code Tool(specifier)},
+ * because a malformed entry such as {@code Bash(mvn *} grants nothing and fails
+ * silently at runtime. A duplicate within a list, and an entry that appears in
+ * both {@code allow} and {@code deny}, are reported too.
  * <p>
- * When {@code allowedTools} is configured, the tool-name part of every entry
- * must be in that list, so a typo such as {@code Bsah(mvn *)} cannot slip
- * through; entries naming MCP tools (prefixed {@code mcp__}) are exempt because
- * their names are defined by the project's servers, not by Claude Code. When
- * {@code forbiddenEntryPatterns} is configured, an {@code allow} entry matching
- * any of the regular expressions is reported, so an over-broad grant such as
- * {@code Bash(*)} can be banned by shape rather than by exact spelling.
- * <p>
- * A settings file without a {@code permissions} section passes, since there is
- * nothing to validate. All problems found are reported together.
+ * When {@code allowedTools} is configured, the tool-name part of every entry must
+ * be in that list, so a typo such as {@code Bsah(mvn *)} cannot slip through;
+ * entries naming MCP tools (prefixed {@code mcp__}) are exempt because their names
+ * are defined by the project's servers. When {@code forbiddenEntryPatterns} is
+ * configured, an {@code allow} entry matching any of the regular expressions is
+ * reported, so an over-broad grant such as {@code Bash(*)} can be banned by shape
+ * rather than by exact spelling. A file without a {@code permissions} section
+ * passes.
  */
 @Named("permissionsFormat")
 public class PermissionsFormatRule extends JsonFileRule {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
@@ -7,23 +7,22 @@ import java.util.regex.Pattern;
 
 /**
  * Repairs the unambiguous ways a Claude Code front matter block is commonly
- * malformed, so an auto-fixing rule can rewrite the file rather than only fail
- * the build:
+ * malformed, so an auto-fixing rule can rewrite the file rather than only fail the
+ * build:
  * <ul>
  * <li>a delimiter written with too many dashes, such as {@code ----}, which
  * {@link FrontMatter} does not recognise as the canonical {@code ---};</li>
- * <li>an opening {@code ---} whose closing delimiter is missing, which leaves
- * the block unterminated; and</li>
+ * <li>an opening {@code ---} whose closing delimiter is missing; and</li>
  * <li>blank lines before the opening delimiter, which Claude Code does not
  * accept — the block must start on the first line.</li>
  * </ul>
  * <p>
  * The repair is deliberately conservative: it only acts when the document opens
- * (past any leading blank lines) with a dashes-only line and the region that
- * would become the block actually contains at least one {@code key: value}
- * entry, so a lone {@code ---} thematic break is never mistaken for front
- * matter. A document whose front matter already parses, or whose problem is not
- * one of the above, is left untouched and reported by the rule as before.
+ * (past any leading blank lines) with a dashes-only line and the region that would
+ * become the block actually contains at least one {@code key: value} entry, so a
+ * lone {@code ---} thematic break is never mistaken for front matter. A document
+ * whose front matter already parses, or whose problem is not one of the above, is
+ * left untouched.
  */
 public final class FrontMatterFixer {
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -6,16 +6,15 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * A parsed Markdown document: its lines plus a mask marking which lines belong
- * to a fenced code block. Parsing the fence mask once, at construction, lets the
- * structural checks share it instead of each rebuilding it.
+ * A parsed Markdown document: its lines plus a mask marking which lines belong to
+ * a fenced code block. Parsing the mask once, at construction, lets the structural
+ * checks share it instead of each rebuilding it.
  * <p>
- * Headings are recognised on whole lines outside fenced code blocks, so a
- * heading mentioned inside a {@code ```} or {@code ~~~} fence or in prose is not
- * treated as document structure. The fence mask includes the opening and closing
- * delimiters themselves, so heading detection and body detection agree on what is
- * code and what is structure. A fence opened with one delimiter is only closed by
- * the same delimiter, so a {@code ~~~} line inside a {@code ```} block stays code.
+ * Headings are recognised on whole lines outside fenced code blocks, so a heading
+ * mentioned inside a fence or in prose is not treated as document structure. The
+ * mask includes the opening and closing delimiters themselves, so heading and body
+ * detection agree on what is code; a fence is only closed by the delimiter that
+ * opened it, so a {@code ~~~} line inside a {@code ```} block stays code.
  */
 public final class MarkdownDocument {
 

--- a/code/context/src/main/java/io/github/adamw7/context/Finder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/Finder.java
@@ -11,14 +11,12 @@ import java.util.stream.Collectors;
  * resolution step.
  *
  * <p>Resolution is by simple file name (a referenced {@code Foo} resolves to a
- * {@code Foo} source file of the configured {@link Language}). The containers are
- * indexed by file name once at construction, so each reference resolves in
- * constant time rather than by scanning every container. Comments, string and
- * character literals are stripped before matching so that class names mentioned
- * there are not reported as dependencies. Two source files sharing the same
- * simple name in different packages still cannot be told apart — that needs
- * package-aware resolution, which this name-based finder does not attempt (see
- * {@link PackageAwareFinder}); the first one encountered while indexing wins.
+ * {@code Foo} source file of the configured {@link Language}), with the containers
+ * indexed by file name once at construction so each reference resolves in constant
+ * time. Comments, string and character literals are stripped before matching, so
+ * class names mentioned there are not reported as dependencies. Two source files
+ * sharing a simple name in different packages cannot be told apart — the first one
+ * indexed wins; that needs the package-aware {@link PackageAwareFinder}.
  */
 public class Finder extends AbstractFinder {
 

--- a/code/context/src/main/java/io/github/adamw7/context/PackageAwareFinder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/PackageAwareFinder.java
@@ -11,20 +11,17 @@ import java.util.stream.Collectors;
  * A {@link Context} that resolves dependencies using each source's {@code package}
  * declaration and {@code import} statements, so two classes that share a simple
  * name in different packages can be told apart — the gap the name-based
- * {@link Finder} explicitly leaves open. A referenced {@code Foo} resolves, in
- * order of preference, to: an explicitly imported {@code a.b.Foo}; a {@code Foo}
- * in the referencing file's own package; a {@code Foo} reachable through a
- * wildcard import {@code a.b.*}; or, only when exactly one {@code Foo} exists in
- * the whole project, that sole candidate. An ambiguous reference with no import to
+ * {@link Finder} leaves open. A referenced {@code Foo} resolves, in order of
+ * preference, to an explicitly imported {@code a.b.Foo}, a {@code Foo} in the
+ * referencing file's own package, one reachable through a wildcard import
+ * {@code a.b.*}, or — only when exactly one {@code Foo} exists in the whole
+ * project — that sole candidate. An ambiguous reference with no import to
  * disambiguate it is left unresolved rather than guessed.
  *
- * <p>Like {@link Finder}, traversal is the depth-bounded breadth-first expansion
- * provided by {@link AbstractFinder} in which every class is visited once, so
- * cycles terminate and the root is never reported as its own dependency. Comments
- * and string or character literals are stripped before matching. The
- * package/import grammar this relies on ({@code package a.b;} and
- * {@code import a.b.C;}) is shared by Java, Kotlin and Scala, so it serves every
- * {@link Language} the finder supports.
+ * <p>Traversal is the depth-bounded breadth-first expansion of
+ * {@link AbstractFinder}, and comments and string or character literals are
+ * stripped before matching. The package/import grammar this relies on is shared by
+ * Java, Kotlin and Scala, so it serves every {@link Language} the finder supports.
  */
 public class PackageAwareFinder extends AbstractFinder {
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/TlsConfiguration.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/TlsConfiguration.java
@@ -12,33 +12,27 @@ import org.springframework.context.annotation.Configuration;
  * Hardens the embedded server's HTTPS transport. When the streamable HTTP
  * transport is served over HTTPS (SSL enabled through {@code server.ssl.*}), this
  * customiser applies two guarantees regardless of what the deployment
- * configuration requested, so they hold independent of how {@code server.ssl.*}
- * is set:
+ * configuration requested:
  *
  * <ol>
  * <li>the only enabled protocol is pinned to {@code TLSv1.3}, so older, weaker
  * protocols can never be negotiated; and</li>
  * <li>the post-quantum {@code X25519MLKEM768} hybrid group is preferred for the
- * TLS 1.3 key exchange, with classical elliptic-curve groups kept as a fallback
- * so peers that cannot do the hybrid exchange still connect.</li>
+ * TLS 1.3 key exchange, with classical elliptic-curve groups kept as a fallback so
+ * peers that cannot do the hybrid exchange still connect.</li>
  * </ol>
  *
  * <p>{@code X25519MLKEM768} combines a NIST ML-KEM-768 key encapsulation with the
- * classical X25519 exchange; the derived secret stays secure as long as
- * <em>either</em> primitive holds, which defends against "harvest now, decrypt
- * later" attacks by a future quantum adversary. It is requested through the
- * JVM-wide {@code jdk.tls.namedGroups} property, which lists the hybrid group
- * first (so it is preferred) followed by classical groups (so the handshake
- * degrades gracefully). Because that list also names supported classical groups,
- * a JDK whose TLS provider does not yet ship {@code X25519MLKEM768} — such as the
- * SunJSSE provider in JDK 25 — simply ignores the unknown group and negotiates a
- * classical one; the hybrid exchange then activates automatically once the
- * provider supports it, with no code change. The property is set only when HTTPS
- * is enabled, before the connector starts its TLS stack, so SunJSSE reads it when
- * initialising its supported groups.
+ * classical X25519 exchange, so the derived secret stays secure as long as
+ * <em>either</em> primitive holds — the defence against "harvest now, decrypt
+ * later". It is requested through the JVM-wide {@code jdk.tls.namedGroups}
+ * property, which lists the hybrid group first and the classical ones after, so a
+ * JDK whose TLS provider does not yet ship it (SunJSSE in JDK 25) ignores the
+ * unknown group and negotiates a classical one, picking the hybrid up later with
+ * no code change. The property is set only when HTTPS is enabled, before the
+ * connector starts its TLS stack.
  *
- * <p>Plain HTTP and disabled SSL are left untouched — there is no TLS to
- * constrain in those cases.
+ * <p>Plain HTTP and disabled SSL are left untouched.
  */
 @Configuration
 public class TlsConfiguration {

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
@@ -8,20 +8,19 @@ import io.github.adamw7.tools.data.structure.internal.DoubleHashing;
 import io.github.adamw7.tools.data.structure.internal.Primes;
 
 /**
- * A primitive {@code int}-keyed sibling of {@link OpenAddressingMap}. It uses
- * the same double-hashing open-addressing strategy, but stores keys in an
- * {@code int[]} so that lookups and inserts never box the key. This makes it an
- * allocation-light choice for large, integer-keyed maps where the autoboxing of
- * a {@code Map<Integer, V>} would dominate.
+ * A primitive {@code int}-keyed sibling of {@link OpenAddressingMap}: the same
+ * double-hashing open-addressing strategy, but keys live in an {@code int[]} so
+ * lookups and inserts never box. That makes it an allocation-light choice for
+ * large, integer-keyed maps where the autoboxing of a {@code Map<Integer, V>}
+ * would dominate.
  *
- * <p>It deliberately does <em>not</em> implement {@link java.util.Map}, because
- * that interface is defined in terms of {@code Object} keys and would reintroduce
- * the boxing this class exists to avoid. The API mirrors the relevant map
- * operations with primitive {@code int} keys instead.
- *
- * <p>Like {@link OpenAddressingMap}, {@code null} values are stored faithfully
- * and reported by {@link #containsKey(int)}; only {@link #get(int)} cannot tell a
- * stored {@code null} from an absent key. The class is not thread-safe.
+ * <p>It deliberately does <em>not</em> implement {@link java.util.Map}, which is
+ * defined in terms of {@code Object} keys and would reintroduce the boxing this
+ * class exists to avoid; the API mirrors the relevant map operations with
+ * primitive keys instead. As in {@link OpenAddressingMap}, {@code null} values are
+ * stored faithfully and reported by {@link #containsKey(int)}; only
+ * {@link #get(int)} cannot tell a stored {@code null} from an absent key. Not
+ * thread-safe.
  */
 public class IntKeyOpenAddressingMap<V> {
 

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
@@ -115,17 +115,17 @@ public abstract class AbstractUniqueness<T extends ColumnarDataSource> implement
 	protected abstract Result checkSubset(String[] newCandidates);
 
 	/**
-	 * Runs the uniqueness check over the already-open {@link #dataSource}. The public
-	 * {@link #exec} opens the source before calling this; {@link #execForAllColumns}
-	 * opens the source to read its column names and then reuses that same open source,
-	 * so neither entry point opens the source twice &mdash; which the open-once
-	 * map-backed in-memory sources reject with {@code DataSource is already open}.
+	 * Runs the uniqueness check over the already-open {@link #dataSource}. Both public
+	 * entry points open the source exactly once before calling this — {@link #exec}
+	 * directly, {@link #execForAllColumns} while reading the column names — because
+	 * the open-once map-backed in-memory sources reject a second open with
+	 * {@code DataSource is already open}.
 	 *
 	 * <p>Implementations must not close the source: the subset search that follows a
 	 * successful check {@link IterableDataSource#reset() resets} it between passes,
-	 * and a source that owns its connection (the Parquet ones) cannot be reopened
-	 * once closed. The public entry points close the source exactly once, after the
-	 * whole check &mdash; subsets included &mdash; has finished.
+	 * and a source that owns its connection (the Parquet ones) cannot be reopened once
+	 * closed. The public entry points close it exactly once, after the whole check —
+	 * subsets included — has finished.
 	 */
 	protected abstract Result execOnOpenSource(String[] keyCandidates);
 

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
@@ -34,16 +34,14 @@ import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 
 /**
  * Wires an MCP server over one of four transports, selected with
- * {@code --transport.mode}: stdio (the default), a streamable HTTP transport
- * ({@code streamable-http}) registered at {@code /mcp}, a stateless HTTP transport
- * ({@code stateless-http}) also registered at {@code /mcp} that answers each
- * JSON-RPC request in isolation without keeping any session, or the legacy HTTP+SSE
- * transport ({@code sse}) registered at {@code /sse} (the event stream) and
- * {@code /mcp/message} (the JSON-RPC POST endpoint) for clients that predate
- * streamable HTTP. Concrete servers only supply their {@link #serverName() name}
- * and their {@link #tools() tools}; everything else is shared here. Subclasses are
- * the {@code @Configuration} beans, so the {@code @Bean} methods below are picked
- * up through them.
+ * {@code --transport.mode}: stdio (the default); a streamable HTTP transport
+ * ({@code streamable-http}) at {@code /mcp}; a stateless HTTP transport
+ * ({@code stateless-http}), also at {@code /mcp}, answering each JSON-RPC request
+ * in isolation without keeping any session; and the legacy HTTP+SSE transport
+ * ({@code sse}) at {@code /sse} and {@code /mcp/message} for clients that predate
+ * streamable HTTP. Concrete servers supply only their {@link #serverName() name}
+ * and their {@link #tools() tools}, and are the {@code @Configuration} beans
+ * through which the {@code @Bean} methods below are picked up.
  */
 public abstract class AbstractMcpConfiguration {
 


### PR DESCRIPTION
The class and method Javadoc had grown into narrative essays — several
blocks ran 200-300 words — so the summary a reader actually needs was
buried in rationale.

Rewrite the 65 blocks of 120 words or more across adopt,
claude-code-enforcer, code/context, data, and mcp-common: keep the
opening summary and the genuinely non-obvious "why", drop the
restatements and the walkthroughs of what the code already shows. No
behaviour changes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FWqHEytDZZjLkmvPqsFuUg