### PR TITLE
fix(adopt): correct five defects in the conform, clone, CLI and trust steps

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -127,7 +127,7 @@ public final class CliArguments {
 			case "--label" -> consumeValue(args, index, labels::add);
 			case "--assignee" -> consumeValue(args, index, assignees::add);
 			case "--rule-version" -> consumeValue(args, index, value -> ruleVersion = optionalText(value));
-			case "--report" -> consumeValue(args, index, value -> reportFile = Path.of(value));
+			case "--report" -> consumeValue(args, index, value -> reportFile = optionalPath(value));
 			case "--draft" -> {
 				draft = true;
 				yield index + 1;
@@ -150,10 +150,11 @@ public final class CliArguments {
 
 	/**
 	 * A blank workspace or branch positional counts as not supplied — the rule
-	 * {@link Text} defines for every optional input — so it falls back to its
-	 * default rather than resolving the empty path or being rejected as an invalid
-	 * branch. A blank repository positional is dropped the same way, leaving the run
-	 * with whatever the {@code --repo} and {@code --repos} flags named.
+	 * {@link Text} defines for every optional input, and the one every optional flag
+	 * value follows too — so it falls back to its default rather than resolving the
+	 * empty path or being rejected as an invalid branch. A blank repository
+	 * positional is dropped the same way, leaving the run with whatever the
+	 * {@code --repo} and {@code --repos} flags named.
 	 */
 	private void consumePositional(String argument) {
 		switch (positionals) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
@@ -54,10 +54,17 @@ public class ClaudeMdConformanceStep implements AdoptionStep {
 		conformClaudeMd(checkout);
 	}
 
+	/**
+	 * The reshaped text is put back on the file's own line terminators before it is
+	 * compared or written. {@link ClaudeMdConformer} works in LF throughout, so a
+	 * CRLF {@code CLAUDE.md} would otherwise come back with every one of its lines
+	 * changed — a whole-file diff in the adoption's first commit, and a file the
+	 * step no longer recognises as already conforming on a re-adoption.
+	 */
 	private void conformClaudeMd(Path checkout) {
 		Path claudeMd = checkout.resolve(CLAUDE_MD);
 		String original = read(claudeMd);
-		String conformed = conformer.conform(original);
+		String conformed = LineTerminators.matching(conformer.conform(original), original);
 		if (conformed.equals(original)) {
 			log.info("{} already satisfies the claudeMdFormat rule; left unchanged", CLAUDE_MD);
 		} else {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
@@ -61,9 +61,23 @@ public class ClaudeTrustStore {
 		return true;
 	}
 
+	/**
+	 * A field the document does not carry is created, and one that is already an
+	 * object is used as-is. A field carrying anything else is refused rather than
+	 * replaced, for the same reason {@link #asObjectOrFresh} refuses a non-object
+	 * document: writing over it would discard whatever it held, and this is Claude
+	 * Code's own per-user state rather than a file the adoption owns.
+	 */
 	private ObjectNode objectChild(ObjectNode parent, String name) {
 		JsonNode existing = parent.get(name);
-		return existing instanceof ObjectNode object ? object : parent.putObject(name);
+		if (existing == null || existing.isNull()) {
+			return parent.putObject(name);
+		}
+		if (existing instanceof ObjectNode object) {
+			return object;
+		}
+		throw new AdoptionException("Refusing to overwrite '" + name + "' in the Claude config;"
+				+ " expected a JSON object but found " + existing.getNodeType() + ": " + configFile);
 	}
 
 	private ObjectNode readRoot() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -39,8 +39,6 @@ public class CloneStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(CloneStep.class);
 
-	/** The remote a clone records, and the one {@link PushStep} publishes the branch to. */
-
 	@Override
 	public String name() {
 		return "clone";
@@ -76,12 +74,26 @@ public class CloneStep extends AbstractCommandStep {
 	 * directory the other repository left behind.
 	 */
 	private void requireCheckoutOfTheSameRepository(AdoptionContext context, CommandRunner runner) {
-		String origin = originUrl(context, runner);
-		if (!context.isSameRepository(origin)) {
+		String transcript = originTranscript(context, runner);
+		if (!namesThisRepository(context, transcript)) {
 			throw new AdoptionException(context.repositoryDirectory() + " already holds a checkout of "
-					+ Redaction.of(origin) + ", not of " + context.displayUrl()
+					+ Redaction.of(transcript.strip()) + ", not of " + context.displayUrl()
 					+ ". Adopt this repository into its own --workspace, or remove that directory first.");
 		}
+	}
+
+	/**
+	 * The transcript merges the command's standard error into its standard output, so
+	 * the {@code origin} URL is not reliably the whole of it: a git that warns —
+	 * about an unreadable system config, say — puts that line in there too, and
+	 * reading the transcript as one URL then failed a checkout that was the right one
+	 * all along, naming the warning as the repository it supposedly held. Every line
+	 * is therefore asked in turn, which keeps the conservative reading
+	 * {@link AdoptionContext#isSameRepository} is built on: noise names no repository,
+	 * so a transcript carrying nothing else still answers no.
+	 */
+	private boolean namesThisRepository(AdoptionContext context, String transcript) {
+		return transcript.lines().map(String::strip).anyMatch(context::isSameRepository);
 	}
 
 	/**
@@ -89,7 +101,7 @@ public class CloneStep extends AbstractCommandStep {
 	 * than adopted: it cannot be shown to be the repository under adoption, and
 	 * {@link PushStep} would have nowhere to publish the branch to anyway.
 	 */
-	private String originUrl(AdoptionContext context, CommandRunner runner) {
+	private String originTranscript(AdoptionContext context, CommandRunner runner) {
 		CommandResult result = runner.run(context.repositoryDirectory(),
 				List.of("git", "remote", "get-url", AdoptionContext.REMOTE));
 		if (!result.succeeded()) {
@@ -98,7 +110,7 @@ public class CloneStep extends AbstractCommandStep {
 					+ "' remote, so it can be neither confirmed to be " + context.displayUrl() + " nor pushed to it: "
 					+ Redaction.of(result.output().strip()));
 		}
-		return result.output().strip();
+		return result.output();
 	}
 
 	/**
@@ -113,8 +125,16 @@ public class CloneStep extends AbstractCommandStep {
 		runOrFail(runner, context.repositoryDirectory(), List.of("git", "fetch", AdoptionContext.REMOTE));
 	}
 
+	/**
+	 * A checkout is recognised by its {@code .git} whether that is the directory a
+	 * plain clone leaves or the file a linked worktree does. Insisting on the
+	 * directory read a worktree as uncloned and ran {@code git clone} into a
+	 * directory that was not empty, which git refuses — so the step aborted on a
+	 * checkout it was meant to reuse, and did so without ever confirming it held the
+	 * repository under adoption.
+	 */
 	private boolean alreadyCloned(AdoptionContext context) {
 		Path gitDirectory = context.repositoryDirectory().resolve(".git");
-		return Files.isDirectory(gitDirectory);
+		return Files.exists(gitDirectory);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/LineTerminators.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/LineTerminators.java
@@ -2,12 +2,14 @@ package io.github.adamw7.tools.adopt.step;
 
 /**
  * Keeps text the adoption writes into an existing file on the line terminator
- * that file already uses. Both installers that edit a project file — the POM
- * rewrite in {@link PomEnforcerInstaller} and the block
- * {@link GradleGuardInstaller} appends — produce LF text, so writing it into a
- * CRLF file would leave the new region with terminators mixed into an otherwise
- * CRLF file, or (for the POM, whose terminators XML parsing has already
- * normalised) flip every line of it to LF and reformat the whole file.
+ * that file already uses. Every place that edits a file in the checkout — the POM
+ * rewrite in {@link PomEnforcerInstaller}, the block
+ * {@link GradleGuardInstaller} appends, and the {@code CLAUDE.md}
+ * {@link ClaudeMdConformanceStep} reshapes — produces LF text, so writing it into
+ * a CRLF file would leave the new region with terminators mixed into an otherwise
+ * CRLF file, or (for the POM and the {@code CLAUDE.md}, whose terminators the
+ * reading has already normalised) flip every line of it to LF and reformat the
+ * whole file.
  */
 final class LineTerminators {
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -199,6 +199,23 @@ class CliArgumentsTest {
 		assertEquals(Path.of("/tmp/report.json"), cli.reportFile().orElseThrow());
 	}
 
+	/**
+	 * A blank value counts as not supplied for every other optional input, so a
+	 * blank {@code --report} must not leave the run writing a file named after
+	 * whitespace.
+	 */
+	@Test
+	void blankReportFileCountsAsNotSupplied() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--report", "  " });
+		assertTrue(cli.reportFile().isEmpty());
+	}
+
+	@Test
+	void stripsTheReportFileName() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--report", " /tmp/report.json " });
+		assertEquals(Path.of("/tmp/report.json"), cli.reportFile().orElseThrow());
+	}
+
 	@Test
 	void mixesFlagsAndPositionals() {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--draft", "/tmp/ws", "feature/x" });

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStepTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -64,6 +65,33 @@ class ClaudeMdConformanceStepTest {
 	void leavesAnAlreadyConformingClaudeMdByteIdentical(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		writeClaudeMd(context, "# CLAUDE.md\n\nSee AGENTS.md.\n");
+		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
+		String conformed = claudeMd(context);
+		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
+		assertEquals(conformed, claudeMd(context), "a conforming CLAUDE.md must be left untouched");
+	}
+
+	/**
+	 * The conformer works in LF throughout, so a CRLF {@code CLAUDE.md} came back
+	 * with every one of its lines changed — a whole-file diff in the adoption's
+	 * first commit, on a file the run only meant to add a heading to.
+	 */
+	@Test
+	void keepsACrlfClaudeMdOnCrlf(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		writeClaudeMd(context, "# CLAUDE.md\r\n\r\n## Project purpose\r\n\r\nA repo.\r\n");
+		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
+		String claudeMd = claudeMd(context);
+		assertTrue(claudeMd.contains("\r\n"), "the file's CRLF terminators must survive the reshape");
+		assertFalse(claudeMd.replace("\r\n", "").contains("\n"), "no line may be left on a bare LF");
+		assertTrue(claudeMd.contains("## Project\r\n"), "the reshape must still have run");
+	}
+
+	/** An already conforming CRLF file must be recognised as conforming, not rewritten. */
+	@Test
+	void leavesAnAlreadyConformingCrlfClaudeMdByteIdentical(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		writeClaudeMd(context, "# CLAUDE.md\r\n\r\nSee AGENTS.md.\r\n");
 		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
 		String conformed = claudeMd(context);
 		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStoreTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStoreTest.java
@@ -112,6 +112,33 @@ class ClaudeTrustStoreTest {
 	}
 
 	/**
+	 * The refusal has to reach inside the document too. A {@code projects} field
+	 * carrying something other than an object was quietly replaced with a fresh one,
+	 * discarding whatever it held — the very outcome the top-level check exists to
+	 * prevent.
+	 */
+	@Test
+	void refusesToOverwriteAProjectsFieldThatIsNotAnObject(@TempDir Path dir) throws IOException {
+		Path config = dir.resolve(".claude.json");
+		String original = "{\"projects\":[\"do not lose me\"],\"numStartups\":4}";
+		Files.writeString(config, original);
+
+		assertThrows(AdoptionException.class, () -> new ClaudeTrustStore(config).trust(dir.resolve("repo")));
+		assertEquals(original, Files.readString(config));
+	}
+
+	/** A {@code projects} field the config carries as JSON null is simply created. */
+	@Test
+	void treatsANullProjectsFieldAsAbsent(@TempDir Path dir) throws IOException {
+		Path config = dir.resolve(".claude.json");
+		Files.writeString(config, "{\"projects\":null,\"numStartups\":4}");
+		Path repo = dir.resolve("repo");
+
+		assertTrue(new ClaudeTrustStore(config).trust(repo));
+		assertTrue(Files.readString(config).contains("hasTrustDialogAccepted"), Files.readString(config));
+	}
+
+	/**
 	 * A half-written or hand-edited config is not something to silently replace:
 	 * the trust flag is worth far less than the user's own Claude Code settings.
 	 */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -86,6 +86,45 @@ class CloneStepTest {
 		assertFalse(failure.getMessage().contains("SECRET"), failure.getMessage());
 	}
 
+	/**
+	 * The runner merges standard error into the transcript, so a git that warns puts
+	 * that line in beside the URL. Reading the whole transcript as the origin refused
+	 * a checkout that was the right one and named the warning as the repository it
+	 * supposedly held.
+	 */
+	@Test
+	void reusesCheckoutWhoseOriginIsReportedAlongsideAWarning(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = origin("warning: unable to access '/etc/gitconfig': Permission denied"
+				+ System.lineSeparator() + "https://github.com/adamw7/tools.git");
+		step.execute(existing, runner);
+		assertEquals(2, runner.count());
+	}
+
+	/** Noise on its own still names no repository, so the checkout is refused. */
+	@Test
+	void refusesCheckoutWhoseOriginIsOnlyNoise(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = origin("warning: unable to access '/etc/gitconfig': Permission denied");
+		assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
+	}
+
+	/**
+	 * A linked worktree records its {@code .git} as a file rather than a directory.
+	 * Insisting on the directory ran {@code git clone} into a directory that was not
+	 * empty, which git refuses — aborting on a checkout the step was meant to reuse.
+	 */
+	@Test
+	void reusesCheckoutWhoseGitIsAFile(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = new AdoptionContext("https://github.com/adamw7/tools.git", existingWorkspace);
+		Files.createDirectories(existing.repositoryDirectory());
+		Files.writeString(existing.repositoryDirectory().resolve(".git"), "gitdir: /elsewhere/.git/worktrees/tools\n");
+		RecordingCommandRunner runner = origin("https://github.com/adamw7/tools.git");
+		step.execute(existing, runner);
+		assertEquals(List.of("git", "remote", "get-url", "origin"), runner.commandAt(0));
+		assertEquals(2, runner.count());
+	}
+
 	@Test
 	void refusesCheckoutWithNoOriginRemote(@TempDir Path existingWorkspace) throws IOException {
 		AdoptionContext existing = checkedOut(existingWorkspace);


### PR DESCRIPTION
Each fix comes with a regression test that fails without it.

- ClaudeMdConformanceStep rewrote a CRLF CLAUDE.md wholesale to LF, because
  ClaudeMdConformer works in LF throughout and the step wrote its output back
  verbatim. The reshape is now put back on the file's own terminators with
  LineTerminators, as the POM and Gradle installers already were, so the
  adoption's first commit no longer shows every line of the file as changed
  and a conforming CRLF file is still recognised as conforming.

- CloneStep read the whole merged stdout/stderr transcript of
  `git remote get-url origin` as the origin URL, so a git that warned made the
  step refuse a checkout that was the right one, naming the warning as the
  repository it supposedly held. Every line of the transcript is now asked in
  turn, which keeps the conservative reading the check is built on: noise names
  no repository, so a transcript carrying nothing else still answers no.

- CloneStep recognised a checkout only by a .git directory, so a linked
  worktree — whose .git is a file — was read as uncloned and `git clone` ran
  into a directory that was not empty, aborting on a checkout the step was
  meant to reuse and without ever confirming which repository it held.

- CliArguments took a blank --report value as a literal path, leaving the run
  writing a report named after whitespace, while every other optional input
  treats a blank value as not supplied.

- ClaudeTrustStore quietly replaced a `projects` field that was not an object
  with a fresh one, discarding whatever it held — the outcome the top-level
  check already refuses. A non-object field is now refused the same way, and a
  JSON null is treated as absent.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MTr2GxqQoCDdDpknoYysjt