### PR TITLE
refactor(claude-code-enforcer): cut duplicated boilerplate from rules and tests

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -91,9 +91,4 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 	void setAutoFix(boolean autoFix) {
 		this.autoFix = autoFix;
 	}
-
-	@Override
-	public String toString() {
-		return String.format("CommandFormatRule[commandsDir=%s]", commandsDir);
-	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/MultiDefinitionRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/MultiDefinitionRule.java
@@ -96,10 +96,4 @@ abstract class MultiDefinitionRule extends ClaudeCodeEnforcerRule {
 	void setSkillsDir(File skillsDir) {
 		this.skillsDir = skillsDir;
 	}
-
-	@Override
-	public String toString() {
-		return String.format("%s[commandsDir=%s, agentsDir=%s, skillsDir=%s]",
-				getClass().getSimpleName(), commandsDir, agentsDir, skillsDir);
-	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRule.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.definition;
 
 import java.io.File;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import javax.inject.Named;
@@ -48,19 +49,13 @@ public class PluginFormatRule extends JsonFileRule {
 	/** Optional whitelist of allowed manifest keys. When set, unknown keys are reported. */
 	private List<String> allowedKeys;
 
+	public PluginFormatRule() {
+		super("pluginFile", "plugin.json");
+	}
+
 	@Override
 	protected File jsonFile() {
 		return pluginFile;
-	}
-
-	@Override
-	protected String fileParameter() {
-		return "pluginFile";
-	}
-
-	@Override
-	protected String description() {
-		return "plugin.json";
 	}
 
 	/** Not every repository ships a plugin, so an absent manifest is a pass. */
@@ -78,7 +73,7 @@ public class PluginFormatRule extends JsonFileRule {
 	}
 
 	private void collectMissingKeys(JsonNode manifest, List<String> violations) {
-		for (String key : requiredKeys()) {
+		for (String key : Objects.requireNonNullElse(requiredKeys, DEFAULT_REQUIRED_KEYS)) {
 			if (!manifest.has(key)) {
 				violations.add("plugin.json is missing required key '" + key + "' in: " + pluginFile);
 			}
@@ -118,10 +113,6 @@ public class PluginFormatRule extends JsonFileRule {
 		}
 	}
 
-	private List<String> requiredKeys() {
-		return requiredKeys != null ? requiredKeys : DEFAULT_REQUIRED_KEYS;
-	}
-
 	void setPluginFile(File pluginFile) {
 		this.pluginFile = pluginFile;
 	}
@@ -132,10 +123,5 @@ public class PluginFormatRule extends JsonFileRule {
 
 	void setAllowedKeys(List<String> allowedKeys) {
 		this.allowedKeys = allowedKeys;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("PluginFormatRule[pluginFile=%s]", pluginFile);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.definition;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.inject.Named;
@@ -91,14 +92,10 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 	private void collectFrontMatterViolations(File skillDirectory, File skillFile, FrontMatter frontMatter,
 			List<String> violations) {
 		FrontMatterChecks checks = new FrontMatterChecks(frontMatter, SKILL_FILE_NAME, skillFile, violations);
-		checks.requireKeys(requiredKeys());
+		checks.requireKeys(Objects.requireNonNullElse(requiredKeys, DEFAULT_REQUIRED_KEYS));
 		checks.allowOnlyKeys(allowedFrontMatterKeys);
 		checks.checkName(skillDirectory.getName());
 		checks.checkDescription(maxDescriptionLength);
-	}
-
-	private List<String> requiredKeys() {
-		return requiredKeys != null ? requiredKeys : DEFAULT_REQUIRED_KEYS;
 	}
 
 	void setSkillsDir(File skillsDir) {
@@ -119,10 +116,5 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 
 	void setAutoFix(boolean autoFix) {
 		this.autoFix = autoFix;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("SkillFilesExistRule[skillsDir=%s]", skillsDir);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.definition;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.inject.Named;
@@ -75,14 +76,10 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 
 	private void collectFrontMatterViolations(File definition, FrontMatter frontMatter, List<String> violations) {
 		FrontMatterChecks checks = new FrontMatterChecks(frontMatter, LABEL, definition, violations);
-		checks.requireKeys(requiredKeys());
+		checks.requireKeys(Objects.requireNonNullElse(requiredKeys, DEFAULT_REQUIRED_KEYS));
 		checks.checkName(DefinitionFiles.baseName(definition));
 		checks.checkDescription(0);
 		checks.checkModel(allowedModels);
-	}
-
-	private List<String> requiredKeys() {
-		return requiredKeys != null ? requiredKeys : DEFAULT_REQUIRED_KEYS;
 	}
 
 	void setAgentsDir(File agentsDir) {
@@ -99,10 +96,5 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 
 	void setAutoFix(boolean autoFix) {
 		this.autoFix = autoFix;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("SubAgentFormatRule[agentsDir=%s]", agentsDir);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRule.java
@@ -17,7 +17,6 @@ import io.github.adamw7.tools.enforcer.rule.MarkdownFormatRule;
 @Named("agentsMdFormat")
 public class AgentsMdFormatRule extends MarkdownFormatRule {
 
-	private static final String DOCUMENT_NAME = "AGENTS.md";
 	private static final List<String> REQUIRED_SECTIONS = List.of(
 			"## Project overview",
 			"## Module layout",
@@ -30,27 +29,16 @@ public class AgentsMdFormatRule extends MarkdownFormatRule {
 	/** The {@code AGENTS.md} file to validate. Injected from the rule configuration. */
 	private File agentsMdFile;
 
+	public AgentsMdFormatRule() {
+		super("AGENTS.md", REQUIRED_SECTIONS);
+	}
+
 	@Override
 	protected File documentFile() {
 		return agentsMdFile;
 	}
 
-	@Override
-	protected String documentName() {
-		return DOCUMENT_NAME;
-	}
-
-	@Override
-	protected List<String> defaultRequiredSections() {
-		return REQUIRED_SECTIONS;
-	}
-
 	void setAgentsMdFile(File agentsMdFile) {
 		this.agentsMdFile = agentsMdFile;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("AgentsMdFormatRule[agentsMdFile=%s]", agentsMdFile);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
@@ -17,7 +17,6 @@ import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
 @Named("claudeMdFormat")
 public class ClaudeMdFormatRule extends MarkdownFormatRule {
 
-	private static final String DOCUMENT_NAME = "CLAUDE.md";
 	private static final String AGENTS_REFERENCE = "AGENTS.md";
 	private static final List<String> REQUIRED_SECTIONS = List.of(
 			"## Project",
@@ -30,19 +29,13 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 	/** The {@code CLAUDE.md} file to validate. Injected from the rule configuration. */
 	private File claudeMdFile;
 
+	public ClaudeMdFormatRule() {
+		super("CLAUDE.md", REQUIRED_SECTIONS);
+	}
+
 	@Override
 	protected File documentFile() {
 		return claudeMdFile;
-	}
-
-	@Override
-	protected String documentName() {
-		return DOCUMENT_NAME;
-	}
-
-	@Override
-	protected List<String> defaultRequiredSections() {
-		return REQUIRED_SECTIONS;
 	}
 
 	@Override
@@ -54,10 +47,5 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 
 	void setClaudeMdFile(File claudeMdFile) {
 		this.claudeMdFile = claudeMdFile;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("ClaudeMdFormatRule[claudeMdFile=%s]", claudeMdFile);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
@@ -142,9 +142,4 @@ public class ContextBudgetRule extends ClaudeCodeEnforcerRule {
 	void setMaxTokens(int maxTokens) {
 		this.maxTokens = maxTokens;
 	}
-
-	@Override
-	public String toString() {
-		return String.format("ContextBudgetRule[files=%s, directories=%s]", files, directories);
-	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRule.java
@@ -52,9 +52,4 @@ public class CrossDocConsistencyRule extends ClaudeCodeEnforcerRule {
 	void setConsistentPatterns(List<String> consistentPatterns) {
 		this.consistentPatterns = consistentPatterns;
 	}
-
-	@Override
-	public String toString() {
-		return String.format("CrossDocConsistencyRule[claudeMdFile=%s, agentsMdFile=%s]", claudeMdFile, agentsMdFile);
-	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -119,9 +119,4 @@ public class MemoryImportsRule extends ClaudeCodeEnforcerRule {
 	void setIgnoredImports(List<String> ignoredImports) {
 		this.ignoredImports = ignoredImports;
 	}
-
-	@Override
-	public String toString() {
-		return String.format("MemoryImportsRule[claudeMdFile=%s]", claudeMdFile);
-	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRule.java
@@ -138,9 +138,4 @@ public class ModuleMapConsistencyRule extends ClaudeCodeEnforcerRule {
 	void setIgnoredModules(List<String> ignoredModules) {
 		this.ignoredModules = ignoredModules;
 	}
-
-	@Override
-	public String toString() {
-		return String.format("ModuleMapConsistencyRule[pomFile=%s, docFiles=%s]", pomFile, docFiles);
-	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRule.java
@@ -52,9 +52,4 @@ public class ReadmeConsistencyRule extends ClaudeCodeEnforcerRule {
 	void setConsistentPatterns(List<String> consistentPatterns) {
 		this.consistentPatterns = consistentPatterns;
 	}
-
-	@Override
-	public String toString() {
-		return String.format("ReadmeConsistencyRule[readmeFile=%s, agentDocFile=%s]", readmeFile, agentDocFile);
-	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
@@ -51,19 +51,13 @@ public class McpConfigFormatRule extends JsonFileRule {
 	/** When true, a server {@code url} must use {@code https} rather than plain {@code http}. */
 	private boolean requireHttps;
 
+	public McpConfigFormatRule() {
+		super("mcpFile", "mcp.json");
+	}
+
 	@Override
 	protected File jsonFile() {
 		return mcpFile;
-	}
-
-	@Override
-	protected String fileParameter() {
-		return "mcpFile";
-	}
-
-	@Override
-	protected String description() {
-		return "mcp.json";
 	}
 
 	@Override
@@ -175,10 +169,5 @@ public class McpConfigFormatRule extends JsonFileRule {
 
 	void setRequireHttps(boolean requireHttps) {
 		this.requireHttps = requireHttps;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("McpConfigFormatRule[mcpFile=%s]", mcpFile);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.mcp;
 
 import java.io.File;
 import java.util.List;
+import java.util.Objects;
 
 import javax.inject.Named;
 
@@ -50,19 +51,13 @@ public class McpServersValidRule extends JsonFileRule {
 	/** Optional override for the allowed transport types. */
 	private List<String> allowedTypes;
 
+	public McpServersValidRule() {
+		super("mcpFile", "mcp.json");
+	}
+
 	@Override
 	protected File jsonFile() {
 		return mcpFile;
-	}
-
-	@Override
-	protected String fileParameter() {
-		return "mcpFile";
-	}
-
-	@Override
-	protected String description() {
-		return "mcp.json";
 	}
 
 	/** A project-level {@code .mcp.json} is optional in Claude Code, so an absent file is a pass. */
@@ -97,7 +92,7 @@ public class McpServersValidRule extends JsonFileRule {
 		String type = JsonNodes.textAt(server, TYPE_KEY, "").strip();
 		if (type.isBlank()) {
 			collectInferredTransportViolations(name, server, violations);
-		} else if (!allowedTypes().contains(type)) {
+		} else if (!Objects.requireNonNullElse(allowedTypes, DEFAULT_ALLOWED_TYPES).contains(type)) {
 			add(name, "has an unsupported type: " + type, violations);
 		} else if (type.equals(STDIO_TYPE)) {
 			collectCommandViolation(name, server, violations);
@@ -153,10 +148,6 @@ public class McpServersValidRule extends JsonFileRule {
 		}
 	}
 
-	private List<String> allowedTypes() {
-		return allowedTypes != null ? allowedTypes : DEFAULT_ALLOWED_TYPES;
-	}
-
 	void setMcpFile(File mcpFile) {
 		this.mcpFile = mcpFile;
 	}
@@ -171,10 +162,5 @@ public class McpServersValidRule extends JsonFileRule {
 
 	void setAllowedTypes(List<String> allowedTypes) {
 		this.allowedTypes = allowedTypes;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("McpServersValidRule[mcpFile=%s]", mcpFile);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -1,7 +1,11 @@
 package io.github.adamw7.tools.enforcer.rule;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
 import java.util.List;
+import java.util.StringJoiner;
 
 import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -185,6 +189,58 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 			throw new EnforcerRuleException(description + " is empty: " + file);
 		}
 		return content;
+	}
+
+	/**
+	 * Names the rule by the inputs it was configured with: every {@code File} or
+	 * {@code List<File>} parameter the concrete rule declares, from the most derived
+	 * class up, skipping the ones left unset and the shared reporting parameters
+	 * declared here. Maven identifies a rule in its log by this string, so what
+	 * matters is which files the failing configuration pointed at — deriving that
+	 * from the parameters themselves saves every rule repeating the same override.
+	 */
+	@Override
+	public final String toString() {
+		StringJoiner parameters = new StringJoiner(", ", getClass().getSimpleName() + "[", "]");
+		for (Class<?> type = getClass(); type != ClaudeCodeEnforcerRule.class; type = type.getSuperclass()) {
+			appendParameters(type, parameters);
+		}
+		return parameters.toString();
+	}
+
+	private void appendParameters(Class<?> type, StringJoiner parameters) {
+		for (Field field : type.getDeclaredFields()) {
+			appendParameter(field, parameters);
+		}
+	}
+
+	private void appendParameter(Field field, StringJoiner parameters) {
+		Object value = isFileParameter(field) ? valueOf(field) : null;
+		if (value != null) {
+			parameters.add(field.getName() + "=" + value);
+		}
+	}
+
+	private static boolean isFileParameter(Field field) {
+		return !field.isSynthetic() && !Modifier.isStatic(field.getModifiers())
+				&& (field.getType() == File.class || isFileList(field));
+	}
+
+	private static boolean isFileList(Field field) {
+		return field.getType() == List.class
+				&& field.getGenericType() instanceof ParameterizedType parameterized
+				&& parameterized.getActualTypeArguments()[0] == File.class;
+	}
+
+	/** Null when the field cannot be read, since a log label must never break a build. */
+	private Object valueOf(Field field) {
+		try {
+			field.setAccessible(true);
+			return field.get(this);
+		} catch (ReflectiveOperationException | RuntimeException e) {
+			getLog().debug("Could not read rule parameter " + field.getName() + ": " + e.getMessage());
+			return null;
+		}
 	}
 
 	public void setSeverity(String severity) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -16,25 +16,40 @@ import com.fasterxml.jackson.databind.JsonNode;
  * thrown, so it is reported through the shared {@link #report} path alongside any
  * structural problems.
  * <p>
- * Subclasses contribute the file, its parameter name, a human-readable description
- * used in messages, the report header, and the document-specific checks against
- * the parsed {@link JsonNode}. A misconfigured rule or a missing or empty file
- * always fails, because that is a build-setup mistake; a rule whose file is
- * optional overrides {@link #handleMissingFile} to pass instead.
+ * A subclass names its file parameter and the human-readable description used in
+ * messages at construction, and contributes the file itself, the report header,
+ * and the document-specific checks against the parsed {@link JsonNode}. A
+ * misconfigured rule or a missing or empty file always fails, because that is a
+ * build-setup mistake; a rule whose file is optional overrides
+ * {@link #handleMissingFile} to pass instead.
  */
 public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
+
+	private final String fileParameter;
+	private final String description;
+
+	/**
+	 * @param fileParameter the configuration parameter name, used in the "not
+	 *                      configured" message, e.g. {@code settingsFile}
+	 * @param description   human-readable file name used in messages, e.g.
+	 *                      {@code settings.json}
+	 */
+	protected JsonFileRule(String fileParameter, String description) {
+		this.fileParameter = fileParameter;
+		this.description = description;
+	}
 
 	@Override
 	public final void execute() throws EnforcerRuleException {
 		File file = jsonFile();
-		requireConfigured(file, fileParameter());
+		requireConfigured(file, fileParameter);
 		if (!file.isFile()) {
 			handleMissingFile(file);
 			report(header(), List.of());
 			return;
 		}
 		List<String> violations = new ArrayList<>();
-		JsonNode root = JsonNodes.parseObject(requireContent(file, description()), description(), violations);
+		JsonNode root = JsonNodes.parseObject(requireContent(file, description), description, violations);
 		if (root != null) {
 			collectViolations(root, violations);
 		}
@@ -43,12 +58,6 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 
 	/** The JSON file to validate. Injected from the rule configuration. */
 	protected abstract File jsonFile();
-
-	/** The configuration parameter name, used in the "not configured" message, e.g. {@code settingsFile}. */
-	protected abstract String fileParameter();
-
-	/** Human-readable file name used in messages, e.g. {@code settings.json}. */
-	protected abstract String description();
 
 	/** Document-specific checks against the parsed JSON. */
 	protected abstract void collectViolations(JsonNode root, List<String> violations);
@@ -59,15 +68,15 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 	 * {@code settings.json permissions are not well formed:}.
 	 */
 	protected String header() {
-		return description() + " is not well formed:";
+		return description + " is not well formed:";
 	}
 
 	@Override
 	protected List<String> howToFix() {
 		return List.of(
-				"Open " + description() + " and confirm it parses as valid JSON.",
+				"Open " + description + " and confirm it parses as valid JSON.",
 				"Correct every structural item listed above so it matches what the rule expects.",
-				"Re-run the build to confirm " + description() + " is well formed.");
+				"Re-run the build to confirm " + description + " is well formed.");
 	}
 
 	/**
@@ -78,6 +87,6 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 	 * one's failure.
 	 */
 	protected void handleMissingFile(File file) throws EnforcerRuleException {
-		requireExists(file, description());
+		requireExists(file, description);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.rule;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -36,6 +37,9 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	private static final Pattern MARKDOWN_LINK = Pattern.compile("\\[[^\\]]*\\]\\(([^)]+)\\)");
 	private static final Pattern EXTERNAL_REFERENCE = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+.-]*:.*");
 
+	private final String documentName;
+	private final List<String> defaultRequiredSections;
+
 	/** Optional override for the title heading. Falls back to the subclass default. */
 	private String titleHeading;
 
@@ -57,6 +61,17 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	/** Base directory for resolving relative file references. Defaults to the document's directory. */
 	private File referenceBaseDir;
 
+	/**
+	 * @param documentName            human-readable file name used in messages, e.g.
+	 *                                {@code CLAUDE.md}
+	 * @param defaultRequiredSections the section headings the document must contain
+	 *                                unless the configuration overrides them
+	 */
+	protected MarkdownFormatRule(String documentName, List<String> defaultRequiredSections) {
+		this.documentName = documentName;
+		this.defaultRequiredSections = defaultRequiredSections;
+	}
+
 	@Override
 	public void execute() throws EnforcerRuleException {
 		MarkdownDocument document = readDocument();
@@ -75,10 +90,9 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	protected abstract File documentFile();
 
 	/** Human-readable file name used in messages, e.g. {@code CLAUDE.md}. */
-	protected abstract String documentName();
-
-	/** The default section headings the document must contain. */
-	protected abstract List<String> defaultRequiredSections();
+	protected final String documentName() {
+		return documentName;
+	}
 
 	/**
 	 * The default title heading the document must start with. A document is titled
@@ -86,7 +100,7 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	 * document titled otherwise overrides this.
 	 */
 	protected String defaultTitleHeading() {
-		return "# " + documentName();
+		return "# " + documentName;
 	}
 
 	/** Hook for document-specific checks. The default implementation does nothing. */
@@ -103,11 +117,11 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	final String titleHeading() {
-		return titleHeading != null ? titleHeading : defaultTitleHeading();
+		return Objects.requireNonNullElseGet(titleHeading, this::defaultTitleHeading);
 	}
 
 	final List<String> requiredSections() {
-		return requiredSections != null ? requiredSections : defaultRequiredSections();
+		return Objects.requireNonNullElse(requiredSections, defaultRequiredSections);
 	}
 
 	public void setTitleHeading(String titleHeading) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
@@ -148,9 +148,4 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 	void setUseDefaultPatterns(boolean useDefaultPatterns) {
 		this.useDefaultPatterns = useDefaultPatterns;
 	}
-
-	@Override
-	public String toString() {
-		return String.format("NoSecretsRule[files=%s, directories=%s]", files, directories);
-	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
@@ -1,10 +1,12 @@
 package io.github.adamw7.tools.enforcer.settings;
 
 import java.io.File;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Resolves the base directory that a hook command's {@code $CLAUDE_PROJECT_DIR}
- * variable expands to, and performs that expansion on a single command token.
+ * variable expands to, and performs that expansion on the tokens of a command.
  * Both hook rules share this so the two accepted spellings of the variable and
  * the "grandparent of the settings file" fallback live in exactly one place.
  */
@@ -19,6 +21,16 @@ final class ClaudeProjectDir {
 	ClaudeProjectDir(File override, File settingsFile) {
 		this.override = override;
 		this.settingsFile = settingsFile;
+	}
+
+	/**
+	 * The paths every {@code $CLAUDE_PROJECT_DIR}-rooted token of {@code command}
+	 * resolves to. A command chains more than one script often enough — an
+	 * {@code &&} between two hooks — that stopping at the first reference would
+	 * leave the rest unchecked.
+	 */
+	List<String> expandAll(String command) {
+		return CommandTokens.of(command).stream().map(this::expand).filter(Objects::nonNull).toList();
 	}
 
 	/** The path {@code token} resolves to when it references the project dir, else null. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -2,7 +2,6 @@ package io.github.adamw7.tools.enforcer.settings;
 
 import java.io.File;
 import java.util.List;
-import java.util.Objects;
 
 import javax.inject.Named;
 
@@ -48,19 +47,13 @@ public class HookCommandsValidRule extends JsonFileRule {
 	/** When true (default), a {@code $CLAUDE_PROJECT_DIR} script reference must resolve to an existing file. */
 	private boolean validateScriptReferences = true;
 
+	public HookCommandsValidRule() {
+		super("settingsFile", "settings.json");
+	}
+
 	@Override
 	protected File jsonFile() {
 		return settingsFile;
-	}
-
-	@Override
-	protected String fileParameter() {
-		return "settingsFile";
-	}
-
-	@Override
-	protected String description() {
-		return "settings.json";
 	}
 
 	@Override
@@ -148,18 +141,12 @@ public class HookCommandsValidRule extends JsonFileRule {
 		violations.add("hook event '" + event + "' " + problem);
 	}
 
-	/**
-	 * The resolved on-disk paths of every {@code $CLAUDE_PROJECT_DIR}-rooted token
-	 * in the command. A command chains more than one script often enough — an
-	 * {@code &&} between two hooks — that stopping at the first reference would
-	 * leave the rest unchecked.
-	 */
+	/** The resolved on-disk paths the command's {@code $CLAUDE_PROJECT_DIR} tokens point at. */
 	private List<String> localScriptPaths(String command) {
 		if (!validateScriptReferences) {
 			return List.of();
 		}
-		ClaudeProjectDir projectDirs = new ClaudeProjectDir(projectDir, settingsFile);
-		return CommandTokens.of(command).stream().map(projectDirs::expand).filter(Objects::nonNull).toList();
+		return new ClaudeProjectDir(projectDir, settingsFile).expandAll(command);
 	}
 
 	void setSettingsFile(File settingsFile) {
@@ -176,10 +163,5 @@ public class HookCommandsValidRule extends JsonFileRule {
 
 	void setValidateScriptReferences(boolean validateScriptReferences) {
 		this.validateScriptReferences = validateScriptReferences;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("HookCommandsValidRule[settingsFile=%s]", settingsFile);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -181,27 +180,16 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	/**
-	 * The absolute paths every {@code $CLAUDE_PROJECT_DIR} token of a command
-	 * resolves to that land inside the hooks directory. A command chaining two
-	 * scripts references both, so stopping at the first would leave the second
-	 * unchecked and then report it as an orphan.
+	 * The absolute paths a command's {@code $CLAUDE_PROJECT_DIR} tokens resolve to
+	 * that land inside the hooks directory. A path outside it belongs to another
+	 * rule's concern, so it is dropped rather than reported here.
 	 */
 	private List<Path> scriptsInHooksDir(String command) {
 		Path hooks = canonical(hooksDir.toPath());
-		ClaudeProjectDir projectDirs = new ClaudeProjectDir(projectDir, settingsFile);
-		return CommandTokens.of(command).stream()
-				.map(token -> resolveInHooks(projectDirs, token, hooks))
-				.filter(Objects::nonNull)
+		return new ClaudeProjectDir(projectDir, settingsFile).expandAll(command).stream()
+				.map(expanded -> canonical(new File(expanded).toPath()))
+				.filter(resolved -> resolved.startsWith(hooks))
 				.toList();
-	}
-
-	private Path resolveInHooks(ClaudeProjectDir projectDirs, String token, Path hooks) {
-		String expanded = projectDirs.expand(token);
-		if (expanded == null) {
-			return null;
-		}
-		Path resolved = canonical(new File(expanded).toPath());
-		return resolved.startsWith(hooks) ? resolved : null;
 	}
 
 	/**
@@ -257,10 +245,5 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 
 	void setReportUnreferencedScripts(boolean reportUnreferencedScripts) {
 		this.reportUnreferencedScripts = reportUnreferencedScripts;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("HooksFormatRule[hooksDir=%s]", hooksDir);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRule.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.settings;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.inject.Named;
 
@@ -42,7 +43,7 @@ public class LocalSettingsIgnoredRule extends ClaudeCodeEnforcerRule {
 		requireExists(gitignoreFile, ".gitignore");
 		Gitignore gitignore = Gitignore.parse(MarkdownText.read(gitignoreFile, ".gitignore"));
 		List<String> violations = new ArrayList<>();
-		for (String path : ignoredPaths()) {
+		for (String path : Objects.requireNonNullElse(ignoredPaths, DEFAULT_IGNORED_PATHS)) {
 			collectUncoveredPath(gitignore, path, violations);
 		}
 		report("Local settings are not ignored:", violations);
@@ -71,20 +72,11 @@ public class LocalSettingsIgnoredRule extends ClaudeCodeEnforcerRule {
 		return withoutDot.startsWith("/") ? withoutDot.substring(1) : withoutDot;
 	}
 
-	private List<String> ignoredPaths() {
-		return ignoredPaths != null ? ignoredPaths : DEFAULT_IGNORED_PATHS;
-	}
-
 	void setGitignoreFile(File gitignoreFile) {
 		this.gitignoreFile = gitignoreFile;
 	}
 
 	void setIgnoredPaths(List<String> ignoredPaths) {
 		this.ignoredPaths = ignoredPaths;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("LocalSettingsIgnoredRule[gitignoreFile=%s]", gitignoreFile);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
@@ -59,19 +59,13 @@ public class PermissionsFormatRule extends JsonFileRule {
 	/** Optional regular expressions no {@code allow} entry may match, e.g. {@code Bash\(\*\)}. */
 	private List<String> forbiddenEntryPatterns;
 
+	public PermissionsFormatRule() {
+		super("settingsFile", "settings.json");
+	}
+
 	@Override
 	protected File jsonFile() {
 		return settingsFile;
-	}
-
-	@Override
-	protected String fileParameter() {
-		return "settingsFile";
-	}
-
-	@Override
-	protected String description() {
-		return "settings.json";
 	}
 
 	@Override
@@ -209,10 +203,5 @@ public class PermissionsFormatRule extends JsonFileRule {
 
 	void setForbiddenEntryPatterns(List<String> forbiddenEntryPatterns) {
 		this.forbiddenEntryPatterns = forbiddenEntryPatterns;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("PermissionsFormatRule[settingsFile=%s]", settingsFile);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
@@ -37,19 +37,13 @@ public class SettingsJsonValidRule extends JsonFileRule {
 	/** Permission entries that must not appear in {@code permissions.allow}. */
 	private List<String> forbiddenPermissions;
 
+	public SettingsJsonValidRule() {
+		super("settingsFile", "settings.json");
+	}
+
 	@Override
 	protected File jsonFile() {
 		return settingsFile;
-	}
-
-	@Override
-	protected String fileParameter() {
-		return "settingsFile";
-	}
-
-	@Override
-	protected String description() {
-		return "settings.json";
 	}
 
 	@Override
@@ -100,10 +94,5 @@ public class SettingsJsonValidRule extends JsonFileRule {
 
 	void setForbiddenPermissions(List<String> forbiddenPermissions) {
 		this.forbiddenPermissions = forbiddenPermissions;
-	}
-
-	@Override
-	public String toString() {
-		return String.format("SettingsJsonValidRule[settingsFile=%s]", settingsFile);
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
@@ -1,12 +1,12 @@
 package io.github.adamw7.tools.enforcer.definition;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -182,29 +182,5 @@ class CommandFormatRuleTest {
 		CommandFormatRule rule = new CommandFormatRule();
 		rule.setCommandsDir(commandsDir.toFile());
 		return rule;
-	}
-
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
-
-	private static String readString(Path file) {
-		try {
-			return Files.readString(file);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read " + file, e);
-		}
-	}
-
-	private static void createDirectory(Path dir) {
-		try {
-			Files.createDirectory(dir);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not create " + dir, e);
-		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/DefinitionFilesTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/DefinitionFilesTest.java
@@ -1,5 +1,7 @@
 package io.github.adamw7.tools.enforcer.definition;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -7,9 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -40,7 +39,7 @@ class DefinitionFilesTest {
 
 	@Test
 	void verifyDirectoryFailsWhenPathIsAFileRatherThanADirectory() {
-		File file = writeString(tempDir.resolve("review.md"), "body");
+		File file = writeString(tempDir.resolve("review.md"), "body").toFile();
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
 				() -> DefinitionFiles.verifyDirectory(file, "Skills"));
@@ -81,7 +80,7 @@ class DefinitionFilesTest {
 
 	@Test
 	void markdownFilesReturnsEmptyArrayWhenPathIsNotAListableDirectory() {
-		File file = writeString(tempDir.resolve("review.md"), "body");
+		File file = writeString(tempDir.resolve("review.md"), "body").toFile();
 
 		assertArrayEquals(new File[0], DefinitionFiles.markdownFiles(file));
 	}
@@ -112,7 +111,7 @@ class DefinitionFilesTest {
 
 	@Test
 	void subdirectoriesReturnsEmptyArrayWhenPathIsNotAListableDirectory() {
-		File file = writeString(tempDir.resolve("review.md"), "body");
+		File file = writeString(tempDir.resolve("review.md"), "body").toFile();
 
 		assertArrayEquals(new File[0], DefinitionFiles.subdirectories(file));
 	}
@@ -134,21 +133,5 @@ class DefinitionFilesTest {
 	/** Names in the array's own order, so a test can assert the helper's sorting rather than re-sort it. */
 	private static String[] names(File[] files) {
 		return Arrays.stream(files).map(File::getName).toArray(String[]::new);
-	}
-
-	private static File writeString(Path file, String content) {
-		try {
-			return Files.writeString(file, content).toFile();
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
-
-	private static void createDirectory(Path dir) {
-		try {
-			Files.createDirectory(dir);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not create " + dir, e);
-		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRuleTest.java
@@ -1,12 +1,10 @@
 package io.github.adamw7.tools.enforcer.definition;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -116,11 +114,4 @@ class PluginFormatRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
@@ -1,12 +1,12 @@
 package io.github.adamw7.tools.enforcer.definition;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -235,29 +235,5 @@ class SkillFilesExistRuleTest {
 		SkillFilesExistRule rule = new SkillFilesExistRule();
 		rule.setSkillsDir(skillsDir.toFile());
 		return rule;
-	}
-
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
-
-	private static String readString(Path file) {
-		try {
-			return Files.readString(file);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read " + file, e);
-		}
-	}
-
-	private static Path createDirectory(Path dir) {
-		try {
-			return Files.createDirectory(dir);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not create " + dir, e);
-		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
@@ -1,12 +1,12 @@
 package io.github.adamw7.tools.enforcer.definition;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -184,29 +184,5 @@ class SubAgentFormatRuleTest {
 		SubAgentFormatRule rule = new SubAgentFormatRule();
 		rule.setAgentsDir(agentsDir.toFile());
 		return rule;
-	}
-
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
-
-	private static String readString(Path file) {
-		try {
-			return Files.readString(file);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read " + file, e);
-		}
-	}
-
-	private static void createDirectory(Path dir) {
-		try {
-			Files.createDirectory(dir);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not create " + dir, e);
-		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
@@ -1,12 +1,11 @@
 package io.github.adamw7.tools.enforcer.definition;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -138,27 +137,10 @@ class UniqueDescriptionsRuleTest {
 	}
 
 	private Path agentsDir() {
-		return createDirectories(tempDir.resolve("agents"));
+		return createDirectory(tempDir.resolve("agents"));
 	}
 
 	private Path skillsDir() {
-		return createDirectories(tempDir.resolve("skills"));
-	}
-
-	private void writeString(Path file, String content) {
-		try {
-			Files.createDirectories(file.getParent());
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
-
-	private static Path createDirectories(Path dir) {
-		try {
-			return Files.createDirectories(dir);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not create " + dir, e);
-		}
+		return createDirectory(tempDir.resolve("skills"));
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRuleTest.java
@@ -1,12 +1,11 @@
 package io.github.adamw7.tools.enforcer.definition;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -22,9 +21,9 @@ class UniqueNamesRuleTest {
 
 	@Test
 	void passesWhenEveryNameIsUnique() {
-		Path commands = createDir("commands");
-		Path agents = createDir("agents");
-		Path skills = createDir("skills");
+		Path commands = createDirectory(tempDir.resolve("commands"));
+		Path agents = createDirectory(tempDir.resolve("agents"));
+		Path skills = createDirectory(tempDir.resolve("skills"));
 		writeMarkdown(commands.resolve("commit.md"));
 		writeMarkdown(agents.resolve("reviewer.md"));
 		createSkill(skills, "planner");
@@ -34,16 +33,16 @@ class UniqueNamesRuleTest {
 
 	@Test
 	void passesWhenNoDefinitionsExist() {
-		Path commands = createDir("commands");
-		Path agents = createDir("agents");
-		Path skills = createDir("skills");
+		Path commands = createDirectory(tempDir.resolve("commands"));
+		Path agents = createDirectory(tempDir.resolve("agents"));
+		Path skills = createDirectory(tempDir.resolve("skills"));
 
 		assertDoesNotThrow(ruleFor(commands, agents, skills)::execute);
 	}
 
 	@Test
 	void passesWhenOnlyOneDirectoryIsConfigured() {
-		Path skills = createDir("skills");
+		Path skills = createDirectory(tempDir.resolve("skills"));
 		createSkill(skills, "commit");
 		createSkill(skills, "review");
 
@@ -55,7 +54,7 @@ class UniqueNamesRuleTest {
 
 	@Test
 	void ignoresNonMarkdownFiles() {
-		Path commands = createDir("commands");
+		Path commands = createDirectory(tempDir.resolve("commands"));
 		writeString(commands.resolve("notes.txt"), "not a command");
 
 		UniqueNamesRule rule = new UniqueNamesRule();
@@ -66,8 +65,8 @@ class UniqueNamesRuleTest {
 
 	@Test
 	void ignoresSubdirectoriesNamedLikeMarkdownInTheCommandsDirectory() {
-		Path commands = createDir("commands");
-		createDir("commands/review.md");
+		Path commands = createDirectory(tempDir.resolve("commands"));
+		createDirectory(tempDir.resolve("commands/review.md"));
 		writeMarkdown(commands.resolve("review.md/inner.md"));
 
 		UniqueNamesRule rule = new UniqueNamesRule();
@@ -93,8 +92,8 @@ class UniqueNamesRuleTest {
 
 	@Test
 	void failsWhenACommandAndASubAgentShareAName() {
-		Path commands = createDir("commands");
-		Path agents = createDir("agents");
+		Path commands = createDirectory(tempDir.resolve("commands"));
+		Path agents = createDirectory(tempDir.resolve("agents"));
 		writeMarkdown(commands.resolve("review.md"));
 		writeMarkdown(agents.resolve("review.md"));
 
@@ -111,8 +110,8 @@ class UniqueNamesRuleTest {
 
 	@Test
 	void failsWhenASubAgentAndASkillShareAName() {
-		Path agents = createDir("agents");
-		Path skills = createDir("skills");
+		Path agents = createDirectory(tempDir.resolve("agents"));
+		Path skills = createDirectory(tempDir.resolve("skills"));
 		writeMarkdown(agents.resolve("commit.md"));
 		createSkill(skills, "commit");
 
@@ -126,8 +125,8 @@ class UniqueNamesRuleTest {
 
 	@Test
 	void downgradesClashToAWarningWhenSeverityIsWarn() {
-		Path commands = createDir("commands");
-		Path agents = createDir("agents");
+		Path commands = createDirectory(tempDir.resolve("commands"));
+		Path agents = createDirectory(tempDir.resolve("agents"));
 		writeMarkdown(commands.resolve("review.md"));
 		writeMarkdown(agents.resolve("review.md"));
 
@@ -151,33 +150,12 @@ class UniqueNamesRuleTest {
 		return rule;
 	}
 
-	private Path createDir(String name) {
-		try {
-			return Files.createDirectories(tempDir.resolve(name));
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not create " + name, e);
-		}
-	}
-
 	private void createSkill(Path skillsDir, String name) {
-		Path skill = skillsDir.resolve(name);
-		try {
-			Files.createDirectories(skill);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not create skill " + name, e);
-		}
-		writeString(skill.resolve("SKILL.md"), "# " + name);
+		writeString(createDirectory(skillsDir.resolve(name)).resolve("SKILL.md"), "# " + name);
 	}
 
 	private void writeMarkdown(Path file) {
 		writeString(file, "# " + file.getFileName());
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRuleTest.java
@@ -1,13 +1,10 @@
 package io.github.adamw7.tools.enforcer.doc;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -133,11 +130,4 @@ class AgentsMdFormatRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -1,13 +1,10 @@
 package io.github.adamw7.tools.enforcer.doc;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -380,11 +377,4 @@ class ClaudeMdFormatRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
@@ -1,5 +1,7 @@
 package io.github.adamw7.tools.enforcer.doc;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -7,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -190,23 +191,5 @@ class ContextBudgetRuleTest {
 		ContextBudgetRule rule = new ContextBudgetRule();
 		rule.setFiles(List.of(file.toFile()));
 		return rule;
-	}
-
-	private static void writeString(Path file, String content) {
-		try {
-			Files.createDirectories(file.getParent());
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
-
-	private static void writeBytes(Path file, byte[] content) {
-		try {
-			Files.createDirectories(file.getParent());
-			Files.write(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
@@ -1,12 +1,10 @@
 package io.github.adamw7.tools.enforcer.doc;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -112,11 +110,4 @@ class CrossDocConsistencyRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
@@ -1,12 +1,12 @@
 package io.github.adamw7.tools.enforcer.doc;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -233,13 +233,6 @@ class ImportGraphTest {
 	}
 
 	private File write(String name, String content) {
-		Path file = tempDir.resolve(name);
-		try {
-			Files.createDirectories(file.getParent());
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-		return file.toFile();
+		return writeString(tempDir.resolve(name), content).toFile();
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
@@ -1,11 +1,11 @@
 package io.github.adamw7.tools.enforcer.doc;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -209,12 +209,4 @@ class MemoryImportsRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.createDirectories(file.getParent());
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRuleTest.java
@@ -1,12 +1,12 @@
 package io.github.adamw7.tools.enforcer.doc;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -145,12 +145,6 @@ class ModuleMapConsistencyRuleTest {
 	}
 
 	private Path write(String name, String content) {
-		Path file = tempDir.resolve(name);
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-		return file;
+		return writeString(tempDir.resolve(name), content);
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRuleTest.java
@@ -1,12 +1,10 @@
 package io.github.adamw7.tools.enforcer.doc;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -129,11 +127,4 @@ class ReadmeConsistencyRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
@@ -1,12 +1,10 @@
 package io.github.adamw7.tools.enforcer.mcp;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -210,11 +208,4 @@ class McpConfigFormatRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRuleTest.java
@@ -1,12 +1,10 @@
 package io.github.adamw7.tools.enforcer.mcp;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -159,11 +157,4 @@ class McpServersValidRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/BaselineTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/BaselineTest.java
@@ -1,14 +1,12 @@
 package io.github.adamw7.tools.enforcer.rule;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -156,19 +154,7 @@ class BaselineTest {
 	}
 
 	private File writeString(String content) {
-		Path file = tempDir.resolve("baseline.txt");
-		try {
-			return Files.writeString(file, content).toFile();
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
+		return TestFiles.writeString(tempDir.resolve("baseline.txt"), content).toFile();
 	}
 
-	private static String readString(File file) {
-		try {
-			return Files.readString(file.toPath());
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.enforcer.rule;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -10,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -153,14 +153,6 @@ class JsonFileRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
-
 	/**
 	 * Minimal concrete rule that records what the base class hands to
 	 * {@link #collectViolations} so the shared scaffolding can be asserted in
@@ -172,6 +164,10 @@ class JsonFileRuleTest {
 		private boolean optional;
 		private final List<String> injectedViolations = new ArrayList<>();
 		private JsonNode parsedRoot;
+
+		TestJsonRule() {
+			super("testFile", "test.json");
+		}
 
 		void setFile(File file) {
 			this.file = file;
@@ -188,16 +184,6 @@ class JsonFileRuleTest {
 		@Override
 		protected File jsonFile() {
 			return file;
-		}
-
-		@Override
-		protected String fileParameter() {
-			return "testFile";
-		}
-
-		@Override
-		protected String description() {
-			return "test.json";
 		}
 
 		@Override

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/TestFiles.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/TestFiles.java
@@ -1,0 +1,82 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * The file-system fixtures every rule test builds: nearly all of them lay out a
+ * temporary directory of documents and then assert on what a rule says about it.
+ * Each operation wraps its {@link IOException} in an {@link UncheckedIOException}
+ * so a fixture can be written inline, without a {@code throws} clause on the test
+ * method or a {@code try} block that has nothing to do with what is being
+ * asserted.
+ * <p>
+ * A failure here is a broken fixture, never the behaviour under test, which is
+ * why it is thrown unchecked rather than reported: the test that follows would
+ * have nothing meaningful to assert.
+ */
+public final class TestFiles {
+
+	private TestFiles() {
+	}
+
+	/** Writes {@code content} to {@code file}, creating its parent directories first. */
+	public static Path writeString(Path file, String content) {
+		try {
+			Files.createDirectories(file.getParent());
+			return Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	/** Writes raw bytes, for a fixture that must not be decodable as text. */
+	public static Path writeBytes(Path file, byte[] content) {
+		try {
+			Files.createDirectories(file.getParent());
+			return Files.write(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	public static String readString(Path file) {
+		try {
+			return Files.readString(file);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read " + file, e);
+		}
+	}
+
+	public static String readString(File file) {
+		return readString(file.toPath());
+	}
+
+	/** Creates {@code dir} and any missing parent, and returns it so a fixture reads as one expression. */
+	public static Path createDirectory(Path dir) {
+		try {
+			return Files.createDirectories(dir);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create " + dir, e);
+		}
+	}
+
+	/**
+	 * Links {@code link} to {@code target}, or skips the calling test where the
+	 * filesystem has no symbolic links — Windows without developer mode. Unlike the
+	 * other fixtures this one aborts rather than fails, because a filesystem that
+	 * cannot express the fixture says nothing about the rule under test.
+	 */
+	public static void assumeSymlink(Path link, Path target) {
+		try {
+			Files.createSymbolicLink(link, target);
+		} catch (IOException | UnsupportedOperationException e) {
+			assumeTrue(false, "filesystem does not support symbolic links");
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRuleTest.java
@@ -1,13 +1,11 @@
 package io.github.adamw7.tools.enforcer.secret;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -115,12 +113,4 @@ class NoSecretsRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.createDirectories(file.getParent());
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -1,12 +1,10 @@
 package io.github.adamw7.tools.enforcer.settings;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -273,11 +271,4 @@ class HookCommandsValidRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -1,5 +1,8 @@
 package io.github.adamw7.tools.enforcer.settings;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.assumeSymlink;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -8,10 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.FileSystems;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+import io.github.adamw7.tools.enforcer.rule.TestFiles;
 
 class HooksFormatRuleTest {
 
@@ -292,12 +293,7 @@ class HooksFormatRuleTest {
 	}
 
 	private void writeBytes(String name, byte[] content) {
-		Path file = hooksDir().resolve(name);
-		try {
-			Files.write(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
+		TestFiles.writeBytes(hooksDir().resolve(name), content);
 	}
 
 	private File settingsReferencing(String command) {
@@ -310,7 +306,7 @@ class HooksFormatRuleTest {
 
 	private Path hooksDir() {
 		Path dir = tempDir.resolve(".claude").resolve("hooks");
-		createDirectories(dir);
+		createDirectory(dir);
 		return dir;
 	}
 
@@ -332,30 +328,5 @@ class HooksFormatRuleTest {
 
 	private boolean supportsExecutableBit() {
 		return FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
-	}
-
-	private void assumeSymlink(Path link, Path target) {
-		try {
-			Files.createSymbolicLink(link, target);
-		} catch (IOException | UnsupportedOperationException e) {
-			assumeTrue(false, "filesystem does not support symbolic links");
-		}
-	}
-
-	private void writeString(Path file, String content) {
-		try {
-			Files.createDirectories(file.getParent());
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
-
-	private static void createDirectories(Path dir) {
-		try {
-			Files.createDirectories(dir);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not create " + dir, e);
-		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRuleTest.java
@@ -1,12 +1,10 @@
 package io.github.adamw7.tools.enforcer.settings;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -82,11 +80,4 @@ class LocalSettingsIgnoredRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRuleTest.java
@@ -1,12 +1,10 @@
 package io.github.adamw7.tools.enforcer.settings;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -158,11 +156,4 @@ class PermissionsFormatRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRuleTest.java
@@ -1,12 +1,10 @@
 package io.github.adamw7.tools.enforcer.settings;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -95,11 +93,4 @@ class SettingsJsonValidRuleTest {
 		return rule;
 	}
 
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownTextTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownTextTest.java
@@ -1,14 +1,14 @@
 package io.github.adamw7.tools.enforcer.text;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.assumeSymlink;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
@@ -109,29 +109,5 @@ class MarkdownTextTest {
 		UncheckedIOException exception = assertThrows(UncheckedIOException.class,
 				() -> MarkdownText.read(missing.toFile(), "absent.md"));
 		assertTrue(exception.getMessage().contains("absent.md"), exception.getMessage());
-	}
-
-	private static void writeString(Path file, String content) {
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-	}
-
-	private static String readString(Path file) {
-		try {
-			return Files.readString(file);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read " + file, e);
-		}
-	}
-
-	private static void assumeSymlink(Path link, Path target) {
-		try {
-			Files.createSymbolicLink(link, target);
-		} catch (IOException | UnsupportedOperationException e) {
-			assumeTrue(false, "filesystem does not support symbolic links");
-		}
 	}
 }


### PR DESCRIPTION
Every rule repeated the same four hand-written pieces. Derive them once
instead:

- toString is now final on ClaudeCodeEnforcerRule and built from the File
  parameters a rule declares, replacing 20 identical overrides.
- JsonFileRule and MarkdownFormatRule take the file parameter name, the
  description, and the required sections at construction, so a subclass
  states them once rather than as two or three overrides.
- Single-use "configured value or default" accessors become
  Objects.requireNonNullElse at their one call site.
- Both hook rules share ClaudeProjectDir.expandAll for $CLAUDE_PROJECT_DIR
  token expansion.
- The 36 copies of the same try/catch fixture writers across the test suite
  move to a shared TestFiles helper.

Behaviour is unchanged: all 504 tests pass and the two-phase doc check
still passes on this repository's own files.