### PR TITLE
fix(assembly): strip the base image's unused Pebble binary from the runtime image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -858,6 +858,12 @@ Points worth knowing before changing any of it:
   `linux/arm64`.
 - **`USER` is the numeric `10001:10001`**, because Kubernetes' `runAsNonRoot`
   admission check cannot verify a name-based user.
+- **The runtime stage deletes `/usr/bin/pebble`** (and `/var/lib/pebble`).
+  Ubuntu 26.04, the base of `eclipse-temurin:25-jre`, ships Canonical's Pebble
+  service manager there; this image never runs it, the entrypoint being the JVM
+  itself. It is a static Go binary outside dpkg's control, so the Go CVEs it
+  vendors cannot be patched by an upgrade and fail `docker.yml`'s Trivy gate on
+  their own. Expect the same of any future unused binary the base image adds.
 - **Logging goes through `docker/log4j2-console.properties`**, selected with
   `-Dlog4j2.configurationFile` in `JDK_JAVA_OPTIONS`. The `data` module's own
   config is file-only on purpose: its MCP server speaks JSON-RPC over stdio, and

--- a/assembly/Dockerfile
+++ b/assembly/Dockerfile
@@ -46,6 +46,17 @@ LABEL org.opencontainers.image.title="tools" \
       org.opencontainers.image.revision="${REVISION}" \
       org.opencontainers.image.created="${CREATED}"
 
+# Ubuntu 26.04 — what eclipse-temurin:25-jre is built on — ships Canonical's
+# Pebble service manager at /usr/bin/pebble. Nothing here uses it: the entrypoint
+# below is the JVM itself. It is a statically linked Go binary carrying its own
+# copy of golang.org/x/net and the Go standard library, and it is not tracked by
+# dpkg, so a `apt-get upgrade` cannot patch it and every CVE fixed upstream stays
+# reported against this image — enough on its own to fail the Trivy scan in
+# docker.yml, which is set to fail on fixable HIGH/CRITICAL findings. Deleting it
+# drops that dead code and its findings; it reclaims no space, since the file
+# lives in a base-image layer this only whites out.
+RUN rm -f /usr/bin/pebble && rm -rf /var/lib/pebble
+
 # Create the unprivileged user before copying, so COPY --chown can set ownership
 # as it writes. A `RUN chown` afterwards would rewrite every copied file into a
 # second layer, storing the whole distribution twice in the image.


### PR DESCRIPTION
The weekly docker.yml run went red on the Trivy gate. Every jar in the
image scanned clean; all five fixable HIGH findings came from a single
file the build never asked for, /usr/bin/pebble — Canonical's Pebble
service manager, shipped in the Ubuntu 26.04 layer under
eclipse-temurin:25-jre. It is a static Go binary vendoring
golang.org/x/net 0.40.0 and the Go standard library, and it is not
tracked by dpkg, so no apt upgrade can ever patch it.

Nothing in this image runs it: the entrypoint is the JVM itself. Delete
it, along with /var/lib/pebble, in the runtime stage before dropping to
the unprivileged user. `rm -f` keeps the build working on a base image
that does not carry it.

The delete reclaims no space — the file lives in a base-image layer this
only whites out — so the gain is the scan and the dead code, not size.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018gec4RsjBmt6tXqNJV6PDZ