### PR TITLE
refactor(adopt): remove duplication and tighten the module's seams

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -16,6 +16,14 @@ public final class AdoptionContext {
 	/** Feature branch the adoption commits, pushes, and raises a pull request from. */
 	public static final String DEFAULT_BRANCH = "claude/adopt-claude-code";
 
+	/**
+	 * The remote the adoption fetches from, starts an already-published branch at,
+	 * and pushes to. Named once here because the clone, the branch, and the push must
+	 * agree on it: a branch started from one remote and pushed to another is rejected
+	 * as a non-fast-forward.
+	 */
+	public static final String REMOTE = "origin";
+
 	private final RepositoryUrl repository;
 	private final Path workspace;
 	private final Path repositoryDirectory;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
@@ -42,7 +42,7 @@ public class AdoptionReportWriter {
 
 	private ObjectNode toBatchNode(List<AdoptionRun> runs) {
 		ObjectNode node = mapper.createObjectNode();
-		node.put("succeeded", runs.stream().allMatch(AdoptionRun::succeeded));
+		node.put("succeeded", AdoptionRun.allSucceeded(runs));
 		ArrayNode repositories = node.putArray("repositories");
 		runs.stream().map(this::toNode).forEach(repositories::add);
 		return node;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionRun.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionRun.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -23,6 +24,19 @@ public record AdoptionRun(String repositoryUrl, String branchName, AdoptionRepor
 
 	public boolean succeeded() {
 		return report.succeeded();
+	}
+
+	/**
+	 * Whether a whole run landed. The fold lives here because the answer is read in
+	 * three places that must agree — the CLI's exit status, the MCP result's
+	 * success flag, and the {@code succeeded} field of the report itself — and a
+	 * report that contradicted the exit code would be the worst of the three to
+	 * debug.
+	 *
+	 * @param runs the runs of one batch, which succeeds only when every one of them did
+	 */
+	public static boolean allSucceeded(List<AdoptionRun> runs) {
+		return runs.stream().allMatch(AdoptionRun::succeeded);
 	}
 
 	/** @return why this repository's adoption stopped, or empty when it completed */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -51,7 +51,7 @@ public final class CliArguments {
 	private Path reportFile;
 	private int positionals;
 	private String positionalUrl;
-	private int flaggedRepositories;
+	private boolean flagsNamedARepository;
 
 	private CliArguments() {
 	}
@@ -175,9 +175,7 @@ public final class CliArguments {
 	}
 
 	private void addFlaggedRepository(String url) {
-		if (Text.isPresent(url)) {
-			flaggedRepositories++;
-		}
+		flagsNamedARepository = flagsNamedARepository || Text.isPresent(url);
 		addRepository(url);
 	}
 
@@ -219,7 +217,7 @@ public final class CliArguments {
 	 * batch of local repositories names them all with {@code --repo}.
 	 */
 	private void requirePositionalNamesARepository() {
-		if (positionalUrl != null && flaggedRepositories > 0 && namesNoOwner(positionalUrl)) {
+		if (positionalUrl != null && flagsNamedARepository && namesNoOwner(positionalUrl)) {
 			throw new IllegalArgumentException("The first argument is read as a repository URL, but " + positionalUrl
 					+ " names no repository owner. Name the workspace with --workspace,"
 					+ " or the repository with --repo. " + USAGE);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Platform.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Platform.java
@@ -1,0 +1,22 @@
+package io.github.adamw7.tools.adopt;
+
+import java.util.Locale;
+
+/**
+ * The host operating system, as the adoption needs to read it. Windows is the one
+ * platform the adoption treats differently — a build wrapper is {@code mvnw.cmd}
+ * rather than {@code mvnw} there, and a bare program name has to be resolved
+ * through {@code PATHEXT} before {@link ProcessBuilder} will start it — so the
+ * detection lives here rather than being spelled out by each place that branches
+ * on it.
+ */
+public final class Platform {
+
+	private Platform() {
+	}
+
+	/** @return whether the JVM is running on Windows */
+	public static boolean isWindows() {
+		return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("windows");
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Redaction.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Redaction.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
  */
 public final class Redaction {
 
-	static final String MASK = "***";
+	private static final String MASK = "***";
 
 	/**
 	 * The user information between a URL's {@code ://} and its {@code @}. The match

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -16,8 +16,8 @@ import java.util.stream.Stream;
  */
 public final class RepositoryUrl {
 
-	private static final String SCHEME = "^[a-zA-Z][a-zA-Z0-9+.-]*://";
-	private static final String SEGMENT_SEPARATORS = "[/:]";
+	private static final Pattern SCHEME = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+.-]*://");
+	private static final Pattern SEGMENT_SEPARATORS = Pattern.compile("[/:]");
 	private static final int SEGMENTS_WITH_A_HOST = 3;
 	private static final String GIT_SUFFIX = ".git";
 
@@ -115,7 +115,7 @@ public final class RepositoryUrl {
 		if (!Text.isPresent(repositoryUrl)) {
 			return "";
 		}
-		String withoutScheme = repositoryUrl.strip().replaceFirst(SCHEME, "");
+		String withoutScheme = SCHEME.matcher(repositoryUrl.strip()).replaceFirst("");
 		String path = USER_INFO.matcher(withoutScheme).replaceFirst("").replace(':', '/');
 		return stripGitSuffix(stripTrailingSlash(path)).toLowerCase(Locale.ROOT);
 	}
@@ -134,7 +134,7 @@ public final class RepositoryUrl {
 	 * for that separator.
 	 */
 	private static String lastSegment(String url) {
-		String withoutScheme = url.replaceFirst(SCHEME, "");
+		String withoutScheme = SCHEME.matcher(url).replaceFirst("");
 		int separator = Math.max(withoutScheme.lastIndexOf('/'), withoutScheme.lastIndexOf(':'));
 		return withoutScheme.substring(separator + 1);
 	}
@@ -187,7 +187,7 @@ public final class RepositoryUrl {
 	}
 
 	private static List<String> segments(String url) {
-		return Stream.of(url.replaceFirst(SCHEME, "").split(SEGMENT_SEPARATORS))
+		return Stream.of(SEGMENT_SEPARATORS.split(SCHEME.matcher(url).replaceFirst("")))
 				.filter(segment -> !segment.isBlank())
 				.toList();
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import io.github.adamw7.tools.adopt.Platform;
+
 /**
  * Resolves a command's program name to a form {@link ProcessBuilder} can actually
  * launch on the host operating system.
@@ -38,7 +40,7 @@ final class ExecutableResolver {
 	private final List<String> pathExtensions;
 
 	ExecutableResolver() {
-		this(isWindows(), pathDirectoriesFromEnvironment(), pathExtensionsFromEnvironment());
+		this(Platform.isWindows(), pathDirectoriesFromEnvironment(), pathExtensionsFromEnvironment());
 	}
 
 	ExecutableResolver(boolean windows, List<Path> pathDirectories, List<String> pathExtensions) {
@@ -101,10 +103,6 @@ final class ExecutableResolver {
 
 	private boolean hasPathSeparator(String program) {
 		return program.indexOf('/') >= 0 || program.indexOf('\\') >= 0;
-	}
-
-	private static boolean isWindows() {
-		return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("windows");
 	}
 
 	private static List<Path> pathDirectoriesFromEnvironment() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -23,7 +23,7 @@ import io.github.adamw7.tools.adopt.Redaction;
  */
 public class ProcessCommandRunner implements CommandRunner {
 
-	static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(10);
+	private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(10);
 
 	private final Duration timeout;
 	private final ExecutableResolver resolver;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -18,6 +18,7 @@ import io.github.adamw7.tools.adopt.BatchAdoption;
 import io.github.adamw7.tools.adopt.Checkouts;
 import io.github.adamw7.tools.adopt.GitHubRepoAdopter;
 import io.github.adamw7.tools.adopt.RepositoryUrls;
+import io.github.adamw7.tools.adopt.Text;
 import io.github.adamw7.tools.adopt.Workspaces;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
@@ -42,12 +43,15 @@ import io.github.adamw7.tools.mcp.ToolResult;
 public class AdoptTool implements McpTool {
 
 	/**
-	 * The adoption run the tool delegates to once the arguments are mapped, filling
-	 * in the report it is handed so a failed repository still reports how far it got.
+	 * Builds the adoption a call runs, from the arguments that call supplied. The
+	 * seam is a factory rather than the adoption itself so the pipeline — and the
+	 * command runner behind it — is assembled once and then adopts every repository
+	 * of the batch, exactly as the command line does; assembling it per repository
+	 * would hand each one its own step instances. Tests substitute a recording
+	 * adoption and clone nothing.
 	 */
 	public interface Pipeline {
-		void adopt(AdoptionContext context, AdoptionReport report, PullRequestOptions options, boolean includeAssets,
-				Optional<String> ruleVersion);
+		BatchAdoption.Adoption create(PullRequestOptions options, boolean includeAssets, Optional<String> ruleVersion);
 	}
 
 	private static final Logger log = LogManager.getLogger(AdoptTool.class);
@@ -99,10 +103,10 @@ public class AdoptTool implements McpTool {
 		this.pipeline = pipeline;
 	}
 
-	private static void runDefaultPipeline(AdoptionContext context, AdoptionReport report, PullRequestOptions options,
-			boolean includeAssets, Optional<String> ruleVersion) {
-		GitHubRepoAdopter.withDefaultPipeline(new ProcessCommandRunner(), options, includeAssets, ruleVersion)
-				.adopt(context, report);
+	private static BatchAdoption.Adoption runDefaultPipeline(PullRequestOptions options, boolean includeAssets,
+			Optional<String> ruleVersion) {
+		return GitHubRepoAdopter.withDefaultPipeline(new ProcessCommandRunner(), options, includeAssets,
+				ruleVersion)::adopt;
 	}
 
 	@Override
@@ -113,11 +117,8 @@ public class AdoptTool implements McpTool {
 	@Override
 	public ToolResult apply(Map<String, Object> arguments) {
 		log.info("Calling MCP adopt tool for {}", arguments);
-		PullRequestOptions options = optionsFrom(arguments);
-		boolean includeAssets = ToolArguments.optionalBoolean(arguments, "assets", false);
-		Optional<String> ruleVersion = ruleVersion(arguments);
-		BatchAdoption batch = new BatchAdoption(
-				(context, report) -> pipeline.adopt(context, report, options, includeAssets, ruleVersion));
+		BatchAdoption batch = new BatchAdoption(pipeline.create(optionsFrom(arguments),
+				ToolArguments.optionalBoolean(arguments, "assets", false), ruleVersion(arguments)));
 		return result(batch.adoptAll(repositoryUrls(arguments), checkoutsFrom(arguments)));
 	}
 
@@ -128,7 +129,7 @@ public class AdoptTool implements McpTool {
 	 */
 	private ToolResult result(List<AdoptionRun> runs) {
 		String report = reportWriter.toJson(runs);
-		return runs.stream().allMatch(AdoptionRun::succeeded) ? ToolResult.success(report) : ToolResult.error(report);
+		return AdoptionRun.allSucceeded(runs) ? ToolResult.success(report) : ToolResult.error(report);
 	}
 
 	/** Every repository of a call is adopted into one workspace, on one branch name. */
@@ -201,8 +202,8 @@ public class AdoptTool implements McpTool {
 	 *         was blank — the same rule every other optional argument follows
 	 */
 	private Optional<String> ruleVersion(Map<String, Object> arguments) {
-		String supplied = text(arguments, "rule_version").strip();
-		return supplied.isEmpty() ? Optional.empty() : Optional.of(supplied);
+		String supplied = text(arguments, "rule_version");
+		return Text.isPresent(supplied) ? Optional.of(supplied.strip()) : Optional.empty();
 	}
 
 	/** @return the argument's text, empty when it was not supplied */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
@@ -29,7 +29,6 @@ public class BranchStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(BranchStep.class);
 
-	private static final String REMOTE = "origin";
 
 	@Override
 	public String name() {
@@ -70,7 +69,7 @@ public class BranchStep extends AbstractCommandStep {
 	}
 
 	private String remoteBranch(AdoptionContext context) {
-		return REMOTE + "/" + context.branchName();
+		return AdoptionContext.REMOTE + "/" + context.branchName();
 	}
 
 	private boolean hasRef(AdoptionContext context, CommandRunner runner, String ref) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildWrapper.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildWrapper.java
@@ -4,8 +4,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
+
+import io.github.adamw7.tools.adopt.Platform;
 
 /**
  * Finds the build wrapper script a checkout ships with — {@code mvnw} for Maven,
@@ -28,7 +29,7 @@ final class BuildWrapper {
 
 	/** The wrapper for the host platform: the Windows script there, the POSIX one everywhere else. */
 	BuildWrapper(String posixName, String windowsName) {
-		this(posixName, windowsName, isWindows());
+		this(posixName, windowsName, Platform.isWindows());
 	}
 
 	BuildWrapper(String posixName, String windowsName, boolean windows) {
@@ -54,9 +55,5 @@ final class BuildWrapper {
 	Optional<String> in(Path repositoryDirectory) {
 		Path wrapper = repositoryDirectory.resolve(fileName);
 		return Files.isRegularFile(wrapper) ? Optional.of(wrapper.toAbsolutePath().toString()) : Optional.empty();
-	}
-
-	private static boolean isWindows() {
-		return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("windows");
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
@@ -28,7 +28,7 @@ public class ClaudeMdConformanceStep implements AdoptionStep {
 
 	private static final Logger log = LogManager.getLogger(ClaudeMdConformanceStep.class);
 
-	static final String CLAUDE_MD = AdoptionAssets.CLAUDE_MD_FILE;
+	private static final String CLAUDE_MD = AdoptionAssets.CLAUDE_MD_FILE;
 
 	private final ClaudeMdConformer conformer;
 	private final AssetInstaller agentsMdInstaller;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -64,8 +64,7 @@ public class ClaudeMdConformer {
 	}
 
 	private List<String> splitLines(String content) {
-		String normalized = content.replace("\r\n", "\n").replace("\r", "\n");
-		return new ArrayList<>(List.of(normalized.split("\n", -1)));
+		return new ArrayList<>(List.of(LineTerminators.normalized(content).split("\n", -1)));
 	}
 
 	/**
@@ -90,10 +89,15 @@ public class ClaudeMdConformer {
 		return lines.stream().map(String::strip).filter(line -> !line.isEmpty()).findFirst().orElse("");
 	}
 
+	/**
+	 * Renaming a heading in place leaves the line count untouched, so one outline
+	 * serves every required section here — unlike {@link #ensureSection}, which
+	 * inserts lines and has to read the document afresh each time.
+	 */
 	private void canonicalizeHeadings(List<String> lines) {
-		boolean[] fence = fenceMask(lines);
-		Set<Integer> claimed = reservedHeadings(lines, fence);
-		REQUIRED_SECTIONS.forEach(required -> canonicalize(lines, fence, required, claimed));
+		Outline outline = Outline.of(lines);
+		Set<Integer> claimed = reservedHeadings(outline);
+		REQUIRED_SECTIONS.forEach(required -> canonicalize(outline, required, claimed));
 	}
 
 	/**
@@ -101,25 +105,25 @@ public class ClaudeMdConformer {
 	 * a near-match search never renames a heading that is already serving another
 	 * required section.
 	 */
-	private Set<Integer> reservedHeadings(List<String> lines, boolean[] fence) {
-		return matchesOutsideFences(lines, fence, line -> REQUIRED_SECTIONS.contains(line.strip()))
+	private Set<Integer> reservedHeadings(Outline outline) {
+		return outline.matching(line -> REQUIRED_SECTIONS.contains(line.strip()))
 				.boxed()
 				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
-	private void canonicalize(List<String> lines, boolean[] fence, String required, Set<Integer> claimed) {
-		if (indexOfHeading(lines, fence, required) >= 0) {
+	private void canonicalize(Outline outline, String required, Set<Integer> claimed) {
+		if (outline.indexOfHeading(required) >= 0) {
 			return;
 		}
-		int index = firstNearMatch(lines, fence, required, claimed);
+		int index = firstNearMatch(outline, required, claimed);
 		if (index >= 0) {
-			lines.set(index, required);
+			outline.lines().set(index, required);
 			claimed.add(index);
 		}
 	}
 
-	private int firstNearMatch(List<String> lines, boolean[] fence, String required, Set<Integer> claimed) {
-		return matchesOutsideFences(lines, fence, line -> isNearMatch(line.strip(), required))
+	private int firstNearMatch(Outline outline, String required, Set<Integer> claimed) {
+		return outline.matching(line -> isNearMatch(line.strip(), required))
 				.filter(index -> !claimed.contains(index))
 				.findFirst()
 				.orElse(-1);
@@ -131,7 +135,7 @@ public class ClaudeMdConformer {
 	 * ({@code ## Project purpose} for {@code ## Project}). The trailing space keeps
 	 * {@code ## Maven} from matching an unrelated {@code ## Mavenish} heading.
 	 */
-	private boolean isNearMatch(String stripped, String required) {
+	private static boolean isNearMatch(String stripped, String required) {
 		String actual = stripped.toLowerCase(Locale.ROOT);
 		String wanted = required.toLowerCase(Locale.ROOT);
 		return isHeading(stripped) && (actual.equals(wanted) || actual.startsWith(wanted + " "));
@@ -148,75 +152,88 @@ public class ClaudeMdConformer {
 	}
 
 	/**
-	 * The fence mask is rebuilt per section because appending a section or
+	 * The outline is taken afresh per section because appending a section or
 	 * inserting a stub shifts the lines the next one is found at, and the sections
 	 * are few enough for that to stay cheap.
 	 */
 	private void ensureSection(List<String> lines, String required) {
-		boolean[] fence = fenceMask(lines);
-		int index = indexOfHeading(lines, fence, required);
+		Outline outline = Outline.of(lines);
+		int index = outline.indexOfHeading(required);
 		if (index < 0) {
 			lines.addAll(List.of("", required, "", STUB_BODY));
-		} else if (!hasBody(lines, fence, index)) {
+		} else if (!outline.hasBody(index)) {
 			lines.addAll(index + 1, List.of("", STUB_BODY));
 		}
 	}
 
-	/**
-	 * Mirrors how the rule decides a section is non-empty: before the next heading
-	 * at its own level or shallower, the section must carry prose, a code block, or
-	 * a deeper sub-heading. Blank lines are neither, so the scan looks past them and
-	 * the first line that decides settles the section.
-	 */
-	private boolean hasBody(List<String> lines, boolean[] fence, int headingIndex) {
-		int level = headingLevel(lines.get(headingIndex).strip());
-		return IntStream.range(headingIndex + 1, lines.size())
-				.filter(index -> fence[index] || !lines.get(index).isBlank())
-				.limit(1)
-				.anyMatch(index -> fence[index] || isBodyLine(lines.get(index).strip(), level));
-	}
-
 	/** A deeper sub-heading continues the section; one at its level or shallower ends it. */
-	private boolean isBodyLine(String line, int level) {
+	private static boolean isBodyLine(String line, int level) {
 		return !isHeading(line) || headingLevel(line) > level;
 	}
 
-	private int headingLevel(String heading) {
+	private static int headingLevel(String heading) {
 		return (int) heading.chars().takeWhile(character -> character == '#').count();
 	}
 
 	private void ensureAgentsReference(List<String> lines) {
-		boolean[] fence = fenceMask(lines);
-		if (matchesOutsideFences(lines, fence, line -> line.contains(AGENTS_REFERENCE)).findAny().isEmpty()) {
-			lines.addAll(titleIndex(lines, fence) + 1, List.of("", AGENTS_REFERENCE_LINE, ""));
+		Outline outline = Outline.of(lines);
+		if (outline.matching(line -> line.contains(AGENTS_REFERENCE)).findAny().isEmpty()) {
+			lines.addAll(outline.titleIndex() + 1, List.of("", AGENTS_REFERENCE_LINE, ""));
 		}
 	}
 
-	/**
-	 * The title is the first non-blank line by the time this runs, and a fence marker
-	 * would itself be a non-blank line before it, so the title can never be one the
-	 * mask covers. A document with no title line at all falls back to the top.
-	 */
-	private int titleIndex(List<String> lines, boolean[] fence) {
-		return Math.max(indexOfHeading(lines, fence, TITLE), 0);
-	}
-
-	/** @return the index of the heading outside code fences, or {@code -1} when absent */
-	private int indexOfHeading(List<String> lines, boolean[] fence, String heading) {
-		return matchesOutsideFences(lines, fence, line -> line.strip().equals(heading)).findFirst().orElse(-1);
-	}
-
-	/** The indices of the lines outside code fences whose text matches, in document order. */
-	private IntStream matchesOutsideFences(List<String> lines, boolean[] fence, Predicate<String> match) {
-		return IntStream.range(0, lines.size()).filter(index -> !fence[index] && match.test(lines.get(index)));
-	}
-
-	private boolean isHeading(String stripped) {
+	private static boolean isHeading(String stripped) {
 		return stripped.startsWith("#");
 	}
 
-	private boolean[] fenceMask(List<String> lines) {
-		return scanFences(lines).mask();
+	/**
+	 * The document as the reshape reads it: the lines themselves, and which of them
+	 * sit inside a code fence. The two travel together because every search the
+	 * reshape makes is "outside fences", and a mask taken from lines other than the
+	 * ones it is applied to would quietly mis-answer — so a reshape that inserts or
+	 * removes lines takes a fresh outline rather than carrying this one on.
+	 *
+	 * <p>Renaming a line in place keeps the outline valid, since the mask is indexed
+	 * by line number and the count has not moved.
+	 */
+	private record Outline(List<String> lines, boolean[] fence) {
+
+		static Outline of(List<String> lines) {
+			return new Outline(lines, scanFences(lines).mask());
+		}
+
+		/** The indices of the lines outside code fences whose text matches, in document order. */
+		IntStream matching(Predicate<String> match) {
+			return IntStream.range(0, lines.size()).filter(index -> !fence[index] && match.test(lines.get(index)));
+		}
+
+		/** @return the index of the heading outside code fences, or {@code -1} when absent */
+		int indexOfHeading(String heading) {
+			return matching(line -> line.strip().equals(heading)).findFirst().orElse(-1);
+		}
+
+		/**
+		 * The title is the first non-blank line by the time this is asked, and a fence
+		 * marker would itself be a non-blank line before it, so the title can never be
+		 * one the mask covers. A document with no title line at all falls back to the top.
+		 */
+		int titleIndex() {
+			return Math.max(indexOfHeading(TITLE), 0);
+		}
+
+		/**
+		 * Mirrors how the rule decides a section is non-empty: before the next heading
+		 * at its own level or shallower, the section must carry prose, a code block, or
+		 * a deeper sub-heading. Blank lines are neither, so the scan looks past them and
+		 * the first line that decides settles the section.
+		 */
+		boolean hasBody(int headingIndex) {
+			int level = headingLevel(lines.get(headingIndex).strip());
+			return IntStream.range(headingIndex + 1, lines.size())
+					.filter(index -> fence[index] || !lines.get(index).isBlank())
+					.limit(1)
+					.anyMatch(index -> fence[index] || isBodyLine(lines.get(index).strip(), level));
+		}
 	}
 
 	/**
@@ -229,7 +246,7 @@ public class ClaudeMdConformer {
 	private record Fences(boolean[] mask, String openAtEnd) {
 	}
 
-	private Fences scanFences(List<String> lines) {
+	private static Fences scanFences(List<String> lines) {
 		boolean[] mask = new boolean[lines.size()];
 		String open = null;
 		for (int index = 0; index < lines.size(); index++) {
@@ -243,7 +260,7 @@ public class ClaudeMdConformer {
 	 * it. A fence is closed only by the marker it was opened with, so a {@code ~~~}
 	 * line inside a {@code ```} block stays content.
 	 */
-	private String applyFence(String line, String open, boolean[] mask, int index) {
+	private static String applyFence(String line, String open, boolean[] mask, int index) {
 		String marker = fenceMarker(line);
 		if (open == null) {
 			mask[index] = marker != null;
@@ -253,7 +270,7 @@ public class ClaudeMdConformer {
 		return open.equals(marker) ? null : open;
 	}
 
-	private String fenceMarker(String line) {
+	private static String fenceMarker(String line) {
 		if (line.startsWith(BACKTICK_FENCE)) {
 			return BACKTICK_FENCE;
 		}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
@@ -27,8 +27,8 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  */
 public class ClaudeTrustStore {
 
-	static final String PROJECTS = "projects";
-	static final String TRUST_FLAG = "hasTrustDialogAccepted";
+	private static final String PROJECTS = "projects";
+	private static final String TRUST_FLAG = "hasTrustDialogAccepted";
 
 	private final Path configFile;
 	private final ObjectMapper mapper = new ObjectMapper();

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -40,7 +40,6 @@ public class CloneStep extends AbstractCommandStep {
 	private static final Logger log = LogManager.getLogger(CloneStep.class);
 
 	/** The remote a clone records, and the one {@link PushStep} publishes the branch to. */
-	private static final String REMOTE = "origin";
 
 	@Override
 	public String name() {
@@ -92,9 +91,10 @@ public class CloneStep extends AbstractCommandStep {
 	 */
 	private String originUrl(AdoptionContext context, CommandRunner runner) {
 		CommandResult result = runner.run(context.repositoryDirectory(),
-				List.of("git", "remote", "get-url", REMOTE));
+				List.of("git", "remote", "get-url", AdoptionContext.REMOTE));
 		if (!result.succeeded()) {
-			throw new AdoptionException(context.repositoryDirectory() + " is a checkout with no '" + REMOTE
+			throw new AdoptionException(context.repositoryDirectory() + " is a checkout with no '"
+					+ AdoptionContext.REMOTE
 					+ "' remote, so it can be neither confirmed to be " + context.displayUrl() + " nor pushed to it: "
 					+ Redaction.of(result.output().strip()));
 		}
@@ -109,8 +109,8 @@ public class CloneStep extends AbstractCommandStep {
 	 * branch and leave {@link PushStep} refused as a non-fast-forward.
 	 */
 	private void refresh(AdoptionContext context, CommandRunner runner) {
-		log.info("Fetching {} in {}", REMOTE, context.repositoryDirectory());
-		runOrFail(runner, context.repositoryDirectory(), List.of("git", "fetch", REMOTE));
+		log.info("Fetching {} in {}", AdoptionContext.REMOTE, context.repositoryDirectory());
+		runOrFail(runner, context.repositoryDirectory(), List.of("git", "fetch", AdoptionContext.REMOTE));
 	}
 
 	private boolean alreadyCloned(AdoptionContext context) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
@@ -19,7 +19,7 @@ final class EnforcerRuleVersion {
 
 	static final String BUILD_PROPERTIES = "/adopt-build.properties";
 	static final String RULE_VERSION_KEY = "enforcer.rule.version";
-	static final String SNAPSHOT_SUFFIX = "-SNAPSHOT";
+	private static final String SNAPSHOT_SUFFIX = "-SNAPSHOT";
 
 	private EnforcerRuleVersion() {
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
@@ -23,7 +23,7 @@ import io.github.adamw7.tools.adopt.AdoptionException;
 public class GradleBuildSystem implements BuildSystem {
 
 	static final String GRADLE = "gradle";
-	static final List<String> VERIFY_ARGUMENTS = List.of("-q", GradleGuardInstaller.GUARD_TASK);
+	private static final List<String> VERIFY_ARGUMENTS = List.of("-q", GradleGuardInstaller.GUARD_TASK);
 	static final String GROOVY_BUILD_FILE = "build.gradle";
 	static final String KOTLIN_BUILD_FILE = "build.gradle.kts";
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/LineTerminators.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/LineTerminators.java
@@ -25,7 +25,16 @@ final class LineTerminators {
 	 * converted body and a part carried over verbatim — is not double-converted.
 	 */
 	static String matching(String text, String sample) {
-		String normalized = text.replace(CRLF, LF).replace(CR, LF);
+		String normalized = normalized(text);
 		return sample.contains(CRLF) ? normalized.replace(LF, CRLF) : normalized;
+	}
+
+	/**
+	 * Rewrites every terminator to LF, so text assembled from parts that disagree —
+	 * or read from a CRLF file and then reshaped line by line — is worked on in one
+	 * shape and converted back only when it is written.
+	 */
+	static String normalized(String text) {
+		return text.replace(CRLF, LF).replace(CR, LF);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -19,8 +19,8 @@ import java.util.Optional;
  */
 public class MavenBuildSystem implements BuildSystem {
 
-	static final String MAVEN = "mvn";
-	static final List<String> VERIFY_ARGUMENTS = List.of("-q", "-N", "validate");
+	private static final String MAVEN = "mvn";
+	private static final List<String> VERIFY_ARGUMENTS = List.of("-q", "-N", "validate");
 
 	private static final String POM = "pom.xml";
 
@@ -28,7 +28,7 @@ public class MavenBuildSystem implements BuildSystem {
 	private final BuildWrapper wrapper;
 
 	public MavenBuildSystem() {
-		this(new PomEnforcerInstaller());
+		this(Optional.empty());
 	}
 
 	/**
@@ -37,7 +37,7 @@ public class MavenBuildSystem implements BuildSystem {
 	 *                    {@code tools} build running the adoption
 	 */
 	public MavenBuildSystem(Optional<String> ruleVersion) {
-		this(ruleVersion.<PomEnforcerInstaller>map(PomEnforcerInstaller::new).orElseGet(PomEnforcerInstaller::new));
+		this(PomEnforcerInstaller.pinning(ruleVersion));
 	}
 
 	public MavenBuildSystem(PomEnforcerInstaller installer) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt.step;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -21,6 +22,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import io.github.adamw7.tools.adopt.AdoptionException;
@@ -86,8 +88,14 @@ final class PomDocument {
 		this.spans = spansOf(document, original);
 	}
 
+	/**
+	 * The file is read once and the DOM parsed from that same text, so the parsed
+	 * elements and the lexical spans they are paired with can never come from two
+	 * different reads of a file that changed in between.
+	 */
 	static PomDocument read(Path file) {
-		return new PomDocument(file, AdoptionFiles.read(file, DESCRIPTION), parse(file));
+		String original = AdoptionFiles.read(file, DESCRIPTION);
+		return new PomDocument(file, original, parse(file, original));
 	}
 
 	Element root() {
@@ -349,9 +357,9 @@ final class PomDocument {
 		return node != null && node.getNodeType() == Node.TEXT_NODE && node.getTextContent().isBlank();
 	}
 
-	private static Document parse(Path file) {
+	private static Document parse(Path file, String original) {
 		try {
-			return builder().parse(file.toFile());
+			return builder().parse(new InputSource(new StringReader(original)));
 		} catch (IOException | SAXException e) {
 			throw new AdoptionException("Could not read POM: " + file, e);
 		}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -21,12 +21,12 @@ import org.w3c.dom.Element;
  */
 public class PomEnforcerInstaller {
 
-	static final String ENFORCER_GROUP_ID = "org.apache.maven.plugins";
+	private static final String ENFORCER_GROUP_ID = "org.apache.maven.plugins";
 	static final String ENFORCER_ARTIFACT_ID = "maven-enforcer-plugin";
 	static final String ENFORCER_VERSION = "3.6.3";
-	static final String RULE_ARTIFACT_ID = "tools.claude-code-enforcer";
-	static final String RULE_GROUP_ID = "io.github.adamw7";
-	static final String CLAUDE_MD_FILE = "${project.basedir}/CLAUDE.md";
+	private static final String RULE_ARTIFACT_ID = "tools.claude-code-enforcer";
+	private static final String RULE_GROUP_ID = "io.github.adamw7";
+	private static final String CLAUDE_MD_FILE = "${project.basedir}/CLAUDE.md";
 
 	/** The one place a plugin both runs from and is added to; see {@link #enforcerPluginOfTheBuild}. */
 	private static final List<String> BUILD_PLUGINS = List.of("build", "plugins");
@@ -70,6 +70,15 @@ public class PomEnforcerInstaller {
 	public PomEnforcerInstaller(String ruleVersion) {
 		String release = EnforcerRuleVersion.requireRelease(ruleVersion);
 		this.ruleVersion = () -> release;
+	}
+
+	/**
+	 * The installer for an optionally supplied version: the one named, or the running
+	 * build's when none was. Naming the choice here keeps callers from spelling out
+	 * which of the two constructors an empty {@link Optional} means.
+	 */
+	static PomEnforcerInstaller pinning(Optional<String> ruleVersion) {
+		return ruleVersion.map(PomEnforcerInstaller::new).orElseGet(PomEnforcerInstaller::new);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -46,7 +46,7 @@ public class PullRequestStep extends AbstractCommandStep {
 	 * request need not — or cannot — be opened, matched against its own wording:
 	 * "a pull request for branch ... already exists" and "No commits between ...".
 	 */
-	static final List<String> TOLERATED_FAILURES = List.of("already exists", "no commits between");
+	private static final List<String> TOLERATED_FAILURES = List.of("already exists", "no commits between");
 
 	private final PullRequestOptions options;
 	private final ObjectMapper mapper = new ObjectMapper();

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PushStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PushStep.java
@@ -25,7 +25,7 @@ public class PushStep extends AbstractCommandStep {
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
 		log.info("Pushing branch {} from {}", context.branchName(), context.repositoryDirectory());
-		List<String> command = List.of("git", "push", "-u", "origin", context.branchName());
+		List<String> command = List.of("git", "push", "-u", AdoptionContext.REMOTE, context.branchName());
 		runOrFail(runner, context.repositoryDirectory(), command);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
@@ -38,7 +38,7 @@ public class ToolchainStep implements AdoptionStep {
 	 * about. It answers the weaker question — whether the credentials belong to
 	 * anyone — because there is nothing better to ask.
 	 */
-	static final List<String> AUTHENTICATION_PROBE = List.of(GITHUB_CLI, "api", "user");
+	private static final List<String> AUTHENTICATION_PROBE = List.of(GITHUB_CLI, "api", "user");
 
 	private final List<String> tools;
 	private final ToolProbe probe = new ToolProbe();

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContexts.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContexts.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 public final class AdoptionContexts {
 
 	private static final String REPOSITORY_URL = "https://github.com/adamw7/demo.git";
+	private static final Path WORKSPACE = Path.of("/tmp/workspace");
 
 	private AdoptionContexts() {
 	}
@@ -24,6 +25,16 @@ public final class AdoptionContexts {
 		AdoptionContext context = new AdoptionContext(REPOSITORY_URL, workspace);
 		Files.createDirectories(context.repositoryDirectory());
 		return context;
+	}
+
+	/**
+	 * A context that touches no filesystem, for the steps that only shell out and
+	 * never read the checkout — the branch, the commit, the push, the pull request.
+	 * Their tests care about the command that was run, not about a directory
+	 * existing.
+	 */
+	public static AdoptionContext of() {
+		return new AdoptionContext(REPOSITORY_URL, WORKSPACE);
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
-import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
@@ -137,8 +136,7 @@ class GitHubRepoAdopterTest {
 	 */
 	@Test
 	void withDefaultPipelineHonoursPullRequestOptionsAndTheAssetsFlag() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "missing"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(1, "missing");
 		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, PullRequestOptions.defaults(),
 				true, Optional.empty());
 		assertThrows(AdoptionException.class, () -> adopter.adopt(context, new AdoptionReport()));

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/PlatformCommands.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/PlatformCommands.java
@@ -1,8 +1,9 @@
 package io.github.adamw7.tools.adopt.command;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Stream;
+
+import io.github.adamw7.tools.adopt.Platform;
 
 /**
  * Platform-appropriate command lines for the {@link ProcessCommandRunner}
@@ -17,8 +18,7 @@ import java.util.stream.Stream;
  */
 final class PlatformCommands {
 
-	private static final boolean WINDOWS = System.getProperty("os.name", "")
-			.toLowerCase(Locale.ROOT).startsWith("windows");
+	private static final boolean WINDOWS = Platform.isWindows();
 
 	private PlatformCommands() {
 	}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/RecordingCommandRunner.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/RecordingCommandRunner.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Test {@link CommandRunner} that records every invocation and answers each one
@@ -24,6 +25,39 @@ public class RecordingCommandRunner implements CommandRunner {
 
 	public RecordingCommandRunner(Function<List<String>, CommandResult> strategy) {
 		this.strategy = strategy;
+	}
+
+	/** A runner whose every command succeeds, answering the transcript a test wants read back. */
+	public static RecordingCommandRunner answering(String output) {
+		return answering(0, output);
+	}
+
+	/**
+	 * A runner whose every command fails the same way — the shape a test takes when
+	 * it is about how a step reports a failure rather than about which command failed.
+	 */
+	public static RecordingCommandRunner failing(int exitCode, String output) {
+		return answering(exitCode, output);
+	}
+
+	private static RecordingCommandRunner answering(int exitCode, String output) {
+		return new RecordingCommandRunner(command -> new CommandResult(command, exitCode, output));
+	}
+
+	/**
+	 * A runner that succeeds except for the commands the predicate picks out, so a
+	 * test can fail exactly the one step it is about and let the rest of the pipeline
+	 * run.
+	 */
+	public static RecordingCommandRunner failingWhen(Predicate<List<String>> failing, int exitCode, String output) {
+		return new RecordingCommandRunner(command -> failing.test(command)
+				? new CommandResult(command, exitCode, output)
+				: new CommandResult(command, 0, ""));
+	}
+
+	/** The common case of {@link #failingWhen}: the command contains this word. */
+	public static RecordingCommandRunner failingOn(String word, int exitCode, String output) {
+		return failingWhen(command -> command.contains(word), exitCode, output);
 	}
 
 	@Override

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.AdoptionReport;
+import io.github.adamw7.tools.adopt.BatchAdoption;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 import io.github.adamw7.tools.mcp.ToolResult;
 
@@ -36,22 +37,33 @@ class AdoptToolTest {
 
 		private final List<AdoptionContext> contexts = new ArrayList<>();
 		private final List<PullRequestOptions> optionsPerRepository = new ArrayList<>();
-		private AdoptionContext context;
-		private PullRequestOptions options;
 		private boolean includeAssets;
 		private Optional<String> ruleVersion = Optional.empty();
+		private int pipelinesCreated;
 
 		@Override
-		public void adopt(AdoptionContext context, AdoptionReport report, PullRequestOptions options,
-				boolean includeAssets, Optional<String> ruleVersion) {
-			this.contexts.add(context);
-			this.optionsPerRepository.add(options);
-			this.context = context;
-			this.options = options;
+		public BatchAdoption.Adoption create(PullRequestOptions options, boolean includeAssets,
+				Optional<String> ruleVersion) {
 			this.includeAssets = includeAssets;
 			this.ruleVersion = ruleVersion;
+			pipelinesCreated++;
+			return (context, report) -> adopt(context, options, report);
+		}
+
+		private void adopt(AdoptionContext context, PullRequestOptions options, AdoptionReport report) {
+			contexts.add(context);
+			optionsPerRepository.add(options);
 			report.recordStep("pull-request");
 			report.recordPullRequestUrl(PR_URL);
+		}
+
+		/** The last repository's, which for a single-repository call is the only one. */
+		AdoptionContext context() {
+			return contexts.getLast();
+		}
+
+		PullRequestOptions options() {
+			return optionsPerRepository.getLast();
 		}
 	}
 
@@ -114,7 +126,7 @@ class AdoptToolTest {
 	 */
 	@Test
 	void answersWithAnErrorResultCarryingTheReportWhenARepositoryFails() throws IOException {
-		AdoptTool failing = new AdoptTool((context, report, options, includeAssets, ruleVersion) -> {
+		AdoptTool failing = new AdoptTool((options, includeAssets, ruleVersion) -> (context, report) -> {
 			report.recordStep("clone");
 			throw new AdoptionException("boom");
 		});
@@ -129,26 +141,26 @@ class AdoptToolTest {
 	@Test
 	void adoptsWithDefaultsWhenOnlyTheUrlIsGiven() {
 		tool.apply(Map.of("repository_url", REPO_URL));
-		assertEquals(REPO_URL, pipeline.context.repositoryUrl());
-		assertEquals(AdoptionContext.DEFAULT_BRANCH, pipeline.context.branchName());
-		assertEquals(PullRequestOptions.defaults(), pipeline.options);
+		assertEquals(REPO_URL, pipeline.context().repositoryUrl());
+		assertEquals(AdoptionContext.DEFAULT_BRANCH, pipeline.context().branchName());
+		assertEquals(PullRequestOptions.defaults(), pipeline.options());
 		assertFalse(pipeline.includeAssets);
-		assertTrue(Files.isDirectory(pipeline.context.workspace()));
+		assertTrue(Files.isDirectory(pipeline.context().workspace()));
 	}
 
 	@Test
 	void usesTheSuppliedWorkspaceAndBranch(@TempDir Path dir) {
 		Path workspace = dir.resolve("workspace");
 		tool.apply(Map.of("repository_url", REPO_URL, "workspace", workspace.toString(), "branch", "feature/x"));
-		assertEquals(workspace, pipeline.context.workspace());
+		assertEquals(workspace, pipeline.context().workspace());
 		assertTrue(Files.isDirectory(workspace));
-		assertEquals("feature/x", pipeline.context.branchName());
+		assertEquals("feature/x", pipeline.context().branchName());
 	}
 
 	@Test
 	void fallsBackToTheDefaultBranchWhenBlank() {
 		tool.apply(Map.of("repository_url", REPO_URL, "branch", "  "));
-		assertEquals(AdoptionContext.DEFAULT_BRANCH, pipeline.context.branchName());
+		assertEquals(AdoptionContext.DEFAULT_BRANCH, pipeline.context().branchName());
 	}
 
 	@Test
@@ -157,12 +169,12 @@ class AdoptToolTest {
 				"title", "My title", "body", "My body",
 				"reviewers", "octocat, hubot", "labels", "automation", "assignees", "adamw7",
 				"draft", true, "assets", true));
-		assertEquals("My title", pipeline.options.title());
-		assertEquals("My body", pipeline.options.body());
-		assertEquals(List.of("octocat", "hubot"), pipeline.options.reviewers());
-		assertEquals(List.of("automation"), pipeline.options.labels());
-		assertEquals(List.of("adamw7"), pipeline.options.assignees());
-		assertTrue(pipeline.options.draft());
+		assertEquals("My title", pipeline.options().title());
+		assertEquals("My body", pipeline.options().body());
+		assertEquals(List.of("octocat", "hubot"), pipeline.options().reviewers());
+		assertEquals(List.of("automation"), pipeline.options().labels());
+		assertEquals(List.of("adamw7"), pipeline.options().assignees());
+		assertTrue(pipeline.options().draft());
 		assertTrue(pipeline.includeAssets);
 	}
 
@@ -188,7 +200,7 @@ class AdoptToolTest {
 	@Test
 	void ignoresBlankCommaSeparatedEntries() {
 		tool.apply(Map.of("repository_url", REPO_URL, "reviewers", " , octocat ,, "));
-		assertEquals(List.of("octocat"), pipeline.options.reviewers());
+		assertEquals(List.of("octocat"), pipeline.options().reviewers());
 	}
 
 	/**
@@ -204,9 +216,9 @@ class AdoptToolTest {
 				"reviewers", List.of("octocat", "hubot"),
 				"labels", List.of("automation"),
 				"assignees", List.of(" adamw7 ", "  ")));
-		assertEquals(List.of("octocat", "hubot"), pipeline.options.reviewers());
-		assertEquals(List.of("automation"), pipeline.options.labels());
-		assertEquals(List.of("adamw7"), pipeline.options.assignees());
+		assertEquals(List.of("octocat", "hubot"), pipeline.options().reviewers());
+		assertEquals(List.of("automation"), pipeline.options().labels());
+		assertEquals(List.of("adamw7"), pipeline.options().assignees());
 	}
 
 	@Test
@@ -262,7 +274,7 @@ class AdoptToolTest {
 	 */
 	@Test
 	void adoptsTheRestOfTheListAfterARepositoryFails() throws IOException {
-		AdoptTool failing = new AdoptTool((context, report, options, includeAssets, ruleVersion) -> {
+		AdoptTool failing = new AdoptTool((options, includeAssets, ruleVersion) -> (context, report) -> {
 			if (REPO_URL.equals(context.repositoryUrl())) {
 				throw new AdoptionException("boom");
 			}
@@ -274,6 +286,18 @@ class AdoptToolTest {
 		assertEquals("boom", node.get("repositories").get(0).get("failure").asText());
 		assertTrue(node.get("repositories").get(1).get("succeeded").asBoolean());
 		assertEquals(PR_URL, node.get("repositories").get(1).get("pullRequestUrl").asText());
+	}
+
+	/**
+	 * The pipeline is assembled once and adopts the whole batch, as the command line
+	 * does; building it per repository would hand each its own step instances and its
+	 * own command runner.
+	 */
+	@Test
+	void buildsOnePipelineForTheWholeBatch() {
+		tool.apply(Map.of("repository_urls", List.of(REPO_URL, OTHER_URL)));
+		assertEquals(1, pipeline.pipelinesCreated);
+		assertEquals(2, pipeline.contexts.size());
 	}
 
 	/** The metadata is the call's, not the first repository's: every adoption gets it. */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AbstractCommandStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AbstractCommandStepTest.java
@@ -39,8 +39,7 @@ class AbstractCommandStepTest {
 
 	@Test
 	void returnsResultWhenCommandSucceeds() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 0, "done"));
+		RecordingCommandRunner runner = RecordingCommandRunner.answering("done");
 		CommandResult result = step.run(runner, workspace, List.of("git", "status"));
 		assertEquals("done", result.output());
 		assertEquals(List.of("git", "status"), runner.commandAt(0));
@@ -48,16 +47,14 @@ class AbstractCommandStepTest {
 
 	@Test
 	void failedCommandThrowsAdoptionException() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "rejected"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(1, "rejected");
 		assertThrows(AdoptionException.class,
 				() -> step.run(runner, workspace, List.of("git", "push")));
 	}
 
 	@Test
 	void failureMessageCarriesStepNameExitCodeCommandAndOutput() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 128, "fatal: rejected"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(128, "fatal: rejected");
 		AdoptionException exception = assertThrows(AdoptionException.class,
 				() -> step.run(runner, workspace, List.of("git", "push", "origin", "main")));
 		String message = exception.getMessage();

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BranchStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BranchStepTest.java
@@ -3,21 +3,20 @@ package io.github.adamw7.tools.adopt.step;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionContexts;
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class BranchStepTest {
 
-	private final AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git",
-			Path.of("/tmp/workspace"), "claude/adopt-claude-code");
+	private final AdoptionContext context = AdoptionContexts.of();
 	private final BranchStep step = new BranchStep();
 
 	@Test
@@ -69,8 +68,7 @@ class BranchStepTest {
 
 	@Test
 	void failedCheckoutAbortsAdoption() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 128, "fatal: a branch named ... already exists"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(128, "fatal: a branch named ... already exists");
 		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.io.TempDir;
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionContexts;
 import io.github.adamw7.tools.adopt.AdoptionException;
-import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class BuildToolchainStepTest {
@@ -48,8 +47,7 @@ class BuildToolchainStepTest {
 	void anAbsentBuildToolAbortsTheAdoption(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 127, "gradle: not found"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(127, "gradle: not found");
 		AdoptionException thrown = assertThrows(AdoptionException.class,
 				() -> new BuildToolchainStep().execute(context, runner));
 		assertTrue(thrown.getMessage().contains("gradle"), thrown.getMessage());
@@ -121,8 +119,7 @@ class BuildToolchainStepTest {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
 		AdoptionContexts.write(context, "gradlew", "#!/bin/sh\n");
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 126, "Permission denied"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(126, "Permission denied");
 
 		AdoptionException failure = assertThrows(AdoptionException.class,
 				() -> new BuildToolchainStep(

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
@@ -139,8 +139,7 @@ class ClaudeInitStepTest {
 	@Test
 	void failedInitAbortsAdoption(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "boom"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(1, "boom");
 		assertThrows(AdoptionException.class, () -> new ClaudeInitStep().execute(context, runner));
 	}
 
@@ -171,8 +170,7 @@ class ClaudeInitStepTest {
 	void restoresExistingClaudeDirMemoryWhenInitFails(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		writeClaudeDirMemory(context);
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "boom"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(1, "boom");
 		assertThrows(AdoptionException.class, () -> new ClaudeInitStep().execute(context, runner));
 		assertEquals("# project memory", Files.readString(claudeDirMemory(context)));
 	}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -311,13 +312,8 @@ class ClaudeMdConformerTest {
 
 	/** Mirrors how the rule looks for the reference: fenced lines do not count. */
 	private boolean referencesAgentsMdOutsideFences(String content) {
-		boolean fenced = false;
-		boolean found = false;
-		for (String line : content.lines().toList()) {
-			found = found || (!fenced && line.contains(ClaudeMdConformer.AGENTS_REFERENCE));
-			fenced = line.strip().startsWith("```") != fenced;
-		}
-		return found;
+		return linesOutsideFences(content).stream()
+				.anyMatch(line -> line.contains(ClaudeMdConformer.AGENTS_REFERENCE));
 	}
 
 	@Test
@@ -338,11 +334,9 @@ class ClaudeMdConformerTest {
 	}
 
 	private String requiredSectionsBody() {
-		StringBuilder builder = new StringBuilder();
-		for (String section : ClaudeMdConformer.REQUIRED_SECTIONS) {
-			builder.append(section).append("\n\nContent.\n\n");
-		}
-		return builder.toString();
+		return ClaudeMdConformer.REQUIRED_SECTIONS.stream()
+				.map(section -> section + "\n\nContent.\n\n")
+				.collect(Collectors.joining());
 	}
 
 	private static final String UNTERMINATED_FENCE = """
@@ -381,17 +375,27 @@ class ClaudeMdConformerTest {
 
 	/** Mirrors how the rule finds headings: a heading inside a fence is code, not structure. */
 	private List<String> headingsOutsideFences(String content) {
-		List<String> headings = new ArrayList<>();
-		boolean fenced = false;
-		for (String line : content.lines().map(String::strip).toList()) {
-			fenced = collectHeading(headings, line, fenced);
-		}
-		return headings;
+		return linesOutsideFences(content).stream().filter(line -> line.startsWith("#")).toList();
 	}
 
-	private boolean collectHeading(List<String> headings, String line, boolean fenced) {
-		if (!fenced && line.startsWith("#")) {
-			headings.add(line);
+	/**
+	 * The document's lines that sit outside a code fence, stripped. The one place
+	 * these tests read fences, so the two questions they ask of a reshaped document —
+	 * which headings it carries, and whether it references {@code AGENTS.md} — cannot
+	 * come to different answers about what is code.
+	 */
+	private List<String> linesOutsideFences(String content) {
+		List<String> outside = new ArrayList<>();
+		boolean fenced = false;
+		for (String line : content.lines().map(String::strip).toList()) {
+			fenced = collect(outside, line, fenced);
+		}
+		return outside;
+	}
+
+	private boolean collect(List<String> outside, String line, boolean fenced) {
+		if (!fenced) {
+			outside.add(line);
 		}
 		return line.startsWith("```") != fenced;
 	}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -89,8 +89,7 @@ class CloneStepTest {
 	@Test
 	void refusesCheckoutWithNoOriginRemote(@TempDir Path existingWorkspace) throws IOException {
 		AdoptionContext existing = checkedOut(existingWorkspace);
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 2, "error: No such remote 'origin'"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(2, "error: No such remote 'origin'");
 		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
 		assertTrue(failure.getMessage().contains("no 'origin' remote"), failure.getMessage());
 	}
@@ -106,8 +105,7 @@ class CloneStepTest {
 
 	@Test
 	void failedCloneAbortsAdoption() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 128, "fatal: repository not found"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(128, "fatal: repository not found");
 		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
@@ -3,20 +3,19 @@ package io.github.adamw7.tools.adopt.step;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionContexts;
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class CommitStepTest {
 
-	private final AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git",
-			Path.of("/tmp/workspace"));
+	private final AdoptionContext context = AdoptionContexts.of();
 
 	@Test
 	void stagesChecksThenCommitsWithMessage() {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerStepTest.java
@@ -52,8 +52,7 @@ class EnforcerStepTest {
 	@Test
 	void wiresGuardIntoAGroovyGradleBuild(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
-		Path buildFile = context.repositoryDirectory().resolve("build.gradle");
-		Files.writeString(buildFile, "plugins { id 'java' }\n");
+		Path buildFile = AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
 		new EnforcerStep().execute(context, new RecordingCommandRunner());
 		assertTrue(Files.readString(buildFile).contains("enforceClaudeMd"));
 	}
@@ -61,8 +60,7 @@ class EnforcerStepTest {
 	@Test
 	void wiresGuardIntoAKotlinGradleBuild(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
-		Path buildFile = context.repositoryDirectory().resolve("build.gradle.kts");
-		Files.writeString(buildFile, "plugins { java }\n");
+		Path buildFile = AdoptionContexts.write(context, "build.gradle.kts", "plugins { java }\n");
 		new EnforcerStep().execute(context, new RecordingCommandRunner());
 		assertTrue(Files.readString(buildFile).contains("enforceClaudeMd"));
 	}
@@ -86,8 +84,7 @@ class EnforcerStepTest {
 	@Test
 	void leavesAnAlreadyWiredPomByteForByteUnchanged(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
-		Path pom = context.repositoryDirectory().resolve("pom.xml");
-		Files.writeString(pom, POM);
+		Path pom = AdoptionContexts.write(context, "pom.xml", POM);
 		EnforcerStep step = mavenStep();
 		step.execute(context, new RecordingCommandRunner());
 		String afterFirstWiring = Files.readString(pom);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
@@ -28,7 +28,7 @@ class GradleGuardInstallerTest {
 	@Test
 	void theGroovyGuardResolvesTheFileBeforeDoLast(@TempDir Path dir) throws IOException {
 		Path buildFile = write(dir, "build.gradle", "plugins { id 'java' }\n");
-		new GradleGuardInstaller().install(buildFile);
+		installer.install(buildFile);
 		String script = Files.readString(buildFile);
 		assertTrue(script.indexOf("project.file('CLAUDE.md')") < script.indexOf("doLast"),
 				"the file must be resolved at configuration time, before doLast: " + script);
@@ -39,7 +39,7 @@ class GradleGuardInstallerTest {
 	@Test
 	void theKotlinGuardResolvesTheFileBeforeDoLast(@TempDir Path dir) throws IOException {
 		Path buildFile = write(dir, "build.gradle.kts", "plugins { java }\n");
-		new GradleGuardInstaller().install(buildFile);
+		installer.install(buildFile);
 		String script = Files.readString(buildFile);
 		assertTrue(script.indexOf("project.file(\"CLAUDE.md\")") < script.indexOf("doLast"),
 				"the file must be resolved at configuration time, before doLast: " + script);
@@ -55,8 +55,7 @@ class GradleGuardInstallerTest {
 
 	@Test
 	void appendsGroovyGuardToBuildGradle(@TempDir Path directory) throws IOException {
-		Path buildFile = directory.resolve("build.gradle");
-		Files.writeString(buildFile, "plugins { id 'java' }\n");
+		Path buildFile = write(directory, "build.gradle", "plugins { id 'java' }\n");
 		assertTrue(installer.install(buildFile));
 		String content = Files.readString(buildFile);
 		assertTrue(content.contains("tasks.register('enforceClaudeMd')"));
@@ -66,8 +65,7 @@ class GradleGuardInstallerTest {
 
 	@Test
 	void appendsKotlinGuardToBuildGradleKts(@TempDir Path directory) throws IOException {
-		Path buildFile = directory.resolve("build.gradle.kts");
-		Files.writeString(buildFile, "plugins { java }\n");
+		Path buildFile = write(directory, "build.gradle.kts", "plugins { java }\n");
 		assertTrue(installer.install(buildFile));
 		String content = Files.readString(buildFile);
 		assertTrue(content.contains("tasks.register(\"enforceClaudeMd\")"));
@@ -76,8 +74,7 @@ class GradleGuardInstallerTest {
 
 	@Test
 	void matchesCarriageReturnLineEndingsWhenAppendingTheGuard(@TempDir Path directory) throws IOException {
-		Path buildFile = directory.resolve("build.gradle");
-		Files.writeString(buildFile, "plugins { id 'java' }\r\n");
+		Path buildFile = write(directory, "build.gradle", "plugins { id 'java' }\r\n");
 		assertTrue(installer.install(buildFile));
 		String content = Files.readString(buildFile);
 		assertTrue(content.contains("tasks.register('enforceClaudeMd')"), "the guard must be appended");
@@ -94,8 +91,7 @@ class GradleGuardInstallerTest {
 
 	@Test
 	void leavesAnAlreadyGuardedBuildUnchanged(@TempDir Path directory) throws IOException {
-		Path buildFile = directory.resolve("build.gradle");
-		Files.writeString(buildFile, "plugins { id 'java' }\n");
+		Path buildFile = write(directory, "build.gradle", "plugins { id 'java' }\n");
 		installer.install(buildFile);
 		String afterFirstInstall = Files.readString(buildFile);
 		assertFalse(installer.install(buildFile));
@@ -109,16 +105,16 @@ class GradleGuardInstallerTest {
 	 */
 	@Test
 	void installsTheGuardWhenTheScriptOnlyMentionsTheTaskInAComment(@TempDir Path directory) throws IOException {
-		Path buildFile = directory.resolve("build.gradle");
-		Files.writeString(buildFile, "// TODO: one day add an enforceClaudeMd task\nplugins { id 'java' }\n");
+		Path buildFile = write(directory, "build.gradle",
+				"// TODO: one day add an enforceClaudeMd task\nplugins { id 'java' }\n");
 		assertTrue(installer.install(buildFile));
 		assertTrue(Files.readString(buildFile).contains("tasks.register('enforceClaudeMd')"));
 	}
 
 	@Test
 	void installsTheGuardWhenAnEarlierDeclarationWasCommentedOut(@TempDir Path directory) throws IOException {
-		Path buildFile = directory.resolve("build.gradle.kts");
-		Files.writeString(buildFile, "// tasks.register(\"enforceClaudeMd\") { }\nplugins { java }\n");
+		Path buildFile = write(directory, "build.gradle.kts",
+				"// tasks.register(\"enforceClaudeMd\") { }\nplugins { java }\n");
 		assertTrue(installer.install(buildFile));
 		assertTrue(Files.readString(buildFile).contains("tasks.register(\"enforceClaudeMd\")"));
 	}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -277,6 +277,17 @@ class PomEnforcerInstallerTest {
 		return pom;
 	}
 
+	/**
+	 * Writes the POM, wires the rule into it, and answers the rewritten text — the
+	 * three lines almost every test here opens with. The few that assert on the
+	 * install's own answer, or install a second time, keep using {@link #write}.
+	 */
+	private String install(Path dir, String content) throws IOException {
+		Path pom = write(dir, content);
+		installer.install(pom);
+		return Files.readString(pom);
+	}
+
 	@Test
 	void addsEnforcerPluginToExistingBuild(@TempDir Path dir) throws IOException {
 		Path pom = write(dir, POM_WITH_BUILD);
@@ -290,27 +301,21 @@ class PomEnforcerInstallerTest {
 
 	@Test
 	void pinsEnforcerPluginVersionWhenCreatingIt(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, POM_WITH_BUILD);
-		installer.install(pom);
-		String result = Files.readString(pom);
+		String result = install(dir, POM_WITH_BUILD);
 		assertTrue(result.contains("<version>" + PomEnforcerInstaller.ENFORCER_VERSION + "</version>"),
 				"a freshly created maven-enforcer-plugin must declare a version so the adopted build validates");
 	}
 
 	@Test
 	void bindsExecutionToTheRootModuleOnly(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, POM_WITH_BUILD);
-		installer.install(pom);
-		String result = Files.readString(pom);
+		String result = install(dir, POM_WITH_BUILD);
 		assertTrue(result.contains("<inherited>false</inherited>"),
 				"CLAUDE.md lives only at the repository root, so child modules must not inherit the execution");
 	}
 
 	@Test
 	void configuresClaudeMdFileForTheRule(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, POM_WITH_BUILD);
-		installer.install(pom);
-		String result = Files.readString(pom);
+		String result = install(dir, POM_WITH_BUILD);
 		assertTrue(result.contains("<claudeMdFile>"));
 		assertTrue(result.contains("${project.basedir}/CLAUDE.md"));
 	}
@@ -327,9 +332,7 @@ class PomEnforcerInstallerTest {
 
 	@Test
 	void keepsExistingEnforcerExecution(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, POM_WITH_ENFORCER);
-		installer.install(pom);
-		assertTrue(Files.readString(pom).contains("requireMavenVersion"));
+		assertTrue(install(dir, POM_WITH_ENFORCER).contains("requireMavenVersion"));
 	}
 
 	@Test
@@ -351,9 +354,7 @@ class PomEnforcerInstallerTest {
 
 	@Test
 	void keepsExistingCompilerPlugin(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, POM_WITH_BUILD);
-		installer.install(pom);
-		assertTrue(Files.readString(pom).contains("maven-compiler-plugin"));
+		assertTrue(install(dir, POM_WITH_BUILD).contains("maven-compiler-plugin"));
 	}
 
 	@Test
@@ -454,16 +455,12 @@ class PomEnforcerInstallerTest {
 
 	@Test
 	void preservesDefaultPomNamespace(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, POM_WITH_BUILD);
-		installer.install(pom);
-		assertTrue(Files.readString(pom).contains("http://maven.apache.org/POM/4.0.0"));
+		assertTrue(install(dir, POM_WITH_BUILD).contains("http://maven.apache.org/POM/4.0.0"));
 	}
 
 	@Test
 	void leavesExistingFormattingUntouchedAndOnlyIndentsTheNewBlock(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, POM_WITH_BUILD);
-		installer.install(pom);
-		String result = Files.readString(pom);
+		String result = install(dir, POM_WITH_BUILD);
 		assertTrue(result.contains(
 				"      <plugin>\n"
 						+ "        <groupId>org.apache.maven.plugins</groupId>\n"
@@ -482,9 +479,7 @@ class PomEnforcerInstallerTest {
 
 	@Test
 	void preservesAnExistingXmlDeclarationOnItsOwnLine(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + POM_WITH_BUILD);
-		installer.install(pom);
-		String result = Files.readString(pom);
+		String result = install(dir, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + POM_WITH_BUILD);
 		assertTrue(result.startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project "),
 				"the original declaration must be kept verbatim on its own line, not rewritten");
 		assertEquals(1, countOccurrences(result, "<?xml"), "the declaration must not be duplicated");
@@ -492,9 +487,7 @@ class PomEnforcerInstallerTest {
 
 	@Test
 	void preservesCarriageReturnLineEndingsRatherThanReformattingToLf(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, POM_WITH_BUILD.replace("\n", "\r\n"));
-		installer.install(pom);
-		String result = Files.readString(pom);
+		String result = install(dir, POM_WITH_BUILD.replace("\n", "\r\n"));
 		assertTrue(result.contains("tools.claude-code-enforcer"), "the rule must still be wired in");
 		assertFalse(stripCrlf(result).contains("\n"),
 				"a CRLF POM must stay CRLF; no line may be left with a bare LF ending");
@@ -514,9 +507,7 @@ class PomEnforcerInstallerTest {
 
 	@Test
 	void indentsTheAddedBlockToTheDocumentsOwnIndentationUnit(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, POM_FOUR_SPACE_INDENT);
-		installer.install(pom);
-		String result = Files.readString(pom);
+		String result = install(dir, POM_FOUR_SPACE_INDENT);
 		assertTrue(result.contains("\n    <modelVersion>4.0.0</modelVersion>\n"),
 				"the four-space original lines must be preserved");
 		assertTrue(result.contains("\n    <build>\n"),
@@ -542,9 +533,7 @@ class PomEnforcerInstallerTest {
 
 	@Test
 	void doesNotAddATrailingNewlineToAPomThatHadNone(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, POM_WITH_BUILD.stripTrailing());
-		installer.install(pom);
-		String result = Files.readString(pom);
+		String result = install(dir, POM_WITH_BUILD.stripTrailing());
 		assertTrue(result.endsWith("</project>"), "the file must end exactly as it did:\n" + result);
 	}
 
@@ -556,18 +545,14 @@ class PomEnforcerInstallerTest {
 	 */
 	@Test
 	void preservesADeclarationThatSharesItsLineWithTheRootElement(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, "<?xml version=\"1.0\"?>" + POM_WITH_BUILD);
-		installer.install(pom);
-		String result = Files.readString(pom);
+		String result = install(dir, "<?xml version=\"1.0\"?>" + POM_WITH_BUILD);
 		assertTrue(result.startsWith("<?xml version=\"1.0\"?><project "), "unexpected start:\n" + result);
 		assertEquals(1, countOccurrences(result, "<?xml"), "the declaration must not be duplicated");
 	}
 
 	@Test
 	void fallsBackToATwoSpaceUnitForAPomWithNoIndentation(@TempDir Path dir) throws IOException {
-		Path pom = write(dir, POM_WITHOUT_BUILD.replace("\n  ", "\n"));
-		installer.install(pom);
-		String result = Files.readString(pom);
+		String result = install(dir, POM_WITHOUT_BUILD.replace("\n  ", "\n"));
 		assertTrue(result.contains("\n  <build>\n"),
 				"a POM carrying no indentation of its own must get the two-space default:\n" + result);
 		assertTrue(result.contains("\n    <plugins>\n"), "nesting must scale by the default unit:\n" + result);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -156,8 +156,7 @@ class PullRequestStepTest {
 
 	@Test
 	void leavesUrlAbsentWhenListOutputIsNotJson() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 0, "not json at all"));
+		RecordingCommandRunner runner = RecordingCommandRunner.answering("not json at all");
 		AdoptionReport report = new AdoptionReport();
 		step.execute(context, runner, report);
 		assertTrue(report.pullRequestUrl().isEmpty());
@@ -165,8 +164,7 @@ class PullRequestStepTest {
 
 	@Test
 	void leavesUrlAbsentWhenUrlFieldIsMissing() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 0, "[{\"number\": 1}]"));
+		RecordingCommandRunner runner = RecordingCommandRunner.answering("[{\"number\": 1}]");
 		AdoptionReport report = new AdoptionReport();
 		step.execute(context, runner, report);
 		assertTrue(report.pullRequestUrl().isEmpty());
@@ -188,8 +186,7 @@ class PullRequestStepTest {
 	/** Output cut short mid-document — a killed {@code gh}, a truncated pipe. */
 	@Test
 	void leavesUrlAbsentWhenListOutputIsTruncatedJson() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 0, "[{\"url\": "));
+		RecordingCommandRunner runner = RecordingCommandRunner.answering("[{\"url\": ");
 		AdoptionReport report = new AdoptionReport();
 		step.execute(context, runner, report);
 		assertTrue(report.pullRequestUrl().isEmpty());

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PushStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PushStepTest.java
@@ -3,20 +3,18 @@ package io.github.adamw7.tools.adopt.step;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionContexts;
 import io.github.adamw7.tools.adopt.AdoptionException;
-import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class PushStepTest {
 
-	private final AdoptionContext context = new AdoptionContext("https://github.com/adamw7/tools.git",
-			Path.of("/tmp/workspace"), "claude/adopt-claude-code");
+	private final AdoptionContext context = AdoptionContexts.of();
 	private final PushStep step = new PushStep();
 
 	@Test
@@ -29,8 +27,7 @@ class PushStepTest {
 
 	@Test
 	void rejectedPushAborts() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "rejected"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(1, "rejected");
 		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolProbeTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolProbeTest.java
@@ -74,8 +74,7 @@ class ToolProbeTest {
 
 	@Test
 	void succeedsIsFalseForANonZeroExit() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "not logged in"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(1, "not logged in");
 		assertFalse(probe.succeeds(List.of("gh", "auth", "status"), directory, runner));
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
@@ -65,9 +65,7 @@ class ToolchainStepTest {
 	/** A token GitHub answers, but not for this repository, cannot open the pull request either. */
 	@Test
 	void aTokenThatCannotSeeTheRepositoryAbortsTheAdoption() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> command.contains("repos/adamw7/demo") ? new CommandResult(command, 1, "HTTP 404")
-						: new CommandResult(command, 0, ""));
+		RecordingCommandRunner runner = RecordingCommandRunner.failingOn("repos/adamw7/demo", 1, "HTTP 404");
 		AdoptionException thrown = assertThrows(AdoptionException.class,
 				() -> new ToolchainStep().execute(context, runner));
 		assertTrue(thrown.getMessage().contains("adamw7/demo"), thrown.getMessage());
@@ -99,9 +97,7 @@ class ToolchainStepTest {
 	 */
 	@Test
 	void anUnauthenticatedGitHubCliAbortsTheAdoption() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> command.contains("api") ? new CommandResult(command, 1, "HTTP 401")
-						: new CommandResult(command, 0, ""));
+		RecordingCommandRunner runner = RecordingCommandRunner.failingOn("api", 1, "HTTP 401");
 		AdoptionException thrown = assertThrows(AdoptionException.class,
 				() -> new ToolchainStep().execute(context, runner));
 		assertTrue(thrown.getMessage().contains("cannot reach"), thrown.getMessage());
@@ -162,8 +158,7 @@ class ToolchainStepTest {
 
 	@Test
 	void reportsAMissingToolWithoutProbingTheGitHubLogin() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "missing"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(1, "missing");
 		assertThrows(AdoptionException.class, () -> new ToolchainStep().execute(context, runner));
 		assertEquals(3, runner.count());
 	}
@@ -178,9 +173,7 @@ class ToolchainStepTest {
 
 	@Test
 	void aToolThatExitsNonZeroAbortsTheAdoption() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> command.contains("gh") ? new CommandResult(command, 127, "gh: not found")
-						: new CommandResult(command, 0, ""));
+		RecordingCommandRunner runner = RecordingCommandRunner.failingOn("gh", 127, "gh: not found");
 		AdoptionException thrown = assertThrows(AdoptionException.class,
 				() -> new ToolchainStep().execute(context, runner));
 		assertTrue(thrown.getMessage().contains("gh"), thrown.getMessage());
@@ -207,8 +200,7 @@ class ToolchainStepTest {
 
 	@Test
 	void reportsMissingToolsInDeclarationOrder() {
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "missing"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(1, "missing");
 		AdoptionException thrown = assertThrows(AdoptionException.class,
 				() -> new ToolchainStep(List.of("git", "gh")).execute(context, runner));
 		assertTrue(thrown.getMessage().contains("git, gh"), thrown.getMessage());

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.io.TempDir;
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionContexts;
 import io.github.adamw7.tools.adopt.AdoptionException;
-import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
 class VerifyStepTest {
@@ -56,8 +55,7 @@ class VerifyStepTest {
 	void failedVerificationAbortsAdoption(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		writePom(context);
-		RecordingCommandRunner runner = new RecordingCommandRunner(
-				command -> new CommandResult(command, 1, "CLAUDE.md is malformed"));
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(1, "CLAUDE.md is malformed");
 		assertThrows(AdoptionException.class, () -> new VerifyStep().execute(context, runner));
 	}
 


### PR DESCRIPTION
Applies the reuse, simplification, efficiency, and altitude findings from a
review of the whole adopt module. Behaviour is unchanged.

Reuse:
- Add Platform.isWindows(), replacing three copies of the os.name check
  (BuildWrapper, ExecutableResolver, and the PlatformCommands test helper).
- Name the "origin" remote once on AdoptionContext; the clone, the branch, and
  the push must agree on it and each declared it separately.
- Add LineTerminators.normalized and call it from ClaudeMdConformer, which
  repeated the same CRLF/CR to LF rewrite.
- Read the optional rule_version argument through Text.isPresent, the rule every
  other optional argument already follows.
- Give AdoptionRun.allSucceeded a home, so the CLI exit status, the MCP result
  flag, and the report's own field cannot disagree.

Simplification:
- Replace the boolean[] fence array threaded through eight ClaudeMdConformer
  methods with an Outline record carrying the lines and their mask together.
- Turn the CliArguments repository counter into the boolean it is only ever
  read as.
- Fold MavenBuildSystem's Optional-to-installer dance into
  PomEnforcerInstaller.pinning.
- Make fifteen package-private constants private; none was read outside its
  own class.

Efficiency:
- Compile RepositoryUrl's scheme and separator patterns once, matching the
  idiom the class already uses for USER_INFO.
- Read a POM once and parse the DOM from that text, so the parsed elements and
  the lexical spans they are paired with come from a single read.

Altitude:
- Make the MCP Pipeline seam a factory, so one pipeline adopts a whole batch as
  the command line does rather than being rebuilt per repository.

Tests:
- Add RecordingCommandRunner.answering/failing/failingOn and AdoptionContexts.of,
  and route the hand-rolled fixtures through them.
- Collapse the write/install/read preamble repeated across
  PomEnforcerInstallerTest, unify ClaudeMdConformerTest's three fence scanners
  into one, and make EnforcerStepTest and GradleGuardInstallerTest consistent
  with the helpers they already had.
- Pin that the MCP tool builds one pipeline for the whole batch.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q2EhMPdiwhRpWW9rKA2c1P