### PR TITLE
refactor(test-common): share the ArchUnit rules duplicated across modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,7 @@ validation from runtime to compile time.
 ```
 tools (root pom, packaging=pom)
 ├── claude-code-enforcer        # custom maven-enforcer rule validating CLAUDE.md
+├── test-common                 # shared ArchUnit rule libraries, published as a test-jar
 ├── mcp-common                  # shared MCP server scaffolding (transport wiring, tool SPI)
 ├── data                        # data sources, uniqueness checks, structures, MCP server
 ├── code
@@ -170,8 +171,8 @@ tools (root pom, packaging=pom)
 └── data-test                   # standalone test module for the data module
 ```
 
-Root reactor modules are `claude-code-enforcer`, `mcp-common`, `data`, `code`,
-`adopt`, `grpc-example`, and `assembly`.
+Root reactor modules are `claude-code-enforcer`, `test-common`, `mcp-common`,
+`data`, `code`, `adopt`, `grpc-example`, and `assembly`.
 The `data-test` module is built separately (it is not in the root `<modules>`
 list).
 
@@ -383,6 +384,19 @@ CLAUDE.md check; the other workflows build normally and are unaffected.
   spawning a real `git`, `claude` or `gh`, and no `*IT` may depend on `PushStep`
   or `PullRequestStep` — the integration tests run against real GitHub
   repositories, so their pipeline stops at the branch step.
+- **Shared rule libraries.** The rules above that hold for *every* module are
+  declared once in the `test-common` module and imported with ArchUnit's
+  `ArchTests.in(...)`, so each module's architecture test states only what is
+  specific to that module. `CommonCodingConventions` carries the universal
+  production rules (loggers, public/static/`Optional` fields, `java.time`, log4j2
+  logging, no `System.exit`, no standard streams, no generic exceptions, no Joda
+  Time); `CommonTestConventions` carries the test-side conventions; and
+  `CommonNamingConventions` carries the `Abstract` prefix rule, kept separate
+  because `claude-code-enforcer` is exempt — its abstract rule bases
+  (`ClaudeCodeEnforcerRule`, `MarkdownFormatRule`, `JsonFileRule`) are public API
+  that poms configure by name. Adding a repository-wide convention means editing
+  one library, not six tests; an exemption means a module not importing a
+  library, which stays visible in that module's test.
 - **Integration tests** are gated behind the `integration-tests` profile
   (defined in `data`, `code/context`, and `adopt`) and are the tests that need
   something real: `mvn -P integration-tests verify`. Test classes ending in `IT`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,12 +52,14 @@ run `mvn install` from the repository root. The main capabilities are:
   `--report <file>`, and an MCP server exposes the pipeline as an `adopt_repo`
   tool.
 
-Module map (root reactor: `claude-code-enforcer`, `mcp-common`, `data`, `code`,
-`adopt`, `grpc-example`, `assembly`; `data-test` is built separately):
+Module map (root reactor: `claude-code-enforcer`, `test-common`, `mcp-common`,
+`data`, `code`, `adopt`, `grpc-example`, `assembly`; `data-test` is built
+separately):
 
 ```
 tools (root pom, packaging=pom)
 ├── claude-code-enforcer   # custom maven-enforcer rules validating CLAUDE.md/AGENTS.md & agent config
+├── test-common            # shared ArchUnit rule libraries (test-jar), reused by every module's architecture tests
 ├── mcp-common             # shared MCP server scaffolding
 ├── data                   # data sources, uniqueness checks, structures, MCP server
 ├── code
@@ -177,8 +179,11 @@ paths.
   conventions on the tests themselves — test methods must sit in `*Test`/`*IT`
   classes, no `@Disabled`, JUnit 5 only, no `System.out`/`err`, and no
   `Thread.sleep`; in `adopt` it also pins that step tests never spawn a real
-  process and the `*IT`s never push or open a pull request. Keep new code within
-  these rules.
+  process and the `*IT`s never push or open a pull request. The rules that apply
+  to every module live once in `test-common` (`CommonCodingConventions`,
+  `CommonNamingConventions`, `CommonTestConventions`) and are pulled in with
+  `ArchTests.in(...)`, so a module's own test states only what is specific to it.
+  Keep new code within these rules.
 - **Integration tests** (`*IT`) are gated behind the `integration-tests` profile
   and cover what needs something real: the MCP servers over HTTP, and `adopt`'s
   `MultiRepoAdoptionIT`, which clones real GitHub sample repositories to prove a

--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -115,6 +115,13 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>io.github.adamw7</groupId>
+			<artifactId>tools.test-common</artifactId>
+			<version>${revision}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.tngtech.archunit</groupId>
 			<artifactId>archunit-junit5</artifactId>
 			<scope>test</scope>

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
@@ -4,29 +4,25 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 import java.io.IOException;
-import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.util.Optional;
-
-import org.apache.logging.log4j.Logger;
 
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.lang.ArchRule;
-import com.tngtech.archunit.library.GeneralCodingRules;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
 import io.github.adamw7.tools.adopt.step.BuildSystem;
 import io.github.adamw7.tools.mcp.McpTool;
+import io.github.adamw7.tools.test.architecture.CommonCodingConventions;
+import io.github.adamw7.tools.test.architecture.CommonNamingConventions;
 
 /**
  * Architecture rules for the adopt module, enforced with ArchUnit so the
@@ -50,6 +46,12 @@ public class AdoptArchitectureTest {
 
 	private static final String CLONE_STEP = ADOPT_PACKAGE + ".step.CloneStep";
 	private static final String PROCESS_COMMAND_RUNNER = ADOPT_PACKAGE + ".command.ProcessCommandRunner";
+
+	@ArchTest
+	static final ArchTests commonCodingConventions = ArchTests.in(CommonCodingConventions.class);
+
+	@ArchTest
+	static final ArchTests commonNamingConventions = ArchTests.in(CommonNamingConventions.class);
 
 	@ArchTest
 	static final ArchRule commandLayerDoesNotDependOnSteps = noClasses()
@@ -189,89 +191,7 @@ public class AdoptArchitectureTest {
 					+ "assembling steps is never made to translate an IOException step by step");
 
 	@ArchTest
-	static final ArchRule abstractTypesArePrefixed = classes()
-			.that().haveModifier(JavaModifier.ABSTRACT).and().areNotInterfaces()
-			.should().haveSimpleNameStartingWith("Abstract")
-			.because("abstract classes are named with an Abstract prefix for clarity");
-
-	@ArchTest
 	static final ArchRule packagesAreFreeOfCycles = slices()
 			.matching("io.github.adamw7.tools.adopt.(*)..")
 			.should().beFreeOfCycles();
-
-	@ArchTest
-	static final ArchRule loggersArePrivateStaticFinal = fields()
-			.that().haveRawType(Logger.class)
-			.should().bePrivate().andShould().beStatic().andShould().beFinal()
-			.because("loggers are private static final by convention");
-
-	@ArchTest
-	static final ArchRule exceptionsAreNamedConsistently = classes()
-			.that().haveSimpleNameEndingWith("Exception")
-			.should().beAssignableTo(Exception.class)
-			.because("types named *Exception must actually be exceptions")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule publicFieldsAreImmutable = fields()
-			.that().arePublic()
-			.should().beFinal()
-			.because("a public field is part of the type's API surface and must not be reassignable")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule mutableStaticStateIsVolatile = fields()
-			.that().areStatic()
-			.and().areNotFinal()
-			.should().haveModifier(JavaModifier.VOLATILE)
-			.because("a mutable static field is shared across every thread, so it must be volatile "
-					+ "for its updates to publish safely")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule optionalFieldsAreForbidden = noFields()
-			.should().haveRawType(Optional.class)
-			.because("Optional models a possibly-absent return value, not a field; a field should hold "
-					+ "the value itself and be null-checked, never wrapped in an Optional")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule noLegacyDateTimeApi = noClasses()
-			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
-			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
-			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
-			.because("logging must go through log4j2 so configuration stays in one place");
-
-	@ArchTest
-	static final ArchRule noPrintStackTrace = noClasses()
-			.should().callMethod(Throwable.class, "printStackTrace")
-			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
-			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
-			.because("failures must be reported through log4j2, never printed as a raw stack trace");
-
-	@ArchTest
-	static final ArchRule adoptionDoesNotHaltTheJvm = noClasses()
-			.should().callMethod(System.class, "exit", int.class)
-			.because("the adoption pipeline reports failure by throwing AdoptionException, never by terminating the JVM");
-
-	@ArchTest
-	static final ArchRule noStandardStreams = GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
-
-	@ArchTest
-	static final ArchRule noJavaUtilLogging = GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
-
-	@ArchTest
-	static final ArchRule noGenericExceptionsThrown = GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
-
-	@ArchTest
-	static final ArchRule noJodaTime = GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/TestConventionsArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/TestConventionsArchitectureTest.java
@@ -1,34 +1,26 @@
 package io.github.adamw7.tools.adopt.architecture;
 
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
-
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.lang.ArchRule;
 
+import io.github.adamw7.tools.test.architecture.CommonTestConventions;
+
 /**
- * Conventions enforced on the module's own test code, mirroring the other
- * modules so the constraints that keep the unit suite fast and honest cannot be
- * bypassed, plus the two this module needs for itself: its step tests must not
- * spawn real processes, and its integration tests must stay read-only towards
- * the real GitHub repositories they run against. Only test classes are analysed
- * via {@link ImportOption.OnlyIncludeTests}.
+ * Applies the shared {@link CommonTestConventions} to the adopt module's own
+ * test code, plus the two rules this module needs for itself: its step tests
+ * must not spawn real processes, and its integration tests must stay read-only
+ * towards the real GitHub repositories they run against. Only test classes are
+ * analysed via {@link ImportOption.OnlyIncludeTests}.
  */
 @AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
 public class TestConventionsArchitectureTest {
 
 	static final String TEST_PACKAGE = "io.github.adamw7.tools.adopt";
-
-	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
 
 	private static final String STEP_TEST_PACKAGE = "..adopt.step..";
 	private static final String PROCESS_COMMAND_RUNNER = TEST_PACKAGE + ".command.ProcessCommandRunner";
@@ -36,50 +28,7 @@ public class TestConventionsArchitectureTest {
 	private static final String PULL_REQUEST_STEP = TEST_PACKAGE + ".step.PullRequestStep";
 
 	@ArchTest
-	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
-			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
-			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
-			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
-			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
-					+ "so a test method in a differently named class silently never runs");
-
-	@ArchTest
-	static final ArchRule noDisabledTestMethods = noMethods()
-			.should().beAnnotatedWith(Disabled.class)
-			.because("a disabled test gives false confidence; delete it or fix what it guards");
-
-	@ArchTest
-	static final ArchRule noDisabledTestClasses = noClasses()
-			.should().beAnnotatedWith(Disabled.class)
-			.because("a disabled test gives false confidence; delete it or fix what it guards");
-
-	@ArchTest
-	static final ArchRule testsUseJunit5 = noClasses()
-			.should().dependOnClassesThat().resideInAPackage("org.junit")
-			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
-
-	@ArchTest
-	static final ArchRule testsDoNotSleep = noClasses()
-			.should().callMethod(Thread.class, "sleep", long.class)
-			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
-			.orShould().callMethod(TimeUnit.class, "sleep", long.class)
-			.because("a test that sleeps is slow and flaky; wait on a condition instead");
-
-	@ArchTest
-	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
-			.should().accessField(System.class, "out")
-			.orShould().accessField(System.class, "err")
-			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
-			.that().areAnnotatedWith(BeforeAll.class)
-			.or().areAnnotatedWith(AfterAll.class)
-			.should().beStatic()
-			.because("JUnit 5 runs @BeforeAll/@AfterAll once per class only when they are static; "
-					+ "a non-static one fails at runtime unless the class opts into the PER_CLASS lifecycle")
-			.allowEmptyShould(true);
+	static final ArchTests commonTestConventions = ArchTests.in(CommonTestConventions.class);
 
 	@ArchTest
 	static final ArchRule stepTestsDoNotSpawnProcesses = noClasses()
@@ -98,11 +47,4 @@ public class TestConventionsArchitectureTest {
 					+ "branch step: a test that pushed or opened a pull request would write to repositories "
 					+ "nobody asked it to write to")
 			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule testMethodsAreRunnableByJunit = methods()
-			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
-			.should().notBePrivate()
-			.andShould().notBeStatic()
-			.because("JUnit 5 silently ignores a private or static test method, so it never runs");
 }

--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -35,6 +35,13 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>io.github.adamw7</groupId>
+			<artifactId>tools.test-common</artifactId>
+			<version>${revision}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.tngtech.archunit</groupId>
 			<artifactId>archunit-junit5</artifactId>
 			<scope>test</scope>

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
@@ -1,24 +1,18 @@
 package io.github.adamw7.tools.enforcer.architecture;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
-
-import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.util.Optional;
 
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.lang.ArchRule;
-import com.tngtech.archunit.library.GeneralCodingRules;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.test.architecture.CommonCodingConventions;
 
 /**
  * Architecture rules for the enforcer module. They pin the layering that the
@@ -31,6 +25,9 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 public class EnforcerArchitectureTest {
 
 	static final String ENFORCER_PACKAGE = "io.github.adamw7.tools.enforcer";
+
+	@ArchTest
+	static final ArchTests commonCodingConventions = ArchTests.in(CommonCodingConventions.class);
 
 	@ArchTest
 	static final ArchRule layersDependInOneDirection = layeredArchitecture()
@@ -64,78 +61,4 @@ public class EnforcerArchitectureTest {
 			.and().doNotHaveModifier(JavaModifier.ABSTRACT)
 			.should().beAssignableTo(ClaudeCodeEnforcerRule.class)
 			.because("every concrete *Rule is an enforcer rule and must extend the shared base");
-
-	@ArchTest
-	static final ArchRule exceptionsAreNamedConsistently = classes()
-			.that().haveSimpleNameEndingWith("Exception")
-			.should().beAssignableTo(Exception.class)
-			.because("types named *Exception must actually be exceptions")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule publicFieldsAreImmutable = fields()
-			.that().arePublic()
-			.should().beFinal()
-			.because("a public field is part of the type's API surface and must not be reassignable")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule mutableStaticStateIsVolatile = fields()
-			.that().areStatic()
-			.and().areNotFinal()
-			.should().haveModifier(JavaModifier.VOLATILE)
-			.because("a mutable static field is shared across every thread, so it must be volatile "
-					+ "for its updates to publish safely")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule optionalFieldsAreForbidden = noFields()
-			.should().haveRawType(Optional.class)
-			.because("Optional models a possibly-absent return value, not a field; a field should hold "
-					+ "the value itself and be null-checked, never wrapped in an Optional")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule noLegacyDateTimeApi = noClasses()
-			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
-			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
-			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
-			.because("logging must go through log4j2 so configuration stays in one place");
-
-	@ArchTest
-	static final ArchRule noAccessToStandardStreams =
-			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
-
-	@ArchTest
-	static final ArchRule noGenericExceptionsAreThrown =
-			GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
-
-	@ArchTest
-	static final ArchRule noJavaUtilLogging =
-			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
-
-	@ArchTest
-	static final ArchRule noJodaTime =
-			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
-
-	@ArchTest
-	static final ArchRule noPrintStackTrace = noClasses()
-			.should().callMethod(Throwable.class, "printStackTrace")
-			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
-			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
-			.because("failures must be reported through log4j2, never printed as a raw stack trace");
-
-	@ArchTest
-	static final ArchRule enforcerDoesNotHaltTheJvm = noClasses()
-			.should().callMethod(System.class, "exit", int.class)
-			.because("an enforcer rule reports violations by throwing, never by killing the JVM");
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/TestConventionsArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/TestConventionsArchitectureTest.java
@@ -1,83 +1,24 @@
 package io.github.adamw7.tools.enforcer.architecture;
 
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
-
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.junit.ArchTests;
+
+import io.github.adamw7.tools.test.architecture.CommonTestConventions;
 
 /**
- * Conventions enforced on the module's own test code, so the constraints that
- * keep the unit suite fast and honest cannot be bypassed by how a test is
- * written. Unlike the production architecture rules, this class analyses only
- * the test classes via {@link ImportOption.OnlyIncludeTests}.
+ * Applies the shared {@link CommonTestConventions} to the enforcer module's own
+ * test code, so the constraints that keep the unit suite fast and honest cannot
+ * be bypassed by how a test is written. Unlike the production architecture
+ * rules, this class analyses only the test classes via
+ * {@link ImportOption.OnlyIncludeTests}.
  */
 @AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
 public class TestConventionsArchitectureTest {
 
 	static final String TEST_PACKAGE = "io.github.adamw7.tools.enforcer";
 
-	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
-
 	@ArchTest
-	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
-			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
-			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
-			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
-			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
-					+ "so a test method in a differently named class silently never runs");
-
-	@ArchTest
-	static final ArchRule noDisabledTestMethods = noMethods()
-			.should().beAnnotatedWith(Disabled.class)
-			.because("a disabled test gives false confidence; delete it or fix what it guards");
-
-	@ArchTest
-	static final ArchRule noDisabledTestClasses = noClasses()
-			.should().beAnnotatedWith(Disabled.class)
-			.because("a disabled test gives false confidence; delete it or fix what it guards");
-
-	@ArchTest
-	static final ArchRule testsUseJunit5 = noClasses()
-			.should().dependOnClassesThat().resideInAPackage("org.junit")
-			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
-
-	@ArchTest
-	static final ArchRule testsDoNotSleep = noClasses()
-			.should().callMethod(Thread.class, "sleep", long.class)
-			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
-			.orShould().callMethod(TimeUnit.class, "sleep", long.class)
-			.because("a test that sleeps is slow and flaky; wait on a condition instead");
-
-	@ArchTest
-	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
-			.should().accessField(System.class, "out")
-			.orShould().accessField(System.class, "err")
-			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
-			.that().areAnnotatedWith(BeforeAll.class)
-			.or().areAnnotatedWith(AfterAll.class)
-			.should().beStatic()
-			.because("JUnit 5 runs @BeforeAll/@AfterAll once per class only when they are static; "
-					+ "a non-static one fails at runtime unless the class opts into the PER_CLASS lifecycle")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule testMethodsAreRunnableByJunit = methods()
-			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
-			.should().notBePrivate()
-			.andShould().notBeStatic()
-			.because("JUnit 5 silently ignores a private or static test method, so it never runs");
+	static final ArchTests commonTestConventions = ArchTests.in(CommonTestConventions.class);
 }

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -86,6 +86,13 @@
 			<artifactId>log4j-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.github.adamw7</groupId>
+			<artifactId>tools.test-common</artifactId>
+			<version>${revision}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.tngtech.archunit</groupId>
 			<artifactId>archunit-junit5</artifactId>
 			<scope>test</scope>

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractClassContextTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractClassContextTool.java
@@ -27,7 +27,7 @@ abstract class AbstractClassContextTool implements ContextTool {
 	protected static final int DEFAULT_DEPTH = 1;
 	protected static final int MAX_DEPTH = 10;
 
-	private final Logger log = LogManager.getLogger(getClass());
+	private static final Logger log = LogManager.getLogger(AbstractClassContextTool.class);
 
 	protected final PathPolicy pathPolicy;
 

--- a/code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java
@@ -1,26 +1,20 @@
 package io.github.adamw7.context.architecture;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
-import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.util.Optional;
 import java.util.Properties;
 
-import org.apache.logging.log4j.Logger;
-
-import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.lang.ArchRule;
-import com.tngtech.archunit.library.GeneralCodingRules;
 
 import io.github.adamw7.context.tree.ProjectTreeSerializer;
+import io.github.adamw7.tools.test.architecture.CommonCodingConventions;
+import io.github.adamw7.tools.test.architecture.CommonNamingConventions;
 
 /**
  * Architecture rules for the context module. The context finder and project
@@ -37,6 +31,12 @@ public class ContextArchitectureTest {
 	private static final String CONTEXT_ANY_PACKAGE = "io.github.adamw7.context..";
 	private static final String MCP_PACKAGE = "..context.mcp..";
 	private static final String MCP_COMMON_PACKAGE = "io.github.adamw7.tools.mcp..";
+
+	@ArchTest
+	static final ArchTests commonCodingConventions = ArchTests.in(CommonCodingConventions.class);
+
+	@ArchTest
+	static final ArchTests commonNamingConventions = ArchTests.in(CommonNamingConventions.class);
 
 	@ArchTest
 	static final ArchRule coreDoesNotDependOnMcpAdapter = noClasses()
@@ -64,79 +64,6 @@ public class ContextArchitectureTest {
 			.because("every concrete *Serializer must honour the ProjectTreeSerializer contract");
 
 	@ArchTest
-	static final ArchRule loggersArePrivateAndFinal = fields()
-			.that().haveRawType(Logger.class)
-			.should().bePrivate()
-			.andShould().beFinal()
-			.because("loggers are private, immutable collaborators owned by their declaring class");
-
-	@ArchTest
-	static final ArchRule publicFieldsAreImmutable = fields()
-			.that().arePublic()
-			.should().beFinal()
-			.because("a public field is part of the type's API surface and must not be reassignable")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule mutableStaticStateIsVolatile = fields()
-			.that().areStatic()
-			.and().areNotFinal()
-			.should().haveModifier(JavaModifier.VOLATILE)
-			.because("a mutable static field is shared across every thread, so it must be volatile "
-					+ "for its updates to publish safely")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule optionalFieldsAreForbidden = noFields()
-			.should().haveRawType(Optional.class)
-			.because("Optional models a possibly-absent return value, not a field; a field should hold "
-					+ "the value itself and be null-checked, never wrapped in an Optional")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule noLegacyDateTimeApi = noClasses()
-			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
-			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
-			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
-			.because("logging must go through log4j2 so configuration stays in one place");
-
-	@ArchTest
-	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()
-			.that().areNotInterfaces()
-			.and().areTopLevelClasses()
-			.and().haveModifier(JavaModifier.ABSTRACT)
-			.should().haveSimpleNameStartingWith("Abstract")
-			.because("an Abstract prefix signals at a glance that a type is meant to be extended, not used directly");
-
-	@ArchTest
-	static final ArchRule exceptionsAreNamedConsistently = classes()
-			.that().haveSimpleNameEndingWith("Exception")
-			.should().beAssignableTo(Exception.class)
-			.because("types named *Exception must actually be exceptions")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule noPrintStackTrace = noClasses()
-			.should().callMethod(Throwable.class, "printStackTrace")
-			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
-			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
-			.because("failures must be reported through log4j2, never printed as a raw stack trace");
-
-	@ArchTest
-	static final ArchRule contextCoreDoesNotHaltTheJvm = noClasses()
-			.should().callMethod(System.class, "exit", int.class)
-			.because("the context core is a reusable library and must never terminate the host JVM; it should throw instead");
-
-	@ArchTest
 	static final ArchRule onlyTlsConfigurationMutatesJvmWideProperties = noClasses()
 			.that().doNotHaveSimpleName("TlsConfiguration")
 			.should().callMethod(System.class, "setProperty", String.class, String.class)
@@ -146,20 +73,4 @@ public class ContextArchitectureTest {
 					+ "the one sanctioned place to set them, so a stray setProperty elsewhere cannot clobber "
 					+ "the pinned TLS protocol and key-exchange configuration")
 			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule noAccessToStandardStreams =
-			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
-
-	@ArchTest
-	static final ArchRule noGenericExceptionsAreThrown =
-			GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
-
-	@ArchTest
-	static final ArchRule noJavaUtilLogging =
-			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
-
-	@ArchTest
-	static final ArchRule noJodaTime =
-			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
 }

--- a/code/context/src/test/java/io/github/adamw7/context/architecture/TestConventionsArchitectureTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/architecture/TestConventionsArchitectureTest.java
@@ -1,83 +1,24 @@
 package io.github.adamw7.context.architecture;
 
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
-
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.junit.ArchTests;
+
+import io.github.adamw7.tools.test.architecture.CommonTestConventions;
 
 /**
- * Conventions enforced on the module's own test code, so the constraints that
- * keep the unit suite fast and honest cannot be bypassed by how a test is
- * written. Unlike the production architecture rules, this class analyses only
- * the test classes via {@link ImportOption.OnlyIncludeTests}.
+ * Applies the shared {@link CommonTestConventions} to the context module's own
+ * test code, so the constraints that keep the unit suite fast and honest cannot
+ * be bypassed by how a test is written. Unlike the production architecture
+ * rules, this class analyses only the test classes via
+ * {@link ImportOption.OnlyIncludeTests}.
  */
 @AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
 public class TestConventionsArchitectureTest {
 
 	static final String TEST_PACKAGE = "io.github.adamw7.context";
 
-	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
-
 	@ArchTest
-	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
-			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
-			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
-			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
-			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
-					+ "so a test method in a differently named class silently never runs");
-
-	@ArchTest
-	static final ArchRule noDisabledTestMethods = noMethods()
-			.should().beAnnotatedWith(Disabled.class)
-			.because("a disabled test gives false confidence; delete it or fix what it guards");
-
-	@ArchTest
-	static final ArchRule noDisabledTestClasses = noClasses()
-			.should().beAnnotatedWith(Disabled.class)
-			.because("a disabled test gives false confidence; delete it or fix what it guards");
-
-	@ArchTest
-	static final ArchRule testsUseJunit5 = noClasses()
-			.should().dependOnClassesThat().resideInAPackage("org.junit")
-			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
-
-	@ArchTest
-	static final ArchRule testsDoNotSleep = noClasses()
-			.should().callMethod(Thread.class, "sleep", long.class)
-			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
-			.orShould().callMethod(TimeUnit.class, "sleep", long.class)
-			.because("a test that sleeps is slow and flaky; wait on a condition instead");
-
-	@ArchTest
-	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
-			.should().accessField(System.class, "out")
-			.orShould().accessField(System.class, "err")
-			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
-			.that().areAnnotatedWith(BeforeAll.class)
-			.or().areAnnotatedWith(AfterAll.class)
-			.should().beStatic()
-			.because("JUnit 5 runs @BeforeAll/@AfterAll once per class only when they are static; "
-					+ "a non-static one fails at runtime unless the class opts into the PER_CLASS lifecycle")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule testMethodsAreRunnableByJunit = methods()
-			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
-			.should().notBePrivate()
-			.andShould().notBeStatic()
-			.because("JUnit 5 silently ignores a private or static test method, so it never runs");
+	static final ArchTests commonTestConventions = ArchTests.in(CommonTestConventions.class);
 }

--- a/code/protogen-maven-plugin/pom.xml
+++ b/code/protogen-maven-plugin/pom.xml
@@ -101,6 +101,13 @@
 			<artifactId>mockito-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.github.adamw7</groupId>
+			<artifactId>tools.test-common</artifactId>
+			<version>${revision}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.tngtech.archunit</groupId>
 			<artifactId>archunit-junit5</artifactId>
 			<scope>test</scope>

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/ProtogenArchitectureTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/ProtogenArchitectureTest.java
@@ -1,24 +1,20 @@
 package io.github.adamw7.tools.code.architecture;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
-import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.util.Optional;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.maven.plugin.Mojo;
 
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.lang.ArchRule;
-import com.tngtech.archunit.library.GeneralCodingRules;
+
+import io.github.adamw7.tools.test.architecture.CommonCodingConventions;
+import io.github.adamw7.tools.test.architecture.CommonNamingConventions;
 
 /**
  * Architecture rules for the protogen Maven plugin. The {@code format} package
@@ -35,6 +31,12 @@ public class ProtogenArchitectureTest {
 
 	private static final String FORMAT_PACKAGE = "..code.format..";
 	private static final String GEN_PACKAGE = "..code.gen..";
+
+	@ArchTest
+	static final ArchTests commonCodingConventions = ArchTests.in(CommonCodingConventions.class);
+
+	@ArchTest
+	static final ArchTests commonNamingConventions = ArchTests.in(CommonNamingConventions.class);
 
 	@ArchTest
 	static final ArchRule formatDoesNotDependOnGeneration = noClasses()
@@ -54,93 +56,4 @@ public class ProtogenArchitectureTest {
 			.and().doNotHaveModifier(JavaModifier.ABSTRACT)
 			.should().beAssignableTo(Mojo.class)
 			.because("every concrete *Mojo is a Maven goal and must implement the Mojo contract");
-
-	@ArchTest
-	static final ArchRule loggersAreConstants = fields()
-			.that().haveRawType(Logger.class)
-			.should().bePrivate()
-			.andShould().beStatic()
-			.andShould().beFinal()
-			.because("loggers are shared, immutable, class-scoped collaborators");
-
-	@ArchTest
-	static final ArchRule publicFieldsAreImmutable = fields()
-			.that().arePublic()
-			.should().beFinal()
-			.because("a public field is part of the type's API surface and must not be reassignable")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule mutableStaticStateIsVolatile = fields()
-			.that().areStatic()
-			.and().areNotFinal()
-			.should().haveModifier(JavaModifier.VOLATILE)
-			.because("a mutable static field is shared across every thread, so it must be volatile "
-					+ "for its updates to publish safely")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule optionalFieldsAreForbidden = noFields()
-			.should().haveRawType(Optional.class)
-			.because("Optional models a possibly-absent return value, not a field; a field should hold "
-					+ "the value itself and be null-checked, never wrapped in an Optional")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule noLegacyDateTimeApi = noClasses()
-			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
-			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
-			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
-			.because("logging must go through log4j2 so configuration stays in one place");
-
-	@ArchTest
-	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()
-			.that().areNotInterfaces()
-			.and().areTopLevelClasses()
-			.and().haveModifier(JavaModifier.ABSTRACT)
-			.should().haveSimpleNameStartingWith("Abstract")
-			.because("an Abstract prefix signals at a glance that a type is meant to be extended, not used directly");
-
-	@ArchTest
-	static final ArchRule exceptionsAreNamedConsistently = classes()
-			.that().haveSimpleNameEndingWith("Exception")
-			.should().beAssignableTo(Exception.class)
-			.because("types named *Exception must actually be exceptions");
-
-	@ArchTest
-	static final ArchRule noPrintStackTrace = noClasses()
-			.should().callMethod(Throwable.class, "printStackTrace")
-			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
-			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
-			.because("failures must be reported through log4j2, never printed as a raw stack trace");
-
-	@ArchTest
-	static final ArchRule pluginDoesNotHaltTheJvm = noClasses()
-			.should().callMethod(System.class, "exit", int.class)
-			.because("a Maven plugin must fail the build by throwing MojoExecutionException, never by terminating the JVM");
-
-	@ArchTest
-	static final ArchRule noAccessToStandardStreams =
-			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
-
-	@ArchTest
-	static final ArchRule noGenericExceptionsAreThrown =
-			GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
-
-	@ArchTest
-	static final ArchRule noJavaUtilLogging =
-			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
-
-	@ArchTest
-	static final ArchRule noJodaTime =
-			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
 }

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/TestConventionsArchitectureTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/architecture/TestConventionsArchitectureTest.java
@@ -1,83 +1,24 @@
 package io.github.adamw7.tools.code.architecture;
 
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
-
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.junit.ArchTests;
+
+import io.github.adamw7.tools.test.architecture.CommonTestConventions;
 
 /**
- * Conventions enforced on the module's own test code, so the constraints that
- * keep the unit suite fast and honest cannot be bypassed by how a test is
- * written. Unlike the production architecture rules, this class analyses only
- * the test classes via {@link ImportOption.OnlyIncludeTests}.
+ * Applies the shared {@link CommonTestConventions} to the protogen module's own
+ * test code, so the constraints that keep the unit suite fast and honest cannot
+ * be bypassed by how a test is written. Unlike the production architecture
+ * rules, this class analyses only the test classes via
+ * {@link ImportOption.OnlyIncludeTests}.
  */
 @AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
 public class TestConventionsArchitectureTest {
 
 	static final String TEST_PACKAGE = "io.github.adamw7.tools.code";
 
-	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
-
 	@ArchTest
-	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
-			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
-			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
-			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
-			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
-					+ "so a test method in a differently named class silently never runs");
-
-	@ArchTest
-	static final ArchRule noDisabledTestMethods = noMethods()
-			.should().beAnnotatedWith(Disabled.class)
-			.because("a disabled test gives false confidence; delete it or fix what it guards");
-
-	@ArchTest
-	static final ArchRule noDisabledTestClasses = noClasses()
-			.should().beAnnotatedWith(Disabled.class)
-			.because("a disabled test gives false confidence; delete it or fix what it guards");
-
-	@ArchTest
-	static final ArchRule testsUseJunit5 = noClasses()
-			.should().dependOnClassesThat().resideInAPackage("org.junit")
-			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
-
-	@ArchTest
-	static final ArchRule testsDoNotSleep = noClasses()
-			.should().callMethod(Thread.class, "sleep", long.class)
-			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
-			.orShould().callMethod(TimeUnit.class, "sleep", long.class)
-			.because("a test that sleeps is slow and flaky; wait on a condition instead");
-
-	@ArchTest
-	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
-			.should().accessField(System.class, "out")
-			.orShould().accessField(System.class, "err")
-			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
-			.that().areAnnotatedWith(BeforeAll.class)
-			.or().areAnnotatedWith(AfterAll.class)
-			.should().beStatic()
-			.because("JUnit 5 runs @BeforeAll/@AfterAll once per class only when they are static; "
-					+ "a non-static one fails at runtime unless the class opts into the PER_CLASS lifecycle")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule testMethodsAreRunnableByJunit = methods()
-			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
-			.should().notBePrivate()
-			.andShould().notBeStatic()
-			.because("JUnit 5 silently ignores a private or static test method, so it never runs");
+	static final ArchTests commonTestConventions = ArchTests.in(CommonTestConventions.class);
 }

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -156,6 +156,13 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>io.github.adamw7</groupId>
+			<artifactId>tools.test-common</artifactId>
+			<version>${revision}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.tngtech.archunit</groupId>
 			<artifactId>archunit-junit5</artifactId>
 			<scope>test</scope>

--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
@@ -5,24 +5,19 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
-
-import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.util.Optional;
-
-import org.apache.logging.log4j.Logger;
 
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.lang.ArchRule;
-import com.tngtech.archunit.library.GeneralCodingRules;
 
 import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
+import io.github.adamw7.tools.test.architecture.CommonCodingConventions;
+import io.github.adamw7.tools.test.architecture.CommonNamingConventions;
 
 /**
  * Architecture rules for the data module, enforced with ArchUnit so that the
@@ -45,6 +40,12 @@ public class DataArchitectureTest {
 	private static final String CONCURRENT_PACKAGE = "java.util.concurrent..";
 
 	@ArchTest
+	static final ArchTests commonCodingConventions = ArchTests.in(CommonCodingConventions.class);
+
+	@ArchTest
+	static final ArchTests commonNamingConventions = ArchTests.in(CommonNamingConventions.class);
+
+	@ArchTest
 	static final ArchRule interfacesDoNotDependOnImplementations = noClasses()
 			.that().resideInAPackage(INTERFACES_PACKAGE)
 			.should().dependOnClassesThat().resideInAnyPackage("..source.db..", "..source.file..")
@@ -55,12 +56,6 @@ public class DataArchitectureTest {
 			.that().resideInAPackage(INTERNAL_PACKAGE)
 			.should().onlyBeAccessed().byAnyPackage(STRUCTURE_PACKAGE)
 			.because("structure.internal is an implementation detail of the structure package");
-
-	@ArchTest
-	static final ArchRule exceptionsAreNamedConsistently = classes()
-			.that().haveSimpleNameEndingWith("Exception")
-			.should().beAssignableTo(Exception.class)
-			.because("types named *Exception must actually be exceptions");
 
 	@ArchTest
 	static final ArchRule packagesAreFreeOfCycles = slices()
@@ -81,64 +76,10 @@ public class DataArchitectureTest {
 			.because("every concrete data source must honour the IterableDataSource contract");
 
 	@ArchTest
-	static final ArchRule loggersAreConstants = fields()
-			.that().haveRawType(Logger.class)
-			.should().bePrivate()
-			.andShould().beStatic()
-			.andShould().beFinal()
-			.because("loggers are shared, immutable, class-scoped collaborators");
-
-	@ArchTest
-	static final ArchRule publicFieldsAreImmutable = fields()
-			.that().arePublic()
-			.should().beFinal()
-			.because("a public field is part of the type's API surface and must not be reassignable");
-
-	@ArchTest
-	static final ArchRule mutableStaticStateIsVolatile = fields()
-			.that().areStatic()
-			.and().areNotFinal()
-			.should().haveModifier(JavaModifier.VOLATILE)
-			.because("a mutable static field is shared across every thread, so it must be volatile "
-					+ "for its updates to publish safely — as Switch.isOff and PathValidator.allowedBaseDir already are")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule optionalFieldsAreForbidden = noFields()
-			.should().haveRawType(Optional.class)
-			.because("Optional models a possibly-absent return value, not a field; a field should hold "
-					+ "the value itself and be null-checked, never wrapped in an Optional")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule noLegacyDateTimeApi = noClasses()
-			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
-			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
-			.allowEmptyShould(true);
-
-	@ArchTest
 	static final ArchRule jdbcStaysInTheDbPackage = noClasses()
 			.that().resideOutsideOfPackage(DB_PACKAGE)
 			.should().dependOnClassesThat().resideInAPackage("java.sql..")
 			.because("JDBC is an implementation detail of the db data sources; no other package may touch java.sql");
-
-	@ArchTest
-	static final ArchRule productionCodeDoesNotUseStandardStreams = noClasses()
-			.should().accessField(System.class, "out")
-			.orShould().accessField(System.class, "err")
-			.because("production code must log through log4j2 instead of the console");
-
-	@ArchTest
-	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()
-			.that().areNotInterfaces()
-			.and().areTopLevelClasses()
-			.and().haveModifier(JavaModifier.ABSTRACT)
-			.should().haveSimpleNameStartingWith("Abstract")
-			.because("an Abstract prefix signals at a glance that a type is meant to be extended, not used directly");
 
 	@ArchTest
 	static final ArchRule dataStructuresStayIndependentOfDataSources = noClasses()
@@ -182,40 +123,6 @@ public class DataArchitectureTest {
 			.and().resideOutsideOfPackage(MCP_PACKAGE)
 			.should().dependOnClassesThat().resideInAPackage(MCP_PACKAGE)
 			.because("the MCP adapter is a delivery mechanism on top of the uniqueness core, not a dependency of it");
-
-	@ArchTest
-	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
-			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
-			.because("logging must go through log4j2 so configuration stays in one place");
-
-	@ArchTest
-	static final ArchRule noAccessToStandardStreams =
-			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
-
-	@ArchTest
-	static final ArchRule noGenericExceptionsAreThrown =
-			GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
-
-	@ArchTest
-	static final ArchRule noJavaUtilLogging =
-			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
-
-	@ArchTest
-	static final ArchRule noJodaTime =
-			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
-
-	@ArchTest
-	static final ArchRule noPrintStackTrace = noClasses()
-			.should().callMethod(Throwable.class, "printStackTrace")
-			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
-			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
-			.because("failures must be reported through log4j2, never printed as a raw stack trace");
-
-	@ArchTest
-	static final ArchRule productionCodeDoesNotHaltTheJvm = noClasses()
-			.should().callMethod(System.class, "exit", int.class)
-			.because("a library must never terminate the host JVM; it should throw instead");
 
 	@ArchTest
 	static final ArchRule sourceLayersDependInOneDirection = layeredArchitecture()

--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/TestConventionsArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/TestConventionsArchitectureTest.java
@@ -1,83 +1,24 @@
 package io.github.adamw7.tools.data.architecture;
 
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
-
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.junit.ArchTests;
+
+import io.github.adamw7.tools.test.architecture.CommonTestConventions;
 
 /**
- * Conventions enforced on the module's own test code, so the constraints that
- * keep the unit suite fast and honest cannot be bypassed by how a test is
- * written. Unlike the production architecture rules, this class analyses only
- * the test classes via {@link ImportOption.OnlyIncludeTests}.
+ * Applies the shared {@link CommonTestConventions} to the data module's own
+ * test code, so the constraints that keep the unit suite fast and honest cannot
+ * be bypassed by how a test is written. Unlike the production architecture
+ * rules, this class analyses only the test classes via
+ * {@link ImportOption.OnlyIncludeTests}.
  */
 @AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
 public class TestConventionsArchitectureTest {
 
 	static final String TEST_PACKAGE = "io.github.adamw7.tools.data";
 
-	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
-
 	@ArchTest
-	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
-			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
-			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
-			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
-			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
-					+ "so a test method in a differently named class silently never runs");
-
-	@ArchTest
-	static final ArchRule noDisabledTestMethods = noMethods()
-			.should().beAnnotatedWith(Disabled.class)
-			.because("a disabled test gives false confidence; delete it or fix what it guards");
-
-	@ArchTest
-	static final ArchRule noDisabledTestClasses = noClasses()
-			.should().beAnnotatedWith(Disabled.class)
-			.because("a disabled test gives false confidence; delete it or fix what it guards");
-
-	@ArchTest
-	static final ArchRule testsUseJunit5 = noClasses()
-			.should().dependOnClassesThat().resideInAPackage("org.junit")
-			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
-
-	@ArchTest
-	static final ArchRule testsDoNotSleep = noClasses()
-			.should().callMethod(Thread.class, "sleep", long.class)
-			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
-			.orShould().callMethod(TimeUnit.class, "sleep", long.class)
-			.because("a test that sleeps is slow and flaky; wait on a condition instead");
-
-	@ArchTest
-	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
-			.should().accessField(System.class, "out")
-			.orShould().accessField(System.class, "err")
-			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
-			.that().areAnnotatedWith(BeforeAll.class)
-			.or().areAnnotatedWith(AfterAll.class)
-			.should().beStatic()
-			.because("JUnit 5 runs @BeforeAll/@AfterAll once per class only when they are static; "
-					+ "a non-static one fails at runtime unless the class opts into the PER_CLASS lifecycle")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule testMethodsAreRunnableByJunit = methods()
-			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
-			.should().notBePrivate()
-			.andShould().notBeStatic()
-			.because("JUnit 5 silently ignores a private or static test method, so it never runs");
+	static final ArchTests commonTestConventions = ArchTests.in(CommonTestConventions.class);
 }

--- a/mcp-common/pom.xml
+++ b/mcp-common/pom.xml
@@ -61,6 +61,13 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>io.github.adamw7</groupId>
+			<artifactId>tools.test-common</artifactId>
+			<version>${revision}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.tngtech.archunit</groupId>
 			<artifactId>archunit-junit5</artifactId>
 			<scope>test</scope>

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/McpCommonArchitectureTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/McpCommonArchitectureTest.java
@@ -1,24 +1,16 @@
 package io.github.adamw7.tools.mcp.architecture;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 
-import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.util.Optional;
-
-import org.apache.logging.log4j.Logger;
-
-import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.lang.ArchRule;
-import com.tngtech.archunit.library.GeneralCodingRules;
 
 import io.github.adamw7.tools.mcp.McpTool;
+import io.github.adamw7.tools.test.architecture.CommonCodingConventions;
+import io.github.adamw7.tools.test.architecture.CommonNamingConventions;
 
 /**
  * Architecture rules for the shared MCP scaffolding module. They keep the
@@ -34,6 +26,12 @@ public class McpCommonArchitectureTest {
 	static final String MCP_PACKAGE = "io.github.adamw7.tools.mcp";
 
 	@ArchTest
+	static final ArchTests commonCodingConventions = ArchTests.in(CommonCodingConventions.class);
+
+	@ArchTest
+	static final ArchTests commonNamingConventions = ArchTests.in(CommonNamingConventions.class);
+
+	@ArchTest
 	static final ArchRule toolSpiIsAContract = classes()
 			.that().haveSimpleName("McpTool")
 			.should().beInterfaces()
@@ -46,94 +44,4 @@ public class McpCommonArchitectureTest {
 			.should().beAssignableTo(McpTool.class)
 			.because("every concrete *Tool must honour the McpTool contract")
 			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule loggersAreConstants = fields()
-			.that().haveRawType(Logger.class)
-			.should().bePrivate()
-			.andShould().beStatic()
-			.andShould().beFinal()
-			.because("loggers are shared, immutable, class-scoped collaborators");
-
-	@ArchTest
-	static final ArchRule publicFieldsAreImmutable = fields()
-			.that().arePublic()
-			.should().beFinal()
-			.because("a public field is part of the type's API surface and must not be reassignable")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule mutableStaticStateIsVolatile = fields()
-			.that().areStatic()
-			.and().areNotFinal()
-			.should().haveModifier(JavaModifier.VOLATILE)
-			.because("a mutable static field is shared across every thread, so it must be volatile "
-					+ "for its updates to publish safely")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule optionalFieldsAreForbidden = noFields()
-			.should().haveRawType(Optional.class)
-			.because("Optional models a possibly-absent return value, not a field; a field should hold "
-					+ "the value itself and be null-checked, never wrapped in an Optional")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule noLegacyDateTimeApi = noClasses()
-			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
-			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
-			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
-			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
-			.because("logging must go through log4j2 so configuration stays in one place");
-
-	@ArchTest
-	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()
-			.that().areNotInterfaces()
-			.and().areTopLevelClasses()
-			.and().haveModifier(JavaModifier.ABSTRACT)
-			.should().haveSimpleNameStartingWith("Abstract")
-			.because("an Abstract prefix signals at a glance that a type is meant to be extended, not used directly");
-
-	@ArchTest
-	static final ArchRule exceptionsAreNamedConsistently = classes()
-			.that().haveSimpleNameEndingWith("Exception")
-			.should().beAssignableTo(Exception.class)
-			.because("types named *Exception must actually be exceptions")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule scaffoldingDoesNotHaltTheJvm = noClasses()
-			.should().callMethod(System.class, "exit", int.class)
-			.because("shared scaffolding must never terminate the host server; it should throw instead");
-
-	@ArchTest
-	static final ArchRule noPrintStackTrace = noClasses()
-			.should().callMethod(Throwable.class, "printStackTrace")
-			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
-			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
-			.because("failures must be reported through log4j2, never printed as a raw stack trace");
-
-	@ArchTest
-	static final ArchRule noAccessToStandardStreams =
-			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
-
-	@ArchTest
-	static final ArchRule noGenericExceptionsAreThrown =
-			GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
-
-	@ArchTest
-	static final ArchRule noJavaUtilLogging =
-			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
-
-	@ArchTest
-	static final ArchRule noJodaTime =
-			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
 }

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/TestConventionsArchitectureTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/TestConventionsArchitectureTest.java
@@ -1,83 +1,24 @@
 package io.github.adamw7.tools.mcp.architecture;
 
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
-
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.junit.ArchTests;
+
+import io.github.adamw7.tools.test.architecture.CommonTestConventions;
 
 /**
- * Conventions enforced on the module's own test code, so the constraints that
- * keep the unit suite fast and honest cannot be bypassed by how a test is
- * written. Unlike the production architecture rules, this class analyses only
- * the test classes via {@link ImportOption.OnlyIncludeTests}.
+ * Applies the shared {@link CommonTestConventions} to the shared MCP scaffolding module's own
+ * test code, so the constraints that keep the unit suite fast and honest cannot
+ * be bypassed by how a test is written. Unlike the production architecture
+ * rules, this class analyses only the test classes via
+ * {@link ImportOption.OnlyIncludeTests}.
  */
 @AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
 public class TestConventionsArchitectureTest {
 
 	static final String TEST_PACKAGE = "io.github.adamw7.tools.mcp";
 
-	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
-
 	@ArchTest
-	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
-			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
-			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
-			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
-			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
-					+ "so a test method in a differently named class silently never runs");
-
-	@ArchTest
-	static final ArchRule noDisabledTestMethods = noMethods()
-			.should().beAnnotatedWith(Disabled.class)
-			.because("a disabled test gives false confidence; delete it or fix what it guards");
-
-	@ArchTest
-	static final ArchRule noDisabledTestClasses = noClasses()
-			.should().beAnnotatedWith(Disabled.class)
-			.because("a disabled test gives false confidence; delete it or fix what it guards");
-
-	@ArchTest
-	static final ArchRule testsUseJunit5 = noClasses()
-			.should().dependOnClassesThat().resideInAPackage("org.junit")
-			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
-
-	@ArchTest
-	static final ArchRule testsDoNotSleep = noClasses()
-			.should().callMethod(Thread.class, "sleep", long.class)
-			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
-			.orShould().callMethod(TimeUnit.class, "sleep", long.class)
-			.because("a test that sleeps is slow and flaky; wait on a condition instead");
-
-	@ArchTest
-	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
-			.should().accessField(System.class, "out")
-			.orShould().accessField(System.class, "err")
-			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
-			.that().areAnnotatedWith(BeforeAll.class)
-			.or().areAnnotatedWith(AfterAll.class)
-			.should().beStatic()
-			.because("JUnit 5 runs @BeforeAll/@AfterAll once per class only when they are static; "
-					+ "a non-static one fails at runtime unless the class opts into the PER_CLASS lifecycle")
-			.allowEmptyShould(true);
-
-	@ArchTest
-	static final ArchRule testMethodsAreRunnableByJunit = methods()
-			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
-			.should().notBePrivate()
-			.andShould().notBeStatic()
-			.because("JUnit 5 silently ignores a private or static test method, so it never runs");
+	static final ArchTests commonTestConventions = ArchTests.in(CommonTestConventions.class);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
 	</developers>
 	<modules>
 		<module>claude-code-enforcer</module>
+		<module>test-common</module>
 		<module>mcp-common</module>
 		<module>data</module>
 		<module>code</module>

--- a/test-common/pom.xml
+++ b/test-common/pom.xml
@@ -1,0 +1,76 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>io.github.adamw7</groupId>
+		<artifactId>tools</artifactId>
+		<version>${revision}</version>
+	</parent>
+	<artifactId>tools.test-common</artifactId>
+	<packaging>jar</packaging>
+	<name>Shared test scaffolding</name>
+	<description>Shared ArchUnit rule libraries reused by every module's architecture tests.</description>
+	<url>https://github.com/adamw7/tools</url>
+	<properties>
+		<!-- This module carries no production code, only the rule libraries the
+		     other modules' architecture tests import, so keep it out of the
+		     GitHub Packages deployment that maven-deploy-plugin performs on
+		     `mvn deploy`. (The Maven Central release profile excludes it via the
+		     central-publishing plugin's skipPublishing flag below.) -->
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
+	<build>
+		<plugins>
+			<!-- The rules live in src/test/java so archunit-junit5 can stay
+			     test-scoped as the root pom declares it. Attaching a test-jar is
+			     what makes them reachable from the other modules' test
+			     classpaths. The main jar this module also produces is empty by
+			     design; nothing depends on it and it is never published. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-test-jar</id>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<profiles>
+		<profile>
+			<!-- This module is test scaffolding for the reactor, not a reusable
+			     library, so keep it out of the Maven Central bundle that the
+			     release profile publishes. skipPublishing is honoured per module
+			     by the central-publishing-maven-plugin. -->
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<configuration>
+							<skipPublishing>true</skipPublishing>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/test-common/src/test/java/io/github/adamw7/tools/test/architecture/CommonCodingConventions.java
+++ b/test-common/src/test/java/io/github/adamw7/tools/test/architecture/CommonCodingConventions.java
@@ -1,0 +1,118 @@
+package io.github.adamw7.tools.test.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.Optional;
+
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.GeneralCodingRules;
+
+/**
+ * The coding conventions every module's production code follows, held in one
+ * place so a module's architecture test states only what is specific to that
+ * module. A module imports them with
+ * {@code @ArchTest static final ArchTests commonCodingConventions = ArchTests.in(CommonCodingConventions.class);}
+ * and the importing test's {@code @AnalyzeClasses} decides which classes they
+ * run against.
+ * <p>
+ * Rules here must hold for every module. A convention that only most modules
+ * follow belongs in {@link CommonNamingConventions} or in the module's own test,
+ * so an exemption stays visible rather than silently weakening the shared rule.
+ * The logger rule names its type by string so this module needs no log4j
+ * dependency of its own.
+ */
+public class CommonCodingConventions {
+
+	private static final String LOG4J_LOGGER = "org.apache.logging.log4j.Logger";
+
+	@ArchTest
+	static final ArchRule loggersAreConstants = fields()
+			.that().haveRawType(LOG4J_LOGGER)
+			.should().bePrivate()
+			.andShould().beStatic()
+			.andShould().beFinal()
+			.because("loggers are shared, immutable, class-scoped collaborators")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule publicFieldsAreImmutable = fields()
+			.that().arePublic()
+			.should().beFinal()
+			.because("a public field is part of the type's API surface and must not be reassignable")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule mutableStaticStateIsVolatile = fields()
+			.that().areStatic()
+			.and().areNotFinal()
+			.should().haveModifier(JavaModifier.VOLATILE)
+			.because("a mutable static field is shared across every thread, so it must be volatile "
+					+ "for its updates to publish safely")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule optionalFieldsAreForbidden = noFields()
+			.should().haveRawType(Optional.class)
+			.because("Optional models a possibly-absent return value, not a field; a field should hold "
+					+ "the value itself and be null-checked, never wrapped in an Optional")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule exceptionsAreNamedConsistently = classes()
+			.that().haveSimpleNameEndingWith("Exception")
+			.should().beAssignableTo(Exception.class)
+			.because("types named *Exception must actually be exceptions")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule noLegacyDateTimeApi = noClasses()
+			.should().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.GregorianCalendar")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.DateFormat")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.text.SimpleDateFormat")
+			.because("date and time handling must use java.time, not the legacy Date/Calendar API")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule productionCodeLogsThroughLog4j = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.System$Logger")
+			.because("logging must go through log4j2 so configuration stays in one place");
+
+	@ArchTest
+	static final ArchRule noPrintStackTrace = noClasses()
+			.should().callMethod(Throwable.class, "printStackTrace")
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
+			.because("failures must be reported through log4j2, never printed as a raw stack trace");
+
+	@ArchTest
+	static final ArchRule productionCodeDoesNotHaltTheJvm = noClasses()
+			.should().callMethod(System.class, "exit", int.class)
+			.because("every module here is embedded in a host process — a Maven build, an MCP server, a "
+					+ "caller's application — so failure is reported by throwing, never by terminating the JVM");
+
+	@ArchTest
+	static final ArchRule noAccessToStandardStreams =
+			GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
+
+	@ArchTest
+	static final ArchRule noGenericExceptionsAreThrown =
+			GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
+
+	@ArchTest
+	static final ArchRule noJavaUtilLogging =
+			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+
+	@ArchTest
+	static final ArchRule noJodaTime =
+			GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
+}

--- a/test-common/src/test/java/io/github/adamw7/tools/test/architecture/CommonNamingConventions.java
+++ b/test-common/src/test/java/io/github/adamw7/tools/test/architecture/CommonNamingConventions.java
@@ -1,0 +1,29 @@
+package io.github.adamw7.tools.test.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+/**
+ * Naming conventions that hold for every module except {@code
+ * claude-code-enforcer}, whose abstract rule base classes ({@code
+ * ClaudeCodeEnforcerRule}, {@code MarkdownFormatRule}, {@code JsonFileRule})
+ * are named after the maven-enforcer rules that extend them and are public API
+ * that poms configure by name. Keeping these rules apart from
+ * {@link CommonCodingConventions} makes that exemption a visible choice — one
+ * module not importing this library — instead of a rule quietly weakened for
+ * everybody.
+ */
+public class CommonNamingConventions {
+
+	@ArchTest
+	static final ArchRule abstractClassesAreNamedWithAbstractPrefix = classes()
+			.that().areNotInterfaces()
+			.and().areTopLevelClasses()
+			.and().haveModifier(JavaModifier.ABSTRACT)
+			.should().haveSimpleNameStartingWith("Abstract")
+			.because("an Abstract prefix signals at a glance that a type is meant to be extended, not used directly")
+			.allowEmptyShould(true);
+}

--- a/test-common/src/test/java/io/github/adamw7/tools/test/architecture/CommonTestConventions.java
+++ b/test-common/src/test/java/io/github/adamw7/tools/test/architecture/CommonTestConventions.java
@@ -1,0 +1,84 @@
+package io.github.adamw7.tools.test.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+/**
+ * The conventions every module enforces on its own test code, so the
+ * constraints that keep the unit suite fast and honest cannot be bypassed by
+ * how a test is written. A module imports them with
+ * {@code @ArchTest static final ArchTests commonTestConventions = ArchTests.in(CommonTestConventions.class);}
+ * from a test annotated
+ * {@code @AnalyzeClasses(importOptions = ImportOption.OnlyIncludeTests.class)},
+ * which is what narrows these rules to that module's test classes.
+ *
+ * @see ImportOption.OnlyIncludeTests
+ */
+public class CommonTestConventions {
+
+	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
+
+	@ArchTest
+	static final ArchRule testMethodsLiveInProperlyNamedClasses = methods()
+			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
+			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("Test")
+			.orShould().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
+			.because("surefire only runs *Test classes and failsafe only runs *IT classes, "
+					+ "so a test method in a differently named class silently never runs");
+
+	@ArchTest
+	static final ArchRule noDisabledTestMethods = noMethods()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule noDisabledTestClasses = noClasses()
+			.should().beAnnotatedWith(Disabled.class)
+			.because("a disabled test gives false confidence; delete it or fix what it guards");
+
+	@ArchTest
+	static final ArchRule testsUseJunit5 = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("org.junit")
+			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
+
+	@ArchTest
+	static final ArchRule testsDoNotSleep = noClasses()
+			.should().callMethod(Thread.class, "sleep", long.class)
+			.orShould().callMethod(Thread.class, "sleep", long.class, int.class)
+			.orShould().callMethod(TimeUnit.class, "sleep", long.class)
+			.because("a test that sleeps is slow and flaky; wait on a condition instead");
+
+	@ArchTest
+	static final ArchRule testsDoNotAccessStandardStreams = noClasses()
+			.should().accessField(System.class, "out")
+			.orShould().accessField(System.class, "err")
+			.because("a test that prints to the console adds noise instead of asserting; assert on the value instead")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule beforeAllAndAfterAllMethodsAreStatic = methods()
+			.that().areAnnotatedWith(BeforeAll.class)
+			.or().areAnnotatedWith(AfterAll.class)
+			.should().beStatic()
+			.because("JUnit 5 runs @BeforeAll/@AfterAll once per class only when they are static; "
+					+ "a non-static one fails at runtime unless the class opts into the PER_CLASS lifecycle")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule testMethodsAreRunnableByJunit = methods()
+			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
+			.should().notBePrivate()
+			.andShould().notBeStatic()
+			.because("JUnit 5 silently ignores a private or static test method, so it never runs");
+}


### PR DESCRIPTION
Six modules each carried their own copy of the same architecture rules:
thirteen production rules (loggers, public/static/Optional fields,
java.time, log4j2 logging, no System.exit, no standard streams, no
generic exceptions, no Joda Time) repeated in every *ArchitectureTest,
and eight test-side conventions repeated verbatim in six
TestConventionsArchitectureTest files that differed only in their
package declaration and TEST_PACKAGE constant.

Declare them once in a new test-common module and import them with
ArchUnit's ArchTests.in(...), so each module's architecture test states
only what is specific to that module. The rules live in src/test/java
and ship as a test-jar, which keeps archunit-junit5 test-scoped as the
root pom declares it; the module is excluded from both the GitHub
Packages deployment and the Maven Central bundle.

Coverage is unchanged. Rules that existed under different names per
module (adoptionDoesNotHaltTheJvm, pluginDoesNotHaltTheJvm,
noStandardStreams, loggersArePrivateStaticFinal, ...) collapse into one
name each. Two deliberate adjustments:

- data dropped productionCodeDoesNotUseStandardStreams, which duplicated
  the GeneralCodingRules standard-streams rule it declared alongside.
- The Abstract-prefix rule sits in a separate CommonNamingConventions so
  claude-code-enforcer can stay exempt: its abstract rule bases are
  public API that poms configure by name. An exemption is now a module
  not importing a library rather than a rule weakened for everyone.

AbstractClassContextTool's logger becomes private static final, the
convention CLAUDE.md documents and every other class follows. It was
the one instance-level logger, and the reason the context module's copy
of the rule omitted beStatic(); the log line it feeds already names the
concrete tool, so nothing is lost.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018XBXkDN5E1ZNFcQrrHKyUq