### PR TITLE
fix(adopt): mask a clone password that carries an '@'

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Redaction.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Redaction.java
@@ -19,8 +19,15 @@ public final class Redaction {
 
 	static final String MASK = "***";
 
-	/** The user information between a URL's {@code ://} and its {@code @}. */
-	private static final Pattern CREDENTIALS = Pattern.compile("(?<=://)[^/@\\s]+(?=@)");
+	/**
+	 * The user information between a URL's {@code ://} and its {@code @}. The match
+	 * runs to the <em>last</em> {@code @} before the path, because that is where git
+	 * itself ends the user information: a password carrying an unencoded {@code @} —
+	 * {@code https://user:p@ss@host/owner/repo.git} — is one credential, not a
+	 * credential followed by a host. Stopping at the first {@code @} left the rest of
+	 * the password in the text this class exists to keep it out of.
+	 */
+	private static final Pattern CREDENTIALS = Pattern.compile("(?<=://)[^/\\s]+(?=@)");
 
 	private Redaction() {
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -71,9 +71,22 @@ public final class RepositoryUrl {
 	}
 
 	private static String repositoryName(String repositoryUrl) {
-		String withoutTrailingSlash = stripTrailingSlash(repositoryUrl);
-		String lastSegment = withoutTrailingSlash.substring(withoutTrailingSlash.lastIndexOf('/') + 1);
+		String lastSegment = lastSegment(stripTrailingSlash(repositoryUrl));
 		return requireName(stripGitSuffix(lastSegment), repositoryUrl);
+	}
+
+	/**
+	 * The URL's final path segment, ended by either separator git accepts — so the
+	 * scp-like {@code git@host:repo}, whose {@code ':'} is the path separator it is,
+	 * names the checkout directory {@code repo} rather than {@code git@host:repo}.
+	 * This is the same reading of {@code ':'} that {@link #repositorySlug} already
+	 * takes; the scheme is dropped first so its own {@code "://"} is never mistaken
+	 * for that separator.
+	 */
+	private static String lastSegment(String url) {
+		String withoutScheme = url.replaceFirst(SCHEME, "");
+		int separator = Math.max(withoutScheme.lastIndexOf('/'), withoutScheme.lastIndexOf(':'));
+		return withoutScheme.substring(separator + 1);
 	}
 
 	/**
@@ -84,11 +97,22 @@ public final class RepositoryUrl {
 	 * rather than several steps later on a checkout directory nobody intended.
 	 */
 	private static String requireName(String name, String repositoryUrl) {
-		if (name.isEmpty() || ".".equals(name) || "..".equals(name)) {
+		if (name.isEmpty() || ".".equals(name) || "..".equals(name) || isPath(name)) {
 			throw new IllegalArgumentException(
 					"repositoryUrl must end in a repository name but was: " + Redaction.of(repositoryUrl));
 		}
 		return name;
+	}
+
+	/**
+	 * A repository name never carries a backslash, so a last segment that does is a
+	 * path rather than a name — a Windows-style {@code C:\repos\tools}, or a segment
+	 * carrying a {@code ..} traversal. Resolving one against the workspace would put
+	 * the checkout outside it on a platform that reads {@code '\'} as a separator, so
+	 * it is refused for the same reason an empty or alias segment is.
+	 */
+	private static boolean isPath(String name) {
+		return name.indexOf('\\') >= 0;
 	}
 
 	/**
@@ -126,7 +150,19 @@ public final class RepositoryUrl {
 		return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
 	}
 
+	/**
+	 * The suffix is matched case-insensitively, because git clones
+	 * {@code .../repo.GIT} as readily as {@code .../repo.git} and both name the one
+	 * repository. Keeping the case would name the checkout {@code repo.GIT} and ask
+	 * GitHub about {@code owner/repo.GIT}, which answers 404 and stops the adoption
+	 * on its very first step.
+	 */
 	private static String stripGitSuffix(String segment) {
-		return segment.endsWith(GIT_SUFFIX) ? segment.substring(0, segment.length() - GIT_SUFFIX.length()) : segment;
+		int suffixStart = segment.length() - GIT_SUFFIX.length();
+		return endsWithGitSuffix(segment, suffixStart) ? segment.substring(0, suffixStart) : segment;
+	}
+
+	private static boolean endsWithGitSuffix(String segment, int suffixStart) {
+		return suffixStart >= 0 && segment.regionMatches(true, suffixStart, GIT_SUFFIX, 0, GIT_SUFFIX.length());
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -77,11 +77,11 @@ public class AdoptTool implements McpTool {
 							Map.entry("title", Map.of("type", "string", "description", "pull request title")),
 							Map.entry("body", Map.of("type", "string", "description", "pull request body")),
 							Map.entry("reviewers", Map.of("type", "string",
-									"description", "comma-separated reviewers to request")),
+									"description", "comma-separated reviewers to request; an array is accepted too")),
 							Map.entry("labels", Map.of("type", "string",
-									"description", "comma-separated labels to apply")),
+									"description", "comma-separated labels to apply; an array is accepted too")),
 							Map.entry("assignees", Map.of("type", "string",
-									"description", "comma-separated assignees")),
+									"description", "comma-separated assignees; an array is accepted too")),
 							Map.entry("draft", Map.of("type", "boolean",
 									"description", "open the pull request as a draft")),
 							Map.entry("assets", Map.of("type", "boolean",
@@ -157,12 +157,14 @@ public class AdoptTool implements McpTool {
 
 	/**
 	 * @return a list argument's entries, read from a real JSON array or from the
-	 *         comma-separated string a loosely-typed client sends instead
+	 *         comma-separated string a loosely-typed client sends instead. Both
+	 *         shapes are stripped and their blank entries dropped, so which one the
+	 *         client chose cannot change the list the pipeline is handed.
 	 */
 	private List<String> textList(Map<String, Object> arguments, String key) {
 		Object value = arguments.get(key);
 		if (value instanceof Collection<?> entries) {
-			return entries.stream().map(String::valueOf).toList();
+			return texts(entries.stream().map(String::valueOf));
 		}
 		return commaSeparated(arguments, key);
 	}
@@ -180,10 +182,18 @@ public class AdoptTool implements McpTool {
 		return Workspaces.resolveNamed(text(arguments, "workspace"));
 	}
 
+	/**
+	 * The three list arguments are read through {@link #textList} rather than as
+	 * plain text, because a client that sends a JSON array — the natural shape, and
+	 * the one {@code repository_urls} takes on this very tool — would otherwise have
+	 * the list's {@code toString()} split on its commas and reach {@code gh} as
+	 * {@code --reviewer "[octocat"}, failing the last step of an otherwise complete
+	 * adoption.
+	 */
 	private PullRequestOptions optionsFrom(Map<String, Object> arguments) {
 		return new PullRequestOptions(text(arguments, "title"), text(arguments, "body"),
-				commaSeparated(arguments, "reviewers"), commaSeparated(arguments, "labels"),
-				commaSeparated(arguments, "assignees"), ToolArguments.optionalBoolean(arguments, "draft", false));
+				textList(arguments, "reviewers"), textList(arguments, "labels"),
+				textList(arguments, "assignees"), ToolArguments.optionalBoolean(arguments, "draft", false));
 	}
 
 	/**
@@ -201,6 +211,10 @@ public class AdoptTool implements McpTool {
 	}
 
 	private List<String> commaSeparated(Map<String, Object> arguments, String key) {
-		return Stream.of(text(arguments, key).split(",")).map(String::strip).filter(entry -> !entry.isEmpty()).toList();
+		return texts(Stream.of(text(arguments, key).split(",")));
+	}
+
+	private List<String> texts(Stream<String> entries) {
+		return entries.map(String::strip).filter(entry -> !entry.isEmpty()).toList();
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
@@ -65,8 +65,8 @@ This creates an executable JAR in `adopt/target/tools.adopt-{version}.jar`.
 - `branch` (string, optional): feature branch name; defaults to
   `claude/adopt-claude-code`
 - `title` / `body` (string, optional): pull request title and body
-- `reviewers` / `labels` / `assignees` (string, optional): comma-separated
-  values applied to the pull request
+- `reviewers` / `labels` / `assignees` (comma-separated string, or an array of
+  strings, optional): values applied to the pull request
 - `draft` (boolean, optional): open the pull request as a draft
 - `assets` (boolean, optional): also commit starter Claude Code configuration
   assets (`AGENTS.md`, `.claude/settings.json`, a session-start hook,

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RedactionTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RedactionTest.java
@@ -44,6 +44,18 @@ class RedactionTest {
 		assertFalse(masked.contains("pw"), masked);
 	}
 
+	/**
+	 * git ends the user information at the last '@' before the host, so a password
+	 * carrying an unencoded one is a single credential. Masking only as far as the
+	 * first '@' left the rest of it in the log, the failure message, and the report.
+	 */
+	@Test
+	void masksAPasswordThatCarriesAnAtSign() {
+		String masked = Redaction.of("https://user:p@ss@github.com/owner/repo.git");
+		assertEquals("https://***@github.com/owner/repo.git", masked);
+		assertFalse(masked.contains("ss@github"), masked);
+	}
+
 	@Test
 	void masksEveryUrlOfATextThatCarriesSeveral() {
 		assertEquals("https://***@github.com/a.git and https://***@github.com/b.git",

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
@@ -53,6 +53,41 @@ class RepositoryUrlTest {
 		assertEquals("tools", RepositoryUrl.of("git@github.com:adamw7/tools.git").name());
 	}
 
+	/**
+	 * The scp-like form's ':' is a path separator, so a host-only URL ends at it. A
+	 * name taken from the last '/' alone read the whole URL as the repository and
+	 * named the checkout directory {@code git@host:tools}, which a filesystem that
+	 * reserves ':' cannot even resolve.
+	 */
+	@Test
+	void derivesTheNameFromAnSshUrlThatNamesNoOwner() {
+		assertEquals("tools", RepositoryUrl.of("git@host:tools.git").name());
+		assertEquals("tools", RepositoryUrl.of("git@host:tools").name());
+	}
+
+	/**
+	 * git clones {@code .../tools.GIT} as readily as {@code .../tools.git}, and both
+	 * name the one repository — so keeping the case would name the checkout
+	 * {@code tools.GIT} and ask GitHub about a repository that answers 404.
+	 */
+	@Test
+	void stripsTheGitSuffixWhateverItsCase() {
+		assertEquals("tools", RepositoryUrl.of("https://github.com/adamw7/tools.GIT").name());
+		assertEquals("adamw7/tools", RepositoryUrl.of("https://github.com/adamw7/tools.GIT").slug().orElseThrow());
+	}
+
+	/**
+	 * A last segment carrying a backslash is a path rather than a name, and resolving
+	 * one against the workspace would put the checkout outside it wherever '\' is a
+	 * separator.
+	 */
+	@Test
+	void aUrlWhoseNameIsAPathIsRejected() {
+		assertThrows(IllegalArgumentException.class,
+				() -> RepositoryUrl.of("https://github.com/adamw7/a\\..\\..\\evil"));
+		assertThrows(IllegalArgumentException.class, () -> RepositoryUrl.of("C:\\repos\\tools"));
+	}
+
 	@Test
 	void derivesTheNameFromANestedGroupUrl() {
 		assertEquals("tools", RepositoryUrl.of("https://gitlab.com/group/subgroup/tools.git").name());

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
@@ -191,6 +191,24 @@ class AdoptToolTest {
 		assertEquals(List.of("octocat"), pipeline.options.reviewers());
 	}
 
+	/**
+	 * A JSON array is the natural shape for a list, and the one this very tool takes
+	 * for {@code repository_urls}. Read as plain text it became the list's own
+	 * {@code toString()} split on its commas, and reached gh as
+	 * {@code --reviewer "[octocat"} — failing the last step of an otherwise complete
+	 * adoption.
+	 */
+	@Test
+	void readsPullRequestListsSentAsJsonArrays() {
+		tool.apply(Map.of("repository_url", REPO_URL,
+				"reviewers", List.of("octocat", "hubot"),
+				"labels", List.of("automation"),
+				"assignees", List.of(" adamw7 ", "  ")));
+		assertEquals(List.of("octocat", "hubot"), pipeline.options.reviewers());
+		assertEquals(List.of("automation"), pipeline.options.labels());
+		assertEquals(List.of("adamw7"), pipeline.options.assignees());
+	}
+
 	@Test
 	void answersWithTheJsonReport() throws IOException {
 		ToolResult result = tool.apply(Map.of("repository_url", REPO_URL));


### PR DESCRIPTION
The credentials pattern stopped at the first '@', so a URL whose password
carries an unencoded one was only half masked:

    https://user:p@ss@github.com/owner/repo.git
 -> https://***@ss@github.com/owner/repo.git

git ends the user information at the last '@' before the host, so that
whole span is one credential. The trailing fragment reached all three
places this class exists to keep a secret out of: the log, the message of
the AdoptionException a failing command raises, and the failure and
repositoryUrl fields of the JSON report written to disk and answered to
MCP clients.

Drop '@' from the negated class so the match runs greedily to the last one
before the path. A URL with no credentials still has no '@' to anchor on,
and the scp-like form still carries no scheme to match after.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HjDpH1QvBfq4LuggeRYgDQ