### PR TITLE
fix(adopt): repair three failures found by end-to-end runs on real repositories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,13 @@ Maven project. The notable capabilities are:
   `PATH` for a `gradle` used to abort the adoption of a repository the host could
   build perfectly well. The wrapper is launched by its absolute path, since
   `ProcessBuilder` resolves a relative program name against the JVM's working
-  directory rather than the command's. The pull request metadata — title, body,
+  directory rather than the command's, and a POSIX wrapper the project committed
+  without its executable bit — the usual state of one added from Windows — is
+  launched through `sh` rather than as a program, since it would otherwise be
+  refused with "Permission denied". `BuildSystem.toolProbe` answers the whole
+  probe command rather than a program name so `BuildToolchainStep` probes that
+  same launcher: `sh --version` is not portable, so probing the program alone
+  would answer for the shell instead of for the build tool. The pull request metadata — title, body,
   reviewers, labels, assignees, and draft flag — is supplied through
   `PullRequestOptions`, exposed on the command line as `--title`, `--body`,
   repeatable `--reviewer`/`--label`/`--assignee`, and `--draft` (parsed by
@@ -102,7 +108,12 @@ Maven project. The notable capabilities are:
   never meet, though, so `CloneStep` guards the other half of that collision: a
   checkout it reuses instead of cloning is first confirmed to be the repository
   under adoption, by comparing the repository its `origin` names with the one the
-  run was given. Two URLs name one repository when they agree once their scheme,
+  run was given. That comparison reads the raw configured remote (`git config
+  --get-all remote.origin.url`) rather than `git remote get-url`, which expands
+  the caller's `url.<base>.insteadOf` rewrites and so answers a host and path the
+  checkout never recorded: against a mirror or a proxied clone the reused checkout
+  was refused as a different repository, aborting the adoption of the very
+  repository it held. Two URLs name one repository when they agree once their scheme,
   credentials, `.git` suffix, trailing slash, and letter case are set aside — so a
   checkout cloned over SSH is reused by a run given the HTTPS URL — and anything
   else is refused, because re-cloning costs a clone while adopting the wrong

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -38,15 +38,20 @@ public interface BuildSystem {
 	List<String> verifyCommand(Path repositoryDirectory);
 
 	/**
-	 * The program {@link #verifyCommand(Path)} launches, so {@link BuildToolchainStep}
-	 * can probe it before the pipeline spends a {@code claude init} on a checkout it
-	 * will not be able to verify. The verification launches the first word of its
-	 * own command, so that is what the default probes.
+	 * The command that shows the build tool {@link #verifyCommand(Path)} launches can
+	 * actually be run, so {@link BuildToolchainStep} can probe it before the pipeline
+	 * spends a {@code claude init} on a checkout it will not be able to verify.
 	 *
-	 * @return the program to probe, or empty when the verification needs nothing
-	 *         beyond the shell
+	 * <p>A whole command rather than a program name, because a build system may need
+	 * more than one word to launch its tool — a wrapper the checkout committed
+	 * without its executable bit goes through {@code sh}, whose own
+	 * {@code --version} is not portable — and probing only the program would then
+	 * answer for the shell rather than for the build tool.
+	 *
+	 * @return the probe command, or empty when the verification needs nothing beyond
+	 *         the shell
 	 */
-	default Optional<String> requiredTool(Path repositoryDirectory) {
-		return Optional.of(verifyCommand(repositoryDirectory).get(0));
+	default Optional<List<String>> toolProbe(Path repositoryDirectory) {
+		return Optional.of(List.of(verifyCommand(repositoryDirectory).get(0), ToolProbe.VERSION_FLAG));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
@@ -44,8 +45,8 @@ public class BuildToolchainStep extends AbstractBuildSystemStep {
 	@Override
 	protected void onDetected(BuildSystem buildSystem, AdoptionContext context, CommandRunner runner) {
 		Path repositoryDirectory = context.repositoryDirectory();
-		buildSystem.requiredTool(repositoryDirectory).ifPresentOrElse(
-				tool -> requireRunnable(tool, buildSystem, repositoryDirectory, runner),
+		buildSystem.toolProbe(repositoryDirectory).ifPresentOrElse(
+				command -> requireRunnable(command, buildSystem, repositoryDirectory, runner),
 				() -> log.info("The {} guard needs no build tool of its own in {}", buildSystem.name(),
 						repositoryDirectory));
 	}
@@ -55,15 +56,17 @@ public class BuildToolchainStep extends AbstractBuildSystemStep {
 	 * shipping a build wrapper is that wrapper rather than a program on the
 	 * {@code PATH} — so the failure says the tool could not be run rather than that
 	 * it was not installed, which for a wrapper present but unusable would be wrong.
+	 * The whole probe command is named in the failure, since for a wrapper that is
+	 * how the operator reproduces it.
 	 */
-	private void requireRunnable(String tool, BuildSystem buildSystem, Path repositoryDirectory,
+	private void requireRunnable(List<String> command, BuildSystem buildSystem, Path repositoryDirectory,
 			CommandRunner runner) {
-		if (probe.isInstalled(tool, repositoryDirectory, runner)) {
+		if (probe.succeeds(command, repositoryDirectory, runner)) {
 			return;
 		}
 		throw new AdoptionException(name() + " failed: " + repositoryDirectory + " builds with "
-				+ buildSystem.name() + " but " + tool + " could not be run, so the CLAUDE.md guard"
-				+ " could not be verified. Install " + buildSystem.name() + " on the PATH, or commit the"
-				+ " project's build wrapper.");
+				+ buildSystem.name() + " but " + CommandResult.describe(command) + " could not be run, so the"
+				+ " CLAUDE.md guard could not be verified. Install " + buildSystem.name() + " on the PATH, or"
+				+ " commit the project's build wrapper.");
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildWrapper.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildWrapper.java
@@ -25,7 +25,11 @@ import io.github.adamw7.tools.adopt.command.CommandLine;
  */
 final class BuildWrapper {
 
+	/** Launches a wrapper the checkout committed without its executable bit; see {@link #launch}. */
+	private static final String SHELL = "sh";
+
 	private final String fileName;
+	private final boolean windows;
 
 	/** The wrapper for the host platform: the Windows script there, the POSIX one everywhere else. */
 	BuildWrapper(String posixName, String windowsName) {
@@ -34,6 +38,7 @@ final class BuildWrapper {
 
 	BuildWrapper(String posixName, String windowsName, boolean windows) {
 		this.fileName = windows ? windowsName : posixName;
+		this.windows = windows;
 	}
 
 	/**
@@ -42,7 +47,45 @@ final class BuildWrapper {
 	 * system's "wrapper, else the PATH tool" from being written out again.
 	 */
 	List<String> commandIn(Path repositoryDirectory, String fallback, List<String> arguments) {
-		return CommandLine.of(in(repositoryDirectory).orElse(fallback)).addAll(arguments).toList();
+		return CommandLine.of().addAll(launcherIn(repositoryDirectory, fallback)).addAll(arguments).toList();
+	}
+
+	/**
+	 * The probe that shows this build tool can actually be launched in the checkout,
+	 * built from the same launcher {@link #commandIn} uses so what
+	 * {@link BuildToolchainStep} checks is what {@link VerifyStep} will run. Probing
+	 * the launcher rather than the wrapper's file name matters for a wrapper that has
+	 * to go through {@link #SHELL}: {@code sh --version} is not portable — under
+	 * {@code dash} it exits non-zero — so a probe of the program alone would report
+	 * a wrapper that runs perfectly well as one that could not be run.
+	 */
+	List<String> probeIn(Path repositoryDirectory, String fallback) {
+		return commandIn(repositoryDirectory, fallback, List.of(ToolProbe.VERSION_FLAG));
+	}
+
+	/**
+	 * The program-and-arguments prefix that launches the build tool: the checkout's
+	 * wrapper, or {@code fallback} off the {@code PATH} when it ships none.
+	 */
+	private List<String> launcherIn(Path repositoryDirectory, String fallback) {
+		return in(repositoryDirectory).map(this::launch).orElse(List.of(fallback));
+	}
+
+	/**
+	 * A wrapper whose executable bit the project never committed — the usual state of
+	 * one added from Windows, where git records no such bit — cannot be launched as a
+	 * program at all: the checkout is refused with "Permission denied", which
+	 * {@link BuildToolchainStep} reports as a wrapper that could not be run and which
+	 * aborted the adoption of a repository whose build was fine. Running it through
+	 * {@code sh} is what the project's own CI does with it, and needs no change to
+	 * the checkout — where a {@code chmod} would leave a mode change in the adoption's
+	 * commit that nobody asked for.
+	 *
+	 * <p>Only the POSIX wrapper is ever shelled: the Windows {@code .bat}/{@code .cmd}
+	 * carries no executable bit to miss and is not a shell script.
+	 */
+	private List<String> launch(String wrapper) {
+		return windows || Files.isExecutable(Path.of(wrapper)) ? List.of(wrapper) : List.of(SHELL, wrapper);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -13,6 +13,8 @@ import org.apache.logging.log4j.Logger;
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.Failures;
+import io.github.adamw7.tools.adopt.Redaction;
+import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
 /**
@@ -69,14 +71,15 @@ public class ClaudeInitStep extends AbstractCommandStep {
 		}
 		log.info("Running claude init in {}", checkout);
 		Optional<Path> relocated = relocateExistingClaudeDirMemory(checkout);
+		CommandResult result;
 		try {
-			runOrFail(runner, checkout, claudeCommand);
+			result = runOrFail(runner, checkout, claudeCommand);
 		} catch (RuntimeException e) {
 			Failures.alsoRun(e, () -> restoreRelocated(relocated, checkout));
 			throw e;
 		}
 		restoreRelocated(relocated, checkout);
-		requireGenerated(context);
+		requireGenerated(context, result);
 	}
 
 	private void restoreRelocated(Optional<Path> relocated, Path checkout) {
@@ -122,10 +125,20 @@ public class ClaudeInitStep extends AbstractCommandStep {
 		}
 	}
 
-	private void requireGenerated(AdoptionContext context) {
+	/**
+	 * The CLI's own transcript is carried into the failure, because a run that exits
+	 * cleanly without writing the file has said why in it — it declined, it asked a
+	 * question headless mode could not answer, it wrote somewhere else — and that
+	 * transcript is otherwise discarded, {@link #runOrFail} only reporting the output
+	 * of a command that failed. Without it the adoption stops on a message that names
+	 * the missing file and nothing that would explain it.
+	 */
+	private void requireGenerated(AdoptionContext context, CommandResult result) {
 		if (!Files.isRegularFile(context.repositoryDirectory().resolve(CLAUDE_MD))) {
 			throw new AdoptionException(name() + " completed but " + CLAUDE_MD + " was not found in "
-					+ context.repositoryDirectory());
+					+ context.repositoryDirectory() + ". " + CommandResult.describe(claudeCommand)
+					+ " exited " + result.exitCode() + " and said:" + System.lineSeparator()
+					+ Redaction.of(result.output().strip()));
 		}
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -100,10 +100,19 @@ public class CloneStep extends AbstractCommandStep {
 	 * A directory carrying a {@code .git} but no {@code origin} is reported rather
 	 * than adopted: it cannot be shown to be the repository under adoption, and
 	 * {@link PushStep} would have nowhere to publish the branch to anyway.
+	 *
+	 * <p>The remote is read from the configuration rather than with {@code git remote
+	 * get-url}, which expands the {@code url.<base>.insteadOf} rewrites the caller's
+	 * git may configure and so answers a URL the checkout never recorded. A rewrite
+	 * onto a mirror or a proxy names a different host and path from the one the run
+	 * was given, so the reused checkout was refused as a different repository — and
+	 * the adoption of the very repository it held aborted at its second step, in
+	 * exactly the environments that configure one. Only the raw configured value
+	 * can be compared with the URL the run was asked to adopt.
 	 */
 	private String originTranscript(AdoptionContext context, CommandRunner runner) {
 		CommandResult result = runner.run(context.repositoryDirectory(),
-				List.of("git", "remote", "get-url", AdoptionContext.REMOTE));
+				List.of("git", "config", "--get-all", "remote." + AdoptionContext.REMOTE + ".url"));
 		if (!result.succeeded()) {
 			throw new AdoptionException(context.repositoryDirectory() + " is a checkout with no '"
 					+ AdoptionContext.REMOTE

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
@@ -48,7 +48,7 @@ public class FallbackBuildSystem implements BuildSystem {
 	 * nothing to check ahead of time.
 	 */
 	@Override
-	public Optional<String> requiredTool(Path repositoryDirectory) {
+	public Optional<List<String>> toolProbe(Path repositoryDirectory) {
 		return Optional.empty();
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
@@ -60,6 +60,12 @@ public class GradleBuildSystem implements BuildSystem {
 		return wrapper.commandIn(repositoryDirectory, GRADLE, VERIFY_ARGUMENTS);
 	}
 
+	/** Probes whatever {@link #verifyCommand(Path)} will launch — the wrapper, however it has to be run. */
+	@Override
+	public Optional<List<String>> toolProbe(Path repositoryDirectory) {
+		return Optional.of(wrapper.probeIn(repositoryDirectory, GRADLE));
+	}
+
 	/**
 	 * Prefers the Groovy build file over the Kotlin one when a checkout carries
 	 * both, matching the order most Gradle projects resolve them in.

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -68,4 +68,10 @@ public class MavenBuildSystem implements BuildSystem {
 	public List<String> verifyCommand(Path repositoryDirectory) {
 		return wrapper.commandIn(repositoryDirectory, MAVEN, VERIFY_ARGUMENTS);
 	}
+
+	/** Probes whatever {@link #verifyCommand(Path)} will launch — the wrapper, however it has to be run. */
+	@Override
+	public Optional<List<String>> toolProbe(Path repositoryDirectory) {
+		return Optional.of(wrapper.probeIn(repositoryDirectory, MAVEN));
+	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
@@ -22,7 +22,11 @@ final class ToolProbe {
 
 	private static final Logger log = LogManager.getLogger(ToolProbe.class);
 
-	private static final String VERSION_FLAG = "--version";
+	/**
+	 * Package-visible so {@link BuildWrapper} builds its own probe with the same flag
+	 * rather than a copy of it that could drift.
+	 */
+	static final String VERSION_FLAG = "--version";
 
 	/**
 	 * @return the tools whose {@code --version} probe could not be run or exited

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -85,15 +85,13 @@ class BuildSystemsTest {
 	@Test
 	void mavenRequiresTheToolItsVerificationLaunches(@TempDir Path directory) {
 		BuildSystem maven = new MavenBuildSystem();
-		assertEquals(Optional.of(maven.verifyCommand(directory).get(0)), maven.requiredTool(directory));
-		assertEquals(Optional.of("mvn"), maven.requiredTool(directory));
+		assertEquals(Optional.of(List.of("mvn", "--version")), maven.toolProbe(directory));
 	}
 
 	@Test
 	void gradleRequiresTheToolItsVerificationLaunches(@TempDir Path directory) {
 		BuildSystem gradle = new GradleBuildSystem();
-		assertEquals(Optional.of(gradle.verifyCommand(directory).get(0)), gradle.requiredTool(directory));
-		assertEquals(Optional.of("gradle"), gradle.requiredTool(directory));
+		assertEquals(Optional.of(List.of("gradle", "--version")), gradle.toolProbe(directory));
 	}
 
 	/**
@@ -102,7 +100,7 @@ class BuildSystemsTest {
 	 */
 	@Test
 	void gradleVerifiesWithTheCheckoutsWrapperWhenItShipsOne(@TempDir Path directory) throws IOException {
-		Path wrapper = Files.writeString(directory.resolve("gradlew"), "#!/bin/sh\n");
+		Path wrapper = executable(directory.resolve("gradlew"));
 		GradleBuildSystem gradle = new GradleBuildSystem(new BuildWrapper("gradlew", "gradlew.bat", false));
 		assertEquals(List.of(wrapper.toAbsolutePath().toString(), "-q", "enforceClaudeMd"),
 				gradle.verifyCommand(directory));
@@ -110,19 +108,48 @@ class BuildSystemsTest {
 
 	@Test
 	void mavenVerifiesWithTheCheckoutsWrapperWhenItShipsOne(@TempDir Path directory) throws IOException {
-		Path wrapper = Files.writeString(directory.resolve("mvnw"), "#!/bin/sh\n");
+		Path wrapper = executable(directory.resolve("mvnw"));
 		MavenBuildSystem maven = new MavenBuildSystem(new PomEnforcerInstaller("2.6.0"),
 				new BuildWrapper("mvnw", "mvnw.cmd", false));
 		assertEquals(List.of(wrapper.toAbsolutePath().toString(), "-q", "-N", "validate"),
 				maven.verifyCommand(directory));
 	}
 
+	/**
+	 * A wrapper committed without its executable bit — the usual state of one added
+	 * from Windows — cannot be launched as a program, so it is run through sh. It was
+	 * otherwise refused with "Permission denied" and aborted the adoption of a
+	 * repository whose build was fine.
+	 */
+	@Test
+	void aWrapperWithoutItsExecutableBitIsLaunchedThroughTheShell(@TempDir Path directory) throws IOException {
+		Path wrapper = Files.writeString(directory.resolve("gradlew"), "#!/bin/sh\n");
+		GradleBuildSystem gradle = new GradleBuildSystem(new BuildWrapper("gradlew", "gradlew.bat", false));
+		assertEquals(List.of("sh", wrapper.toAbsolutePath().toString(), "-q", "enforceClaudeMd"),
+				gradle.verifyCommand(directory));
+	}
+
+	/**
+	 * The probe of a shelled wrapper must be the whole launcher: `sh --version` is
+	 * not portable — under dash it exits non-zero — so probing the program alone
+	 * answered for the shell rather than for the build tool.
+	 */
+	@Test
+	void aShelledWrapperIsProbedThroughTheShellToo(@TempDir Path directory) throws IOException {
+		Path wrapper = Files.writeString(directory.resolve("mvnw"), "#!/bin/sh\n");
+		MavenBuildSystem maven = new MavenBuildSystem(new PomEnforcerInstaller("2.6.0"),
+				new BuildWrapper("mvnw", "mvnw.cmd", false));
+		assertEquals(Optional.of(List.of("sh", wrapper.toAbsolutePath().toString(), "--version")),
+				maven.toolProbe(directory));
+	}
+
 	/** The wrapper the verification launches is the one the toolchain step probes. */
 	@Test
 	void theWrapperIsWhatTheToolchainStepProbes(@TempDir Path directory) throws IOException {
-		Path wrapper = Files.writeString(directory.resolve("gradlew"), "#!/bin/sh\n");
+		Path wrapper = executable(directory.resolve("gradlew"));
 		GradleBuildSystem gradle = new GradleBuildSystem(new BuildWrapper("gradlew", "gradlew.bat", false));
-		assertEquals(Optional.of(wrapper.toAbsolutePath().toString()), gradle.requiredTool(directory));
+		assertEquals(Optional.of(List.of(wrapper.toAbsolutePath().toString(), "--version")),
+				gradle.toolProbe(directory));
 	}
 
 	/**
@@ -151,6 +178,12 @@ class BuildSystemsTest {
 	 */
 	@Test
 	void theFallbackRequiresNoToolOfItsOwn(@TempDir Path directory) {
-		assertEquals(Optional.empty(), new FallbackBuildSystem().requiredTool(directory));
+		assertEquals(Optional.empty(), new FallbackBuildSystem().toolProbe(directory));
+	}
+
+	private Path executable(Path wrapper) throws IOException {
+		Files.writeString(wrapper, "#!/bin/sh\n");
+		assertTrue(wrapper.toFile().setExecutable(true), "could not make " + wrapper + " executable");
+		return wrapper;
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
@@ -103,6 +103,25 @@ class BuildToolchainStepTest {
 	void probesTheCheckoutsWrapperRatherThanThePathWhenOneIsShipped(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
+		Path wrapper = executableWrapper(context);
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+
+		new BuildToolchainStep(List.of(new GradleBuildSystem(new BuildWrapper("gradlew", "gradlew.bat", false))))
+				.execute(context, runner);
+
+		assertEquals(List.of(wrapper.toString(), "--version"), runner.commandAt(0));
+	}
+
+	/**
+	 * A wrapper the project committed without its executable bit is probed through sh,
+	 * exactly as the verification will launch it. Probing it as a program instead
+	 * failed with "Permission denied" and aborted the adoption of a repository whose
+	 * build was fine — the usual state of a wrapper added from Windows.
+	 */
+	@Test
+	void probesAWrapperWithoutItsExecutableBitThroughTheShell(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
 		AdoptionContexts.write(context, "gradlew", "#!/bin/sh\n");
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		Path wrapper = context.repositoryDirectory().resolve("gradlew").toAbsolutePath();
@@ -110,7 +129,14 @@ class BuildToolchainStepTest {
 		new BuildToolchainStep(List.of(new GradleBuildSystem(new BuildWrapper("gradlew", "gradlew.bat", false))))
 				.execute(context, runner);
 
-		assertEquals(List.of(wrapper.toString(), "--version"), runner.commandAt(0));
+		assertEquals(List.of("sh", wrapper.toString(), "--version"), runner.commandAt(0));
+	}
+
+	private Path executableWrapper(AdoptionContext context) throws IOException {
+		AdoptionContexts.write(context, "gradlew", "#!/bin/sh\n");
+		Path wrapper = context.repositoryDirectory().resolve("gradlew").toAbsolutePath();
+		assertTrue(wrapper.toFile().setExecutable(true), "could not make " + wrapper + " executable");
+		return wrapper;
 	}
 
 	/** A wrapper that cannot be run is named in the failure, not passed off as a missing PATH tool. */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
@@ -150,6 +150,31 @@ class ClaudeInitStepTest {
 		assertThrows(AdoptionException.class, () -> new ClaudeInitStep().execute(context, runner));
 	}
 
+	/**
+	 * A CLI run that exits cleanly without writing the file has said why in its own
+	 * transcript, which runOrFail discards for a command that succeeded. Reporting the
+	 * missing file alone left the adoption stopped on a message nothing could explain.
+	 */
+	@Test
+	void missingClaudeMdIsReportedWithWhatTheCliSaid(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		RecordingCommandRunner runner = RecordingCommandRunner.answering("I did not create a CLAUDE.md");
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> new ClaudeInitStep().execute(context, runner));
+		assertTrue(thrown.getMessage().contains("I did not create a CLAUDE.md"), thrown.getMessage());
+	}
+
+	/** The transcript is redacted like every other one, since it is the run's reported failure. */
+	@Test
+	void theReportedTranscriptCarriesNoCredentials(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		RecordingCommandRunner runner = RecordingCommandRunner
+				.answering("cloned https://x-access-token:secret@github.com/adamw7/tools.git");
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> new ClaudeInitStep().execute(context, runner));
+		assertFalse(thrown.getMessage().contains("secret"), thrown.getMessage());
+	}
+
 	@Test
 	void movesExistingClaudeDirMemoryAsideSoHeadlessInitWritesRootFile(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -43,7 +43,7 @@ class CloneStepTest {
 		AdoptionContext existing = checkedOut(existingWorkspace);
 		RecordingCommandRunner runner = origin("https://github.com/adamw7/tools.git");
 		step.execute(existing, runner);
-		assertEquals(List.of("git", "remote", "get-url", "origin"), runner.commandAt(0));
+		assertEquals(List.of("git", "config", "--get-all", "remote.origin.url"), runner.commandAt(0));
 		assertEquals(List.of("git", "fetch", "origin"), runner.commandAt(1));
 		assertEquals(2, runner.count());
 	}
@@ -121,7 +121,26 @@ class CloneStepTest {
 		Files.writeString(existing.repositoryDirectory().resolve(".git"), "gitdir: /elsewhere/.git/worktrees/tools\n");
 		RecordingCommandRunner runner = origin("https://github.com/adamw7/tools.git");
 		step.execute(existing, runner);
-		assertEquals(List.of("git", "remote", "get-url", "origin"), runner.commandAt(0));
+		assertEquals(List.of("git", "config", "--get-all", "remote.origin.url"), runner.commandAt(0));
+		assertEquals(2, runner.count());
+	}
+
+	/**
+	 * The remote is read from the configuration, not with {@code git remote get-url},
+	 * which expands the caller's {@code url.<base>.insteadOf} rewrites: a rewrite onto
+	 * a mirror or a proxy answers a host and path the checkout never recorded, and the
+	 * reused checkout was refused as a different repository. Asking git for the raw
+	 * configured value is what makes the comparison against the run's own URL possible
+	 * at all.
+	 */
+	@Test
+	void readsTheConfiguredOriginRatherThanTheRewrittenOne(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("--get-all")
+				? new CommandResult(command, 0, "https://github.com/adamw7/tools.git")
+				: new CommandResult(command, 0, "https://mirror.corp/github/adamw7/tools.git"));
+		step.execute(existing, runner);
+		assertEquals(List.of("git", "config", "--get-all", "remote.origin.url"), runner.commandAt(0));
 		assertEquals(2, runner.count());
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
@@ -109,7 +109,7 @@ class VerifyStepTest {
 		}
 
 		@Override
-		public Optional<String> requiredTool(Path repositoryDirectory) {
+		public Optional<List<String>> toolProbe(Path repositoryDirectory) {
 			return Optional.empty();
 		}
 	}


### PR DESCRIPTION
Adopting real GitHub repositories turned up three defects the unit tests could
not see, each aborting an adoption that should have completed.

CloneStep read a reused checkout's remote with `git remote get-url`, which
expands the caller's `url.<base>.insteadOf` rewrites and so answers a host and
path the checkout never recorded. Against a mirror or a proxied clone the
checkout was refused as a different repository, aborting the adoption of the
very repository it held — and with it the whole re-run story the step exists
for. It now reads the raw configured value, the only one comparable with the
URL the run was given.

BuildWrapper launched a checkout's `mvnw`/`gradlew` as a program, which fails
with "Permission denied" for a wrapper committed without its executable bit —
the usual state of one added from Windows. It is now launched through `sh`,
which needs no change to the checkout, and `BuildSystem.toolProbe` answers the
whole probe command rather than a program name so BuildToolchainStep probes
that same launcher: `sh --version` is not portable, so probing the program
alone would have answered for the shell.

ClaudeInitStep discarded the CLI's transcript when the command exited cleanly,
so a run that wrote no CLAUDE.md failed on a message naming the missing file
and nothing that would explain it. The transcript is now carried into the
failure, redacted like every other one.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014CfFqHt4GpYTM9rSaYzyjj