### PR TITLE
fix(adopt): confirm a reused checkout is the repository under adoption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,21 @@ Maven project. The notable capabilities are:
   repository's checkout directory inside its own adoption, so a URL naming no
   repository, or one colliding with a checkout another repository of the run
   already claimed, is that repository's recorded failure rather than an abort of
-  the whole run before its first clone. The MCP tool
+  the whole run before its first clone. Two runs into one named `--workspace`
+  never meet, though, so `CloneStep` guards the other half of that collision: a
+  checkout it reuses instead of cloning is first confirmed to be the repository
+  under adoption, by comparing the repository its `origin` names with the one the
+  run was given. Two URLs name one repository when they agree once their scheme,
+  credentials, `.git` suffix, trailing slash, and letter case are set aside — so a
+  checkout cloned over SSH is reused by a run given the HTTPS URL — and anything
+  else is refused, because re-cloning costs a clone while adopting the wrong
+  repository branches, commits, and pushes its working tree and opens a pull
+  request against it. A checkout with no `origin` at all is refused for the same
+  reason, and would have nowhere to push to besides. The reused checkout is then
+  refreshed with a `git fetch`: `BranchStep` decides where to start the feature
+  branch from the remote-tracking refs, so a stale checkout would restart a branch
+  an earlier run had already published and leave `PushStep` refused as a
+  non-fast-forward. The MCP tool
   takes the same list as `repository_urls` (a JSON array, or a comma-separated
   string) beside `repository_url`, and answers with an error result carrying the
   report — not a bare exception — when a repository fails.
@@ -377,8 +391,10 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
   adoption against real GitHub URLs, cloning GitHub's `octocat/Hello-World` and
   `octocat/Spoon-Knife` samples with the real `git`, to prove that a batch gives
   each repository its own checkout, that a repository which cannot be cloned
-  costs only itself, and that two real URLs for one repository are refused
-  before anything is cloned. That IT stops the pipeline at the branch step, so
+  costs only itself, that two real URLs for one repository are refused before
+  anything is cloned, and that a checkout directory already holding a *different*
+  repository is refused rather than adopted. That IT stops the pipeline at the
+  branch step, so
   it stays read-only towards GitHub: it never runs `claude`, never pushes, and
   never opens a pull request, and it needs no `gh` login. Because it clones
   over the network, a host with a git `url.<base>.insteadOf` rewrite records the

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -47,6 +47,17 @@ public final class AdoptionContext {
 		return repository.slug();
 	}
 
+	/**
+	 * Asks the question a step has about a checkout it found — is this the
+	 * repository I was asked to adopt? — without handing it the credentialled clone
+	 * URL to compare for itself.
+	 *
+	 * @see RepositoryUrl#isSameRepositoryAs(String)
+	 */
+	public boolean isSameRepository(String otherUrl) {
+		return repository.isSameRepositoryAs(otherUrl);
+	}
+
 	public Path workspace() {
 		return workspace;
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -1,7 +1,9 @@
 package io.github.adamw7.tools.adopt;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
@@ -19,16 +21,26 @@ public final class RepositoryUrl {
 	private static final int SEGMENTS_WITH_A_HOST = 3;
 	private static final String GIT_SUFFIX = ".git";
 
+	/**
+	 * The user information a URL carries before its host, ended by the last
+	 * {@code @} that precedes the path — the same reading {@link Redaction} takes,
+	 * but applied once the scheme is gone, so the scp-like {@code git@host:owner/repo}
+	 * loses its {@code git@} too. It names no repository either way.
+	 */
+	private static final Pattern USER_INFO = Pattern.compile("^[^/]*@");
+
 	private final String value;
 	private final String redacted;
 	private final String name;
 	private final String slug;
+	private final String identity;
 
 	private RepositoryUrl(String value) {
 		this.value = value;
 		this.redacted = Redaction.of(value);
 		this.name = repositoryName(value);
 		this.slug = repositorySlug(value);
+		this.identity = identity(value);
 	}
 
 	/**
@@ -68,6 +80,44 @@ public final class RepositoryUrl {
 	 */
 	public Optional<String> slug() {
 		return Optional.ofNullable(slug);
+	}
+
+	/**
+	 * Whether another clone URL names this same repository, comparing the two
+	 * without the parts that vary between the forms one repository is cloned by:
+	 * the scheme, the credentials, the {@code .git} suffix, a trailing slash, and
+	 * letter case — and reading the scp-like form's {@code ':'} as the path
+	 * separator it is. So {@code https://token@github.com/Octocat/Hello-World.git}
+	 * and {@code git@github.com:octocat/hello-world} are one repository, while
+	 * {@code .../alice/tools} and {@code .../bob/tools} are two.
+	 *
+	 * <p>Anything that does not reduce to the same text is answered as a different
+	 * repository. The comparison is deliberately conservative in that direction,
+	 * because the caller is deciding whether a checkout it found is the one it was
+	 * asked to adopt: refusing a checkout that was in fact the right one costs a
+	 * clone, while accepting the wrong one commits to it, pushes it, and opens its
+	 * pull request.
+	 *
+	 * @param otherUrl the URL to compare against, typically a checkout's recorded
+	 *                 {@code origin}; blank or {@code null} names no repository and
+	 *                 so matches none
+	 */
+	public boolean isSameRepositoryAs(String otherUrl) {
+		return identity.equals(identity(otherUrl));
+	}
+
+	/**
+	 * @return the comparable form of a clone URL, or the empty string for text that
+	 *         names no repository at all — which never equals the identity of a
+	 *         parsed URL, since {@link #of} rejects a blank one
+	 */
+	private static String identity(String repositoryUrl) {
+		if (!Text.isPresent(repositoryUrl)) {
+			return "";
+		}
+		String withoutScheme = repositoryUrl.strip().replaceFirst(SCHEME, "");
+		String path = USER_INFO.matcher(withoutScheme).replaceFirst("").replace(':', '/');
+		return stripGitSuffix(stripTrailingSlash(path)).toLowerCase(Locale.ROOT);
 	}
 
 	private static String repositoryName(String repositoryUrl) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -8,6 +8,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.Redaction;
+import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
@@ -16,10 +19,28 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * a checkout that already exists (its {@code .git} directory is present) is
  * reused rather than re-cloned, so re-running the adoption against the same
  * workspace does not abort on an "already exists" clone failure.
+ *
+ * <p>A reused checkout is confirmed to be the repository under adoption before
+ * anything is done to it, by comparing the repository its {@code origin} names
+ * with the one the run was given. A checkout directory is named after the
+ * repository alone, so two repositories of the same name — {@code alice/tools}
+ * and {@code bob/tools}, or one repository and its fork — claim one directory
+ * under a named {@code --workspace}. {@link io.github.adamw7.tools.adopt.Checkouts}
+ * catches that collision within a single run, but two runs against the same
+ * workspace never meet; without this check the second adoption would silently
+ * branch, commit, and push the first repository's working tree, and report the
+ * first repository's pull request as the second's.
+ *
+ * <p>The checkout is then refreshed with {@code git fetch}, because every later
+ * decision about the feature branch is taken against the remote-tracking refs a
+ * stale checkout has out of date.
  */
 public class CloneStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(CloneStep.class);
+
+	/** The remote a clone records, and the one {@link PushStep} publishes the branch to. */
+	private static final String REMOTE = "origin";
 
 	@Override
 	public String name() {
@@ -29,13 +50,67 @@ public class CloneStep extends AbstractCommandStep {
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
 		if (alreadyCloned(context)) {
-			log.info("{} already contains a checkout; skipping clone", context.repositoryDirectory());
-			return;
+			reuse(context, runner);
+		} else {
+			cloneAfresh(context, runner);
 		}
+	}
+
+	private void cloneAfresh(AdoptionContext context, CommandRunner runner) {
 		log.info("Cloning {} into {}", context.displayUrl(), context.repositoryDirectory());
 		List<String> command = List.of("git", "clone", context.repositoryUrl(),
 				context.repositoryDirectory().toString());
 		runOrFail(runner, context.workspace(), command);
+	}
+
+	private void reuse(AdoptionContext context, CommandRunner runner) {
+		requireCheckoutOfTheSameRepository(context, runner);
+		log.info("{} already contains a checkout of {}; skipping clone", context.repositoryDirectory(),
+				context.displayUrl());
+		refresh(context, runner);
+	}
+
+	/**
+	 * The failure names both repositories and the directory they disagree about,
+	 * since that is what the operator has to act on — and it says what to do, because
+	 * neither answer is obvious: adopt into a workspace of its own, or clear the
+	 * directory the other repository left behind.
+	 */
+	private void requireCheckoutOfTheSameRepository(AdoptionContext context, CommandRunner runner) {
+		String origin = originUrl(context, runner);
+		if (!context.isSameRepository(origin)) {
+			throw new AdoptionException(context.repositoryDirectory() + " already holds a checkout of "
+					+ Redaction.of(origin) + ", not of " + context.displayUrl()
+					+ ". Adopt this repository into its own --workspace, or remove that directory first.");
+		}
+	}
+
+	/**
+	 * A directory carrying a {@code .git} but no {@code origin} is reported rather
+	 * than adopted: it cannot be shown to be the repository under adoption, and
+	 * {@link PushStep} would have nowhere to publish the branch to anyway.
+	 */
+	private String originUrl(AdoptionContext context, CommandRunner runner) {
+		CommandResult result = runner.run(context.repositoryDirectory(),
+				List.of("git", "remote", "get-url", REMOTE));
+		if (!result.succeeded()) {
+			throw new AdoptionException(context.repositoryDirectory() + " is a checkout with no '" + REMOTE
+					+ "' remote, so it can be neither confirmed to be " + context.displayUrl() + " nor pushed to it: "
+					+ Redaction.of(result.output().strip()));
+		}
+		return result.output().strip();
+	}
+
+	/**
+	 * Brings the reused checkout's remote-tracking refs up to date, so
+	 * {@link BranchStep} sees a feature branch an earlier adoption published and
+	 * resumes from its tip. A checkout that predates that push carries no
+	 * {@code origin/<branch>} ref, which would restart the branch at the default
+	 * branch and leave {@link PushStep} refused as a non-fast-forward.
+	 */
+	private void refresh(AdoptionContext context, CommandRunner runner) {
+		log.info("Fetching {} in {}", REMOTE, context.repositoryDirectory());
+		runOrFail(runner, context.repositoryDirectory(), List.of("git", "fetch", REMOTE));
 	}
 
 	private boolean alreadyCloned(AdoptionContext context) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
@@ -1,7 +1,9 @@
 package io.github.adamw7.tools.adopt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 
@@ -87,5 +89,18 @@ class AdoptionContextTest {
 				Path.of("/tmp/workspace"));
 		assertEquals("https://x-access-token:secret@github.com/owner/repo.git", context.repositoryUrl());
 		assertEquals("https://***@github.com/owner/repo.git", context.displayUrl());
+	}
+
+	/**
+	 * A step deciding whether a checkout it found is the repository under adoption
+	 * asks the context, so the credentialled clone URL stays where only the clone
+	 * command sees it.
+	 */
+	@Test
+	void answersWhetherAnotherUrlNamesTheRepositoryUnderAdoption() {
+		AdoptionContext context = new AdoptionContext("https://x-access-token:secret@github.com/owner/repo.git",
+				Path.of("/tmp/workspace"));
+		assertTrue(context.isSameRepository("git@github.com:owner/repo.git"));
+		assertFalse(context.isSameRepository("https://github.com/someone-else/repo.git"));
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MultiRepoAdoptionIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MultiRepoAdoptionIT.java
@@ -84,7 +84,7 @@ class MultiRepoAdoptionIT {
 	 * independent checkouts. Asserting each checkout's {@code origin} — rather than
 	 * only that two directories exist — is what catches a second adoption that
 	 * silently reused the first repository's working tree, since the clone step
-	 * reuses an existing checkout by design and would report success either way.
+	 * reuses an existing checkout by design.
 	 */
 	@Test
 	void adoptsTwoRealRepositoriesIntoTheirOwnCheckouts() throws IOException {
@@ -165,6 +165,33 @@ class MultiRepoAdoptionIT {
 		assertCheckedOut(HELLO_WORLD);
 		assertCheckedOut(SPOON_KNIFE);
 		assertBatchReport(report, false, List.of(HELLO_WORLD, "https://github.com/owner/.git", SPOON_KNIFE));
+	}
+
+	/**
+	 * Within one run {@link Checkouts} refuses the second claim on a checkout
+	 * directory, but two runs into one named workspace never meet — and a checkout
+	 * directory is named after the repository alone, while one repository name
+	 * belongs to many owners. Only the clone step's own check then stands between
+	 * the operator and an adoption that branches, commits, and pushes a repository
+	 * nobody asked it to touch, so the collision is staged the way it arises: a real
+	 * checkout of one repository sitting under the directory name the next run's
+	 * repository claims.
+	 */
+	@Test
+	void refusesACheckoutDirectoryHoldingADifferentRepository() {
+		Path checkout = workspace.resolve("Spoon-Knife");
+		git(workspace, "clone", HELLO_WORLD, checkout.toString());
+		CliArguments cli = parse("--repo", SPOON_KNIFE, "--workspace", workspace.toString(), "--branch", BRANCH);
+
+		AdoptionException failure = assertThrows(AdoptionException.class,
+				() -> Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter()));
+
+		assertTrue(failure.getMessage().contains(checkout.toString()), failure.getMessage());
+		assertTrue(failure.getMessage().contains("Hello-World"), failure.getMessage());
+		assertTrue(git(checkout, "remote", "get-url", "origin").endsWith("Hello-World.git"),
+				"the checkout of another repository must be left as it was found");
+		assertFalse(BRANCH.equals(git(checkout, "rev-parse", "--abbrev-ref", "HEAD")),
+				"the adoption branch must never be created in another repository's checkout");
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -156,5 +157,44 @@ class RepositoryUrlTest {
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
 				() -> RepositoryUrl.of("https://x-access-token:secret@github.com/owner/.git"));
 		assertTrue(exception.getMessage().contains("https://***@github.com/owner/.git"), exception.getMessage());
+	}
+
+	/**
+	 * The forms one repository is cloned by: GitHub offers its HTTPS and SSH URLs
+	 * side by side, CI adds a token, and a checkout's recorded {@code origin} may be
+	 * any of them. All name the repository the adoption was asked for.
+	 */
+	@Test
+	void everyFormOfOneRepositoryIsTheSameRepository() {
+		RepositoryUrl url = RepositoryUrl.of("https://github.com/octocat/Hello-World.git");
+		assertTrue(url.isSameRepositoryAs("https://github.com/octocat/Hello-World.git"));
+		assertTrue(url.isSameRepositoryAs("https://github.com/octocat/Hello-World"));
+		assertTrue(url.isSameRepositoryAs("https://github.com/octocat/hello-world.GIT"));
+		assertTrue(url.isSameRepositoryAs("https://github.com/octocat/Hello-World/"));
+		assertTrue(url.isSameRepositoryAs("git@github.com:octocat/Hello-World.git"));
+		assertTrue(url.isSameRepositoryAs("ssh://git@github.com/octocat/Hello-World"));
+		assertTrue(url.isSameRepositoryAs("https://x-access-token:secret@github.com/octocat/Hello-World.git"));
+	}
+
+	/**
+	 * A checkout directory is named after the repository alone, so these are the
+	 * URLs that claim one directory while naming different repositories — the
+	 * collision the reuse of an existing checkout has to catch.
+	 */
+	@Test
+	void twoOwnersOfOneRepositoryNameAreDifferentRepositories() {
+		RepositoryUrl url = RepositoryUrl.of("https://github.com/alice/tools.git");
+		assertFalse(url.isSameRepositoryAs("https://github.com/bob/tools.git"));
+		assertFalse(url.isSameRepositoryAs("https://gitlab.com/alice/tools.git"));
+		assertFalse(url.isSameRepositoryAs("/tmp/workspace/tools"));
+	}
+
+	/** Text that names no repository matches none, rather than every URL or the last one asked. */
+	@Test
+	void noUrlAtAllIsNoRepository() {
+		RepositoryUrl url = RepositoryUrl.of("https://github.com/alice/tools.git");
+		assertFalse(url.isSameRepositoryAs(null));
+		assertFalse(url.isSameRepositoryAs(""));
+		assertFalse(url.isSameRepositoryAs("  "));
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -1,7 +1,9 @@
 package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -31,13 +33,75 @@ class CloneStepTest {
 		assertEquals(workspace, runner.invocations().get(0).workingDirectory());
 	}
 
+	/**
+	 * The checkout is reused rather than re-cloned, but only once its {@code origin}
+	 * has confirmed it to be the repository under adoption — and it is refreshed, so
+	 * the branch step reads remote-tracking refs that are up to date.
+	 */
 	@Test
-	void skipsCloneWhenCheckoutAlreadyExists(@TempDir Path existingWorkspace) throws IOException {
-		AdoptionContext existing = new AdoptionContext("https://github.com/adamw7/tools.git", existingWorkspace);
-		Files.createDirectories(existing.repositoryDirectory().resolve(".git"));
-		RecordingCommandRunner runner = new RecordingCommandRunner();
+	void reusesCheckoutOfTheSameRepositoryInsteadOfCloning(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = origin("https://github.com/adamw7/tools.git");
 		step.execute(existing, runner);
-		assertEquals(0, runner.count());
+		assertEquals(List.of("git", "remote", "get-url", "origin"), runner.commandAt(0));
+		assertEquals(List.of("git", "fetch", "origin"), runner.commandAt(1));
+		assertEquals(2, runner.count());
+	}
+
+	/**
+	 * The checkout an earlier run left behind was cloned from whichever of the
+	 * repository's URLs that run was given, so a reuse that only accepted the URL
+	 * back verbatim would re-clone over a checkout that was already the right one.
+	 */
+	@Test
+	void reusesCheckoutClonedFromAnotherFormOfTheSameUrl(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = origin("git@github.com:adamw7/Tools");
+		step.execute(existing, runner);
+		assertEquals(2, runner.count());
+	}
+
+	/**
+	 * Two repositories of one name claim one checkout directory. Within a run
+	 * {@code Checkouts} refuses the second; across two runs into the same
+	 * {@code --workspace} only this check stands between the operator and an
+	 * adoption that branches, commits, and pushes the wrong repository.
+	 */
+	@Test
+	void refusesCheckoutOfADifferentRepository(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = origin("https://github.com/someone-else/tools.git");
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
+		assertTrue(failure.getMessage().contains("someone-else/tools"), failure.getMessage());
+		assertTrue(failure.getMessage().contains("adamw7/tools"), failure.getMessage());
+		assertEquals(1, runner.count(), "nothing may be done to a checkout of another repository");
+	}
+
+	/** The origin of a checkout that fails the check is reported without its credentials. */
+	@Test
+	void masksCredentialsOfTheRefusedCheckoutsOrigin(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = origin("https://x-access-token:SECRET@github.com/someone-else/tools.git");
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
+		assertFalse(failure.getMessage().contains("SECRET"), failure.getMessage());
+	}
+
+	@Test
+	void refusesCheckoutWithNoOriginRemote(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				command -> new CommandResult(command, 2, "error: No such remote 'origin'"));
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
+		assertTrue(failure.getMessage().contains("no 'origin' remote"), failure.getMessage());
+	}
+
+	@Test
+	void failedFetchAbortsAdoption(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("fetch")
+				? new CommandResult(command, 128, "fatal: could not read from remote repository")
+				: new CommandResult(command, 0, "https://github.com/adamw7/tools.git"));
+		assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
 	}
 
 	@Test
@@ -50,5 +114,17 @@ class CloneStepTest {
 	@Test
 	void isNamedClone() {
 		assertEquals("clone", step.name());
+	}
+
+	/** A checkout of the repository under test, as an earlier run would have left it. */
+	private AdoptionContext checkedOut(Path existingWorkspace) throws IOException {
+		AdoptionContext existing = new AdoptionContext("https://github.com/adamw7/tools.git", existingWorkspace);
+		Files.createDirectories(existing.repositoryDirectory().resolve(".git"));
+		return existing;
+	}
+
+	/** A runner answering every command with the URL git would report as the checkout's origin. */
+	private RecordingCommandRunner origin(String url) {
+		return new RecordingCommandRunner(command -> new CommandResult(command, 0, url + System.lineSeparator()));
 	}
 }


### PR DESCRIPTION
`CloneStep` reuses a checkout the workspace already holds rather than
re-cloning it, deciding on the presence of a `.git` directory alone. A
checkout directory is named after the repository, and one repository name
belongs to many owners, so `alice/tools` and `bob/tools` — or a repository
and its fork — claim one directory under a named `--workspace`. `Checkouts`
catches that collision within a run, but two runs into one workspace never
meet: the second adoption branched, committed and pushed the first
repository's working tree, and reported the first repository's pull request
as the second's.

A reused checkout is now confirmed to be the repository under adoption by
comparing the repository its `origin` names with the one the run was given,
and one with no `origin` at all is refused rather than adopted. The two URLs
are compared without the parts that vary between the forms a repository is
cloned by — scheme, credentials, `.git` suffix, trailing slash and case —
so a checkout cloned over SSH is reused by a run given the HTTPS URL, while
anything else is refused: re-cloning costs a clone, adopting the wrong
repository costs a pull request against it. The comparison lives on
`RepositoryUrl` and is reached through `AdoptionContext`, so no step needs
the credentialled clone URL to make it.

The reused checkout is then refreshed with `git fetch`, because `BranchStep`
picks the feature branch's start point from the remote-tracking refs: a
stale checkout restarted a branch an earlier run had already published, and
left `PushStep` refused as a non-fast-forward.

`MultiRepoAdoptionIT` covers the refusal against real GitHub repositories by
staging the collision the way it arises — a real checkout of one repository
under the directory name the next run's repository claims.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FHfnmJzFUUei8sbCNVoR6c