### PR TITLE
feat(adopt): add --dry-run, --timeout and --help behind AdoptionOptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,22 @@ Maven project. The notable capabilities are:
   `PullRequestOptions`, exposed on the command line as `--title`, `--body`,
   repeatable `--reviewer`/`--label`/`--assignee`, and `--draft` (parsed by
   `CliArguments` alongside the positional URL, workspace, and branch arguments).
+  That record and the rest of a run's configuration — the starter assets, the rule
+  version, the dry-run flag, and the per-command timeout — are grouped into an
+  `AdoptionOptions`, which both entry points build and hand to
+  `GitHubRepoAdopter.withDefaultPipeline` and the MCP tool's `Pipeline` seam, so
+  neither grows a parameter per switch and the two cannot drift apart on what an
+  omitted option means. `--dry-run` (`dry_run` on the MCP tool) rehearses an
+  adoption: the pipeline is assembled *without* `PushStep` and `PullRequestStep`
+  rather than with steps that decide to do nothing, so nothing is left that could
+  push and the report's `completedSteps` ends at `verify` — everything before it
+  still runs, leaving the adoption's commits in the workspace to be read before
+  any of it reaches GitHub. `--timeout <minutes>` (`timeout_minutes`, bounded to a
+  day since the MCP server is long-lived) overrides the runner's ten-minute
+  default. `--help`/`-h` answers with the usage line and adopts nothing, rather
+  than being refused as an unknown option with the very line it asked for; it goes
+  to the log, whose console appender writes to standard error, because the same
+  jar is the MCP server and its stdio transport owns standard output.
   One run adopts a **list of repositories**: repeatable `--repo <url>` and
   `--repos <file>` (one URL per line, `#` comments and blank lines skipped, read
   by `RepositoryUrls`) add to the positional URL, duplicates are dropped, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,14 @@ run `mvn install` from the repository root. The main capabilities are:
   GitHub Actions workflow plus `.github/claude-md-guard.sh` check as the
   build-tool-agnostic fallback) and commit that, verify the guard passes on the
   generated file, then push the branch and open a pull request (`gh pr create`)
-  with metadata from `PullRequestOptions` (exposed as CLI flags such as
-  `--title`, `--reviewer`, and `--draft`); the default branch is never written to
-  directly. One run adopts a list of repositories — repeatable `--repo <url>` or
+  with metadata from `PullRequestOptions` (which, with the rest of a run's
+  configuration, is grouped into an `AdoptionOptions` both entry points build and
+  hand to the pipeline factory; exposed as CLI flags such as `--title`,
+  `--reviewer`, `--draft`, and `--timeout <minutes>`); the default branch is never
+  written to directly. `--dry-run` (`dry_run` on the MCP tool) assembles the
+  pipeline without the push and pull-request steps, so a run can be rehearsed into
+  the workspace without writing to GitHub, and `--help` answers with the usage
+  line. One run adopts a list of repositories — repeatable `--repo <url>` or
   `--repos <file>` on the command line, `repository_urls` on the MCP tool — each
   with its own report, and a repository that fails does not stop the rest — a
   malformed URL included, since each checkout is claimed inside its own

--- a/README.md
+++ b/README.md
@@ -762,6 +762,27 @@ mvn -pl adopt exec:java \
     -Dexec.args="https://github.com/owner/repo.git [workspace-directory] [branch-name]"
 ```
 
+`--help` (or `-h`) prints the usage line and adopts nothing, so the arguments can
+be asked for without naming a repository.
+
+Before letting a run write to GitHub, `--dry-run` rehearses it: the repository is
+cloned, branched, and committed on, and the guard is wired in and verified, but
+the branch is never pushed and no pull request is opened. The pipeline is
+assembled *without* those two steps rather than with steps that decide to do
+nothing, so the report's `completedSteps` ends at `verify` and says what really
+happened. The checkout is left in the workspace for the adoption's commits to be
+read before any of it is published:
+
+```bash
+mvn -pl adopt exec:java \
+    -Dexec.args="https://github.com/owner/repo.git --workspace /tmp/adoptions --dry-run"
+```
+
+Every external command is bounded by a timeout — 10 minutes by default —
+overridable with `--timeout <minutes>`, for a repository whose `claude init` or
+whose first Maven build against a cold `~/.m2` needs longer, or for a batch that
+should fail fast instead.
+
 One run can adopt **a list of repositories** rather than a single one: repeat
 `--repo <url>` for each, or point `--repos <file>` at a file naming one
 repository per line (blank lines are skipped and a `#` line is a comment, so a
@@ -824,10 +845,17 @@ shared immutable `AdoptionContext` (the repository URL, the workspace, the
 derived checkout directory, and the feature-branch name):
 
 ```java
-CommandRunner runner = new ProcessCommandRunner();
-GitHubRepoAdopter.withDefaultPipeline(runner, PullRequestOptions.defaults(), false, Optional.empty())
+AdoptionOptions options = AdoptionOptions.defaults();
+CommandRunner runner = new ProcessCommandRunner(options.commandTimeout());
+GitHubRepoAdopter.withDefaultPipeline(runner, options)
     .adopt(new AdoptionContext("https://github.com/owner/repo.git", workspace), new AdoptionReport());
 ```
+
+`AdoptionOptions` is how a run is configured — the pull request's metadata, the
+starter assets, the rule version to pin, whether it is a dry run, and how long
+one command may take. Both entry points build one, so the command line and the
+MCP tool cannot drift apart on what an omitted option means, and the pipeline
+factory does not grow a parameter per switch.
 
 The report is a parameter rather than a return value alone, so a run that fails
 part-way still leaves the caller holding the steps that did complete and the
@@ -839,8 +867,7 @@ its report) per repository — a failing repository is recorded rather than
 allowed to abandon the rest:
 
 ```java
-GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(
-    runner, PullRequestOptions.defaults(), false, Optional.empty());
+GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, AdoptionOptions.defaults());
 List<AdoptionRun> runs = new BatchAdoption(adopter::adopt).adoptAll(contexts);
 ```
 
@@ -914,7 +941,8 @@ The default pipeline runs these steps in order:
    failing the adoption locally if the file is missing or malformed rather than
    after the pull request lands.
 11. **`PushStep`** — pushes the feature branch to origin and sets its upstream
-    (`git push -u origin <branch>`).
+    (`git push -u origin <branch>`). Left out of a `--dry-run` pipeline, together
+    with the step below it.
 12. **`PullRequestStep`** — opens a pull request from the branch with
    `gh pr create`, targeting the repository's default branch as the base. The
    pull request metadata is supplied through `PullRequestOptions` — title, body,
@@ -934,8 +962,9 @@ External `git`/`claude`/`gh` invocations go through a `CommandRunner` abstractio
 so the steps are unit-tested without spawning real processes. The default
 `ProcessCommandRunner` merges standard error into standard output for a single
 ordered transcript, and **bounds every command with a configurable timeout**
-(10 minutes by default) so a stalled clone or a stuck `claude` run cannot hang
-the adoption — on expiry the child process is destroyed and the failure is
+(10 minutes by default, `--timeout <minutes>` on the command line and
+`timeout_minutes` on the MCP tool) so a stalled clone or a stuck `claude` run
+cannot hang the adoption — on expiry the child process is destroyed and the failure is
 reported with whatever output was captured so far. A step whose command exits
 non-zero aborts the pipeline with an `AdoptionException` carrying the command
 transcript.

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
@@ -1,0 +1,74 @@
+package io.github.adamw7.tools.adopt;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
+import io.github.adamw7.tools.adopt.step.PullRequestOptions;
+
+/**
+ * How one adoption run is configured: the metadata its pull request carries,
+ * whether the starter assets are committed, which {@code claude-code-enforcer}
+ * version a Maven project pins, whether the run publishes anything at all, and how
+ * long a single external command may take. Grouping them keeps
+ * {@link GitHubRepoAdopter#withDefaultPipeline} and the MCP tool's pipeline seam
+ * from growing a parameter every time the pipeline gains a switch — the same
+ * reason {@link PullRequestOptions} exists one level down.
+ *
+ * <p>Both entry points build one of these, so the command line and the MCP tool
+ * cannot drift apart on what an omitted option means. The timeout is here rather
+ * than left to the caller's {@link ProcessCommandRunner} because it is part of the
+ * same answer: an operator who raises it does so for the run, not for one command.
+ *
+ * @param pullRequest     the metadata {@link io.github.adamw7.tools.adopt.step.PullRequestStep}
+ *                        opens its pull request with, defaulting to the adoption's own
+ * @param includeAssets   whether the starter Claude Code configuration assets are
+ *                        committed alongside the {@code CLAUDE.md}
+ * @param ruleVersion     the released {@code claude-code-enforcer} version to pin
+ *                        into an adopted Maven project, or {@code null} to resolve
+ *                        the version of the {@code tools} build running the
+ *                        adoption — read through {@link #pinnedRuleVersion()},
+ *                        which is the accessor that says so in its type
+ * @param dryRun          whether the run stops after the verification, committing
+ *                        the adoption locally but pushing nothing and opening no
+ *                        pull request
+ * @param commandTimeout  how long any one external command may run before it is
+ *                        destroyed, defaulting to
+ *                        {@link ProcessCommandRunner#DEFAULT_TIMEOUT}
+ */
+public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAssets, String ruleVersion,
+		boolean dryRun, Duration commandTimeout) {
+
+	public AdoptionOptions {
+		pullRequest = pullRequest == null ? PullRequestOptions.defaults() : pullRequest;
+		ruleVersion = Text.isPresent(ruleVersion) ? ruleVersion.strip() : null;
+		commandTimeout = commandTimeout == null ? ProcessCommandRunner.DEFAULT_TIMEOUT : requirePositive(commandTimeout);
+	}
+
+	/** The adoption's own pull request, no assets, published for real, at the default timeout. */
+	public static AdoptionOptions defaults() {
+		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, false, null);
+	}
+
+	/**
+	 * @return the released rule version to pin, or empty to resolve the version of
+	 *         the {@code tools} build running the adoption. Preferred over the
+	 *         record's own {@link #ruleVersion()}, which answers {@code null} for
+	 *         the same case.
+	 */
+	public Optional<String> pinnedRuleVersion() {
+		return Optional.ofNullable(ruleVersion);
+	}
+
+	/**
+	 * A run is rejected here rather than at the first command it would have killed,
+	 * so {@code --timeout 0} fails while the operator is still reading the command
+	 * line instead of after a clone.
+	 */
+	private static Duration requirePositive(Duration commandTimeout) {
+		if (commandTimeout.isNegative() || commandTimeout.isZero()) {
+			throw new IllegalArgumentException("commandTimeout must be positive but was " + commandTimeout);
+		}
+		return commandTimeout;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -18,10 +19,13 @@ import io.github.adamw7.tools.adopt.step.PullRequestOptions;
  * metadata ({@code --title}, {@code --body}, repeatable
  * {@code --reviewer}/{@code --label}/{@code --assignee}, {@code --draft}), the
  * starter-assets step ({@code --assets}), the {@code claude-code-enforcer}
- * version to wire in ({@code --rule-version}), and a JSON report of the outcome
+ * version to wire in ({@code --rule-version}), a rehearsal that publishes nothing
+ * ({@code --dry-run}), how long any one external command may take
+ * ({@code --timeout <minutes>}), and a JSON report of the outcome
  * ({@code --report <file>}). A blank workspace or branch positional falls back to
  * its default; an unknown flag, or one missing its value, fails with the usage
- * line rather than being ignored.
+ * line rather than being ignored — as does {@code --help}, which asks for that
+ * line and so is answered with it instead.
  *
  * <p>The positional slots keep their meaning whatever else is on the command line
  * — the first is always a repository URL, never a workspace — so a run driven
@@ -35,7 +39,13 @@ public final class CliArguments {
 			+ " [--repo <github-repo-url>]... [--repos <file>]"
 			+ " [--workspace <directory>] [--branch <name>]"
 			+ " [--title <title>] [--body <body>] [--reviewer <user>]... [--label <label>]..."
-			+ " [--assignee <user>]... [--draft] [--assets] [--rule-version <version>] [--report <file>]";
+			+ " [--assignee <user>]... [--draft] [--assets] [--rule-version <version>]"
+			+ " [--dry-run] [--timeout <minutes>] [--report <file>] [--help]";
+
+	static final String HELP_FLAG = "--help";
+	static final String HELP_SHORTHAND = "-h";
+
+	private static final String TIMEOUT_FLAG = "--timeout";
 
 	private final List<String> repositoryUrls = new ArrayList<>();
 	private Path workspace;
@@ -48,7 +58,10 @@ public final class CliArguments {
 	private boolean draft;
 	private boolean assets;
 	private String ruleVersion;
+	private boolean dryRun;
+	private Duration commandTimeout;
 	private Path reportFile;
+	private boolean help;
 	private int positionals;
 	private String positionalUrl;
 	private boolean flagsNamedARepository;
@@ -62,9 +75,16 @@ public final class CliArguments {
 		while (args != null && index < args.length) {
 			index = cli.consume(args, index);
 		}
-		cli.requireRepositoryUrls();
-		cli.requirePositionalNamesARepository();
+		cli.requireSomethingToAdopt();
 		return cli;
+	}
+
+	/**
+	 * @return whether the run asked for the usage line rather than for an adoption,
+	 *         with {@code --help} or {@code -h}
+	 */
+	public boolean helpRequested() {
+		return help;
 	}
 
 	/**
@@ -88,25 +108,26 @@ public final class CliArguments {
 		return new PullRequestOptions(title, body, reviewers, labels, assignees, draft);
 	}
 
-	public boolean includeAssets() {
-		return assets;
-	}
-
-	/**
-	 * @return the released {@code claude-code-enforcer} version to pin into an
-	 *         adopted Maven project's POM, or empty to resolve the version of the
-	 *         {@code tools} build running the adoption
-	 */
-	public Optional<String> ruleVersion() {
-		return Optional.ofNullable(ruleVersion);
+	/** How this run is configured, as the pipeline and the command runner read it. */
+	public AdoptionOptions adoptionOptions() {
+		return new AdoptionOptions(pullRequestOptions(), assets, ruleVersion, dryRun, commandTimeout);
 	}
 
 	public Optional<Path> reportFile() {
 		return Optional.ofNullable(reportFile);
 	}
 
+	/**
+	 * {@code -h} is tested before the {@code --} prefix, since it carries none and
+	 * would otherwise be read as the run's first positional — a repository URL,
+	 * which is the one reading of it nobody means.
+	 */
 	private int consume(String[] args, int index) {
 		String argument = args[index];
+		if (HELP_FLAG.equals(argument) || HELP_SHORTHAND.equals(argument)) {
+			help = true;
+			return index + 1;
+		}
 		if (argument.startsWith("--")) {
 			return consumeFlag(args, index);
 		}
@@ -127,6 +148,7 @@ public final class CliArguments {
 			case "--label" -> consumeValue(args, index, labels::add);
 			case "--assignee" -> consumeValue(args, index, assignees::add);
 			case "--rule-version" -> consumeValue(args, index, value -> ruleVersion = optionalText(value));
+			case TIMEOUT_FLAG -> consumeValue(args, index, value -> commandTimeout = optionalTimeout(value));
 			case "--report" -> consumeValue(args, index, value -> reportFile = optionalPath(value));
 			case "--draft" -> {
 				draft = true;
@@ -134,6 +156,10 @@ public final class CliArguments {
 			}
 			case "--assets" -> {
 				assets = true;
+				yield index + 1;
+			}
+			case "--dry-run" -> {
+				dryRun = true;
 				yield index + 1;
 			}
 			default -> throw new IllegalArgumentException("Unknown option " + flag + ". " + USAGE);
@@ -196,6 +222,47 @@ public final class CliArguments {
 
 	private String optionalText(String value) {
 		return Text.isPresent(value) ? value.strip() : null;
+	}
+
+	/**
+	 * The timeout is read as whole minutes rather than as an ISO-8601 duration,
+	 * because it is set in the units the operator is reasoning about — how long a
+	 * {@code claude init} over their largest repository takes. A blank value counts
+	 * as not supplied, like every other optional flag's, and falls back to the
+	 * pipeline's default.
+	 */
+	private Duration optionalTimeout(String value) {
+		return Text.isPresent(value) ? Duration.ofMinutes(minutes(value.strip())) : null;
+	}
+
+	private long minutes(String value) {
+		long parsed = parseMinutes(value);
+		if (parsed <= 0) {
+			throw new IllegalArgumentException(
+					TIMEOUT_FLAG + " must be a positive number of minutes, but was " + value + ". " + USAGE);
+		}
+		return parsed;
+	}
+
+	private long parseMinutes(String value) {
+		try {
+			return Long.parseLong(value);
+		} catch (NumberFormatException e) {
+			throw new IllegalArgumentException(
+					TIMEOUT_FLAG + " must be a whole number of minutes, but was " + value + ". " + USAGE, e);
+		}
+	}
+
+	/**
+	 * A run that asked for the usage line is not asked to adopt anything, so the
+	 * repository requirements are not applied to it: {@code --help} on its own would
+	 * otherwise be refused with the very line it asked to be shown.
+	 */
+	private void requireSomethingToAdopt() {
+		if (!help) {
+			requireRepositoryUrls();
+			requirePositionalNamesARepository();
+		}
 	}
 
 	private void requireRepositoryUrls() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -2,7 +2,6 @@ package io.github.adamw7.tools.adopt;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -19,7 +18,6 @@ import io.github.adamw7.tools.adopt.step.ClaudeMdConformanceStep;
 import io.github.adamw7.tools.adopt.step.CloneStep;
 import io.github.adamw7.tools.adopt.step.CommitStep;
 import io.github.adamw7.tools.adopt.step.EnforcerStep;
-import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 import io.github.adamw7.tools.adopt.step.PullRequestStep;
 import io.github.adamw7.tools.adopt.step.PushStep;
 import io.github.adamw7.tools.adopt.step.ToolchainStep;
@@ -42,7 +40,9 @@ import io.github.adamw7.tools.adopt.step.VerifyStep;
  * {@link AdoptionReport} of the steps that completed and the pull request's URL;
  * a caller that needs the report of a run that <em>fails</em> supplies its own to
  * {@link #adopt(AdoptionContext, AdoptionReport)} and still holds it afterwards.
- * The default pipeline optionally includes an {@link AssetsStep}.
+ * What the default pipeline contains is decided by {@link AdoptionOptions}: an
+ * {@link AssetsStep} is included on request, and a dry run leaves out the two
+ * steps that write to GitHub.
  */
 public class GitHubRepoAdopter {
 
@@ -56,14 +56,8 @@ public class GitHubRepoAdopter {
 		this.steps = List.copyOf(steps);
 	}
 
-	/**
-	 * @param ruleVersion the released {@code claude-code-enforcer} version a Maven
-	 *                    project's POM should pin, or empty to resolve the version of
-	 *                    the {@code tools} build running the adoption
-	 */
-	public static GitHubRepoAdopter withDefaultPipeline(CommandRunner runner, PullRequestOptions options,
-			boolean includeAssets, Optional<String> ruleVersion) {
-		return new GitHubRepoAdopter(runner, defaultSteps(options, includeAssets, ruleVersion));
+	public static GitHubRepoAdopter withDefaultPipeline(CommandRunner runner, AdoptionOptions options) {
+		return new GitHubRepoAdopter(runner, defaultSteps(options));
 	}
 
 	/**
@@ -71,9 +65,8 @@ public class GitHubRepoAdopter {
 	 * build-system list, so the guard that is wired in is the guard that is verified
 	 * with the tool that was probed.
 	 */
-	public static List<AdoptionStep> defaultSteps(PullRequestOptions options, boolean includeAssets,
-			Optional<String> ruleVersion) {
-		List<BuildSystem> buildSystems = BuildSystems.defaults(ruleVersion);
+	public static List<AdoptionStep> defaultSteps(AdoptionOptions options) {
+		List<BuildSystem> buildSystems = BuildSystems.defaults(options.pinnedRuleVersion());
 		List<AdoptionStep> steps = new ArrayList<>(List.of(
 				new ToolchainStep(),
 				new CloneStep(),
@@ -85,14 +78,34 @@ public class GitHubRepoAdopter {
 				new CommitStep("Adopt Claude Code: add CLAUDE.md"),
 				new EnforcerStep(buildSystems),
 				new CommitStep("Add claude-code-enforcer to the build")));
-		if (includeAssets) {
+		if (options.includeAssets()) {
 			steps.add(new AssetsStep());
 			steps.add(new CommitStep("Add Claude Code configuration assets"));
 		}
 		steps.add(new VerifyStep(buildSystems));
-		steps.add(new PushStep());
-		steps.add(new PullRequestStep(options));
+		addPublication(steps, options);
 		return List.copyOf(steps);
+	}
+
+	/**
+	 * A dry run ends at the verification, so the pipeline is assembled without the
+	 * two steps that write to GitHub rather than with steps that decide for
+	 * themselves to do nothing. The report then says what a dry run really did: the
+	 * steps it completed stop at {@code verify}, instead of listing a {@code push}
+	 * and a {@code pull-request} that only pretended to run.
+	 *
+	 * <p>Everything before the verification still happens for real — the checkout is
+	 * cloned, branched, and committed on — so the operator has the adoption's commits
+	 * in the workspace to read before any of it is published.
+	 */
+	private static void addPublication(List<AdoptionStep> steps, AdoptionOptions options) {
+		if (options.dryRun()) {
+			log.info("Dry run: the adoption will be committed to the checkout but never pushed,"
+					+ " and no pull request will be opened");
+			return;
+		}
+		steps.add(new PushStep());
+		steps.add(new PullRequestStep(options.pullRequest()));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -3,6 +3,9 @@ package io.github.adamw7.tools.adopt;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
 
@@ -19,18 +22,28 @@ import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
  * say how far the adoption got and why it stopped. A run over several
  * repositories writes the batch document {@link AdoptionReportWriter} describes.
  *
+ * <p>{@code --help} is answered with the usage line and nothing is adopted, so the
+ * flag every operator reaches for first is not refused as an unknown option. The
+ * line goes to the log, which the console appender writes to standard error: the
+ * same jar is the adoption MCP server, whose stdio transport owns standard output.
+ *
  * <p>A repository whose adoption fails does not stop the ones behind it — nor does
  * one whose URL names no repository at all: the batch runs to the end and the
  * failures are raised together afterwards, so the process still exits non-zero.
  */
 public class Main {
 
+	private static final Logger log = LogManager.getLogger(Main.class);
+
 	public static void main(String[] args) {
 		CliArguments cli = CliArguments.parse(args);
-		CommandRunner runner = new ProcessCommandRunner();
-		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, cli.pullRequestOptions(),
-				cli.includeAssets(), cli.ruleVersion());
-		runAndReport(cli, checkouts(cli), adopter);
+		if (cli.helpRequested()) {
+			log.info(CliArguments.USAGE);
+			return;
+		}
+		AdoptionOptions options = cli.adoptionOptions();
+		CommandRunner runner = new ProcessCommandRunner(options.commandTimeout());
+		runAndReport(cli, checkouts(cli), GitHubRepoAdopter.withDefaultPipeline(runner, options));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -23,7 +23,14 @@ import io.github.adamw7.tools.adopt.Redaction;
  */
 public class ProcessCommandRunner implements CommandRunner {
 
-	private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(10);
+	/**
+	 * How long a command may run when the caller names no timeout of its own. Sized
+	 * for the longest command the pipeline runs — a {@code claude init} over a whole
+	 * repository — rather than for a {@code git rev-parse}. Public because the run's
+	 * {@link io.github.adamw7.tools.adopt.AdoptionOptions} answers it as the default
+	 * an operator's {@code --timeout} overrides.
+	 */
+	public static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(10);
 
 	private final Duration timeout;
 	private final ExecutableResolver resolver;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -1,16 +1,17 @@
 package io.github.adamw7.tools.adopt.mcp;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionOptions;
 import io.github.adamw7.tools.adopt.AdoptionReport;
 import io.github.adamw7.tools.adopt.AdoptionReportWriter;
 import io.github.adamw7.tools.adopt.AdoptionRun;
@@ -18,7 +19,6 @@ import io.github.adamw7.tools.adopt.BatchAdoption;
 import io.github.adamw7.tools.adopt.Checkouts;
 import io.github.adamw7.tools.adopt.GitHubRepoAdopter;
 import io.github.adamw7.tools.adopt.RepositoryUrls;
-import io.github.adamw7.tools.adopt.Text;
 import io.github.adamw7.tools.adopt.Workspaces;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
@@ -29,11 +29,16 @@ import io.github.adamw7.tools.mcp.ToolResult;
 
 /**
  * The MCP tool that runs the adoption pipeline: given one GitHub repository URL or
- * a list of them — plus optional workspace, branch, pull-request metadata, and the
- * starter-assets flag — it adopts Claude Code exactly as the command line does and
- * answers with the run's JSON {@link AdoptionReport}. The pipeline is injected
- * behind the {@link Pipeline} seam so tests exercise the argument mapping without
- * cloning anything.
+ * a list of them — plus the optional workspace, branch, and {@link AdoptionOptions}
+ * the call configures the run with — it adopts Claude Code exactly as the command
+ * line does and answers with the run's JSON {@link AdoptionReport}. The pipeline is
+ * injected behind the {@link Pipeline} seam so tests exercise the argument mapping
+ * without cloning anything.
+ *
+ * <p>A {@code dry_run} call is the one an agent should reach for first: it clones,
+ * branches, and commits into the workspace, but pushes nothing and opens no pull
+ * request, so what the adoption would do can be read off the report and the
+ * checkout before any of it reaches GitHub.
  *
  * <p>A repository whose adoption fails does not strand the rest of the list: the
  * result carries every repository's report, marked as an error result when any of
@@ -51,10 +56,15 @@ public class AdoptTool implements McpTool {
 	 * adoption and clone nothing.
 	 */
 	public interface Pipeline {
-		BatchAdoption.Adoption create(PullRequestOptions options, boolean includeAssets, Optional<String> ruleVersion);
+		BatchAdoption.Adoption create(AdoptionOptions options);
 	}
 
 	private static final Logger log = LogManager.getLogger(AdoptTool.class);
+
+	private static final int DEFAULT_TIMEOUT_MINUTES = (int) ProcessCommandRunner.DEFAULT_TIMEOUT.toMinutes();
+
+	/** A day, past which a stuck command is a stuck server rather than a slow adoption. */
+	private static final int MAX_TIMEOUT_MINUTES = 24 * 60;
 
 	private final Pipeline pipeline;
 	private final AdoptionReportWriter reportWriter = new AdoptionReportWriter();
@@ -92,7 +102,13 @@ public class AdoptTool implements McpTool {
 									"description", "also commit starter Claude Code configuration assets")),
 							Map.entry("rule_version", Map.of("type", "string",
 									"description", "released claude-code-enforcer version to wire into an adopted "
-											+ "Maven project; defaults to the version of this build"))),
+											+ "Maven project; defaults to the version of this build")),
+							Map.entry("dry_run", Map.of("type", "boolean",
+									"description", "rehearse the adoption: clone, branch, and commit in the "
+											+ "workspace, but push nothing and open no pull request")),
+							Map.entry("timeout_minutes", Map.of("type", "integer",
+									"description", "how long any one git/claude/gh/build command may run before it "
+											+ "is killed; defaults to " + DEFAULT_TIMEOUT_MINUTES))),
 					"required", List.of()));
 
 	public AdoptTool() {
@@ -103,10 +119,9 @@ public class AdoptTool implements McpTool {
 		this.pipeline = pipeline;
 	}
 
-	private static BatchAdoption.Adoption runDefaultPipeline(PullRequestOptions options, boolean includeAssets,
-			Optional<String> ruleVersion) {
-		return GitHubRepoAdopter.withDefaultPipeline(new ProcessCommandRunner(), options, includeAssets,
-				ruleVersion)::adopt;
+	private static BatchAdoption.Adoption runDefaultPipeline(AdoptionOptions options) {
+		return GitHubRepoAdopter.withDefaultPipeline(new ProcessCommandRunner(options.commandTimeout()),
+				options)::adopt;
 	}
 
 	@Override
@@ -117,8 +132,7 @@ public class AdoptTool implements McpTool {
 	@Override
 	public ToolResult apply(Map<String, Object> arguments) {
 		log.info("Calling MCP adopt tool for {}", arguments);
-		BatchAdoption batch = new BatchAdoption(pipeline.create(optionsFrom(arguments),
-				ToolArguments.optionalBoolean(arguments, "assets", false), ruleVersion(arguments)));
+		BatchAdoption batch = new BatchAdoption(pipeline.create(adoptionOptionsFrom(arguments)));
 		return result(batch.adoptAll(repositoryUrls(arguments), checkoutsFrom(arguments)));
 	}
 
@@ -191,19 +205,32 @@ public class AdoptTool implements McpTool {
 	 * {@code --reviewer "[octocat"}, failing the last step of an otherwise complete
 	 * adoption.
 	 */
-	private PullRequestOptions optionsFrom(Map<String, Object> arguments) {
+	private PullRequestOptions pullRequestOptionsFrom(Map<String, Object> arguments) {
 		return new PullRequestOptions(text(arguments, "title"), text(arguments, "body"),
 				textList(arguments, "reviewers"), textList(arguments, "labels"),
 				textList(arguments, "assignees"), ToolArguments.optionalBoolean(arguments, "draft", false));
 	}
 
 	/**
-	 * @return the rule version to pin, empty when the argument was not supplied or
-	 *         was blank — the same rule every other optional argument follows
+	 * The call's whole configuration, in the shape the command line builds too, so
+	 * the two entry points cannot drift apart on what an omitted argument means. A
+	 * blank {@code rule_version} is normalised to "not supplied" by
+	 * {@link AdoptionOptions} itself, as every other optional argument is.
 	 */
-	private Optional<String> ruleVersion(Map<String, Object> arguments) {
-		String supplied = text(arguments, "rule_version");
-		return Text.isPresent(supplied) ? Optional.of(supplied.strip()) : Optional.empty();
+	private AdoptionOptions adoptionOptionsFrom(Map<String, Object> arguments) {
+		return new AdoptionOptions(pullRequestOptionsFrom(arguments),
+				ToolArguments.optionalBoolean(arguments, "assets", false), text(arguments, "rule_version"),
+				ToolArguments.optionalBoolean(arguments, "dry_run", false), commandTimeout(arguments));
+	}
+
+	/**
+	 * The timeout is bounded rather than merely positive: this tool runs inside a
+	 * long-lived server, where a client asking for a week-long timeout would hand it
+	 * a command it can never reclaim.
+	 */
+	private Duration commandTimeout(Map<String, Object> arguments) {
+		return Duration.ofMinutes(ToolArguments.optionalBoundedInt(arguments, "timeout_minutes",
+				DEFAULT_TIMEOUT_MINUTES, 1, MAX_TIMEOUT_MINUTES));
 	}
 
 	/** @return the argument's text, empty when it was not supplied */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
@@ -71,6 +71,17 @@ This creates an executable JAR in `adopt/target/tools.adopt-{version}.jar`.
 - `assets` (boolean, optional): also commit starter Claude Code configuration
   assets (`AGENTS.md`, `.claude/settings.json`, a session-start hook,
   `.mcp.json`, and an `@claude`-mention GitHub Actions workflow)
+- `rule_version` (string, optional): the released `claude-code-enforcer` version
+  to wire into an adopted Maven project; defaults to the version of the `tools`
+  build running the server, and a `-SNAPSHOT` is refused either way
+- `dry_run` (boolean, optional): rehearse the adoption — clone, branch, commit,
+  wire in the guard, and verify it, but push nothing and open no pull request.
+  The pipeline is assembled without those two steps, so `completedSteps` ends at
+  `verify` and the checkout is left in the workspace to be read. Worth reaching
+  for before letting a call write to GitHub
+- `timeout_minutes` (integer, optional): how long any one `git`/`claude`/`gh`/build
+  command may run before it is killed. Defaults to 10, and is bounded to a day —
+  this server is long-lived, so a command it could never reclaim is refused
 
 **Returns** a JSON report:
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionOptionsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionOptionsTest.java
@@ -1,0 +1,89 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
+import io.github.adamw7.tools.adopt.step.PullRequestOptions;
+
+class AdoptionOptionsTest {
+
+	@Test
+	void defaultsAdoptForRealWithTheAdoptionsOwnPullRequest() {
+		AdoptionOptions options = AdoptionOptions.defaults();
+		assertEquals(PullRequestOptions.defaults(), options.pullRequest());
+		assertFalse(options.includeAssets());
+		assertFalse(options.dryRun());
+		assertEquals(Optional.empty(), options.pinnedRuleVersion());
+		assertEquals(ProcessCommandRunner.DEFAULT_TIMEOUT, options.commandTimeout());
+	}
+
+	/**
+	 * Both entry points hand over what their caller supplied, absences included, so
+	 * the record fills them in rather than leaving each one to remember to.
+	 */
+	@Test
+	void fillsInWhatWasNotSupplied() {
+		AdoptionOptions options = new AdoptionOptions(null, false, null, false, null);
+		assertEquals(PullRequestOptions.defaults(), options.pullRequest());
+		assertEquals(ProcessCommandRunner.DEFAULT_TIMEOUT, options.commandTimeout());
+	}
+
+	/**
+	 * A blank rule version is "not supplied" — the rule {@link Text} defines for every
+	 * optional input — so the running build's version is resolved rather than a blank
+	 * one being wired into the adopted POM.
+	 */
+	@Test
+	void aBlankRuleVersionIsNotSupplied() {
+		assertEquals(Optional.empty(), optionsPinning("   ").pinnedRuleVersion());
+		assertEquals(Optional.empty(), optionsPinning(null).pinnedRuleVersion());
+	}
+
+	@Test
+	void aNamedRuleVersionIsStrippedAndKept() {
+		assertEquals(Optional.of("2.6.0"), optionsPinning(" 2.6.0 ").pinnedRuleVersion());
+	}
+
+	/**
+	 * A zero or negative timeout would kill every command before it started, so it is
+	 * refused where the options are built rather than at the first command that ran.
+	 */
+	@Test
+	void refusesATimeoutThatIsNotPositive() {
+		assertThrows(IllegalArgumentException.class, () -> timingOut(Duration.ZERO));
+		assertThrows(IllegalArgumentException.class, () -> timingOut(Duration.ofMinutes(-1)));
+	}
+
+	@Test
+	void keepsATimeoutTheCallerNamed() {
+		assertEquals(Duration.ofMinutes(30), timingOut(Duration.ofMinutes(30)).commandTimeout());
+	}
+
+	/** The pull request is copied defensively by its own record, so the options carry that too. */
+	@Test
+	void carriesThePullRequestMetadataItWasGiven() {
+		PullRequestOptions pullRequest = new PullRequestOptions("Title", "Body", List.of("octocat"), List.of(),
+				List.of(), true);
+		AdoptionOptions options = new AdoptionOptions(pullRequest, true, "2.6.0", true, Duration.ofMinutes(1));
+		assertEquals(pullRequest, options.pullRequest());
+		assertTrue(options.includeAssets());
+		assertTrue(options.dryRun());
+	}
+
+	private AdoptionOptions optionsPinning(String ruleVersion) {
+		return new AdoptionOptions(PullRequestOptions.defaults(), false, ruleVersion, false, null);
+	}
+
+	private AdoptionOptions timingOut(Duration commandTimeout) {
+		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, false, commandTimeout);
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -8,12 +8,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 
 class CliArgumentsTest {
@@ -173,7 +175,7 @@ class CliArgumentsTest {
 	void defaultsPullRequestOptionsWhenNoFlagsGiven() {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL });
 		assertEquals(PullRequestOptions.defaults(), cli.pullRequestOptions());
-		assertFalse(cli.includeAssets());
+		assertFalse(cli.adoptionOptions().includeAssets());
 		assertTrue(cli.reportFile().isEmpty());
 	}
 
@@ -195,7 +197,7 @@ class CliArgumentsTest {
 	@Test
 	void parsesAssetsAndReportFlags() {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--assets", "--report", "/tmp/report.json" });
-		assertTrue(cli.includeAssets());
+		assertTrue(cli.adoptionOptions().includeAssets());
 		assertEquals(Path.of("/tmp/report.json"), cli.reportFile().orElseThrow());
 	}
 
@@ -256,12 +258,12 @@ class CliArgumentsTest {
 	@Test
 	void parsesTheRuleVersionFlag() {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--rule-version", "2.6.0" });
-		assertEquals(Optional.of("2.6.0"), cli.ruleVersion());
+		assertEquals(Optional.of("2.6.0"), cli.adoptionOptions().pinnedRuleVersion());
 	}
 
 	@Test
 	void noRuleVersionFlagLeavesTheRunningBuildsVersionToBeResolved() {
-		assertEquals(Optional.empty(), CliArguments.parse(new String[] { REPO_URL }).ruleVersion());
+		assertEquals(Optional.empty(), CliArguments.parse(new String[] { REPO_URL }).adoptionOptions().pinnedRuleVersion());
 	}
 
 	/**
@@ -272,7 +274,7 @@ class CliArgumentsTest {
 	@Test
 	void aBlankRuleVersionFallsBackToTheDefault() {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--rule-version", "  " });
-		assertEquals(Optional.empty(), cli.ruleVersion());
+		assertEquals(Optional.empty(), cli.adoptionOptions().pinnedRuleVersion());
 	}
 
 	@Test
@@ -324,6 +326,75 @@ class CliArgumentsTest {
 	void aBlankRepositoryFlagDoesNotRejectALocalRepositoryPositional() {
 		CliArguments cli = CliArguments.parse(new String[] { "/tmp/checkouts/repo", "--repo", "  " });
 		assertEquals(List.of("/tmp/checkouts/repo"), cli.repositoryUrls());
+	}
+
+	/**
+	 * The flag an operator reaches for first used to be refused as an unknown
+	 * option — with the very usage line it was asking for, which made the refusal
+	 * read like a bug rather than an answer.
+	 */
+	@Test
+	void answersHelpWithoutRequiringARepository() {
+		assertTrue(CliArguments.parse(new String[] { CliArguments.HELP_FLAG }).helpRequested());
+		assertTrue(CliArguments.parse(new String[] { CliArguments.HELP_SHORTHAND }).helpRequested());
+	}
+
+	/**
+	 * {@code -h} carries no {@code --} prefix, so nothing but an explicit test keeps
+	 * it from being read as the run's first positional: a repository URL.
+	 */
+	@Test
+	void theHelpShorthandIsNotReadAsARepositoryUrl() {
+		assertEquals(List.of(), CliArguments.parse(new String[] { CliArguments.HELP_SHORTHAND }).repositoryUrls());
+	}
+
+	@Test
+	void helpBesideARealRunStillOnlyAsksForTheUsage() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, CliArguments.HELP_FLAG });
+		assertTrue(cli.helpRequested());
+		assertEquals(List.of(REPO_URL), cli.repositoryUrls());
+	}
+
+	@Test
+	void adoptsForRealUnlessTheDryRunFlagIsGiven() {
+		assertFalse(CliArguments.parse(new String[] { REPO_URL }).adoptionOptions().dryRun());
+		assertTrue(CliArguments.parse(new String[] { REPO_URL, "--dry-run" }).adoptionOptions().dryRun());
+	}
+
+	@Test
+	void readsTheCommandTimeoutAsWholeMinutes() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--timeout", "45" });
+		assertEquals(Duration.ofMinutes(45), cli.adoptionOptions().commandTimeout());
+	}
+
+	@Test
+	void fallsBackToTheDefaultTimeoutWhenNoneIsNamed() {
+		assertEquals(ProcessCommandRunner.DEFAULT_TIMEOUT,
+				CliArguments.parse(new String[] { REPO_URL }).adoptionOptions().commandTimeout());
+		assertEquals(ProcessCommandRunner.DEFAULT_TIMEOUT,
+				CliArguments.parse(new String[] { REPO_URL, "--timeout", "  " }).adoptionOptions().commandTimeout());
+	}
+
+	/**
+	 * A timeout that is not a positive number of minutes is refused while the
+	 * operator is still reading the command line, rather than at the first command
+	 * it would have killed — or, for a zero, never having run one at all.
+	 */
+	@Test
+	void refusesATimeoutThatIsNotAPositiveNumberOfMinutes() {
+		assertUsageFailure(new String[] { REPO_URL, "--timeout", "0" });
+		assertUsageFailure(new String[] { REPO_URL, "--timeout", "-5" });
+		assertUsageFailure(new String[] { REPO_URL, "--timeout", "soon" });
+	}
+
+	@Test
+	void carriesThePullRequestMetadataAndTheAssetsFlagIntoTheAdoptionOptions() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--title", "My title", "--assets",
+				"--rule-version", " 2.6.0 " });
+		AdoptionOptions options = cli.adoptionOptions();
+		assertEquals("My title", options.pullRequest().title());
+		assertTrue(options.includeAssets());
+		assertEquals(Optional.of("2.6.0"), options.pinnedRuleVersion());
 	}
 
 	private void assertUsageFailure(String[] args) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -137,25 +136,53 @@ class GitHubRepoAdopterTest {
 	@Test
 	void withDefaultPipelineHonoursPullRequestOptionsAndTheAssetsFlag() {
 		RecordingCommandRunner runner = RecordingCommandRunner.failing(1, "missing");
-		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, PullRequestOptions.defaults(),
-				true, Optional.empty());
+		GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, withAssets());
 		assertThrows(AdoptionException.class, () -> adopter.adopt(context, new AdoptionReport()));
 		assertEquals(List.of("git", "--version"), runner.commandAt(0));
 	}
 
 	@Test
 	void defaultPipelineBranchesCommitsPushesAndOpensAPullRequest() {
-		List<String> names = GitHubRepoAdopter.defaultSteps(PullRequestOptions.defaults(), false, Optional.empty()).stream()
-				.map(AdoptionStep::name).toList();
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
-				"commit", "enforcer", "commit", "verify", "push", "pull-request"), names);
+				"commit", "enforcer", "commit", "verify", "push", "pull-request"),
+				stepNames(AdoptionOptions.defaults()));
 	}
 
 	@Test
 	void defaultPipelineWithAssetsInstallsAndCommitsThemBeforeVerification() {
-		List<String> names = GitHubRepoAdopter.defaultSteps(PullRequestOptions.defaults(), true, Optional.empty()).stream()
-				.map(AdoptionStep::name).toList();
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
-				"commit", "enforcer", "commit", "assets", "commit", "verify", "push", "pull-request"), names);
+				"commit", "enforcer", "commit", "assets", "commit", "verify", "push", "pull-request"),
+				stepNames(withAssets()));
+	}
+
+	/**
+	 * A dry run is assembled without the two steps that write to GitHub rather than
+	 * with steps that decide to do nothing, so nothing is left that could push if a
+	 * later change got the condition wrong. Everything before the verification stays,
+	 * because a rehearsal that skipped the commits would prove nothing.
+	 */
+	@Test
+	void aDryRunPipelineStopsAtTheVerification() {
+		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
+				"commit", "enforcer", "commit", "verify"), stepNames(dryRun()));
+	}
+
+	@Test
+	void aDryRunPipelineStillInstallsTheAssetsWhenAskedFor() {
+		AdoptionOptions options = new AdoptionOptions(PullRequestOptions.defaults(), true, null, true, null);
+		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
+				"commit", "enforcer", "commit", "assets", "commit", "verify"), stepNames(options));
+	}
+
+	private List<String> stepNames(AdoptionOptions options) {
+		return GitHubRepoAdopter.defaultSteps(options).stream().map(AdoptionStep::name).toList();
+	}
+
+	private AdoptionOptions withAssets() {
+		return new AdoptionOptions(PullRequestOptions.defaults(), true, null, false, null);
+	}
+
+	private AdoptionOptions dryRun() {
+		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, true, null);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -45,6 +46,17 @@ class MainTest {
 	@Test
 	void rejectsUnknownOptionBeforeAnyWorkStarts() {
 		assertThrows(IllegalArgumentException.class, () -> Main.main(new String[] { REPO_URL, "--frobnicate" }));
+	}
+
+	/**
+	 * {@code --help} returns instead of adopting, so the flag can be asked for
+	 * without a repository — and, when one is named beside it, without cloning that
+	 * repository as a side effect of asking what the arguments are.
+	 */
+	@Test
+	void answersHelpWithoutAdoptingAnything() {
+		assertDoesNotThrow(() -> Main.main(new String[] { "--help" }));
+		assertDoesNotThrow(() -> Main.main(new String[] { REPO_URL, "-h" }));
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -21,8 +22,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.AdoptionOptions;
 import io.github.adamw7.tools.adopt.AdoptionReport;
 import io.github.adamw7.tools.adopt.BatchAdoption;
+import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 import io.github.adamw7.tools.mcp.ToolResult;
 
@@ -37,17 +40,14 @@ class AdoptToolTest {
 
 		private final List<AdoptionContext> contexts = new ArrayList<>();
 		private final List<PullRequestOptions> optionsPerRepository = new ArrayList<>();
-		private boolean includeAssets;
-		private Optional<String> ruleVersion = Optional.empty();
+		private AdoptionOptions adoptionOptions = AdoptionOptions.defaults();
 		private int pipelinesCreated;
 
 		@Override
-		public BatchAdoption.Adoption create(PullRequestOptions options, boolean includeAssets,
-				Optional<String> ruleVersion) {
-			this.includeAssets = includeAssets;
-			this.ruleVersion = ruleVersion;
+		public BatchAdoption.Adoption create(AdoptionOptions options) {
+			this.adoptionOptions = options;
 			pipelinesCreated++;
-			return (context, report) -> adopt(context, options, report);
+			return (context, report) -> adopt(context, options.pullRequest(), report);
 		}
 
 		private void adopt(AdoptionContext context, PullRequestOptions options, AdoptionReport report) {
@@ -126,7 +126,7 @@ class AdoptToolTest {
 	 */
 	@Test
 	void answersWithAnErrorResultCarryingTheReportWhenARepositoryFails() throws IOException {
-		AdoptTool failing = new AdoptTool((options, includeAssets, ruleVersion) -> (context, report) -> {
+		AdoptTool failing = new AdoptTool(options -> (context, report) -> {
 			report.recordStep("clone");
 			throw new AdoptionException("boom");
 		});
@@ -144,7 +144,7 @@ class AdoptToolTest {
 		assertEquals(REPO_URL, pipeline.context().repositoryUrl());
 		assertEquals(AdoptionContext.DEFAULT_BRANCH, pipeline.context().branchName());
 		assertEquals(PullRequestOptions.defaults(), pipeline.options());
-		assertFalse(pipeline.includeAssets);
+		assertFalse(pipeline.adoptionOptions.includeAssets());
 		assertTrue(Files.isDirectory(pipeline.context().workspace()));
 	}
 
@@ -175,19 +175,19 @@ class AdoptToolTest {
 		assertEquals(List.of("automation"), pipeline.options().labels());
 		assertEquals(List.of("adamw7"), pipeline.options().assignees());
 		assertTrue(pipeline.options().draft());
-		assertTrue(pipeline.includeAssets);
+		assertTrue(pipeline.adoptionOptions.includeAssets());
 	}
 
 	@Test
 	void passesTheRuleVersionOnToThePipeline() {
 		tool.apply(Map.of("repository_url", REPO_URL, "rule_version", " 2.6.0 "));
-		assertEquals(Optional.of("2.6.0"), pipeline.ruleVersion);
+		assertEquals(Optional.of("2.6.0"), pipeline.adoptionOptions.pinnedRuleVersion());
 	}
 
 	@Test
 	void aBlankRuleVersionLeavesTheRunningBuildsVersionToBeResolved() {
 		tool.apply(Map.of("repository_url", REPO_URL, "rule_version", "  "));
-		assertEquals(Optional.empty(), pipeline.ruleVersion);
+		assertEquals(Optional.empty(), pipeline.adoptionOptions.pinnedRuleVersion());
 	}
 
 	@Test
@@ -195,6 +195,55 @@ class AdoptToolTest {
 		Object properties = tool.getToolDefinition().inputSchema().get("properties");
 		assertTrue(properties instanceof Map<?, ?> declared && declared.containsKey("rule_version"),
 				"the version must be settable through the tool: " + properties);
+	}
+
+	/**
+	 * The flag an agent should reach for before letting the pipeline write to
+	 * GitHub, so it has to survive the argument mapping rather than be silently
+	 * dropped into a run that pushes.
+	 */
+	@Test
+	void passesTheDryRunFlagOnToThePipeline() {
+		tool.apply(Map.of("repository_url", REPO_URL, "dry_run", true));
+		assertTrue(pipeline.adoptionOptions.dryRun());
+	}
+
+	@Test
+	void adoptsForRealWhenNoDryRunIsAskedFor() {
+		tool.apply(Map.of("repository_url", REPO_URL));
+		assertFalse(pipeline.adoptionOptions.dryRun());
+	}
+
+	@Test
+	void passesTheCommandTimeoutOnToThePipeline() {
+		tool.apply(Map.of("repository_url", REPO_URL, "timeout_minutes", 25));
+		assertEquals(Duration.ofMinutes(25), pipeline.adoptionOptions.commandTimeout());
+	}
+
+	@Test
+	void fallsBackToTheRunnersOwnTimeoutWhenNoneIsAskedFor() {
+		tool.apply(Map.of("repository_url", REPO_URL));
+		assertEquals(ProcessCommandRunner.DEFAULT_TIMEOUT, pipeline.adoptionOptions.commandTimeout());
+	}
+
+	/**
+	 * The tool runs inside a long-lived server, so a timeout it could never reclaim
+	 * is refused before the first clone rather than honoured.
+	 */
+	@Test
+	void refusesATimeoutOutsideTheAllowedRange() {
+		assertThrows(IllegalArgumentException.class,
+				() -> tool.apply(Map.of("repository_url", REPO_URL, "timeout_minutes", 0)));
+		assertThrows(IllegalArgumentException.class,
+				() -> tool.apply(Map.of("repository_url", REPO_URL, "timeout_minutes", 24 * 60 + 1)));
+	}
+
+	@Test
+	void declaresTheDryRunAndTimeoutArguments() {
+		Object properties = tool.getToolDefinition().inputSchema().get("properties");
+		assertTrue(properties instanceof Map<?, ?> declared && declared.containsKey("dry_run")
+				&& declared.containsKey("timeout_minutes"),
+				"a rehearsal and a longer command budget must be askable for: " + properties);
 	}
 
 	@Test
@@ -274,7 +323,7 @@ class AdoptToolTest {
 	 */
 	@Test
 	void adoptsTheRestOfTheListAfterARepositoryFails() throws IOException {
-		AdoptTool failing = new AdoptTool((options, includeAssets, ruleVersion) -> (context, report) -> {
+		AdoptTool failing = new AdoptTool(options -> (context, report) -> {
 			if (REPO_URL.equals(context.repositoryUrl())) {
 				throw new AdoptionException("boom");
 			}
@@ -306,7 +355,7 @@ class AdoptToolTest {
 		tool.apply(Map.of("repository_urls", List.of(REPO_URL, OTHER_URL), "title", "My title", "assets", true));
 		assertEquals(List.of("My title", "My title"),
 				pipeline.optionsPerRepository.stream().map(PullRequestOptions::title).toList());
-		assertTrue(pipeline.includeAssets);
+		assertTrue(pipeline.adoptionOptions.includeAssets());
 	}
 
 	@Test


### PR DESCRIPTION
The pipeline had no rehearsal mode: every run that got past the
verification pushed a branch and opened a pull request. `--dry-run`
(`dry_run` on the MCP tool) assembles the pipeline *without* PushStep and
PullRequestStep, rather than with steps that decide to do nothing, so
nothing is left that could publish and the report's completedSteps ends
at `verify`. Everything before it still runs for real, leaving the
adoption's commits in the workspace to be read first.

The ten-minute per-command timeout was unreachable: ProcessCommandRunner
took a Duration, but both entry points called the no-arg constructor.
`--timeout <minutes>` (`timeout_minutes`, bounded to a day on the
long-lived MCP server) overrides it, for a repository whose `claude init`
or whose first build against a cold ~/.m2 needs longer.

`--help`/`-h` answered with "Unknown option --help" — the one flag every
operator tries first, refused with the very usage line it asked for. It
now logs that line and adopts nothing; the console appender writes to
standard error, which the MCP server's stdio transport leaves free.

The three would each have added a parameter to withDefaultPipeline and to
the MCP Pipeline seam, so a run's configuration is grouped into an
AdoptionOptions record — the same reason PullRequestOptions exists one
level down. Both entry points build one, so they cannot drift apart on
what an omitted option means. CliArguments.includeAssets()/ruleVersion()
go with it: production reads them through the record now, and two ways to
read one setting is the drift the record exists to prevent.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TNTyAT6wZfVhbzcYesPH9p