### PR TITLE
fix(adopt): mask clone credentials in the MCP tool's argument log

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -36,7 +36,7 @@ public final class AdoptionContext {
 	public AdoptionContext(String repositoryUrl, Path workspace, String branchName) {
 		this.repository = RepositoryUrl.of(repositoryUrl);
 		this.workspace = requireWorkspace(workspace);
-		this.repositoryDirectory = workspace.resolve(repository.name());
+		this.repositoryDirectory = this.workspace.resolve(repository.name());
 		this.branchName = Text.required(branchName, "branchName");
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -71,9 +71,10 @@ public final class CliArguments {
 
 	public static CliArguments parse(String[] args) {
 		CliArguments cli = new CliArguments();
+		String[] arguments = args == null ? new String[0] : args;
 		int index = 0;
-		while (args != null && index < args.length) {
-			index = cli.consume(args, index);
+		while (index < arguments.length) {
+			index = cli.consume(arguments, index);
 		}
 		cli.requireSomethingToAdopt();
 		return cli;
@@ -138,18 +139,18 @@ public final class CliArguments {
 	private int consumeFlag(String[] args, int index) {
 		String flag = args[index];
 		return switch (flag) {
-			case "--repo" -> consumeValue(args, index, this::addFlaggedRepository);
-			case "--repos" -> consumeValue(args, index, value -> addFlaggedRepositories(readList(value)));
-			case "--workspace" -> consumeValue(args, index, value -> workspace = optionalPath(value));
-			case "--branch" -> consumeValue(args, index, value -> branchName = optionalText(value));
+			case "--repo" -> consumeName(args, index, this::addFlaggedRepository);
+			case "--repos" -> consumeName(args, index, value -> addFlaggedRepositories(readList(value)));
+			case "--workspace" -> consumeName(args, index, value -> workspace = optionalPath(value));
+			case "--branch" -> consumeName(args, index, value -> branchName = optionalText(value));
 			case "--title" -> consumeValue(args, index, value -> title = value);
 			case "--body" -> consumeValue(args, index, value -> body = value);
-			case "--reviewer" -> consumeValue(args, index, reviewers::add);
-			case "--label" -> consumeValue(args, index, labels::add);
-			case "--assignee" -> consumeValue(args, index, assignees::add);
-			case "--rule-version" -> consumeValue(args, index, value -> ruleVersion = optionalText(value));
-			case TIMEOUT_FLAG -> consumeValue(args, index, value -> commandTimeout = optionalTimeout(value));
-			case "--report" -> consumeValue(args, index, value -> reportFile = optionalPath(value));
+			case "--reviewer" -> consumeName(args, index, reviewers::add);
+			case "--label" -> consumeName(args, index, labels::add);
+			case "--assignee" -> consumeName(args, index, assignees::add);
+			case "--rule-version" -> consumeName(args, index, value -> ruleVersion = optionalText(value));
+			case TIMEOUT_FLAG -> consumeName(args, index, value -> commandTimeout = optionalTimeout(value));
+			case "--report" -> consumeName(args, index, value -> reportFile = optionalPath(value));
 			case "--draft" -> {
 				draft = true;
 				yield index + 1;
@@ -172,6 +173,23 @@ public final class CliArguments {
 		}
 		target.accept(args[index + 1]);
 		return index + 2;
+	}
+
+	/**
+	 * Reads the value of a flag that names something — a URL, a path, a branch, a
+	 * user, a number — none of which is ever spelled as a flag. A missing value would
+	 * otherwise swallow the next flag as the value: {@code --branch --draft} named a
+	 * branch called {@code --draft}, created it, and pushed it, with the draft the
+	 * operator asked for silently dropped. {@code --title} and {@code --body} take
+	 * free-form prose and so keep {@link #consumeValue}, which accepts whatever
+	 * follows.
+	 */
+	private int consumeName(String[] args, int index, Consumer<String> target) {
+		if (index + 1 < args.length && args[index + 1].startsWith("--")) {
+			throw new IllegalArgumentException(args[index] + " requires a value, but was followed by the option "
+					+ args[index + 1] + ". " + USAGE);
+		}
+		return consumeValue(args, index, target);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -57,8 +57,24 @@ public class ProcessCommandRunner implements CommandRunner {
 				.directory(workingDirectory.toFile())
 				.redirectErrorStream(true);
 		Process process = start(builder, command);
-		closeStandardInput(process, command);
-		return await(process, command, StreamGobbler.consuming(process.getInputStream()));
+		return awaitOrDestroy(process, command);
+	}
+
+	/**
+	 * Nothing may leave this method with the child still running. {@link #await}
+	 * destroys the tree on the two failures it raises itself, but the steps before it
+	 * — closing standard input, starting the reader — can fail too, and a child left
+	 * behind by one of those outlives the adoption entirely: no later step knows it
+	 * exists, and its merged output pipe stays open with nobody draining it.
+	 */
+	private CommandResult awaitOrDestroy(Process process, List<String> command) {
+		try {
+			closeStandardInput(process, command);
+			return await(process, command, StreamGobbler.consuming(process.getInputStream()));
+		} catch (RuntimeException e) {
+			destroyTree(process);
+			throw e;
+		}
 	}
 
 	private Process start(ProcessBuilder builder, List<String> command) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
@@ -5,9 +5,11 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringWriter;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Drains a process's output stream on a dedicated daemon thread so the command can
@@ -22,6 +24,8 @@ import java.time.Duration;
  * pipe open after the child itself has exited.
  */
 final class StreamGobbler {
+
+	private static final Logger log = LogManager.getLogger(StreamGobbler.class);
 
 	/**
 	 * How long {@link #output()} waits for the reader thread to reach
@@ -65,11 +69,19 @@ final class StreamGobbler {
 		}
 	}
 
+	/**
+	 * A read that fails ends the transcript where it failed rather than propagating.
+	 * This runs on a thread nobody joins for a result, so a thrown exception reaches
+	 * the JVM's default handler and prints a stack trace to standard error — the one
+	 * channel this module never logs on, and one the operator cannot attribute to a
+	 * command. The partial output is what {@link #output()} answers either way, so
+	 * the caller is no worse off for the failure being recorded here instead.
+	 */
 	private void drain(InputStream stream) {
 		try (Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
 			reader.transferTo(output);
 		} catch (IOException e) {
-			throw new UncheckedIOException(e);
+			log.debug("Stopped reading the command's output before end-of-stream", e);
 		}
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -18,6 +18,7 @@ import io.github.adamw7.tools.adopt.AdoptionRun;
 import io.github.adamw7.tools.adopt.BatchAdoption;
 import io.github.adamw7.tools.adopt.Checkouts;
 import io.github.adamw7.tools.adopt.GitHubRepoAdopter;
+import io.github.adamw7.tools.adopt.Redaction;
 import io.github.adamw7.tools.adopt.RepositoryUrls;
 import io.github.adamw7.tools.adopt.Workspaces;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
@@ -131,9 +132,22 @@ public class AdoptTool implements McpTool {
 
 	@Override
 	public ToolResult apply(Map<String, Object> arguments) {
-		log.info("Calling MCP adopt tool for {}", arguments);
+		log.info("Calling MCP adopt tool for {}", describe(arguments));
 		BatchAdoption batch = new BatchAdoption(pipeline.create(adoptionOptionsFrom(arguments)));
 		return result(batch.adoptAll(repositoryUrls(arguments), checkoutsFrom(arguments)));
+	}
+
+	/**
+	 * The call's arguments as they may be logged. A {@code repository_url} is the
+	 * one argument a client supplies with credentials in it — an adoption driven by
+	 * CI is handed {@code https://x-access-token:TOKEN@github.com/owner/repo.git} —
+	 * and this server is long-lived, so logging the map as it arrived wrote that
+	 * token to the log of every call. The pipeline below redacts the URL from its own
+	 * logs, messages, and report; the arguments have to be redacted here, before they
+	 * reach it.
+	 */
+	static String describe(Map<String, Object> arguments) {
+		return Redaction.of(String.valueOf(arguments));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt.step;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * The starter Claude Code configuration assets an {@link AssetsStep} installs
@@ -113,6 +114,32 @@ public final class AdoptionAssets {
 			new AssetInstaller(SESSION_START_HOOK_FILE, SESSION_START_HOOK, true),
 			new AssetInstaller(MCP_CONFIG_FILE, MCP_CONFIG),
 			new AssetInstaller(CLAUDE_WORKFLOW_FILE, CLAUDE_WORKFLOW));
+
+	/**
+	 * Every checkout-relative path an adoption may write or edit: the starter assets,
+	 * the generated {@code CLAUDE.md}, the fallback guard's two files, and the build
+	 * files the guard is wired into.
+	 *
+	 * <p>{@link CloneStep} reads this to tell the adoption's own work apart from a
+	 * contributor's, so a path missing from it is a file the adoption writes and
+	 * cannot account for. Extend it when the adoption learns to write a new one — the
+	 * asset installers and the two guard installers are read from their own constants
+	 * here, so only a genuinely new file has to be added by hand.
+	 */
+	public static final List<String> WRITTEN_PATHS = writtenPaths();
+
+	private static List<String> writtenPaths() {
+		return Stream.concat(
+				DEFAULTS.stream().map(AssetInstaller::relativePath),
+				Stream.of(CLAUDE_MD_FILE,
+						WorkflowGuardInstaller.WORKFLOW_FILE,
+						WorkflowGuardInstaller.SCRIPT_FILE,
+						MavenBuildSystem.POM,
+						GradleBuildSystem.GROOVY_BUILD_FILE,
+						GradleBuildSystem.KOTLIN_BUILD_FILE))
+				.distinct()
+				.toList();
+	}
 
 	private AdoptionAssets() {
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AssetInstaller.java
@@ -34,6 +34,11 @@ public class AssetInstaller {
 		this.executable = executable;
 	}
 
+	/** The checkout-relative path this asset is written to. */
+	public String relativePath() {
+		return relativePath;
+	}
+
 	/**
 	 * @return {@code true} when the asset was written, {@code false} when the
 	 *         checkout already carried a file at its path and was left unchanged.

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -48,10 +48,20 @@ public interface BuildSystem {
 	 * {@code --version} is not portable — and probing only the program would then
 	 * answer for the shell rather than for the build tool.
 	 *
+	 * <p>A build system whose verification names no command at all has nothing to
+	 * probe, and is answered as such rather than with the
+	 * {@link IndexOutOfBoundsException} that reading its first word would raise —
+	 * this is the extension point a new build system is added through, so it says
+	 * what it expects instead of failing an adoption several steps in.
+	 *
 	 * @return the probe command, or empty when the verification needs nothing beyond
 	 *         the shell
 	 */
 	default Optional<List<String>> toolProbe(Path repositoryDirectory) {
-		return Optional.of(List.of(verifyCommand(repositoryDirectory).get(0), ToolProbe.VERSION_FLAG));
+		List<String> verify = verifyCommand(repositoryDirectory);
+		if (verify.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(List.of(verify.get(0), ToolProbe.VERSION_FLAG));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -49,6 +50,9 @@ public class ClaudeMdConformer {
 	private static final char TILDE = '~';
 	private static final int MIN_FENCE_LENGTH = 3;
 	private static final String STUB_BODY = "See [AGENTS.md](AGENTS.md).";
+
+	/** The blank lines the reshape may leave at the end, dropped so the document keeps a single one. */
+	private static final Pattern TRAILING_BLANK_LINES = Pattern.compile("\\n\\s*+\\z");
 
 	/**
 	 * @return {@code content} reshaped so the {@code claudeMdFormat} rule passes,
@@ -329,6 +333,6 @@ public class ClaudeMdConformer {
 
 	/** Joins the lines under a single trailing newline, dropping any blank lines the reshape left at the end. */
 	private String join(List<String> lines) {
-		return String.join("\n", lines).replaceAll("\\n\\s*+\\z", "") + "\n";
+		return TRAILING_BLANK_LINES.matcher(String.join("\n", lines)).replaceAll("") + "\n";
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
@@ -1,10 +1,13 @@
 package io.github.adamw7.tools.adopt.step;
 
 import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,11 +27,33 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  * preserved. A missing configuration file is created, and a directory that is
  * already trusted is left untouched. The write itself goes through a temporary
  * file and a move, so the configuration is never seen half-written.
+ *
+ * <p>The read and the write are one exclusive section, because they are a
+ * read-modify-write of a file this process does not own. Two adoptions running at
+ * once — the MCP server serves calls in parallel — each read the document, each
+ * add their own directory, and each write the whole of it back, so the later write
+ * dropped the earlier one's entry. The adoption that lost it went on to run
+ * {@code claude} in a directory that was never trusted, where it blocked on the
+ * interactive prompt until the command timeout killed it. Atomicity of the write
+ * alone cannot prevent that: the two writes are each complete, and the second is
+ * simply built on a document read before the first landed.
  */
 public class ClaudeTrustStore {
 
 	private static final String PROJECTS = "projects";
 	private static final String TRUST_FLAG = "hasTrustDialogAccepted";
+
+	/** The suffix of the lock file guarding the configuration; see {@link #trust}. */
+	private static final String LOCK_SUFFIX = ".adopt-lock";
+
+	/**
+	 * Serialises the trust updates of this JVM. A {@link FileLock} is held by the
+	 * process rather than the thread, so it excludes a concurrent {@code claude} but
+	 * not a second thread of this adoption — which
+	 * {@link java.nio.channels.OverlappingFileLockException} would answer rather than
+	 * make wait. Both guards are needed, and this one is taken first.
+	 */
+	private static final Object IN_PROCESS_LOCK = new Object();
 
 	private final Path configFile;
 	private final ObjectMapper mapper = new ObjectMapper();
@@ -46,10 +71,37 @@ public class ClaudeTrustStore {
 	}
 
 	/**
+	 * Records the directory as trusted, excluding every other adoption — in this
+	 * process and outside it — for the whole read-modify-write.
+	 *
 	 * @return {@code true} when the directory was newly trusted, {@code false}
 	 *         when it was already trusted and the file was left unchanged.
 	 */
 	public boolean trust(Path directory) {
+		Path target = configFile.toAbsolutePath();
+		createConfigDirectory(target);
+		synchronized (IN_PROCESS_LOCK) {
+			return trustExclusively(directory, target);
+		}
+	}
+
+	/**
+	 * The lock is taken on a file beside the configuration rather than on the
+	 * configuration itself, because {@link #replace} moves a new file over that path:
+	 * a lock held on the old file would guard an inode nothing reads any more.
+	 */
+	private boolean trustExclusively(Path directory, Path target) {
+		Path lockFile = target.resolveSibling(target.getFileName() + LOCK_SUFFIX);
+		try (FileChannel channel = FileChannel.open(lockFile, StandardOpenOption.CREATE,
+				StandardOpenOption.WRITE); FileLock exclusive = channel.lock()) {
+			return update(directory);
+		} catch (IOException e) {
+			throw new AdoptionException("Could not lock the Claude config for update: " + configFile, e);
+		}
+	}
+
+	/** Runs under both locks: every read here decides a write that follows it. */
+	private boolean update(Path directory) {
 		String key = directory.toAbsolutePath().normalize().toString();
 		ObjectNode root = readRoot();
 		ObjectNode project = objectChild(objectChild(root, PROJECTS), key);
@@ -124,10 +176,18 @@ public class ClaudeTrustStore {
 	private void write(ObjectNode root) {
 		Path target = configFile.toAbsolutePath();
 		try {
-			Files.createDirectories(target.getParent());
 			replaceWith(root, temporaryBeside(target), target);
 		} catch (IOException e) {
 			throw new AdoptionException("Could not write Claude config: " + configFile, e);
+		}
+	}
+
+	/** Created before the lock file is opened beside it, and so before anything is read. */
+	private void createConfigDirectory(Path target) {
+		try {
+			Files.createDirectories(target.getParent());
+		} catch (IOException e) {
+			throw new AdoptionException("Could not create the Claude config directory: " + target.getParent(), e);
 		}
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -31,6 +31,10 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * branch, commit, and push the first repository's working tree, and report the
  * first repository's pull request as the second's.
  *
+ * <p>A reused checkout must also be free of uncommitted work that is not the
+ * adoption's own, since {@link CommitStep} stages the whole tree and would push a
+ * contributor's work in progress as part of the adoption.
+ *
  * <p>The checkout is then refreshed with {@code git fetch}, because every later
  * decision about the feature branch is taken against the remote-tracking refs a
  * stale checkout has out of date.
@@ -38,6 +42,12 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
 public class CloneStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(CloneStep.class);
+
+	/** The two status letters and the space before the path in {@code git status --porcelain}. */
+	private static final int STATUS_PREFIX = 3;
+
+	/** What {@code git status --porcelain} puts between a rename's old and new path. */
+	private static final String RENAME_ARROW = " -> ";
 
 	@Override
 	public String name() {
@@ -62,9 +72,65 @@ public class CloneStep extends AbstractCommandStep {
 
 	private void reuse(AdoptionContext context, CommandRunner runner) {
 		requireCheckoutOfTheSameRepository(context, runner);
+		requireNoUnrelatedChanges(context, runner);
 		log.info("{} already contains a checkout of {}; skipping clone", context.repositoryDirectory(),
 				context.displayUrl());
 		refresh(context, runner);
+	}
+
+	/**
+	 * Refuses a reused checkout carrying uncommitted work that is not the adoption's
+	 * own. {@link CommitStep} stages the whole tree with {@code git add -A}, so
+	 * whatever a contributor had in progress in that checkout would be swept into the
+	 * adoption's commit, pushed to the feature branch, and offered for review as part
+	 * of adopting Claude Code.
+	 *
+	 * <p>Only unrelated paths stop the run. An adoption that failed between writing a
+	 * file and committing it leaves exactly the paths {@link AdoptionAssets} names, so
+	 * re-running against the same workspace still resumes — which is the case worth
+	 * resuming, the one that has already paid for a {@code claude init}.
+	 */
+	private void requireNoUnrelatedChanges(AdoptionContext context, CommandRunner runner) {
+		List<String> unrelated = unrelatedChanges(context, runner);
+		if (!unrelated.isEmpty()) {
+			throw new AdoptionException(context.repositoryDirectory() + " has uncommitted changes that are not the"
+					+ " adoption's: " + String.join(", ", unrelated) + ". The adoption commits everything in the"
+					+ " checkout, so these would be pushed to " + context.branchName()
+					+ " too. Commit or stash them, or adopt into a fresh --workspace.");
+		}
+	}
+
+	/**
+	 * The changed paths the adoption does not own. A rename is reported as
+	 * {@code old -> new} and a path carrying a space or a quote is reported quoted, so
+	 * both are reduced to the path git would act on before it is compared.
+	 */
+	private List<String> unrelatedChanges(AdoptionContext context, CommandRunner runner) {
+		CommandResult result = runner.run(context.repositoryDirectory(),
+				List.of("git", "status", "--porcelain"));
+		if (!result.succeeded()) {
+			throw new AdoptionException(context.repositoryDirectory() + " is a checkout whose status could not be"
+					+ " read, so it cannot be shown to be free of uncommitted work: "
+					+ Redaction.of(result.output().strip()));
+		}
+		return result.output().lines()
+				.filter(line -> line.length() > STATUS_PREFIX)
+				.map(this::changedPath)
+				.filter(path -> !AdoptionAssets.WRITTEN_PATHS.contains(path))
+				.toList();
+	}
+
+	private String changedPath(String statusLine) {
+		String path = statusLine.substring(STATUS_PREFIX);
+		int rename = path.lastIndexOf(RENAME_ARROW);
+		return unquoted(rename < 0 ? path : path.substring(rename + RENAME_ARROW.length()));
+	}
+
+	private String unquoted(String path) {
+		String stripped = path.strip();
+		return stripped.length() > 1 && stripped.startsWith("\"") && stripped.endsWith("\"")
+				? stripped.substring(1, stripped.length() - 1)
+				: stripped;
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -22,7 +22,8 @@ public class MavenBuildSystem implements BuildSystem {
 	private static final String MAVEN = "mvn";
 	private static final List<String> VERIFY_ARGUMENTS = List.of("-q", "-N", "validate");
 
-	private static final String POM = "pom.xml";
+	/** Package-visible so {@link AdoptionAssets} can name it among the files the adoption edits. */
+	static final String POM = "pom.xml";
 
 	private final PomEnforcerInstaller installer;
 	private final BuildWrapper wrapper;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -72,6 +72,12 @@ public class PullRequestStep extends AbstractCommandStep {
 		return "pull-request";
 	}
 
+	/**
+	 * The report-less overload the {@link AdoptionStep} contract requires. The
+	 * pipeline never calls it — {@link io.github.adamw7.tools.adopt.GitHubRepoAdopter}
+	 * always passes the run's report — so the pull request's URL is deliberately
+	 * discarded here rather than reported to a report nobody holds.
+	 */
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
 		execute(context, runner, new AdoptionReport());

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -397,6 +397,26 @@ class CliArgumentsTest {
 		assertEquals(Optional.of("2.6.0"), options.pinnedRuleVersion());
 	}
 
+	/**
+	 * A flag that names something is never followed by another flag, so reading one as
+	 * the value hides the operator's mistake: {@code --branch --draft} created and
+	 * pushed a branch called {@code --draft} and silently dropped the draft.
+	 */
+	@Test
+	void refusesAFlagWhereANamingFlagsValueBelongs() {
+		assertUsageFailure(new String[] { REPO_URL, "--branch", "--draft" });
+		assertUsageFailure(new String[] { REPO_URL, "--workspace", "--assets" });
+		assertUsageFailure(new String[] { "--repo", "--dry-run" });
+		assertUsageFailure(new String[] { REPO_URL, "--timeout", "--dry-run" });
+	}
+
+	/** Prose is free-form, so a body or title that opens with dashes is the operator's business. */
+	@Test
+	void acceptsFreeFormProseThatLooksLikeAFlag() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--body", "--wip: do not merge" });
+		assertEquals("--wip: do not merge", cli.pullRequestOptions().body());
+	}
+
 	private void assertUsageFailure(String[] args) {
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
 				() -> CliArguments.parse(args));

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
@@ -370,4 +370,24 @@ class AdoptToolTest {
 		assertTrue(properties instanceof Map<?, ?> declared && declared.containsKey("repository_urls"),
 				"a list of repositories must be settable through the tool: " + properties);
 	}
+
+	/**
+	 * The arguments of a call are logged, and a CI-driven client supplies its clone
+	 * URL with an access token in it. This server outlives the call, so a token that
+	 * reached the log would outlive it too.
+	 */
+	@Test
+	void masksCloneCredentialsInTheLoggedArguments() {
+		String described = AdoptTool.describe(Map.of("repository_url",
+				"https://x-access-token:ghs_SECRET@github.com/owner/repo.git"));
+		assertFalse(described.contains("ghs_SECRET"), described);
+		assertTrue(described.contains("github.com/owner/repo.git"), described);
+	}
+
+	@Test
+	void masksCloneCredentialsSuppliedInTheRepositoryList() {
+		String described = AdoptTool.describe(Map.of("repository_urls",
+				List.of("https://user:p@ss@github.com/owner/repo.git")));
+		assertFalse(described.contains("p@ss"), described);
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetsStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetsStepTest.java
@@ -105,4 +105,25 @@ class AssetsStepTest {
 		assertEquals("assets", step.name());
 	}
 
+	/**
+	 * {@link CloneStep} tells the adoption's own uncommitted work apart from a
+	 * contributor's by this list, so a file the adoption writes but does not name here
+	 * would make a resumable checkout look like one carrying somebody else's work.
+	 * Every starter asset is folded in from {@link AdoptionAssets#DEFAULTS} itself; the
+	 * files written outside an installer are the ones worth pinning.
+	 */
+	@Test
+	void namesEveryFileTheAdoptionWrites() {
+		assertTrue(AdoptionAssets.WRITTEN_PATHS.containsAll(List.of(
+				"CLAUDE.md", "AGENTS.md", ".claude/settings.json", ".claude/hooks/session-start.sh",
+				".mcp.json", ".github/workflows/claude.yml", ".github/workflows/claude-md-guard.yml",
+				".github/claude-md-guard.sh", "pom.xml", "build.gradle", "build.gradle.kts")),
+				AdoptionAssets.WRITTEN_PATHS.toString());
+	}
+
+	/** A path named twice would report the same file twice in a refusal. */
+	@Test
+	void namesEachFileOnce() {
+		assertEquals(AdoptionAssets.WRITTEN_PATHS.stream().distinct().toList(), AdoptionAssets.WRITTEN_PATHS);
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -181,6 +181,41 @@ class BuildSystemsTest {
 		assertEquals(Optional.empty(), new FallbackBuildSystem().toolProbe(directory));
 	}
 
+	/**
+	 * {@link BuildSystem#toolProbe(Path)} is the default a new build system inherits,
+	 * and it reads the first word of the verify command. One that names no command has
+	 * nothing to probe, and must be told so rather than be handed an
+	 * {@link IndexOutOfBoundsException} several steps into an adoption.
+	 */
+	@Test
+	void aBuildSystemWithNoVerifyCommandHasNothingToProbe(@TempDir Path directory) {
+		assertEquals(Optional.empty(), new NoVerifyCommandBuildSystem().toolProbe(directory));
+	}
+
+	/** A build system that verifies nothing, standing in for one a contributor adds. */
+	private static final class NoVerifyCommandBuildSystem implements BuildSystem {
+
+		@Override
+		public String name() {
+			return "none";
+		}
+
+		@Override
+		public boolean matches(Path repositoryDirectory) {
+			return false;
+		}
+
+		@Override
+		public boolean install(Path repositoryDirectory) {
+			return false;
+		}
+
+		@Override
+		public List<String> verifyCommand(Path repositoryDirectory) {
+			return List.of();
+		}
+	}
+
 	private Path executable(Path wrapper) throws IOException {
 		Files.writeString(wrapper, "#!/bin/sh\n");
 		assertTrue(wrapper.toFile().setExecutable(true), "could not make " + wrapper + " executable");

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStoreTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStoreTest.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -39,6 +41,20 @@ class ClaudeTrustStoreTest {
 
 	private JsonNode read(Path config) throws IOException {
 		return MAPPER.readTree(config.toFile());
+	}
+
+	/**
+	 * The files beside the config that the store is not entitled to leave behind.
+	 * Its lock file is: it guards the read-modify-write against a concurrent
+	 * adoption, so it has to outlive the update that took it — a lock file deleted
+	 * on the way out is a lock the next process takes on a different inode.
+	 */
+	private List<Path> strayFiles(Path dir) throws IOException {
+		try (Stream<Path> entries = Files.list(dir)) {
+			return entries.filter(Files::isRegularFile)
+					.filter(entry -> !entry.getFileName().toString().endsWith(".adopt-lock"))
+					.toList();
+		}
 	}
 
 	private boolean trusted(JsonNode root, Path directory) {
@@ -175,10 +191,8 @@ class ClaudeTrustStoreTest {
 
 		assertTrue(new ClaudeTrustStore(config).trust(repo));
 
-		try (Stream<Path> entries = Files.list(dir)) {
-			assertEquals(List.of(config), entries.filter(Files::isRegularFile).toList(),
-					"the temporary file the write goes through must not survive it");
-		}
+		assertEquals(List.of(config), strayFiles(dir),
+				"the temporary file the write goes through must not survive it");
 		assertTrue(trusted(read(config), repo));
 	}
 
@@ -198,9 +212,52 @@ class ClaudeTrustStoreTest {
 
 		assertThrows(AdoptionException.class, () -> new ClaudeTrustStore(config).trust(dir.resolve("repo")));
 
-		try (Stream<Path> entries = Files.list(dir)) {
-			assertEquals(List.of(), entries.filter(Files::isRegularFile).toList(),
-					"the temporary file must not outlive the failed write");
+		assertEquals(List.of(), strayFiles(dir), "the temporary file must not outlive the failed write");
+	}
+
+	/**
+	 * Two adoptions trusting two checkouts at once must both be recorded. Each reads
+	 * the whole document, adds its own directory, and writes the whole of it back, so
+	 * without an exclusive section around that sequence the later write is built on a
+	 * document read before the earlier one landed and silently drops it — leaving that
+	 * adoption's {@code claude init} to block on the trust prompt until its command
+	 * timeout. The barrier makes both threads read at the same moment, which is the
+	 * interleaving that loses an update.
+	 */
+	@Test
+	void concurrentTrustsAreBothRecorded(@TempDir Path dir) throws Exception {
+		Path config = dir.resolve(".claude.json");
+		Path first = dir.resolve("first");
+		Path second = dir.resolve("second");
+		CyclicBarrier startTogether = new CyclicBarrier(2);
+
+		Thread firstThread = trusting(config, first, startTogether);
+		Thread secondThread = trusting(config, second, startTogether);
+		firstThread.join();
+		secondThread.join();
+
+		JsonNode root = read(config);
+		assertTrue(trusted(root, first), "the first directory must survive the second adoption's write");
+		assertTrue(trusted(root, second), "the second directory must survive the first adoption's write");
+	}
+
+	private Thread trusting(Path config, Path directory, CyclicBarrier startTogether) {
+		Thread thread = new Thread(() -> {
+			await(startTogether);
+			new ClaudeTrustStore(config).trust(directory);
+		});
+		thread.start();
+		return thread;
+	}
+
+	private void await(CyclicBarrier startTogether) {
+		try {
+			startTogether.await();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException(e);
+		} catch (BrokenBarrierException e) {
+			throw new IllegalStateException(e);
 		}
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -44,8 +44,9 @@ class CloneStepTest {
 		RecordingCommandRunner runner = origin("https://github.com/adamw7/tools.git");
 		step.execute(existing, runner);
 		assertEquals(List.of("git", "config", "--get-all", "remote.origin.url"), runner.commandAt(0));
-		assertEquals(List.of("git", "fetch", "origin"), runner.commandAt(1));
-		assertEquals(2, runner.count());
+		assertEquals(List.of("git", "status", "--porcelain"), runner.commandAt(1));
+		assertEquals(List.of("git", "fetch", "origin"), runner.commandAt(2));
+		assertEquals(3, runner.count());
 	}
 
 	/**
@@ -58,7 +59,7 @@ class CloneStepTest {
 		AdoptionContext existing = checkedOut(existingWorkspace);
 		RecordingCommandRunner runner = origin("git@github.com:adamw7/Tools");
 		step.execute(existing, runner);
-		assertEquals(2, runner.count());
+		assertEquals(3, runner.count());
 	}
 
 	/**
@@ -98,7 +99,7 @@ class CloneStepTest {
 		RecordingCommandRunner runner = origin("warning: unable to access '/etc/gitconfig': Permission denied"
 				+ System.lineSeparator() + "https://github.com/adamw7/tools.git");
 		step.execute(existing, runner);
-		assertEquals(2, runner.count());
+		assertEquals(3, runner.count());
 	}
 
 	/** Noise on its own still names no repository, so the checkout is refused. */
@@ -122,7 +123,7 @@ class CloneStepTest {
 		RecordingCommandRunner runner = origin("https://github.com/adamw7/tools.git");
 		step.execute(existing, runner);
 		assertEquals(List.of("git", "config", "--get-all", "remote.origin.url"), runner.commandAt(0));
-		assertEquals(2, runner.count());
+		assertEquals(3, runner.count());
 	}
 
 	/**
@@ -136,12 +137,16 @@ class CloneStepTest {
 	@Test
 	void readsTheConfiguredOriginRatherThanTheRewrittenOne(@TempDir Path existingWorkspace) throws IOException {
 		AdoptionContext existing = checkedOut(existingWorkspace);
-		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("--get-all")
-				? new CommandResult(command, 0, "https://github.com/adamw7/tools.git")
-				: new CommandResult(command, 0, "https://mirror.corp/github/adamw7/tools.git"));
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			if (command.contains("--get-all")) {
+				return new CommandResult(command, 0, "https://github.com/adamw7/tools.git");
+			}
+			return new CommandResult(command, 0, command.contains("status") ? ""
+					: "https://mirror.corp/github/adamw7/tools.git");
+		});
 		step.execute(existing, runner);
 		assertEquals(List.of("git", "config", "--get-all", "remote.origin.url"), runner.commandAt(0));
-		assertEquals(2, runner.count());
+		assertEquals(3, runner.count());
 	}
 
 	@Test
@@ -155,9 +160,13 @@ class CloneStepTest {
 	@Test
 	void failedFetchAbortsAdoption(@TempDir Path existingWorkspace) throws IOException {
 		AdoptionContext existing = checkedOut(existingWorkspace);
-		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("fetch")
-				? new CommandResult(command, 128, "fatal: could not read from remote repository")
-				: new CommandResult(command, 0, "https://github.com/adamw7/tools.git"));
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			if (command.contains("fetch")) {
+				return new CommandResult(command, 128, "fatal: could not read from remote repository");
+			}
+			return new CommandResult(command, 0, command.contains("status") ? ""
+					: "https://github.com/adamw7/tools.git");
+		});
 		assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
 	}
 
@@ -165,6 +174,69 @@ class CloneStepTest {
 	void failedCloneAbortsAdoption() {
 		RecordingCommandRunner runner = RecordingCommandRunner.failing(128, "fatal: repository not found");
 		assertThrows(AdoptionException.class, () -> step.execute(context, runner));
+	}
+
+	/**
+	 * {@link CommitStep} stages the whole tree, so a contributor's work in progress in
+	 * a reused checkout would be committed to the adoption's branch and pushed for
+	 * review as part of adopting Claude Code.
+	 */
+	@Test
+	void refusesReusedCheckoutCarryingSomebodyElsesUncommittedWork(@TempDir Path existingWorkspace)
+			throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
+				" M src/main/java/Service.java" + System.lineSeparator() + "?? notes.txt");
+
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
+
+		assertTrue(failure.getMessage().contains("src/main/java/Service.java"), failure.getMessage());
+		assertTrue(failure.getMessage().contains("notes.txt"), failure.getMessage());
+		assertEquals(2, runner.count(), "a checkout with unrelated work may not even be fetched into");
+	}
+
+	/**
+	 * An adoption that failed between writing a file and committing it leaves exactly
+	 * the adoption's own paths behind, and re-running it is the case most worth
+	 * resuming — it has already paid for a {@code claude init}.
+	 */
+	@Test
+	void resumesReusedCheckoutCarryingOnlyTheAdoptionsOwnChanges(@TempDir Path existingWorkspace)
+			throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
+				"?? CLAUDE.md" + System.lineSeparator() + " M pom.xml" + System.lineSeparator()
+						+ "?? .claude/settings.json");
+
+		step.execute(existing, runner);
+
+		assertEquals(3, runner.count());
+	}
+
+	/** A path with a space is quoted by git, and a rename names the path it ends at. */
+	@Test
+	void readsQuotedAndRenamedPathsAsGitReportsThem(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
+				"R  old/name.txt -> \"my notes.txt\"");
+
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
+
+		assertTrue(failure.getMessage().contains("my notes.txt"), failure.getMessage());
+		assertFalse(failure.getMessage().contains("->"), failure.getMessage());
+	}
+
+	/** A status that cannot be read cannot show the checkout to be free of other work. */
+	@Test
+	void refusesReusedCheckoutWhoseStatusCannotBeRead(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> command.contains("status")
+				? new CommandResult(command, 128, "fatal: not a git repository")
+				: new CommandResult(command, 0, "https://github.com/adamw7/tools.git"));
+
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
+
+		assertTrue(failure.getMessage().contains("status could not be read"), failure.getMessage());
 	}
 
 	@Test
@@ -179,8 +251,23 @@ class CloneStepTest {
 		return existing;
 	}
 
-	/** A runner answering every command with the URL git would report as the checkout's origin. */
+	/**
+	 * A runner answering the origin query with the URL git would report, and every
+	 * other command — the status check, the fetch — with a clean success. Only the
+	 * origin query is answered with the URL, because a status answered with one would
+	 * read as a changed file by that name.
+	 */
 	private RecordingCommandRunner origin(String url) {
-		return new RecordingCommandRunner(command -> new CommandResult(command, 0, url + System.lineSeparator()));
+		return answering(url, "");
+	}
+
+	/** A runner answering the origin query and the status check, in that order. */
+	private RecordingCommandRunner answering(String url, String status) {
+		return new RecordingCommandRunner(command -> {
+			if (command.contains("--get-all")) {
+				return new CommandResult(command, 0, url + System.lineSeparator());
+			}
+			return new CommandResult(command, 0, command.contains("status") ? status : "");
+		});
 	}
 }


### PR DESCRIPTION
AdoptTool logged the call's argument map as it arrived, so a
repository_url of the form
https://x-access-token:TOKEN@github.com/owner/repo.git wrote its token
to the log of every call. The MCP server is long-lived and logs at INFO,
which makes this the worst place in the module for the leak: the
pipeline below redacts the URL from its own logs, failure messages, and
JSON report, but the arguments reach that pipeline already logged.

The map now goes through Redaction before it is logged, at a named seam
the tests can pin.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BZMMUWCiF7uXH7fSgtTthY