### PR TITLE
ci(docker): take the image build off pull requests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,28 +1,29 @@
 name: Java Maven Build and Docker
 
 on:
-  # Pull requests build, run and scan the image but never push it, so a
-  # packaging regression is caught in review rather than at the next release.
-  # No paths filter on purpose: the image contains the built jars, so a change
-  # anywhere in the reactor — source, pom, or dependency version — can break it.
-  pull_request:
-    branches: [main]
+  # Not on pull requests: the image build, smoke run and scan add minutes to
+  # every review for a packaging path that changes rarely. It runs weekly
+  # instead, so a packaging regression — or a fresh CVE in the base image —
+  # still surfaces well before the next release, and always on the release
+  # itself. Trigger it by hand after touching the assembly or the Dockerfile.
+  schedule:
+    # Saturdays at 03:00 UTC, clear of the other weekend workflows.
+    - cron: '0 3 * * 6'
   release:
     types: [created]
   workflow_dispatch:
 
 # The workflow only reads the repository; `packages: write` is what lets the
 # job push the released image to GHCR with the built-in token. It is unused on
-# pull requests, where the push step is skipped (and where GITHUB_TOKEN is
-# read-only for forks regardless).
+# the scheduled and manual runs, where the push step is skipped.
 permissions:
   contents: read
   packages: write
 
 concurrency:
   group: docker-${{ github.ref }}
-  # Superseded pull-request runs are worth cancelling; a release run is not.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Neither a release nor a weekly run is worth cancelling half-way.
+  cancel-in-progress: false
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}
@@ -102,11 +103,9 @@ jobs:
           echo "${not_unique}" | grep -q 'country is NOT unique'
           echo "${unique}" | grep -q 'id is unique'
 
-      # Fails the release on fixable HIGH/CRITICAL findings, so a vulnerable base
-      # image is caught before the push rather than after. Advisory on pull
-      # requests: a fresh upstream CVE is real, but it is not the PR author's to
-      # fix, and blocking every open PR on it helps nobody. The findings are
-      # still printed in the log.
+      # Fails on fixable HIGH/CRITICAL findings, so a vulnerable base image is
+      # caught before the push rather than after — and, on the weekly run, while
+      # there is still time to fix it rather than at the release.
       - name: Scan the image for vulnerabilities
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -114,7 +113,7 @@ jobs:
           format: table
           severity: HIGH,CRITICAL
           ignore-unfixed: true
-          exit-code: ${{ github.event_name == 'pull_request' && '0' || '1' }}
+          exit-code: '1'
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'release'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -485,10 +485,9 @@ longer and carry no timeout.
 
 ## Continuous integration
 
-Workflows live in `.github/workflows/`. Two gate pull requests to `main`:
-`maven.yml` (the build and the doc checks) and `docker.yml` (the image build,
-smoke run and scan — it pushes nothing outside a release); the rest run on a
-schedule, manually, or on a release.
+Workflows live in `.github/workflows/`. One gates pull requests to `main`:
+`maven.yml` (the build and the doc checks); the rest run on a schedule,
+manually, or on a release.
 
 | Workflow | Trigger | What it runs |
 | --- | --- | --- |
@@ -498,7 +497,7 @@ schedule, manually, or on a release.
 | `coverage.yml` | weekly (Saturdays) | `mvn verify -Pcoverage`, uploads JaCoCo reports as an artifact. |
 | `pitest.yml` | weekly (Sundays); manual | `mvn install -Ppitest`, uploads PIT mutation reports as an artifact. |
 | `maven-windows.yml` | weekly (Sundays); manual | `mvn install` on a `windows-latest` runner, to catch platform-specific regressions the Linux build would miss. |
-| `docker.yml` | PR → `main`; on GitHub release; manual dispatch | `mvn -B package`, then builds `assembly/Dockerfile` for `linux/amd64`, **runs** it against a sample CSV to prove `SampleApp` launches and logs, and scans it with Trivy (blocking on a release, advisory on a PR). Only on a release does it push a `linux/amd64,linux/arm64` image to GHCR, tagged with the release version and `latest`, with SBOM and provenance. |
+| `docker.yml` | weekly (Saturdays); on GitHub release; manual dispatch | `mvn -B package`, then builds `assembly/Dockerfile` for `linux/amd64`, **runs** it against a sample CSV to prove `SampleApp` launches and logs, and scans it with Trivy (failing on fixable HIGH/CRITICAL findings). Only on a release does it push a `linux/amd64,linux/arm64` image to GHCR, tagged with the release version and `latest`, with SBOM and provenance. Deliberately **not** on pull requests — the image build costs minutes per review for a packaging path that changes rarely, so dispatch it by hand when touching `assembly` or the Dockerfile. |
 | `maven-publish.yml` | on GitHub release | Deploys to **GitHub Packages** (`-P github-packages`). See "Releasing". |
 | `central-publish.yml` | on GitHub release; manual dispatch | Deploys to **Maven Central** (`-P release`), or a staged-only dry run on manual dispatch. See "Releasing". |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,19 +227,21 @@ paths.
 
 ## Continuous integration and commits
 
-Two workflows gate pull requests to `main`. `maven.yml` bootstraps the enforcer
+One workflow gates pull requests to `main`: `maven.yml` bootstraps the enforcer
 rule and then runs `mvn -B package -DenforceClaudeMd` — the only workflow that
 runs the doc checks. Its `package` step is capped at **120 seconds**
 (`timeout-minutes: 2` plus a wall-clock check that fails with a `::error::`
 annotation), so a change that slows the build down red-flags the PR; profile it
-rather than raising the cap. `docker.yml` builds the image, runs it against a
-sample CSV and scans it, pushing nothing outside a release. Everything else runs
-on a schedule or a release, so a green PR is not proof the whole matrix passes:
+rather than raising the cap. Everything else runs on a schedule or a release, so
+a green PR is not proof the whole matrix passes:
 
-- **Scheduled** — `integration-tests.yml` daily; `codeql.yml` and
-  `coverage.yml` Saturdays; `pitest.yml` and `maven-windows.yml` Sundays.
+- **Scheduled** — `integration-tests.yml` daily; `codeql.yml`, `coverage.yml`
+  and `docker.yml` Saturdays; `pitest.yml` and `maven-windows.yml` Sundays.
   `maven-windows.yml` runs `mvn install` on `windows-latest`, so keep path,
-  line-ending, and file-locking assumptions platform-neutral.
+  line-ending, and file-locking assumptions platform-neutral. `docker.yml`
+  builds the image, runs it against a sample CSV and scans it, pushing nothing
+  outside a release — run it by hand (`workflow_dispatch`) after changing the
+  assembly or the Dockerfile rather than waiting for the weekly run.
 - **On a GitHub release** — `docker.yml` again, this time pushing the multi-arch
   image to GHCR; `maven-publish.yml` (GitHub Packages); and
   `central-publish.yml` (Maven Central).

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -686,8 +686,10 @@ flowchart TB
 Which workflow runs what, and what leaves the build. `maven.yml` is the gate on
 every pull request to `main` — and the only workflow that runs the CLAUDE.md
 checks; the heavier and slower checks are scheduled, and everything that
-publishes fires on a GitHub release. Triggers below are the ones in
-`.github/workflows/`; every workflow builds on JDK 25 (Temurin).
+publishes fires on a GitHub release. `docker.yml` sits in both halves: it builds,
+smoke-runs and scans the image on its weekly run, and does the same again on a
+release before pushing the multi-arch image to GHCR. Triggers below are the ones
+in `.github/workflows/`; every workflow builds on JDK 25 (Temurin).
 
 ```mermaid
 flowchart TB
@@ -706,10 +708,10 @@ flowchart TB
         covWf["<b>coverage.yml</b><br/><i>Saturdays · JaCoCo, 80% floor</i>"]
         pitWf["<b>pitest.yml</b><br/><i>Sundays · mutation testing</i>"]
         winWf["<b>maven-windows.yml</b><br/><i>Sundays · the build on Windows</i>"]
+        dockerWf["<b>docker.yml</b><br/><i>Saturdays · builds, smoke-runs<br/>and scans the image; on a release,<br/>also pushes it to GHCR</i>"]
     end
 
     subgraph publish ["On a release"]
-        dockerWf["<b>docker.yml</b><br/><i>builds, smoke-runs and scans<br/>the image, pushes it to GHCR</i>"]
         ghPkg["<b>maven-publish.yml</b><br/><i>GitHub Packages</i>"]
         central["<b>central-publish.yml</b><br/><i>Maven Central; dispatch =<br/>staged-only dry run</i>"]
     end
@@ -720,8 +722,10 @@ flowchart TB
     sched --> covWf
     sched --> pitWf
     sched --> winWf
+    sched --> dockerWf
     manual --> pitWf
     manual --> winWf
+    manual --> dockerWf
     manual --> central
     rel --> dockerWf
     rel --> ghPkg


### PR DESCRIPTION
The image build, smoke run and Trivy scan added several minutes to every
review for a packaging path that changes rarely, while `maven.yml` — the
one workflow that still gates a PR — is held to a 120-second cap.

`docker.yml` now runs weekly (Saturdays 03:00 UTC, clear of the other
weekend workflows), on a release, and on manual dispatch, so a packaging
regression or a fresh base-image CVE still surfaces well before the next
release. With no pull-request runs left, the Trivy scan is blocking
everywhere rather than advisory, and superseded runs are no longer
cancelled.

Updates CLAUDE.md, AGENTS.md and the C4 CI diagram to match; the diagram
also regains a `docker.yml` node that reflects both of its cadences.