### PR TITLE
test: close the highest-value test-coverage gaps found by mutation testing

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
@@ -39,7 +39,8 @@ final class ExecutableResolver {
 	private final List<String> pathExtensions;
 
 	ExecutableResolver() {
-		this(Platform.isWindows(), pathDirectoriesFromEnvironment(), pathExtensionsFromEnvironment());
+		this(Platform.isWindows(), pathDirectories(System.getenv("PATH")),
+				pathExtensions(System.getenv("PATHEXT")));
 	}
 
 	ExecutableResolver(boolean windows, List<Path> pathDirectories, List<String> pathExtensions) {
@@ -101,8 +102,13 @@ final class ExecutableResolver {
 		return program.indexOf('/') >= 0 || program.indexOf('\\') >= 0;
 	}
 
-	private static List<Path> pathDirectoriesFromEnvironment() {
-		return splitPathList(System.getenv("PATH")).stream()
+	/**
+	 * The {@code PATH} entries to search, given the raw variable. Entries that are not
+	 * legal paths on this platform are dropped rather than failing the resolution, so
+	 * one malformed entry cannot stop the rest of the search.
+	 */
+	static List<Path> pathDirectories(String pathValue) {
+		return splitPathList(pathValue).stream()
 				.map(ExecutableResolver::toPath)
 				.flatMap(Optional::stream)
 				.toList();
@@ -116,15 +122,21 @@ final class ExecutableResolver {
 		}
 	}
 
-	private static List<String> pathExtensionsFromEnvironment() {
-		List<String> configured = splitPathList(System.getenv("PATHEXT")).stream()
+	/**
+	 * The executable extensions to try, given the raw {@code PATHEXT}. Each is
+	 * normalised to a leading dot and lower case so it can be appended to a program
+	 * name directly, whatever casing the environment used. An unset or empty variable
+	 * falls back to {@link #DEFAULT_PATH_EXTENSIONS}.
+	 */
+	static List<String> pathExtensions(String pathExtValue) {
+		List<String> configured = splitPathList(pathExtValue).stream()
 				.map(extension -> extension.startsWith(".") ? extension : "." + extension)
 				.map(extension -> extension.toLowerCase(Locale.ROOT))
 				.toList();
 		return configured.isEmpty() ? DEFAULT_PATH_EXTENSIONS : configured;
 	}
 
-	private static List<String> splitPathList(String value) {
+	static List<String> splitPathList(String value) {
 		if (value == null || value.isBlank()) {
 			return List.of();
 		}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ExecutableResolverTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ExecutableResolverTest.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.adopt.command;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -106,5 +107,51 @@ class ExecutableResolverTest {
 		ExecutableResolver resolver = new ExecutableResolver(true, List.of(), EXTENSIONS);
 		List<String> command = List.of();
 		assertSame(command, resolver.resolve(command));
+	}
+
+	@Test
+	void splitsAPathListOnThePlatformSeparator() {
+		String value = String.join(File.pathSeparator, "one", "two", "three");
+		assertEquals(List.of("one", "two", "three"), ExecutableResolver.splitPathList(value));
+	}
+
+	@Test
+	void skipsBlankEntriesInAPathList() {
+		// A trailing separator, or two in a row, is common in a hand-edited PATH and
+		// would otherwise resolve to the working directory.
+		String value = String.join(File.pathSeparator, "one", "", "  ", "two", "");
+		assertEquals(List.of("one", "two"), ExecutableResolver.splitPathList(value));
+	}
+
+	@Test
+	void anUnsetPathListIsEmpty() {
+		assertEquals(List.of(), ExecutableResolver.splitPathList(null));
+		assertEquals(List.of(), ExecutableResolver.splitPathList(""));
+		assertEquals(List.of(), ExecutableResolver.splitPathList("   "));
+	}
+
+	@Test
+	void readsPathDirectoriesFromThePathValue() {
+		String value = String.join(File.pathSeparator, "one", "two");
+		assertEquals(List.of(Path.of("one"), Path.of("two")), ExecutableResolver.pathDirectories(value));
+	}
+
+	@Test
+	void anUnsetPathYieldsNoDirectories() {
+		assertEquals(List.of(), ExecutableResolver.pathDirectories(null));
+	}
+
+	@Test
+	void pathExtensionsAreNormalisedToALeadingDotAndLowerCase() {
+		// Windows spells PATHEXT in upper case and without dots on some hosts; both have
+		// to end up appendable to a bare program name.
+		assertEquals(List.of(".exe", ".cmd", ".bat"),
+				ExecutableResolver.pathExtensions(String.join(File.pathSeparator, ".EXE", "CMD", ".bat")));
+	}
+
+	@Test
+	void anUnsetPathExtFallsBackToTheDefaultExtensions() {
+		assertEquals(EXTENSIONS, ExecutableResolver.pathExtensions(null));
+		assertEquals(EXTENSIONS, ExecutableResolver.pathExtensions(""));
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
@@ -69,6 +69,64 @@ class ContextBudgetRuleTest {
 	}
 
 	@Test
+	void passesWhenTheFileIsExactlyOnTheByteBudget() {
+		// The budget is a maximum, not a ceiling to stay under, so a file measuring
+		// exactly maxBytes must pass. Together with the test below this pins which side
+		// of the comparison the boundary falls on; a rule that rejected an exact fit,
+		// or accepted one byte over, still satisfies the round-number tests.
+		ContextBudgetRule rule = ruleForFile("x".repeat(50));
+		rule.setMaxBytes(50);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenTheFileIsOneByteOverTheBudget() {
+		ContextBudgetRule rule = ruleForFile("x".repeat(51));
+		rule.setMaxBytes(50);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("is 51 bytes, over the 50-byte budget"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenTheFileIsExactlyOnTheLineBudget() {
+		ContextBudgetRule rule = ruleForFile("one\ntwo\n");
+		rule.setMaxLines(2);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenTheFileIsOneLineOverTheBudget() {
+		ContextBudgetRule rule = ruleForFile("one\ntwo\nthree\n");
+		rule.setMaxLines(2);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("has 3 lines, over the 2-line budget"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenTheFileIsExactlyOnTheTokenBudget() {
+		// Tokens round up at four characters each, so 40 characters is exactly 10.
+		ContextBudgetRule rule = ruleForFile("x".repeat(40));
+		rule.setMaxTokens(10);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenTheFileIsOneTokenOverTheBudget() {
+		// One character past the exact fit rounds up to the eleventh token.
+		ContextBudgetRule rule = ruleForFile("x".repeat(41));
+		rule.setMaxTokens(10);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("estimated 11 tokens, over the 10-token budget"),
+				exception.getMessage());
+	}
+
+	@Test
 	void failsWhenTheLineBudgetIsExceeded() {
 		ContextBudgetRule rule = ruleForFile("one\ntwo\nthree\n");
 		rule.setMaxLines(2);

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -46,6 +46,11 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 		return size() == 0;
 	}
 
+	/** The current backing-array length; exposed for tests that assert growth behaviour. */
+	int capacity() {
+		return array.length;
+	}
+
 	@Override
 	public boolean containsKey(Object key) {
 		return find(key) != null;

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMapTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMapTest.java
@@ -135,6 +135,86 @@ public class IntKeyOpenAddressingMapTest {
 	}
 
 	@Test
+	public void growsOnePutBeforeTheTableWouldFill() {
+		// The table grows while one slot is still free rather than once it is full, so
+		// a probe chain always terminates on an empty slot. Pinning the exact capacity
+		// either side of the trigger is what keeps the growth policy from drifting: a
+		// table that waited for the last slot, or grew a put early, still passes every
+		// test that only checks the entries survive.
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>(8);
+		for (int i = 0; i < 7; ++i) {
+			map.put(i, "v" + i);
+		}
+		assertEquals(7, map.size());
+		assertEquals(8, map.capacity(), "the seventh entry still fits the original table");
+
+		map.put(7, "v7");
+		assertEquals(8, map.size());
+		assertEquals(9, map.capacity(), "the eighth entry grows the table by one slot");
+		for (int i = 0; i < 8; ++i) {
+			assertEquals("v" + i, map.get(i));
+		}
+	}
+
+	@Test
+	public void churnOfDistinctKeysGrowsTheTableEvenWhileEmpty() {
+		// The mirror of repeatedRemoveAndReAddOfSameKeyDoesNotGrowTheTable: a tombstone
+		// can only be revived by its own key, so churning *distinct* keys leaves one
+		// behind on every cycle until no slot is empty. The table must then grow to
+		// clear them, even though it holds nothing.
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>(8);
+		int initialCapacity = map.capacity();
+		for (int key = 0; key < 30; ++key) {
+			map.put(key, "v" + key);
+			map.remove(key);
+		}
+		assertEquals(0, map.size());
+		assertTrue(map.isEmpty());
+		assertTrue(map.capacity() > initialCapacity,
+				"tombstones from distinct keys must force the table to grow");
+
+		map.put(999, "last");
+		assertEquals("last", map.get(999), "the map still works once the tombstones are cleared");
+		assertEquals(1, map.size());
+	}
+
+	@Test
+	public void clearKeepsTheCurrentCapacity() {
+		// Unlike OpenAddressingMap.clear(), which resizes to the size it held, this map
+		// reuses the array it already has.
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>(8);
+		for (int i = 0; i < 5; ++i) {
+			map.put(i, "v" + i);
+		}
+		assertEquals(8, map.capacity());
+
+		map.clear();
+		assertEquals(8, map.capacity());
+		assertEquals(0, map.size());
+	}
+
+	@Test
+	public void keyProbingTheFirstSlotIsFound() {
+		// indexOf reports absence as -1 and presence as the slot index, so a key living
+		// at slot 0 is the case that separates the two. In the default capacity-64 table
+		// (prime 61) key -3 probes slot 0 first.
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(-3, "first slot");
+		assertTrue(map.containsKey(-3));
+		assertEquals("first slot", map.get(-3));
+		assertEquals("first slot", map.getOrDefault(-3, "fallback"));
+		assertEquals("first slot", map.remove(-3));
+		assertFalse(map.containsKey(-3));
+	}
+
+	@Test
+	public void notEmptyAfterPut() {
+		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
+		map.put(1, "A");
+		assertFalse(map.isEmpty());
+	}
+
+	@Test
 	public void negativeKeysAreSupported() {
 		IntKeyOpenAddressingMap<String> map = new IntKeyOpenAddressingMap<>();
 		map.put(-1, "minus one");

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
@@ -362,6 +362,15 @@ public class MapTest {
 
 	@ParameterizedTest
 	@MethodSource("allImplementations")
+	public void keySetDoesNotContainAnAbsentKey(Map<Integer, String> map) {
+		map.put(1, "A");
+		Set<Integer> keySet = map.keySet();
+		assertTrue(keySet.contains(1));
+		assertFalse(keySet.contains(2));
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
 	public void keySetIsALiveViewOfTheMap(Map<Integer, String> map) {
 		map.put(1, "A");
 		map.put(2, "B");
@@ -425,5 +434,73 @@ public class MapTest {
 		for (int i = 0; i < 100; ++i) {
 			assertEquals("v" + i, map.get(i));
 		}
+	}
+
+	@Test
+	public void growsOnePutBeforeTheTableWouldFill() {
+		// The table grows while one slot is still free rather than once it is full, so
+		// a probe chain always terminates on an empty slot. Pinning the exact capacity
+		// either side of the trigger is what keeps the growth policy from drifting: a
+		// table that waited for the last slot, or grew a put early, still passes every
+		// test that only checks the entries survive.
+		OpenAddressingMap<Integer, String> map = new OpenAddressingMap<>(8);
+		for (int i = 0; i < 7; ++i) {
+			map.put(i, "v" + i);
+		}
+		assertEquals(7, map.size());
+		assertEquals(8, map.capacity(), "the seventh entry still fits the original table");
+
+		map.put(7, "v7");
+		assertEquals(8, map.size());
+		assertEquals(9, map.capacity(), "the eighth entry grows the table by one slot");
+		for (int i = 0; i < 8; ++i) {
+			assertEquals("v" + i, map.get(i));
+		}
+	}
+
+	@Test
+	public void churnOfDistinctKeysGrowsTheTableEvenWhileEmpty() {
+		// A tombstone can only be revived by its own key, so churning distinct keys
+		// leaves one behind on every cycle until no slot is empty. The table must then
+		// grow to clear them, even though it holds nothing.
+		OpenAddressingMap<Integer, String> map = new OpenAddressingMap<>(8);
+		int initialCapacity = map.capacity();
+		for (int key = 0; key < 30; ++key) {
+			map.put(key, "v" + key);
+			map.remove(key);
+		}
+		assertEquals(0, map.size());
+		assertTrue(map.isEmpty());
+		assertTrue(map.capacity() > initialCapacity,
+				"tombstones from distinct keys must force the table to grow");
+
+		map.put(999, "last");
+		assertEquals("last", map.get(999), "the map still works once the tombstones are cleared");
+		assertEquals(1, map.size());
+	}
+
+	@Test
+	public void clearResizesToTheSizeTheMapHeld() {
+		// clear() rebuilds the array at the size the map held rather than reusing the
+		// grown one, so clearing a table that grew hands the memory back.
+		OpenAddressingMap<Integer, String> map = new OpenAddressingMap<>(8);
+		for (int i = 0; i < 5; ++i) {
+			map.put(i, "v" + i);
+		}
+		assertEquals(8, map.capacity());
+
+		map.clear();
+		assertEquals(0, map.size());
+		assertEquals(5, map.capacity(), "the cleared table shrinks to the size it held");
+	}
+
+	@Test
+	public void clearOnAnEmptyMapShrinksToTheMinimumTable() {
+		// An array of 2 would force prime == 1, so 3 is the floor a cleared empty map
+		// lands on rather than 0.
+		OpenAddressingMap<Integer, String> map = new OpenAddressingMap<>(8);
+		map.clear();
+		assertEquals(0, map.size());
+		assertEquals(3, map.capacity());
 	}
 }


### PR DESCRIPTION
## Why

Line coverage is near-saturated — a measured `mvn -Pcoverage verify` gives **96.7% instruction / 92.9% branch** across 2027 tests, ~17 points above the 80% JaCoCo gate — so it no longer says much about where the tests are weak. Running `mvn -Ppitest install` and excluding the two modules whose classes are entirely protobuf-generated puts the hand-written mutation score at **89.6%**, and that report does point somewhere specific.

This PR closes the three worst gaps it found. Each was a case where production behaviour could be changed or deleted outright and the whole suite stayed green.

## What

**`data` — the open-addressing maps' growth contract was entirely unasserted.**
In both `OpenAddressingMap` and `IntKeyOpenAddressingMap`, PIT killed neither `removed call to resize` / `removed call to checkIfResizeNeeded` nor the boundary and arithmetic mutants on the `size + 1 >= length` trigger. The growth logic could be removed from `put` without a single failure. `IntKeyOpenAddressingMap.capacity()` is even commented "exposed for tests that assert growth behaviour", yet `replaced int return with 0` on it also survived — nothing meaningfully asserted capacity. The existing tests fill the maps and check the entries survive, but never pin *when* the table grows.

Added: the exact capacity either side of the trigger; that churning *distinct* keys grows the table even while it holds nothing (the mirror of the existing same-key test, and the path that clears accumulated tombstones); what `clear()` does to the capacity in each map, which differs between the two; the slot-0 lookup that separates `indexOf`'s `-1` sentinel from a genuine index; and a negative `keySet().contains` assertion.

`OpenAddressingMap` gains the package-private `capacity()` accessor its primitive-keyed sibling already exposes, so both tests read the capacity the same way rather than one of them reaching into the protected array.

**`claude-code-enforcer` — the context budgets were never tested at their boundary.**
Every budget test used a round limit with content comfortably under or over it, so all six `ConditionalsBoundaryMutator` mutants on the byte, line and token thresholds survived. A rule that rejected a file measuring exactly `maxBytes`, or accepted one a byte over, passed unchanged — in the rule that guards CLAUDE.md's own 32 KB budget. Added the exact-fit and one-unit-over pair for each of the three budgets.

**`adopt` — the resolver's `PATH`/`PATHEXT` parsing was unreachable from a test.**
`ExecutableResolver` was the weakest hand-written class in the repo at 67%. Its injectable constructor is genuinely well covered; the environment-reading helpers behind the no-arg one were not exercised at all — splitting, blank-entry filtering, extension normalisation and the fallback to the default extensions all survived. They called `System.getenv` directly, so they now take the raw value as a parameter and the no-arg constructor passes it in. Behaviour is unchanged; the parsing is now testable.

## Result

| Class | Before | After |
|---|---|---|
| `ExecutableResolver` | 67% | **94%** |
| `IntKeyOpenAddressingMap` | 72% | **90%** |
| `ContextBudgetRule` | 76% | **92%** |
| `OpenAddressingMap` | 80% | **90%** |

Overall coverage moves from 96.7%/92.9% to **96.8%/93.4%** — deliberately a small change, since these tests were added to pin behaviour that was already executed but unasserted, not to reach unexecuted lines.

## Verification

- `mvn -Pcoverage verify` — green, JaCoCo gate passes
- `mvn -B package -DenforceClaudeMd` (the PR gate) — green
- Targeted `mvn -Ppitest test` per class to confirm the specific mutants are dead

The one production change beyond the new `capacity()` accessor is the `ExecutableResolver` parameterisation; both are behaviour-preserving.

## Not included

The analysis surfaced findings I deliberately left out of this PR, since they are build/CI changes rather than tests:

- `data-test` is outside the root `<modules>`, referenced by no other pom, and built by no workflow — so `MemoryLeakTest` has never run in CI. Worth either wiring up or deleting.
- `pitest.yml` has no `mutationThreshold` and no exclusions for generated code, so the headline score it reports is ~60% protobuf noise (4009 generated mutants against 2901 real ones) and could not detect a regression.
- `adopt`'s MCP server has no HTTP integration test, unlike `data` and `code/context`.
- Neither `coverage.yml` nor `pitest.yml` runs on PRs, so both gates are up to a week behind the change that breaks them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdTrfiEkqkJGmUmMoXGePy)_