### PR TITLE
docs(adopt): fix the javadoc reference that breaks the release build

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandResult.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandResult.java
@@ -9,6 +9,13 @@ import io.github.adamw7.tools.adopt.Redaction;
  * standard-output/standard-error text the command produced. The originating
  * command is kept so failures can be reported without the caller having to
  * remember what it asked for.
+ *
+ * @param command  the command that was run, program first, as it was handed to
+ *                 the runner — credentials included, so anything reporting it
+ *                 goes through {@link #describe()}
+ * @param exitCode the code the command exited with, zero meaning success
+ * @param output   the command's standard output and standard error, merged into
+ *                 one ordered transcript
  */
 public record CommandResult(List<String> command, int exitCode, String output) {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -87,7 +87,7 @@ public class GradleGuardInstaller {
 	 * The task name only counts when it appears in a registration outside a comment,
 	 * so a script that merely mentions {@value #GUARD_TASK} — in a {@code // TODO},
 	 * or in a declaration someone commented out — is still given the task rather
-	 * than left without the one {@link GradleBuildSystem#verifyCommand()} runs.
+	 * than left without the one {@link GradleBuildSystem#verifyCommand(Path)} runs.
 	 */
 	private boolean declaresGuard(String script) {
 		return DECLARATION.matcher(withoutCommentLines(script)).find();

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
@@ -14,6 +14,13 @@ import io.github.adamw7.tools.adopt.Text;
  * and the lists are defensively copied and never {@code null}, so the command line
  * and the MCP tool map their arguments straight in and no {@code null} can reach
  * {@code gh}'s arguments.
+ *
+ * @param title     the pull request's title, or blank for {@value #DEFAULT_TITLE}
+ * @param body      the pull request's body, or blank for the adoption's own
+ * @param reviewers the users to request a review from, empty to request nobody
+ * @param labels    the labels to apply, empty to apply none
+ * @param assignees the users to assign, empty to assign nobody
+ * @param draft     whether the pull request is opened as a draft
  */
 public record PullRequestOptions(String title, String body, List<String> reviewers, List<String> labels,
 		List<String> assignees, boolean draft) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
@@ -18,8 +18,8 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
  *
  * <p>Both files are committed, so the guard is shared with every contributor. The
  * script is the single source of truth: the workflow invokes it and
- * {@link FallbackBuildSystem#verifyCommand()} runs the same script locally, so the
- * adoption fails before the branch is pushed just as it would in CI.
+ * {@link FallbackBuildSystem#verifyCommand(Path)} runs the same script locally, so
+ * the adoption fails before the branch is pushed just as it would in CI.
  *
  * <p>The two are installed independently and neither is ever overwritten — the
  * rule {@link AssetInstaller} applies to every file the adoption writes — so a


### PR DESCRIPTION
WorkflowGuardInstaller linked FallbackBuildSystem#verifyCommand(), which
takes a Path, so doclint failed the javadoc jar the release and GitHub
Packages profiles attach. GradleGuardInstaller carried the same broken
form, latent only because it documents a private method.

Also document the CommandResult and PullRequestOptions record components,
the two public records javadoc warned had none.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013jVXqxrZpMS6fThe8PL4HB