### PR TITLE
fix(enforcer,adopt): three defects that let a broken configuration pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -556,9 +556,12 @@ profile:
 - `HookCommandsValidRule` (`hookCommandsValid`) validates the `hooks` section of
   `.claude/settings.json`: every event maps to an array of groups, each group
   carries a `hooks` array, and every hook declares a non-blank `type` (a
-  `command` hook also a non-blank `command`). A `$CLAUDE_PROJECT_DIR`-rooted
-  script command is resolved against `projectDir` and must exist on disk. An
-  optional `allowedEvents` list rejects mistyped events and
+  `command` hook also a non-blank `command`). A project-local script command —
+  rooted at `$CLAUDE_PROJECT_DIR`, or written as the plain repository-relative
+  path Claude Code resolves the same way — is resolved against `projectDir` and
+  must exist on disk; only the program of each chained command is read as a
+  relative script, so an argument that looks like a path is not required to
+  exist. An optional `allowedEvents` list rejects mistyped events and
   `validateScriptReferences` toggles the script-existence check.
 - `HooksFormatRule` (`hooksFormat`) validates the hook scripts under a configured
   `hooksDir` (e.g. `.claude/hooks`): every regular file must be non-empty, start
@@ -566,8 +569,9 @@ profile:
   (`requireExecutable`), and an optional `allowedExtensions` list rejects a stray
   file. Where `hookCommandsValid` validates the JSON shape of the `hooks` section,
   this rule validates the scripts themselves; when a `settingsFile` is configured
-  it also cross-checks the wiring, so a command hook whose `$CLAUDE_PROJECT_DIR`
-  path lands in the hooks directory must point at a script that exists there (with
+  it also cross-checks the wiring, so a command hook whose project-local path —
+  `$CLAUDE_PROJECT_DIR`-rooted or plain repository-relative — lands in the hooks
+  directory must point at a script that exists there (with
   symlinks resolved so a script cannot escape the directory), and
   `reportUnreferencedScripts` flags a script no hook references. An absent
   `hooksDir` is a pass because hooks are optional.

--- a/README.md
+++ b/README.md
@@ -71,9 +71,12 @@ consistent and in their expected shape:
   section of `.claude/settings.json`: every event must map to an array of groups,
   each group must carry a `hooks` array, and every hook must declare a non-blank
   `type` (a `command` hook also a non-blank `command`). A command that points at
-  a project-local script through `$CLAUDE_PROJECT_DIR` is resolved against
-  `projectDir` and must exist on disk, so a renamed or missing hook script is
-  caught. An optional `allowedEvents` whitelist rejects a mistyped event such as
+  a project-local script — through `$CLAUDE_PROJECT_DIR`, or as the plain
+  repository-relative path Claude Code resolves the same way — is resolved
+  against `projectDir` and must exist on disk, so a renamed or missing hook
+  script is caught; only the program of each chained command is read as a
+  relative script, so an argument that looks like a path is not required to
+  exist. An optional `allowedEvents` whitelist rejects a mistyped event such as
   `SessionSart`, and `validateScriptReferences` can switch the script check off.
 - **`mcpServersValid`** (`McpServersValidRule`) — validates the project's
   `.mcp.json`. A project-level MCP file is optional, so an absent file passes;
@@ -99,7 +102,8 @@ consistent and in their expected shape:
   whitelist rejects a stray file. Where `hookCommandsValid` validates the JSON
   shape of the `hooks` section, this rule validates the scripts themselves; when
   a `settingsFile` is configured it also cross-checks the wiring, so a command
-  hook whose `$CLAUDE_PROJECT_DIR` path lands in the hooks directory must point
+  hook whose project-local path — `$CLAUDE_PROJECT_DIR`-rooted or plain
+  repository-relative — lands in the hooks directory must point
   at a script that exists there, and `reportUnreferencedScripts` flags a script
   no hook references. An absent `hooksDir` is a pass because hooks are optional.
 - **`uniqueDescriptions`** (`UniqueDescriptionsRule`) — reads the `description`

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
@@ -48,7 +48,7 @@ public final class AdoptionAssets {
 			        "hooks": [
 			          {
 			            "type": "command",
-			            "command": ".claude/hooks/session-start.sh"
+			            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
 			          }
 			        ]
 			      }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -43,10 +43,18 @@ public class PullRequestStep extends AbstractCommandStep {
 
 	/**
 	 * The conditions {@code gh pr create} reports as a failure that mean the pull
-	 * request need not — or cannot — be opened, matched against its own wording:
-	 * "a pull request for branch ... already exists" and "No commits between ...".
+	 * request need not — or cannot — be opened, matched against its own wording: the
+	 * two spellings of "a pull request already exists" (the client-side check names
+	 * the branches, the GraphQL error names the head) and "No commits between ...".
+	 *
+	 * <p>Each fragment names a pull request, because the transcript these are matched
+	 * against is the whole of {@code gh}'s merged output. A bare "already exists"
+	 * also matched a failure that had nothing to do with an open pull request — a
+	 * label {@code gh} could not add, a ref the push had already published — and left
+	 * the adoption reported as complete with no pull request opened and none to find.
 	 */
-	private static final List<String> TOLERATED_FAILURES = List.of("already exists", "no commits between");
+	private static final List<String> TOLERATED_FAILURES = List.of("a pull request for branch",
+			"a pull request already exists", "no commits between");
 
 	private final PullRequestOptions options;
 	private final ObjectMapper mapper = new ObjectMapper();

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetsStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetsStepTest.java
@@ -67,6 +67,20 @@ class AssetsStepTest {
 		assertTrue(settings.contains(AdoptionAssets.SESSION_START_HOOK_FILE));
 	}
 
+	/**
+	 * The hook is wired through {@code $CLAUDE_PROJECT_DIR} rather than by a bare
+	 * relative path, so it resolves to the checkout's own script whatever directory
+	 * the session was started in — and so the {@code hookCommandsValid} guard the
+	 * adoption is wiring in can see which script it points at.
+	 */
+	@Test
+	void settingsRootTheHookAtTheProjectDirectory(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		step.execute(context, new RecordingCommandRunner());
+		String settings = Files.readString(context.repositoryDirectory().resolve(AdoptionAssets.SETTINGS_FILE));
+		assertTrue(settings.contains("$CLAUDE_PROJECT_DIR/" + AdoptionAssets.SESSION_START_HOOK_FILE), settings);
+	}
+
 	@Test
 	void isIdempotentAcrossReRuns(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -233,6 +233,40 @@ class PullRequestStepTest {
 		assertTrue(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("create")));
 	}
 
+	/** The other wording gh reports it with, when its own pre-check missed the pull request. */
+	@Test
+	void anAlreadyOpenPullRequestReportedByGraphQlIsNotAFailure() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("create")
+				? new CommandResult(command, 1, "pull request create failed: GraphQL: A pull request already exists"
+						+ " for adamw7:claude/adopt-claude-code.")
+				: new CommandResult(command, 0, "[]"));
+		step.execute(context, runner);
+		assertTrue(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("create")));
+	}
+
+	/**
+	 * The tolerated wordings are matched against gh's whole merged transcript, so a
+	 * fragment that does not name a pull request matches a failure that has nothing
+	 * to do with one. A bare "already exists" swallowed these, and the adoption was
+	 * reported as complete with no pull request opened and none to find.
+	 */
+	@Test
+	void aFailureMentioningSomethingElseThatAlreadyExistsStillAbortsAdoption() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("create")
+				? new CommandResult(command, 1, "could not add label: 'infra' already exists on another repository")
+				: new CommandResult(command, 0, "[]"));
+		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
+	}
+
+	@Test
+	void aRefThatAlreadyExistsStillAbortsAdoption() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("create")
+				? new CommandResult(command, 1, "pull request create failed: GraphQL: A ref named"
+						+ " \"refs/heads/claude/adopt-claude-code\" already exists in the repository")
+				: new CommandResult(command, 0, "[]"));
+		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
+	}
+
 	@Test
 	void aCreationFailureThatIsNotBenignStillAbortsAdoption() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("create")

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
@@ -242,6 +243,29 @@ class PullRequestStepTest {
 				: new CommandResult(command, 0, "[]"));
 		step.execute(context, runner);
 		assertTrue(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("create")));
+	}
+
+	/**
+	 * Tolerating the creation is only half of it: the pull request gh refused to
+	 * open a second time is the one the report must carry, which the read-back that
+	 * follows is what supplies.
+	 */
+	@Test
+	void recordsTheUrlOfThePullRequestThatAlreadyExisted() {
+		AtomicInteger listCalls = new AtomicInteger();
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			if (command.contains("create")) {
+				return new CommandResult(command, 1, "a pull request for branch \"claude/adopt-claude-code\""
+						+ " into branch \"main\" already exists:\n" + PR_URL);
+			}
+			// The pre-check misses it — a restricted token, a proxied host — and the
+			// read-back after the tolerated creation is what finds it.
+			return new CommandResult(command, 0,
+					listCalls.getAndIncrement() == 0 ? "[]" : "[{\"url\":\"" + PR_URL + "\"}]");
+		});
+		AdoptionReport report = new AdoptionReport();
+		step.execute(context, runner, report);
+		assertEquals(PR_URL, report.pullRequestUrl().orElseThrow());
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRule.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.enforcer.definition;
 
 import java.io.File;
+import java.util.Locale;
 import java.util.Optional;
 
 import javax.inject.Named;
@@ -52,7 +53,14 @@ public class UniqueDescriptionsRule extends MultiDefinitionRule {
 				.filter(value -> !value.isBlank());
 	}
 
+	/**
+	 * Case is folded in the root locale rather than the machine's, so which
+	 * descriptions count as duplicates is a property of the definitions and not of
+	 * where the build runs. The default locale folds {@code I} to a dotless
+	 * {@code ı} in Turkish, which made two descriptions collide on one developer's
+	 * machine and not on another's — the least reproducible way for a rule to fail.
+	 */
 	private String normalize(String text) {
-		return text.strip().toLowerCase().replaceAll("\\s+", " ");
+		return text.strip().toLowerCase(Locale.ROOT).replaceAll("\\s+", " ");
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Locale;
 
 import javax.inject.Named;
 
@@ -156,7 +157,7 @@ public class McpConfigFormatRule extends JsonFileRule {
 			if (scheme == null || uri.getHost() == null) {
 				return null;
 			}
-			String lower = scheme.toLowerCase();
+			String lower = scheme.toLowerCase(Locale.ROOT);
 			return lower.equals(HTTP_SCHEME) || lower.equals(HTTPS_SCHEME) ? lower : null;
 		} catch (URISyntaxException e) {
 			return null;

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
@@ -5,12 +5,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
- * Resolves the base directory that a hook command's {@code $CLAUDE_PROJECT_DIR}
- * variable expands to, and performs that expansion on the tokens of a command.
- * Both hook rules share this so the two accepted spellings of the variable and
- * the "grandparent of the settings file" fallback live in exactly one place.
+ * Resolves the project-local scripts a hook command runs, against the base
+ * directory its {@code $CLAUDE_PROJECT_DIR} variable expands to. Both hook rules
+ * share this so the two accepted spellings of the variable, the "grandparent of the
+ * settings file" fallback, and what counts as a project-local script live in
+ * exactly one place.
  * <p>
  * The unbraced spelling ends where the variable name does, as a shell reads it, so
  * {@code $CLAUDE_PROJECT_DIR_BACKUP} is a different variable and not this one with
@@ -34,6 +36,24 @@ final class ClaudeProjectDir {
 	}
 
 	/**
+	 * The project-local scripts {@code command} runs: every token rooted at
+	 * {@code $CLAUDE_PROJECT_DIR}, plus the program of each chained command written
+	 * as a plain repository-relative path.
+	 * <p>
+	 * Both spellings name the same file — Claude Code runs a hook from the project
+	 * directory, so {@code .claude/hooks/session-start.sh} resolves exactly where
+	 * {@code $CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh} does — and a
+	 * settings.json is as likely to be written either way. Reading only the variable
+	 * left the relative spelling unchecked: a hook pointing at a script that had been
+	 * renamed passed, which is the very failure these rules exist to catch, and
+	 * {@code hooksFormat} reported the script it really did reference as referenced
+	 * by nothing.
+	 */
+	List<String> scriptsIn(String command) {
+		return Stream.concat(expandAll(command).stream(), relativePrograms(command).stream()).distinct().toList();
+	}
+
+	/**
 	 * The paths every {@code $CLAUDE_PROJECT_DIR}-rooted token of {@code command}
 	 * resolves to. A command chains more than one script often enough — an
 	 * {@code &&} between two hooks — that stopping at the first reference would
@@ -41,6 +61,33 @@ final class ClaudeProjectDir {
 	 */
 	List<String> expandAll(String command) {
 		return CommandTokens.of(command).stream().map(this::expand).filter(Objects::nonNull).toList();
+	}
+
+	/**
+	 * Only a program is read as a relative script, never an argument — see
+	 * {@link CommandTokens#programsOf} — so a hook passing a path to the script it
+	 * runs does not have that path required to exist too.
+	 */
+	private List<String> relativePrograms(String command) {
+		return CommandTokens.programsOf(command).stream()
+				.map(this::withoutQuotes)
+				.filter(ClaudeProjectDir::isRelativeScript)
+				.map(program -> new File(resolve(), program).getPath())
+				.toList();
+	}
+
+	/**
+	 * Whether a program names a repository-relative script rather than a tool the
+	 * shell finds for itself: {@code .claude/hooks/session-start.sh} and
+	 * {@code ./run.sh} do, while {@code bash}, {@code python3}, and {@code npx} name
+	 * no path at all and are looked up on the {@code PATH}. An absolute path, a
+	 * home-relative one, and one carrying a shell expansion all name a file outside
+	 * the repository's control — or one only a shell can resolve — so none of them is
+	 * a script this rule may require.
+	 */
+	private static boolean isRelativeScript(String program) {
+		return program.indexOf('/') > 0 && program.indexOf('$') < 0 && !program.startsWith("~")
+				&& !program.startsWith("-");
 	}
 
 	/** The path {@code token} resolves to when it references the project dir, else null. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
@@ -48,9 +48,18 @@ final class ClaudeProjectDir {
 	 * renamed passed, which is the very failure these rules exist to catch, and
 	 * {@code hooksFormat} reported the script it really did reference as referenced
 	 * by nothing.
+	 * <p>
+	 * A command that names one script both ways yields it once. The separators are
+	 * normalised before the comparison because the two spellings are assembled
+	 * differently — an expansion keeps the separators the command was written with,
+	 * a relative program is resolved as a {@link File} — and on a platform where
+	 * those disagree the same script would otherwise be reported as two.
 	 */
 	List<String> scriptsIn(String command) {
-		return Stream.concat(expandAll(command).stream(), relativePrograms(command).stream()).distinct().toList();
+		return Stream.concat(expandAll(command).stream(), relativePrograms(command).stream())
+				.map(path -> new File(path).getPath())
+				.distinct()
+				.toList();
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
@@ -2,11 +2,12 @@ package io.github.adamw7.tools.enforcer.settings;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.IntPredicate;
 
 /**
  * Splits a hook command into the tokens a shell would see. Both hook rules need
- * this to find the {@code $CLAUDE_PROJECT_DIR} references inside a command, so
- * the splitting lives here rather than in each of them.
+ * this to find the script paths inside a command, so the splitting lives here
+ * rather than in each of them.
  * <p>
  * Splitting is on whitespace and on the shell separators {@code ;}, {@code &} and
  * {@code |}, all <em>outside</em> quotes. Whitespace alone is not enough: a command
@@ -17,6 +18,11 @@ import java.util.List;
  * {@code "$CLAUDE_PROJECT_DIR/my hook.sh"} into two halves. The quote characters are
  * kept on the token, since {@link ClaudeProjectDir} strips them as part of expanding
  * it.
+ * <p>
+ * {@link #programsOf} answers the narrower question of which tokens a shell would
+ * actually <em>run</em>, which is what a rule reading a bare relative path as a
+ * script has to go on: only a program can be one, never an argument that happens to
+ * look like a path.
  */
 final class CommandTokens {
 
@@ -25,52 +31,80 @@ final class CommandTokens {
 	private static final char SINGLE_QUOTE = '\'';
 
 	/** The shell operators that end a token just as whitespace does. */
-	private static final String SEPARATORS = ";&|";
+	private static final String OPERATORS = ";&|";
 
 	private CommandTokens() {
 	}
 
 	/** The command's tokens, in order, with empty ones dropped. */
 	static List<String> of(String command) {
-		List<String> tokens = new ArrayList<>();
-		StringBuilder token = new StringBuilder();
-		char quote = NONE;
-		for (int i = 0; i < command.length(); i++) {
-			quote = append(command.charAt(i), quote, token, tokens);
-		}
-		addToken(token, tokens);
-		return tokens;
+		return split(command, CommandTokens::isTokenSeparator);
 	}
 
 	/**
-	 * Appends one character to the token being built and returns the quote
+	 * The program each command in the string runs: the first token of every
+	 * {@code ;}/{@code &}/{@code |}-separated segment, in order.
+	 * <p>
+	 * A hook chaining two scripts runs two programs, and only a program is a script
+	 * the rules may resolve as a bare relative path. An argument is not, however much
+	 * it looks like one: a hook invoked as {@code .claude/hooks/build.sh --out
+	 * target/log.txt} names one script and one output file, and requiring the second
+	 * to exist would fail a build over a file the hook is about to write.
+	 */
+	static List<String> programsOf(String command) {
+		return split(command, CommandTokens::isOperator).stream()
+				.map(CommandTokens::of)
+				.filter(tokens -> !tokens.isEmpty())
+				.map(List::getFirst)
+				.toList();
+	}
+
+	/** Splits on every {@code separator} character outside quotes, dropping the empty pieces. */
+	private static List<String> split(String command, IntPredicate separator) {
+		List<String> pieces = new ArrayList<>();
+		StringBuilder piece = new StringBuilder();
+		char quote = NONE;
+		for (int i = 0; i < command.length(); i++) {
+			quote = append(command.charAt(i), quote, piece, pieces, separator);
+		}
+		addPiece(piece, pieces);
+		return pieces;
+	}
+
+	/**
+	 * Appends one character to the piece being built and returns the quote
 	 * character still open afterwards, so the caller stays a plain loop.
 	 */
-	private static char append(char character, char quote, StringBuilder token, List<String> tokens) {
+	private static char append(char character, char quote, StringBuilder piece, List<String> pieces,
+			IntPredicate separator) {
 		if (quote != NONE) {
-			token.append(character);
+			piece.append(character);
 			return character == quote ? NONE : quote;
 		}
 		if (character == DOUBLE_QUOTE || character == SINGLE_QUOTE) {
-			token.append(character);
+			piece.append(character);
 			return character;
 		}
-		if (isSeparator(character)) {
-			addToken(token, tokens);
+		if (separator.test(character)) {
+			addPiece(piece, pieces);
 			return NONE;
 		}
-		token.append(character);
+		piece.append(character);
 		return NONE;
 	}
 
-	private static boolean isSeparator(char character) {
-		return Character.isWhitespace(character) || SEPARATORS.indexOf(character) >= 0;
+	private static boolean isTokenSeparator(int character) {
+		return Character.isWhitespace(character) || isOperator(character);
 	}
 
-	private static void addToken(StringBuilder token, List<String> tokens) {
-		if (token.length() > 0) {
-			tokens.add(token.toString());
-			token.setLength(0);
+	private static boolean isOperator(int character) {
+		return OPERATORS.indexOf(character) >= 0;
+	}
+
+	private static void addPiece(StringBuilder piece, List<String> pieces) {
+		if (piece.length() > 0) {
+			pieces.add(piece.toString());
+			piece.setLength(0);
 		}
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -17,11 +17,14 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
  * {@code hooks} array, and every hook in it must declare a non-blank {@code type};
  * a {@code command} hook must also declare a non-blank {@code command}.
  * <p>
- * A command that points at a project-local script through the
- * {@code $CLAUDE_PROJECT_DIR} variable is resolved against {@code projectDir} (the
+ * A command that points at a project-local script — through the
+ * {@code $CLAUDE_PROJECT_DIR} variable, or as the plain repository-relative path
+ * Claude Code resolves the same way — is resolved against {@code projectDir} (the
  * parent of the settings file's directory by default) and must exist on disk, so a
  * renamed or missing hook script is caught; the check is on by default and can be
- * switched off with {@code validateScriptReferences}. An event name outside a
+ * switched off with {@code validateScriptReferences}. Only the program of each
+ * chained command is read as a relative script, never an argument, so a hook passing
+ * a path it is about to write is not required to exist. An event name outside a
  * configured {@code allowedEvents} is reported, which catches a mistyped
  * {@code SessionSart}. A settings file without a {@code hooks} key is allowed, but
  * a {@code hooks} that is present and is not an object is reported rather than
@@ -141,12 +144,12 @@ public class HookCommandsValidRule extends JsonFileRule {
 		violations.add("hook event '" + event + "' " + problem);
 	}
 
-	/** The resolved on-disk paths the command's {@code $CLAUDE_PROJECT_DIR} tokens point at. */
+	/** The resolved on-disk paths of the project-local scripts the command runs. */
 	private List<String> localScriptPaths(String command) {
 		if (!validateScriptReferences) {
 			return List.of();
 		}
-		return new ClaudeProjectDir(projectDir, settingsFile).expandAll(command);
+		return new ClaudeProjectDir(projectDir, settingsFile).scriptsIn(command);
 	}
 
 	void setSettingsFile(File settingsFile) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -38,8 +38,10 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * note left in the directory.
  * <p>
  * When {@code settingsFile} is configured, any command hook whose command resolves
- * a {@code $CLAUDE_PROJECT_DIR} path into the hooks directory must point at a
- * script that exists there, catching a hook renamed on disk but not in settings;
+ * a project-local path into the hooks directory — written with
+ * {@code $CLAUDE_PROJECT_DIR} or as the plain repository-relative path Claude Code
+ * resolves the same way — must point at a script that exists there, catching a hook
+ * renamed on disk but not in settings;
  * {@code reportUnreferencedScripts} also reports a script no hook references. The
  * {@code hooksDir} parameter must be configured, but an absent directory is a pass
  * because hooks are optional. All problems found are reported together.
@@ -180,13 +182,13 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	/**
-	 * The absolute paths a command's {@code $CLAUDE_PROJECT_DIR} tokens resolve to
-	 * that land inside the hooks directory. A path outside it belongs to another
-	 * rule's concern, so it is dropped rather than reported here.
+	 * The absolute paths of the project-local scripts a command runs that land inside
+	 * the hooks directory. A path outside it belongs to another rule's concern, so it
+	 * is dropped rather than reported here.
 	 */
 	private List<Path> scriptsInHooksDir(String command) {
 		Path hooks = canonical(hooksDir.toPath());
-		return new ClaudeProjectDir(projectDir, settingsFile).expandAll(command).stream()
+		return new ClaudeProjectDir(projectDir, settingsFile).scriptsIn(command).stream()
 				.map(expanded -> canonical(new File(expanded).toPath()))
 				.filter(resolved -> resolved.startsWith(hooks))
 				.toList();

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.Locale;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,26 @@ class UniqueDescriptionsRuleTest {
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, agentsRule()::execute);
 		assertTrue(exception.getMessage().contains("is used by 2"), exception.getMessage());
+	}
+
+	/**
+	 * Case is folded in the root locale, so which descriptions count as duplicates is
+	 * a property of the definitions rather than of the machine running the build.
+	 * Turkish folds {@code I} to a dotless {@code ı}, which made these two collide
+	 * there and nowhere else — a rule failing on one developer's machine and passing
+	 * on CI.
+	 */
+	@Test
+	void comparesDescriptionsTheSameWayInEveryLocale() {
+		writeAgent("installer", "Installs the CLI.");
+		writeAgent("inspector", "ınstalls the clı.");
+		Locale original = Locale.getDefault();
+		try {
+			Locale.setDefault(Locale.of("tr", "TR"));
+			assertDoesNotThrow(agentsRule()::execute);
+		} finally {
+			Locale.setDefault(original);
+		}
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDirTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDirTest.java
@@ -1,0 +1,147 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * What both hook rules read a hook command as: which of its tokens name a script
+ * inside the repository, and where each resolves to. The rules themselves only
+ * decide what to say about the answer, so the resolution is pinned here rather
+ * than twice over through them.
+ */
+class ClaudeProjectDirTest {
+
+	private static final String HOOK = ".claude/hooks/session-start.sh";
+
+	@TempDir
+	private Path projectDir;
+
+	@Test
+	void resolvesAScriptRootedAtTheProjectVariable() {
+		assertEquals(List.of(resolved(HOOK)), scriptsIn("$CLAUDE_PROJECT_DIR/" + HOOK));
+	}
+
+	@Test
+	void resolvesAScriptRootedAtTheBracedProjectVariable() {
+		assertEquals(List.of(resolved(HOOK)), scriptsIn("${CLAUDE_PROJECT_DIR}/" + HOOK));
+	}
+
+	/**
+	 * Claude Code runs a hook from the project directory, so a bare relative path
+	 * names the same file the variable spells out. A settings.json is as likely to be
+	 * written either way, and reading only the variable left the other unchecked.
+	 */
+	@Test
+	void resolvesAPlainRepositoryRelativeProgram() {
+		assertEquals(List.of(resolved(HOOK)), scriptsIn(HOOK));
+	}
+
+	@Test
+	void resolvesADotSlashProgram() {
+		assertEquals(List.of(resolved("./run.sh")), scriptsIn("./run.sh"));
+	}
+
+	@Test
+	void resolvesAQuotedRelativeProgram() {
+		assertEquals(List.of(resolved(HOOK)), scriptsIn("\"" + HOOK + "\""));
+	}
+
+	@Test
+	void resolvesTheProgramOfEveryChainedCommand() {
+		assertEquals(List.of(resolved("a.d/a.sh"), resolved("b.d/b.sh")), scriptsIn("a.d/a.sh && b.d/b.sh"));
+	}
+
+	/**
+	 * The two spellings name one script, so a command using both must not have it
+	 * reported — or baselined — twice.
+	 */
+	@Test
+	void namesAScriptOnceWhenACommandUsesBothSpellings() {
+		assertEquals(List.of(resolved(HOOK)), scriptsIn("$CLAUDE_PROJECT_DIR/" + HOOK + " && " + HOOK));
+	}
+
+	@Test
+	void readsNoScriptFromABareProgramName() {
+		assertEquals(List.of(), scriptsIn("npx some-linter"));
+	}
+
+	/** Only a program is a script; an argument the hook is about to write is not. */
+	@Test
+	void readsNoScriptFromAnArgumentThatLooksLikeAPath() {
+		assertEquals(List.of(resolved("build.d/build.sh")), scriptsIn("build.d/build.sh --out target/log.txt"));
+	}
+
+	@Test
+	void readsNoScriptFromAnInterpretersArgument() {
+		assertEquals(List.of(), scriptsIn("bash " + HOOK));
+	}
+
+	@Test
+	void readsNoScriptFromAnAbsoluteProgram() {
+		assertEquals(List.of(), scriptsIn("/usr/local/bin/lint"));
+	}
+
+	@Test
+	void readsNoScriptFromAHomeRelativeProgram() {
+		assertEquals(List.of(), scriptsIn("~/bin/lint.sh"));
+	}
+
+	/** Only a shell can resolve another variable, so the path it would produce is unknown. */
+	@Test
+	void readsNoScriptFromAProgramCarryingAnotherExpansion() {
+		assertEquals(List.of(), scriptsIn("$HOME/bin/lint.sh"));
+	}
+
+	@Test
+	void readsNoScriptFromAVariableThatMerelyStartsTheSameWay() {
+		assertEquals(List.of(), scriptsIn("bash $CLAUDE_PROJECT_DIR_BACKUP/run.sh"));
+	}
+
+	@Test
+	void readsNoScriptFromABlankCommand() {
+		assertEquals(List.of(), scriptsIn("   "));
+	}
+
+	@Test
+	void prefersTheConfiguredProjectDirectoryOverTheSettingsLocation() {
+		File override = projectDir.resolve("elsewhere").toFile();
+		ClaudeProjectDir resolver = new ClaudeProjectDir(override, settingsFile());
+
+		assertEquals(override, resolver.resolve());
+	}
+
+	/** Settings live at {@code <project>/.claude/settings.json}, so the project is two levels up. */
+	@Test
+	void fallsBackToTheGrandparentOfTheSettingsFile() {
+		ClaudeProjectDir resolver = new ClaudeProjectDir(null, settingsFile());
+
+		assertEquals(projectDir.toFile().getAbsoluteFile(), resolver.resolve());
+	}
+
+	@Test
+	void resolvesAgainstTheGrandparentWhenNoProjectDirectoryIsConfigured() {
+		List<String> scripts = new ClaudeProjectDir(null, settingsFile()).scriptsIn(HOOK);
+
+		assertEquals(1, scripts.size(), scripts.toString());
+		assertTrue(scripts.getFirst().endsWith(new File(HOOK).getPath()), scripts.toString());
+	}
+
+	private List<String> scriptsIn(String command) {
+		return new ClaudeProjectDir(projectDir.toFile(), settingsFile()).scriptsIn(command);
+	}
+
+	private String resolved(String relativePath) {
+		return new File(projectDir.toFile(), relativePath).getPath();
+	}
+
+	private File settingsFile() {
+		return projectDir.resolve(".claude").resolve("settings.json").toFile();
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
@@ -63,4 +63,40 @@ class CommandTokensTest {
 	void keepsAQuotedSeparatorInsideItsToken() {
 		assertEquals(List.of("echo", "\"a;b\""), CommandTokens.of("echo \"a;b\""));
 	}
+
+	@Test
+	void readsTheProgramOfASingleCommand() {
+		assertEquals(List.of(".claude/hooks/session-start.sh"),
+				CommandTokens.programsOf(".claude/hooks/session-start.sh"));
+	}
+
+	@Test
+	void readsTheProgramOfEveryChainedCommand() {
+		assertEquals(List.of("a.sh", "b.sh", "c.sh"), CommandTokens.programsOf("a.sh && b.sh; c.sh --flag"));
+	}
+
+	@Test
+	void doesNotReadAnArgumentAsAProgram() {
+		assertEquals(List.of("build.sh"), CommandTokens.programsOf("build.sh --out target/log.txt"));
+	}
+
+	@Test
+	void readsAnInterpreterAsTheProgramRatherThanTheScriptItRuns() {
+		assertEquals(List.of("bash"), CommandTokens.programsOf("bash .claude/hooks/run.sh"));
+	}
+
+	@Test
+	void keepsAQuotedProgramWithASpaceWhole() {
+		assertEquals(List.of("\"my hook.sh\""), CommandTokens.programsOf("\"my hook.sh\" --flag"));
+	}
+
+	@Test
+	void readsNoProgramFromAQuotedSeparator() {
+		assertEquals(List.of("echo"), CommandTokens.programsOf("echo \"a;b\""));
+	}
+
+	@Test
+	void yieldsNoProgramsForABlankCommand() {
+		assertEquals(List.of(), CommandTokens.programsOf("   "));
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
@@ -99,4 +99,20 @@ class CommandTokensTest {
 	void yieldsNoProgramsForABlankCommand() {
 		assertEquals(List.of(), CommandTokens.programsOf("   "));
 	}
+
+	@Test
+	void yieldsNoProgramsForOperatorsAlone() {
+		assertEquals(List.of(), CommandTokens.programsOf("&& ;| "));
+	}
+
+	/** A program is the first token of its own segment, however the operators are spaced. */
+	@Test
+	void readsTheProgramAfterAnOperatorWithNoSurroundingSpace() {
+		assertEquals(List.of("a.sh", "b.sh"), CommandTokens.programsOf("a.sh --flag&&b.sh --flag"));
+	}
+
+	@Test
+	void doesNotSplitASegmentOnAQuotedOperator() {
+		assertEquals(List.of("run.sh", "b.sh"), CommandTokens.programsOf("run.sh \"a;b\"; b.sh"));
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -283,6 +283,61 @@ class HookCommandsValidRuleTest {
 		assertTrue(exception.getMessage().endsWith("absent.sh"), exception.getMessage());
 	}
 
+	/**
+	 * A hook is as often wired by the repository-relative path Claude Code resolves
+	 * against the project directory as by the {@code $CLAUDE_PROJECT_DIR} spelling,
+	 * and a script renamed out from under either one is the failure this rule exists
+	 * to catch.
+	 */
+	@Test
+	void failsWhenARelativeScriptReferenceIsMissing() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing(".claude/hooks/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("references a missing script"), exception.getMessage());
+	}
+
+	@Test
+	void passesWhenARelativeScriptReferenceExists() {
+		writeString(tempDir.resolve(".claude/hooks/session-start.sh"), "#!/bin/sh\necho hi\n");
+		HookCommandsValidRule rule = ruleFor(hooksReferencing(".claude/hooks/session-start.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/**
+	 * Only the program of a command is a script; an argument that happens to look
+	 * like a path is not, and requiring it to exist would fail the build over a file
+	 * the hook is about to write.
+	 */
+	@Test
+	void doesNotRequireAnArgumentThatLooksLikeAPath() {
+		writeString(tempDir.resolve(".claude/hooks/build.sh"), "#!/bin/sh\necho hi\n");
+		HookCommandsValidRule rule = ruleFor(hooksReferencing(".claude/hooks/build.sh --out target/log.txt"));
+		rule.setProjectDir(tempDir.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/** A bare program name is looked up on the PATH, so it is no repository file to require. */
+	@Test
+	void doesNotReadABareProgramNameAsAProjectScript() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("npx some-linter"));
+		rule.setProjectDir(tempDir.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void doesNotRequireAnAbsoluteProgramToLiveInTheProject() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("/usr/local/bin/absent-tool"));
+		rule.setProjectDir(tempDir.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
 	@Test
 	void namesTheSettingsFileInItsDescription() {
 		HookCommandsValidRule rule = ruleFor(hooksReferencing("echo hi"));

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.settings;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -328,6 +329,27 @@ class HookCommandsValidRuleTest {
 		rule.setProjectDir(tempDir.toFile());
 
 		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void passesWhenScriptReferenceValidationIsDisabledForARelativeScript() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing(".claude/hooks/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setValidateScriptReferences(false);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/** One script named both ways is one script, so it is not reported — or baselined — twice. */
+	@Test
+	void reportsAScriptNamedBothWaysOnlyOnce() {
+		HookCommandsValidRule rule = ruleFor(
+				hooksReferencing("$CLAUDE_PROJECT_DIR/.claude/hooks/gone.sh && .claude/hooks/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertEquals(1, exception.getMessage().lines().filter(line -> line.contains("gone.sh")).count(),
+				exception.getMessage());
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -128,6 +128,34 @@ class HooksFormatRuleTest {
 		assertTrue(exception.getMessage().contains("orphan.sh"), exception.getMessage());
 	}
 
+	/**
+	 * A settings.json is as likely to wire a hook by the repository-relative path
+	 * Claude Code resolves against the project directory. Reading only the
+	 * {@code $CLAUDE_PROJECT_DIR} spelling left the script it really does reference
+	 * reported as referenced by nothing.
+	 */
+	@Test
+	void treatsARelativeReferenceAsReferencing() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing(".claude/hooks/session-start.sh"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setReportUnreferencedScripts(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenSettingsReferencesAMissingScriptRelatively() {
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing(".claude/hooks/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("references a missing hook script"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+	}
+
 	@Test
 	void treatsAQuotedReferenceAsReferencing() {
 		writeScript("session-start.sh", "#!/bin/sh\n", true);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -156,6 +156,32 @@ class HooksFormatRuleTest {
 		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
 	}
 
+	/** A hook chaining two scripts references both, whichever spelling each is written with. */
+	@Test
+	void treatsEveryScriptOfAMixedChainedCommandAsReferenced() {
+		writeScript("first.sh", "#!/bin/sh\n", true);
+		writeScript("second.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing(
+				"$CLAUDE_PROJECT_DIR/.claude/hooks/first.sh && .claude/hooks/second.sh"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setReportUnreferencedScripts(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/** An argument is not a script, so it cannot mark one referenced or be required to exist. */
+	@Test
+	void doesNotTreatAnArgumentThatLooksLikeAPathAsAScript() {
+		writeScript("build.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing(".claude/hooks/build.sh --out .claude/hooks/absent.sh"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setReportUnreferencedScripts(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
 	@Test
 	void treatsAQuotedReferenceAsReferencing() {
 		writeScript("session-start.sh", "#!/bin/sh\n", true);


### PR DESCRIPTION
- adopt: `gh pr create` failures were tolerated on a bare "already exists"
  substring matched against gh's whole merged transcript, so a failure that
  had nothing to do with an open pull request — a label gh could not add, a
  ref the push had already published — was swallowed and the adoption was
  reported complete with no pull request opened and none to find. The
  tolerated fragments now each name a pull request, covering both wordings
  gh uses (the client-side check and the GraphQL error).

- enforcer: the hook rules resolved only $CLAUDE_PROJECT_DIR-rooted script
  references, so a hook wired by the plain repository-relative path Claude
  Code resolves the same way was invisible to both. hookCommandsValid
  silently passed a hook pointing at a script that did not exist — the very
  failure it exists to catch — and hooksFormat reported the script it really
  did reference as referenced by nothing. Only the program of each chained
  command is read as a relative script, so an argument that looks like a
  path is not required to exist. The starter settings.json adopt installs
  now roots its hook at $CLAUDE_PROJECT_DIR too, matching this repository's
  own wiring.

- enforcer: uniqueDescriptions folded case in the default locale, so which
  descriptions counted as duplicates depended on the machine running the
  build — Turkish folds I to a dotless i, making two descriptions collide
  there and nowhere else. Folded in the root locale now, as every other
  comparison in these modules already is; McpConfigFormatRule's scheme
  comparison too.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RDawYGuTBm7eKTSTLc3Szy