### PR TITLE
fix(claude-code-enforcer): correct six defects in fence parsing, auto-fix, and reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -633,7 +633,12 @@ violations. Record the current violations once — set `<writeBaseline>true</wri
 or run the build with `-Dclaude.enforcer.writeBaseline=true`, which writes the file
 and passes — then commit it; each stored signature has the absolute project base
 directory normalised to `${basedir}` so a checked-in baseline stays portable
-between a developer's clone and CI.
+between a developer's clone and CI. Configure `<baseDir>${project.basedir}</baseDir>`
+alongside the baseline so that token stands for the project itself: Maven runs
+every module of a reactor from wherever it was invoked, so without it the token
+falls back to the working directory and a baseline recorded from the repository
+root would suppress nothing when the build is started from a module directory or
+an IDE.
 
 The front-matter rules (`skillFilesExist`, `subAgentFormat`, `commandFormat`)
 also accept an `autoFix` option (off by default). When enabled and a definition's

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.inject.Named;
 
@@ -88,8 +89,22 @@ public class ContextBudgetRule extends ClaudeCodeEnforcerRule {
 			violations.add(file + " is " + file.length() + " bytes, over the " + maxBytes + "-byte budget");
 		}
 		if (maxLines > 0 || maxTokens > 0) {
-			collectContentViolations(file, MarkdownText.read(file, file.getName()), violations);
+			collectDecodedViolations(file, violations);
 		}
+	}
+
+	/**
+	 * The line and token budgets need the file's text, so a file that cannot be
+	 * decoded is reported rather than read. Only the byte budget applies to it, and
+	 * an undecodable file must not abort the build before the rest are measured.
+	 */
+	private void collectDecodedViolations(File file, List<String> violations) {
+		Optional<String> content = MarkdownText.readIfText(file);
+		if (content.isEmpty()) {
+			violations.add(file + " cannot be read as text, so its line and token budgets cannot be measured");
+			return;
+		}
+		collectContentViolations(file, content.get(), violations);
 	}
 
 	private void collectContentViolations(File file, String content, List<String> violations) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Baseline.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Baseline.java
@@ -26,6 +26,13 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
  * developer's clone and CI. Normalisation is applied both when reading the file
  * and when comparing a live violation, so a hand-written entry with an absolute
  * path still matches.
+ * <p>
+ * The base directory is the one the rule was configured with, not the build's
+ * working directory: Maven runs every module of a reactor from wherever it was
+ * invoked, so a working-directory token would resolve to a different prefix
+ * depending on whether the build was started from the repository root, from a
+ * module directory, or by an IDE — and a baseline recorded under one would quietly
+ * suppress nothing under another.
  */
 final class Baseline {
 
@@ -33,42 +40,46 @@ final class Baseline {
 	private static final String BASE_DIR_TOKEN = "${basedir}";
 
 	private final Set<String> accepted;
+	private final Signatures signatures;
 
-	private Baseline(Set<String> accepted) {
+	private Baseline(Set<String> accepted, Signatures signatures) {
 		this.accepted = accepted;
+		this.signatures = signatures;
 	}
 
 	/**
-	 * Reads the accepted violations from {@code file}. A null or absent file yields
+	 * Reads the accepted violations from {@code file}, resolving the
+	 * {@code ${basedir}} token against {@code baseDir}. A null or absent file yields
 	 * an empty baseline that suppresses nothing, so a rule with no configured
 	 * baseline — or one whose baseline has not been recorded yet — behaves exactly
 	 * as it did before.
 	 */
-	static Baseline read(File file) throws EnforcerRuleException {
+	static Baseline read(File file, File baseDir) throws EnforcerRuleException {
+		Signatures signatures = Signatures.rootedAt(baseDir);
 		if (file == null || !file.isFile()) {
-			return new Baseline(Set.of());
+			return new Baseline(Set.of(), signatures);
 		}
 		try {
 			Set<String> accepted = new LinkedHashSet<>();
 			Files.readAllLines(file.toPath(), StandardCharsets.UTF_8)
-					.forEach(line -> addAccepted(accepted, line));
-			return new Baseline(accepted);
+					.forEach(line -> addAccepted(accepted, line, signatures));
+			return new Baseline(accepted, signatures);
 		} catch (IOException e) {
 			throw new EnforcerRuleException("Could not read baseline file " + file, e);
 		}
 	}
 
-	private static void addAccepted(Set<String> accepted, String line) {
+	private static void addAccepted(Set<String> accepted, String line, Signatures signatures) {
 		String stripped = line.strip();
 		if (!stripped.isEmpty() && !stripped.startsWith(COMMENT_PREFIX)) {
-			accepted.add(normalize(stripped));
+			accepted.add(signatures.normalize(stripped));
 		}
 	}
 
 	/** The violations this baseline does not already accept, in their original order. */
 	List<String> newViolations(List<String> violations) {
 		return violations.stream()
-				.filter(violation -> !accepted.contains(normalize(violation)))
+				.filter(violation -> !accepted.contains(signatures.normalize(violation)))
 				.toList();
 	}
 
@@ -77,39 +88,51 @@ final class Baseline {
 	 * out that the baseline has grown stale and those lines can be removed.
 	 */
 	List<String> staleEntries(List<String> violations) {
-		Set<String> current = violations.stream().map(Baseline::normalize).collect(Collectors.toSet());
+		Set<String> current = violations.stream().map(signatures::normalize).collect(Collectors.toSet());
 		return accepted.stream().filter(entry -> !current.contains(entry)).toList();
 	}
 
 	/**
 	 * Writes {@code violations} to {@code file} as a fresh baseline, replacing any
 	 * previous content, so a team can record the current violations once and then
-	 * gate only new ones. Signatures are normalised, de-duplicated, and sorted so
-	 * the file stays stable and diffable, and a header comment explains it. Missing
-	 * parent directories are created first.
+	 * gate only new ones. Signatures are normalised against {@code baseDir},
+	 * de-duplicated, and sorted so the file stays stable and diffable, and a header
+	 * comment explains it. Missing parent directories are created first.
 	 */
-	static void write(File file, List<String> violations) throws EnforcerRuleException {
+	static void write(File file, List<String> violations, File baseDir) throws EnforcerRuleException {
 		try {
 			Path path = file.toPath().toAbsolutePath();
 			Files.createDirectories(path.getParent());
-			Files.writeString(path, render(violations), StandardCharsets.UTF_8);
+			Files.writeString(path, render(violations, Signatures.rootedAt(baseDir)), StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new EnforcerRuleException("Could not write baseline file " + file, e);
 		}
 	}
 
-	private static String render(List<String> violations) {
+	private static String render(List<String> violations, Signatures signatures) {
 		StringBuilder content = new StringBuilder();
 		content.append("# Claude Code enforcer baseline: violations this rule accepts and does not fail on.\n");
 		content.append("# Delete a line to make that violation fail the build again; a new violation is never\n");
 		content.append("# suppressed. Regenerate by re-running the build with the rule's writeBaseline flag set.\n");
-		violations.stream().map(Baseline::normalize).distinct().sorted()
+		violations.stream().map(signatures::normalize).distinct().sorted()
 				.forEach(line -> content.append(line).append('\n'));
 		return content.toString();
 	}
 
-	private static String normalize(String signature) {
-		String base = Path.of("").toAbsolutePath().toString();
-		return signature.replace(base, BASE_DIR_TOKEN);
+	/**
+	 * Rewrites the project base directory in a violation message as the
+	 * {@code ${basedir}} token, which is what makes a recorded baseline portable.
+	 */
+	private record Signatures(String base) {
+
+		/** Rooted at {@code baseDir}, or at the working directory when none was configured. */
+		static Signatures rootedAt(File baseDir) {
+			Path base = baseDir != null ? baseDir.toPath() : Path.of("");
+			return new Signatures(base.toAbsolutePath().normalize().toString());
+		}
+
+		String normalize(String signature) {
+			return signature.replace(base, BASE_DIR_TOKEN);
+		}
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -51,8 +51,18 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	private boolean writeBaseline;
 
 	/**
+	 * The directory a baseline's {@code ${basedir}} token stands for, normally
+	 * configured as {@code ${project.basedir}}. When null it falls back to the
+	 * build's working directory, which is only the same thing when Maven was
+	 * invoked from that project's own directory.
+	 */
+	private File baseDir;
+
+	/**
 	 * Reports the violations as a single grouped message. In write-baseline mode it
-	 * records every violation to {@link #baselineFile} and passes. Otherwise it drops
+	 * records every violation to {@link #baselineFile} and passes, writing the HTML
+	 * report as the pass it is — the report always shows the un-suppressed
+	 * violations, and that mode suppresses all of them. Otherwise it drops
 	 * the violations already accepted by the baseline, writes the HTML report when
 	 * {@link #reportFile} is configured, then throws when severity is {@code error}
 	 * and a new violation remains, logs a warning when severity is {@code warn}, or
@@ -61,9 +71,10 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	protected final void report(String header, List<String> violations) throws EnforcerRuleException {
 		if (isWriteBaselineRequested()) {
 			recordBaseline(violations);
+			writeReport(header, List.of());
 			return;
 		}
-		Baseline baseline = Baseline.read(baselineFile);
+		Baseline baseline = Baseline.read(baselineFile, baseDir);
 		List<String> newViolations = baseline.newViolations(violations);
 		writeReport(header, newViolations);
 		logSuppressed(violations.size() - newViolations.size());
@@ -84,7 +95,7 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	}
 
 	private void recordBaseline(List<String> violations) throws EnforcerRuleException {
-		Baseline.write(baselineFile, violations);
+		Baseline.write(baselineFile, violations, baseDir);
 		getLog().info("Recorded " + violations.size() + " violation(s) to the baseline " + baselineFile);
 	}
 
@@ -190,5 +201,9 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 
 	public void setWriteBaseline(boolean writeBaseline) {
 		this.writeBaseline = writeBaseline;
+	}
+
+	public void setBaseDir(File baseDir) {
+		this.baseDir = baseDir;
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -30,6 +30,7 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 		requireConfigured(file, fileParameter());
 		if (!file.isFile()) {
 			handleMissingFile(file);
+			report(header(), List.of());
 			return;
 		}
 		List<String> violations = new ArrayList<>();
@@ -72,7 +73,9 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 	/**
 	 * How to react when the file is absent. The default fails the build, because a
 	 * missing required file is a build-setup mistake. A rule whose file is optional
-	 * overrides this to return without reporting.
+	 * overrides this to return, and the absent file is then reported as a pass — so
+	 * a configured HTML report reflects that run rather than keeping the previous
+	 * one's failure.
 	 */
 	protected void handleMissingFile(File file) throws EnforcerRuleException {
 		requireExists(file, description());

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
@@ -1,10 +1,9 @@
 package io.github.adamw7.tools.enforcer.secret;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 
 import javax.inject.Named;
@@ -13,6 +12,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.enforcer.rule.ScanTargets;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
 /**
  * Enforcer rule that fails the build when a configured file contains what looks
@@ -114,12 +114,11 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 
 	/** The file's lines, or none when it cannot be decoded as text (e.g. a binary asset). */
 	private List<String> readTextLines(File file) {
-		try {
-			return Files.readString(file.toPath()).lines().toList();
-		} catch (IOException e) {
-			getLog().debug("Skipping undecodable file " + file + ": " + e.getMessage());
-			return List.of();
+		Optional<String> content = MarkdownText.readIfText(file);
+		if (content.isEmpty()) {
+			getLog().debug("Skipping undecodable file " + file);
 		}
+		return content.map(text -> text.lines().toList()).orElseGet(List::of);
 	}
 
 	private List<SecretPattern> patterns() {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -6,9 +6,11 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Named;
@@ -81,13 +83,33 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 		report("Hook scripts are not well formed:", violations);
 	}
 
+	/**
+	 * The regular files directly under the hooks directory, sorted.
+	 * {@link File#listFiles} yields entries in an unspecified, filesystem-dependent
+	 * order, which would let this rule report the same violations in a different
+	 * order run-to-run and so churn both the HTML report and a recorded baseline.
+	 */
 	private List<File> scriptFiles() {
 		File[] files = hooksDir.listFiles(File::isFile);
-		return files != null ? List.of(files) : List.of();
+		if (files == null) {
+			return List.of();
+		}
+		Arrays.sort(files);
+		return List.of(files);
 	}
 
+	/**
+	 * A file that cannot be decoded as text is reported rather than read, because
+	 * the hooks directory holds whatever a repository put there and an undecodable
+	 * file must not abort the build before the remaining scripts are checked.
+	 */
 	private void collectScriptViolations(File script, List<String> violations) {
-		String content = MarkdownText.read(script, "hook script");
+		Optional<String> text = MarkdownText.readIfText(script);
+		if (text.isEmpty()) {
+			violations.add("hook script cannot be read as a text script: " + script);
+			return;
+		}
+		String content = text.get();
 		if (content.isBlank()) {
 			violations.add("hook script is empty: " + script);
 			return;

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
@@ -29,7 +29,15 @@ public final class FrontMatterFixer {
 	private static final char DASH = '-';
 	private static final int MIN_DELIMITER_DASHES = 3;
 	private static final String CANONICAL_DELIMITER = "---";
-	private static final Pattern KEY_ENTRY = Pattern.compile("[A-Za-z0-9_][A-Za-z0-9_. -]*:(\\s.*)?");
+	/**
+	 * A {@code key:} or {@code key: value} entry. The key is a single identifier —
+	 * {@code name}, {@code description}, {@code allowed-tools} — with no spaces in
+	 * it, which is the shape every Claude Code front matter key takes. Allowing a
+	 * space would make ordinary prose such as {@code Some notes: here.} look like an
+	 * entry, and a document opening with a thematic break followed by that prose
+	 * would then be repaired into front matter it never had.
+	 */
+	private static final Pattern KEY_ENTRY = Pattern.compile("[A-Za-z0-9_][A-Za-z0-9_.-]*:(\\s.*)?");
 
 	private FrontMatterFixer() {
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -13,13 +13,22 @@ import java.util.Set;
  * Headings are recognised on whole lines outside fenced code blocks, so a heading
  * mentioned inside a fence or in prose is not treated as document structure. The
  * mask includes the opening and closing delimiters themselves, so heading and body
- * detection agree on what is code; a fence is only closed by the delimiter that
- * opened it, so a {@code ~~~} line inside a {@code ```} block stays code.
+ * detection agree on what is code.
+ * <p>
+ * A fence is closed only by a run of the <em>same</em> character, at least as long
+ * as the one that opened it, carrying no info string. All three conditions matter,
+ * because documentation about Markdown nests one fence inside another: a
+ * {@code ~~~} line inside a {@code ```} block, the {@code ```java} line of an
+ * example inside a {@code ````} wrapper, and a {@code ```} example inside a
+ * {@code ````} wrapper all stay content. Closing on the first character alone would
+ * end the block early and then treat the real closing delimiter as a fresh opening
+ * one, silently masking the rest of the document as code.
  */
 public final class MarkdownDocument {
 
-	private static final String BACKTICK_FENCE = "```";
-	private static final String TILDE_FENCE = "~~~";
+	private static final char BACKTICK = '`';
+	private static final char TILDE = '~';
+	private static final int MIN_FENCE_LENGTH = 3;
 	private static final String HEADING_PREFIX = "#";
 	private static final char HEADING_CHAR = '#';
 
@@ -152,40 +161,67 @@ public final class MarkdownDocument {
 
 	private static boolean[] fenceMask(List<String> lines) {
 		boolean[] mask = new boolean[lines.size()];
-		String openMarker = null;
+		Delimiter open = null;
 		for (int i = 0; i < lines.size(); i++) {
-			openMarker = applyFence(lines.get(i).strip(), openMarker, mask, i);
+			open = applyFence(lines.get(i).strip(), open, mask, i);
 		}
 		return mask;
 	}
 
 	/**
-	 * Marks line {@code index} as code or structure and returns the fence marker
-	 * still open afterwards. A fence is only closed by the marker it was opened
-	 * with, so a {@code ~~~} line inside a {@code ```} block, or the reverse, stays
-	 * content rather than ending the block.
+	 * Marks line {@code index} as code or structure and returns the fence delimiter
+	 * still open afterwards.
 	 */
-	private static String applyFence(String line, String openMarker, boolean[] mask, int index) {
-		String marker = fenceMarker(line);
-		if (openMarker == null) {
-			mask[index] = marker != null;
-			return marker;
+	private static Delimiter applyFence(String line, Delimiter open, boolean[] mask, int index) {
+		Delimiter delimiter = delimiterOf(line);
+		if (open == null) {
+			mask[index] = delimiter != null;
+			return delimiter;
 		}
 		mask[index] = true;
-		return closesFence(marker, openMarker) ? null : openMarker;
+		return delimiter != null && delimiter.closes(open) ? null : open;
 	}
 
-	private static boolean closesFence(String marker, String openMarker) {
-		return marker != null && marker.charAt(0) == openMarker.charAt(0);
+	/** The fence delimiter a line declares, or null when the line is not one. */
+	private static Delimiter delimiterOf(String line) {
+		if (line.isEmpty() || !isFenceCharacter(line.charAt(0))) {
+			return null;
+		}
+		char character = line.charAt(0);
+		int length = runLength(line, character);
+		if (length < MIN_FENCE_LENGTH) {
+			return null;
+		}
+		return new Delimiter(character, length, !line.substring(length).isBlank());
 	}
 
-	private static String fenceMarker(String line) {
-		if (line.startsWith(BACKTICK_FENCE)) {
-			return BACKTICK_FENCE;
+	private static boolean isFenceCharacter(char character) {
+		return character == BACKTICK || character == TILDE;
+	}
+
+	private static int runLength(String line, char character) {
+		int length = 0;
+		while (length < line.length() && line.charAt(length) == character) {
+			length++;
 		}
-		if (line.startsWith(TILDE_FENCE)) {
-			return TILDE_FENCE;
+		return length;
+	}
+
+	/**
+	 * One fence delimiter line: the character it is written with, how many of them
+	 * it runs, and whether anything follows them — the info string of an opening
+	 * delimiter, such as the {@code java} of {@code ```java}.
+	 */
+	private record Delimiter(char character, int length, boolean info) {
+
+		/**
+		 * True when this line closes the block {@code open} started. A closing
+		 * delimiter uses the same character, is at least as long, and carries no
+		 * info string, so a shorter or annotated fence nested inside the block is
+		 * content rather than its end.
+		 */
+		boolean closes(Delimiter open) {
+			return character == open.character() && length >= open.length() && !info;
 		}
-		return null;
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -29,6 +30,21 @@ public final class MarkdownText {
 			return stripByteOrderMark(Files.readString(file.toPath()));
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not read " + description + " at " + file, e);
+		}
+	}
+
+	/**
+	 * Reads {@code file} the way {@link #read} does, but yields empty instead of
+	 * throwing when it cannot be decoded as text. A rule that scans a directory it
+	 * does not control meets binary and non-UTF-8 files, and an
+	 * {@link UncheckedIOException} escaping a rule aborts the build as an internal
+	 * error rather than as the violation the rule exists to report.
+	 */
+	public static Optional<String> readIfText(File file) {
+		try {
+			return Optional.of(stripByteOrderMark(Files.readString(file.toPath())));
+		} catch (IOException e) {
+			return Optional.empty();
 		}
 	}
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -232,6 +232,37 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
+	void treatsAnAnnotatedBacktickLineInsideABacktickFenceAsCode() {
+		// ```java is an opening delimiter, not a closing one. Ending the block on it
+		// would leave the real ``` to open a fresh fence that swallows the rest of
+		// the document, so every heading below would be reported missing.
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing",
+				"```\nexample:\n```java\nint x;\n```\n\n## Testing"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void treatsAShorterFenceInsideALongerOneAsCode() {
+		// The four-backtick wrapper is how a document shows a fenced example, so the
+		// inner three-backtick delimiters and everything they wrap stay code.
+		ClaudeMdFormatRule rule = ruleFor(
+				VALID_CONTENT + "\n````markdown\n```java\nTODO in an example\n```\n````\n");
+		rule.setForbiddenTokens(java.util.List.of("TODO"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void scansTheContentThatFollowsANestedFence() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n```\n```java\n```\n\nTODO left behind\n");
+		rule.setForbiddenTokens(java.util.List.of("TODO"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("forbidden token: TODO"), exception.getMessage());
+	}
+
+	@Test
 	void passesWhenSectionsAreInConfiguredOrder() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
 		rule.setEnforceSectionOrder(true);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
@@ -146,6 +146,33 @@ class ContextBudgetRuleTest {
 		assertTrue(baseline.isFile(), "expected the baseline file to be written");
 	}
 
+	@Test
+	void writeBaselineModeRefreshesTheReportAsThePassItIs() throws IOException {
+		ContextBudgetRule rule = ruleForFile("x".repeat(100));
+		rule.setMaxBytes(50);
+		File report = tempDir.resolve("report.html").toFile();
+		rule.setReportFile(report);
+		rule.setBaselineFile(tempDir.resolve("baseline.txt").toFile());
+		rule.setWriteBaseline(true);
+		rule.setLog(new CapturingLogger());
+
+		assertDoesNotThrow(rule::execute);
+		String html = Files.readString(report.toPath());
+		assertTrue(html.contains("Check passed"), html);
+	}
+
+	@Test
+	void reportsAMarkdownFileThatCannotBeDecodedInsteadOfFailingTheBuildOutright() {
+		Path directory = tempDir.resolve("skills");
+		writeBytes(directory.resolve("broken.md"), new byte[] { (byte) 0xFF, (byte) 0xFE, (byte) 0x00 });
+		ContextBudgetRule rule = new ContextBudgetRule();
+		rule.setDirectories(List.of(directory.toFile()));
+		rule.setMaxLines(10);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("cannot be read as text"), exception.getMessage());
+	}
+
 	private ContextBudgetRule ruleForFile(String content) {
 		Path file = tempDir.resolve("CLAUDE.md");
 		writeString(file, content);
@@ -158,6 +185,15 @@ class ContextBudgetRuleTest {
 		try {
 			Files.createDirectories(file.getParent());
 			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private static void writeBytes(Path file, byte[] content) {
+		try {
+			Files.createDirectories(file.getParent());
+			Files.write(file, content);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not write " + file, e);
 		}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -152,25 +153,35 @@ class ContextBudgetRuleTest {
 		rule.setMaxBytes(50);
 		File report = tempDir.resolve("report.html").toFile();
 		rule.setReportFile(report);
-		rule.setBaselineFile(tempDir.resolve("baseline.txt").toFile());
+		File baseline = tempDir.resolve("baseline.txt").toFile();
+		rule.setBaselineFile(baseline);
 		rule.setWriteBaseline(true);
 		rule.setLog(new CapturingLogger());
 
 		assertDoesNotThrow(rule::execute);
 		String html = Files.readString(report.toPath());
 		assertTrue(html.contains("Check passed"), html);
+		// Every violation was recorded, so none is left un-suppressed to report.
+		assertFalse(html.contains("over the 50-byte budget"), html);
+		assertTrue(Files.readString(baseline.toPath()).contains("over the 50-byte budget"),
+				Files.readString(baseline.toPath()));
 	}
 
 	@Test
 	void reportsAMarkdownFileThatCannotBeDecodedInsteadOfFailingTheBuildOutright() {
 		Path directory = tempDir.resolve("skills");
 		writeBytes(directory.resolve("broken.md"), new byte[] { (byte) 0xFF, (byte) 0xFE, (byte) 0x00 });
+		writeString(directory.resolve("fine.md"), "one\ntwo\n");
 		ContextBudgetRule rule = new ContextBudgetRule();
 		rule.setDirectories(List.of(directory.toFile()));
-		rule.setMaxLines(10);
+		rule.setMaxLines(1);
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
 		assertTrue(exception.getMessage().contains("cannot be read as text"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("broken.md"), exception.getMessage());
+		// The undecodable file no longer aborts the run before the next one is measured.
+		assertTrue(exception.getMessage().contains("fine.md"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("2 lines, over the 1-line budget"), exception.getMessage());
 	}
 
 	private ContextBudgetRule ruleForFile(String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/BaselineTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/BaselineTest.java
@@ -118,6 +118,8 @@ class BaselineTest {
 
 		String content = readString(file);
 		assertTrue(content.contains("${basedir}/CLAUDE.md is over budget"), content);
+		assertFalse(content.contains(projectDir() + "/CLAUDE.md"), content);
+		// The working directory is not the project, so it is left as it was written.
 		assertTrue(content.contains(workingDir + "/elsewhere.md is over budget"), content);
 	}
 
@@ -125,11 +127,13 @@ class BaselineTest {
 	void aBaselineRecordedInOneProjectDirectoryStillSuppressesWhenReadFromAnother() {
 		File file = writeString("${basedir}/CLAUDE.md is over budget\n");
 		File otherCheckout = tempDir.resolve("elsewhere/checkout").toFile();
+		String outsideTheProject = tempDir.resolve("unrelated").toFile() + "/CLAUDE.md is over budget";
 
 		List<String> newViolations = assertDoesNotThrow(() -> Baseline.read(file, otherCheckout)
-				.newViolations(List.of(otherCheckout + "/CLAUDE.md is over budget")));
+				.newViolations(List.of(otherCheckout + "/CLAUDE.md is over budget", outsideTheProject)));
 
-		assertTrue(newViolations.isEmpty(), newViolations.toString());
+		// The token matches only what sits under the configured project directory.
+		assertEquals(List.of(outsideTheProject), newViolations);
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/BaselineTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/BaselineTest.java
@@ -24,7 +24,7 @@ class BaselineTest {
 	void aNullFileSuppressesNothing() {
 		List<String> violations = List.of("a", "b");
 
-		assertEquals(violations, assertDoesNotThrow(() -> Baseline.read(null).newViolations(violations)));
+		assertEquals(violations, assertDoesNotThrow(() -> Baseline.read(null, projectDir()).newViolations(violations)));
 	}
 
 	@Test
@@ -32,14 +32,14 @@ class BaselineTest {
 		File absent = tempDir.resolve("absent.txt").toFile();
 		List<String> violations = List.of("a", "b");
 
-		assertEquals(violations, assertDoesNotThrow(() -> Baseline.read(absent).newViolations(violations)));
+		assertEquals(violations, assertDoesNotThrow(() -> Baseline.read(absent, projectDir()).newViolations(violations)));
 	}
 
 	@Test
 	void recordedViolationsAreSuppressedAndNewOnesRemainInOrder() {
 		File file = writeString("known one\nknown two\n");
 
-		List<String> newViolations = assertDoesNotThrow(() -> Baseline.read(file)
+		List<String> newViolations = assertDoesNotThrow(() -> Baseline.read(file, projectDir())
 				.newViolations(List.of("known one", "fresh", "known two", "another fresh")));
 
 		assertEquals(List.of("fresh", "another fresh"), newViolations);
@@ -49,7 +49,7 @@ class BaselineTest {
 	void blankLinesAndCommentsInTheBaselineAreIgnored() {
 		File file = writeString("# a comment\n\nknown one\n   \n# another\n");
 
-		List<String> newViolations = assertDoesNotThrow(() -> Baseline.read(file)
+		List<String> newViolations = assertDoesNotThrow(() -> Baseline.read(file, projectDir())
 				.newViolations(List.of("known one", "# a comment", "fresh")));
 
 		assertEquals(List.of("# a comment", "fresh"), newViolations);
@@ -60,17 +60,17 @@ class BaselineTest {
 		File file = tempDir.resolve("baseline.txt").toFile();
 		List<String> violations = List.of(tempDir + "/CLAUDE.md is over budget", "AGENTS.md drifted");
 
-		assertDoesNotThrow(() -> Baseline.write(file, violations));
+		assertDoesNotThrow(() -> Baseline.write(file, violations, projectDir()));
 
-		assertTrue(assertDoesNotThrow(() -> Baseline.read(file).newViolations(violations)).isEmpty());
+		assertTrue(assertDoesNotThrow(() -> Baseline.read(file, projectDir()).newViolations(violations)).isEmpty());
 	}
 
 	@Test
 	void aWrittenBaselineNormalisesTheProjectBaseDirectorySoItIsPortable() {
 		File file = tempDir.resolve("baseline.txt").toFile();
-		String base = Path.of("").toAbsolutePath().toString();
+		String base = projectDir().toString();
 
-		assertDoesNotThrow(() -> Baseline.write(file, List.of(base + "/CLAUDE.md is over budget")));
+		assertDoesNotThrow(() -> Baseline.write(file, List.of(base + "/CLAUDE.md is over budget"), projectDir()));
 
 		String content = readString(file);
 		assertTrue(content.contains("${basedir}/CLAUDE.md is over budget"), content);
@@ -80,9 +80,9 @@ class BaselineTest {
 	@Test
 	void aTokenisedEntryMatchesALiveViolationCarryingTheAbsolutePath() {
 		File file = writeString("${basedir}/CLAUDE.md is over budget\n");
-		String base = Path.of("").toAbsolutePath().toString();
+		String base = projectDir().toString();
 
-		List<String> newViolations = assertDoesNotThrow(() -> Baseline.read(file)
+		List<String> newViolations = assertDoesNotThrow(() -> Baseline.read(file, projectDir())
 				.newViolations(List.of(base + "/CLAUDE.md is over budget")));
 
 		assertTrue(newViolations.isEmpty(), newViolations.toString());
@@ -92,7 +92,7 @@ class BaselineTest {
 	void aWrittenBaselineIsSortedDeduplicatedAndCarriesAHeader() {
 		File file = tempDir.resolve("baseline.txt").toFile();
 
-		assertDoesNotThrow(() -> Baseline.write(file, List.of("b violation", "a violation", "b violation")));
+		assertDoesNotThrow(() -> Baseline.write(file, List.of("b violation", "a violation", "b violation"), projectDir()));
 
 		assertTrue(readString(file).startsWith("#"), "expected a leading comment header");
 		assertEquals(List.of("a violation", "b violation"), filteredLines(file));
@@ -102,10 +102,49 @@ class BaselineTest {
 	void staleEntriesAreTheRecordedViolationsNoCurrentViolationMatches() {
 		File file = writeString("still failing\nfixed since\n");
 
-		List<String> stale = assertDoesNotThrow(() -> Baseline.read(file)
+		List<String> stale = assertDoesNotThrow(() -> Baseline.read(file, projectDir())
 				.staleEntries(List.of("still failing", "brand new")));
 
 		assertEquals(List.of("fixed since"), stale);
+	}
+
+	@Test
+	void theConfiguredBaseDirectoryIsTokenisedRatherThanTheWorkingDirectory() {
+		File file = tempDir.resolve("baseline.txt").toFile();
+		String workingDir = Path.of("").toAbsolutePath().toString();
+
+		assertDoesNotThrow(() -> Baseline.write(file, List.of(projectDir() + "/CLAUDE.md is over budget",
+				workingDir + "/elsewhere.md is over budget"), projectDir()));
+
+		String content = readString(file);
+		assertTrue(content.contains("${basedir}/CLAUDE.md is over budget"), content);
+		assertTrue(content.contains(workingDir + "/elsewhere.md is over budget"), content);
+	}
+
+	@Test
+	void aBaselineRecordedInOneProjectDirectoryStillSuppressesWhenReadFromAnother() {
+		File file = writeString("${basedir}/CLAUDE.md is over budget\n");
+		File otherCheckout = tempDir.resolve("elsewhere/checkout").toFile();
+
+		List<String> newViolations = assertDoesNotThrow(() -> Baseline.read(file, otherCheckout)
+				.newViolations(List.of(otherCheckout + "/CLAUDE.md is over budget")));
+
+		assertTrue(newViolations.isEmpty(), newViolations.toString());
+	}
+
+	@Test
+	void anUnconfiguredBaseDirectoryFallsBackToTheWorkingDirectory() {
+		File file = tempDir.resolve("baseline.txt").toFile();
+		String workingDir = Path.of("").toAbsolutePath().toString();
+
+		assertDoesNotThrow(() -> Baseline.write(file, List.of(workingDir + "/CLAUDE.md is over budget"), null));
+
+		assertTrue(readString(file).contains("${basedir}/CLAUDE.md is over budget"), readString(file));
+	}
+
+	/** The project base directory a rule would be configured with, as {@code ${project.basedir}}. */
+	private File projectDir() {
+		return tempDir.toFile();
 	}
 
 	private static List<String> filteredLines(File file) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.rule;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -140,6 +141,8 @@ class JsonFileRuleTest {
 		assertDoesNotThrow(optional::execute);
 		String html = Files.readString(report.toPath());
 		assertTrue(html.contains("Check passed"), html);
+		assertFalse(html.contains("Check failed"), html);
+		assertFalse(html.contains("something is wrong"), html);
 	}
 
 	private TestJsonRule ruleFor(String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
@@ -123,6 +123,25 @@ class JsonFileRuleTest {
 		assertTrue(html.contains("Check passed"), html);
 	}
 
+	@Test
+	void anAbsentOptionalFileRefreshesTheReportRatherThanLeavingTheLastFailure() throws IOException {
+		File report = tempDir.resolve("report.html").toFile();
+		TestJsonRule failing = ruleFor("{ }");
+		failing.addViolation("something is wrong");
+		failing.setReportFile(report);
+		assertThrows(EnforcerRuleException.class, failing::execute);
+
+		Files.delete(tempDir.resolve("test.json"));
+		TestJsonRule optional = new TestJsonRule();
+		optional.setOptional(true);
+		optional.setFile(tempDir.resolve("test.json").toFile());
+		optional.setReportFile(report);
+
+		assertDoesNotThrow(optional::execute);
+		String html = Files.readString(report.toPath());
+		assertTrue(html.contains("Check passed"), html);
+	}
+
 	private TestJsonRule ruleFor(String content) {
 		Path file = tempDir.resolve("test.json");
 		writeString(file, content);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.settings;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -249,6 +250,8 @@ class HooksFormatRuleTest {
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
 		assertTrue(exception.getMessage().contains("cannot be read as a text script"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("logo.png"), exception.getMessage());
+		assertFalse(exception.getMessage().contains("is empty"), exception.getMessage());
 	}
 
 	@Test
@@ -257,7 +260,11 @@ class HooksFormatRuleTest {
 		writeScript("session-start.sh", "echo hi\n", true);
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
+		// Both are reported: the undecodable file no longer aborts the run before
+		// the script after it is looked at.
+		assertTrue(exception.getMessage().contains("logo.png"), exception.getMessage());
 		assertTrue(exception.getMessage().contains("shebang"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("session-start.sh"), exception.getMessage());
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.enforcer.settings;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -242,10 +243,54 @@ class HooksFormatRuleTest {
 		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("shebang")), logger.warnings().toString());
 	}
 
+	@Test
+	void reportsAFileThatCannotBeDecodedAsTextInsteadOfFailingTheBuildOutright() {
+		writeBytes("logo.png", new byte[] { (byte) 0x89, 0x50, 0x4E, 0x47, (byte) 0xFF, (byte) 0xFE });
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
+		assertTrue(exception.getMessage().contains("cannot be read as a text script"), exception.getMessage());
+	}
+
+	@Test
+	void keepsCheckingTheOtherScriptsAfterAFileThatIsNotText() {
+		writeBytes("logo.png", new byte[] { (byte) 0xFF, (byte) 0xFE, (byte) 0x00 });
+		writeScript("session-start.sh", "echo hi\n", true);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
+		assertTrue(exception.getMessage().contains("shebang"), exception.getMessage());
+	}
+
+	@Test
+	void reportsScriptsInASortedOrderRatherThanTheFilesystemOrder() {
+		for (String name : List.of("zeta.sh", "alpha.sh", "mid.sh", "beta.sh")) {
+			writeScript(name, "echo hi\n", true);
+		}
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
+		assertEquals(List.of("alpha.sh", "beta.sh", "mid.sh", "zeta.sh"), reportedScripts(exception.getMessage()));
+	}
+
+	/** The script names named by the shebang violations, in the order the rule reported them. */
+	private List<String> reportedScripts(String message) {
+		return message.lines()
+				.filter(line -> line.contains("shebang"))
+				.map(line -> line.substring(line.lastIndexOf(File.separatorChar) + 1))
+				.toList();
+	}
+
 	private HooksFormatRule ruleFor() {
 		HooksFormatRule rule = new HooksFormatRule();
 		rule.setHooksDir(hooksDir().toFile());
 		return rule;
+	}
+
+	private void writeBytes(String name, byte[] content) {
+		Path file = hooksDir().resolve(name);
+		try {
+			Files.write(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
 	}
 
 	private File settingsReferencing(String command) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
@@ -93,6 +93,33 @@ class FrontMatterFixerTest {
 	}
 
 	@Test
+	void doesNotMistakeAThematicBreakFollowedByProseContainingAColonForFrontMatter() {
+		String content = """
+				---
+
+				Some notes: here is what the colon is doing.
+				More prose.
+				""";
+
+		assertTrue(FrontMatterFixer.repair(content).isEmpty(), () -> FrontMatterFixer.repair(content).toString());
+	}
+
+	@Test
+	void doesNotSwallowBodyProseContainingAColonIntoAnUnclosedBlock() {
+		String content = """
+				---
+				name: reviewer
+
+				Use this skill when: you need a review.
+				""";
+
+		Optional<String> repaired = FrontMatterFixer.repair(content);
+
+		assertTrue(repaired.isPresent());
+		assertTrue(repaired.get().endsWith("---\nUse this skill when: you need a review.\n"), repaired.get());
+	}
+
+	@Test
 	void leavesContentWithoutAFrontMatterIntentUntouched() {
 		String content = """
 				# Title

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -116,7 +117,9 @@ class FrontMatterFixerTest {
 		Optional<String> repaired = FrontMatterFixer.repair(content);
 
 		assertTrue(repaired.isPresent());
-		assertTrue(repaired.get().endsWith("---\nUse this skill when: you need a review.\n"), repaired.get());
+		assertEquals("---\nname: reviewer\n\n---\nUse this skill when: you need a review.\n", repaired.get());
+		assertEquals(Optional.of("reviewer"), FrontMatter.parse(repaired.get()).flatMap(fm -> fm.value("name")));
+		assertEquals(List.of("name"), FrontMatter.parse(repaired.get()).orElseThrow().keys());
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
@@ -1,0 +1,174 @@
+package io.github.adamw7.tools.enforcer.text;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Asserts the fenced-code-block mask line by line rather than through a rule's
+ * pass or fail, because every structural check the rules make — headings,
+ * section bodies, forbidden tokens, line lengths, file references, and the
+ * memory imports {@code ImportGraph} reads — is a question asked of this mask.
+ * A delimiter mistaken for the end of a block silently reclassifies everything
+ * after it, so the exact set of code lines is what needs pinning.
+ */
+class MarkdownDocumentTest {
+
+	@Test
+	void masksAFencedBlockIncludingBothOfItsDelimiters() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				```
+				int x;
+				```
+
+				## Section
+				""");
+
+		assertEquals(List.of(2, 3, 4), fencedLines(document));
+	}
+
+	@Test
+	void anAnnotatedBacktickLineDoesNotCloseABacktickFence() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				```
+				example:
+				```java
+				int x;
+				```
+
+				## Section
+				body
+				""");
+
+		// Lines 2 to 6 are the whole block: ```java is an opening delimiter, so it
+		// cannot end it and leave line 6's ``` to open a second fence.
+		assertEquals(List.of(2, 3, 4, 5, 6), fencedLines(document));
+		assertEquals(Set.of("# Title", "## Section"), document.headings());
+	}
+
+	@Test
+	void aShorterFenceDoesNotCloseALongerOne() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				````markdown
+				```java
+				int x;
+				```
+				````
+
+				## Section
+				body
+				""");
+
+		assertEquals(List.of(2, 3, 4, 5, 6), fencedLines(document));
+		assertEquals(Set.of("# Title", "## Section"), document.headings());
+	}
+
+	@Test
+	void aLongerFenceClosesAShorterOne() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				```
+				int x;
+				`````
+
+				## Section
+				""");
+
+		assertEquals(List.of(0, 1, 2), fencedLines(document));
+		assertTrue(document.hasHeading("## Section"));
+	}
+
+	@Test
+	void aTildeLineDoesNotCloseABacktickFence() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				```
+				~~~
+				```
+
+				# After
+				""");
+
+		assertEquals(List.of(0, 1, 2), fencedLines(document));
+		assertTrue(document.hasHeading("# After"));
+	}
+
+	@Test
+	void aClosingDelimiterMayCarryTrailingWhitespace() {
+		// Written without a text block, which would strip the trailing spaces away.
+		MarkdownDocument document = MarkdownDocument.parse("```\nint x;\n```   \n\n## Section\n");
+
+		assertEquals(List.of(0, 1, 2), fencedLines(document));
+		assertTrue(document.hasHeading("## Section"));
+	}
+
+	@Test
+	void anUnclosedFenceMasksEverythingBelowIt() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				```
+				int x;
+				## Section
+				""");
+
+		assertEquals(List.of(2, 3, 4), fencedLines(document));
+		assertFalse(document.hasHeading("## Section"));
+	}
+
+	@Test
+	void aRunOfFewerThanThreeMarkersIsNotAFence() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				``inline``
+
+				## Section
+				""");
+
+		assertEquals(List.of(), fencedLines(document));
+		assertEquals(Set.of("# Title", "## Section"), document.headings());
+	}
+
+	@Test
+	void findsATokenOnTheContentThatFollowsANestedFence() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				```
+				```java
+				```
+
+				TODO left behind
+				""");
+
+		assertEquals(List.of(0, 1, 2), fencedLines(document));
+		assertTrue(document.containsOutsideFences("TODO"));
+	}
+
+	@Test
+	void doesNotFindATokenWrappedByALongerFence() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				````markdown
+				```java
+				TODO in an example
+				```
+				````
+				""");
+
+		assertFalse(document.containsOutsideFences("TODO"));
+	}
+
+	/** The indices of the lines the document masks as fenced code, in document order. */
+	private static List<Integer> fencedLines(MarkdownDocument document) {
+		return IntStream.range(0, document.lineCount()).filter(document::isInsideFence).boxed().toList();
+	}
+}


### PR DESCRIPTION
Six problems found by auditing the module, each with a regression test that
fails without its fix:

- MarkdownDocument closed a fenced code block on the first character of a
  delimiter alone, so a ```java line inside a ``` block ended it and the real
  closing delimiter opened a fresh fence that masked the rest of the document as
  code. Headings below it were reported missing, containsOutsideFences went
  blind, and ImportGraph skipped every @import that followed. A fence now closes
  only on the same character, at least as long, and with no info string, so the
  nested-fence idioms that documentation about Markdown uses stay content.

- FrontMatterFixer accepted a key containing spaces, so prose such as
  "Some notes: here." looked like a YAML entry. A document opening with a lone
  --- thematic break was repaired into front matter it never had, and body prose
  was swallowed into an unclosed block — both written back to disk under
  autoFix. The key pattern is now a single identifier, which is the shape every
  Claude Code front matter key takes.

- HooksFormatRule and ContextBudgetRule read scanned files with a reader that
  wraps a decoding failure in an UncheckedIOException, so one binary file under
  .claude/hooks aborted the build as an internal error instead of reporting a
  violation. Both now read through MarkdownText.readIfText and report the file,
  leaving the remaining ones checked; NoSecretsRule shares that helper rather
  than repeating it.

- HooksFormatRule listed its scripts in filesystem order, so the same violations
  came out in a different order run to run and churned both the HTML report and
  a recorded baseline. They are sorted, as every other listing helper already
  does for that reason.

- JsonFileRule returned without reporting when an optional file was absent, so a
  configured reportFile kept the previous run's failure; the write-baseline path
  skipped the report for the same reason. Both now report, keeping the base
  class's promise that the report always reflects the latest run.

- Baseline resolved its ${basedir} token against the JVM working directory
  rather than the project, so a baseline recorded from the repository root
  suppressed nothing when the build was started from a module directory or an
  IDE. The directory is now the new baseDir parameter, documented in AGENTS.md
  as ${project.basedir}, falling back to the working directory when unset.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PJoryV1xE8SjqeuTKEWsB9