### PR TITLE
test(adopt): pin the module's layering and safety rules with ArchUnit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,14 +339,38 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
   `Date`/`Calendar` API); and production code logs through log4j2 (never
   `System.out`/`err`, `java.util.logging`, `java.lang.System.Logger`,
   `printStackTrace`, or `System.exit`), with packages kept free of cycles. New
-  code must satisfy these rules or the module's test suite fails. A companion
+  code must satisfy these rules or the module's test suite fails.
+  `AdoptArchitectureTest` adds the rules that keep the adoption pipeline a plain,
+  testable library: the `command` package is the only place a process is spawned
+  (`ProcessBuilder`, `Process`, `ProcessHandle`, `Runtime`) and everything else
+  goes through the `CommandRunner` contract, which is also all a step may know of
+  it — never `ProcessCommandRunner` itself; a step never reaches back to the
+  `GitHubRepoAdopter`, `BatchAdoption`, `CliArguments` or `Main` that assemble and
+  run it, and holds no mutable field, since one step instance adopts every
+  repository of a batch; `AdoptionContext.repositoryUrl()`, which answers the
+  clone URL with its credentials intact, is called by `CloneStep` alone —
+  everything else reads the redacted `displayUrl()`; the adoption speaks no
+  network protocol of its own (`java.net`/`javax.net` are out of bounds outside
+  the MCP delivery package) because it shells out to `git` and `gh`; the `mcp`
+  package is a delivery mechanism nothing else depends on, and the only place
+  that knows the shared MCP scaffolding or Spring; implementations are pinned to
+  their contracts by name (`*Step` to `AdoptionStep`, `*BuildSystem` to
+  `BuildSystem`, `*CommandRunner` to `CommandRunner`, `*Tool` to `McpTool`); the
+  only public `static void main` methods are the two `Main` entry points the pom
+  names; and no public method declares a checked `IOException`, since the
+  pipeline reports failure with the unchecked `AdoptionException`. A companion
   `TestConventionsArchitectureTest` in the same `...architecture` package
   analyses only the *test* classes (via `ImportOption.OnlyIncludeTests`) and pins
   conventions on the tests themselves: every `@Testable` method must live in a
   `*Test` or `*IT` class so surefire/failsafe actually runs it, no test is
   `@Disabled`, tests use JUnit 5 only (no JUnit 4 `org.junit` API), no test
   writes to `System.out`/`err` (assert on the value instead), and no test
-  calls `Thread.sleep` (sleeping is slow and flaky — wait on a condition).
+  calls `Thread.sleep` (sleeping is slow and flaky — wait on a condition). In
+  `adopt` it pins two more, both about what the tests are allowed to touch: a
+  step test drives its step through the recording `CommandRunner` rather than
+  spawning a real `git`, `claude` or `gh`, and no `*IT` may depend on `PushStep`
+  or `PullRequestStep` — the integration tests run against real GitHub
+  repositories, so their pipeline stops at the branch step.
 - **Integration tests** are gated behind the `integration-tests` profile
   (defined in `data`, `code/context`, and `adopt`) and are the tests that need
   something real: `mvn -P integration-tests verify`. Test classes ending in `IT`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,9 @@ paths.
 - **Architecture tests** (ArchUnit) live in each module's `.architecture` test
   package and enforce package layering and coding rules — data-source contracts
   must not depend on their implementations, the uniqueness core must not depend
-  on its MCP adapter, JDBC stays confined to the `source.db` package, loggers are
+  on its MCP adapter, JDBC stays confined to the `source.db` package, the
+  adoption spawns processes only in its `command` package and only its clone
+  step reads the credentialled clone URL, loggers are
   `private static final`, abstract types carry an `Abstract` prefix, public
   fields are `final`, mutable static state is `volatile`, fields are never
   `Optional`, date/time uses `java.time` (not the legacy `Date`/`Calendar` API),
@@ -166,7 +168,9 @@ paths.
   stay free of cycles. A companion `TestConventionsArchitectureTest` pins
   conventions on the tests themselves — test methods must sit in `*Test`/`*IT`
   classes, no `@Disabled`, JUnit 5 only, no `System.out`/`err`, and no
-  `Thread.sleep`. Keep new code within these rules.
+  `Thread.sleep`; in `adopt` it also pins that step tests never spawn a real
+  process and the `*IT`s never push or open a pull request. Keep new code within
+  these rules.
 - **Integration tests** (`*IT`) are gated behind the `integration-tests` profile
   and cover what needs something real: the MCP servers over HTTP, and `adopt`'s
   `MultiRepoAdoptionIT`, which clones real GitHub sample repositories to prove a

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
@@ -2,10 +2,13 @@ package io.github.adamw7.tools.adopt.architecture;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
+import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.Optional;
@@ -19,26 +22,67 @@ import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.library.GeneralCodingRules;
 
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
+import io.github.adamw7.tools.adopt.step.BuildSystem;
+import io.github.adamw7.tools.mcp.McpTool;
 
 /**
  * Architecture rules for the adopt module, enforced with ArchUnit so the
- * package layering and coding conventions cannot rot. Only production classes
- * are analysed; test classes are excluded via {@link ImportOption}.
+ * package layering and coding conventions cannot rot. The pipeline is a plain
+ * library: the {@code step} package holds the stages, the {@code command}
+ * package is the only place a process is spawned, and the {@code mcp} package is
+ * a delivery mechanism on top of both. Only production classes are analysed;
+ * test classes are excluded via {@link ImportOption}.
  */
 @AnalyzeClasses(packages = AdoptArchitectureTest.ADOPT_PACKAGE, importOptions = ImportOption.DoNotIncludeTests.class)
 public class AdoptArchitectureTest {
 
 	static final String ADOPT_PACKAGE = "io.github.adamw7.tools.adopt";
 
+	private static final String ADOPT_ANY_PACKAGE = "io.github.adamw7.tools.adopt..";
 	private static final String COMMAND_PACKAGE = "..adopt.command..";
 	private static final String STEP_PACKAGE = "..adopt.step..";
+	private static final String MCP_PACKAGE = "..adopt.mcp..";
+	private static final String MCP_COMMON_PACKAGE = "io.github.adamw7.tools.mcp..";
+	private static final String SPRING_PACKAGE = "org.springframework..";
+
+	private static final String CLONE_STEP = ADOPT_PACKAGE + ".step.CloneStep";
+	private static final String PROCESS_COMMAND_RUNNER = ADOPT_PACKAGE + ".command.ProcessCommandRunner";
 
 	@ArchTest
 	static final ArchRule commandLayerDoesNotDependOnSteps = noClasses()
 			.that().resideInAPackage(COMMAND_PACKAGE)
 			.should().dependOnClassesThat().resideInAPackage(STEP_PACKAGE)
 			.because("the command-runner layer must not know about the adoption steps that use it");
+
+	@ArchTest
+	static final ArchRule coreDoesNotDependOnMcpAdapter = noClasses()
+			.that().resideInAPackage(ADOPT_ANY_PACKAGE)
+			.and().resideOutsideOfPackage(MCP_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage(MCP_PACKAGE)
+			.because("the MCP adapter is a delivery mechanism on top of the adoption pipeline, not a dependency of it");
+
+	@ArchTest
+	static final ArchRule onlyTheMcpAdapterKnowsTheScaffolding = noClasses()
+			.that().resideOutsideOfPackage(MCP_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage(MCP_COMMON_PACKAGE)
+			.because("only the mcp delivery package builds on the shared MCP scaffolding");
+
+	@ArchTest
+	static final ArchRule onlyTheMcpAdapterKnowsSpring = noClasses()
+			.that().resideOutsideOfPackage(MCP_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage(SPRING_PACKAGE)
+			.because("Spring Boot hosts the MCP server; the pipeline itself stays a plain library that the "
+					+ "command line runs without a container");
+
+	@ArchTest
+	static final ArchRule mcpToolsImplementTheContract = classes()
+			.that().resideInAPackage(MCP_PACKAGE)
+			.and().haveSimpleNameEndingWith("Tool")
+			.should().beAssignableTo(McpTool.class)
+			.because("a *Tool in the mcp package is what the server exposes, so it must honour the McpTool SPI");
 
 	@ArchTest
 	static final ArchRule stepsImplementTheContract = classes()
@@ -55,6 +99,94 @@ public class AdoptArchitectureTest {
 			.and().areNotInterfaces()
 			.should().resideInAPackage(STEP_PACKAGE)
 			.because("every adoption step belongs to the step package that defines the pipeline");
+
+	@ArchTest
+	static final ArchRule adoptionStepsAreNamedStep = classes()
+			.that().areAssignableTo(AdoptionStep.class)
+			.and().areNotInterfaces()
+			.should().haveSimpleNameEndingWith("Step")
+			.because("the pipeline reads as the list of steps it runs, so every implementation carries the "
+					+ "suffix that says it is one");
+
+	@ArchTest
+	static final ArchRule buildSystemsImplementTheContract = classes()
+			.that().haveSimpleNameEndingWith("BuildSystem")
+			.and().areNotInterfaces()
+			.should().beAssignableTo(BuildSystem.class)
+			.andShould().resideInAPackage(STEP_PACKAGE)
+			.because("supporting a new build tool means adding a BuildSystem beside the others, "
+					+ "never branching on the build tool inside a step");
+
+	@ArchTest
+	static final ArchRule commandRunnersImplementTheContract = classes()
+			.that().haveSimpleNameEndingWith("CommandRunner")
+			.and().areNotInterfaces()
+			.should().beAssignableTo(CommandRunner.class)
+			.andShould().resideInAPackage(COMMAND_PACKAGE)
+			.because("the runner is the single seam every step shells out through; an implementation "
+					+ "outside that contract would bypass the redaction and timeout it applies");
+
+	@ArchTest
+	static final ArchRule processExecutionStaysInTheCommandPackage = noClasses()
+			.that().resideOutsideOfPackage(COMMAND_PACKAGE)
+			.should().dependOnClassesThat().haveFullyQualifiedName("java.lang.ProcessBuilder")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.Process")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.ProcessHandle")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.Runtime")
+			.because("spawning a process is the command package's job alone; every other class asks a "
+					+ "CommandRunner, which is what makes the pipeline testable without real git, claude and gh");
+
+	@ArchTest
+	static final ArchRule stepsShellOutThroughTheRunnerContract = noClasses()
+			.that().resideInAPackage(STEP_PACKAGE)
+			.should().dependOnClassesThat().haveFullyQualifiedName(PROCESS_COMMAND_RUNNER)
+			.because("a step is handed the CommandRunner to use, so tests drive it with a recording stub; "
+					+ "reaching for the process-spawning implementation would make it untestable");
+
+	@ArchTest
+	static final ArchRule stepsDoNotDependOnThePipelineThatRunsThem = noClasses()
+			.that().resideInAPackage(STEP_PACKAGE)
+			.should().dependOnClassesThat().haveFullyQualifiedName(ADOPT_PACKAGE + ".GitHubRepoAdopter")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName(ADOPT_PACKAGE + ".BatchAdoption")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName(ADOPT_PACKAGE + ".CliArguments")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName(ADOPT_PACKAGE + ".Main")
+			.because("steps are ordered and assembled from outside; one that reached back to the adopter, "
+					+ "the batch, or the command line could no longer be reordered or reused");
+
+	@ArchTest
+	static final ArchRule onlyTheCloneStepReadsTheCredentialledUrl = noClasses()
+			.that().doNotHaveFullyQualifiedName(CLONE_STEP)
+			.should().callMethod(AdoptionContext.class, "repositoryUrl")
+			.because("repositoryUrl() answers the clone URL with its credentials intact; only the git clone "
+					+ "command may see them, and everything else reads the redacted displayUrl()");
+
+	@ArchTest
+	static final ArchRule adoptionReachesGitHubThroughItsTools = noClasses()
+			.that().resideOutsideOfPackage(MCP_PACKAGE)
+			.should().dependOnClassesThat().resideInAnyPackage("java.net..", "javax.net..")
+			.because("the adoption never speaks a network protocol itself: it shells out to git and gh, which "
+					+ "carry the operator's own credentials, host keys, and proxy configuration");
+
+	@ArchTest
+	static final ArchRule stepStateIsImmutable = fields()
+			.that().areDeclaredInClassesThat().resideInAPackage(STEP_PACKAGE)
+			.should().beFinal()
+			.because("one step instance adopts every repository of a batch, so a mutable field would leak "
+					+ "one repository's state into the next");
+
+	@ArchTest
+	static final ArchRule entryPointsAreNamedMain = methods()
+			.that().haveName("main").and().arePublic().and().areStatic()
+			.should().beDeclaredInClassesThat().haveSimpleName("Main")
+			.because("the module ships two entry points — the pipeline CLI and the MCP server — and the pom "
+					+ "names both by class, so a main method anywhere else is unreachable in practice");
+
+	@ArchTest
+	static final ArchRule publicApiDoesNotDeclareCheckedExceptions = noMethods()
+			.that().arePublic()
+			.should().declareThrowableOfType(IOException.class)
+			.because("the pipeline reports failure with the unchecked AdoptionException, so a caller "
+					+ "assembling steps is never made to translate an IOException step by step");
 
 	@ArchTest
 	static final ArchRule abstractTypesArePrefixed = classes()

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/TestConventionsArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/TestConventionsArchitectureTest.java
@@ -18,7 +18,10 @@ import com.tngtech.archunit.lang.ArchRule;
 /**
  * Conventions enforced on the module's own test code, mirroring the other
  * modules so the constraints that keep the unit suite fast and honest cannot be
- * bypassed. Only test classes are analysed via {@link ImportOption.OnlyIncludeTests}.
+ * bypassed, plus the two this module needs for itself: its step tests must not
+ * spawn real processes, and its integration tests must stay read-only towards
+ * the real GitHub repositories they run against. Only test classes are analysed
+ * via {@link ImportOption.OnlyIncludeTests}.
  */
 @AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
 public class TestConventionsArchitectureTest {
@@ -26,6 +29,11 @@ public class TestConventionsArchitectureTest {
 	static final String TEST_PACKAGE = "io.github.adamw7.tools.adopt";
 
 	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
+
+	private static final String STEP_TEST_PACKAGE = "..adopt.step..";
+	private static final String PROCESS_COMMAND_RUNNER = TEST_PACKAGE + ".command.ProcessCommandRunner";
+	private static final String PUSH_STEP = TEST_PACKAGE + ".step.PushStep";
+	private static final String PULL_REQUEST_STEP = TEST_PACKAGE + ".step.PullRequestStep";
 
 	@ArchTest
 	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
@@ -71,6 +79,24 @@ public class TestConventionsArchitectureTest {
 			.should().beStatic()
 			.because("JUnit 5 runs @BeforeAll/@AfterAll once per class only when they are static; "
 					+ "a non-static one fails at runtime unless the class opts into the PER_CLASS lifecycle")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule stepTestsDoNotSpawnProcesses = noClasses()
+			.that().resideInAPackage(STEP_TEST_PACKAGE)
+			.should().dependOnClassesThat().haveFullyQualifiedName(PROCESS_COMMAND_RUNNER)
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.ProcessBuilder")
+			.because("a step is tested through the recording CommandRunner; running the real git, claude or "
+					+ "gh would make the test slow, machine-dependent, and able to touch a real repository");
+
+	@ArchTest
+	static final ArchRule integrationTestsNeitherPushNorOpenPullRequests = noClasses()
+			.that().haveSimpleNameEndingWith("IT")
+			.should().dependOnClassesThat().haveFullyQualifiedName(PUSH_STEP)
+			.orShould().dependOnClassesThat().haveFullyQualifiedName(PULL_REQUEST_STEP)
+			.because("the integration tests clone real GitHub repositories, so their pipeline stops at the "
+					+ "branch step: a test that pushed or opened a pull request would write to repositories "
+					+ "nobody asked it to write to")
 			.allowEmptyShould(true);
 
 	@ArchTest


### PR DESCRIPTION
The adopt module's architecture test covered the generic conventions and
two layering rules, leaving the properties that actually make the
adoption pipeline safe and testable to convention alone. Add thirteen
rules to AdoptArchitectureTest and two to its test-conventions companion:

- the command package is the only place a process is spawned, and a step
  knows only the CommandRunner contract, never ProcessCommandRunner;
- a step neither reaches back to the adopter, batch, CLI or Main that
  assembles it, nor holds a mutable field — one instance adopts every
  repository of a batch;
- only CloneStep calls AdoptionContext.repositoryUrl(), which answers the
  clone URL with its credentials intact; everything else reads
  displayUrl();
- the adoption speaks no network protocol of its own, shelling out to git
  and gh instead;
- the mcp package is a delivery mechanism nothing else depends on, and
  the only place that knows the MCP scaffolding or Spring;
- implementations are pinned to their contracts by name (*Step,
  *BuildSystem, *CommandRunner, *Tool), main() lives only in the two Main
  entry points, and no public method declares a checked IOException;
- step tests never spawn a real process, and no *IT depends on PushStep
  or PullRequestStep, so the integration tests stay read-only towards the
  real repositories they clone.

Each rule was verified to fail on an injected violation, not merely to
pass. CLAUDE.md and AGENTS.md record the added rules.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ShhDPMYJZ8JuQyAMCweKKL