### PR TITLE
fix(claude-code-enforcer): close six holes that let bad config pass the gate

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
@@ -1,0 +1,168 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
+
+/**
+ * The {@code @path} memory imports reachable from a root document, together with
+ * the fewest hops each target sits from that root.
+ * <p>
+ * The hop count is what makes {@link MemoryImportsRule} decide the same way every
+ * run. Claude Code loads a file that any chain reaches within its hop limit, so
+ * whether a target is loaded depends on its <em>shortest</em> chain, not on
+ * whichever chain a traversal happens to walk first. The graph is therefore built
+ * breadth-first, so the first time a file is reached is by its shortest chain, and
+ * the rule reads that answer instead of counting hops as it recurses.
+ * <p>
+ * Imports are recognised the way Claude Code evaluates them: an {@code @} preceded
+ * by start-of-line or whitespace and followed by a path, outside fenced code
+ * blocks and inline code spans, so {@code `@claude`} in prose is not an import. A
+ * home-relative import ({@code @~/...}) does not match the path syntax at all and
+ * so is skipped, as is any import the {@code ignored} predicate accepts. A file
+ * that cannot be read as text is treated as a leaf rather than a failure, because
+ * an imported file may be any format.
+ */
+final class ImportGraph {
+
+	/** One {@code @path} import: the path as its author wrote it, and the file it resolves to. */
+	record Reference(String text, File target) {
+	}
+
+	private static final Pattern IMPORT = Pattern.compile("(?<=^|\\s)@([A-Za-z0-9_./-]+)");
+	private static final Pattern CODE_SPAN = Pattern.compile("`[^`]*`");
+	private static final Pattern TRAILING_DOTS = Pattern.compile("\\.+$");
+
+	private final Map<Path, List<Reference>> references = new LinkedHashMap<>();
+	private final Map<Path, Integer> hops = new LinkedHashMap<>();
+	private final Predicate<String> ignored;
+	private final Consumer<String> unreadable;
+
+	private ImportGraph(Predicate<String> ignored, Consumer<String> unreadable) {
+		this.ignored = ignored;
+		this.unreadable = unreadable;
+	}
+
+	/**
+	 * Walks every import reachable from {@code root}. Imports the {@code ignored}
+	 * predicate accepts are left out of the graph entirely, so they neither carry
+	 * a hop count nor pull their target in. {@code unreadable} receives a message
+	 * for each import target that could not be read as text.
+	 */
+	static ImportGraph from(File root, Predicate<String> ignored, Consumer<String> unreadable) {
+		ImportGraph graph = new ImportGraph(ignored, unreadable);
+		graph.explore(root);
+		return graph;
+	}
+
+	/** The imports {@code file} declares, in document order, or none when it was never reached. */
+	List<Reference> importsOf(File file) {
+		return references.getOrDefault(normalized(file), List.of());
+	}
+
+	/**
+	 * The fewest hops from the root to {@code file}, or {@link Integer#MAX_VALUE}
+	 * when no chain of imports reaches it.
+	 */
+	int hopsTo(File file) {
+		return hops.getOrDefault(normalized(file), Integer.MAX_VALUE);
+	}
+
+	/** The absolute, symlink-free-of-dot-segments path a file is keyed by. */
+	static Path normalized(File file) {
+		return file.toPath().toAbsolutePath().normalize();
+	}
+
+	/** Breadth-first, so a file is first reached by its shortest chain of imports. */
+	private void explore(File root) {
+		Deque<File> queue = new ArrayDeque<>();
+		hops.put(normalized(root), 0);
+		queue.add(root);
+		while (!queue.isEmpty()) {
+			expand(queue.poll(), queue);
+		}
+	}
+
+	private void expand(File file, Deque<File> queue) {
+		Path path = normalized(file);
+		List<Reference> found = referencesIn(file);
+		references.put(path, found);
+		int depth = hops.get(path);
+		for (Reference reference : found) {
+			enqueue(reference, depth + 1, queue);
+		}
+	}
+
+	/** A target is queued once, at the first — and so shortest — depth it is reached by. */
+	private void enqueue(Reference reference, int depth, Deque<File> queue) {
+		Path path = normalized(reference.target());
+		if (reference.target().isFile() && !hops.containsKey(path)) {
+			hops.put(path, depth);
+			queue.add(reference.target());
+		}
+	}
+
+	private List<Reference> referencesIn(File file) {
+		MarkdownDocument document = MarkdownDocument.parse(readSafely(file));
+		List<Reference> found = new ArrayList<>();
+		for (int i = 0; i < document.lineCount(); i++) {
+			collectLineReferences(file, document, i, found);
+		}
+		return found;
+	}
+
+	private void collectLineReferences(File file, MarkdownDocument document, int index, List<Reference> found) {
+		if (document.isInsideFence(index)) {
+			return;
+		}
+		Matcher matcher = IMPORT.matcher(CODE_SPAN.matcher(document.line(index)).replaceAll(" "));
+		while (matcher.find()) {
+			addReference(file, withoutTrailingDots(matcher.group(1)), found);
+		}
+	}
+
+	private void addReference(File file, String imported, List<Reference> found) {
+		if (!ignored.test(imported)) {
+			found.add(new Reference(imported, resolve(file, imported)));
+		}
+	}
+
+	/** Drops sentence punctuation, so "see @docs/setup.md." imports {@code docs/setup.md}. */
+	private String withoutTrailingDots(String imported) {
+		return TRAILING_DOTS.matcher(imported).replaceAll("");
+	}
+
+	private File resolve(File file, String imported) {
+		if (imported.startsWith("/")) {
+			return new File(imported);
+		}
+		return new File(file.getParentFile(), imported);
+	}
+
+	/**
+	 * The file's content, or empty when it cannot be read as text. An imported
+	 * file may be any format, so a binary target is treated as a leaf rather than
+	 * a failure — its existence is verified by the rule, not here.
+	 */
+	private String readSafely(File file) {
+		try {
+			return Files.readString(file.toPath());
+		} catch (IOException e) {
+			unreadable.accept("Skipping unreadable import target " + file + ": " + e.getMessage());
+			return "";
+		}
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -1,8 +1,6 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -10,15 +8,13 @@ import java.util.Deque;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.inject.Named;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
+import io.github.adamw7.tools.enforcer.doc.ImportGraph.Reference;
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
-import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
 
 /**
  * Enforcer rule that validates the {@code @path} memory imports of
@@ -28,6 +24,12 @@ import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
  * memory is never loaded at all. The rule follows every import recursively and
  * reports a target that does not exist, a circular import, and an import nested
  * deeper than {@code maxDepth} hops.
+ * <p>
+ * Depth is counted along an import's <em>shortest</em> chain from
+ * {@code CLAUDE.md}, which {@link ImportGraph} works out up front. A file two
+ * chains reach is loaded as long as one of them is short enough, so judging it by
+ * whichever chain the traversal walked into first would report — or miss — a
+ * violation depending on the order the imports happen to be written in.
  * <p>
  * Imports are recognised the way Claude Code evaluates them: an {@code @} preceded
  * by start-of-line or whitespace and followed by a path, outside fenced code
@@ -39,9 +41,6 @@ import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
 @Named("memoryImports")
 public class MemoryImportsRule extends ClaudeCodeEnforcerRule {
 
-	private static final Pattern IMPORT = Pattern.compile("(?<=^|\\s)@([A-Za-z0-9_./-]+)");
-	private static final Pattern CODE_SPAN = Pattern.compile("`[^`]*`");
-	private static final Pattern TRAILING_DOTS = Pattern.compile("\\.+$");
 	private static final int DEFAULT_MAX_DEPTH = 5;
 
 	/** The {@code CLAUDE.md} file whose imports are validated. Injected from the rule configuration. */
@@ -53,41 +52,50 @@ public class MemoryImportsRule extends ClaudeCodeEnforcerRule {
 	/** Optional import paths to skip verbatim, e.g. a path only present on developer machines. */
 	private List<String> ignoredImports;
 
+	/**
+	 * One walk of the import graph: the chain currently being followed, which is
+	 * what a cycle is detected against, the files already scanned, and the
+	 * problems found so far.
+	 */
+	private record Traversal(ImportGraph graph, Deque<Path> chain, Set<Path> scanned, List<String> violations) {
+
+		static Traversal of(ImportGraph graph) {
+			return new Traversal(graph, new ArrayDeque<>(), new LinkedHashSet<>(), new ArrayList<>());
+		}
+	}
+
 	@Override
 	public void execute() throws EnforcerRuleException {
 		requireConfigured(claudeMdFile, "claudeMdFile");
 		requireExists(claudeMdFile, "CLAUDE.md");
-		List<String> violations = new ArrayList<>();
-		scan(claudeMdFile.getAbsoluteFile(), 0, new ArrayDeque<>(), new LinkedHashSet<>(), violations);
-		report("Memory imports are not well formed:", violations);
+		File root = claudeMdFile.getAbsoluteFile();
+		Traversal traversal = Traversal.of(ImportGraph.from(root, this::isIgnored, this::debug));
+		scan(root, traversal);
+		report("Memory imports are not well formed:", traversal.violations());
 	}
 
-	private void scan(File file, int depth, Deque<Path> stack, Set<Path> visited, List<String> violations) {
-		Path path = normalized(file);
-		visited.add(path);
-		stack.push(path);
-		for (String imported : importsIn(file)) {
-			checkImport(file, imported, depth, stack, visited, violations);
+	private void scan(File file, Traversal traversal) {
+		Path path = ImportGraph.normalized(file);
+		traversal.scanned().add(path);
+		traversal.chain().push(path);
+		for (Reference reference : traversal.graph().importsOf(file)) {
+			checkImport(file, reference, traversal);
 		}
-		stack.pop();
+		traversal.chain().pop();
 	}
 
-	private void checkImport(File file, String imported, int depth, Deque<Path> stack, Set<Path> visited,
-			List<String> violations) {
-		if (isIgnored(imported)) {
-			return;
-		}
-		File target = resolve(file, imported);
-		Path path = normalized(target);
-		if (stack.contains(path)) {
-			violations.add(file + " has a circular import: @" + imported);
-		} else if (!target.isFile()) {
-			violations.add(file + " imports a missing file: @" + imported + " (resolved to " + target + ")");
-		} else if (depth + 1 > maxDepth) {
-			violations.add(file + " import @" + imported + " is nested deeper than " + maxDepth
+	private void checkImport(File file, Reference reference, Traversal traversal) {
+		Path path = ImportGraph.normalized(reference.target());
+		if (traversal.chain().contains(path)) {
+			traversal.violations().add(file + " has a circular import: @" + reference.text());
+		} else if (!reference.target().isFile()) {
+			traversal.violations().add(file + " imports a missing file: @" + reference.text()
+					+ " (resolved to " + reference.target() + ")");
+		} else if (traversal.graph().hopsTo(reference.target()) > maxDepth) {
+			traversal.violations().add(file + " import @" + reference.text() + " is nested deeper than " + maxDepth
 					+ " hops and will not be loaded");
-		} else if (!visited.contains(path)) {
-			scan(target, depth + 1, stack, visited, violations);
+		} else if (!traversal.scanned().contains(path)) {
+			scan(reference.target(), traversal);
 		}
 	}
 
@@ -95,53 +103,9 @@ public class MemoryImportsRule extends ClaudeCodeEnforcerRule {
 		return ignoredImports != null && ignoredImports.contains(imported);
 	}
 
-	private File resolve(File file, String imported) {
-		if (imported.startsWith("/")) {
-			return new File(imported);
-		}
-		return new File(file.getParentFile(), imported);
-	}
-
-	private Path normalized(File file) {
-		return file.toPath().toAbsolutePath().normalize();
-	}
-
-	private List<String> importsIn(File file) {
-		MarkdownDocument document = MarkdownDocument.parse(readSafely(file));
-		List<String> imports = new ArrayList<>();
-		for (int i = 0; i < document.lineCount(); i++) {
-			collectLineImports(document, i, imports);
-		}
-		return imports;
-	}
-
-	private void collectLineImports(MarkdownDocument document, int index, List<String> imports) {
-		if (document.isInsideFence(index)) {
-			return;
-		}
-		Matcher matcher = IMPORT.matcher(CODE_SPAN.matcher(document.line(index)).replaceAll(" "));
-		while (matcher.find()) {
-			imports.add(withoutTrailingDots(matcher.group(1)));
-		}
-	}
-
-	/** Drops sentence punctuation, so "see @docs/setup.md." imports {@code docs/setup.md}. */
-	private String withoutTrailingDots(String imported) {
-		return TRAILING_DOTS.matcher(imported).replaceAll("");
-	}
-
-	/**
-	 * The file's content, or empty when it cannot be read as text. An imported
-	 * file may be any format, so a binary target is treated as a leaf rather than
-	 * a failure — its existence has already been verified.
-	 */
-	private String readSafely(File file) {
-		try {
-			return Files.readString(file.toPath());
-		} catch (IOException e) {
-			getLog().debug("Skipping unreadable import target " + file + ": " + e.getMessage());
-			return "";
-		}
+	/** Reached only for an import target that cannot be read, so the log is looked up lazily. */
+	private void debug(String message) {
+		getLog().debug(message);
 	}
 
 	void setClaudeMdFile(File claudeMdFile) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRule.java
@@ -23,15 +23,20 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
  * {@code pomFile} (XML comments are ignored, so a commented-out module does not
  * count) and fails when a module's name — the last path segment, for a nested
  * entry such as {@code code/context} — does not appear in each configured doc
- * file. The check is presence-only by design, since how a doc arranges its module
- * map is prose. Modules listed in {@code ignoredModules} are exempt, and a pom
- * with no {@code <module>} entries fails as a build-setup mistake.
+ * file as a whole identifier. The check is presence-only by design, since how a
+ * doc arranges its module map is prose; matching whole identifiers rather than
+ * bare substrings is what keeps "presence-only" from degenerating into "any word
+ * that happens to contain the name". Modules listed in {@code ignoredModules} are
+ * exempt, and a pom with no {@code <module>} entries fails as a build-setup
+ * mistake.
  */
 @Named("moduleMapConsistency")
 public class ModuleMapConsistencyRule extends ClaudeCodeEnforcerRule {
 
 	private static final Pattern XML_COMMENT = Pattern.compile("(?s)<!--.*?-->");
 	private static final Pattern MODULE = Pattern.compile("<module>\\s*([^<]+?)\\s*</module>");
+	private static final String IDENTIFIER_BOUNDARY_BEFORE = "(?<![A-Za-z0-9_-])";
+	private static final String IDENTIFIER_BOUNDARY_AFTER = "(?![A-Za-z0-9_-])";
 
 	/** The aggregator {@code pom.xml} whose {@code <module>} entries are the source of truth. */
 	private File pomFile;
@@ -92,10 +97,24 @@ public class ModuleMapConsistencyRule extends ClaudeCodeEnforcerRule {
 		String content = requireContent(docFile, docFile.getName());
 		for (String module : modules) {
 			String name = moduleName(module);
-			if (!isIgnored(name) && !content.contains(name)) {
+			if (!isIgnored(name) && !mentions(content, name)) {
 				violations.add(docFile + " does not mention module '" + name + "' declared in " + pomFile);
 			}
 		}
+	}
+
+	/**
+	 * True when {@code name} appears as a whole identifier rather than as a bare
+	 * substring, so the word "metadata" no longer documents a module called
+	 * {@code data} and "claude-code-enforcer" no longer documents one called
+	 * {@code code}. A neighbouring character that could continue an identifier —
+	 * a letter, a digit, an underscore, or the hyphen these names are written
+	 * with — disqualifies the match; punctuation around it, such as the backticks
+	 * and slashes of {@code `code/context`}, does not.
+	 */
+	private boolean mentions(String content, String name) {
+		return Pattern.compile(IDENTIFIER_BOUNDARY_BEFORE + Pattern.quote(name) + IDENTIFIER_BOUNDARY_AFTER)
+				.matcher(content).find();
 	}
 
 	/** The last path segment, so a nested reactor entry such as {@code code/context} is looked up as {@code context}. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
@@ -28,8 +28,10 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
  * mixes a stdio and a remote transport in one entry.</li>
  * </ul>
  * <p>
- * A project-level {@code .mcp.json} is optional, so an absent file is a pass; all
- * problems found are reported together.
+ * A project-level {@code .mcp.json} is optional, so an absent file is a pass, as is
+ * one that declares no {@code mcpServers}; an {@code mcpServers} that is present
+ * and is not an object is reported rather than skipped, so a mistyped section
+ * cannot pass unvalidated. All problems found are reported together.
  */
 @Named("mcpConfigFormat")
 public class McpConfigFormatRule extends JsonFileRule {
@@ -76,8 +78,12 @@ public class McpConfigFormatRule extends JsonFileRule {
 
 	@Override
 	protected void collectViolations(JsonNode mcp, List<String> violations) {
+		if (!mcp.has(MCP_SERVERS_KEY)) {
+			return;
+		}
 		JsonNode servers = JsonNodes.objectAt(mcp, MCP_SERVERS_KEY);
 		if (servers == null) {
+			violations.add("mcp.json 'mcpServers' must be a JSON object");
 			return;
 		}
 		for (String name : JsonNodes.fieldNames(servers)) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonNodes.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonNodes.java
@@ -4,8 +4,11 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 /**
  * Null-safe accessors over Jackson {@link JsonNode} that mirror the optional
@@ -15,7 +18,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public final class JsonNodes {
 
-	private static final ObjectMapper MAPPER = new ObjectMapper();
+	/**
+	 * Parses strictly, because these rules exist to catch a hand-edited
+	 * configuration file that Claude Code will not read the way its author meant.
+	 * Jackson's defaults stop at the first complete value and let a later
+	 * definition of a key silently win, so content after the closing brace, and a
+	 * duplicated key, would both parse clean; both are rejected here instead.
+	 */
+	private static final ObjectMapper MAPPER = JsonMapper.builder()
+			.enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+			.enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+			.build();
 
 	private JsonNodes() {
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
@@ -1,0 +1,66 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Splits a hook command into the tokens a shell would see. Both hook rules need
+ * this to find the {@code $CLAUDE_PROJECT_DIR} references inside a command, so
+ * the splitting lives here rather than in each of them.
+ * <p>
+ * Splitting is on whitespace <em>outside</em> quotes, because a hook script path
+ * containing a space is legitimate and is quoted for exactly that reason; a plain
+ * whitespace split would tear {@code "$CLAUDE_PROJECT_DIR/my hook.sh"} into two
+ * halves and then report a script that is really there as missing. The quote
+ * characters are kept on the token, since {@link ClaudeProjectDir} strips them as
+ * part of expanding it.
+ */
+final class CommandTokens {
+
+	private static final char NONE = 0;
+	private static final char DOUBLE_QUOTE = '"';
+	private static final char SINGLE_QUOTE = '\'';
+
+	private CommandTokens() {
+	}
+
+	/** The command's tokens, in order, with empty ones dropped. */
+	static List<String> of(String command) {
+		List<String> tokens = new ArrayList<>();
+		StringBuilder token = new StringBuilder();
+		char quote = NONE;
+		for (int i = 0; i < command.length(); i++) {
+			quote = append(command.charAt(i), quote, token, tokens);
+		}
+		addToken(token, tokens);
+		return tokens;
+	}
+
+	/**
+	 * Appends one character to the token being built and returns the quote
+	 * character still open afterwards, so the caller stays a plain loop.
+	 */
+	private static char append(char character, char quote, StringBuilder token, List<String> tokens) {
+		if (quote != NONE) {
+			token.append(character);
+			return character == quote ? NONE : quote;
+		}
+		if (character == DOUBLE_QUOTE || character == SINGLE_QUOTE) {
+			token.append(character);
+			return character;
+		}
+		if (Character.isWhitespace(character)) {
+			addToken(token, tokens);
+			return NONE;
+		}
+		token.append(character);
+		return NONE;
+	}
+
+	private static void addToken(StringBuilder token, List<String> tokens) {
+		if (token.length() > 0) {
+			tokens.add(token.toString());
+			token.setLength(0);
+		}
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.settings;
 
 import java.io.File;
 import java.util.List;
+import java.util.Objects;
 
 import javax.inject.Named;
 
@@ -23,7 +24,9 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
  * renamed or missing hook script is caught; the check is on by default and can be
  * switched off with {@code validateScriptReferences}. An event name outside a
  * configured {@code allowedEvents} is reported, which catches a mistyped
- * {@code SessionSart}. A settings file without a {@code hooks} object is allowed.
+ * {@code SessionSart}. A settings file without a {@code hooks} key is allowed, but
+ * a {@code hooks} that is present and is not an object is reported rather than
+ * skipped, so a mistyped section cannot pass unvalidated.
  */
 @Named("hookCommandsValid")
 public class HookCommandsValidRule extends JsonFileRule {
@@ -67,8 +70,12 @@ public class HookCommandsValidRule extends JsonFileRule {
 
 	@Override
 	protected void collectViolations(JsonNode settings, List<String> violations) {
+		if (!settings.has(HOOKS_KEY)) {
+			return;
+		}
 		JsonNode hooks = JsonNodes.objectAt(settings, HOOKS_KEY);
 		if (hooks == null) {
+			violations.add("settings.json 'hooks' must be a JSON object");
 			return;
 		}
 		for (String event : JsonNodes.fieldNames(hooks)) {
@@ -125,8 +132,13 @@ public class HookCommandsValidRule extends JsonFileRule {
 			add(event, "has a command hook with an empty 'command'", violations);
 			return;
 		}
-		String script = validateScriptReferences ? localScriptPath(command) : null;
-		if (script != null && !new File(script).exists()) {
+		for (String script : localScriptPaths(command)) {
+			collectMissingScriptViolation(event, script, violations);
+		}
+	}
+
+	private void collectMissingScriptViolation(String event, String script, List<String> violations) {
+		if (!new File(script).exists()) {
 			add(event, "references a missing script: " + script, violations);
 		}
 	}
@@ -136,16 +148,18 @@ public class HookCommandsValidRule extends JsonFileRule {
 		violations.add("hook event '" + event + "' " + problem);
 	}
 
-	/** The resolved on-disk path of a {@code $CLAUDE_PROJECT_DIR}-rooted token, or null when none is referenced. */
-	private String localScriptPath(String command) {
-		ClaudeProjectDir projectDirs = new ClaudeProjectDir(projectDir, settingsFile);
-		for (String token : command.split("\\s+")) {
-			String expanded = projectDirs.expand(token);
-			if (expanded != null) {
-				return expanded;
-			}
+	/**
+	 * The resolved on-disk paths of every {@code $CLAUDE_PROJECT_DIR}-rooted token
+	 * in the command. A command chains more than one script often enough — an
+	 * {@code &&} between two hooks — that stopping at the first reference would
+	 * leave the rest unchecked.
+	 */
+	private List<String> localScriptPaths(String command) {
+		if (!validateScriptReferences) {
+			return List.of();
 		}
-		return null;
+		ClaudeProjectDir projectDirs = new ClaudeProjectDir(projectDir, settingsFile);
+		return CommandTokens.of(command).stream().map(projectDirs::expand).filter(Objects::nonNull).toList();
 	}
 
 	void setSettingsFile(File settingsFile) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.inject.Named;
@@ -134,11 +135,13 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private void addReferencedScript(String command, Set<Path> referenced, List<String> violations) {
-		Path script = scriptInHooksDir(command);
-		if (script == null) {
-			return;
+		for (Path script : scriptsInHooksDir(command)) {
+			referenced.add(script);
+			collectMissingScriptViolation(script, violations);
 		}
-		referenced.add(script);
+	}
+
+	private void collectMissingScriptViolation(Path script, List<String> violations) {
 		if (!script.toFile().exists()) {
 			violations.add("settings.json references a missing hook script: " + script);
 		}
@@ -155,17 +158,19 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 		}
 	}
 
-	/** The absolute path a command's {@code $CLAUDE_PROJECT_DIR} token resolves to when it lands in the hooks directory, else null. */
-	private Path scriptInHooksDir(String command) {
+	/**
+	 * The absolute paths every {@code $CLAUDE_PROJECT_DIR} token of a command
+	 * resolves to that land inside the hooks directory. A command chaining two
+	 * scripts references both, so stopping at the first would leave the second
+	 * unchecked and then report it as an orphan.
+	 */
+	private List<Path> scriptsInHooksDir(String command) {
 		Path hooks = canonical(hooksDir.toPath());
 		ClaudeProjectDir projectDirs = new ClaudeProjectDir(projectDir, settingsFile);
-		for (String token : command.split("\\s+")) {
-			Path resolved = resolveInHooks(projectDirs, token, hooks);
-			if (resolved != null) {
-				return resolved;
-			}
-		}
-		return null;
+		return CommandTokens.of(command).stream()
+				.map(token -> resolveInHooks(projectDirs, token, hooks))
+				.filter(Objects::nonNull)
+				.toList();
 	}
 
 	private Path resolveInHooks(ClaudeProjectDir projectDirs, String token, Path hooks) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
@@ -1,0 +1,245 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.doc.ImportGraph.Reference;
+
+/**
+ * Tests for the import graph behind {@link MemoryImportsRule}. The hop counts are
+ * what the rule's verdict rests on, so they are asserted directly here rather than
+ * only through the violations the rule happens to phrase.
+ */
+class ImportGraphTest {
+
+	private static final Predicate<String> NOTHING_IGNORED = imported -> false;
+
+	@TempDir
+	private Path tempDir;
+
+	private final List<String> unreadable = new ArrayList<>();
+
+	@Test
+	void theRootSitsZeroHopsFromItself() {
+		File root = write("CLAUDE.md", "# CLAUDE.md\n");
+
+		assertEquals(0, graphFrom(root).hopsTo(root));
+	}
+
+	@Test
+	void countsOneHopForADirectImport() {
+		File target = write("docs.md", "# Docs\n");
+		File root = write("CLAUDE.md", "See @docs.md\n");
+
+		assertEquals(1, graphFrom(root).hopsTo(target));
+	}
+
+	@Test
+	void countsAHopPerLinkOfAChain() {
+		File deep = write("third.md", "# Third\n");
+		write("second.md", "See @third.md\n");
+		write("first.md", "See @second.md\n");
+		File root = write("CLAUDE.md", "See @first.md\n");
+
+		assertEquals(3, graphFrom(root).hopsTo(deep));
+	}
+
+	@Test
+	void countsTheShortestChainWhenTheDirectImportComesFirst() {
+		File target = write("shared.md", "# Shared\n");
+		write("long.md", "See @shared.md\n");
+		File root = write("CLAUDE.md", "See @shared.md and @long.md\n");
+
+		assertEquals(1, graphFrom(root).hopsTo(target));
+	}
+
+	@Test
+	void countsTheShortestChainWhenTheLongChainComesFirst() {
+		File target = write("shared.md", "# Shared\n");
+		write("long.md", "See @shared.md\n");
+		File root = write("CLAUDE.md", "See @long.md and @shared.md\n");
+
+		// The answer must not depend on which import is written first, which is
+		// the whole reason the graph is built breadth-first.
+		assertEquals(1, graphFrom(root).hopsTo(target));
+	}
+
+	@Test
+	void reportsAnUnreachableFileAsInfinitelyFarAway() {
+		File stranger = write("stranger.md", "# Stranger\n");
+		File root = write("CLAUDE.md", "# CLAUDE.md\n");
+
+		assertEquals(Integer.MAX_VALUE, graphFrom(root).hopsTo(stranger));
+	}
+
+	@Test
+	void keepsAMissingTargetAsAReferenceWithoutAHopCount() {
+		File root = write("CLAUDE.md", "See @absent.md\n");
+		ImportGraph graph = graphFrom(root);
+
+		assertEquals(List.of("absent.md"), textOf(graph.importsOf(root)));
+		assertEquals(Integer.MAX_VALUE, graph.hopsTo(new File(tempDir.toFile(), "absent.md")));
+	}
+
+	@Test
+	void terminatesOnACycleAndKeepsTheFirstHopCount() {
+		File loop = write("loop.md", "Back to @CLAUDE.md\n");
+		File root = write("CLAUDE.md", "See @loop.md\n");
+		ImportGraph graph = graphFrom(root);
+
+		assertEquals(1, graph.hopsTo(loop));
+		assertEquals(0, graph.hopsTo(root));
+	}
+
+	@Test
+	void keepsImportsInDocumentOrder() {
+		write("a.md", "# A\n");
+		write("b.md", "# B\n");
+		File root = write("CLAUDE.md", "See @b.md then @a.md\n");
+
+		assertEquals(List.of("b.md", "a.md"), textOf(graphFrom(root).importsOf(root)));
+	}
+
+	@Test
+	void yieldsNoImportsForAFileTheRootNeverReaches() {
+		File stranger = write("stranger.md", "See @somewhere.md\n");
+		File root = write("CLAUDE.md", "# CLAUDE.md\n");
+
+		assertEquals(List.of(), graphFrom(root).importsOf(stranger));
+	}
+
+	@Test
+	void leavesOutAnIgnoredImport() {
+		File target = write("docs.md", "# Docs\n");
+		File root = write("CLAUDE.md", "See @docs.md\n");
+		ImportGraph graph = ImportGraph.from(root, "docs.md"::equals, unreadable::add);
+
+		// An ignored import is not an edge at all, so it neither shows up as a
+		// reference nor drags its target into the graph.
+		assertEquals(List.of(), graph.importsOf(root));
+		assertEquals(Integer.MAX_VALUE, graph.hopsTo(target));
+	}
+
+	@Test
+	void ignoresImportsInsideFencedCodeBlocks() {
+		File root = write("CLAUDE.md", "# CLAUDE.md\n\n```\n@docs.md\n```\n");
+
+		assertEquals(List.of(), graphFrom(root).importsOf(root));
+	}
+
+	@Test
+	void ignoresImportsInsideInlineCodeSpans() {
+		File root = write("CLAUDE.md", "an `@claude`-mention workflow\n");
+
+		assertEquals(List.of(), graphFrom(root).importsOf(root));
+	}
+
+	@Test
+	void ignoresAHomeRelativeImport() {
+		File root = write("CLAUDE.md", "Also @~/personal/prefs.md is loaded.\n");
+
+		assertEquals(List.of(), graphFrom(root).importsOf(root));
+	}
+
+	@Test
+	void dropsSentencePunctuationFromTheImportPath() {
+		File root = write("CLAUDE.md", "See @docs.md.\n");
+
+		assertEquals(List.of("docs.md"), textOf(graphFrom(root).importsOf(root)));
+	}
+
+	@Test
+	void resolvesARelativeImportAgainstTheImportingFile() {
+		File sibling = write("docs/sibling.md", "# Sibling\n");
+		write("docs/inner.md", "See @sibling.md\n");
+		File root = write("CLAUDE.md", "See @docs/inner.md\n");
+
+		assertEquals(2, graphFrom(root).hopsTo(sibling));
+	}
+
+	@Test
+	void resolvesAnAbsoluteImportAsAnAbsolutePath() {
+		File absolute = write("elsewhere.md", "# Elsewhere\n");
+		File root = write("CLAUDE.md", "See @" + absolute.getAbsolutePath() + "\n");
+
+		// A leading slash means the path is not relative to the importing file.
+		assertEquals(1, graphFrom(root).hopsTo(absolute));
+	}
+
+	@Test
+	void treatsAnImportTargetThatIsNotTextAsALeaf() throws IOException {
+		Path binary = tempDir.resolve("logo.md");
+		Files.write(binary, new byte[] { (byte) 0xC3, (byte) 0x28, (byte) 0xA0 });
+		File root = write("CLAUDE.md", "See @logo.md\n");
+		ImportGraph graph = graphFrom(root);
+
+		// Its existence still counts — an imported file may be any format — but it
+		// contributes no imports of its own.
+		assertEquals(1, graph.hopsTo(binary.toFile()));
+		assertEquals(List.of(), graph.importsOf(binary.toFile()));
+	}
+
+	@Test
+	void announcesAnImportTargetThatCannotBeReadAsText() throws IOException {
+		Path binary = tempDir.resolve("logo.md");
+		Files.write(binary, new byte[] { (byte) 0xC3, (byte) 0x28, (byte) 0xA0 });
+		File root = write("CLAUDE.md", "See @logo.md\n");
+
+		graphFrom(root);
+
+		assertEquals(1, unreadable.size(), unreadable.toString());
+		assertTrue(unreadable.get(0).startsWith("Skipping unreadable import target"), unreadable.toString());
+		assertTrue(unreadable.get(0).contains("logo.md"), unreadable.toString());
+	}
+
+	@Test
+	void saysNothingAboutFilesItCanRead() {
+		write("docs.md", "# Docs\n");
+		File root = write("CLAUDE.md", "See @docs.md\n");
+
+		graphFrom(root);
+
+		assertTrue(unreadable.isEmpty(), unreadable.toString());
+	}
+
+	@Test
+	void normalizesAwayDotSegments() {
+		File root = write("CLAUDE.md", "# CLAUDE.md\n");
+		File roundabout = new File(tempDir.toFile(), "docs/../CLAUDE.md");
+
+		assertEquals(ImportGraph.normalized(root), ImportGraph.normalized(roundabout));
+		assertFalse(roundabout.getPath().equals(ImportGraph.normalized(roundabout).toString()));
+	}
+
+	private ImportGraph graphFrom(File root) {
+		return ImportGraph.from(root, NOTHING_IGNORED, unreadable::add);
+	}
+
+	private List<String> textOf(List<Reference> references) {
+		return references.stream().map(Reference::text).toList();
+	}
+
+	private File write(String name, String content) {
+		Path file = tempDir.resolve(name);
+		try {
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+		return file.toFile();
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
@@ -14,6 +14,8 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+
 class MemoryImportsRuleTest {
 
 	@TempDir
@@ -170,6 +172,33 @@ class MemoryImportsRuleTest {
 		// The long chain is written first here and the direct import second; the
 		// verdict must not depend on which one the traversal walks into first.
 		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void stillChecksAnImportThatIsNotOnTheIgnoreList() {
+		MemoryImportsRule rule = ruleFor("# CLAUDE.md\n\nSee @docs/absent.md\n");
+		rule.setIgnoredImports(List.of("something/else.md"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("imports a missing file"), exception.getMessage());
+	}
+
+	@Test
+	void acceptsAnImportTargetThatIsNotText() throws IOException {
+		Files.write(tempDir.resolve("logo.md"), new byte[] { (byte) 0xC3, (byte) 0x28, (byte) 0xA0 });
+		MemoryImportsRule rule = ruleFor("# CLAUDE.md\n\nSee @logo.md\n");
+		rule.setLog(new CapturingLogger());
+
+		// An imported file may be any format, so an unreadable one is a leaf that
+		// is noted in the debug log rather than a violation.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void namesTheFileInItsDescription() {
+		MemoryImportsRule rule = ruleFor("# CLAUDE.md\n");
+
+		assertTrue(rule.toString().contains("CLAUDE.md"), rule.toString());
 	}
 
 	private MemoryImportsRule ruleFor(String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
@@ -122,6 +122,56 @@ class MemoryImportsRuleTest {
 		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nSee @docs/inner.md\n")::execute);
 	}
 
+	@Test
+	void passesWhenALongChainReachesAFileThatIsAlsoImportedDirectly() {
+		writeString(tempDir.resolve("shallow.md"), "See @leaf.md\n");
+		writeString(tempDir.resolve("leaf.md"), "# Leaf\n");
+		writeString(tempDir.resolve("a.md"), "See @b.md\n");
+		writeString(tempDir.resolve("b.md"), "See @c.md\n");
+		writeString(tempDir.resolve("c.md"), "See @d.md\n");
+		writeString(tempDir.resolve("d.md"), "See @shallow.md\n");
+		MemoryImportsRule rule = ruleFor("# CLAUDE.md\n\nSee @shallow.md and @a.md\n");
+		rule.setMaxDepth(5);
+
+		// leaf.md is two hops away down the direct chain, so Claude Code loads it;
+		// the fact that the a-b-c-d chain also reaches it six hops out does not
+		// make it unloadable.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void reportsADeepChainWhateverOrderTheImportsAreWrittenIn() {
+		writeString(tempDir.resolve("shallow.md"), "See @leaf.md\n");
+		writeString(tempDir.resolve("leaf.md"), "# Leaf\n");
+		writeString(tempDir.resolve("a.md"), "See @b.md\n");
+		writeString(tempDir.resolve("b.md"), "See @c.md\n");
+		writeString(tempDir.resolve("c.md"), "See @d.md\n");
+		writeString(tempDir.resolve("d.md"), "See @shallow.md\n");
+		MemoryImportsRule rule = ruleFor("# CLAUDE.md\n\nSee @a.md\n");
+		rule.setMaxDepth(5);
+
+		// Same files, but nothing imports shallow.md directly any more, so its
+		// only chain is six hops long and leaf.md really is out of reach.
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("nested deeper than 5 hops"), exception.getMessage());
+	}
+
+	@Test
+	void countsDepthAlongTheShortestChainRegardlessOfImportOrder() {
+		writeString(tempDir.resolve("shallow.md"), "See @leaf.md\n");
+		writeString(tempDir.resolve("leaf.md"), "# Leaf\n");
+		writeString(tempDir.resolve("a.md"), "See @b.md\n");
+		writeString(tempDir.resolve("b.md"), "See @c.md\n");
+		writeString(tempDir.resolve("c.md"), "See @d.md\n");
+		writeString(tempDir.resolve("d.md"), "See @shallow.md\n");
+		MemoryImportsRule rule = ruleFor("# CLAUDE.md\n\nSee @a.md and @shallow.md\n");
+		rule.setMaxDepth(5);
+
+		// The long chain is written first here and the direct import second; the
+		// verdict must not depend on which one the traversal walks into first.
+		assertDoesNotThrow(rule::execute);
+	}
+
 	private MemoryImportsRule ruleFor(String content) {
 		Path file = tempDir.resolve("CLAUDE.md");
 		writeString(file, content);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRuleTest.java
@@ -94,6 +94,28 @@ class ModuleMapConsistencyRuleTest {
 		assertTrue(exception.getMessage().contains("'context'"), exception.getMessage());
 	}
 
+	@Test
+	void failsWhenAModuleNameOnlyAppearsInsideALongerWord() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor(POM, "The context module stores metadata somewhere.\n")::execute);
+
+		// "metadata" is not a mention of the module called 'data'.
+		assertTrue(exception.getMessage().contains("does not mention module 'data'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAModuleNameOnlyAppearsInsideAHyphenatedName() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("<project><modules><module>code</module></modules></project>",
+						"The claude-code-enforcer module.\n")::execute);
+		assertTrue(exception.getMessage().contains("does not mention module 'code'"), exception.getMessage());
+	}
+
+	@Test
+	void acceptsAModuleNamedInsideMarkdownPunctuation() {
+		assertDoesNotThrow(ruleFor(POM, "Modules: `data`, and `code/context` for the finder.\n")::execute);
+	}
+
 	private ModuleMapConsistencyRule ruleFor(String pomContent, String docContent) {
 		ModuleMapConsistencyRule rule = new ModuleMapConsistencyRule();
 		rule.setPomFile(write("pom.xml", pomContent).toFile());

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRuleTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -114,6 +115,26 @@ class ModuleMapConsistencyRuleTest {
 	@Test
 	void acceptsAModuleNamedInsideMarkdownPunctuation() {
 		assertDoesNotThrow(ruleFor(POM, "Modules: `data`, and `code/context` for the finder.\n")::execute);
+	}
+
+	@Test
+	void writesAnHtmlReportExplainingHowToFixTheModuleMap() throws IOException {
+		ModuleMapConsistencyRule rule = ruleFor(POM, "Only the data module.\n");
+		File report = tempDir.resolve("report.html").toFile();
+		rule.setReportFile(report);
+
+		assertThrows(EnforcerRuleException.class, rule::execute);
+		String html = Files.readString(report.toPath());
+		assertTrue(html.contains("does not mention module &#39;context&#39;"), html);
+		assertTrue(html.contains("ignoredModules"), html);
+	}
+
+	@Test
+	void namesThePomAndDocsInItsDescription() {
+		ModuleMapConsistencyRule rule = ruleFor(POM, "The data module and the context module.\n");
+
+		assertTrue(rule.toString().contains("pom.xml"), rule.toString());
+		assertTrue(rule.toString().contains("CLAUDE.md"), rule.toString());
 	}
 
 	private ModuleMapConsistencyRule ruleFor(String pomContent, String docContent) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
@@ -137,6 +137,21 @@ class McpConfigFormatRuleTest {
 		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("args")), logger.warnings().toString());
 	}
 
+	@Test
+	void failsWhenMcpServersIsNotAnObject() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": [ { \"command\": \"npx\", \"url\": \"nonsense\" } ] }")::execute);
+
+		// An 'mcpServers' of the wrong shape used to look exactly like an absent
+		// one, so every server inside it went unvalidated.
+		assertTrue(exception.getMessage().contains("'mcpServers' must be a JSON object"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenThereAreNoMcpServersAtAll() {
+		assertDoesNotThrow(ruleFor("{ \"other\": true }")::execute);
+	}
+
 	private McpConfigFormatRule ruleFor(String content) {
 		Path file = tempDir.resolve(".mcp.json");
 		writeString(file, content);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
@@ -152,6 +152,56 @@ class McpConfigFormatRuleTest {
 		assertDoesNotThrow(ruleFor("{ \"other\": true }")::execute);
 	}
 
+	@Test
+	void leavesAServerEntryThatIsNotAnObjectToTheTransportRule() {
+		// This rule validates the fields around a transport; whether an entry is
+		// an object at all is McpServersValidRule's call, so it is not reported
+		// twice.
+		assertDoesNotThrow(ruleFor("{ \"mcpServers\": { \"fs\": \"npx\" } }")::execute);
+	}
+
+	@Test
+	void ignoresAUrlThatIsNotAString() {
+		assertDoesNotThrow(ruleFor("{ \"mcpServers\": { \"remote\": { \"type\": \"sse\", \"url\": 8080 } } }")::execute);
+	}
+
+	@Test
+	void failsWhenAUrlHasNoScheme() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"remote\": { \"url\": \"example.com/sse\" } } }")::execute);
+		assertTrue(exception.getMessage().contains("malformed 'url'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAUrlHasNoHost() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"remote\": { \"url\": \"http:///sse\" } } }")::execute);
+		assertTrue(exception.getMessage().contains("malformed 'url'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAUrlUsesASchemeThatIsNotHttp() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"remote\": { \"url\": \"ftp://example.com/sse\" } } }")::execute);
+		assertTrue(exception.getMessage().contains("malformed 'url'"), exception.getMessage());
+	}
+
+	@Test
+	void acceptsAnUppercaseUrlScheme() {
+		McpConfigFormatRule rule = ruleFor(
+				"{ \"mcpServers\": { \"remote\": { \"url\": \"HTTPS://example.com/sse\" } } }");
+		rule.setRequireHttps(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void namesTheMcpFileInItsDescription() {
+		McpConfigFormatRule rule = ruleFor(VALID_MCP);
+
+		assertTrue(rule.toString().contains(".mcp.json"), rule.toString());
+	}
+
 	private McpConfigFormatRule ruleFor(String content) {
 		Path file = tempDir.resolve(".mcp.json");
 		writeString(file, content);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonNodesTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonNodesTest.java
@@ -144,6 +144,32 @@ class JsonNodesTest {
 		assertEquals(List.of(), JsonNodes.fieldNames(parse("{}")));
 	}
 
+	@Test
+	void parseObjectRejectsContentAfterTheClosingBrace() {
+		List<String> violations = new ArrayList<>();
+
+		// Jackson stops at the first complete value by default, so this used to
+		// parse clean and the trailing text was never seen.
+		JsonNode root = JsonNodes.parseObject("{\"a\":1} and then some", "settings.json", violations);
+
+		assertNull(root);
+		assertEquals(1, violations.size());
+		assertTrue(violations.get(0).startsWith("settings.json is not valid JSON:"), violations.toString());
+	}
+
+	@Test
+	void parseObjectRejectsADuplicatedKey() {
+		List<String> violations = new ArrayList<>();
+
+		// The second definition silently won before, which is exactly the kind of
+		// shadowing these rules exist to catch.
+		JsonNode root = JsonNodes.parseObject("{\"a\":{\"x\":1},\"a\":{\"x\":2}}", "settings.json", violations);
+
+		assertNull(root);
+		assertEquals(1, violations.size());
+		assertTrue(violations.get(0).contains("Duplicate field 'a'"), violations.toString());
+	}
+
 	private static JsonNode parse(String json) {
 		try {
 			return MAPPER.readTree(json);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
@@ -1,0 +1,51 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class CommandTokensTest {
+
+	@Test
+	void splitsOnWhitespace() {
+		assertEquals(List.of("bash", "run.sh", "--flag"), CommandTokens.of("bash run.sh --flag"));
+	}
+
+	@Test
+	void collapsesRunsOfWhitespace() {
+		assertEquals(List.of("bash", "run.sh"), CommandTokens.of("  bash \t\n run.sh  "));
+	}
+
+	@Test
+	void keepsADoubleQuotedPathWithASpaceInOneToken() {
+		assertEquals(List.of("bash", "\"my hook.sh\""), CommandTokens.of("bash \"my hook.sh\""));
+	}
+
+	@Test
+	void keepsASingleQuotedPathWithASpaceInOneToken() {
+		assertEquals(List.of("bash", "'my hook.sh'"), CommandTokens.of("bash 'my hook.sh'"));
+	}
+
+	@Test
+	void treatsAQuoteInsideTheOtherQuoteAsOrdinaryText() {
+		assertEquals(List.of("echo", "\"it's here\""), CommandTokens.of("echo \"it's here\""));
+	}
+
+	@Test
+	void keepsAnUnclosedQuoteAsOneTrailingToken() {
+		assertEquals(List.of("bash", "\"my hook.sh"), CommandTokens.of("bash \"my hook.sh"));
+	}
+
+	@Test
+	void yieldsNoTokensForABlankCommand() {
+		assertEquals(List.of(), CommandTokens.of("   "));
+	}
+
+	@Test
+	void keepsAQuotedSegmentAttachedToItsSurroundingToken() {
+		assertEquals(List.of("\"$CLAUDE_PROJECT_DIR\"/my", "hook.sh"),
+				CommandTokens.of("\"$CLAUDE_PROJECT_DIR\"/my hook.sh"));
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -172,6 +172,46 @@ class HookCommandsValidRuleTest {
 		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("gone.sh")), logger.warnings().toString());
 	}
 
+	@Test
+	void failsWhenHooksIsNotAnObject() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"hooks\": [ { \"SessionStart\": [] } ] }")::execute);
+
+		// A 'hooks' of the wrong shape used to look exactly like an absent one, so
+		// the whole section went unvalidated instead of being reported.
+		assertTrue(exception.getMessage().contains("'hooks' must be a JSON object"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenHooksIsAString() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"hooks\": \"SessionStart\" }")::execute);
+		assertTrue(exception.getMessage().contains("'hooks' must be a JSON object"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheSecondOfTwoChainedScriptsIsMissing() {
+		writeString(tempDir.resolve("first.sh"), "#!/bin/sh\necho hi\n");
+		HookCommandsValidRule rule = ruleFor(
+				hooksReferencing("$CLAUDE_PROJECT_DIR/first.sh && $CLAUDE_PROJECT_DIR/second.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		// Every reference in the command is checked, not just the first one.
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("second.sh"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenAQuotedScriptPathContainsASpace() {
+		writeString(tempDir.resolve("my hook.sh"), "#!/bin/sh\necho hi\n");
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("\\\"$CLAUDE_PROJECT_DIR/my hook.sh\\\""));
+		rule.setProjectDir(tempDir.toFile());
+
+		// The quotes hold the path together, so it is not split at the space and
+		// then reported as two missing scripts.
+		assertDoesNotThrow(rule::execute);
+	}
+
 	private String hooksReferencing(String command) {
 		return """
 				{ "hooks": { "SessionStart": [ { "hooks": [ { "type": "command", "command": "%s" } ] } ] } }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -212,6 +212,53 @@ class HookCommandsValidRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
+	@Test
+	void failsWhenAnEventDoesNotMapToAnArray() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"hooks\": { \"SessionStart\": { \"type\": \"command\" } } }")::execute);
+		assertTrue(exception.getMessage().contains("must be a JSON array"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAGroupIsNotAnObject() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"hooks\": { \"SessionStart\": [ \"not-a-group\" ] } }")::execute);
+		assertTrue(exception.getMessage().contains("entry that is not a JSON object"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAHookEntryIsNotAnObject() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				ruleFor("{ \"hooks\": { \"SessionStart\": [ { \"hooks\": [ \"echo hi\" ] } ] } }")::execute);
+		assertTrue(exception.getMessage().contains("hook that is not a JSON object"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenTheEventIsOnTheAllowedList() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("echo hi"));
+		rule.setAllowedEvents(List.of("SessionStart", "PreToolUse"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void leavesAHookOfAnotherTypeAlone() {
+		String content = """
+				{ "hooks": { "SessionStart": [ { "hooks": [ { "type": "output" } ] } ] } }
+				""";
+
+		// Only a command hook carries a 'command', so a hook of another type must
+		// not be held to that requirement.
+		assertDoesNotThrow(ruleFor(content)::execute);
+	}
+
+	@Test
+	void namesTheSettingsFileInItsDescription() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("echo hi"));
+
+		assertTrue(rule.toString().contains("settings.json"), rule.toString());
+	}
+
 	private String hooksReferencing(String command) {
 		return """
 				{ "hooks": { "SessionStart": [ { "hooks": [ { "type": "command", "command": "%s" } ] } ] } }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -139,6 +139,34 @@ class HooksFormatRuleTest {
 	}
 
 	@Test
+	void treatsEveryScriptAChainedCommandReferencesAsReferenced() {
+		writeScript("first.sh", "#!/bin/sh\n", true);
+		writeScript("second.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("$CLAUDE_PROJECT_DIR/.claude/hooks/first.sh"
+				+ " && $CLAUDE_PROJECT_DIR/.claude/hooks/second.sh"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setReportUnreferencedScripts(true);
+
+		// Both references count. Stopping at the first one left second.sh looking
+		// like an orphan even though the very same command runs it.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenTheSecondScriptOfAChainedCommandIsMissing() {
+		writeScript("first.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("$CLAUDE_PROJECT_DIR/.claude/hooks/first.sh"
+				+ " && $CLAUDE_PROJECT_DIR/.claude/hooks/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing hook script"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+	}
+
+	@Test
 	void doesNotTreatASymlinkedScriptPointingOutsideAsInsideTheHooksDirectory() {
 		Path outside = tempDir.resolve("outside.sh");
 		writeString(outside, "#!/bin/sh\n");

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -183,6 +183,54 @@ class HooksFormatRuleTest {
 	}
 
 	@Test
+	void passesWhenTheExtensionIsOnTheAllowedList() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setAllowedExtensions(List.of("sh", "py"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenAScriptHasNoExtensionAtAll() {
+		writeScript("session-start", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setAllowedExtensions(List.of("sh"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("disallowed extension"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheConfiguredSettingsFileDoesNotExist() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(tempDir.resolve("absent.json").toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("settings.json does not exist"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheSettingsFileIsNotValidJson() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		Path settings = tempDir.resolve(".claude/settings.json");
+		writeString(settings, "{ not json");
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settings.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("not valid JSON"), exception.getMessage());
+	}
+
+	@Test
+	void namesTheHooksDirectoryInItsDescription() {
+		HooksFormatRule rule = ruleFor();
+
+		assertTrue(rule.toString().contains("hooks"), rule.toString());
+	}
+
+	@Test
 	void warnSeverityLogsInsteadOfFailing() {
 		writeScript("session-start.sh", "echo hi\n", true);
 		HooksFormatRule rule = ruleFor();


### PR DESCRIPTION
Each of these made a rule quietly accept configuration it exists to reject,
which is the worst failure mode for a build gate: the check runs, reports
nothing, and the problem ships.

- hookCommandsValid and mcpConfigFormat treated a wrong-typed section exactly
  like an absent one, because JsonNodes.objectAt returns null for both. A
  "hooks": [] or an "mcpServers" array meant the entire section went
  unvalidated. Both now report it, following the shape permissionsFormat
  already used.
- memoryImports judged an import's depth by whichever chain the traversal
  happened to walk into first, so a file reached early by a short chain was
  never re-scanned and a too-deep import below it went unreported. Depth is
  now counted along an import's shortest chain, which the new ImportGraph
  works out breadth-first before the rule walks it, so the verdict no longer
  depends on the order imports are written in.
- moduleMapConsistency matched module names as bare substrings, so "metadata"
  documented the data module and "claude-code-enforcer" documented code. It
  now matches whole identifiers.
- Both hook rules stopped at the first $CLAUDE_PROJECT_DIR reference in a
  command, leaving the second script of a chained command unchecked and then
  reporting it as unreferenced. They now check every reference, splitting the
  command with a shared quote-aware tokenizer so a quoted path containing a
  space survives intact.
- JSON parsing accepted content after the closing brace and let a duplicated
  key silently win. It is now strict about both.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MV9DdHDTjqbSGfmGLz4uFC