### PR TITLE
fix(adopt): use build wrappers, isolate input failures, mask credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,14 @@ Maven project. The notable capabilities are:
   verified by running that task; a repository with no recognised build file falls
   back to a GitHub Actions workflow and the portable `.github/claude-md-guard.sh`
   check it runs, verified by running that script — so a build-less repository
-  still keeps the guard. The pull request metadata — title, body,
+  still keeps the guard. A checkout that ships a build wrapper (`mvnw`, `gradlew`,
+  or their Windows `.cmd`/`.bat` forms) is verified with that wrapper rather than
+  with a build tool off the `PATH`, so the guard runs under the version the
+  project pinned; most Gradle projects ship only the wrapper, so probing the
+  `PATH` for a `gradle` used to abort the adoption of a repository the host could
+  build perfectly well. The wrapper is launched by its absolute path, since
+  `ProcessBuilder` resolves a relative program name against the JVM's working
+  directory rather than the command's. The pull request metadata — title, body,
   reviewers, labels, assignees, and draft flag — is supplied through
   `PullRequestOptions`, exposed on the command line as `--title`, `--body`,
   repeatable `--reviewer`/`--label`/`--assignee`, and `--draft` (parsed by
@@ -70,7 +77,12 @@ Maven project. The notable capabilities are:
   workspace. `BatchAdoption` runs the pipeline once per repository with a report
   each and does *not* stop at the first failure: the adoptions are independent, so
   a failed one is recorded and the batch runs to the end, with `Main` raising the
-  failures together afterwards so the process still exits non-zero. The MCP tool
+  failures together afterwards so the process still exits non-zero. That covers
+  the failures a repository's *inputs* raise too — `Checkouts` claims each
+  repository's checkout directory inside its own adoption, so a URL naming no
+  repository, or one colliding with a checkout another repository of the run
+  already claimed, is that repository's recorded failure rather than an abort of
+  the whole run before its first clone. The MCP tool
   takes the same list as `repository_urls` (a JSON array, or a comma-separated
   string) beside `repository_url`, and answers with an error result carrying the
   report — not a bare exception — when a repository fails.
@@ -97,7 +109,12 @@ Maven project. The notable capabilities are:
   (completed steps, the pull request URL read back with `gh pr list --json url`,
   and whether the run succeeded plus the failing step's message when it did not);
   `--report <file>` writes it as JSON for scripting, on the failure path too, so
-  an abandoned run still records how far it got. A run over several repositories
+  an abandoned run still records how far it got. Everything that outlives a run —
+  the log, a failing command's message, and that report — reports clone URLs
+  through `Redaction`, which masks the user information of a URL carrying a
+  scheme, so the `https://x-access-token:TOKEN@github.com/...` a CI runner hands
+  the adoption never reaches a file on disk or an MCP client; `git` is still
+  handed the URL as it was given. A run over several repositories
   writes the batch document instead — an overall `succeeded` and a `repositories`
   array of those same per-repository documents — while a single-repository run
   keeps writing its document unwrapped, so the shape existing consumers parse is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,10 @@ run `mvn install` from the repository root. The main capabilities are:
   `--title`, `--reviewer`, and `--draft`); the default branch is never written to
   directly. One run adopts a list of repositories — repeatable `--repo <url>` or
   `--repos <file>` on the command line, `repository_urls` on the MCP tool — each
-  with its own report, and a repository that fails does not stop the rest. An optional `--assets` flag commits starter Claude Code
+  with its own report, and a repository that fails does not stop the rest — a
+  malformed URL included, since each checkout is claimed inside its own
+  adoption. Clone-URL credentials are masked in every log, message, and report.
+  An optional `--assets` flag commits starter Claude Code
   configuration assets (an `AGENTS.md` pointer, `.claude/settings.json`, a
   session-start hook stub, `.mcp.json`, and an `@claude`-mention workflow); each
   run returns an `AdoptionReport` with the pull request URL, written as JSON via

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -32,8 +32,14 @@ public final class AdoptionContext {
 		this.branchName = Text.required(branchName, "branchName");
 	}
 
+	/** The clone URL as given, credentials included, for the commands that need it. */
 	public String repositoryUrl() {
 		return repository.value();
+	}
+
+	/** @see RepositoryUrl#redacted() */
+	public String displayUrl() {
+		return repository.redacted();
 	}
 
 	/** @see RepositoryUrl#slug() */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
@@ -51,7 +51,7 @@ public class AdoptionReportWriter {
 	private ObjectNode toNode(AdoptionRun run) {
 		ObjectNode node = mapper.createObjectNode();
 		node.put("repositoryUrl", run.repositoryUrl());
-		node.put("branch", run.context().branchName());
+		node.put("branch", run.branchName());
 		node.put("pullRequestUrl", run.report().pullRequestUrl().orElse(null));
 		node.put("succeeded", run.succeeded());
 		node.put("failure", run.failure().orElse(null));

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionRun.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionRun.java
@@ -3,19 +3,23 @@ package io.github.adamw7.tools.adopt;
 import java.util.Optional;
 
 /**
- * One repository's adoption within a run: the inputs it was given and the report
+ * One repository's adoption within a run: what it was asked to do and the report
  * it produced. A batch answers with a list of these rather than a list of bare
  * reports, because a report on its own does not say which repository it belongs
  * to — and a run over several repositories is read repository by repository.
  *
- * @param context the inputs the adoption was run with
- * @param report  what the adoption achieved, and why it stopped when it did
+ * <p>The repository and branch are held as text rather than as the
+ * {@link AdoptionContext} they came from, because a repository whose URL names no
+ * repository at all never gets a context and still has to be reported: surviving
+ * that is the whole point of {@link BatchAdoption}.
+ *
+ * @param repositoryUrl the repository that was adopted, with any clone credentials
+ *                      masked — a run is a reporting artifact, written to the
+ *                      report file and answered to MCP clients
+ * @param branchName    the feature branch the adoption was to be made on
+ * @param report        what the adoption achieved, and why it stopped when it did
  */
-public record AdoptionRun(AdoptionContext context, AdoptionReport report) {
-
-	public String repositoryUrl() {
-		return context.repositoryUrl();
-	}
+public record AdoptionRun(String repositoryUrl, String branchName, AdoptionReport report) {
 
 	public boolean succeeded() {
 		return report.succeeded();

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
@@ -16,6 +16,13 @@ import org.apache.logging.log4j.Logger;
  * batch means. Repositories are adopted sequentially because every adoption
  * shells out to {@code git}, {@code claude}, and {@code gh}, whose output a
  * parallel batch would interleave.
+ *
+ * <p>Claiming a repository's checkout is part of its own adoption rather than a
+ * preparation the whole run shares, so a URL that names no repository, or one
+ * whose checkout directory another repository of the run already claimed, is that
+ * repository's recorded failure and not the batch's. Otherwise a single malformed
+ * line in a {@code --repos} file stopped every repository behind it before the
+ * first clone, and left the run with no report to say so.
  */
 public final class BatchAdoption {
 
@@ -37,20 +44,30 @@ public final class BatchAdoption {
 		this.adoption = adoption;
 	}
 
-	/** @return one run per repository, in the order the repositories were given */
-	public List<AdoptionRun> adoptAll(List<AdoptionContext> contexts) {
-		log.info("Adopting Claude Code into {} repositories", contexts.size());
-		return contexts.stream().map(this::adoptOne).toList();
+	/**
+	 * @param repositoryUrls the repositories to adopt, in the order they were given
+	 * @param checkouts      this run's workspace and branch, giving each repository
+	 *                       its own checkout directory
+	 * @return one run per repository, in the order the repositories were given
+	 */
+	public List<AdoptionRun> adoptAll(List<String> repositoryUrls, Checkouts checkouts) {
+		log.info("Adopting Claude Code into {} repositories", repositoryUrls.size());
+		return repositoryUrls.stream().map(url -> adoptOne(url, checkouts)).toList();
 	}
 
-	private AdoptionRun adoptOne(AdoptionContext context) {
+	/**
+	 * The URL is redacted up front so a repository that fails its claim — and so
+	 * never has a context to ask — is still reported without its credentials.
+	 */
+	private AdoptionRun adoptOne(String repositoryUrl, Checkouts checkouts) {
 		AdoptionReport report = new AdoptionReport();
+		String displayUrl = Redaction.of(repositoryUrl);
 		try {
-			adoption.adopt(context, report);
+			adoption.adopt(checkouts.claim(repositoryUrl), report);
 		} catch (RuntimeException e) {
-			recordFailure(context, report, e);
+			recordFailure(displayUrl, report, e);
 		}
-		return new AdoptionRun(context, report);
+		return new AdoptionRun(displayUrl, checkouts.branchName(), report);
 	}
 
 	/**
@@ -59,8 +76,8 @@ public final class BatchAdoption {
 	 * of it. A failure the pipeline already described — naming the step that raised
 	 * it — is left alone, since that reads better than the bare message.
 	 */
-	private void recordFailure(AdoptionContext context, AdoptionReport report, RuntimeException failure) {
-		log.error("Adoption failed for {}", context.repositoryUrl(), failure);
+	private void recordFailure(String displayUrl, AdoptionReport report, RuntimeException failure) {
+		log.error("Adoption failed for {}", displayUrl, failure);
 		if (report.failure().isEmpty()) {
 			report.recordFailure(Failures.describe(failure));
 		}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Checkouts.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Checkouts.java
@@ -2,14 +2,13 @@ package io.github.adamw7.tools.adopt;
 
 import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
- * Gives every repository of a run its own checkout, as the {@link AdoptionContext}
- * list the run works through: one workspace, one branch name, in the order the
- * URLs were given. Both entry points come through here, so the command line and
- * the MCP tool cannot drift apart on how a run's contexts are made.
+ * Gives every repository of a run its own checkout: one workspace, one branch
+ * name, and a directory no other repository of the run has claimed. Both entry
+ * points come through here, so the command line and the MCP tool cannot drift
+ * apart on how a run's contexts are made.
  *
  * <p>Two repositories that would clone into the same checkout directory are
  * rejected rather than adopted. A checkout is named after the repository alone, so
@@ -17,36 +16,55 @@ import java.util.Map;
  * repository's {@code .../repo} and {@code .../repo.git} forms. The second
  * adoption would otherwise run every step against the first repository's working
  * tree and report its pull request as the second's.
+ *
+ * <p>Contexts are claimed one repository at a time rather than built for the whole
+ * run up front, because both failures a claim can raise — a URL that names no
+ * repository, and a checkout directory already taken — belong to the repository
+ * that raised them. Building them all up front made either one abort the batch
+ * before its first clone and leave the run with no report at all, which is exactly
+ * what {@link BatchAdoption} keeps from happening for every failure the pipeline
+ * itself raises.
  */
 public final class Checkouts {
 
-	private Checkouts() {
+	private final Path workspace;
+	private final String branchName;
+
+	/** The checkout each repository of the run has taken, so a second claim on one is caught. */
+	private final Map<Path, String> urlsByCheckout = new HashMap<>();
+
+	/**
+	 * @param workspace  the directory every clone is created under
+	 * @param branchName the feature branch every adoption commits on
+	 */
+	public Checkouts(Path workspace, String branchName) {
+		this.workspace = workspace;
+		this.branchName = branchName;
+	}
+
+	/** The branch every repository of this run is adopted on. */
+	public String branchName() {
+		return branchName;
 	}
 
 	/**
-	 * @param repositoryUrls the repositories to adopt, without duplicates
-	 * @param workspace      the directory every clone is created under
-	 * @param branchName     the feature branch every adoption commits on
-	 * @throws IllegalArgumentException when two repositories would clone into the
-	 *                                  same checkout directory
+	 * Claims this run's checkout directory for one repository.
+	 *
+	 * @return the context to adopt it with
+	 * @throws IllegalArgumentException when the URL names no repository, or when
+	 *                                  another repository of the run already claimed
+	 *                                  the checkout directory it would clone into
 	 */
-	public static List<AdoptionContext> forRun(List<String> repositoryUrls, Path workspace, String branchName) {
-		List<AdoptionContext> contexts = repositoryUrls.stream()
-				.map(url -> new AdoptionContext(url, workspace, branchName))
-				.toList();
-		requireDistinctCheckouts(contexts);
-		return contexts;
+	public AdoptionContext claim(String repositoryUrl) {
+		AdoptionContext context = new AdoptionContext(repositoryUrl, workspace, branchName);
+		requireCheckoutUnclaimed(context);
+		return context;
 	}
 
-	private static void requireDistinctCheckouts(List<AdoptionContext> contexts) {
-		Map<Path, String> urlsByCheckout = new HashMap<>();
-		contexts.forEach(context -> requireCheckoutUnclaimed(urlsByCheckout, context));
-	}
-
-	private static void requireCheckoutUnclaimed(Map<Path, String> urlsByCheckout, AdoptionContext context) {
-		String claimedBy = urlsByCheckout.putIfAbsent(context.repositoryDirectory(), context.repositoryUrl());
+	private void requireCheckoutUnclaimed(AdoptionContext context) {
+		String claimedBy = urlsByCheckout.putIfAbsent(context.repositoryDirectory(), context.displayUrl());
 		if (claimedBy != null) {
-			throw new IllegalArgumentException("Cannot adopt " + context.repositoryUrl() + " and " + claimedBy
+			throw new IllegalArgumentException("Cannot adopt " + context.displayUrl() + " and " + claimedBy
 					+ " in one run: both would clone into " + context.repositoryDirectory()
 					+ ". Adopt them in separate runs, or into separate workspaces.");
 		}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -106,11 +106,11 @@ public class GitHubRepoAdopter {
 	 * @return the same report, once every step has completed
 	 */
 	public AdoptionReport adopt(AdoptionContext context, AdoptionReport report) {
-		log.info("Adopting Claude Code into {}", context.repositoryUrl());
+		log.info("Adopting Claude Code into {}", context.displayUrl());
 		for (AdoptionStep step : steps) {
 			runStep(step, context, report);
 		}
-		log.info("Adoption complete for {}", context.repositoryUrl());
+		log.info("Adoption complete for {}", context.displayUrl());
 		return report;
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -19,9 +19,9 @@ import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
  * say how far the adoption got and why it stopped. A run over several
  * repositories writes the batch document {@link AdoptionReportWriter} describes.
  *
- * <p>A repository whose adoption fails does not stop the ones behind it: the batch
- * runs to the end and the failures are raised together afterwards, so the process
- * still exits non-zero.
+ * <p>A repository whose adoption fails does not stop the ones behind it — nor does
+ * one whose URL names no repository at all: the batch runs to the end and the
+ * failures are raised together afterwards, so the process still exits non-zero.
  */
 public class Main {
 
@@ -30,7 +30,7 @@ public class Main {
 		CommandRunner runner = new ProcessCommandRunner();
 		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, cli.pullRequestOptions(),
 				cli.includeAssets(), cli.ruleVersion());
-		runAndReport(cli, contexts(cli), adopter);
+		runAndReport(cli, checkouts(cli), adopter);
 	}
 
 	/**
@@ -42,9 +42,8 @@ public class Main {
 	 * @throws AdoptionException when any repository's adoption failed, naming each
 	 *                           one and why it stopped
 	 */
-	static List<AdoptionRun> runAndReport(CliArguments cli, List<AdoptionContext> contexts,
-			GitHubRepoAdopter adopter) {
-		List<AdoptionRun> runs = new BatchAdoption(adopter::adopt).adoptAll(contexts);
+	static List<AdoptionRun> runAndReport(CliArguments cli, Checkouts checkouts, GitHubRepoAdopter adopter) {
+		List<AdoptionRun> runs = new BatchAdoption(adopter::adopt).adoptAll(cli.repositoryUrls(), checkouts);
 		try {
 			requireEveryAdoptionSucceeded(runs);
 		} catch (RuntimeException e) {
@@ -56,8 +55,8 @@ public class Main {
 	}
 
 	/** Every repository of a run is adopted into one workspace, on one branch name. */
-	static List<AdoptionContext> contexts(CliArguments cli) {
-		return Checkouts.forRun(cli.repositoryUrls(), Workspaces.resolve(cli.workspace()), cli.branchName());
+	static Checkouts checkouts(CliArguments cli) {
+		return new Checkouts(Workspaces.resolve(cli.workspace()), cli.branchName());
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Redaction.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Redaction.java
@@ -1,0 +1,37 @@
+package io.github.adamw7.tools.adopt;
+
+import java.util.regex.Pattern;
+
+/**
+ * Masks the credentials a clone URL can carry before the text reaches somewhere
+ * it outlives the run. An adoption driven by CI is handed URLs of the form
+ * {@code https://x-access-token:TOKEN@github.com/owner/repo.git}, and the
+ * adoption puts that URL in three places a secret must not reach: the log, the
+ * message of the {@link AdoptionException} a failing command raises, and the
+ * {@code failure} field of the JSON report written to disk and answered to MCP
+ * clients.
+ *
+ * <p>Only the user information of a URL with a scheme is masked, so the
+ * scp-like {@code git@host:owner/repo} — whose {@code git@} is the well-known
+ * user every such URL carries, not a credential — reads as it was given.
+ */
+public final class Redaction {
+
+	static final String MASK = "***";
+
+	/** The user information between a URL's {@code ://} and its {@code @}. */
+	private static final Pattern CREDENTIALS = Pattern.compile("(?<=://)[^/@\\s]+(?=@)");
+
+	private Redaction() {
+	}
+
+	/**
+	 * @return the text with every URL's credentials replaced by {@value #MASK},
+	 *         or the text unchanged when it carries none. A {@code null} text is
+	 *         answered with {@code null}, so a caller passing a command's output
+	 *         through does not have to null-check first.
+	 */
+	public static String of(String text) {
+		return text == null ? null : CREDENTIALS.matcher(text).replaceAll(MASK);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -20,11 +20,13 @@ public final class RepositoryUrl {
 	private static final String GIT_SUFFIX = ".git";
 
 	private final String value;
+	private final String redacted;
 	private final String name;
 	private final String slug;
 
 	private RepositoryUrl(String value) {
 		this.value = value;
+		this.redacted = Redaction.of(value);
 		this.name = repositoryName(value);
 		this.slug = repositorySlug(value);
 	}
@@ -37,9 +39,21 @@ public final class RepositoryUrl {
 		return new RepositoryUrl(Text.required(repositoryUrl, "repositoryUrl"));
 	}
 
-	/** The URL as given, stripped of surrounding whitespace. */
+	/**
+	 * The URL as given, stripped of surrounding whitespace — the one {@code git}
+	 * is handed, credentials included. Anything that outlives the run reports
+	 * {@link #redacted()} instead.
+	 */
 	public String value() {
 		return value;
+	}
+
+	/**
+	 * @return the URL with any clone credentials masked, for the logs, failure
+	 *         messages, and JSON report a secret must not reach
+	 */
+	public String redacted() {
+		return redacted;
 	}
 
 	/** The repository name the checkout directory is created under. */
@@ -72,7 +86,7 @@ public final class RepositoryUrl {
 	private static String requireName(String name, String repositoryUrl) {
 		if (name.isEmpty() || ".".equals(name) || "..".equals(name)) {
 			throw new IllegalArgumentException(
-					"repositoryUrl must end in a repository name but was: " + repositoryUrl);
+					"repositoryUrl must end in a repository name but was: " + Redaction.of(repositoryUrl));
 		}
 		return name;
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandResult.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandResult.java
@@ -2,6 +2,8 @@ package io.github.adamw7.tools.adopt.command;
 
 import java.util.List;
 
+import io.github.adamw7.tools.adopt.Redaction;
+
 /**
  * Outcome of running an external command: the exit code and the combined
  * standard-output/standard-error text the command produced. The originating
@@ -21,9 +23,11 @@ public record CommandResult(List<String> command, int exitCode, String output) {
 	/**
 	 * The command as it would be typed, for the failures raised before there is a
 	 * result to describe — a process that could not be started, or one destroyed on
-	 * its timeout — so every report of a command reads the same way.
+	 * its timeout — so every report of a command reads the same way. A clone URL's
+	 * credentials are masked here, at the one place a command is turned into text,
+	 * so no caller can report the arguments verbatim by forgetting to.
 	 */
 	public static String describe(List<String> command) {
-		return String.join(" ", command);
+		return Redaction.of(String.join(" ", command));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
@@ -51,15 +51,26 @@ final class ExecutableResolver {
 		if (!windows || command.isEmpty()) {
 			return command;
 		}
-		return locate(command.get(0))
-				.map(executable -> rewrite(executable, command))
+		return executable(command.get(0))
+				.map(resolved -> rewrite(resolved, command))
 				.orElse(command);
 	}
 
+	private Optional<Path> executable(String program) {
+		return hasPathSeparator(program) ? given(program) : locate(program);
+	}
+
+	/**
+	 * A program named by its path needs no {@code PATH} search, but a batch script at
+	 * that path still has to go through {@code cmd.exe} — which is how a checkout's
+	 * own {@code gradlew.bat} or {@code mvnw.cmd} is launched. Anything else is left
+	 * for {@link ProcessBuilder} to start as it was given.
+	 */
+	private Optional<Path> given(String program) {
+		return toPath(program).filter(Files::isRegularFile).filter(this::isBatchScript);
+	}
+
 	private Optional<Path> locate(String program) {
-		if (hasPathSeparator(program)) {
-			return Optional.empty();
-		}
 		return pathDirectories.stream()
 				.flatMap(directory -> candidates(directory, program))
 				.filter(Files::isRegularFile)

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.Redaction;
 
 /**
  * {@link CommandRunner} backed by {@link ProcessBuilder}. Standard error is
@@ -85,7 +86,7 @@ public class ProcessCommandRunner implements CommandRunner {
 	private AdoptionException timedOut(Process process, List<String> command, StreamGobbler output) {
 		destroyTree(process);
 		return new AdoptionException("Timed out after " + timeout + " running: " + CommandResult.describe(command)
-				+ System.lineSeparator() + output.output());
+				+ System.lineSeparator() + Redaction.of(output.output()));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -118,7 +118,7 @@ public class AdoptTool implements McpTool {
 		Optional<String> ruleVersion = ruleVersion(arguments);
 		BatchAdoption batch = new BatchAdoption(
 				(context, report) -> pipeline.adopt(context, report, options, includeAssets, ruleVersion));
-		return result(batch.adoptAll(contextsFrom(arguments)));
+		return result(batch.adoptAll(repositoryUrls(arguments), checkoutsFrom(arguments)));
 	}
 
 	/**
@@ -132,8 +132,8 @@ public class AdoptTool implements McpTool {
 	}
 
 	/** Every repository of a call is adopted into one workspace, on one branch name. */
-	private List<AdoptionContext> contextsFrom(Map<String, Object> arguments) {
-		return Checkouts.forRun(repositoryUrls(arguments), workspace(arguments), branch(arguments));
+	private Checkouts checkoutsFrom(Map<String, Object> arguments) {
+		return new Checkouts(workspace(arguments), branch(arguments));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractCommandStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractCommandStep.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 import java.util.Optional;
 
 import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.Redaction;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
@@ -54,8 +55,14 @@ public abstract class AbstractCommandStep implements AdoptionStep {
 		return toleratedFailures.stream().map(tolerated -> tolerated.toLowerCase(Locale.ROOT)).anyMatch(output::contains);
 	}
 
+	/**
+	 * The transcript is redacted as well as the command, because a tool that fails
+	 * on a credentialled clone URL echoes it back — {@code fatal: could not read
+	 * Username for 'https://...@github.com'} — and this message becomes the run's
+	 * reported failure.
+	 */
 	private AdoptionException failure(CommandResult result) {
 		return new AdoptionException(name() + " failed (exit " + result.exitCode() + ") running: " + result.describe()
-				+ System.lineSeparator() + result.output());
+				+ System.lineSeparator() + Redaction.of(result.output()));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -29,19 +29,24 @@ public interface BuildSystem {
 	 */
 	boolean install(Path repositoryDirectory);
 
-	/** Command that runs the wired guard so a missing or malformed {@code CLAUDE.md} fails the build. */
-	List<String> verifyCommand();
+	/**
+	 * Command that runs the wired guard so a missing or malformed {@code CLAUDE.md}
+	 * fails the build. The checkout is a parameter because the command depends on
+	 * what the checkout itself ships: a project carrying a build wrapper is built
+	 * with that wrapper rather than with a build tool off the {@code PATH}.
+	 */
+	List<String> verifyCommand(Path repositoryDirectory);
 
 	/**
-	 * The program {@link #verifyCommand()} launches, so {@link BuildToolchainStep}
+	 * The program {@link #verifyCommand(Path)} launches, so {@link BuildToolchainStep}
 	 * can probe it before the pipeline spends a {@code claude init} on a checkout it
 	 * will not be able to verify. The verification launches the first word of its
 	 * own command, so that is what the default probes.
 	 *
 	 * @return the program to probe, or empty when the verification needs nothing
-	 *         beyond the POSIX shell every supported platform already provides
+	 *         beyond the shell
 	 */
-	default Optional<String> requiredTool() {
-		return Optional.of(verifyCommand().get(0));
+	default Optional<String> requiredTool(Path repositoryDirectory) {
+		return Optional.of(verifyCommand(repositoryDirectory).get(0));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
@@ -44,19 +44,26 @@ public class BuildToolchainStep extends AbstractBuildSystemStep {
 	@Override
 	protected void onDetected(BuildSystem buildSystem, AdoptionContext context, CommandRunner runner) {
 		Path repositoryDirectory = context.repositoryDirectory();
-		buildSystem.requiredTool().ifPresentOrElse(
-				tool -> requireInstalled(tool, buildSystem, repositoryDirectory, runner),
+		buildSystem.requiredTool(repositoryDirectory).ifPresentOrElse(
+				tool -> requireRunnable(tool, buildSystem, repositoryDirectory, runner),
 				() -> log.info("The {} guard needs no build tool of its own in {}", buildSystem.name(),
 						repositoryDirectory));
 	}
 
-	private void requireInstalled(String tool, BuildSystem buildSystem, Path repositoryDirectory,
+	/**
+	 * The tool probed is whatever the verification will launch, which for a checkout
+	 * shipping a build wrapper is that wrapper rather than a program on the
+	 * {@code PATH} — so the failure says the tool could not be run rather than that
+	 * it was not installed, which for a wrapper present but unusable would be wrong.
+	 */
+	private void requireRunnable(String tool, BuildSystem buildSystem, Path repositoryDirectory,
 			CommandRunner runner) {
 		if (probe.isInstalled(tool, repositoryDirectory, runner)) {
 			return;
 		}
 		throw new AdoptionException(name() + " failed: " + repositoryDirectory + " builds with "
-				+ buildSystem.name() + " but " + tool + " was not found on the PATH, so the CLAUDE.md guard"
-				+ " could not be verified.");
+				+ buildSystem.name() + " but " + tool + " could not be run, so the CLAUDE.md guard"
+				+ " could not be verified. Install " + buildSystem.name() + " on the PATH, or commit the"
+				+ " project's build wrapper.");
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildWrapper.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildWrapper.java
@@ -1,0 +1,62 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Finds the build wrapper script a checkout ships with — {@code mvnw} for Maven,
+ * {@code gradlew} for Gradle — so the adoption verifies the {@code CLAUDE.md}
+ * guard with the build tool the project itself expects to be built with.
+ *
+ * <p>Most Gradle projects ship only the wrapper and no system-wide {@code gradle},
+ * so probing the {@code PATH} for one failed {@link BuildToolchainStep} and
+ * aborted the adoption of a repository the host could have built perfectly well.
+ * Preferring the wrapper also pins the build to the version the project pinned,
+ * which is the whole reason a wrapper is committed.
+ *
+ * <p>The wrapper is answered as an <em>absolute</em> path, because
+ * {@link ProcessBuilder} resolves a relative program name against the JVM's own
+ * working directory rather than the one the command is given.
+ */
+final class BuildWrapper {
+
+	private final String fileName;
+
+	/** The wrapper for the host platform: the Windows script there, the POSIX one everywhere else. */
+	BuildWrapper(String posixName, String windowsName) {
+		this(posixName, windowsName, isWindows());
+	}
+
+	BuildWrapper(String posixName, String windowsName, boolean windows) {
+		this.fileName = windows ? windowsName : posixName;
+	}
+
+	/**
+	 * The command to run in the checkout: the wrapper it ships, or {@code fallback}
+	 * off the {@code PATH} when it ships none. Assembling it here keeps every build
+	 * system's "wrapper, else the PATH tool" from being written out again.
+	 */
+	List<String> commandIn(Path repositoryDirectory, String fallback, List<String> arguments) {
+		List<String> command = new ArrayList<>();
+		command.add(in(repositoryDirectory).orElse(fallback));
+		command.addAll(arguments);
+		return List.copyOf(command);
+	}
+
+	/**
+	 * @return the absolute path of the checkout's wrapper, or empty when it ships
+	 *         none and the build tool has to come from the {@code PATH}
+	 */
+	Optional<String> in(Path repositoryDirectory) {
+		Path wrapper = repositoryDirectory.resolve(fileName);
+		return Files.isRegularFile(wrapper) ? Optional.of(wrapper.toAbsolutePath().toString()) : Optional.empty();
+	}
+
+	private static boolean isWindows() {
+		return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("windows");
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -32,7 +32,7 @@ public class CloneStep extends AbstractCommandStep {
 			log.info("{} already contains a checkout; skipping clone", context.repositoryDirectory());
 			return;
 		}
-		log.info("Cloning {} into {}", context.repositoryUrl(), context.repositoryDirectory());
+		log.info("Cloning {} into {}", context.displayUrl(), context.repositoryDirectory());
 		List<String> command = List.of("git", "clone", context.repositoryUrl(),
 				context.repositoryDirectory().toString());
 		runOrFail(runner, context.workspace(), command);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
@@ -38,7 +38,7 @@ public class FallbackBuildSystem implements BuildSystem {
 	}
 
 	@Override
-	public List<String> verifyCommand() {
+	public List<String> verifyCommand(Path repositoryDirectory) {
 		return VERIFY_COMMAND;
 	}
 
@@ -48,7 +48,7 @@ public class FallbackBuildSystem implements BuildSystem {
 	 * nothing to check ahead of time.
 	 */
 	@Override
-	public Optional<String> requiredTool() {
+	public Optional<String> requiredTool(Path repositoryDirectory) {
 		return Optional.empty();
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
@@ -13,14 +13,30 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  * guard task with {@link GradleGuardInstaller}, and verifies it by running that
  * task. Gradle has no {@code claude-code-enforcer} equivalent, so the guard is a
  * presence-and-non-empty check rather than the full Maven format rule.
+ *
+ * <p>A checkout that ships a {@code gradlew} is verified with that wrapper rather
+ * than with a {@code gradle} off the {@code PATH}. Most Gradle projects ship only
+ * the wrapper, so this is the ordinary case rather than the exception: without it
+ * {@link BuildToolchainStep} found no {@code gradle} to probe and aborted the
+ * adoption. See {@link BuildWrapper}.
  */
 public class GradleBuildSystem implements BuildSystem {
 
-	static final List<String> VERIFY_COMMAND = List.of("gradle", "-q", GradleGuardInstaller.GUARD_TASK);
+	static final String GRADLE = "gradle";
+	static final List<String> VERIFY_ARGUMENTS = List.of("-q", GradleGuardInstaller.GUARD_TASK);
 	static final String GROOVY_BUILD_FILE = "build.gradle";
 	static final String KOTLIN_BUILD_FILE = "build.gradle.kts";
 
 	private final GradleGuardInstaller installer = new GradleGuardInstaller();
+	private final BuildWrapper wrapper;
+
+	public GradleBuildSystem() {
+		this(new BuildWrapper("gradlew", "gradlew.bat"));
+	}
+
+	GradleBuildSystem(BuildWrapper wrapper) {
+		this.wrapper = wrapper;
+	}
 
 	@Override
 	public String name() {
@@ -40,8 +56,8 @@ public class GradleBuildSystem implements BuildSystem {
 	}
 
 	@Override
-	public List<String> verifyCommand() {
-		return VERIFY_COMMAND;
+	public List<String> verifyCommand(Path repositoryDirectory) {
+		return wrapper.commandIn(repositoryDirectory, GRADLE, VERIFY_ARGUMENTS);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -11,14 +11,21 @@ import java.util.Optional;
  * and verifies the rule with a non-recursive {@code mvn -N validate} so the
  * freshly generated {@code CLAUDE.md} is validated against the full format rule
  * before the branch is pushed.
+ *
+ * <p>A checkout that ships an {@code mvnw} is verified with that wrapper rather
+ * than with a {@code mvn} off the {@code PATH}, so the guard runs under the Maven
+ * version the project pinned and a host with no Maven installed can still adopt
+ * it. See {@link BuildWrapper}.
  */
 public class MavenBuildSystem implements BuildSystem {
 
-	static final List<String> VERIFY_COMMAND = List.of("mvn", "-q", "-N", "validate");
+	static final String MAVEN = "mvn";
+	static final List<String> VERIFY_ARGUMENTS = List.of("-q", "-N", "validate");
 
 	private static final String POM = "pom.xml";
 
 	private final PomEnforcerInstaller installer;
+	private final BuildWrapper wrapper;
 
 	public MavenBuildSystem() {
 		this(new PomEnforcerInstaller());
@@ -34,7 +41,12 @@ public class MavenBuildSystem implements BuildSystem {
 	}
 
 	public MavenBuildSystem(PomEnforcerInstaller installer) {
+		this(installer, new BuildWrapper("mvnw", "mvnw.cmd"));
+	}
+
+	MavenBuildSystem(PomEnforcerInstaller installer, BuildWrapper wrapper) {
 		this.installer = installer;
+		this.wrapper = wrapper;
 	}
 
 	@Override
@@ -53,7 +65,7 @@ public class MavenBuildSystem implements BuildSystem {
 	}
 
 	@Override
-	public List<String> verifyCommand() {
-		return VERIFY_COMMAND;
+	public List<String> verifyCommand(Path repositoryDirectory) {
+		return wrapper.commandIn(repositoryDirectory, MAVEN, VERIFY_ARGUMENTS);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/VerifyStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/VerifyStep.java
@@ -38,6 +38,6 @@ public class VerifyStep extends AbstractBuildSystemStep {
 	protected void onDetected(BuildSystem buildSystem, AdoptionContext context, CommandRunner runner) {
 		log.info("Verifying the CLAUDE.md guard passes with {} in {}", buildSystem.name(),
 				context.repositoryDirectory());
-		runOrFail(runner, context.repositoryDirectory(), buildSystem.verifyCommand());
+		runOrFail(runner, context.repositoryDirectory(), buildSystem.verifyCommand(context.repositoryDirectory()));
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
@@ -79,4 +79,13 @@ class AdoptionContextTest {
 	void aNamedBranchOverridesTheDefault() {
 		assertEquals("feature/adopt", AdoptionContext.branchOrDefault("  feature/adopt  "));
 	}
+
+	/** The clone needs the credentials; everything that reports the run must not carry them. */
+	@Test
+	void reportsTheRepositoryWithoutTheCredentialsItClonesWith() {
+		AdoptionContext context = new AdoptionContext("https://x-access-token:secret@github.com/owner/repo.git",
+				Path.of("/tmp/workspace"));
+		assertEquals("https://x-access-token:secret@github.com/owner/repo.git", context.repositoryUrl());
+		assertEquals("https://***@github.com/owner/repo.git", context.displayUrl());
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportWriterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportWriterTest.java
@@ -139,6 +139,6 @@ class AdoptionReportWriterTest {
 	}
 
 	private AdoptionRun run(AdoptionContext context, AdoptionReport report) {
-		return new AdoptionRun(context, report);
+		return new AdoptionRun(context.displayUrl(), context.branchName(), report);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionRunTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionRunTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Path;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -12,8 +11,8 @@ import org.junit.jupiter.api.Test;
 class AdoptionRunTest {
 
 	private static final String REPO_URL = "https://github.com/owner/repo.git";
+	private static final String BRANCH = "claude/adopt-claude-code";
 
-	private final AdoptionContext context = new AdoptionContext(REPO_URL, Path.of("/tmp/workspace"));
 	private final AdoptionReport report = new AdoptionReport();
 
 	/**
@@ -22,28 +21,29 @@ class AdoptionRunTest {
 	 */
 	@Test
 	void namesTheRepositoryItsReportBelongsTo() {
-		assertEquals(REPO_URL, new AdoptionRun(context, report).repositoryUrl());
+		assertEquals(REPO_URL, run().repositoryUrl());
 	}
 
 	@Test
-	void keepsTheContextAndReportItWasGiven() {
-		AdoptionRun run = new AdoptionRun(context, report);
-		assertEquals(context, run.context());
-		assertEquals(report, run.report());
+	void keepsTheBranchAndReportItWasGiven() {
+		assertEquals(BRANCH, run().branchName());
+		assertEquals(report, run().report());
 	}
 
 	@Test
 	void succeedsWhileItsReportRecordsNoFailure() {
-		AdoptionRun run = new AdoptionRun(context, report);
-		assertTrue(run.succeeded());
-		assertEquals(Optional.empty(), run.failure());
+		assertTrue(run().succeeded());
+		assertEquals(Optional.empty(), run().failure());
 	}
 
 	@Test
 	void failsWithTheReasonItsReportRecorded() {
 		report.recordFailure("clone: repository not found");
-		AdoptionRun run = new AdoptionRun(context, report);
-		assertFalse(run.succeeded());
-		assertEquals("clone: repository not found", run.failure().orElseThrow());
+		assertFalse(run().succeeded());
+		assertEquals("clone: repository not found", run().failure().orElseThrow());
+	}
+
+	private AdoptionRun run() {
+		return new AdoptionRun(REPO_URL, BRANCH, report);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/BatchAdoptionTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/BatchAdoptionTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,12 +14,14 @@ class BatchAdoptionTest {
 
 	private static final String REPO_URL = "https://github.com/owner/repo.git";
 	private static final String OTHER_URL = "https://github.com/owner/other.git";
+	private static final String BRANCH = "claude/adopt-claude-code";
+	private static final Path WORKSPACE = Path.of("/tmp/workspace");
 
 	private final List<String> adopted = new ArrayList<>();
 
 	@Test
 	void adoptsEveryRepositoryInOrder() {
-		List<AdoptionRun> runs = new BatchAdoption(this::record).adoptAll(contexts(REPO_URL, OTHER_URL));
+		List<AdoptionRun> runs = adoptAll(this::record, REPO_URL, OTHER_URL);
 		assertEquals(List.of(REPO_URL, OTHER_URL), adopted);
 		assertEquals(List.of(REPO_URL, OTHER_URL), runs.stream().map(AdoptionRun::repositoryUrl).toList());
 		assertTrue(runs.stream().allMatch(AdoptionRun::succeeded));
@@ -28,8 +29,8 @@ class BatchAdoptionTest {
 
 	@Test
 	void givesEachRepositoryItsOwnReport() {
-		List<AdoptionRun> runs = new BatchAdoption((context, report) -> report.recordStep(context.repositoryUrl()))
-				.adoptAll(contexts(REPO_URL, OTHER_URL));
+		List<AdoptionRun> runs = adoptAll((context, report) -> report.recordStep(context.repositoryUrl()),
+				REPO_URL, OTHER_URL);
 		assertEquals(List.of(REPO_URL), runs.get(0).report().completedSteps());
 		assertEquals(List.of(OTHER_URL), runs.get(1).report().completedSteps());
 	}
@@ -40,7 +41,7 @@ class BatchAdoptionTest {
 	 */
 	@Test
 	void keepsGoingAfterARepositoryFails() {
-		List<AdoptionRun> runs = new BatchAdoption(this::failFirst).adoptAll(contexts(REPO_URL, OTHER_URL));
+		List<AdoptionRun> runs = adoptAll(this::failFirst, REPO_URL, OTHER_URL);
 		assertEquals(List.of(REPO_URL, OTHER_URL), adopted);
 		assertFalse(runs.get(0).succeeded());
 		assertEquals("boom", runs.get(0).failure().orElseThrow());
@@ -49,19 +50,19 @@ class BatchAdoptionTest {
 
 	@Test
 	void keepsTheStepThePipelineAlreadyBlamed() {
-		List<AdoptionRun> runs = new BatchAdoption((context, report) -> {
+		List<AdoptionRun> runs = adoptAll((context, report) -> {
 			report.recordFailure("push: rejected");
 			throw new AdoptionException("boom");
-		}).adoptAll(contexts(REPO_URL));
+		}, REPO_URL);
 		assertEquals("push: rejected", runs.get(0).failure().orElseThrow());
 	}
 
 	/** A failure with no message would otherwise record a bare null as the reason. */
 	@Test
 	void fallsBackToTheFailuresTypeWhenItCarriesNoMessage() {
-		List<AdoptionRun> runs = new BatchAdoption((context, report) -> {
+		List<AdoptionRun> runs = adoptAll((context, report) -> {
 			throw new IllegalStateException();
-		}).adoptAll(contexts(REPO_URL));
+		}, REPO_URL);
 		assertEquals("IllegalStateException", runs.get(0).failure().orElseThrow());
 	}
 
@@ -71,18 +72,17 @@ class BatchAdoptionTest {
 	 */
 	@Test
 	void keepsTheStepsARepositoryCompletedBeforeItFailed() {
-		List<AdoptionRun> runs = new BatchAdoption((context, report) -> {
+		List<AdoptionRun> runs = adoptAll((context, report) -> {
 			report.recordStep("clone");
 			throw new AdoptionException("boom");
-		}).adoptAll(contexts(REPO_URL));
+		}, REPO_URL);
 		assertEquals(List.of("clone"), runs.get(0).report().completedSteps());
 	}
 
 	@Test
-	void answersWithTheContextEachRepositoryWasAdoptedWith() {
-		List<AdoptionContext> contexts = contexts(REPO_URL, OTHER_URL);
-		List<AdoptionRun> runs = new BatchAdoption(this::record).adoptAll(contexts);
-		assertEquals(contexts, runs.stream().map(AdoptionRun::context).toList());
+	void answersWithTheBranchEachRepositoryWasAdoptedOn() {
+		List<AdoptionRun> runs = adoptAll(this::record, REPO_URL, OTHER_URL);
+		assertEquals(List.of(BRANCH, BRANCH), runs.stream().map(AdoptionRun::branchName).toList());
 	}
 
 	/**
@@ -92,16 +92,64 @@ class BatchAdoptionTest {
 	 */
 	@Test
 	void recordsAFailureThePipelineNeverDescribed() {
-		List<AdoptionRun> runs = new BatchAdoption((context, report) -> {
+		List<AdoptionRun> runs = adoptAll((context, report) -> {
 			throw new IllegalArgumentException("workspace must not be null");
-		}).adoptAll(contexts(REPO_URL));
+		}, REPO_URL);
 		assertFalse(runs.get(0).succeeded());
 		assertEquals("workspace must not be null", runs.get(0).failure().orElseThrow());
 	}
 
+	/**
+	 * A URL that names no repository never reaches the pipeline, so before the claim
+	 * moved into the batch it aborted the whole run before its first clone — and left
+	 * no report to say which repositories had been asked for.
+	 */
+	@Test
+	void reportsAUrlThatNamesNoRepositoryWithoutStrandingTheRest() {
+		List<AdoptionRun> runs = adoptAll(this::record, "https://github.com/owner/.git", OTHER_URL);
+		assertEquals(2, runs.size());
+		assertFalse(runs.get(0).succeeded());
+		assertTrue(runs.get(0).failure().orElseThrow().contains("must end in a repository name"),
+				runs.get(0).failure().orElseThrow());
+		assertTrue(runs.get(1).succeeded());
+		assertEquals(List.of(OTHER_URL), adopted);
+	}
+
+	/** The repository that could not be placed is still named in its own run. */
+	@Test
+	void namesTheRepositoryWhoseClaimWasRefused() {
+		List<AdoptionRun> runs = adoptAll(this::record, "https://github.com/owner/.git");
+		assertEquals("https://github.com/owner/.git", runs.get(0).repositoryUrl());
+	}
+
+	/**
+	 * Two repositories that would clone into one checkout are the second one's
+	 * failure, so the first is adopted rather than both being refused.
+	 */
+	@Test
+	void reportsACollidingCheckoutAsTheSecondRepositorysFailure() {
+		List<AdoptionRun> runs = adoptAll(this::record, "https://github.com/owner/tools.git",
+				"https://github.com/other-owner/tools.git");
+		assertTrue(runs.get(0).succeeded());
+		assertFalse(runs.get(1).succeeded());
+		assertTrue(runs.get(1).failure().orElseThrow().contains("both would clone into"),
+				runs.get(1).failure().orElseThrow());
+	}
+
+	/** A run is written to the report file, so a credentialled URL must not reach it. */
+	@Test
+	void masksTheCredentialsOfAReportedUrl() {
+		List<AdoptionRun> runs = adoptAll(this::record, "https://x-access-token:secret@github.com/owner/repo.git");
+		assertEquals("https://***@github.com/owner/repo.git", runs.get(0).repositoryUrl());
+	}
+
 	@Test
 	void adoptsNothingWhenGivenNoRepositories() {
-		assertTrue(new BatchAdoption(this::record).adoptAll(List.of()).isEmpty());
+		assertTrue(adoptAll(this::record).isEmpty());
+	}
+
+	private List<AdoptionRun> adoptAll(BatchAdoption.Adoption adoption, String... repositoryUrls) {
+		return new BatchAdoption(adoption).adoptAll(List.of(repositoryUrls), new Checkouts(WORKSPACE, BRANCH));
 	}
 
 	private void record(AdoptionContext context, AdoptionReport report) {
@@ -113,9 +161,5 @@ class BatchAdoptionTest {
 		if (REPO_URL.equals(context.repositoryUrl())) {
 			throw new AdoptionException("boom");
 		}
-	}
-
-	private List<AdoptionContext> contexts(String... urls) {
-		return Stream.of(urls).map(url -> new AdoptionContext(url, Path.of("/tmp/workspace"))).toList();
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CheckoutsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CheckoutsTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,24 +17,30 @@ class CheckoutsTest {
 	private static final String BRANCH = "feature/x";
 	private static final Path WORKSPACE = Path.of("/tmp/workspace");
 
+	private final Checkouts checkouts = new Checkouts(WORKSPACE, BRANCH);
+
 	@Test
 	void buildsOneContextPerRepositoryInOrder() {
-		List<AdoptionContext> contexts = Checkouts.forRun(List.of(REPO_URL, OTHER_URL), WORKSPACE, BRANCH);
-		assertEquals(List.of(REPO_URL, OTHER_URL), contexts.stream().map(AdoptionContext::repositoryUrl).toList());
+		assertEquals(List.of(REPO_URL, OTHER_URL),
+				claim(REPO_URL, OTHER_URL).stream().map(AdoptionContext::repositoryUrl).toList());
 	}
 
 	@Test
 	void adoptsEveryRepositoryIntoOneWorkspaceOnOneBranch() {
-		List<AdoptionContext> contexts = Checkouts.forRun(List.of(REPO_URL, OTHER_URL), WORKSPACE, BRANCH);
+		List<AdoptionContext> contexts = claim(REPO_URL, OTHER_URL);
 		assertEquals(List.of(WORKSPACE, WORKSPACE), contexts.stream().map(AdoptionContext::workspace).toList());
 		assertEquals(List.of(BRANCH, BRANCH), contexts.stream().map(AdoptionContext::branchName).toList());
 	}
 
 	@Test
+	void namesTheBranchEveryRepositoryOfTheRunIsAdoptedOn() {
+		assertEquals(BRANCH, checkouts.branchName());
+	}
+
+	@Test
 	void givesEachRepositoryItsOwnCheckoutDirectory() {
-		List<AdoptionContext> contexts = Checkouts.forRun(List.of(REPO_URL, OTHER_URL), WORKSPACE, BRANCH);
 		assertEquals(List.of(WORKSPACE.resolve("repo"), WORKSPACE.resolve("other")),
-				contexts.stream().map(AdoptionContext::repositoryDirectory).toList());
+				claim(REPO_URL, OTHER_URL).stream().map(AdoptionContext::repositoryDirectory).toList());
 	}
 
 	/**
@@ -44,9 +51,9 @@ class CheckoutsTest {
 	 */
 	@Test
 	void rejectsTwoOwnersRepositoriesOfTheSameName() {
-		List<String> urls = List.of("https://github.com/owner/tools.git", "https://github.com/other-owner/tools.git");
+		checkouts.claim("https://github.com/owner/tools.git");
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> Checkouts.forRun(urls, WORKSPACE, BRANCH));
+				() -> checkouts.claim("https://github.com/other-owner/tools.git"));
 		assertTrue(exception.getMessage().contains("other-owner/tools"), exception.getMessage());
 		assertTrue(exception.getMessage().contains(WORKSPACE.resolve("tools").toString()), exception.getMessage());
 	}
@@ -58,35 +65,66 @@ class CheckoutsTest {
 	 */
 	@Test
 	void rejectsTheSameRepositoryNamedWithAndWithoutTheGitSuffix() {
-		List<String> urls = List.of("https://github.com/owner/repo", REPO_URL);
-		assertThrows(IllegalArgumentException.class, () -> Checkouts.forRun(urls, WORKSPACE, BRANCH));
+		checkouts.claim("https://github.com/owner/repo");
+		assertThrows(IllegalArgumentException.class, () -> checkouts.claim(REPO_URL));
 	}
 
 	@Test
 	void rejectsTheSameRepositoryNamedWithAndWithoutATrailingSlash() {
-		List<String> urls = List.of("https://github.com/owner/repo/", "https://github.com/owner/repo");
-		assertThrows(IllegalArgumentException.class, () -> Checkouts.forRun(urls, WORKSPACE, BRANCH));
+		checkouts.claim("https://github.com/owner/repo/");
+		assertThrows(IllegalArgumentException.class, () -> checkouts.claim("https://github.com/owner/repo"));
 	}
 
-	/** The collision is named while both repositories are still untouched. */
+	/** The collision names both repositories, since either could be the one meant. */
 	@Test
 	void namesBothCollidingRepositories() {
-		List<String> urls = List.of(REPO_URL, "https://github.com/other-owner/repo.git");
+		checkouts.claim(REPO_URL);
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> Checkouts.forRun(urls, WORKSPACE, BRANCH));
+				() -> checkouts.claim("https://github.com/other-owner/repo.git"));
 		assertTrue(exception.getMessage().contains(REPO_URL), exception.getMessage());
 		assertTrue(exception.getMessage().contains("other-owner/repo.git"), exception.getMessage());
 	}
 
+	/** A collision names the repository it refused, never the credentials its URL carried. */
 	@Test
-	void adoptsASingleRepository() {
-		List<AdoptionContext> contexts = Checkouts.forRun(List.of(REPO_URL), WORKSPACE, BRANCH);
-		assertEquals(1, contexts.size());
-		assertEquals(WORKSPACE.resolve("repo"), contexts.get(0).repositoryDirectory());
+	void masksTheCredentialsOfACollidingUrl() {
+		checkouts.claim(REPO_URL);
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> checkouts.claim("https://x-access-token:secret@github.com/other-owner/repo.git"));
+		assertTrue(exception.getMessage().contains("https://***@github.com/other-owner/repo.git"),
+				exception.getMessage());
+		assertTrue(!exception.getMessage().contains("secret"), exception.getMessage());
+	}
+
+	/**
+	 * A repository the run cannot place is that one repository's failure, so the ones
+	 * behind it still claim their own checkouts.
+	 */
+	@Test
+	void aRefusedClaimLeavesTheRestOfTheRunClaimable() {
+		checkouts.claim(REPO_URL);
+		assertThrows(IllegalArgumentException.class, () -> checkouts.claim("https://github.com/other-owner/repo.git"));
+		assertEquals(WORKSPACE.resolve("other"), checkouts.claim(OTHER_URL).repositoryDirectory());
 	}
 
 	@Test
-	void buildsNoContextsForNoRepositories() {
-		assertTrue(Checkouts.forRun(List.of(), WORKSPACE, BRANCH).isEmpty());
+	void rejectsAUrlThatNamesNoRepository() {
+		assertThrows(IllegalArgumentException.class, () -> checkouts.claim("https://github.com/owner/.git"));
+	}
+
+	/** A refused URL never claims a checkout, so it cannot block the repository that owns it. */
+	@Test
+	void aUrlThatNamesNoRepositoryClaimsNothing() {
+		assertThrows(IllegalArgumentException.class, () -> checkouts.claim("   "));
+		assertEquals(WORKSPACE.resolve("repo"), checkouts.claim(REPO_URL).repositoryDirectory());
+	}
+
+	@Test
+	void adoptsASingleRepository() {
+		assertEquals(WORKSPACE.resolve("repo"), checkouts.claim(REPO_URL).repositoryDirectory());
+	}
+
+	private List<AdoptionContext> claim(String... repositoryUrls) {
+		return Stream.of(repositoryUrls).map(checkouts::claim).toList();
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
@@ -53,8 +53,9 @@ class MainTest {
 	 */
 	@Test
 	void buildsAContextPerRepository(@TempDir Path dir) {
-		List<AdoptionContext> contexts = Main.contexts(CliArguments.parse(
-				new String[] { REPO_URL, "--repo", OTHER_URL, "--workspace", dir.toString(), "--branch", "feature/x" }));
+		CliArguments cli = CliArguments.parse(
+				new String[] { REPO_URL, "--repo", OTHER_URL, "--workspace", dir.toString(), "--branch", "feature/x" });
+		List<AdoptionContext> contexts = claimAll(cli);
 		assertEquals(List.of(REPO_URL, OTHER_URL), contexts.stream().map(AdoptionContext::repositoryUrl).toList());
 		assertEquals(List.of(dir, dir), contexts.stream().map(AdoptionContext::workspace).toList());
 		assertEquals(List.of(dir.resolve("repo"), dir.resolve("other")),
@@ -64,28 +65,29 @@ class MainTest {
 
 	@Test
 	void adoptsARepositoryNamedTwiceOnlyOnce(@TempDir Path dir) {
-		List<AdoptionContext> contexts = Main.contexts(CliArguments
-				.parse(new String[] { REPO_URL, "--repo", REPO_URL, "--workspace", dir.toString() }));
-		assertEquals(List.of(REPO_URL), contexts.stream().map(AdoptionContext::repositoryUrl).toList());
+		CliArguments cli = CliArguments
+				.parse(new String[] { REPO_URL, "--repo", REPO_URL, "--workspace", dir.toString() });
+		assertEquals(List.of(REPO_URL), cli.repositoryUrls());
 	}
 
 	/**
 	 * Two owners' repositories of the same name would clone into one checkout, so the
-	 * run fails on its arguments rather than adopting the first repository twice.
+	 * second is refused — as its own failure, leaving the first adopted.
 	 */
 	@Test
 	void rejectsARunWhoseRepositoriesShareACheckoutDirectory(@TempDir Path dir) {
 		CliArguments cli = CliArguments.parse(new String[] { "https://github.com/owner/tools.git",
 				"--repo", "https://github.com/other-owner/tools.git", "--workspace", dir.toString() });
-		assertThrows(IllegalArgumentException.class, () -> Main.contexts(cli));
+		assertThrows(IllegalArgumentException.class, () -> claimAll(cli));
 	}
 
 	@Test
 	void adoptsTheRepositoriesAListFileNames(@TempDir Path dir) throws IOException {
 		Path list = Files.writeString(dir.resolve("repos.txt"), REPO_URL + "\n" + OTHER_URL + "\n");
-		List<AdoptionContext> contexts = Main.contexts(CliArguments
-				.parse(new String[] { "--repos", list.toString(), "--workspace", dir.toString() }));
-		assertEquals(List.of(REPO_URL, OTHER_URL), contexts.stream().map(AdoptionContext::repositoryUrl).toList());
+		CliArguments cli = CliArguments
+				.parse(new String[] { "--repos", list.toString(), "--workspace", dir.toString() });
+		assertEquals(List.of(REPO_URL, OTHER_URL),
+				claimAll(cli).stream().map(AdoptionContext::repositoryUrl).toList());
 	}
 
 	/**
@@ -94,8 +96,7 @@ class MainTest {
 	 */
 	@Test
 	void createsOneTemporaryWorkspaceForTheWholeBatch() {
-		List<AdoptionContext> contexts = Main
-				.contexts(CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL }));
+		List<AdoptionContext> contexts = claimAll(CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL }));
 		assertEquals(contexts.get(0).workspace(), contexts.get(1).workspace());
 		assertTrue(Files.isDirectory(contexts.get(0).workspace()));
 	}
@@ -105,7 +106,7 @@ class MainTest {
 		Path file = dir.resolve("report.json");
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL,
 				"--workspace", dir.toString(), "--report", file.toString() });
-		List<AdoptionRun> runs = Main.runAndReport(cli, Main.contexts(cli),
+		List<AdoptionRun> runs = Main.runAndReport(cli, Main.checkouts(cli),
 				new GitHubRepoAdopter(new RecordingCommandRunner(), List.of()));
 		assertEquals(List.of(REPO_URL, OTHER_URL), runs.stream().map(AdoptionRun::repositoryUrl).toList());
 		JsonNode node = new ObjectMapper().readTree(Files.readString(file));
@@ -122,7 +123,7 @@ class MainTest {
 	void writesTheReportWhenTheAdoptionFails(@TempDir Path dir) throws IOException {
 		Path file = dir.resolve("report.json");
 		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> Main.runAndReport(cli(dir, file), contexts(dir), failingAdopter()));
+				() -> Main.runAndReport(cli(dir, file), checkouts(dir), failingAdopter()));
 		assertTrue(thrown.getMessage().contains(REPO_URL + ": explode: boom"), thrown.getMessage());
 		JsonNode node = new ObjectMapper().readTree(Files.readString(file));
 		assertFalse(node.get("succeeded").asBoolean());
@@ -132,7 +133,8 @@ class MainTest {
 	@Test
 	void writesTheReportWhenTheAdoptionSucceeds(@TempDir Path dir) throws IOException {
 		Path file = dir.resolve("report.json");
-		Main.runAndReport(cli(dir, file), contexts(dir), new GitHubRepoAdopter(new RecordingCommandRunner(), List.of()));
+		Main.runAndReport(cli(dir, file), checkouts(dir),
+				new GitHubRepoAdopter(new RecordingCommandRunner(), List.of()));
 		JsonNode node = new ObjectMapper().readTree(Files.readString(file));
 		assertTrue(node.get("succeeded").asBoolean());
 		assertTrue(node.get("failure").isNull());
@@ -148,7 +150,7 @@ class MainTest {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL,
 				"--workspace", dir.toString(), "--report", file.toString() });
 		assertThrows(AdoptionException.class,
-				() -> Main.runAndReport(cli, Main.contexts(cli), failingFor(REPO_URL)));
+				() -> Main.runAndReport(cli, Main.checkouts(cli), failingFor(REPO_URL)));
 		JsonNode node = new ObjectMapper().readTree(Files.readString(file));
 		assertFalse(node.get("succeeded").asBoolean());
 		assertEquals(REPO_URL, node.get("repositories").get(0).get("repositoryUrl").asText());
@@ -161,7 +163,7 @@ class MainTest {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL, "--workspace",
 				dir.toString() });
 		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> Main.runAndReport(cli, Main.contexts(cli), failingFor(REPO_URL)));
+				() -> Main.runAndReport(cli, Main.checkouts(cli), failingFor(REPO_URL)));
 		assertTrue(thrown.getMessage().startsWith("Adoption failed for 1 of 2 repositories"), thrown.getMessage());
 	}
 
@@ -173,7 +175,7 @@ class MainTest {
 	void anUnwritableReportDoesNotReplaceTheAdoptionFailure(@TempDir Path dir) throws IOException {
 		Path blockingFile = Files.createFile(dir.resolve("not-a-directory"));
 		AdoptionException thrown = assertThrows(AdoptionException.class, () -> Main
-				.runAndReport(cli(dir, blockingFile.resolve("report.json")), contexts(dir), failingAdopter()));
+				.runAndReport(cli(dir, blockingFile.resolve("report.json")), checkouts(dir), failingAdopter()));
 		assertTrue(thrown.getMessage().contains("explode: boom"), thrown.getMessage());
 		assertEquals(1, thrown.getSuppressed().length);
 	}
@@ -181,7 +183,7 @@ class MainTest {
 	@Test
 	void writesNoReportWhenNoneWasRequested(@TempDir Path dir) {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, dir.toString() });
-		Main.runAndReport(cli, contexts(dir), new GitHubRepoAdopter(new RecordingCommandRunner(), List.of()));
+		Main.runAndReport(cli, checkouts(dir), new GitHubRepoAdopter(new RecordingCommandRunner(), List.of()));
 		assertTrue(cli.reportFile().isEmpty());
 	}
 
@@ -189,8 +191,14 @@ class MainTest {
 		return CliArguments.parse(new String[] { REPO_URL, workspace.toString(), "--report", reportFile.toString() });
 	}
 
-	private List<AdoptionContext> contexts(Path workspace) {
-		return List.of(new AdoptionContext(REPO_URL, workspace));
+	private Checkouts checkouts(Path workspace) {
+		return new Checkouts(workspace, AdoptionContext.DEFAULT_BRANCH);
+	}
+
+	/** The contexts a run would claim, in order, as the batch claims them one at a time. */
+	private List<AdoptionContext> claimAll(CliArguments cli) {
+		Checkouts checkouts = Main.checkouts(cli);
+		return cli.repositoryUrls().stream().map(checkouts::claim).toList();
 	}
 
 	private GitHubRepoAdopter failingAdopter() {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MultiRepoAdoptionIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MultiRepoAdoptionIT.java
@@ -92,7 +92,7 @@ class MultiRepoAdoptionIT {
 		CliArguments cli = parse("--repo", HELLO_WORLD, "--repo", SPOON_KNIFE,
 				"--workspace", workspace.toString(), "--branch", BRANCH, "--report", report.toString());
 
-		List<AdoptionRun> runs = Main.runAndReport(cli, Main.contexts(cli), cloneOnlyAdopter());
+		List<AdoptionRun> runs = Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter());
 
 		assertEquals(List.of(HELLO_WORLD, SPOON_KNIFE), runs.stream().map(AdoptionRun::repositoryUrl).toList());
 		assertTrue(runs.stream().allMatch(AdoptionRun::succeeded), () -> failures(runs));
@@ -113,10 +113,8 @@ class MultiRepoAdoptionIT {
 		Path report = reports.resolve("partial.json");
 		CliArguments cli = parse("--repos", listFile(HELLO_WORLD, MISSING, SPOON_KNIFE).toString(),
 				"--workspace", workspace.toString(), "--branch", BRANCH, "--report", report.toString());
-		List<AdoptionContext> contexts = Main.contexts(cli);
-
 		AdoptionException failure = assertThrows(AdoptionException.class,
-				() -> Main.runAndReport(cli, contexts, cloneOnlyAdopter()));
+				() -> Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter()));
 
 		assertTrue(failure.getMessage().contains("1 of 3 repositories"), failure.getMessage());
 		assertTrue(failure.getMessage().contains(MISSING), failure.getMessage());
@@ -131,20 +129,42 @@ class MultiRepoAdoptionIT {
 	/**
 	 * GitHub offers a repository's HTTPS and SSH URLs side by side, so a list
 	 * assembled by pasting from both names one repository twice in two forms. They
-	 * are not duplicates as text, and they claim one checkout directory — the run
-	 * must be refused on its input rather than adopt the repository twice, with
-	 * nothing cloned by the time it is.
+	 * are not duplicates as text, and they claim one checkout directory — so the
+	 * second is refused rather than adopting the repository twice. The refusal costs
+	 * that URL alone: the first is cloned and adopted as asked.
 	 */
 	@Test
-	void refusesTwoRealUrlsForOneRepositoryBeforeCloningAnything() throws IOException {
+	void refusesTheSecondOfTwoRealUrlsForOneRepository() throws IOException {
 		CliArguments cli = parse("--repo", HELLO_WORLD, "--repo", HELLO_WORLD_OVER_SSH,
 				"--workspace", workspace.toString(), "--branch", BRANCH);
 
-		IllegalArgumentException failure = assertThrows(IllegalArgumentException.class, () -> Main.contexts(cli));
+		AdoptionException failure = assertThrows(AdoptionException.class,
+				() -> Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter()));
 
+		assertTrue(failure.getMessage().contains("1 of 2 repositories"), failure.getMessage());
 		assertTrue(failure.getMessage().contains(HELLO_WORLD_OVER_SSH), failure.getMessage());
 		assertTrue(failure.getMessage().contains(workspace.resolve("Hello-World").toString()), failure.getMessage());
-		assertTrue(isEmpty(workspace), "nothing may be cloned when the run is refused on its input");
+		assertCheckedOut(HELLO_WORLD);
+	}
+
+	/**
+	 * A malformed URL in a list an operator assembled by hand is the other failure
+	 * they hit, and it used to abort the run before its first clone — leaving every
+	 * repository behind it unadopted and no report to say so.
+	 */
+	@Test
+	void adoptsTheRestOfTheListWhenOneUrlNamesNoRepository() throws IOException {
+		Path report = reports.resolve("malformed.json");
+		CliArguments cli = parse("--repos", listFile(HELLO_WORLD, "https://github.com/owner/.git", SPOON_KNIFE).toString(),
+				"--workspace", workspace.toString(), "--branch", BRANCH, "--report", report.toString());
+
+		AdoptionException failure = assertThrows(AdoptionException.class,
+				() -> Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter()));
+
+		assertTrue(failure.getMessage().contains("1 of 3 repositories"), failure.getMessage());
+		assertCheckedOut(HELLO_WORLD);
+		assertCheckedOut(SPOON_KNIFE);
+		assertBatchReport(report, false, List.of(HELLO_WORLD, "https://github.com/owner/.git", SPOON_KNIFE));
 	}
 
 	/**
@@ -218,12 +238,6 @@ class MultiRepoAdoptionIT {
 		CommandResult result = runner.run(directory, command);
 		assertTrue(result.succeeded(), () -> result.describe() + " failed: " + result.output());
 		return result.output().strip();
-	}
-
-	private boolean isEmpty(Path directory) throws IOException {
-		try (var entries = Files.list(directory)) {
-			return entries.findAny().isEmpty();
-		}
 	}
 
 	private String failures(List<AdoptionRun> runs) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RedactionTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RedactionTest.java
@@ -1,0 +1,68 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class RedactionTest {
+
+	/** The shape a CI runner hands the adoption: the token is the password. */
+	@Test
+	void masksAUserAndPasswordInACloneUrl() {
+		assertEquals("https://***@github.com/owner/repo.git",
+				Redaction.of("https://x-access-token:secret@github.com/owner/repo.git"));
+	}
+
+	/** An access token is often the whole user information, with no password at all. */
+	@Test
+	void masksATokenUsedAsTheUserName() {
+		assertEquals("https://***@github.com/owner/repo.git",
+				Redaction.of("https://a-token-value@github.com/owner/repo.git"));
+	}
+
+	@Test
+	void leavesAUrlWithoutCredentialsAlone() {
+		assertEquals("https://github.com/owner/repo.git", Redaction.of("https://github.com/owner/repo.git"));
+	}
+
+	/**
+	 * The scp-like form's {@code git@} is the well-known user every such URL carries,
+	 * not a credential, so masking it would only make the URL harder to recognise.
+	 */
+	@Test
+	void leavesTheScpFormsWellKnownUserAlone() {
+		assertEquals("git@github.com:owner/repo.git", Redaction.of("git@github.com:owner/repo.git"));
+	}
+
+	/** A transcript carries the URL inside a sentence, not on its own. */
+	@Test
+	void masksCredentialsAnywhereInTheText() {
+		String masked = Redaction.of("fatal: could not read Username for 'https://user:pw@github.com': no such device");
+		assertEquals("fatal: could not read Username for 'https://***@github.com': no such device", masked);
+		assertFalse(masked.contains("pw"), masked);
+	}
+
+	@Test
+	void masksEveryUrlOfATextThatCarriesSeveral() {
+		assertEquals("https://***@github.com/a.git and https://***@github.com/b.git",
+				Redaction.of("https://u:1@github.com/a.git and https://v:2@github.com/b.git"));
+	}
+
+	@Test
+	void leavesTextWithNoUrlAlone() {
+		assertEquals("clone: repository not found", Redaction.of("clone: repository not found"));
+	}
+
+	/** A command's captured output can be absent, so callers must not have to null-check first. */
+	@Test
+	void answersNullForNull() {
+		assertNull(Redaction.of(null));
+	}
+
+	@Test
+	void answersBlankForBlank() {
+		assertEquals("", Redaction.of(""));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
@@ -97,4 +97,29 @@ class RepositoryUrlTest {
 		assertTrue(RepositoryUrl.of("file:///tmp/tools").slug().isEmpty());
 		assertTrue(RepositoryUrl.of("tools").slug().isEmpty());
 	}
+
+	/**
+	 * git is handed the URL as given, but everything that outlives the run — the log,
+	 * a failure message, the JSON report — reports the masked form.
+	 */
+	@Test
+	void keepsTheCredentialsGitNeedsAndMasksTheOnesItReports() {
+		RepositoryUrl url = RepositoryUrl.of("https://x-access-token:secret@github.com/owner/repo.git");
+		assertEquals("https://x-access-token:secret@github.com/owner/repo.git", url.value());
+		assertEquals("https://***@github.com/owner/repo.git", url.redacted());
+	}
+
+	@Test
+	void aUrlWithoutCredentialsReadsTheSameEitherWay() {
+		RepositoryUrl url = RepositoryUrl.of("https://github.com/owner/repo.git");
+		assertEquals(url.value(), url.redacted());
+	}
+
+	/** A URL refused on its input is quoted back, so it must be masked there too. */
+	@Test
+	void masksTheCredentialsOfARejectedUrl() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> RepositoryUrl.of("https://x-access-token:secret@github.com/owner/.git"));
+		assertTrue(exception.getMessage().contains("https://***@github.com/owner/.git"), exception.getMessage());
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/CommandResultTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/CommandResultTest.java
@@ -33,4 +33,16 @@ class CommandResultTest {
 	void describesACommandWithoutAResult() {
 		assertEquals("gh pr create", CommandResult.describe(List.of("gh", "pr", "create")));
 	}
+
+	/**
+	 * Every failure message quotes the command that raised it, and those messages are
+	 * logged and written to the run's report, so a clone URL's credentials must not
+	 * survive the one place a command is turned into text.
+	 */
+	@Test
+	void masksTheCredentialsOfAClonedUrl() {
+		String described = CommandResult.describe(
+				List.of("git", "clone", "https://x-access-token:secret@github.com/owner/repo.git", "/tmp/repo"));
+		assertEquals("git clone https://***@github.com/owner/repo.git /tmp/repo", described);
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ExecutableResolverTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ExecutableResolverTest.java
@@ -70,11 +70,34 @@ class ExecutableResolverTest {
 		assertSame(command, resolver.resolve(command));
 	}
 
+	/** A path naming something that is not a batch script is started as it was given. */
 	@Test
 	void windowsLeavesAProgramCarryingABackslashPathUnchanged(@TempDir Path dir) throws IOException {
 		Files.createFile(dir.resolve("mvn.cmd"));
 		ExecutableResolver resolver = new ExecutableResolver(true, List.of(dir), EXTENSIONS);
 		List<String> command = List.of("C:\\tools\\mvn", "-N");
+		assertSame(command, resolver.resolve(command));
+	}
+
+	/**
+	 * A checkout's own build wrapper is launched by its absolute path, and on Windows
+	 * that path names a batch script CreateProcess refuses to start — so an explicit
+	 * path still has to go through cmd.exe.
+	 */
+	@Test
+	void windowsRewritesABatchScriptNamedByItsPathThroughCmd(@TempDir Path dir) throws IOException {
+		Path wrapper = Files.createFile(dir.resolve("gradlew.bat"));
+		ExecutableResolver resolver = new ExecutableResolver(true, List.of(), EXTENSIONS);
+		assertEquals(List.of("cmd.exe", "/c", wrapper.toString(), "-q", "enforceClaudeMd"),
+				resolver.resolve(List.of(wrapper.toString(), "-q", "enforceClaudeMd")));
+	}
+
+	/** A POSIX wrapper is started directly, so its path must reach ProcessBuilder as given. */
+	@Test
+	void posixLeavesAWrapperNamedByItsPathUnchanged(@TempDir Path dir) throws IOException {
+		Path wrapper = Files.createFile(dir.resolve("gradlew"));
+		ExecutableResolver resolver = new ExecutableResolver(false, List.of(), EXTENSIONS);
+		List<String> command = List.of(wrapper.toString(), "-q");
 		assertSame(command, resolver.resolve(command));
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
@@ -207,15 +207,18 @@ class AdoptToolTest {
 	}
 
 	/**
-	 * The collision is refused before anything is cloned, so no repository of the call
-	 * is adopted on the strength of another one's checkout.
+	 * The second of two repositories that would share a checkout is refused, so
+	 * neither is adopted on the strength of the other's working tree. The refusal is
+	 * that repository's own — the first is adopted as asked — and the call answers
+	 * with an error result naming which of the two did not land.
 	 */
 	@Test
-	void rejectsAListWhoseRepositoriesShareACheckoutDirectory() {
-		Map<String, Object> arguments = Map.of("repository_urls",
-				List.of("https://github.com/owner/tools.git", "https://github.com/other-owner/tools.git"));
-		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
-		assertTrue(pipeline.contexts.isEmpty());
+	void rejectsTheSecondOfTwoRepositoriesSharingACheckoutDirectory() {
+		ToolResult result = tool.apply(Map.of("repository_urls",
+				List.of("https://github.com/owner/tools.git", "https://github.com/other-owner/tools.git")));
+		assertTrue(result.isError());
+		assertEquals(List.of("https://github.com/owner/tools.git"),
+				pipeline.contexts.stream().map(AdoptionContext::repositoryUrl).toList());
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AbstractCommandStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AbstractCommandStepTest.java
@@ -66,4 +66,21 @@ class AbstractCommandStepTest {
 		assertTrue(message.contains("git push origin main"), message);
 		assertTrue(message.contains("fatal: rejected"), message);
 	}
+
+	/**
+	 * A tool that fails on a credentialled clone URL echoes it back, and this message
+	 * becomes the run's reported failure — so neither the command nor its transcript
+	 * may carry the secret out of the step.
+	 */
+	@Test
+	void failureMessageMasksCredentialsInTheCommandAndTheTranscript() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> new CommandResult(command, 128,
+				"fatal: could not read Username for 'https://x-access-token:secret@github.com'"));
+		AdoptionException exception = assertThrows(AdoptionException.class, () -> step.run(runner, workspace,
+				List.of("git", "clone", "https://x-access-token:secret@github.com/owner/repo.git")));
+		String message = exception.getMessage();
+		assertTrue(message.contains("git clone https://***@github.com/owner/repo.git"), message);
+		assertTrue(message.contains("Username for 'https://***@github.com'"), message);
+		assertTrue(!message.contains("secret"), message);
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -64,18 +64,18 @@ class BuildSystemsTest {
 	}
 
 	@Test
-	void fallbackVerifyCommandRunsTheGuardScript() {
-		assertEquals(List.of("sh", ".github/claude-md-guard.sh"), new FallbackBuildSystem().verifyCommand());
+	void fallbackVerifyCommandRunsTheGuardScript(@TempDir Path directory) {
+		assertEquals(List.of("sh", ".github/claude-md-guard.sh"), new FallbackBuildSystem().verifyCommand(directory));
 	}
 
 	@Test
-	void mavenVerifyCommandIsANonRecursiveValidate() {
-		assertEquals(List.of("mvn", "-q", "-N", "validate"), new MavenBuildSystem().verifyCommand());
+	void mavenVerifyCommandIsANonRecursiveValidate(@TempDir Path directory) {
+		assertEquals(List.of("mvn", "-q", "-N", "validate"), new MavenBuildSystem().verifyCommand(directory));
 	}
 
 	@Test
-	void gradleVerifyCommandRunsTheGuardTask() {
-		assertEquals(List.of("gradle", "-q", "enforceClaudeMd"), new GradleBuildSystem().verifyCommand());
+	void gradleVerifyCommandRunsTheGuardTask(@TempDir Path directory) {
+		assertEquals(List.of("gradle", "-q", "enforceClaudeMd"), new GradleBuildSystem().verifyCommand(directory));
 	}
 
 	/**
@@ -83,17 +83,46 @@ class BuildSystemsTest {
 	 * launches, or the check passes for a tool the adoption never runs.
 	 */
 	@Test
-	void mavenRequiresTheToolItsVerificationLaunches() {
+	void mavenRequiresTheToolItsVerificationLaunches(@TempDir Path directory) {
 		BuildSystem maven = new MavenBuildSystem();
-		assertEquals(Optional.of(maven.verifyCommand().get(0)), maven.requiredTool());
-		assertEquals(Optional.of("mvn"), maven.requiredTool());
+		assertEquals(Optional.of(maven.verifyCommand(directory).get(0)), maven.requiredTool(directory));
+		assertEquals(Optional.of("mvn"), maven.requiredTool(directory));
 	}
 
 	@Test
-	void gradleRequiresTheToolItsVerificationLaunches() {
+	void gradleRequiresTheToolItsVerificationLaunches(@TempDir Path directory) {
 		BuildSystem gradle = new GradleBuildSystem();
-		assertEquals(Optional.of(gradle.verifyCommand().get(0)), gradle.requiredTool());
-		assertEquals(Optional.of("gradle"), gradle.requiredTool());
+		assertEquals(Optional.of(gradle.verifyCommand(directory).get(0)), gradle.requiredTool(directory));
+		assertEquals(Optional.of("gradle"), gradle.requiredTool(directory));
+	}
+
+	/**
+	 * Most Gradle projects ship only the wrapper, so probing the PATH for a `gradle`
+	 * aborted the adoption of a repository the host could build perfectly well.
+	 */
+	@Test
+	void gradleVerifiesWithTheCheckoutsWrapperWhenItShipsOne(@TempDir Path directory) throws IOException {
+		Path wrapper = Files.writeString(directory.resolve("gradlew"), "#!/bin/sh\n");
+		GradleBuildSystem gradle = new GradleBuildSystem(new BuildWrapper("gradlew", "gradlew.bat", false));
+		assertEquals(List.of(wrapper.toAbsolutePath().toString(), "-q", "enforceClaudeMd"),
+				gradle.verifyCommand(directory));
+	}
+
+	@Test
+	void mavenVerifiesWithTheCheckoutsWrapperWhenItShipsOne(@TempDir Path directory) throws IOException {
+		Path wrapper = Files.writeString(directory.resolve("mvnw"), "#!/bin/sh\n");
+		MavenBuildSystem maven = new MavenBuildSystem(new PomEnforcerInstaller("2.6.0"),
+				new BuildWrapper("mvnw", "mvnw.cmd", false));
+		assertEquals(List.of(wrapper.toAbsolutePath().toString(), "-q", "-N", "validate"),
+				maven.verifyCommand(directory));
+	}
+
+	/** The wrapper the verification launches is the one the toolchain step probes. */
+	@Test
+	void theWrapperIsWhatTheToolchainStepProbes(@TempDir Path directory) throws IOException {
+		Path wrapper = Files.writeString(directory.resolve("gradlew"), "#!/bin/sh\n");
+		GradleBuildSystem gradle = new GradleBuildSystem(new BuildWrapper("gradlew", "gradlew.bat", false));
+		assertEquals(Optional.of(wrapper.toAbsolutePath().toString()), gradle.requiredTool(directory));
 	}
 
 	/**
@@ -121,7 +150,7 @@ class BuildSystemsTest {
 	 * and which has no portable --version probe, so there is nothing to check.
 	 */
 	@Test
-	void theFallbackRequiresNoToolOfItsOwn() {
-		assertEquals(Optional.empty(), new FallbackBuildSystem().requiredTool());
+	void theFallbackRequiresNoToolOfItsOwn(@TempDir Path directory) {
+		assertEquals(Optional.empty(), new FallbackBuildSystem().requiredTool(directory));
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
@@ -88,11 +88,48 @@ class BuildToolchainStepTest {
 		AdoptionContexts.write(context, "pom.xml", "<project/>");
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new BuildToolchainStep().execute(context, runner);
-		assertEquals(MavenBuildSystem.VERIFY_COMMAND.get(0), runner.commandAt(0).get(0));
+		assertEquals(new MavenBuildSystem().verifyCommand(context.repositoryDirectory()).get(0),
+				runner.commandAt(0).get(0));
 	}
 
 	@Test
 	void isNamedBuildToolchain() {
 		assertEquals("build-toolchain", new BuildToolchainStep().name());
+	}
+
+	/**
+	 * Most Gradle projects ship only the wrapper, so probing the PATH for a `gradle`
+	 * aborted the adoption of a repository the host could build perfectly well.
+	 */
+	@Test
+	void probesTheCheckoutsWrapperRatherThanThePathWhenOneIsShipped(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
+		AdoptionContexts.write(context, "gradlew", "#!/bin/sh\n");
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		Path wrapper = context.repositoryDirectory().resolve("gradlew").toAbsolutePath();
+
+		new BuildToolchainStep(List.of(new GradleBuildSystem(new BuildWrapper("gradlew", "gradlew.bat", false))))
+				.execute(context, runner);
+
+		assertEquals(List.of(wrapper.toString(), "--version"), runner.commandAt(0));
+	}
+
+	/** A wrapper that cannot be run is named in the failure, not passed off as a missing PATH tool. */
+	@Test
+	void namesTheWrapperItCouldNotRun(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
+		AdoptionContexts.write(context, "gradlew", "#!/bin/sh\n");
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 126, "Permission denied"));
+
+		AdoptionException failure = assertThrows(AdoptionException.class,
+				() -> new BuildToolchainStep(
+						List.of(new GradleBuildSystem(new BuildWrapper("gradlew", "gradlew.bat", false))))
+								.execute(context, runner));
+
+		assertTrue(failure.getMessage().contains("gradlew"), failure.getMessage());
+		assertTrue(failure.getMessage().contains("could not be run"), failure.getMessage());
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystemTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystemTest.java
@@ -26,8 +26,8 @@ class FallbackBuildSystemTest {
 	}
 
 	@Test
-	void verifyCommandRunsTheGuardScript() {
-		assertEquals(List.of("sh", ".github/claude-md-guard.sh"), buildSystem.verifyCommand());
+	void verifyCommandRunsTheGuardScript(@TempDir Path directory) {
+		assertEquals(List.of("sh", ".github/claude-md-guard.sh"), buildSystem.verifyCommand(directory));
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
@@ -29,7 +29,7 @@ class VerifyStepTest {
 		writePom(context);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new VerifyStep().execute(context, runner);
-		assertEquals(MavenBuildSystem.VERIFY_COMMAND, runner.commandAt(0));
+		assertEquals(new MavenBuildSystem().verifyCommand(context.repositoryDirectory()), runner.commandAt(0));
 		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
 	}
 
@@ -39,7 +39,7 @@ class VerifyStepTest {
 		AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new VerifyStep().execute(context, runner);
-		assertEquals(GradleBuildSystem.VERIFY_COMMAND, runner.commandAt(0));
+		assertEquals(new GradleBuildSystem().verifyCommand(context.repositoryDirectory()), runner.commandAt(0));
 	}
 
 	@Test
@@ -106,12 +106,12 @@ class VerifyStepTest {
 		}
 
 		@Override
-		public List<String> verifyCommand() {
+		public List<String> verifyCommand(Path repositoryDirectory) {
 			return verifyCommand;
 		}
 
 		@Override
-		public Optional<String> requiredTool() {
+		public Optional<String> requiredTool(Path repositoryDirectory) {
 			return Optional.empty();
 		}
 	}


### PR DESCRIPTION
Three fixes to the adoption pipeline.

Build wrappers. `verifyCommand`/`requiredTool` hardcoded `mvn` and `gradle`,
so `BuildToolchainStep` probed the PATH for a build tool the checkout never
expected to find there. Most Gradle projects ship only `gradlew`, so adopting
one aborted right after the clone on a host that could have built it. Both
now take the checkout and prefer the wrapper it ships (`mvnw`/`gradlew`, or
the Windows `.cmd`/`.bat` forms), launched by absolute path since
ProcessBuilder resolves a relative program against the JVM's working
directory. `ExecutableResolver` routes an explicitly-pathed batch script
through `cmd.exe`, which it previously did only for a PATH lookup.

Input failures no longer abort the batch. `Checkouts` built every context up
front, so one malformed URL in a `--repos` file — or two repositories
colliding on a checkout directory — stopped the whole run before its first
clone and left no report at all, contradicting the promise `BatchAdoption`
keeps for every failure the pipeline itself raises. It is now a per-run
planner whose checkout is claimed inside each repository's own adoption, so
a refused claim is that repository's recorded failure and the rest still
land. `AdoptionRun` carries the URL and branch as text, since a repository
that never got a context still has to be reported.

Credentials are masked wherever a run outlives itself. A CI clone URL
carries a token, and it reached the log, the message of every failing
command, and the `failure` field of the JSON report written to disk and
answered to MCP clients. `Redaction` masks the user information of a URL
with a scheme; it is applied at `CommandResult.describe`, at the transcripts
quoted in failures, and behind `AdoptionContext.displayUrl`. `git` is still
handed the URL as given.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015sYRm5WbfDmBBWA83ahgpp