### PR TITLE
build: de-duplicate the poms and fix the version drift they were hiding

### DIFF
--- a/.claude/skills/maven-conventions/SKILL.md
+++ b/.claude/skills/maven-conventions/SKILL.md
@@ -23,7 +23,14 @@ profile, is the most common source of avoidable build friction here.
 - **Plugin versions**: only in the **root** `pom.xml` under
   `<pluginManagement>`.
 - **Module poms reference dependencies and plugins WITHOUT versions.** Never add
-  a `<version>` to a module pom — add or change it in the root instead.
+  a `<version>` to a module pom — add or change it in the root instead. The
+  exceptions are reactor artifacts, which use `${project.version}`.
+- **Artifacts that must move together share one property**, not a version each:
+  `protobuf.version` (runtime *and* `protoc`), `grpc.version`, `derby.version`,
+  `log4j2.version`, `maven.api.version`. `derby.version` and `log4j2.version`
+  are Spring Boot's own property names, so overriding them also moves the
+  siblings the `spring-boot-dependencies` BOM manages (derbyshared, the other
+  log4j2 artifacts) instead of leaving them on Boot's older version.
 
 ### Ask before adding a dependency
 - Use the existing Maven dependencies. **Always ask the user before adding a new
@@ -53,9 +60,15 @@ profile, is the most common source of avoidable build friction here.
   `shellcheck` and works offline. Skip it with `-Dskip.shellcheck=true` when you
   just want a fast loop.
 - **Java 25** is required: JDK 25 on `PATH` with `JAVA_HOME` set.
-- The root reactor modules are: `claude-code-enforcer`, `mcp-common`, `data`,
-  `code`, `adopt`, `grpc-example`, `assembly`. `data-test` is built separately
-  (not in the root `<modules>`).
+- The root reactor modules are: `claude-code-enforcer`, `test-common`,
+  `mcp-common`, `data`, `code`, `adopt`, `grpc-example`, `assembly`. `data-test`
+  is built separately (not in the root `<modules>`).
+- **A typo in `-P` fails the build**, not the run: the root `enforce` execution
+  runs `requireProfileIdsExist`.
+- **A module that is not a reusable library** (example, test harness,
+  distribution) opts out of publishing with `<maven.deploy.skip>` and
+  `<central.skipPublishing>` in its `<properties>` — never by redeclaring the
+  `release` profile.
 
 ## Workflow for a dependency/plugin change
 1. Confirm it isn't already managed in the root pom.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,9 @@ is `Main.java` and which supports stdio (default), streamable HTTP
 
 ## Environment & toolchain
 
-- **Java 25** (`maven.compiler.source`/`target` = 25). A JDK 25 must be on the
+- **Java 25** (the `java.version` property, from which the Spring Boot parent
+  derives `maven.compiler.release`; `source`/`target` are deliberately unset
+  because the compiler plugin ignores them once `release` is set). A JDK 25 must be on the
   `PATH` with `JAVA_HOME` set. In Claude Code web/remote sessions the
   `.claude/hooks/session-start.sh` hook installs `openjdk-25-jdk`, exports
   `JAVA_HOME`, and pre-fetches dependencies (`mvn dependency:go-offline`).
@@ -257,8 +259,10 @@ mvn -B package
 # Run the tests for a single module (-am is required, see below)
 mvn -pl data -am test
 
-# Build the standalone data-test module
-mvn -pl data-test -am test
+# Build the standalone data-test module. It is not in the root <modules>, so
+# -pl cannot select it ("Could not find the selected project in the reactor");
+# run it from its own directory, with tools.data already installed.
+cd data-test && mvn test
 ```
 
 **Always pair `-pl` with `-am`.** A bare `mvn -pl data test` fails before it
@@ -740,6 +744,23 @@ These are hard requirements for any code you add or modify:
   `<pluginManagement>`.
 - **Do not add a new dependency without asking first.** Prefer the existing
   Maven dependencies.
+- A family of artifacts that must move together shares one property rather than
+  a version each: `protobuf.version` (the `protobuf-java` runtime *and* the
+  `protoc` that `protobuf-maven-plugin` runs), `grpc.version`, `derby.version`,
+  `log4j2.version`, `maven.api.version`. `derby.version` and `log4j2.version`
+  are Spring Boot's own property names on purpose — the
+  `spring-boot-dependencies` BOM manages the rest of each family (derbyshared,
+  derbynet, the other log4j2 artifacts) from them, so pinning only the artifacts
+  this repository declares would leave the siblings on Boot's older version.
+- A module that is an example, a test harness or a distribution rather than a
+  reusable library opts out of publication with two properties —
+  `maven.deploy.skip` (GitHub Packages) and `central.skipPublishing` (Maven
+  Central) — not by redeclaring the `release` profile.
+- The root `enforce` execution also runs `requireProfileIdsExist`, so a
+  mistyped `-P` fails the build instead of silently running without the profile.
+  It is satisfied when *any* project in the reactor declares the id, which is
+  what lets the per-module `integration-tests` profile be requested from the
+  root.
 
 ## Releasing
 
@@ -774,8 +795,12 @@ credentials. The release job requires four repository secrets:
 `MAVEN_CENTRAL_USERNAME` and `MAVEN_CENTRAL_PASSWORD` (a Central Portal user
 token), plus `MAVEN_GPG_PRIVATE_KEY` and `MAVEN_GPG_PASSPHRASE` (the signing
 key). Every reactor module is published to Central except `assembly`,
-`grpc-example`, and `protogen-maven-plugin-test`, which are excluded as noted
-above.
+`grpc-example`, `protogen-maven-plugin-test` and `test-common`, each of which
+sets `<central.skipPublishing>true</central.skipPublishing>` in its own
+`<properties>`. That property drives the `skipPublishing` flag the root pom
+configures on the `central-publishing-maven-plugin`, and the plugin honours it
+per module, so the exclusion holds with or without the workflow's `-pl` filter.
+The same modules set `maven.deploy.skip` to stay out of GitHub Packages too.
 
 To publish from a workstation: `mvn -P release deploy` with the same `central`
 server credentials in `~/.m2/settings.xml` and a GPG key on the keyring.

--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -11,7 +11,6 @@
 	<packaging>jar</packaging>
 	<name>Claude Code repository adoption</name>
 	<description>Adopts Claude Code into a GitHub repository: clones it, runs claude init to generate CLAUDE.md, commits and pushes, then wires the claude-code-enforcer into the project build.</description>
-	<url>https://github.com/adamw7/tools</url>
 	<build>
 		<resources>
 			<!-- Default resources copied verbatim: log4j2.properties carries ${...}
@@ -87,7 +86,7 @@
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.mcp-common</artifactId>
-			<version>${revision}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.modelcontextprotocol.sdk</groupId>
@@ -117,7 +116,7 @@
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.test-common</artifactId>
-			<version>${revision}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -11,14 +11,14 @@
 	<packaging>jar</packaging>
 	<name>assembly</name>
 	<description>Builds a runnable SampleApp distribution: a launcher jar plus a lib/ of dependency jars (mainClass: io.github.adamw7.tools.data.SampleApp).</description>
-	<url>https://github.com/adamw7/tools</url>
 	<properties>
-		<!-- This module only assembles a runnable SampleApp distribution, not a
-		     reusable library, so keep it out of the GitHub Packages deployment
-		     that maven-deploy-plugin performs on `mvn deploy`. (The Maven Central
-		     release profile already excludes it via the central-publishing
-		     plugin's skipPublishing flag below.) -->
+		<!-- This module only assembles a runnable SampleApp distribution (a
+		     launcher jar plus its lib/ of dependencies), not a reusable library,
+		     so keep it out of both publications: the GitHub Packages deployment
+		     maven-deploy-plugin performs on `mvn deploy`, and the Maven Central
+		     bundle the root pom's release profile publishes. -->
 		<maven.deploy.skip>true</maven.deploy.skip>
+		<central.skipPublishing>true</central.skipPublishing>
 	</properties>
 	<build>
 		<plugins>
@@ -27,6 +27,7 @@
 				     distribution's launcher. Main-Class plus a lib/-prefixed Class-Path
 				     make `java -jar tools.assembly-<version>.jar` work straight out of
 				     the assembled directory, in the container images and outside them. -->
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>
@@ -39,6 +40,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<descriptors>
@@ -69,25 +71,4 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-	<profiles>
-		<profile>
-			<!-- This module only assembles a runnable SampleApp distribution
-			     (a launcher jar plus its lib/ of dependencies), not a reusable library,
-			     so keep it out of the Maven Central bundle that the release
-			     profile publishes. skipPublishing is honoured per module by the
-			     central-publishing-maven-plugin. -->
-			<id>release</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.sonatype.central</groupId>
-						<artifactId>central-publishing-maven-plugin</artifactId>
-						<configuration>
-							<skipPublishing>true</skipPublishing>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 </project>

--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -11,7 +11,6 @@
 	<packaging>jar</packaging>
 	<name>CLAUDE.md enforcer rule</name>
 	<description>Custom maven-enforcer rule that validates CLAUDE.md documents for structure and naming conventions during the build.</description>
-	<url>https://github.com/adamw7/tools</url>
 	<!-- flatten-maven-plugin is inherited from the root pom, which flattens the
 	     CI-friendly ${revision} out of every module's pom. This module needs it
 	     because it is consumed as a maven-enforcer-plugin dependency resolved
@@ -37,7 +36,7 @@
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.test-common</artifactId>
-			<version>${revision}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -11,7 +11,6 @@
 	<packaging>jar</packaging>
 	<name>Context engineering</name>
 	<description>Fast, regex-based finder that builds the tree of classes used by a given class and assembles context for gen-AI agents, exposed over an MCP server.</description>
-	<url>https://github.com/adamw7/tools</url>
 	<build>
 		<plugins>
 			<plugin>
@@ -53,7 +52,7 @@
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.mcp-common</artifactId>
-			<version>${revision}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.modelcontextprotocol.sdk</groupId>
@@ -88,7 +87,7 @@
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.test-common</artifactId>
-			<version>${revision}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -11,7 +11,6 @@
 	<packaging>pom</packaging>
 	<name>Tooling for code</name>
 	<description>Aggregator module for code-oriented tooling: the protobuf builder-generating Maven plugin and the regex-based class-usage context finder.</description>
-	<url>https://github.com/adamw7/tools</url>
 	<modules>
 		<module>protogen-maven-plugin</module>
 		<module>protogen-maven-plugin-test</module>

--- a/code/protogen-maven-plugin-test/pom.xml
+++ b/code/protogen-maven-plugin-test/pom.xml
@@ -11,11 +11,18 @@
 	<packaging>jar</packaging>
 	<name>protogen-maven-plugin-test</name>
 	<description>Integration test module that exercises the protogen-maven-plugin by generating and compiling protobuf builders end to end.</description>
-	<url>https://github.com/adamw7/tools</url>
 	<properties>
 		<!-- This module only exercises generated protobuf classes, so the
 		     instruction-coverage gate is not meaningful here. -->
 		<jacoco.skip>true</jacoco.skip>
+		<!-- An integration-test harness for the protogen-maven-plugin, not a
+		     reusable library: it has no main Java sources (only src/main/proto),
+		     so its -sources.jar is empty and Central validation rejects it. Keep
+		     it out of both publications: the GitHub Packages deployment
+		     maven-deploy-plugin performs on `mvn deploy`, and the Maven Central
+		     bundle the root pom's release profile publishes. -->
+		<maven.deploy.skip>true</maven.deploy.skip>
+		<central.skipPublishing>true</central.skipPublishing>
 	</properties>
 	<build>
 		<plugins>
@@ -94,27 +101,4 @@
 			<artifactId>protobuf-java</artifactId>
 		</dependency>
 	</dependencies>
-	<profiles>
-		<profile>
-			<!-- This module is an integration-test harness for the
-			     protogen-maven-plugin, not a reusable library: it has no main
-			     Java sources (only src/main/proto), so its -sources.jar is empty
-			     and Central validation rejects it. Keep it out of the Maven
-			     Central bundle that the release profile publishes. skipPublishing
-			     is honoured per module by the central-publishing-maven-plugin, so
-			     the exclusion holds even without the reactor -pl filter. -->
-			<id>release</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.sonatype.central</groupId>
-						<artifactId>central-publishing-maven-plugin</artifactId>
-						<configuration>
-							<skipPublishing>true</skipPublishing>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 </project>

--- a/code/protogen-maven-plugin/pom.xml
+++ b/code/protogen-maven-plugin/pom.xml
@@ -11,7 +11,6 @@
 	<packaging>maven-plugin</packaging>
 	<name>protogen-maven-plugin</name>
 	<description>Maven plugin that generates fluent, type-safe builders for protobuf-generated message classes during the generate-sources phase.</description>
-	<url>https://github.com/adamw7/tools</url>
 	<build>
 		<plugins>
 			<!-- Expose the mockito-core jar path so it can be pre-loaded as a Java
@@ -103,7 +102,7 @@
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.test-common</artifactId>
-			<version>${revision}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/data-test/pom.xml
+++ b/data-test/pom.xml
@@ -11,22 +11,17 @@
 	<packaging>jar</packaging>
 	<name>Test for data</name>
 	<description>Standalone test module that validates the data module's sources, uniqueness checks and data structures independently of the root reactor.</description>
-	<url>https://github.com/adamw7/tools</url>
-	<developers>
-		<developer>
-			<id>adamw7</id>
-			<name>Adam Witkowski</name>
-			<email>adamwitkowski3@gmail.com</email>
-			<url>https://github.com/adamw7</url>
-		</developer>
-	</developers>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<argLine>-Xmx16m</argLine>
+					<!-- The tight heap is the point of this module: it proves the
+					     iterative sources stream rather than buffer. @{argLine} keeps
+					     whatever the build already put there (the JaCoCo agent under
+					     the coverage profile) instead of dropping it. -->
+					<argLine>@{argLine} -Xmx16m</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/data-test/src/main/java/module-info.java
+++ b/data-test/src/main/java/module-info.java
@@ -1,6 +1,9 @@
+// Deliberately no `requires org.junit.*`: the only main source here is this
+// descriptor, so junit is test-scoped and unreadable at main-compile time —
+// naming it fails the build with "module not found". Surefire patches the test
+// classes into this module and adds --add-reads ALL-UNNAMED, so they reach
+// junit from the classpath without it being required here.
 module io.github.adamw7.tools.data.test {
 	requires io.github.adamw7.tools.data;
 	requires org.apache.logging.log4j;
-	requires org.junit.jupiter.api;
-	requires org.junit.platform.commons;
 }

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -11,7 +11,6 @@
 	<packaging>jar</packaging>
 	<name>Tooling for data</name>
 	<description>Data sources (CSV, GZip, JDBC, Parquet; in-memory and iterative), a uniqueness-checking tool, data structures, and an MCP server exposing the uniqueness checker.</description>
-	<url>https://github.com/adamw7/tools</url>
 	<build>
 		<plugins>
 			<!-- Expose the mockito-core jar path (it arrives transitively through
@@ -107,7 +106,7 @@
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.mcp-common</artifactId>
-			<version>${revision}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.modelcontextprotocol.sdk</groupId>
@@ -167,7 +166,7 @@
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.test-common</artifactId>
-			<version>${revision}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -11,11 +11,16 @@
 	<packaging>jar</packaging>
 	<name>grpc-example</name>
 	<description>End-to-end gRPC example demonstrating the protogen-generated, compile-time-safe protobuf builders in a working service.</description>
-	<url>https://github.com/adamw7/tools</url>
 	<properties>
 		<!-- This module only exercises generated protobuf/gRPC classes, so the
 		     instruction-coverage gate is not meaningful here. -->
 		<jacoco.skip>true</jacoco.skip>
+		<!-- An example, not a reusable library, so keep it out of both
+		     publications: the GitHub Packages deployment maven-deploy-plugin
+		     performs on `mvn deploy`, and the Maven Central bundle the root pom's
+		     release profile publishes. -->
+		<maven.deploy.skip>true</maven.deploy.skip>
+		<central.skipPublishing>true</central.skipPublishing>
 		<!-- Default main class for exec:java. Declared as a property (rather than
 		     hard-coded in the plugin <configuration>) so that -Dexec.mainClass on
 		     the command line can override it to run GreeterClient. -->
@@ -134,24 +139,4 @@
 			<artifactId>log4j-core</artifactId>
 		</dependency>
 	</dependencies>
-	<profiles>
-		<profile>
-			<!-- This module only exercises generated protobuf/gRPC classes as an
-			     example, not a reusable library, so keep it out of the Maven
-			     Central bundle that the release profile publishes. skipPublishing
-			     is honoured per module by the central-publishing-maven-plugin. -->
-			<id>release</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.sonatype.central</groupId>
-						<artifactId>central-publishing-maven-plugin</artifactId>
-						<configuration>
-							<skipPublishing>true</skipPublishing>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 </project>

--- a/mcp-common/pom.xml
+++ b/mcp-common/pom.xml
@@ -11,7 +11,6 @@
 	<packaging>jar</packaging>
 	<name>Shared MCP server scaffolding</name>
 	<description>Shared MCP server scaffolding providing transport wiring and the tool SPI reused by the repository's MCP servers.</description>
-	<url>https://github.com/adamw7/tools</url>
 	<build>
 		<plugins>
 			<!-- This module has no module-info.java, so the JPMS name that
@@ -63,7 +62,7 @@
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.test-common</artifactId>
-			<version>${revision}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	child.project.url.inherit.append.path="false">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -18,12 +19,24 @@
 	<url>https://github.com/adamw7/tools</url>
 	<properties>
 		<revision>2.6.0-SNAPSHOT</revision>
-		<maven.compiler.source>25</maven.compiler.source>
-		<maven.compiler.target>25</maven.compiler.target>
+		<!-- The Spring Boot parent derives maven.compiler.release from this, so
+		     javac both targets and validates against the Java 25 API. Setting
+		     maven.compiler.source/target as well would be dead weight: the
+		     compiler plugin ignores them once release is set, and a second copy
+		     of the number is a copy that can drift. -->
 		<java.version>25</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<protobuf.version>4.33.4</protobuf.version>
+		<!-- One version for the whole protobuf toolchain: the protobuf-java
+		     runtime below and the protoc that protobuf-maven-plugin runs. Keeping
+		     them apart let the generated code and the runtime it compiles against
+		     drift by two minor versions. -->
+		<protobuf.version>4.35.1</protobuf.version>
 		<grpc.version>1.83.0</grpc.version>
+		<derby.version>10.17.1.0</derby.version>
+		<log4j2.version>2.26.1</log4j2.version>
+		<!-- Named maven.api.version, not maven.version: Maven itself exposes
+		     ${maven.version} as the running Maven's own version. -->
+		<maven.api.version>4.0.0-rc-5</maven.api.version>
 		<argLine/>
 		<!-- Per-test timeout for unit tests (see the surefire plugin config). The
 		     build runs the reactor in parallel (-T1C in .mvn/maven.config), so
@@ -59,6 +72,13 @@
 		     publishing: -Dcentral.autoPublish=false -Dcentral.waitUntil=validated. -->
 		<central.autoPublish>true</central.autoPublish>
 		<central.waitUntil>published</central.waitUntil>
+		<!-- Whether the release profile keeps this module out of the Maven Central
+		     bundle. Modules that are examples, test harnesses or distributions
+		     rather than reusable libraries set it to true in their own
+		     <properties>, which is one line instead of a copy of the
+		     central-publishing plugin declaration inside a copy of the release
+		     profile. -->
+		<central.skipPublishing>false</central.skipPublishing>
 	</properties>
 	<licenses>
 		<license>
@@ -98,7 +118,6 @@
 	</modules>
 	<dependencyManagement>
 		<dependencies>
-
 			<dependency>
 				<groupId>org.apache.maven.enforcer</groupId>
 				<artifactId>enforcer-api</artifactId>
@@ -129,32 +148,38 @@
 				<version>1.22.2</version>
 				<scope>test</scope>
 			</dependency>
+			<!-- log4j2.version and derby.version are Spring Boot's own property
+			     names. Setting them (rather than only pinning the artifacts we
+			     declare) is what keeps the rest of each family in step: the
+			     spring-boot-dependencies BOM manages derbyshared and derbynet from
+			     derby.version, so leaving it at Boot's value resolved derbyshared
+			     10.16.1.1 underneath derby 10.17.1.0. -->
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-api</artifactId>
-				<version>2.26.1</version>
+				<version>${log4j2.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-core</artifactId>
-				<version>2.26.1</version>
+				<version>${log4j2.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.derby</groupId>
 				<artifactId>derby</artifactId>
-				<version>10.17.1.0</version>
+				<version>${derby.version}</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.derby</groupId>
 				<artifactId>derbyclient</artifactId>
-				<version>10.17.1.0</version>
+				<version>${derby.version}</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.derby</groupId>
 				<artifactId>derbytools</artifactId>
-				<version>10.17.1.0</version>
+				<version>${derby.version}</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
@@ -165,19 +190,19 @@
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-plugin-api</artifactId>
-				<version>4.0.0-rc-5</version>
+				<version>${maven.api.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-model</artifactId>
-				<version>4.0.0-rc-5</version>
+				<version>${maven.api.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-artifact</artifactId>
-				<version>4.0.0-rc-5</version>
+				<version>${maven.api.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
@@ -189,7 +214,7 @@
 			<dependency>
 				<groupId>com.google.protobuf</groupId>
 				<artifactId>protobuf-java</artifactId>
-				<version>4.35.1</version>
+				<version>${protobuf.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.reflections</groupId>
@@ -270,10 +295,12 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<!-- Managed only to attach the exclusion; the version stays the one the
+			     spring-boot-dependencies BOM already supplies, so it cannot fall
+			     behind the parent on the next Spring Boot bump. -->
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter</artifactId>
-				<version>3.5.16</version>
 				<exclusions>
 					<exclusion>
 						<groupId>org.springframework.boot</groupId>
@@ -518,6 +545,11 @@
 								</requirePluginVersions>
 								<dependencyConvergence />
 								<requireNoRepositories />
+								<!-- A profile named on the command line that no pom declares
+								     is silently ignored by Maven, so a typo in -Pcoverage or
+								     -Pintegration-tests looks like a clean run that quietly
+								     skipped the very thing it was asked for. -->
+								<requireProfileIdsExist />
 							</rules>
 						</configuration>
 					</execution>
@@ -869,6 +901,10 @@
 							<publishingServerId>central</publishingServerId>
 							<autoPublish>${central.autoPublish}</autoPublish>
 							<waitUntil>${central.waitUntil}</waitUntil>
+							<!-- Honoured per module, so a module stays out of the bundle by
+							     setting the property rather than redeclaring this plugin
+							     inside a copy of this profile. -->
+							<skipPublishing>${central.skipPublishing}</skipPublishing>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/test-common/pom.xml
+++ b/test-common/pom.xml
@@ -11,14 +11,14 @@
 	<packaging>jar</packaging>
 	<name>Shared test scaffolding</name>
 	<description>Shared ArchUnit rule libraries reused by every module's architecture tests.</description>
-	<url>https://github.com/adamw7/tools</url>
 	<properties>
 		<!-- This module carries no production code, only the rule libraries the
-		     other modules' architecture tests import, so keep it out of the
-		     GitHub Packages deployment that maven-deploy-plugin performs on
-		     `mvn deploy`. (The Maven Central release profile excludes it via the
-		     central-publishing plugin's skipPublishing flag below.) -->
+		     other modules' architecture tests import, so keep it out of both
+		     publications: the GitHub Packages deployment maven-deploy-plugin
+		     performs on `mvn deploy`, and the Maven Central bundle the root pom's
+		     release profile publishes. -->
 		<maven.deploy.skip>true</maven.deploy.skip>
+		<central.skipPublishing>true</central.skipPublishing>
 	</properties>
 	<build>
 		<plugins>
@@ -53,24 +53,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<profiles>
-		<profile>
-			<!-- This module is test scaffolding for the reactor, not a reusable
-			     library, so keep it out of the Maven Central bundle that the
-			     release profile publishes. skipPublishing is honoured per module
-			     by the central-publishing-maven-plugin. -->
-			<id>release</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.sonatype.central</groupId>
-						<artifactId>central-publishing-maven-plugin</artifactId>
-						<configuration>
-							<skipPublishing>true</skipPublishing>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 </project>


### PR DESCRIPTION
The module poms had grown four copies of the same release profile, a
repeated <url> the parent could supply, and versions written twice — and
the second copy had already drifted in three places.

Root pom:
- Pin derby and log4j2 through Spring Boot's own derby.version and
  log4j2.version properties. The spring-boot-dependencies BOM manages the
  rest of each family from them, so pinning only the artifacts declared
  here left derbyshared resolving to 10.16.1.1 underneath derby 10.17.1.0.
- Give protoc and the protobuf-java runtime one protobuf.version. They had
  drifted to 4.33.4 and 4.35.1, so generated code and the runtime it
  compiles against came from different releases.
- Drop maven.compiler.source/target: the Spring Boot parent already derives
  maven.compiler.release from java.version, and the compiler plugin ignores
  source/target once release is set.
- Drop the hard-coded spring-boot-starter version; the entry exists to
  attach an exclusion, and the literal could fall behind the parent.
- Share maven.api.version across the three maven-* artifacts.
- Add requireProfileIdsExist, so a mistyped -P fails instead of silently
  running without the profile.
- Set child.project.url.inherit.append.path=false so modules inherit <url>.

Modules:
- Replace the four copied release profiles with a central.skipPublishing
  property the root pom's plugin config reads, and let grpc-example and
  protogen-maven-plugin-test skip GitHub Packages too, as the other
  non-library modules already did.
- Drop the inherited <url> and, in data-test, the inherited <developers>.
- Use ${project.version} for reactor dependencies, not ${revision}.
- Name the groupId of assembly's jar and assembly plugins.
- Compose data-test's -Xmx16m onto @{argLine} instead of replacing it,
  which dropped the JaCoCo agent under the coverage profile.

data-test could not build either documented way: its main module-info
required junit modules that are test-scoped and so unreadable at
main-compile time, and -pl cannot select a module outside <modules>.
Surefire patches the test classes in with --add-reads ALL-UNNAMED, so the
requires are unnecessary; AGENTS.md now gives the command that works.

Verified: reactor dependency trees are byte-identical before and after
except derbyshared (now 10.17.1.0) and osgi.annotation (8.0.1, the version
its own graph asks for, no longer forced up by the older log4j-bom). Full
build, coverage profile, data and context integration tests, the CLAUDE.md
enforcer checks and the standalone data-test module all pass.