### PR TITLE
fix(claude-code-enforcer): correct seven defects that fail a well-formed project

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
@@ -55,12 +55,11 @@ public class ContextBudgetRule extends ClaudeCodeEnforcerRule {
 		requireLimitConfigured();
 		ScanTargets targets = new ScanTargets(files, directories);
 		targets.requireConfigured();
-		List<String> violations = new ArrayList<>();
 		for (File file : targets.files()) {
 			requireExists(file, file.getName());
-			collectBudgetViolations(file, violations);
 		}
-		for (File file : targets.filesInDirectories(ContextBudgetRule::isMarkdown)) {
+		List<String> violations = new ArrayList<>();
+		for (File file : targets.allFiles(ContextBudgetRule::isMarkdown)) {
 			collectBudgetViolations(file, violations);
 		}
 		report("Context budget exceeded:", violations);

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
@@ -52,28 +53,46 @@ final class DocumentConsistency {
 	 * one document unless {@code requireInBoth} was set.
 	 */
 	List<String> violations(File firstFile, File secondFile) throws EnforcerRuleException {
-		verifyPatterns();
+		List<Pattern> compiled = compilePatterns();
 		Document first = read(firstFile);
 		Document second = read(secondFile);
 		List<String> violations = new ArrayList<>();
-		for (String pattern : patterns) {
+		for (Pattern pattern : compiled) {
 			collect(pattern, first, second, violations);
 		}
 		return violations;
 	}
 
-	/**
-	 * Each pattern must declare a capturing group, since comparison reads
-	 * {@code group(1)}. A pattern without one is a build-setup mistake, so it fails
-	 * with a clear message instead of letting an opaque
-	 * {@link IndexOutOfBoundsException} escape at match time.
-	 */
-	private void verifyPatterns() throws EnforcerRuleException {
+	private List<Pattern> compilePatterns() throws EnforcerRuleException {
+		List<Pattern> compiled = new ArrayList<>();
 		for (String pattern : patterns) {
-			if (Pattern.compile(pattern).matcher("").groupCount() < 1) {
-				throw new EnforcerRuleException(
-						"consistentPattern '" + pattern + "' must declare a capturing group");
-			}
+			compiled.add(verified(pattern));
+		}
+		return compiled;
+	}
+
+	/**
+	 * Each pattern must be a valid regular expression declaring a capturing group,
+	 * since comparison reads {@code group(1)}. Either mistake is a build-setup one,
+	 * so it fails with a message naming the pattern instead of letting an opaque
+	 * {@link java.util.regex.PatternSyntaxException} or
+	 * {@link IndexOutOfBoundsException} escape as an internal build error.
+	 */
+	private Pattern verified(String pattern) throws EnforcerRuleException {
+		Pattern compiled = compile(pattern);
+		if (compiled.matcher("").groupCount() < 1) {
+			throw new EnforcerRuleException(
+					"consistentPattern '" + pattern + "' must declare a capturing group");
+		}
+		return compiled;
+	}
+
+	private Pattern compile(String pattern) throws EnforcerRuleException {
+		try {
+			return Pattern.compile(pattern);
+		} catch (PatternSyntaxException e) {
+			throw new EnforcerRuleException(
+					"consistentPattern '" + pattern + "' is not a valid regular expression: " + e.getDescription());
 		}
 	}
 
@@ -81,21 +100,20 @@ final class DocumentConsistency {
 		return new Document(file.getName(), MarkdownText.read(file, file.getName()));
 	}
 
-	private void collect(String pattern, Document first, Document second, List<String> violations) {
+	private void collect(Pattern pattern, Document first, Document second, List<String> violations) {
 		try {
 			addMismatch(pattern, first, second, violations);
 		} catch (BacktrackLimitExceededException e) {
-			violations.add("pattern '" + pattern
+			violations.add("pattern '" + pattern.pattern()
 					+ "' could not be evaluated within its backtracking budget (possible catastrophic backtracking)");
 		}
 	}
 
-	private void addMismatch(String pattern, Document first, Document second, List<String> violations) {
-		Pattern compiled = Pattern.compile(pattern);
-		Optional<String> firstValue = capture(compiled, first.content());
-		Optional<String> secondValue = capture(compiled, second.content());
+	private void addMismatch(Pattern pattern, Document first, Document second, List<String> violations) {
+		Optional<String> firstValue = capture(pattern, first.content());
+		Optional<String> secondValue = capture(pattern, second.content());
 		if (!firstValue.equals(secondValue) && !isIgnored(firstValue, secondValue)) {
-			violations.add("pattern '" + pattern + "' captured " + describe(first, firstValue) + " but "
+			violations.add("pattern '" + pattern.pattern() + "' captured " + describe(first, firstValue) + " but "
 					+ describe(second, secondValue));
 		}
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
@@ -16,6 +16,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
 /**
  * The {@code @path} memory imports reachable from a root document, together with
@@ -43,7 +44,6 @@ final class ImportGraph {
 	}
 
 	private static final Pattern IMPORT = Pattern.compile("(?<=^|\\s)@([A-Za-z0-9_./-]+)");
-	private static final Pattern CODE_SPAN = Pattern.compile("`[^`]*`");
 	private static final Pattern TRAILING_DOTS = Pattern.compile("\\.+$");
 
 	private final Map<Path, List<Reference>> references = new LinkedHashMap<>();
@@ -128,7 +128,7 @@ final class ImportGraph {
 		if (document.isInsideFence(index)) {
 			return;
 		}
-		Matcher matcher = IMPORT.matcher(CODE_SPAN.matcher(document.line(index)).replaceAll(" "));
+		Matcher matcher = IMPORT.matcher(MarkdownText.withoutCodeSpans(document.line(index)));
 		while (matcher.find()) {
 			addReference(file, withoutTrailingDots(matcher.group(1)), found);
 		}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -59,8 +59,13 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 	/** The JSON file to validate. Injected from the rule configuration. */
 	protected abstract File jsonFile();
 
-	/** Document-specific checks against the parsed JSON. */
-	protected abstract void collectViolations(JsonNode root, List<String> violations);
+	/**
+	 * Document-specific checks against the parsed JSON. A subclass throws only for a
+	 * build-setup mistake in its own configuration, such as a parameter that is not
+	 * the regular expression it must be; a problem with the document itself belongs
+	 * in {@code violations}.
+	 */
+	protected abstract void collectViolations(JsonNode root, List<String> violations) throws EnforcerRuleException;
 
 	/**
 	 * The header that prefixes the grouped violation report. A rule that validates

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
 /**
  * Base for enforcer rules that validate a Markdown document follows an expected
@@ -225,11 +226,16 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 		}
 	}
 
+	/**
+	 * Links are read outside code fences and inline code spans alike, so a sample
+	 * link written as {@code `[label](example.md)`} is documentation rather than a
+	 * reference this rule must resolve on disk.
+	 */
 	private void collectLineReferences(MarkdownDocument document, int index, File baseDir, List<String> violations) {
 		if (document.isInsideFence(index)) {
 			return;
 		}
-		Matcher matcher = MARKDOWN_LINK.matcher(document.line(index));
+		Matcher matcher = MARKDOWN_LINK.matcher(MarkdownText.withoutCodeSpans(document.line(index)));
 		while (matcher.find()) {
 			addReferenceViolation(localReferencePath(linkDestination(matcher.group(1))), baseDir, violations);
 		}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ScanTargets.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ScanTargets.java
@@ -6,7 +6,9 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -22,6 +24,12 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
  * yields entries in a filesystem-dependent order that would otherwise let a rule
  * report its violations differently run to run. An absent directory is skipped,
  * since most Claude Code configuration directories are optional.
+ * <p>
+ * The two parameters overlap freely — naming a file explicitly and scanning the
+ * directory it sits in is a natural way to say "this one especially" — so
+ * {@link #allFiles} yields each file once. A rule that checked both lists in turn
+ * would report the overlapping file's violations twice and record them twice in a
+ * baseline.
  */
 public final class ScanTargets {
 
@@ -45,9 +53,29 @@ public final class ScanTargets {
 		return files;
 	}
 
-	/** Every regular file under the configured directories. */
-	public List<File> filesInDirectories() {
-		return filesInDirectories(path -> true);
+	/**
+	 * Every configured file, then every regular file under the configured
+	 * directories, each listed once.
+	 */
+	public List<File> allFiles() {
+		return allFiles(path -> true);
+	}
+
+	/**
+	 * Every configured file, then the files under the configured directories that
+	 * {@code acceptedInDirectories} matches, each listed once. The predicate narrows
+	 * the directory scan alone: a file named explicitly was chosen by the
+	 * configuration and is checked whatever its name.
+	 */
+	public List<File> allFiles(Predicate<Path> acceptedInDirectories) {
+		Map<Path, File> unique = new LinkedHashMap<>();
+		files.forEach(file -> unique.putIfAbsent(key(file), file));
+		filesInDirectories(acceptedInDirectories).forEach(file -> unique.putIfAbsent(key(file), file));
+		return List.copyOf(unique.values());
+	}
+
+	private static Path key(File file) {
+		return file.toPath().toAbsolutePath().normalize();
 	}
 
 	/** The regular files under the configured directories that {@code accepted} matches. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
+import java.util.regex.PatternSyntaxException;
 
 import javax.inject.Named;
 
@@ -56,10 +57,7 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 		targets.requireConfigured();
 		requirePatterns(patterns);
 		List<String> violations = new ArrayList<>();
-		for (File file : targets.files()) {
-			scanIfPresent(file, patterns, violations);
-		}
-		for (File file : targets.filesInDirectories()) {
+		for (File file : targets.allFiles()) {
 			scanIfPresent(file, patterns, violations);
 		}
 		report("Files contain what look like secrets:", violations);
@@ -121,16 +119,30 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 		return content.map(text -> text.lines().toList()).orElseGet(List::of);
 	}
 
-	private List<SecretPattern> patterns() {
+	private List<SecretPattern> patterns() throws EnforcerRuleException {
 		List<SecretPattern> patterns = new ArrayList<>();
 		if (useDefaultPatterns) {
 			patterns.addAll(SecretPattern.defaults());
 		}
 		List<String> configured = secretPatterns != null ? secretPatterns : List.of();
 		for (String regex : configured) {
-			patterns.add(SecretPattern.of(regex, regex));
+			patterns.add(compiled(regex));
 		}
 		return patterns;
+	}
+
+	/**
+	 * A configured pattern that is not a valid regular expression is a build-setup
+	 * mistake, so it fails with a message naming it rather than letting a
+	 * {@link PatternSyntaxException} escape as an internal build error.
+	 */
+	private SecretPattern compiled(String regex) throws EnforcerRuleException {
+		try {
+			return SecretPattern.of(regex, regex);
+		} catch (PatternSyntaxException e) {
+			throw new EnforcerRuleException(
+					"secretPattern '" + regex + "' is not a valid regular expression: " + e.getDescription());
+		}
 	}
 
 	void setFiles(List<File> files) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
@@ -3,17 +3,27 @@ package io.github.adamw7.tools.enforcer.settings;
 import java.io.File;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Resolves the base directory that a hook command's {@code $CLAUDE_PROJECT_DIR}
  * variable expands to, and performs that expansion on the tokens of a command.
  * Both hook rules share this so the two accepted spellings of the variable and
  * the "grandparent of the settings file" fallback live in exactly one place.
+ * <p>
+ * The unbraced spelling ends where the variable name does, as a shell reads it, so
+ * {@code $CLAUDE_PROJECT_DIR_BACKUP} is a different variable and not this one with
+ * a suffix. Expanding it as this one would invent a path no hook ever named and
+ * report it as a missing script.
  */
 final class ClaudeProjectDir {
 
 	static final String BRACED = "${CLAUDE_PROJECT_DIR}";
 	static final String PLAIN = "$CLAUDE_PROJECT_DIR";
+
+	/** The unbraced spelling, only where the name is not continued by a further identifier character. */
+	private static final Pattern PLAIN_REFERENCE = Pattern.compile(Pattern.quote(PLAIN) + "(?![A-Za-z0-9_])");
 
 	private final File override;
 	private final File settingsFile;
@@ -36,11 +46,15 @@ final class ClaudeProjectDir {
 	/** The path {@code token} resolves to when it references the project dir, else null. */
 	String expand(String token) {
 		String bare = withoutQuotes(token);
-		if (!bare.contains(BRACED) && !bare.contains(PLAIN)) {
+		if (!references(bare)) {
 			return null;
 		}
 		String root = resolve().getPath();
-		return bare.replace(BRACED, root).replace(PLAIN, root);
+		return PLAIN_REFERENCE.matcher(bare.replace(BRACED, root)).replaceAll(Matcher.quoteReplacement(root));
+	}
+
+	private boolean references(String bare) {
+		return bare.contains(BRACED) || PLAIN_REFERENCE.matcher(bare).find();
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
@@ -8,18 +8,24 @@ import java.util.List;
  * this to find the {@code $CLAUDE_PROJECT_DIR} references inside a command, so
  * the splitting lives here rather than in each of them.
  * <p>
- * Splitting is on whitespace <em>outside</em> quotes, because a hook script path
- * containing a space is legitimate and is quoted for exactly that reason; a plain
- * whitespace split would tear {@code "$CLAUDE_PROJECT_DIR/my hook.sh"} into two
- * halves and then report a script that is really there as missing. The quote
- * characters are kept on the token, since {@link ClaudeProjectDir} strips them as
- * part of expanding it.
+ * Splitting is on whitespace and on the shell separators {@code ;}, {@code &} and
+ * {@code |}, all <em>outside</em> quotes. Whitespace alone is not enough: a command
+ * chaining two hooks as {@code hook-a.sh; hook-b.sh} leaves the semicolon glued to
+ * the first path, and the rules would then report a script that is really there as
+ * missing. Quoting is honoured because a hook script path containing a space is
+ * legitimate and is quoted for exactly that reason; a plain split would tear
+ * {@code "$CLAUDE_PROJECT_DIR/my hook.sh"} into two halves. The quote characters are
+ * kept on the token, since {@link ClaudeProjectDir} strips them as part of expanding
+ * it.
  */
 final class CommandTokens {
 
 	private static final char NONE = 0;
 	private static final char DOUBLE_QUOTE = '"';
 	private static final char SINGLE_QUOTE = '\'';
+
+	/** The shell operators that end a token just as whitespace does. */
+	private static final String SEPARATORS = ";&|";
 
 	private CommandTokens() {
 	}
@@ -49,12 +55,16 @@ final class CommandTokens {
 			token.append(character);
 			return character;
 		}
-		if (Character.isWhitespace(character)) {
+		if (isSeparator(character)) {
 			addToken(token, tokens);
 			return NONE;
 		}
 		token.append(character);
 		return NONE;
+	}
+
+	private static boolean isSeparator(char character) {
+		return Character.isWhitespace(character) || SEPARATORS.indexOf(character) >= 0;
 	}
 
 	private static void addToken(StringBuilder token, List<String> tokens) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
@@ -1,13 +1,17 @@
 package io.github.adamw7.tools.enforcer.settings;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -74,7 +78,7 @@ public class PermissionsFormatRule extends JsonFileRule {
 	}
 
 	@Override
-	protected void collectViolations(JsonNode settings, List<String> violations) {
+	protected void collectViolations(JsonNode settings, List<String> violations) throws EnforcerRuleException {
 		if (!settings.has(PERMISSIONS_KEY)) {
 			return;
 		}
@@ -148,13 +152,35 @@ public class PermissionsFormatRule extends JsonFileRule {
 		}
 	}
 
-	private void collectForbiddenEntries(JsonNode permissions, List<String> violations) {
+	private void collectForbiddenEntries(JsonNode permissions, List<String> violations) throws EnforcerRuleException {
 		if (forbiddenEntryPatterns == null) {
 			return;
 		}
-		List<Pattern> patterns = forbiddenEntryPatterns.stream().map(Pattern::compile).toList();
+		List<Pattern> patterns = compiledForbiddenPatterns();
 		for (String entry : textEntries(permissions, ALLOW_KEY)) {
 			addForbiddenEntryViolations(entry, patterns, violations);
+		}
+	}
+
+	/**
+	 * A configured pattern that is not a valid regular expression is a build-setup
+	 * mistake, so it fails with a message naming it rather than letting a
+	 * {@link PatternSyntaxException} escape as an internal build error.
+	 */
+	private List<Pattern> compiledForbiddenPatterns() throws EnforcerRuleException {
+		List<Pattern> patterns = new ArrayList<>();
+		for (String pattern : forbiddenEntryPatterns) {
+			patterns.add(compiled(pattern));
+		}
+		return patterns;
+	}
+
+	private Pattern compiled(String pattern) throws EnforcerRuleException {
+		try {
+			return Pattern.compile(pattern);
+		} catch (PatternSyntaxException e) {
+			throw new EnforcerRuleException("forbiddenEntryPattern '" + pattern
+					+ "' is not a valid regular expression: " + e.getDescription());
 		}
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -1,7 +1,9 @@
 package io.github.adamw7.tools.enforcer.text;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * The YAML front matter block at the top of a Markdown document: the lines
@@ -11,11 +13,26 @@ import java.util.Optional;
  * the flat {@code key: value} shape that Claude Code skill and sub-agent files
  * use, which is all the rules need. Parsing is shared here so every rule agrees
  * on what counts as front matter, which keys it declares, and each key's value.
+ * <p>
+ * A key is only recognised where YAML puts one: at the start of a line, with no
+ * indentation. An indented line continues the value above it, so reading a key out
+ * of one would invent entries an author never declared — the {@code Use this when:}
+ * of a wrapped description would be reported as an unknown key.
+ * <p>
+ * A value written as a block scalar ({@code description: >} or {@code |}, with the
+ * text on the indented lines below) is folded back into a single line, since the
+ * indicator alone is not the value: reading it literally would leave every such
+ * definition claiming the same one-character description and escape any length cap.
+ * The fold joins the continuation lines with single spaces, which is all the
+ * length, blankness, and uniqueness checks need.
  */
 public final class FrontMatter {
 
 	private static final String DELIMITER = "---";
 	private static final char KEY_VALUE_SEPARATOR = ':';
+
+	/** A block scalar header: {@code >} or {@code |} with optional indentation and chomping indicators. */
+	private static final Pattern BLOCK_SCALAR = Pattern.compile("[>|][0-9+-]*");
 
 	private final List<String> lines;
 
@@ -45,18 +62,21 @@ public final class FrontMatter {
 
 	/** True when a {@code key:} entry is present, regardless of its value. */
 	public boolean hasKey(String key) {
-		return lines.stream().anyMatch(line -> isEntryFor(line, key));
+		return indexOfEntry(key) >= 0;
 	}
 
 	/**
 	 * The trimmed value declared for {@code key}, or empty when the key is absent.
-	 * A present key with no value yields an empty string, not an empty optional.
+	 * A present key with no value yields an empty string, not an empty optional, and
+	 * a block scalar yields its folded continuation lines rather than the indicator.
 	 */
 	public Optional<String> value(String key) {
-		return lines.stream()
-				.filter(line -> isEntryFor(line, key))
-				.findFirst()
-				.map(line -> valueOf(line, key));
+		int index = indexOfEntry(key);
+		if (index < 0) {
+			return Optional.empty();
+		}
+		String declared = valueOf(lines.get(index), key);
+		return Optional.of(isBlockScalar(declared) ? folded(index + 1) : declared);
 	}
 
 	/** The declared keys, in document order, without their trailing colon. */
@@ -69,11 +89,12 @@ public final class FrontMatter {
 	 * This shares its definition with {@link #hasKey} and {@link #value}, so the
 	 * three never disagree about whether a line declares a key: a bare {@code key:}
 	 * or a {@code key: value} (or {@code key:\tvalue}) counts, while {@code key:value}
-	 * without a separating space, comments, and list items do not.
+	 * without a separating space, comments, list items, and indented continuation
+	 * lines do not.
 	 */
 	private Optional<String> entryKey(String line) {
 		String stripped = line.strip();
-		if (stripped.startsWith("#") || stripped.startsWith("-")) {
+		if (isIndented(line) || stripped.startsWith("#") || stripped.startsWith("-")) {
 			return Optional.empty();
 		}
 		int separator = stripped.indexOf(KEY_VALUE_SEPARATOR);
@@ -85,10 +106,55 @@ public final class FrontMatter {
 	}
 
 	private boolean isEntryFor(String line, String key) {
+		if (isIndented(line)) {
+			return false;
+		}
 		String stripped = line.strip();
 		return stripped.equals(key + KEY_VALUE_SEPARATOR)
 				|| stripped.startsWith(key + KEY_VALUE_SEPARATOR + " ")
 				|| stripped.startsWith(key + KEY_VALUE_SEPARATOR + "\t");
+	}
+
+	/** True when the line is a continuation of the entry above rather than one of its own. */
+	private boolean isIndented(String line) {
+		return !line.isEmpty() && Character.isWhitespace(line.charAt(0));
+	}
+
+	private int indexOfEntry(String key) {
+		for (int i = 0; i < lines.size(); i++) {
+			if (isEntryFor(lines.get(i), key)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private boolean isBlockScalar(String declared) {
+		return BLOCK_SCALAR.matcher(declared).matches();
+	}
+
+	/**
+	 * The block scalar's continuation lines from {@code from}, joined with single
+	 * spaces. The block runs until the next entry at the block's own level, so blank
+	 * lines inside it are kept as separators and dropped from the result.
+	 */
+	private String folded(int from) {
+		List<String> content = new ArrayList<>();
+		for (int i = from; i < lines.size() && isContinuation(lines.get(i)); i++) {
+			addContent(lines.get(i), content);
+		}
+		return String.join(" ", content);
+	}
+
+	private boolean isContinuation(String line) {
+		return line.isBlank() || isIndented(line);
+	}
+
+	private void addContent(String line, List<String> content) {
+		String stripped = line.strip();
+		if (!stripped.isEmpty()) {
+			content.add(stripped);
+		}
 	}
 
 	private String valueOf(String line, String key) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * A parsed Markdown document: its lines plus a mask marking which lines belong to
@@ -13,7 +14,10 @@ import java.util.Set;
  * Headings are recognised on whole lines outside fenced code blocks, so a heading
  * mentioned inside a fence or in prose is not treated as document structure. The
  * mask includes the opening and closing delimiters themselves, so heading and body
- * detection agree on what is code.
+ * detection agree on what is code. A heading is an ATX one — one to six {@code #}
+ * characters followed by whitespace or nothing else — so a line that merely starts
+ * with a hash, such as {@code #1 rule: run mvn install}, stays prose. Counting it
+ * as a heading would end the section it sits in and report that section as empty.
  * <p>
  * A fence is closed only by a run of the <em>same</em> character, at least as long
  * as the one that opened it, carrying no info string. All three conditions matter,
@@ -29,8 +33,10 @@ public final class MarkdownDocument {
 	private static final char BACKTICK = '`';
 	private static final char TILDE = '~';
 	private static final int MIN_FENCE_LENGTH = 3;
-	private static final String HEADING_PREFIX = "#";
 	private static final char HEADING_CHAR = '#';
+
+	/** One to six {@code #} characters, then whitespace and any text, or nothing at all. */
+	private static final Pattern ATX_HEADING = Pattern.compile("#{1,6}(\\s.*)?");
 
 	private final List<String> lines;
 	private final boolean[] insideFence;
@@ -148,7 +154,7 @@ public final class MarkdownDocument {
 	}
 
 	private static boolean isHeading(String line) {
-		return line.startsWith(HEADING_PREFIX);
+		return ATX_HEADING.matcher(line).matches();
 	}
 
 	private static int headingLevel(String heading) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
@@ -6,6 +6,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
@@ -16,6 +17,7 @@ import java.util.stream.Stream;
 public final class MarkdownText {
 
 	private static final char BYTE_ORDER_MARK = (char) 0xFEFF;
+	private static final Pattern CODE_SPAN = Pattern.compile("`[^`]*`");
 
 	private MarkdownText() {
 	}
@@ -74,6 +76,17 @@ public final class MarkdownText {
 			return content.substring(1);
 		}
 		return content;
+	}
+
+	/**
+	 * The line with every inline code span replaced by a space, so text quoted as
+	 * code is not read as the markup it illustrates. Documentation about Markdown
+	 * writes a sample link or import inside backticks precisely because it is an
+	 * example, and a rule that followed it would report the sample's target as a
+	 * missing file.
+	 */
+	public static String withoutCodeSpans(String line) {
+		return CODE_SPAN.matcher(line).replaceAll(" ");
 	}
 
 	/** The first line that is not blank, stripped of surrounding whitespace, or empty if none. */

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
@@ -220,6 +220,43 @@ class SkillFilesExistRuleTest {
 		assertTrue(readString(file).contains("---\n# Body"), readString(file));
 	}
 
+	@Test
+	void acceptsADescriptionWrittenAsABlockScalar() {
+		Path skillDir = createDirectory(tempDir.resolve("git-commit"));
+		writeString(skillDir.resolve("SKILL.md"), """
+				---
+				name: git-commit
+				description: >
+				  Generate conventional commit messages. Use when: the user says "commit".
+				---
+				# Body
+				""");
+		SkillFilesExistRule rule = ruleFor(tempDir);
+		rule.setAllowedFrontMatterKeys(java.util.List.of("name", "description"));
+
+		// The wrapped prose continues the description, so "Use when" is not an
+		// unknown key the skill declared.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void measuresABlockScalarDescriptionAgainstTheLengthCap() {
+		Path skillDir = createDirectory(tempDir.resolve("git-commit"));
+		writeString(skillDir.resolve("SKILL.md"), """
+				---
+				name: git-commit
+				description: >
+				  %s
+				---
+				# Body
+				""".formatted("x".repeat(60)));
+		SkillFilesExistRule rule = ruleFor(tempDir);
+		rule.setMaxDescriptionLength(20);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("exceeds 20 characters"), exception.getMessage());
+	}
+
 	private void createSkill(String name) {
 		Path skillDir = createDirectory(tempDir.resolve(name));
 		writeString(skillDir.resolve("SKILL.md"), """

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
@@ -101,6 +101,36 @@ class UniqueDescriptionsRuleTest {
 		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("Reviews code.")), logger.warnings().toString());
 	}
 
+	@Test
+	void doesNotTreatTwoBlockScalarDescriptionsAsTheSameOne() {
+		writeAgentWithBlockScalarDescription("reviewer", "Reviews Java code for defects.");
+		writeAgentWithBlockScalarDescription("committer", "Writes conventional commit messages.");
+
+		// Both declare their description as '>'; reading the indicator instead of the
+		// prose below it would make every such definition look identical.
+		assertDoesNotThrow(agentsRule()::execute);
+	}
+
+	@Test
+	void stillReportsTwoBlockScalarDescriptionsThatDoAgree() {
+		writeAgentWithBlockScalarDescription("reviewer", "Reviews Java code for defects.");
+		writeAgentWithBlockScalarDescription("auditor", "Reviews Java code for defects.");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, agentsRule()::execute);
+		assertTrue(exception.getMessage().contains("Reviews Java code for defects."), exception.getMessage());
+	}
+
+	private void writeAgentWithBlockScalarDescription(String name, String description) {
+		writeString(agentsDir().resolve(name + ".md"), """
+				---
+				name: %s
+				description: >
+				  %s
+				---
+				# %s
+				""".formatted(name, description, name));
+	}
+
 	private UniqueDescriptionsRule agentsRule() {
 		UniqueDescriptionsRule rule = new UniqueDescriptionsRule();
 		rule.setAgentsDir(agentsDir().toFile());

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -359,6 +359,28 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
+	void doesNotReportASectionEmptyWhenItsBodyOpensWithHashPrefixedProse() {
+		ClaudeMdFormatRule rule = ruleFor(
+				VALID_CONTENT.replace("## Maven\nVersions live in the root pom.", "## Maven\n#1 rule: run mvn install."));
+
+		// "#1 rule:" is prose, not a heading ending the section, so the Maven section
+		// has a body.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void ignoresALinkQuotedAsCodeWhenValidatingReferences() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+		ClaudeMdFormatRule rule = ruleFor(
+				VALID_CONTENT + "\nWrite a link as `[label](example.md)` in your docs.\n");
+		rule.setValidateFileReferences(true);
+
+		// Documentation about Markdown quotes a sample link as code precisely because
+		// it is an example, so its target is not a reference to resolve on disk.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
 	void warnSeverityLogsInsteadOfFailing() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# CLAUDE.md", "# Wrong"));
 		rule.setSeverity("WARN");

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.doc;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -183,6 +184,37 @@ class ContextBudgetRuleTest {
 		// The undecodable file no longer aborts the run before the next one is measured.
 		assertTrue(exception.getMessage().contains("fine.md"), exception.getMessage());
 		assertTrue(exception.getMessage().contains("2 lines, over the 1-line budget"), exception.getMessage());
+	}
+
+	@Test
+	void measuresAFileNamedAndScannedAsADirectoryEntryOnlyOnce() {
+		Path directory = tempDir.resolve("skills");
+		Path file = writeString(directory.resolve("SKILL.md"), "x".repeat(100));
+		ContextBudgetRule rule = new ContextBudgetRule();
+		rule.setFiles(List.of(file.toFile()));
+		rule.setDirectories(List.of(directory.toFile()));
+		rule.setMaxBytes(10);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertEquals(1, occurrences(exception.getMessage(), "over the 10-byte budget"), exception.getMessage());
+	}
+
+	@Test
+	void stillMeasuresAConfiguredFileThatIsNotMarkdown() {
+		Path file = writeString(tempDir.resolve("notes.txt"), "x".repeat(100));
+		ContextBudgetRule rule = new ContextBudgetRule();
+		rule.setFiles(List.of(file.toFile()));
+		rule.setDirectories(List.of(tempDir.toFile()));
+		rule.setMaxBytes(10);
+
+		// The *.md filter narrows the directory scan; a file named outright was
+		// chosen by the configuration and is measured whatever it is called.
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("notes.txt"), exception.getMessage());
+	}
+
+	private static int occurrences(String message, String token) {
+		return message.split(java.util.regex.Pattern.quote(token), -1).length - 1;
 	}
 
 	private ContextBudgetRule ruleForFile(String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
@@ -99,6 +99,19 @@ class CrossDocConsistencyRuleTest {
 		assertTrue(exception.getMessage().contains("catastrophic backtracking"), exception.getMessage());
 	}
 
+	@Test
+	void failsWithAClearMessageForAPatternThatIsNotAValidRegularExpression() {
+		CrossDocConsistencyRule rule = ruleFor("# CLAUDE.md\nJava 25\n", "# AGENTS.md\nJava 25\n");
+		rule.setConsistentPatterns(List.of("Java (\\d+"));
+
+		// A misconfigured pattern is a build-setup mistake and must name itself,
+		// rather than escaping as a PatternSyntaxException the build reports as an
+		// internal error.
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("not a valid regular expression"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("Java (\\d+"), exception.getMessage());
+	}
+
 	private CrossDocConsistencyRule ruleFor(String claudeContent, String agentsContent) {
 		Path claude = tempDir.resolve("CLAUDE.md");
 		Path agents = tempDir.resolve("AGENTS.md");

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRuleTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.secret;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -103,6 +104,31 @@ class NoSecretsRuleTest {
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
 		assertTrue(exception.getMessage().contains("password"), exception.getMessage());
+	}
+
+	@Test
+	void failsWithAClearMessageForAPatternThatIsNotAValidRegularExpression() {
+		NoSecretsRule rule = ruleForFile("nothing to see here");
+		rule.setSecretPatterns(List.of("(unclosed"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("not a valid regular expression"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("(unclosed"), exception.getMessage());
+	}
+
+	@Test
+	void reportsAFileNamedAndScannedAsADirectoryEntryOnlyOnce() {
+		Path file = writeString(tempDir.resolve("hooks/script.sh"), "export KEY=" + ANTHROPIC_KEY + "\n");
+		NoSecretsRule rule = new NoSecretsRule();
+		rule.setFiles(List.of(file.toFile()));
+		rule.setDirectories(List.of(tempDir.resolve("hooks").toFile()));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertEquals(1, occurrences(exception.getMessage(), "script.sh"), exception.getMessage());
+	}
+
+	private static int occurrences(String message, String token) {
+		return message.split(java.util.regex.Pattern.quote(token), -1).length - 1;
 	}
 
 	private NoSecretsRule ruleForFile(String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
@@ -48,4 +48,19 @@ class CommandTokensTest {
 		assertEquals(List.of("\"$CLAUDE_PROJECT_DIR\"/my", "hook.sh"),
 				CommandTokens.of("\"$CLAUDE_PROJECT_DIR\"/my hook.sh"));
 	}
+
+	@Test
+	void splitsOnASemicolonSoItDoesNotStayGluedToAPath() {
+		assertEquals(List.of("a.sh", "echo", "done"), CommandTokens.of("a.sh; echo done"));
+	}
+
+	@Test
+	void splitsOnPipesAndAmpersandsWithNoSurroundingSpace() {
+		assertEquals(List.of("a.sh", "b.sh", "c.sh"), CommandTokens.of("a.sh&&b.sh|c.sh"));
+	}
+
+	@Test
+	void keepsAQuotedSeparatorInsideItsToken() {
+		assertEquals(List.of("echo", "\"a;b\""), CommandTokens.of("echo \"a;b\""));
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -251,6 +251,39 @@ class HookCommandsValidRuleTest {
 	}
 
 	@Test
+	void passesWhenAChainedCommandEndsAScriptPathWithASemicolon() {
+		writeString(tempDir.resolve("first.sh"), "#!/bin/sh\n");
+		writeString(tempDir.resolve("second.sh"), "#!/bin/sh\n");
+		HookCommandsValidRule rule = ruleFor(
+				hooksReferencing("$CLAUDE_PROJECT_DIR/first.sh; $CLAUDE_PROJECT_DIR/second.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		// The semicolon separates the two commands; keeping it on the first path
+		// would look for a script literally named 'first.sh;'.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void leavesAVariableThatOnlyStartsWithTheProjectDirNameAlone() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("bash $CLAUDE_PROJECT_DIR_BACKUP/run.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		// $CLAUDE_PROJECT_DIR_BACKUP is a different variable, so nothing here names a
+		// project-local script for the rule to resolve.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void stillResolvesTheBracedSpellingFollowedByMoreOfThePath() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("bash ${CLAUDE_PROJECT_DIR}/absent.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("references a missing script"), exception.getMessage());
+		assertTrue(exception.getMessage().endsWith("absent.sh"), exception.getMessage());
+	}
+
+	@Test
 	void namesTheSettingsFileInItsDescription() {
 		HookCommandsValidRule rule = ruleFor(hooksReferencing("echo hi"));
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRuleTest.java
@@ -148,6 +148,16 @@ class PermissionsFormatRuleTest {
 		assertTrue(exception.getMessage().contains("not of the form"), exception.getMessage());
 	}
 
+	@Test
+	void failsWithAClearMessageForAForbiddenPatternThatIsNotAValidRegularExpression() {
+		PermissionsFormatRule rule = ruleFor("{ \"permissions\": { \"allow\": [ \"Bash(mvn *)\" ] } }");
+		rule.setForbiddenEntryPatterns(List.of("Bash(\\*"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("not a valid regular expression"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("Bash(\\*"), exception.getMessage());
+	}
+
 	private PermissionsFormatRule ruleFor(String content) {
 		Path file = tempDir.resolve("settings.json");
 		writeString(file, content);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -106,4 +106,65 @@ class FrontMatterTest {
 
 		assertEquals(List.of("name", "tools"), frontMatter.keys());
 	}
+
+	@Test
+	void doesNotReadAKeyOutOfAnIndentedContinuationLine() {
+		FrontMatter frontMatter = FrontMatter.parse("""
+				---
+				name: demo
+				description: >
+				  Use this when: the user asks for a demo.
+				---
+				""").orElseThrow();
+
+		// The wrapped prose continues the description; "Use this when" is not a key an
+		// author declared, and reporting it would fail the build for an unknown key.
+		assertEquals(List.of("name", "description"), frontMatter.keys());
+		assertFalse(frontMatter.hasKey("Use this when"));
+	}
+
+	@Test
+	void foldsAFoldedBlockScalarIntoItsValue() {
+		FrontMatter frontMatter = FrontMatter.parse("""
+				---
+				name: demo
+				description: >
+				  Generate a demo report.
+
+				  Use when the user asks for one.
+				---
+				""").orElseThrow();
+
+		assertEquals(Optional.of("Generate a demo report. Use when the user asks for one."),
+				frontMatter.value("description"));
+	}
+
+	@Test
+	void foldsALiteralBlockScalarWithChompingIndicator() {
+		FrontMatter frontMatter = FrontMatter.parse("""
+				---
+				description: |-
+				  First line.
+				  Second line.
+				name: demo
+				---
+				""").orElseThrow();
+
+		assertEquals(Optional.of("First line. Second line."), frontMatter.value("description"));
+		assertEquals(Optional.of("demo"), frontMatter.value("name"));
+	}
+
+	@Test
+	void treatsAnEmptyBlockScalarAsAnEmptyValue() {
+		FrontMatter frontMatter = FrontMatter.parse("---\ndescription: >\nname: demo\n---\n").orElseThrow();
+
+		assertEquals(Optional.of(""), frontMatter.value("description"));
+	}
+
+	@Test
+	void doesNotMistakeAPipeCharacterInProseForABlockScalar() {
+		FrontMatter frontMatter = FrontMatter.parse("---\ndescription: a | b\n---\n").orElseThrow();
+
+		assertEquals(Optional.of("a | b"), frontMatter.value("description"));
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
@@ -167,6 +167,40 @@ class MarkdownDocumentTest {
 		assertFalse(document.containsOutsideFences("TODO"));
 	}
 
+	@Test
+	void doesNotTreatAHashPrefixedProseLineAsAHeading() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				## Maven
+
+				#1 rule: run mvn install.
+
+				## Testing
+
+				Body.
+				""");
+
+		// "#1 rule:" is prose, not an ATX heading. Counting it as one would end the
+		// Maven section at its first line and report the section as empty.
+		assertEquals(Set.of("# Title", "## Maven", "## Testing"), document.headings());
+		assertTrue(document.hasBody("## Maven"));
+	}
+
+	@Test
+	void doesNotTreatSevenHashesAsAHeading() {
+		MarkdownDocument document = MarkdownDocument.parse("# Title\n\n####### too deep\n");
+
+		assertEquals(Set.of("# Title"), document.headings());
+	}
+
+	@Test
+	void treatsABareHashAsAHeading() {
+		MarkdownDocument document = MarkdownDocument.parse("# Title\n\n##\n\nbody\n");
+
+		assertEquals(Set.of("# Title", "##"), document.headings());
+	}
+
 	/** The indices of the lines the document masks as fenced code, in document order. */
 	private static List<Integer> fencedLines(MarkdownDocument document) {
 		return IntStream.range(0, document.lineCount()).filter(document::isInsideFence).boxed().toList();


### PR DESCRIPTION
Each of these makes a rule disagree with the document it validates, and most of
them fail a build over a file that is perfectly correct.

- MarkdownDocument counted any line starting with '#' as a heading, so prose
  such as "#1 rule: run mvn install" ended the section it sits in and the
  section was reported empty. A heading is now an ATX one: one to six '#'
  characters followed by whitespace or nothing.
- FrontMatter read a key out of an indented continuation line, so the
  "Use this when:" of a wrapped description was reported as an unknown key.
  Entries are now recognised only where YAML puts them, at column zero.
- FrontMatter read a block scalar value (description: > or |) as the indicator
  itself, so every such definition claimed the same one-character description:
  uniqueDescriptions reported two unrelated skills as duplicates and the
  description length cap measured nothing. The continuation lines are now
  folded into the value.
- CommandTokens split a hook command on whitespace alone, so a chained
  "first.sh; second.sh" looked for a script named "first.sh;", and
  ClaudeProjectDir expanded $CLAUDE_PROJECT_DIR_BACKUP as this variable with a
  suffix. Both are reported as missing scripts. Tokens now break on the shell
  separators too, and the unbraced spelling ends where the variable name does.
- A consistentPattern, secretPattern, or forbiddenEntryPattern that is not a
  valid regular expression escaped as a PatternSyntaxException, which Maven
  reports as an internal error. Each now fails as an EnforcerRuleException
  naming the pattern.
- MarkdownFormatRule resolved a Markdown link written inside an inline code
  span, so documentation about Markdown failed on its own example. Code spans
  are now blanked first, as ImportGraph already did; the two share the helper.
- ScanTargets let a file that is both named in `files` and found under a
  scanned directory be checked twice, so contextBudget and noSecrets reported
  its violations twice and recorded them twice in a baseline.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JLTrzWvxqJL69R6qHryUVt