### PR TITLE
docs: correct the CI, single-module build and enforcer facts

### DIFF
--- a/.claude/skills/maven-conventions/SKILL.md
+++ b/.claude/skills/maven-conventions/SKILL.md
@@ -40,7 +40,7 @@ profile, is the most common source of avoidable build friction here.
 |---|---|
 | `mvn clean install` | Full clean build + install to local repo |
 | `mvn install` | Faster incremental build |
-| `mvn -pl <module> test` | Tests for a single module |
+| `mvn -pl <module> -am test` | Tests for a single module (`-am` is required — a bare `-pl` fails the `ReactorModuleConvergence` rule) |
 | `mvn -P integration-tests verify` | MCP integration tests (`*IT`) |
 | `mvn -Pcoverage verify` | JaCoCo coverage (fails under 80% instruction or branch) |
 | `mvn -Ppitest test` | PIT mutation testing |

--- a/.claude/skills/testing-conventions/SKILL.md
+++ b/.claude/skills/testing-conventions/SKILL.md
@@ -57,8 +57,9 @@ fails the build, not just review.
    If yes → `*IT`. If no → `*Test`.
 2. Put the class in the right package (`.architecture` for ArchUnit rules).
 3. Write focused, fast assertions — behavior, edge cases, and error paths.
-4. Run it: `mvn -pl <module> test` (unit) or
-   `mvn -P integration-tests verify` (integration).
+4. Run it: `mvn -pl <module> -am test` (unit — `-am` is required) or
+   `mvn -P integration-tests verify` (integration). For one class or method,
+   `cd <module> && mvn test -Dtest='SomeTest#someMethod'`.
 5. If a unit test legitimately needs more than 5 s, add `@Timeout(...)`
    with a one-line comment justifying it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,11 +254,31 @@ mvn install
 # Build without installing (what CI runs)
 mvn -B package
 
-# Run the tests for a single module
-mvn -pl data test
+# Run the tests for a single module (-am is required, see below)
+mvn -pl data -am test
 
 # Build the standalone data-test module
 mvn -pl data-test -am test
+```
+
+**Always pair `-pl` with `-am`.** A bare `mvn -pl data test` fails before it
+compiles anything: the root pom's `ReactorModuleConvergence` enforcer rule
+rejects a reactor whose module parents are not part of it, and sibling
+`-SNAPSHOT` dependencies (e.g. `mcp-common`) are not resolvable from the local
+repository until they have been installed. `-am` ("also make") brings the parent
+and the upstream modules back into the reactor and fixes both.
+
+To run a **single test class or method**, note that `-Dtest` applies to every
+module in the reactor, so surefire fails the upstream modules where the pattern
+matches nothing. Use either form:
+
+```bash
+# From the module directory — needs the parent and siblings installed once
+# (mvn install -DskipTests), because they resolve from the local repository.
+cd data && mvn test -Dtest='KeyFinderTest#repeatedRowIsADuplicate'
+
+# From the root, telling surefire not to fail the modules with no match
+mvn -pl data -am test -Dtest=KeyFinderTest -Dsurefire.failIfNoSpecifiedTests=false
 ```
 
 **Always use `clean` after removing a source of code generation.** The build
@@ -322,7 +342,7 @@ longer and carry no timeout.
 ## Testing, coverage & mutation testing
 
 - **Unit tests** run in the normal `test`/`package` lifecycle
-  (`mvn -pl <module> test`). Write tests for all new logic — behavior, edge
+  (`mvn -pl <module> -am test`). Write tests for all new logic — behavior, edge
   cases, and error paths. Surefire enforces a **5-second per-test timeout** (the
   `junit.jupiter.execution.timeout.testable.method.default` JUnit config
   parameter set on the surefire plugin in the root `pom.xml`), so a unit test
@@ -461,17 +481,18 @@ longer and carry no timeout.
 
 ## Continuous integration
 
-Workflows live in `.github/workflows/`. Only the first three below gate pull
-requests to `main`; the rest run on a schedule (or manually).
+Workflows live in `.github/workflows/`. Only the first below gates pull requests
+to `main`; the rest run on a schedule, on a release, or manually.
 
 | Workflow | Trigger | What it runs |
 | --- | --- | --- |
 | `maven.yml` | push, PR → `main` | Installs the enforcer rule, then `mvn -B package -DenforceClaudeMd` on JDK 25 — the **only** workflow that runs the CLAUDE.md/AGENTS.md checks. The build step is capped at **120 s** (`timeout-minutes: 2` plus a wall-clock check). |
-| `docker.yml` | push, PR → `main` | `mvn -B package`, then builds the Docker image from `assembly/Dockerfile`. |
-| `codeql.yml` | push, PR → `main`; weekly | CodeQL security/static analysis for Java (autobuild). |
 | `integration-tests.yml` | daily | `mvn -P integration-tests verify` (MCP streamable-HTTP integration tests, and the `adopt` multi-repository adoption against real GitHub URLs). |
-| `coverage.yml` | weekly | `mvn verify -Pcoverage`, uploads JaCoCo reports as an artifact. |
-| `pitest.yml` | weekly; manual | `mvn install -Ppitest`, uploads PIT mutation reports as an artifact. |
+| `codeql.yml` | weekly (Sat) | CodeQL security/static analysis for Java (autobuild). |
+| `coverage.yml` | weekly (Sat) | `mvn verify -Pcoverage`, uploads JaCoCo reports as an artifact. |
+| `pitest.yml` | weekly (Sun); manual | `mvn install -Ppitest`, uploads PIT mutation reports as an artifact. |
+| `maven-windows.yml` | weekly (Sun); manual | `mvn install` on a `windows-latest` runner, to catch platform-specific regressions the Linux build would miss. |
+| `docker.yml` | on GitHub release | `mvn -B package`, then builds the Docker image from `assembly/Dockerfile` (never runs it). |
 | `maven-publish.yml` | on GitHub release | Deploys to **GitHub Packages** (`-P github-packages`). See "Releasing". |
 | `central-publish.yml` | on GitHub release; manual dispatch | Deploys to **Maven Central** (`-P release`), or a staged-only dry run on manual dispatch. See "Releasing". |
 
@@ -776,8 +797,8 @@ The `central.autoPublish` (default `true`) and `central.waitUntil` (default
 The repository ships two Dockerfiles with different purposes:
 
 - `assembly/Dockerfile` packages the `jar-with-dependencies` built by the
-  `assembly` module. CI (`docker.yml`) builds this image on every push and PR
-  to `main` but never runs it. **Caveat:** the `data` jar is repackaged with
+  `assembly` module. CI (`docker.yml`) builds this image on a GitHub release
+  but never runs it. **Caveat:** the `data` jar is repackaged with
   `spring-boot:repackage` (nested `BOOT-INF/` layout), so this image cannot
   launch `SampleApp` with `java -jar` — see `k8s/README.md` for the full
   explanation.
@@ -806,8 +827,8 @@ automated environment.
   [SECURITY.md](SECURITY.md); do not open a public issue for them.
 - [SECURITY.md](SECURITY.md) also lists which released versions currently
   receive security fixes (only the latest line is supported).
-- `codeql.yml` runs GitHub CodeQL analysis on every push and PR to `main` and on
-  a weekly schedule; keep new code free of the issues it flags.
+- `codeql.yml` runs GitHub CodeQL analysis on a weekly schedule (it does not gate
+  pull requests); keep new code free of the issues it flags.
 
 ## Pull requests & commits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # CLAUDE.md
 
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
 See [AGENTS.md](AGENTS.md) for the full agent guide (repository overview, module
 layout, build/test commands, CI, environment, and release process). AGENTS.md is
 the single source of truth; this file is a quick-reference summary of the
@@ -113,12 +116,36 @@ Common commands (run from the repository root):
 ```bash
 mvn clean install                 # full clean build + install to local repo
 mvn install                       # faster incremental build
-mvn -pl data test                 # tests for a single module
+mvn -pl data -am install          # one module plus the modules it depends on
+mvn -pl data -am test             # tests for a single module
 mvn -B package                    # build without installing (what CI runs)
 mvn -P integration-tests verify   # integration tests (*IT): MCP servers, real-GitHub adoption
 mvn -Pcoverage verify             # JaCoCo coverage (fails under 80% instruction or branch)
 mvn -Ppitest install              # PIT mutation testing (needs a phase past package)
 ```
+
+**Always pair `-pl` with `-am`.** `mvn -pl data test` fails before compiling:
+the root pom's `ReactorModuleConvergence` rule rejects a reactor whose module
+parents are absent from it, and sibling `-SNAPSHOT`s (e.g. `mcp-common`) are not
+resolvable from the local repo until installed. `-am` pulls the parent and the
+upstream modules back into the reactor.
+
+Running a single test class or method needs one of these, because `-Dtest`
+applies to *every* module in the reactor and surefire fails the upstream ones
+where nothing matches:
+
+```bash
+cd data && mvn test -Dtest='KeyFinderTest#repeatedRowIsADuplicate'   # simplest
+mvn -pl data -am test -Dtest=KeyFinderTest -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+The first form needs the parent and siblings installed once (`mvn install
+-DskipTests`), since running from the module directory resolves them from the
+local repo rather than the reactor.
+
+Maven 3.9.X is enforced, not just recommended: the root pom's `enforce`
+execution pins `requireMavenVersion [3.9,4.0)` and `requireJavaVersion 25`, so a
+Maven 4 or older-JDK build fails at `validate` rather than midway.
 
 Use `clean` after removing a code-generation source, so stale generated builders
 in `target/` cannot mask the change.
@@ -193,17 +220,31 @@ paths.
   and cover what needs something real: the MCP servers over HTTP, and `adopt`'s
   `MultiRepoAdoptionIT`, which clones real GitHub sample repositories to prove a
   batch gives each repository its own checkout. It stops at the branch step, so
-  it never pushes or opens a pull request. See *Testing* in AGENTS.md.
+  it never pushes or opens a pull request. The profile is declared per module —
+  in `data`, `code/context`, and `adopt`, each wiring `maven-failsafe-plugin` —
+  not in the root pom, so a new module's `*IT`s stay unrun until that module
+  gets its own copy. See *Testing* in AGENTS.md.
 
 ## Continuous integration and commits
 
-Three workflows gate pull requests to `main`: `maven.yml` (`mvn -B package
--DenforceClaudeMd`, the only one that runs the doc checks), `docker.yml` (builds
-the `assembly` image but never runs it), and `codeql.yml`. The rest are
-scheduled — `integration-tests.yml` daily, `coverage.yml` and `pitest.yml`
-weekly — and `maven-publish.yml` / `central-publish.yml` fire on a GitHub
-release. Every workflow builds on JDK 25 (Temurin). See *Continuous integration*
-and *Releasing* in AGENTS.md.
+One workflow gates pull requests to `main`: `maven.yml`, which bootstraps the
+enforcer rule and then runs `mvn -B package -DenforceClaudeMd` — the only
+workflow that runs the doc checks. Its `package` step is capped at **120
+seconds** (`timeout-minutes: 2` plus a wall-clock check that fails with a
+`::error::` annotation), so a change that slows the build down red-flags the PR;
+profile it rather than raising the cap. Everything else runs on a schedule or a
+release, so a green PR is not proof the whole matrix passes:
+
+- **Scheduled** — `integration-tests.yml` daily; `codeql.yml` and
+  `coverage.yml` weekly (Sat); `pitest.yml` and `maven-windows.yml` weekly
+  (Sun). `maven-windows.yml` runs `mvn install` on `windows-latest`, so keep
+  path, line-ending, and file-locking assumptions platform-neutral.
+- **On a GitHub release** — `docker.yml` (builds the `assembly` image but never
+  runs it), `maven-publish.yml` (GitHub Packages), and `central-publish.yml`
+  (Maven Central).
+
+Every workflow builds on JDK 25 (Temurin). See *Continuous integration* and
+*Releasing* in AGENTS.md.
 
 Use clear, conventional commit messages — the `git-commit` skill writes them
 with this repository's real module scopes — keep changes focused, and add or
@@ -240,13 +281,24 @@ editing them:
   mentioned in both CLAUDE.md and AGENTS.md; `crossDocConsistency` pins facts
   shared with AGENTS.md (the Java version) and `readmeConsistency` pins the
   README against AGENTS.md (the protobuf major version).
-- `memoryImports`, `noSecrets`, `skillFilesExist`, `uniqueNames`,
+- `agentsMdFormat` applies the same title/required-heading checks to AGENTS.md,
+  and `memoryImports`, `noSecrets`, `skillFilesExist`, `uniqueNames`,
   `uniqueDescriptions`, `settingsJsonValid`, `permissionsFormat`,
-  `hookCommandsValid`, `hooksFormat`, `mcpServersValid`, `mcpConfigFormat`, and
-  `pluginFormat` cover the rest of the agent configuration. The last three
-  validate `.mcp.json` and `.claude-plugin/plugin.json`, which this repository
-  does not ship — they pass on the absent file and start enforcing the moment
-  one is added.
+  `hookCommandsValid`, `hooksFormat`, `localSettingsIgnored`, `mcpServersValid`,
+  `mcpConfigFormat`, and `pluginFormat` cover the rest of the agent
+  configuration. The last three validate `.mcp.json` and
+  `.claude-plugin/plugin.json`, which this repository does not ship — they pass
+  on the absent file and start enforcing the moment one is added.
+- Two more rules ship but are **not** wired here: `subAgentFormat`
+  (`.claude/agents`) and `commandFormat` (`.claude/commands`). Unlike
+  `pluginFormat`, a *configured* definition directory must exist — an absent one
+  counts as a build-setup mistake — so they can only be wired once the
+  directory does. Add the directory and the rule together.
+- Every rule extends a common base offering `severity` (`error`, the default, or
+  `warn` to log without failing), an optional `reportFile` for a self-contained
+  HTML report, and an optional `baselineFile` that suppresses already-accepted
+  violations so a new rule can be gated without clearing the backlog first. See
+  *CLAUDE.md enforcement* in AGENTS.md before adding or configuring a rule.
 
 The check is opt-in via the `claude-md-enforce` profile and needs a two-phase
 build, since a maven-enforcer rule must be resolvable as a JAR before the build

--- a/README.md
+++ b/README.md
@@ -1058,8 +1058,10 @@ into the `PER_CLASS` lifecycle).
 
 Run them for a single module with, for example:
 ```
-mvn -pl data test
+mvn -pl data -am test
 ```
+(`-am` is required — a bare `mvn -pl data test` fails the root pom's
+`ReactorModuleConvergence` enforcer rule.)
 or across the whole repository as part of `mvn install`.
 
 # Building


### PR DESCRIPTION
CLAUDE.md and AGENTS.md described a CI setup that no longer matches the
workflows. Only maven.yml gates pull requests to main: docker.yml now fires
on a GitHub release and codeql.yml runs on a weekly schedule, neither gates
a PR, and maven-windows.yml was missing from the docs entirely.

The documented single-module command was also broken. A bare
`mvn -pl data test` fails at validate on the root pom's
ReactorModuleConvergence rule (the module's parent is absent from the
reactor) and cannot resolve sibling -SNAPSHOTs, so `-am` is required.
Record how to run a single test class or method too, since -Dtest applies
to every module in the reactor and surefire fails the upstream ones where
the pattern matches nothing.

Also fill in the enforcer gaps: agentsMdFormat and localSettingsIgnored
were missing from the rule list, subAgentFormat and commandFormat ship but
cannot be wired until .claude/agents and .claude/commands exist (a
configured definition directory must exist, unlike pluginFormat), and the
shared severity/reportFile/baselineFile options were undocumented. Note
that the integration-tests profile is declared per module rather than in
the root pom, and add the standard Claude Code header.

Verified with `mvn -N validate -DenforceClaudeMd` (all 19 rules pass) and
a full `mvn -B package -DenforceClaudeMd`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hcqt5UBD7rfX3qByRcpV7g