### PR TITLE
fix(adopt): keep stdout clean, probe the repository, guard what runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,9 +99,12 @@ Maven project. The notable capabilities are:
   project's CI and every contributor with a build that cannot resolve it — so a
   snapshot build of `tools` cannot adopt a Maven project until a release is
   published. Whether a POM already carries the guard is decided by scanning every
-  `plugin` it declares, wherever it sits — the build, `pluginManagement`, or a
-  profile — because a project that runs the rule behind an opt-in profile would
-  otherwise be given a second, always-on copy of it. Both `gh` invocations name the target repository with
+  `plugin` it *binds* — the build's or a profile's — because a project that runs
+  the rule behind an opt-in profile would otherwise be given a second, always-on
+  copy of it. A `pluginManagement` entry is deliberately not one of them: it pins
+  a version and binds nothing, so a rule declared only there never runs, and
+  counting it as a guard left the project with none while the pull request still
+  claimed one. Both `gh` invocations name the target repository with
   `--repo`, derived from the URL being adopted, rather than letting `gh` infer it
   from the checkout's git remote — a remote rewritten by `url.<base>.insteadOf`,
   a mirror, or a proxy is not readable as a GitHub one and would fail the last

--- a/README.md
+++ b/README.md
@@ -854,9 +854,13 @@ The default pipeline runs these steps in order:
    and a Maven build have already run. Being installed is not enough for `gh`:
    `gh --version` succeeds for a CLI nobody is logged in to, so the login is
    probed too and an unauthenticated `gh` fails here rather than at the very last
-   step. The probe is `gh api user` — an authenticated call to GitHub — rather
-   than `gh auth status`, which reports a rejected `GH_TOKEN` as invalid and
-   still exits zero.
+   step. The probe reads the repository being adopted, `gh api repos/<owner>/<repo>`
+   — the access the pull request will need — rather than `gh auth status`, which
+   reports a rejected `GH_TOKEN` as invalid and still exits zero, and rather than
+   the user-scoped `gh api user`, which a GitHub App installation token (a CI
+   run's `GITHUB_TOKEN`) is refused by even when it can open the pull request
+   perfectly well. A URL naming no owner has no repository to ask about and falls
+   back to `gh api user`.
 2. **`CloneStep`** — clones the target repository into the workspace with
    `git clone`, giving the remaining steps a working checkout.
 3. **`BuildToolchainStep`** — probes the *adopted project's* build tool, now that

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
@@ -1,8 +1,10 @@
 package io.github.adamw7.tools.adopt.step;
 
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,7 +22,8 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  * <p>The whole configuration document is read, updated, and written back through
  * Jackson's tree model, so every unrelated field the file already carries is
  * preserved. A missing configuration file is created, and a directory that is
- * already trusted is left untouched.
+ * already trusted is left untouched. The write itself goes through a temporary
+ * file and a move, so the configuration is never seen half-written.
  */
 public class ClaudeTrustStore {
 
@@ -95,12 +98,55 @@ public class ClaudeTrustStore {
 				+ root.getNodeType() + ": " + configFile);
 	}
 
+	/**
+	 * Writes the document to a sibling temporary file and moves it over the
+	 * configuration, so a reader only ever sees the old file or the new one.
+	 * Truncating {@code ~/.claude.json} in place risked the whole of Claude Code's
+	 * per-user state — its project list, history, and onboarding — on the write
+	 * completing: a crash part-way through left a truncated document behind, and
+	 * this is a live file that an interactive session, or the {@code claude init}
+	 * the adoption is about to run, may be writing at the same moment.
+	 */
 	private void write(ObjectNode root) {
+		Path target = configFile.toAbsolutePath();
 		try {
-			Files.createDirectories(configFile.toAbsolutePath().getParent());
-			mapper.writerWithDefaultPrettyPrinter().writeValue(configFile.toFile(), root);
+			Files.createDirectories(target.getParent());
+			replaceWith(root, temporaryBeside(target), target);
 		} catch (IOException e) {
 			throw new AdoptionException("Could not write Claude config: " + configFile, e);
+		}
+	}
+
+	/** A sibling, so the move stays within one filesystem and can be atomic. */
+	private Path temporaryBeside(Path target) throws IOException {
+		return Files.createTempFile(target.getParent(), ".claude-adopt-", ".json");
+	}
+
+	/**
+	 * The temporary file is removed on every path the move does not take it, so a
+	 * write that fails leaves the configuration directory as it found it rather than
+	 * scattering half-written documents beside the file {@code claude} reads.
+	 */
+	private void replaceWith(ObjectNode root, Path temporary, Path target) throws IOException {
+		try {
+			mapper.writerWithDefaultPrettyPrinter().writeValue(temporary.toFile(), root);
+			replace(temporary, target);
+		} catch (IOException | RuntimeException e) {
+			Files.deleteIfExists(temporary);
+			throw e;
+		}
+	}
+
+	/**
+	 * Falls back to a plain replacing move where the filesystem cannot do an atomic
+	 * one, which still beats writing the configuration in place: the document is
+	 * complete on disk before anything of the old one is touched.
+	 */
+	private void replace(Path temporary, Path target) throws IOException {
+		try {
+			Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+		} catch (AtomicMoveNotSupportedException e) {
+			Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING);
 		}
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -95,15 +95,29 @@ final class PomDocument {
 	}
 
 	/**
-	 * Every {@code plugin} the POM declares, wherever it sits: the build, plugin
-	 * management, or a profile. A project can wire a plugin somewhere other than its
-	 * build — behind an opt-in profile, most often — and a check that only looked there
-	 * would conclude the plugin is absent and add a second declaration of it.
+	 * Every {@code plugin} the POM binds to a build, wherever that build sits: the
+	 * project's own or a profile's. A project can wire a plugin somewhere other than
+	 * its build — behind an opt-in profile, most often — and a check that only looked
+	 * there would conclude the plugin is absent and add a second declaration of it.
+	 *
+	 * <p>A {@code pluginManagement} entry is deliberately not one of them. It says
+	 * which version to use if the plugin is ever bound and nothing more, so a rule
+	 * declared only there is a rule no build ever runs.
 	 */
-	List<Element> plugins() {
+	List<Element> boundPlugins() {
 		return preOrder(root()).stream()
 				.filter(element -> "plugin".equals(element.getLocalName()))
+				.filter(element -> !isManaged(element))
 				.toList();
+	}
+
+	/** Whether the element sits under a {@code pluginManagement}, at any depth. */
+	private static boolean isManaged(Node node) {
+		Node parent = node.getParentNode();
+		while (parent != null && !"pluginManagement".equals(parent.getLocalName())) {
+			parent = parent.getParentNode();
+		}
+		return parent != null;
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -90,13 +90,20 @@ public class PomEnforcerInstaller {
 	}
 
 	/**
-	 * Asks the whole POM rather than only its {@code build/plugins}, because a
-	 * project that already runs the rule may well wire it somewhere else — behind an
-	 * opt-in profile, or in {@code pluginManagement}. Looking only at the build would
-	 * report such a POM as unguarded and wire in a second, duplicate declaration.
+	 * Asks every plugin the POM <em>binds</em>, not only its {@code build/plugins},
+	 * because a project that already runs the rule may well wire it behind an opt-in
+	 * profile. Looking only at the build would report such a POM as unguarded and
+	 * wire in a second, always-on copy of a rule the project already runs on its own
+	 * terms.
+	 *
+	 * <p>What it does not ask is {@code pluginManagement}, which binds nothing: a
+	 * rule declared only there never runs, so treating it as a guard left the project
+	 * with none and the pull request still claiming one — the same silent outcome
+	 * {@link #enforcerPluginOfTheBuild} refuses to produce from the other direction,
+	 * since {@link VerifyStep}'s {@code mvn -N validate} passes either way.
 	 */
 	private boolean declaresClaudeRule(PomDocument pom) {
-		return pom.plugins().stream().anyMatch(this::declaresRuleDependency);
+		return pom.boundPlugins().stream().anyMatch(this::declaresRuleDependency);
 	}
 
 	private boolean declaresRuleDependency(Element plugin) {
@@ -107,7 +114,7 @@ public class PomEnforcerInstaller {
 
 	/**
 	 * The {@code maven-enforcer-plugin} of the POM's own {@code build}, and only that
-	 * one. Where the rule is <em>looked for</em> is the whole POM — see
+	 * one. Where the rule is <em>looked for</em> is every plugin the POM binds — see
 	 * {@link #declaresClaudeRule} — but where it is <em>added</em> cannot be: an
 	 * execution spliced into {@code pluginManagement} only configures a plugin the
 	 * build never runs, and one spliced into a profile runs only when that profile is

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
@@ -20,11 +20,11 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  *
  * <p>Being installed is not enough for {@code gh}: {@code gh --version} succeeds
  * for a GitHub CLI nobody is logged in to, which the adoption would only discover
- * at {@link PullRequestStep}. The login is therefore probed here too, by asking
- * GitHub who the credentials belong to rather than {@code gh} what it has stored —
- * see {@link #AUTHENTICATION_PROBE}. The adopted project's own build tool only
- * becomes known once the repository is cloned, so {@link BuildToolchainStep}
- * probes it there.
+ * at {@link PullRequestStep}. The login is therefore probed here too, by making a
+ * call to GitHub rather than by asking {@code gh} what it has stored — see
+ * {@link #authenticationProbe}. The adopted project's own build tool only becomes
+ * known once the repository is cloned, so {@link BuildToolchainStep} probes it
+ * there.
  */
 public class ToolchainStep implements AdoptionStep {
 
@@ -34,13 +34,9 @@ public class ToolchainStep implements AdoptionStep {
 	static final List<String> DEFAULT_TOOLS = List.of("git", "claude", GITHUB_CLI);
 
 	/**
-	 * The smallest authenticated call to GitHub there is, used in preference to
-	 * {@code gh auth status} because that command reports on credentials it holds
-	 * without its exit code always following: a {@code GH_TOKEN} that GitHub rejects
-	 * makes it print that the token is invalid and still exit zero, so the probe
-	 * passed for a {@code gh} that could not open a pull request — the one thing it
-	 * is here to rule out. Making the call the pull request will need answers the
-	 * question the step is actually asking, and fails when the answer is no.
+	 * The probe for a run whose URL names no owner, and so no repository to ask
+	 * about. It answers the weaker question — whether the credentials belong to
+	 * anyone — because there is nothing better to ask.
 	 */
 	static final List<String> AUTHENTICATION_PROBE = List.of(GITHUB_CLI, "api", "user");
 
@@ -76,11 +72,35 @@ public class ToolchainStep implements AdoptionStep {
 	}
 
 	private void requireGitHubLogin(AdoptionContext context, CommandRunner runner) {
-		if (!tools.contains(GITHUB_CLI) || probe.succeeds(AUTHENTICATION_PROBE, context.workspace(), runner)) {
+		if (!tools.contains(GITHUB_CLI)
+				|| probe.succeeds(authenticationProbe(context), context.workspace(), runner)) {
 			return;
 		}
-		throw new AdoptionException(name() + " failed: " + GITHUB_CLI
-				+ " is installed but cannot authenticate to GitHub, so the pull request could not be opened."
-				+ " Run 'gh auth login', or set GH_TOKEN for a non-interactive host.");
+		throw new AdoptionException(name() + " failed: " + GITHUB_CLI + " is installed but cannot reach "
+				+ context.repositorySlug().orElse("GitHub")
+				+ " with the credentials it holds, so the pull request could not be opened."
+				+ " Run 'gh auth login', or set GH_TOKEN to a token that can write to the repository.");
+	}
+
+	/**
+	 * Asks about the repository the run is going to open a pull request on, rather
+	 * than about the token's owner. {@code gh api user} is a user-scoped call, and a
+	 * GitHub App installation token — what a CI run is handed, and the credential
+	 * behind the {@code x-access-token:TOKEN@github.com} clone URLs the adoption is
+	 * built to accept — is refused by it with "Resource not accessible by
+	 * integration". Probing with it therefore aborted, on its very first step, every
+	 * adoption driven by the CI credential that would have opened the pull request
+	 * perfectly well.
+	 *
+	 * <p>Reading the repository is also the stronger question: it covers a token
+	 * GitHub rejects outright and one that is valid but cannot see this repository,
+	 * both of which stop {@link PullRequestStep}. {@code gh auth status} answers
+	 * neither — it reports the credentials {@code gh} has stored and exits zero even
+	 * while printing that GitHub rejected them.
+	 */
+	private List<String> authenticationProbe(AdoptionContext context) {
+		return context.repositorySlug()
+				.map(slug -> List.of(GITHUB_CLI, "api", "repos/" + slug))
+				.orElse(AUTHENTICATION_PROBE);
 	}
 }

--- a/adopt/src/main/resources/log4j2.properties
+++ b/adopt/src/main/resources/log4j2.properties
@@ -30,9 +30,14 @@ appender.rolling.strategy.delete.ifLastModified.type = IfLastModified
 # Delete all files older than 30 days
 appender.rolling.strategy.delete.ifLastModified.age = 30d
 
-# Console appender so command-line runs show progress on stdout
+# Console appender so command-line runs show progress as the adoption goes.
+# It writes to standard ERROR, not standard output: the same jar is the adoption
+# MCP server, whose default stdio transport uses this process's stdout as the
+# JSON-RPC channel, so a log line on stdout corrupts every frame around it. This
+# is why TransportConfigurer also suppresses the Spring banner.
 appender.console.type = Console
 appender.console.name = consoleLogger
+appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %level - %msg%n
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStoreTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStoreTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -131,5 +133,47 @@ class ClaudeTrustStoreTest {
 
 		assertTrue(new ClaudeTrustStore(config).trust(repo));
 		assertTrue(trusted(read(config), repo));
+	}
+
+	/**
+	 * The config is replaced by a move, not truncated and rewritten in place, so a
+	 * reader only ever sees one whole document. This pins the outcome that matters —
+	 * nothing of the adoption's own scratch work is left beside the config for
+	 * {@code claude} to trip over, and the config itself is complete.
+	 */
+	@Test
+	void leavesNothingBehindBesideTheConfigItWrote(@TempDir Path dir) throws IOException {
+		Path config = dir.resolve(".claude.json");
+		Path repo = dir.resolve("repo");
+
+		assertTrue(new ClaudeTrustStore(config).trust(repo));
+
+		try (Stream<Path> entries = Files.list(dir)) {
+			assertEquals(List.of(config), entries.filter(Files::isRegularFile).toList(),
+					"the temporary file the write goes through must not survive it");
+		}
+		assertTrue(trusted(read(config), repo));
+	}
+
+	/**
+	 * A write that cannot land takes its scratch file with it. Otherwise the failure
+	 * left a stray half-configuration beside {@code ~/.claude.json}, and a batch
+	 * retrying against the same home directory added one per attempt.
+	 *
+	 * <p>The move is made to fail by putting a non-empty directory where the config
+	 * belongs: no filesystem renames a file over one, whatever the caller's
+	 * privileges — unlike an unwritable directory, which does not stop {@code root}.
+	 */
+	@Test
+	void leavesNothingBehindWhenTheWriteCannotLand(@TempDir Path dir) throws IOException {
+		Path config = dir.resolve(".claude.json");
+		Files.createDirectories(config.resolve("nested"));
+
+		assertThrows(AdoptionException.class, () -> new ClaudeTrustStore(config).trust(dir.resolve("repo")));
+
+		try (Stream<Path> entries = Files.list(dir)) {
+			assertEquals(List.of(), entries.filter(Files::isRegularFile).toList(),
+					"the temporary file must not outlive the failed write");
+		}
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -172,6 +172,29 @@ class PomEnforcerInstallerTest {
 			</project>
 			""".formatted(PROFILED_ENFORCER, MANAGED_ENFORCER);
 
+	/** The rule pinned where nothing runs it: {@code pluginManagement} binds no plugin to any phase. */
+	private static final String POM_WITH_RULE_ONLY_MANAGED = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+			  <artifactId>demo</artifactId>
+			  <build>
+			    <pluginManagement>
+			      <plugins>
+			        <plugin>
+			          <artifactId>maven-enforcer-plugin</artifactId>
+			          <dependencies>
+			            <dependency>
+			              <groupId>io.github.adamw7</groupId>
+			              <artifactId>tools.claude-code-enforcer</artifactId>
+			              <version>1.0.0</version>
+			            </dependency>
+			          </dependencies>
+			        </plugin>
+			      </plugins>
+			    </pluginManagement>
+			  </build>
+			</project>
+			""";
+
 	/** Wires the rule the way this repository does: behind an opt-in profile, not in the build. */
 	private static final String POM_WITH_RULE_IN_A_PROFILE = """
 			<project xmlns="http://maven.apache.org/POM/4.0.0">
@@ -354,6 +377,23 @@ class PomEnforcerInstallerTest {
 		Path pom = write(dir, POM_WITH_RULE_IN_A_PROFILE);
 		assertFalse(installer.install(pom), "the rule is already wired in, in the profile");
 		assertEquals(POM_WITH_RULE_IN_A_PROFILE, Files.readString(pom), "the POM must not have been touched");
+	}
+
+	/**
+	 * A profile binds the rule on its own terms and is therefore respected;
+	 * {@code pluginManagement} binds nothing at all. Counting a managed declaration as
+	 * a guard left the project with none, silently: nothing was added, and
+	 * {@link VerifyStep}'s {@code mvn -N validate} passed because the rule never ran,
+	 * so the pull request advertised a guard that did not exist.
+	 */
+	@Test
+	void wiresTheRuleInWhenTheOnlyDeclarationIsManaged(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_RULE_ONLY_MANAGED);
+		assertTrue(installer.install(pom), "a managed rule binds to no phase, so the build still needs one");
+		String result = Files.readString(pom);
+		assertTrue(result.contains("claudeMdFormat"), "the rule must be wired into the build that runs");
+		assertEquals(2, countOccurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
+				"the build needs its own enforcer declaration alongside the managed one");
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
@@ -35,8 +35,54 @@ class ToolchainStepTest {
 	void probesTheGitHubLoginOnceEveryToolIsPresent() {
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new ToolchainStep().execute(context, runner);
-		assertEquals(List.of("gh", "api", "user"), runner.commandAt(3));
+		assertEquals(List.of("gh", "api", "repos/adamw7/demo"), runner.commandAt(3));
 		assertEquals(context.workspace(), runner.invocations().get(3).workingDirectory());
+	}
+
+	/**
+	 * The probe must not be the user-scoped {@code gh api user}. A GitHub App
+	 * installation token — what a CI run is handed, and the credential behind the
+	 * {@code x-access-token:TOKEN@github.com} clone URLs the adoption accepts — is
+	 * refused by that endpoint with "Resource not accessible by integration", so
+	 * probing with it aborted every CI-driven adoption on its very first step even
+	 * though {@code gh pr create} would have worked.
+	 */
+	@Test
+	void neverProbesTheTokensOwnerWhenTheUrlNamesTheRepository() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new ToolchainStep().execute(context, runner);
+		assertFalse(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("user")),
+				runner.invocations().toString());
+	}
+
+	/** An installation token reads its own repository, which is the access the pull request needs. */
+	@Test
+	void anInstallationTokenThatCanReadTheRepositoryCompletesTheStep() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(ToolchainStepTest::installationToken);
+		assertDoesNotThrow(() -> new ToolchainStep().execute(context, runner));
+	}
+
+	/** A token GitHub answers, but not for this repository, cannot open the pull request either. */
+	@Test
+	void aTokenThatCannotSeeTheRepositoryAbortsTheAdoption() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> command.contains("repos/adamw7/demo") ? new CommandResult(command, 1, "HTTP 404")
+						: new CommandResult(command, 0, ""));
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> new ToolchainStep().execute(context, runner));
+		assertTrue(thrown.getMessage().contains("adamw7/demo"), thrown.getMessage());
+	}
+
+	/**
+	 * A URL naming no owner — a local path — leaves no repository to ask about, so
+	 * the weaker question is all there is.
+	 */
+	@Test
+	void asksWhoTheCredentialsBelongToWhenTheUrlNamesNoRepository() {
+		AdoptionContext local = new AdoptionContext("/srv/git/demo", Path.of("/tmp/workspace"));
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new ToolchainStep().execute(local, runner);
+		assertEquals(List.of("gh", "api", "user"), runner.commandAt(3));
 	}
 
 	@Test
@@ -58,7 +104,7 @@ class ToolchainStepTest {
 						: new CommandResult(command, 0, ""));
 		AdoptionException thrown = assertThrows(AdoptionException.class,
 				() -> new ToolchainStep().execute(context, runner));
-		assertTrue(thrown.getMessage().contains("cannot authenticate"), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains("cannot reach"), thrown.getMessage());
 	}
 
 	/**
@@ -74,7 +120,7 @@ class ToolchainStepTest {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::rejectedByGitHub);
 		AdoptionException thrown = assertThrows(AdoptionException.class,
 				() -> new ToolchainStep().execute(context, runner));
-		assertTrue(thrown.getMessage().contains("cannot authenticate"), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains("cannot reach"), thrown.getMessage());
 	}
 
 	/**
@@ -88,6 +134,14 @@ class ToolchainStepTest {
 		new ToolchainStep().execute(context, runner);
 		assertFalse(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("auth")),
 				runner.invocations().toString());
+	}
+
+	/** A {@code gh} holding a GitHub App installation token: refused by {@code user}, fine on the repository. */
+	private static CommandResult installationToken(List<String> command) {
+		if (command.contains("user")) {
+			return new CommandResult(command, 1, "HTTP 403: Resource not accessible by integration");
+		}
+		return new CommandResult(command, 0, "");
 	}
 
 	/** A {@code gh} that is installed and holds a token GitHub answers 401 to. */


### PR DESCRIPTION
Four defects, each of which let the adoption report success while doing
something other than what it claimed.

The module's log4j2 console appender wrote to stdout. The same jar is the
adoption MCP server, whose default stdio transport uses stdout as the
JSON-RPC channel, so every step's log line corrupted the frames around it
— the reason TransportConfigurer already suppresses the Spring banner. The
appender now targets standard error, as the data and code/context modules
manage by shipping no console appender at all.

ToolchainStep probed the GitHub login with the user-scoped `gh api user`,
which a GitHub App installation token is refused by with "Resource not
accessible by integration". That is the credential a CI run is handed, and
the one behind the `x-access-token:TOKEN@github.com` clone URLs the
adoption is built to accept, so every CI-driven adoption aborted on its
first step even though `gh pr create` would have worked. It now reads the
repository being adopted, which is both answerable by an installation
token and the stronger question: it also catches a token that is valid but
cannot see this repository. A URL naming no owner keeps the old probe.

PomEnforcerInstaller counted a rule declared anywhere in the POM as a
guard, including under pluginManagement, which binds nothing to any phase.
Such a project was left exactly as it was, VerifyStep's `mvn -N validate`
passed because the rule never ran, and the pull request advertised a guard
that did not exist — the same silent outcome enforcerPluginOfTheBuild
already refuses to produce from the other direction. Detection now spans
every plugin the POM binds, a profile's included, and no managed one.

ClaudeTrustStore truncated ~/.claude.json and rewrote it in place, risking
the whole of Claude Code's per-user state on the write completing, on a
live file an interactive session may hold open. It now writes a sibling
temporary file and moves it over, cleaning the temporary up on every path
the move does not take it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BAZ8bENUHa6iwAe5yjCJCJ