### PR TITLE
refactor(adopt, claude-code-enforcer): simplify list building

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -1,7 +1,7 @@
 package io.github.adamw7.tools.adopt;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -67,7 +67,17 @@ public class GitHubRepoAdopter {
 	 */
 	public static List<AdoptionStep> defaultSteps(AdoptionOptions options) {
 		List<BuildSystem> buildSystems = BuildSystems.defaults(options.pinnedRuleVersion());
-		List<AdoptionStep> steps = new ArrayList<>(List.of(
+		return Stream.of(
+				adoptionSteps(buildSystems),
+				assetSteps(options),
+				List.<AdoptionStep>of(new VerifyStep(buildSystems)),
+				publicationSteps(options))
+				.flatMap(List::stream)
+				.toList();
+	}
+
+	private static List<AdoptionStep> adoptionSteps(List<BuildSystem> buildSystems) {
+		return List.of(
 				new ToolchainStep(),
 				new CloneStep(),
 				new BuildToolchainStep(buildSystems),
@@ -77,14 +87,14 @@ public class GitHubRepoAdopter {
 				new ClaudeMdConformanceStep(),
 				new CommitStep("Adopt Claude Code: add CLAUDE.md"),
 				new EnforcerStep(buildSystems),
-				new CommitStep("Add claude-code-enforcer to the build")));
-		if (options.includeAssets()) {
-			steps.add(new AssetsStep());
-			steps.add(new CommitStep("Add Claude Code configuration assets"));
+				new CommitStep("Add claude-code-enforcer to the build"));
+	}
+
+	private static List<AdoptionStep> assetSteps(AdoptionOptions options) {
+		if (!options.includeAssets()) {
+			return List.of();
 		}
-		steps.add(new VerifyStep(buildSystems));
-		addPublication(steps, options);
-		return List.copyOf(steps);
+		return List.of(new AssetsStep(), new CommitStep("Add Claude Code configuration assets"));
 	}
 
 	/**
@@ -98,14 +108,13 @@ public class GitHubRepoAdopter {
 	 * cloned, branched, and committed on — so the operator has the adoption's commits
 	 * in the workspace to read before any of it is published.
 	 */
-	private static void addPublication(List<AdoptionStep> steps, AdoptionOptions options) {
+	private static List<AdoptionStep> publicationSteps(AdoptionOptions options) {
 		if (options.dryRun()) {
 			log.info("Dry run: the adoption will be committed to the checkout but never pushed,"
 					+ " and no pull request will be opened");
-			return;
+			return List.of();
 		}
-		steps.add(new PushStep());
-		steps.add(new PullRequestStep(options.pullRequest()));
+		return List.of(new PushStep(), new PullRequestStep(options.pullRequest()));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandLine.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandLine.java
@@ -1,0 +1,65 @@
+package io.github.adamw7.tools.adopt.command;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds the argument list of one command to hand to a {@link CommandRunner}.
+ *
+ * <p>Nearly every adoption step assembles its command the same way: a fixed
+ * program and its leading arguments, then arguments that depend on the run — a
+ * {@code --repo} the URL may not name, a {@code --draft} only a draft pull request
+ * carries, a {@code --reviewer} per requested reviewer. Written out directly that
+ * is a mutable list seeded from a {@link List#of} literal, a run of {@code add}
+ * calls guarded by {@code if}s and {@code forEach}es, and a closing
+ * {@link List#copyOf} — the same six lines in every step, with the command itself
+ * buried in them.
+ *
+ * <p>Collecting it here leaves each step naming only its own arguments, and makes
+ * the immutable result the single way to finish rather than something each step
+ * has to remember.
+ */
+public final class CommandLine {
+
+	private final List<String> arguments = new ArrayList<>();
+
+	private CommandLine() {
+	}
+
+	/** Starts a command with its program name and any arguments it always carries. */
+	public static CommandLine of(String... program) {
+		return new CommandLine().add(program);
+	}
+
+	/** Appends {@code arguments} in order. */
+	public CommandLine add(String... arguments) {
+		this.arguments.addAll(List.of(arguments));
+		return this;
+	}
+
+	/** Appends an already-assembled run of arguments in order. */
+	public CommandLine addAll(List<String> arguments) {
+		this.arguments.addAll(arguments);
+		return this;
+	}
+
+	/** Appends {@code arguments} only when {@code condition} holds, e.g. an optional flag. */
+	public CommandLine addIf(boolean condition, String... arguments) {
+		return condition ? add(arguments) : this;
+	}
+
+	/**
+	 * Appends {@code flag} followed by its value once per entry of {@code values},
+	 * which is how a repeatable option such as {@code --reviewer} is written. An
+	 * empty list leaves the command untouched.
+	 */
+	public CommandLine addEach(String flag, List<String> values) {
+		values.forEach(value -> add(flag, value));
+		return this;
+	}
+
+	/** The assembled command, as an immutable list. */
+	public List<String> toList() {
+		return List.copyOf(arguments);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -86,14 +85,11 @@ final class ExecutableResolver {
 	}
 
 	private List<String> rewrite(Path executable, List<String> command) {
-		List<String> rewritten = new ArrayList<>();
-		if (isBatchScript(executable)) {
-			rewritten.add("cmd.exe");
-			rewritten.add("/c");
-		}
-		rewritten.add(executable.toString());
-		rewritten.addAll(command.subList(1, command.size()));
-		return rewritten;
+		return CommandLine.of()
+				.addIf(isBatchScript(executable), "cmd.exe", "/c")
+				.add(executable.toString())
+				.addAll(command.subList(1, command.size()))
+				.toList();
 	}
 
 	private boolean isBatchScript(Path executable) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -8,6 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandLine;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
@@ -42,9 +42,9 @@ public class BranchStep extends AbstractCommandStep {
 	}
 
 	private List<String> checkoutCommand(AdoptionContext context, CommandRunner runner) {
-		List<String> command = new ArrayList<>(List.of("git", "checkout", "-B", context.branchName()));
+		CommandLine command = CommandLine.of("git", "checkout", "-B", context.branchName());
 		startPoint(context, runner).ifPresent(command::add);
-		return List.copyOf(command);
+		return command.toList();
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildWrapper.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildWrapper.java
@@ -2,11 +2,11 @@ package io.github.adamw7.tools.adopt.step;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import io.github.adamw7.tools.adopt.Platform;
+import io.github.adamw7.tools.adopt.command.CommandLine;
 
 /**
  * Finds the build wrapper script a checkout ships with — {@code mvnw} for Maven,
@@ -42,10 +42,7 @@ final class BuildWrapper {
 	 * system's "wrapper, else the PATH tool" from being written out again.
 	 */
 	List<String> commandIn(Path repositoryDirectory, String fallback, List<String> arguments) {
-		List<String> command = new ArrayList<>();
-		command.add(in(repositoryDirectory).orElse(fallback));
-		command.addAll(arguments);
-		return List.copyOf(command);
+		return CommandLine.of(in(repositoryDirectory).orElse(fallback)).addAll(arguments).toList();
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
@@ -1,12 +1,12 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandLine;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
@@ -63,18 +63,15 @@ public class CommitStep extends AbstractCommandStep {
 	}
 
 	private List<String> commitCommand(AdoptionContext context, CommandRunner runner) {
-		List<String> command = new ArrayList<>(List.of("git"));
+		CommandLine command = CommandLine.of("git");
 		addOverrideIfMissing(command, context, runner, "user.name", FALLBACK_NAME);
 		addOverrideIfMissing(command, context, runner, "user.email", FALLBACK_EMAIL);
-		command.addAll(List.of("commit", "-m", message));
-		return command;
+		return command.add("commit", "-m", message).toList();
 	}
 
-	private void addOverrideIfMissing(List<String> command, AdoptionContext context, CommandRunner runner,
+	private void addOverrideIfMissing(CommandLine command, AdoptionContext context, CommandRunner runner,
 			String key, String fallback) {
-		if (!hasConfig(context, runner, key)) {
-			command.addAll(List.of("-c", key + "=" + fallback));
-		}
+		command.addIf(!hasConfig(context, runner, key), "-c", key + "=" + fallback);
 	}
 
 	private boolean hasConfig(AdoptionContext context, CommandRunner runner, String key) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionReport;
+import io.github.adamw7.tools.adopt.command.CommandLine;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
@@ -100,24 +100,18 @@ public class PullRequestStep extends AbstractCommandStep {
 	}
 
 	private List<String> createCommand(AdoptionContext context) {
-		List<String> command = new ArrayList<>(List.of("gh", "pr", "create", "--title", options.title(), "--body",
-				options.body(), "--head", context.branchName()));
-		addTargetRepository(command, context);
-		if (options.draft()) {
-			command.add("--draft");
-		}
-		addRepeated(command, "--reviewer", options.reviewers());
-		addRepeated(command, "--label", options.labels());
-		addRepeated(command, "--assignee", options.assignees());
-		return List.copyOf(command);
+		CommandLine command = CommandLine.of("gh", "pr", "create", "--title", options.title(), "--body",
+				options.body(), "--head", context.branchName());
+		return withTargetRepository(command, context)
+				.addIf(options.draft(), "--draft")
+				.addEach("--reviewer", options.reviewers())
+				.addEach("--label", options.labels())
+				.addEach("--assignee", options.assignees())
+				.toList();
 	}
 
-	private void addTargetRepository(List<String> command, AdoptionContext context) {
-		context.repositorySlug().ifPresent(slug -> command.addAll(List.of("--repo", slug)));
-	}
-
-	private void addRepeated(List<String> command, String flag, List<String> values) {
-		values.forEach(value -> command.addAll(List.of(flag, value)));
+	private CommandLine withTargetRepository(CommandLine command, AdoptionContext context) {
+		return context.repositorySlug().map(slug -> command.add("--repo", slug)).orElse(command);
 	}
 
 	/**
@@ -140,10 +134,9 @@ public class PullRequestStep extends AbstractCommandStep {
 	}
 
 	private List<String> listCommand(AdoptionContext context) {
-		List<String> command = new ArrayList<>(List.of("gh", "pr", "list", "--head", context.branchName(), "--state",
-				"open", "--json", "url"));
-		addTargetRepository(command, context);
-		return List.copyOf(command);
+		CommandLine command = CommandLine.of("gh", "pr", "list", "--head", context.branchName(), "--state",
+				"open", "--json", "url");
+		return withTargetRepository(command, context).toList();
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/CommandLineTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/CommandLineTest.java
@@ -1,0 +1,73 @@
+package io.github.adamw7.tools.adopt.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class CommandLineTest {
+
+	@Test
+	void ofKeepsTheProgramAndItsArgumentsInOrder() {
+		assertEquals(List.of("git", "checkout", "-B"), CommandLine.of("git", "checkout", "-B").toList());
+	}
+
+	@Test
+	void ofWithoutArgumentsStartsAnEmptyCommand() {
+		assertEquals(List.of(), CommandLine.of().toList());
+	}
+
+	@Test
+	void addAppendsInOrder() {
+		assertEquals(List.of("git", "commit", "-m", "message"),
+				CommandLine.of("git").add("commit").add("-m", "message").toList());
+	}
+
+	@Test
+	void addAllAppendsAnAssembledRun() {
+		assertEquals(List.of("mvnw", "-B", "verify"),
+				CommandLine.of("mvnw").addAll(List.of("-B", "verify")).toList());
+	}
+
+	@Test
+	void addIfAppendsOnlyWhenTheConditionHolds() {
+		assertEquals(List.of("gh", "--draft"), CommandLine.of("gh").addIf(true, "--draft").toList());
+		assertEquals(List.of("gh"), CommandLine.of("gh").addIf(false, "--draft").toList());
+	}
+
+	@Test
+	void addEachRepeatsTheFlagOncePerValue() {
+		assertEquals(List.of("gh", "--reviewer", "ann", "--reviewer", "bob"),
+				CommandLine.of("gh").addEach("--reviewer", List.of("ann", "bob")).toList());
+	}
+
+	@Test
+	void addEachLeavesTheCommandUntouchedForNoValues() {
+		assertEquals(List.of("gh"), CommandLine.of("gh").addEach("--label", List.of()).toList());
+	}
+
+	@Test
+	void toListIsImmutable() {
+		List<String> command = CommandLine.of("git").toList();
+		assertThrows(UnsupportedOperationException.class, () -> command.add("status"));
+	}
+
+	@Test
+	void toListDoesNotSeeLaterAdditions() {
+		CommandLine command = CommandLine.of("git");
+		List<String> assembled = command.toList();
+		command.add("status");
+		assertEquals(List.of("git"), assembled);
+	}
+
+	@Test
+	void addAllCopiesTheSourceList() {
+		List<String> arguments = new ArrayList<>(List.of("verify"));
+		CommandLine command = CommandLine.of("mvn").addAll(arguments);
+		arguments.add("deploy");
+		assertEquals(List.of("mvn", "verify"), command.toList());
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/Duplicates.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/Duplicates.java
@@ -32,13 +32,10 @@ final class Duplicates {
 	 * (e.g. {@code name}) and every source that claims it.
 	 */
 	List<String> violations(String property) {
-		List<String> violations = new ArrayList<>();
-		for (Claim claim : byKey.values()) {
-			if (claim.sources().size() > 1) {
-				violations.add(property + " '" + claim.value() + "' is used by " + claim.sources().size()
-						+ " definitions: " + String.join(", ", claim.sources()));
-			}
-		}
-		return violations;
+		return byKey.values().stream()
+				.filter(claim -> claim.sources().size() > 1)
+				.map(claim -> property + " '" + claim.value() + "' is used by " + claim.sources().size()
+						+ " definitions: " + String.join(", ", claim.sources()))
+				.toList();
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
@@ -5,15 +5,15 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
@@ -117,27 +117,19 @@ final class ImportGraph {
 
 	private List<Reference> referencesIn(File file) {
 		MarkdownDocument document = MarkdownDocument.parse(readSafely(file));
-		List<Reference> found = new ArrayList<>();
-		for (int i = 0; i < document.lineCount(); i++) {
-			collectLineReferences(file, document, i, found);
-		}
-		return found;
+		return IntStream.range(0, document.lineCount())
+				.filter(index -> !document.isInsideFence(index))
+				.mapToObj(document::line)
+				.flatMap(line -> lineReferences(file, line))
+				.toList();
 	}
 
-	private void collectLineReferences(File file, MarkdownDocument document, int index, List<Reference> found) {
-		if (document.isInsideFence(index)) {
-			return;
-		}
-		Matcher matcher = IMPORT.matcher(MarkdownText.withoutCodeSpans(document.line(index)));
-		while (matcher.find()) {
-			addReference(file, withoutTrailingDots(matcher.group(1)), found);
-		}
-	}
-
-	private void addReference(File file, String imported, List<Reference> found) {
-		if (!ignored.test(imported)) {
-			found.add(new Reference(imported, resolve(file, imported)));
-		}
+	private Stream<Reference> lineReferences(File file, String line) {
+		return IMPORT.matcher(MarkdownText.withoutCodeSpans(line))
+				.results()
+				.map(match -> withoutTrailingDots(match.group(1)))
+				.filter(imported -> !ignored.test(imported))
+				.map(imported -> new Reference(imported, resolve(file, imported)));
 	}
 
 	/** Drops sentence punctuation, so "see @docs/setup.md." imports {@code docs/setup.md}. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRule.java
@@ -3,7 +3,6 @@ package io.github.adamw7.tools.enforcer.doc;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.inject.Named;
@@ -83,12 +82,10 @@ public class ModuleMapConsistencyRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private List<String> modules(String pomContent) {
-		Matcher matcher = MODULE.matcher(XML_COMMENT.matcher(pomContent).replaceAll(""));
-		List<String> modules = new ArrayList<>();
-		while (matcher.find()) {
-			modules.add(matcher.group(1));
-		}
-		return modules;
+		return MODULE.matcher(XML_COMMENT.matcher(pomContent).replaceAll(""))
+				.results()
+				.map(module -> module.group(1))
+				.toList();
 	}
 
 	private void collectDocViolations(File docFile, List<String> modules, List<String> violations)

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ScanTargets.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ScanTargets.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,13 +79,10 @@ public final class ScanTargets {
 
 	/** The regular files under the configured directories that {@code accepted} matches. */
 	public List<File> filesInDirectories(Predicate<Path> accepted) {
-		List<File> found = new ArrayList<>();
-		for (File directory : directories) {
-			if (directory.isDirectory()) {
-				found.addAll(walk(directory, accepted));
-			}
-		}
-		return found;
+		return directories.stream()
+				.filter(File::isDirectory)
+				.flatMap(directory -> walk(directory, accepted).stream())
+				.toList();
 	}
 
 	private List<File> walk(File directory, Predicate<Path> accepted) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
@@ -4,8 +4,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import javax.inject.Named;
 
@@ -56,10 +57,10 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 		ScanTargets targets = new ScanTargets(files, directories);
 		targets.requireConfigured();
 		requirePatterns(patterns);
-		List<String> violations = new ArrayList<>();
-		for (File file : targets.allFiles()) {
-			scanIfPresent(file, patterns, violations);
-		}
+		List<String> violations = targets.allFiles().stream()
+				.filter(File::isFile)
+				.flatMap(file -> scan(file, patterns))
+				.toList();
 		report("Files contain what look like secrets:", violations);
 	}
 
@@ -79,30 +80,22 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 		}
 	}
 
-	private void scanIfPresent(File file, List<SecretPattern> patterns, List<String> violations) {
-		if (!file.isFile()) {
-			return;
-		}
+	private Stream<String> scan(File file, List<SecretPattern> patterns) {
 		List<String> lines = readTextLines(file);
-		for (int i = 0; i < lines.size(); i++) {
-			scanLine(file, lines.get(i), i + 1, patterns, violations);
-		}
+		return IntStream.range(0, lines.size())
+				.boxed()
+				.flatMap(index -> scanLine(file, lines.get(index), index + 1, patterns));
 	}
 
-	private void scanLine(File file, String line, int lineNumber, List<SecretPattern> patterns,
-			List<String> violations) {
-		for (SecretPattern pattern : patterns) {
-			collectMatches(file, line, lineNumber, pattern, violations);
-		}
+	private Stream<String> scanLine(File file, String line, int lineNumber, List<SecretPattern> patterns) {
+		return patterns.stream().flatMap(pattern -> matches(file, line, lineNumber, pattern));
 	}
 
-	private void collectMatches(File file, String line, int lineNumber, SecretPattern pattern,
-			List<String> violations) {
-		Matcher matcher = pattern.pattern().matcher(line);
-		while (matcher.find()) {
-			violations.add(file + " line " + lineNumber + " contains what looks like a " + pattern.name()
-					+ ": " + masked(matcher.group()));
-		}
+	private Stream<String> matches(File file, String line, int lineNumber, SecretPattern pattern) {
+		return pattern.pattern().matcher(line)
+				.results()
+				.map(match -> file + " line " + lineNumber + " contains what looks like a " + pattern.name()
+						+ ": " + masked(match.group()));
 	}
 
 	/** The first characters of the match followed by an ellipsis, so the report never echoes the full secret. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/Gitignore.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/Gitignore.java
@@ -1,8 +1,9 @@
 package io.github.adamw7.tools.enforcer.settings;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * A parsed {@code .gitignore}, able to answer whether a repository-relative file
@@ -26,22 +27,19 @@ final class Gitignore {
 	}
 
 	static Gitignore parse(String content) {
-		List<Line> lines = new ArrayList<>();
-		for (String raw : content.lines().toList()) {
-			parseLine(raw.strip(), lines);
-		}
-		return new Gitignore(lines);
+		return new Gitignore(content.lines()
+				.map(String::strip)
+				.filter(line -> !line.isEmpty() && !line.startsWith("#"))
+				.map(Gitignore::parseLine)
+				.toList());
 	}
 
-	private static void parseLine(String line, List<Line> lines) {
-		if (line.isEmpty() || line.startsWith("#")) {
-			return;
-		}
+	private static Line parseLine(String line) {
 		boolean negated = line.startsWith("!");
 		String pattern = negated ? line.substring(1) : line;
 		boolean directoryOnly = pattern.endsWith("/");
 		String body = directoryOnly ? pattern.substring(0, pattern.length() - 1) : pattern;
-		lines.add(new Line(negated, directoryOnly, compile(body)));
+		return new Line(negated, directoryOnly, compile(body));
 	}
 
 	private static Pattern compile(String body) {
@@ -89,8 +87,7 @@ final class Gitignore {
 	 * one of its ancestor directories is.
 	 */
 	boolean covers(String path) {
-		return isIgnored(path, false)
-				|| ancestorsOf(path).stream().anyMatch(ancestor -> isIgnored(ancestor, true));
+		return isIgnored(path, false) || ancestorsOf(path).anyMatch(ancestor -> isIgnored(ancestor, true));
 	}
 
 	/** The verdict of the last matching line, honouring negations; directory-only lines match directories alone. */
@@ -102,14 +99,11 @@ final class Gitignore {
 		return ignored;
 	}
 
-	private List<String> ancestorsOf(String path) {
-		List<String> ancestors = new ArrayList<>();
-		int slash = path.indexOf('/');
-		while (slash >= 0) {
-			ancestors.add(path.substring(0, slash));
-			slash = path.indexOf('/', slash + 1);
-		}
-		return ancestors;
+	/** The directory prefixes of {@code path}, shallowest first: {@code a/b/c.json} yields {@code a} and {@code a/b}. */
+	private Stream<String> ancestorsOf(String path) {
+		return IntStream.range(0, path.length())
+				.filter(index -> path.charAt(index) == '/')
+				.mapToObj(index -> path.substring(0, index));
 	}
 
 	private record Line(boolean negated, boolean directoryOnly, Pattern pattern) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommands.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommands.java
@@ -1,7 +1,9 @@
 package io.github.adamw7.tools.enforcer.settings;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -25,39 +27,29 @@ final class HookCommands {
 	}
 
 	static List<String> from(JsonNode settings) {
-		List<String> commands = new ArrayList<>();
 		JsonNode hooks = JsonNodes.objectAt(settings, HOOKS_KEY);
 		if (hooks == null) {
-			return commands;
+			return List.of();
 		}
-		for (String event : JsonNodes.fieldNames(hooks)) {
-			collectGroups(JsonNodes.arrayAt(hooks, event), commands);
-		}
-		return commands;
+		return JsonNodes.fieldNames(hooks).stream()
+				.flatMap(event -> objects(JsonNodes.arrayAt(hooks, event)))
+				.flatMap(group -> objects(JsonNodes.arrayAt(group, HOOKS_KEY)))
+				.filter(HookCommands::isCommandHook)
+				.map(entry -> JsonNodes.textAt(entry, COMMAND_KEY, "").strip())
+				.toList();
 	}
 
-	private static void collectGroups(JsonNode groups, List<String> commands) {
-		if (groups == null) {
-			return;
+	/** The object elements of an array node, skipping an absent array and any element of another shape. */
+	private static Stream<JsonNode> objects(JsonNode array) {
+		if (array == null) {
+			return Stream.empty();
 		}
-		for (int i = 0; i < groups.size(); i++) {
-			collectEntries(JsonNodes.objectAt(groups, i), commands);
-		}
+		return IntStream.range(0, array.size())
+				.mapToObj(index -> JsonNodes.objectAt(array, index))
+				.filter(Objects::nonNull);
 	}
 
-	private static void collectEntries(JsonNode group, List<String> commands) {
-		JsonNode entries = group != null ? JsonNodes.arrayAt(group, HOOKS_KEY) : null;
-		if (entries == null) {
-			return;
-		}
-		for (int i = 0; i < entries.size(); i++) {
-			collectCommand(JsonNodes.objectAt(entries, i), commands);
-		}
-	}
-
-	private static void collectCommand(JsonNode entry, List<String> commands) {
-		if (entry != null && COMMAND_TYPE.equals(JsonNodes.textAt(entry, TYPE_KEY, "").strip())) {
-			commands.add(JsonNodes.textAt(entry, COMMAND_KEY, "").strip());
-		}
+	private static boolean isCommandHook(JsonNode entry) {
+		return COMMAND_TYPE.equals(JsonNodes.textAt(entry, TYPE_KEY, "").strip());
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -1,9 +1,9 @@
 package io.github.adamw7.tools.enforcer.text;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * The YAML front matter block at the top of a Markdown document: the lines
@@ -139,22 +139,15 @@ public final class FrontMatter {
 	 * lines inside it are kept as separators and dropped from the result.
 	 */
 	private String folded(int from) {
-		List<String> content = new ArrayList<>();
-		for (int i = from; i < lines.size() && isContinuation(lines.get(i)); i++) {
-			addContent(lines.get(i), content);
-		}
-		return String.join(" ", content);
+		return lines.subList(from, lines.size()).stream()
+				.takeWhile(this::isContinuation)
+				.map(String::strip)
+				.filter(line -> !line.isEmpty())
+				.collect(Collectors.joining(" "));
 	}
 
 	private boolean isContinuation(String line) {
 		return line.isBlank() || isIndented(line);
-	}
-
-	private void addContent(String line, List<String> content) {
-		String stripped = line.strip();
-		if (!stripped.isEmpty()) {
-			content.add(stripped);
-		}
 	}
 
 	private String valueOf(String line, String key) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
@@ -97,12 +97,8 @@ public final class FrontMatterFixer {
 	}
 
 	private static boolean containsKeyEntry(List<String> lines, int from, int toExclusive) {
-		for (int i = from; i < toExclusive; i++) {
-			if (KEY_ENTRY.matcher(lines.get(i).strip()).matches()) {
-				return true;
-			}
-		}
-		return false;
+		return lines.subList(from, toExclusive).stream()
+				.anyMatch(line -> KEY_ENTRY.matcher(line.strip()).matches());
 	}
 
 	private static boolean isFrontMatterLine(String line) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -5,6 +5,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * A parsed Markdown document: its lines plus a mask marking which lines belong to
@@ -71,26 +73,22 @@ public final class MarkdownDocument {
 		return MarkdownText.firstNonBlankLine(lines.stream());
 	}
 
+	/** The indices of the lines outside fenced code blocks, in document order. */
+	private IntStream outsideFences() {
+		return IntStream.range(0, lines.size()).filter(index -> !insideFence[index]);
+	}
+
 	/** True when {@code token} appears on a line outside a fenced code block. */
 	public boolean containsOutsideFences(String token) {
-		for (int i = 0; i < lines.size(); i++) {
-			if (!insideFence[i] && lines.get(i).contains(token)) {
-				return true;
-			}
-		}
-		return false;
+		return outsideFences().anyMatch(index -> lines.get(index).contains(token));
 	}
 
 	/** The heading lines outside fenced code blocks, in document order. */
 	public Set<String> headings() {
-		Set<String> headings = new LinkedHashSet<>();
-		for (int i = 0; i < lines.size(); i++) {
-			String trimmed = lines.get(i).strip();
-			if (!insideFence[i] && isHeading(trimmed)) {
-				headings.add(trimmed);
-			}
-		}
-		return headings;
+		return outsideFences()
+				.mapToObj(index -> lines.get(index).strip())
+				.filter(MarkdownDocument::isHeading)
+				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
 	/** True when {@code heading} appears as a real heading outside code fences. */
@@ -119,21 +117,14 @@ public final class MarkdownDocument {
 	public List<String> headingsInOrder(List<String> wanted) {
 		Set<String> required = new LinkedHashSet<>(wanted);
 		List<String> ordered = new ArrayList<>();
-		for (int i = 0; i < lines.size(); i++) {
-			if (!insideFence[i] && required.remove(lines.get(i).strip())) {
-				ordered.add(lines.get(i).strip());
-			}
-		}
+		outsideFences().mapToObj(index -> lines.get(index).strip())
+				.filter(required::remove)
+				.forEach(ordered::add);
 		return ordered;
 	}
 
 	private int headingIndex(String section) {
-		for (int i = 0; i < lines.size(); i++) {
-			if (!insideFence[i] && lines.get(i).strip().equals(section)) {
-				return i;
-			}
-		}
-		return -1;
+		return outsideFences().filter(index -> lines.get(index).strip().equals(section)).findFirst().orElse(-1);
 	}
 
 	private boolean hasBodyAt(int headingIndex) {


### PR DESCRIPTION
Both modules assembled lists the long way round — a mutable ArrayList
threaded through helper methods, or seeded from a List.of literal and
copied back at the end — where the collection could simply be returned.

adopt: add CommandLine, a small fluent builder for a command's argument
list, and use it in the five steps that each wrote out the same seed,
conditional-add and List.copyOf sequence (pull request, commit, branch,
build wrapper, executable resolver). defaultSteps now concatenates the
pipeline's segments instead of mutating a list in place.

claude-code-enforcer: replace `while (matcher.find())` accumulation with
Matcher.results (module map, secrets, import graph), and turn the walks
that passed a violations/commands list down through their helpers into
methods that return what they found (hook commands, gitignore parsing,
directory scanning, front matter folding, duplicates). MarkdownDocument
gains one shared outsideFences() stream in place of three index loops.

No behaviour change; the existing tests cover it, plus new unit tests
for CommandLine.