### PR TITLE
fix(enforcer): resolve a rooted memory import on Windows

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
@@ -139,9 +139,21 @@ final class ImportGraph {
 
 	private File resolve(File file, String imported) {
 		if (imported.startsWith("/")) {
-			return new File(imported);
+			return rootedAt(file, imported);
 		}
 		return new File(file.getParentFile(), imported);
+	}
+
+	/**
+	 * A leading slash means the path starts at a file system root rather than at
+	 * the importing file. Which root that is comes from the importing file, so a
+	 * document resolves the same way wherever the build was launched from — on a
+	 * single-rooted file system the two are the same, but on Windows
+	 * {@code new File("/docs.md")} would pick whichever drive the build happened
+	 * to be started on.
+	 */
+	private File rootedAt(File file, String imported) {
+		return normalized(file).getRoot().resolve(imported.substring(1)).toFile();
 	}
 
 	/**

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
@@ -173,10 +173,21 @@ class ImportGraphTest {
 	@Test
 	void resolvesAnAbsoluteImportAsAnAbsolutePath() {
 		File absolute = write("elsewhere.md", "# Elsewhere\n");
-		File root = write("CLAUDE.md", "See @" + absolute.getAbsolutePath() + "\n");
+		File root = write("CLAUDE.md", "See @" + rooted(absolute) + "\n");
 
 		// A leading slash means the path is not relative to the importing file.
 		assertEquals(1, graphFrom(root).hopsTo(absolute));
+	}
+
+	@Test
+	void resolvesARootedImportAgainstTheImportingFilesRoot() {
+		File root = write("CLAUDE.md", "See @/elsewhere.md\n");
+
+		File target = graphFrom(root).importsOf(root).get(0).target();
+
+		// The root the importing file sits on, not the one the build was launched
+		// from — the two differ on a file system with more than one root.
+		assertEquals(tempDir.getRoot().resolve("elsewhere.md"), ImportGraph.normalized(target));
 	}
 
 	@Test
@@ -234,5 +245,16 @@ class ImportGraphTest {
 
 	private File write(String name, String content) {
 		return writeString(tempDir.resolve(name), content).toFile();
+	}
+
+	/**
+	 * The file as an import writes it: from the file system root, with forward
+	 * slashes. A platform's own absolute path is not import syntax — a Windows one
+	 * carries a drive letter and backslashes, neither of which an import path
+	 * matches.
+	 */
+	private String rooted(File file) {
+		Path path = file.toPath().toAbsolutePath();
+		return "/" + path.getRoot().relativize(path).toString().replace(File.separatorChar, '/');
 	}
 }


### PR DESCRIPTION
ImportGraphTest.resolvesAnAbsoluteImportAsAnAbsolutePath wrote the import
as the platform's own absolute path. On Windows that is a drive letter and
backslashes, neither of which the import pattern matches, so the import
resolved to nothing and the hop count came back as Integer.MAX_VALUE — the
weekly maven-windows.yml run has been red on it.

Write the import the way import syntax actually spells one, from the file
system root with forward slashes, and resolve a leading slash against the
importing file's root rather than the process's working directory, so a
document resolves the same way wherever the build was launched from. On a
single-rooted file system the two are identical, so Linux and macOS
behaviour is unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VAWtEhTk5SeZZoL38coXoG