### PR TITLE
ci: cap the Maven CI build at 120 seconds with a step timeout

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -46,6 +46,14 @@ jobs:
       # -DenforceClaudeMd activates the claude-md-enforce profile so the root
       # build fails when CLAUDE.md is missing or malformed. This is the only
       # workflow that runs the check.
+      #
+      # timeout-minutes: 2 caps the build at 120 seconds. The duration check
+      # below reports and fails on an overrun, but it can only run once mvn has
+      # returned: a build that wedges outright would sit there until the job's
+      # 6-hour default limit. The step timeout is what actually kills it at the
+      # same 120s bound. Scoped to this step, not the job, so the checkout, JDK
+      # setup and enforcer bootstrap do not eat into the build's budget.
+      timeout-minutes: 2
       run: |
         start=$(date +%s)
         mvn -B -ntp package -DenforceClaudeMd --file pom.xml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,6 +291,18 @@ needs to publish the enforcer JAR for the plugin to load; the module's own test
 suite still runs in the `package` step. It is the only workflow that runs the
 CLAUDE.md check; the other workflows build normally and are unaffected.
 
+That `package` step is capped at **120 seconds** two ways: a
+`timeout-minutes: 2` on the step, which cancels a build that wedges outright,
+and a wall-clock check around `mvn` that prints the duration and fails with a
+`::error::` annotation when it exceeds 120 s. The timeout is what enforces the
+bound (the check cannot run until `mvn` returns); the check is what says by how
+much a slow-but-finishing build overran. Both are scoped to the step, so the
+checkout, JDK setup and enforcer bootstrap do not count against the budget. A
+run that trips either limit means the build got slower — profile it rather than
+raising the number. The cap applies only here: `maven-windows.yml` and the
+scheduled coverage, mutation and integration-test builds are legitimately
+longer and carry no timeout.
+
 ## Testing, coverage & mutation testing
 
 - **Unit tests** run in the normal `test`/`package` lifecycle
@@ -438,7 +450,7 @@ requests to `main`; the rest run on a schedule (or manually).
 
 | Workflow | Trigger | What it runs |
 | --- | --- | --- |
-| `maven.yml` | push, PR → `main` | Installs the enforcer rule, then `mvn -B package -DenforceClaudeMd` on JDK 25 — the **only** workflow that runs the CLAUDE.md/AGENTS.md checks. |
+| `maven.yml` | push, PR → `main` | Installs the enforcer rule, then `mvn -B package -DenforceClaudeMd` on JDK 25 — the **only** workflow that runs the CLAUDE.md/AGENTS.md checks. The build step is capped at **120 s** (`timeout-minutes: 2` plus a wall-clock check). |
 | `docker.yml` | push, PR → `main` | `mvn -B package`, then builds the Docker image from `assembly/Dockerfile`. |
 | `codeql.yml` | push, PR → `main`; weekly | CodeQL security/static analysis for Java (autobuild). |
 | `integration-tests.yml` | daily | `mvn -P integration-tests verify` (MCP streamable-HTTP integration tests, and the `adopt` multi-repository adoption against real GitHub URLs). |


### PR DESCRIPTION
The build step already measured its own wall clock and failed with a
`::error::` annotation past 120 s, but that check only runs once `mvn`
returns. A build that wedges outright — a deadlocked test fork that
outlives surefire's own kill, a stuck dependency fetch — never reached
it and sat on the runner until the job's 6-hour default limit.

Add `timeout-minutes: 2` to the step so the same 120 s bound is actually
enforced. The existing check stays: it reports the duration and says by
how much a slow-but-finishing build overran, which a cancelled step
cannot.

Scoped to the step rather than the job, so the checkout, JDK setup and
enforcer bootstrap keep their own budget — recent runs finish the whole
job in 95-110 s, which a job-level cap would sit right on top of. Left
maven-windows.yml and the scheduled coverage, mutation and
integration-test builds alone; those are legitimately longer.

Document the cap in AGENTS.md, in the CI workflow table and alongside
the maven.yml walkthrough.