### PR TITLE
fix(adopt): three defects that broke resumes, ported hosts, and Windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,13 @@ Maven project. The notable capabilities are:
   refused with "Permission denied". `BuildSystem.toolProbe` answers the whole
   probe command rather than a program name so `BuildToolchainStep` probes that
   same launcher: `sh --version` is not portable, so probing the program alone
-  would answer for the shell instead of for the build tool. The pull request metadata — title, body,
+  would answer for the shell instead of for the build tool. The fallback guard's
+  own shell is probed too, with `sh -c 'exit 0'` for the same portability reason —
+  a shell is a tool like any other and is absent from a stock Windows `PATH`, and
+  assuming one left the adoption to discover that at `VerifyStep`, past the clone,
+  the `claude init`, and both commits. What to do about a probe that fails comes
+  from `BuildSystem.toolAdvice`, so a build-less repository is told to find a
+  shell rather than to "install github-actions on the PATH". The pull request metadata — title, body,
   reviewers, labels, assignees, and draft flag — is supplied through
   `PullRequestOptions`, exposed on the command line as `--title`, `--body`,
   repeatable `--reviewer`/`--label`/`--assignee`, and `--draft` (parsed by

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -22,6 +22,24 @@ public final class RepositoryUrl {
 	private static final String GIT_SUFFIX = ".git";
 
 	/**
+	 * The port ending a URL's authority: a {@code ':'} followed by digits and then
+	 * either the path or the end of the URL. It is dropped before the URL is split
+	 * into segments, because splitting on {@code ':'} — which the scp-like form needs
+	 * — otherwise reads the port as a path segment of its own. A
+	 * {@code https://ghe.example.com:8443/owner/repo} then yielded the segments
+	 * {@code [ghe.example.com, 8443, owner, repo]}, whose third-from-last is the port
+	 * rather than the host, so {@link #repositorySlug} concluded the URL named no
+	 * owner: {@code gh} lost its {@code --repo}, the toolchain check fell back to its
+	 * weaker credentials probe, and the command line refused the URL outright.
+	 *
+	 * <p>Only a URL carrying a scheme is treated this way. The scp-like
+	 * {@code git@host:owner/repo} has no scheme and cannot carry a port at all — that
+	 * is what {@code ssh://} exists for — so its {@code ':'} always separates a path,
+	 * even before an owner that happens to be all digits.
+	 */
+	private static final Pattern PORT = Pattern.compile("^([^/]*):\\d+(?=/|$)");
+
+	/**
 	 * The user information a URL carries before its host, ended by the last
 	 * {@code @} that precedes the path — the same reading {@link Redaction} takes,
 	 * but applied once the scheme is gone, so the scp-like {@code git@host:owner/repo}
@@ -107,6 +125,12 @@ public final class RepositoryUrl {
 	}
 
 	/**
+	 * A port is deliberately <em>not</em> dropped here, unlike in
+	 * {@link #authorityAndPath}: two URLs differing only in their port name two
+	 * servers, and answering them as one repository is the direction this comparison
+	 * must never err in — the caller goes on to commit to that checkout, push it, and
+	 * open its pull request. Reading the port as a path segment keeps them apart.
+	 *
 	 * @return the comparable form of a clone URL, or the empty string for text that
 	 *         names no repository at all — which never equals the identity of a
 	 *         parsed URL, since {@link #of} rejects a blank one
@@ -187,9 +211,22 @@ public final class RepositoryUrl {
 	}
 
 	private static List<String> segments(String url) {
-		return Stream.of(SEGMENT_SEPARATORS.split(SCHEME.matcher(url).replaceFirst("")))
+		return Stream.of(SEGMENT_SEPARATORS.split(authorityAndPath(url)))
 				.filter(segment -> !segment.isBlank())
 				.toList();
+	}
+
+	/**
+	 * The URL past its scheme, with any {@link #PORT} dropped, ready to be split on
+	 * the two separators git accepts.
+	 */
+	private static String authorityAndPath(String url) {
+		String withoutScheme = SCHEME.matcher(url).replaceFirst("");
+		return hasScheme(url) ? PORT.matcher(withoutScheme).replaceFirst("$1") : withoutScheme;
+	}
+
+	private static boolean hasScheme(String url) {
+		return SCHEME.matcher(url).find();
 	}
 
 	private static boolean isHost(String segment) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -64,4 +64,17 @@ public interface BuildSystem {
 		}
 		return Optional.of(List.of(verify.get(0), ToolProbe.VERSION_FLAG));
 	}
+
+	/**
+	 * What an operator whose {@link #toolProbe(Path)} could not be run has to do
+	 * about it, named by the build system rather than by {@link BuildToolchainStep}:
+	 * the remedy is not the same for every one of them, and a step that spelled out
+	 * one of them told a project with no build file at all to "install github-actions
+	 * on the PATH", which names nothing installable.
+	 *
+	 * @return the remedy, as a sentence
+	 */
+	default String toolAdvice() {
+		return "Install " + name() + " on the PATH, or commit the project's build wrapper.";
+	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildToolchainStep.java
@@ -21,8 +21,9 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  *
  * <p>The build system is detected through {@link AbstractBuildSystemStep} just as
  * {@link EnforcerStep} and {@link VerifyStep} detect it, so the tool probed is the
- * tool the verification runs. A build system that needs none — the
- * {@link FallbackBuildSystem}, whose guard runs through {@code sh} — is a no-op.
+ * tool the verification runs — including the {@link FallbackBuildSystem}'s shell,
+ * which is a tool like any other and absent from a stock Windows {@code PATH}. A
+ * build system that names no probe at all is a no-op.
  */
 public class BuildToolchainStep extends AbstractBuildSystemStep {
 
@@ -66,7 +67,6 @@ public class BuildToolchainStep extends AbstractBuildSystemStep {
 		}
 		throw new AdoptionException(name() + " failed: " + repositoryDirectory + " builds with "
 				+ buildSystem.name() + " but " + CommandResult.describe(command) + " could not be run, so the"
-				+ " CLAUDE.md guard could not be verified. Install " + buildSystem.name() + " on the PATH, or"
-				+ " commit the project's build wrapper.");
+				+ " CLAUDE.md guard could not be verified. " + buildSystem.toolAdvice());
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -46,6 +46,18 @@ public class CloneStep extends AbstractCommandStep {
 	/** The two status letters and the space before the path in {@code git status --porcelain}. */
 	private static final int STATUS_PREFIX = 3;
 
+	/**
+	 * Makes {@code git status} name every untracked file rather than collapsing a
+	 * wholly-untracked directory into a single entry. Without it a checkout whose
+	 * {@code .claude/} the adoption had just created was reported as the one path
+	 * {@code .claude/}, which is not among {@link AdoptionAssets#WRITTEN_PATHS} — so a
+	 * resumed adoption was refused for changes that were its own. That is the common
+	 * case rather than a corner of one: a repository being adopted has no
+	 * {@code .claude/} to begin with, and the fallback guard's {@code .github/} is
+	 * often new too.
+	 */
+	private static final String UNTRACKED_FILES_ALL = "--untracked-files=all";
+
 	/** What {@code git status --porcelain} puts between a rename's old and new path. */
 	private static final String RENAME_ARROW = " -> ";
 
@@ -107,7 +119,7 @@ public class CloneStep extends AbstractCommandStep {
 	 */
 	private List<String> unrelatedChanges(AdoptionContext context, CommandRunner runner) {
 		CommandResult result = runner.run(context.repositoryDirectory(),
-				List.of("git", "status", "--porcelain"));
+				List.of("git", "status", "--porcelain", UNTRACKED_FILES_ALL));
 		if (!result.succeeded()) {
 			throw new AdoptionException(context.repositoryDirectory() + " is a checkout whose status could not be"
 					+ " read, so it cannot be shown to be free of uncommitted work: "

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
@@ -18,7 +18,18 @@ import java.util.Optional;
  */
 public class FallbackBuildSystem implements BuildSystem {
 
-	static final List<String> VERIFY_COMMAND = List.of("sh", WorkflowGuardInstaller.SCRIPT_FILE);
+	/** The shell the guard script is run with, here and in the workflow that runs it in CI. */
+	static final String SHELL = "sh";
+
+	static final List<String> VERIFY_COMMAND = List.of(SHELL, WorkflowGuardInstaller.SCRIPT_FILE);
+
+	/**
+	 * Asks the shell to do nothing and exit zero, rather than for its version:
+	 * {@code sh --version} is not portable and exits non-zero under {@code dash}, so
+	 * probing with it would report a perfectly good shell as unusable. Every POSIX
+	 * shell answers this one.
+	 */
+	static final List<String> SHELL_PROBE = List.of(SHELL, "-c", "exit 0");
 
 	private final WorkflowGuardInstaller installer = new WorkflowGuardInstaller();
 
@@ -43,12 +54,24 @@ public class FallbackBuildSystem implements BuildSystem {
 	}
 
 	/**
-	 * The guard runs through {@code sh}, which every platform the adoption supports
-	 * already provides and which has no portable {@code --version} probe, so there is
-	 * nothing to check ahead of time.
+	 * The guard runs through {@code sh}, so that is what is probed. Answering "nothing
+	 * to check" instead assumed every host has a shell on its {@code PATH}, which a
+	 * Windows one generally has not: the {@code sh.exe} Git for Windows ships sits
+	 * under the install's {@code usr/bin} and is only on the {@code PATH} if the
+	 * operator opted into the Unix tools. The adoption then ran to
+	 * {@link VerifyStep} — past the clone, the {@code claude init}, and both commits —
+	 * before failing on a shell it could have missed at its second step.
 	 */
 	@Override
 	public Optional<List<String>> toolProbe(Path repositoryDirectory) {
-		return Optional.empty();
+		return Optional.of(SHELL_PROBE);
+	}
+
+	/** Nothing here is installable as "github-actions"; what is missing is a shell. */
+	@Override
+	public String toolAdvice() {
+		return "Put a POSIX " + SHELL + " on the PATH — on Windows, the one Git for Windows installs under"
+				+ " its usr/bin — or give the project a Maven or Gradle build file to wire the guard into"
+				+ " instead.";
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -311,6 +311,20 @@ class CliArgumentsTest {
 	}
 
 	/**
+	 * A self-hosted GitHub reached on its own port names an owner like any other URL,
+	 * so it is a repository positional rather than a workspace mistaken for one.
+	 * Reading the port as a path segment made the check conclude it named no owner and
+	 * refuse the whole run, telling the operator to name the repository with the very
+	 * {@code --repo} they had already used for the others.
+	 */
+	@Test
+	void acceptsAPositionalUrlOnAPortAlongsideTheRepositoryFlags() {
+		String ported = "https://ghe.example.com:8443/owner/repo.git";
+		CliArguments cli = CliArguments.parse(new String[] { ported, "--repo", OTHER_URL });
+		assertEquals(List.of(ported, OTHER_URL), cli.repositoryUrls());
+	}
+
+	/**
 	 * A local path names no owner but is adoptable, so a run whose only repository is
 	 * the positional keeps working — the check only fires when the flags named one too.
 	 */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
@@ -123,6 +123,82 @@ class RepositoryUrlTest {
 	}
 
 	/**
+	 * An enterprise host reached on its own port is the ordinary shape of a
+	 * self-hosted GitHub. Splitting on ':' — which the scp-like form needs — read the
+	 * port as a path segment of its own, so the host check landed on {@code 8443} and
+	 * the URL was reported as naming no owner at all.
+	 */
+	@Test
+	void derivesTheOwnerAndRepositoryFromAHostReachedOnAPort() {
+		assertEquals("adamw7/tools",
+				RepositoryUrl.of("https://ghe.example.com:8443/adamw7/tools.git").slug().orElseThrow());
+		assertEquals("adamw7/tools",
+				RepositoryUrl.of("https://ghe.example.com:8443/adamw7/tools").slug().orElseThrow());
+		assertEquals("adamw7/tools",
+				RepositoryUrl.of("https://ghe.example.com:8443/adamw7/tools/").slug().orElseThrow());
+	}
+
+	@Test
+	void derivesTheOwnerAndRepositoryFromAnSshUrlOnANonDefaultPort() {
+		assertEquals("adamw7/tools",
+				RepositoryUrl.of("ssh://git@ghe.example.com:2222/adamw7/tools.git").slug().orElseThrow());
+	}
+
+	/** The port sits behind the credentials, so both have to be stepped over at once. */
+	@Test
+	void derivesTheOwnerAndRepositoryFromACredentialledUrlOnAPort() {
+		assertEquals("adamw7/tools",
+				RepositoryUrl.of("https://x-access-token:secret@ghe.example.com:8443/adamw7/tools.git")
+						.slug().orElseThrow());
+	}
+
+	/** A port is no part of the checkout directory's name either. */
+	@Test
+	void derivesTheNameFromAHostReachedOnAPort() {
+		assertEquals("tools", RepositoryUrl.of("https://ghe.example.com:8443/adamw7/tools.git").name());
+		assertEquals("tools", RepositoryUrl.of("ssh://git@ghe.example.com:2222/adamw7/tools").name());
+	}
+
+	/** Dropping the port must not promote the host into the owner's slot. */
+	@Test
+	void aUrlOnAPortThatNamesNoOwnerStillNamesNone() {
+		assertTrue(RepositoryUrl.of("https://ghe.example.com:8443/tools.git").slug().isEmpty());
+	}
+
+	/**
+	 * The scp-like form carries no port — that is what {@code ssh://} is for — so its
+	 * ':' always separates a path, even before an owner that happens to read like one.
+	 * Stripping it here would have turned {@code 2222/tools} into a repository with no
+	 * owner.
+	 */
+	@Test
+	void anScpLikeUrlsColonIsAPathSeparatorEvenBeforeDigits() {
+		assertEquals("2222/tools", RepositoryUrl.of("git@github.com:2222/tools.git").slug().orElseThrow());
+		assertEquals("tools", RepositoryUrl.of("git@github.com:2222/tools.git").name());
+	}
+
+	/**
+	 * Two ports on one host are two servers. The comparison may only err towards
+	 * refusing a checkout, since accepting the wrong one commits to it, pushes it,
+	 * and opens its pull request.
+	 */
+	@Test
+	void twoPortsOnOneHostAreDifferentRepositories() {
+		RepositoryUrl url = RepositoryUrl.of("https://ghe.example.com:8443/adamw7/tools.git");
+		assertFalse(url.isSameRepositoryAs("https://ghe.example.com:9443/adamw7/tools.git"));
+		assertFalse(url.isSameRepositoryAs("https://ghe.example.com/adamw7/tools.git"));
+	}
+
+	/** The forms of one repository on a ported host still name that one repository. */
+	@Test
+	void everyFormOfOneRepositoryOnAPortedHostIsTheSameRepository() {
+		RepositoryUrl url = RepositoryUrl.of("https://ghe.example.com:8443/adamw7/tools.git");
+		assertTrue(url.isSameRepositoryAs("https://ghe.example.com:8443/adamw7/tools"));
+		assertTrue(url.isSameRepositoryAs("https://ghe.example.com:8443/adamw7/Tools.GIT"));
+		assertTrue(url.isSameRepositoryAs("https://token@ghe.example.com:8443/adamw7/tools.git"));
+	}
+
+	/**
 	 * A filesystem path names no owner, so reading its last two segments as one
 	 * would point a tool at a repository that does not exist. Reporting no slug
 	 * leaves the caller to fall back to its own inference.

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -173,12 +174,49 @@ class BuildSystemsTest {
 	}
 
 	/**
-	 * The fallback guard runs through sh, which every supported platform provides
-	 * and which has no portable --version probe, so there is nothing to check.
+	 * The fallback guard runs through sh, so sh is what it probes. Answering "nothing
+	 * to check" assumed every host has a shell on its PATH — a stock Windows one has
+	 * not — and left that to be discovered at the verification, three steps and a
+	 * claude init later.
 	 */
 	@Test
-	void theFallbackRequiresNoToolOfItsOwn(@TempDir Path directory) {
-		assertEquals(Optional.empty(), new FallbackBuildSystem().toolProbe(directory));
+	void theFallbackProbesTheShellItsGuardRunsThrough(@TempDir Path directory) {
+		assertEquals(Optional.of(List.of("sh", "-c", "exit 0")),
+				new FallbackBuildSystem().toolProbe(directory));
+	}
+
+	/**
+	 * The probe asks the shell to do nothing rather than for its version, because
+	 * {@code sh --version} is not portable: dash exits non-zero, which would report a
+	 * perfectly good shell as unusable.
+	 */
+	@Test
+	void theFallbackProbeAsksNothingOfTheShellThatDashWouldRefuse(@TempDir Path directory) {
+		assertFalse(new FallbackBuildSystem().toolProbe(directory).orElseThrow().contains("--version"));
+	}
+
+	/** The shell probed and the shell the verification launches must be the one shell. */
+	@Test
+	void theFallbackProbesTheSameShellItVerifiesWith(@TempDir Path directory) {
+		FallbackBuildSystem fallback = new FallbackBuildSystem();
+		assertEquals(fallback.verifyCommand(directory).get(0), fallback.toolProbe(directory).orElseThrow().get(0));
+	}
+
+	/**
+	 * "Install github-actions on the PATH" names nothing installable, which is what
+	 * the step said before each build system answered for its own remedy.
+	 */
+	@Test
+	void theFallbackAdvisesAboutAShellRatherThanAboutItself() {
+		String advice = new FallbackBuildSystem().toolAdvice();
+		assertTrue(advice.contains("sh"), advice);
+		assertFalse(advice.contains("Install github-actions"), advice);
+	}
+
+	@Test
+	void aBuildToolIsAdvisedAboutByName() {
+		assertTrue(new MavenBuildSystem().toolAdvice().contains("maven"), "maven should name itself");
+		assertTrue(new GradleBuildSystem().toolAdvice().contains("gradle"), "gradle should name itself");
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -63,12 +64,75 @@ class BuildToolchainStepTest {
 		assertThrows(AdoptionException.class, () -> new BuildToolchainStep().execute(context, runner));
 	}
 
+	/**
+	 * A checkout with no recognised build file falls to the guard that runs through a
+	 * shell, so the shell is probed like any other build tool.
+	 */
 	@Test
-	void probesNothingForTheFallbackGuardWhichOnlyNeedsAShell(@TempDir Path workspace) throws IOException {
+	void probesTheShellTheFallbackGuardRunsThrough(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new BuildToolchainStep().execute(context, runner);
-		assertEquals(0, runner.count());
+		assertEquals(List.of("sh", "-c", "exit 0"), runner.commandAt(0));
+		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
+		assertEquals(1, runner.count());
+	}
+
+	/**
+	 * A host with no shell on its PATH — a stock Windows one, where the {@code sh.exe}
+	 * Git for Windows ships stays under its usr/bin unless the operator opted into the
+	 * Unix tools — used to run all the way to {@link VerifyStep} before finding out.
+	 */
+	@Test
+	void anAbsentShellAbortsTheAdoptionAtTheSecondStep(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			throw new AdoptionException("Could not start command: " + String.join(" ", command));
+		});
+
+		AdoptionException failure = assertThrows(AdoptionException.class,
+				() -> new BuildToolchainStep().execute(context, runner));
+
+		assertTrue(failure.getMessage().contains("build-toolchain failed"), failure.getMessage());
+		assertTrue(failure.getMessage().contains("sh"), failure.getMessage());
+	}
+
+	/**
+	 * The remedy comes from the build system, so a project with no build file is not
+	 * told to "install github-actions on the PATH", which names nothing installable.
+	 */
+	@Test
+	void theFallbacksFailureAdvisesAboutAShellRatherThanAboutGitHubActions(@TempDir Path workspace)
+			throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(127, "sh: not found");
+
+		AdoptionException failure = assertThrows(AdoptionException.class,
+				() -> new BuildToolchainStep().execute(context, runner));
+
+		assertFalse(failure.getMessage().contains("Install github-actions"), failure.getMessage());
+		assertTrue(failure.getMessage().contains("POSIX sh"), failure.getMessage());
+	}
+
+	/** A shell that answers the probe lets the adoption carry on. */
+	@Test
+	void aShellThatRunsLetsTheFallbackAdoptionProceed(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		assertDoesNotThrow(() -> new BuildToolchainStep().execute(context, runner));
+	}
+
+	/** A Maven checkout is still told to install Maven, not to find a shell. */
+	@Test
+	void aBuildToolsFailureStillAdvisesAboutThatBuildTool(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "pom.xml", "<project/>");
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(127, "mvn: not found");
+
+		AdoptionException failure = assertThrows(AdoptionException.class,
+				() -> new BuildToolchainStep().execute(context, runner));
+
+		assertTrue(failure.getMessage().contains("Install maven on the PATH"), failure.getMessage());
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -44,7 +44,7 @@ class CloneStepTest {
 		RecordingCommandRunner runner = origin("https://github.com/adamw7/tools.git");
 		step.execute(existing, runner);
 		assertEquals(List.of("git", "config", "--get-all", "remote.origin.url"), runner.commandAt(0));
-		assertEquals(List.of("git", "status", "--porcelain"), runner.commandAt(1));
+		assertEquals(List.of("git", "status", "--porcelain", "--untracked-files=all"), runner.commandAt(1));
 		assertEquals(List.of("git", "fetch", "origin"), runner.commandAt(2));
 		assertEquals(3, runner.count());
 	}
@@ -207,6 +207,139 @@ class CloneStepTest {
 		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
 				"?? CLAUDE.md" + System.lineSeparator() + " M pom.xml" + System.lineSeparator()
 						+ "?? .claude/settings.json");
+
+		step.execute(existing, runner);
+
+		assertEquals(3, runner.count());
+	}
+
+	/**
+	 * The status is asked with {@code --untracked-files=all}, because git otherwise
+	 * collapses a wholly-untracked directory into one entry naming the directory. The
+	 * adoption creates {@code .claude/} in a repository that by definition had none,
+	 * so the default reported its own work as the single path {@code .claude/} —
+	 * which is not one of the files it writes, and the resume it is entitled to was
+	 * refused.
+	 */
+	@Test
+	void asksForEveryUntrackedFileRatherThanTheDirectoriesTheyAreIn(@TempDir Path existingWorkspace)
+			throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = origin("https://github.com/adamw7/tools.git");
+
+		step.execute(existing, runner);
+
+		assertTrue(runner.commandAt(1).contains("--untracked-files=all"), runner.commandAt(1).toString());
+	}
+
+	/**
+	 * Every file the adoption writes into a directory the repository did not have, as
+	 * {@code --untracked-files=all} names them. This is the state a run that stopped
+	 * between {@link AssetsStep} and its commit leaves behind.
+	 */
+	@Test
+	void resumesReusedCheckoutWhoseAssetDirectoriesAreEntirelyNew(@TempDir Path existingWorkspace)
+			throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git", String.join(
+				System.lineSeparator(),
+				"?? .claude/hooks/session-start.sh",
+				"?? .claude/settings.json",
+				"?? .github/workflows/claude.yml",
+				"?? .mcp.json",
+				"?? AGENTS.md",
+				"?? CLAUDE.md"));
+
+		step.execute(existing, runner);
+
+		assertEquals(3, runner.count());
+	}
+
+	/** The fallback guard's two files land under a {@code .github/} a project may equally not have had. */
+	@Test
+	void resumesReusedCheckoutCarryingTheFallbackGuardsOwnFiles(@TempDir Path existingWorkspace)
+			throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git", String.join(
+				System.lineSeparator(),
+				"?? .github/claude-md-guard.sh",
+				"?? .github/workflows/claude-md-guard.yml"));
+
+		step.execute(existing, runner);
+
+		assertEquals(3, runner.count());
+	}
+
+	/** Both Gradle build files the guard may be appended to are the adoption's own edits. */
+	@Test
+	void resumesReusedCheckoutCarryingAnEditedGradleBuildFile(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
+				" M build.gradle" + System.lineSeparator() + " M build.gradle.kts");
+
+		step.execute(existing, runner);
+
+		assertEquals(3, runner.count());
+	}
+
+	/**
+	 * A collapsed directory entry names no file the adoption writes, so it is refused
+	 * rather than guessed at: were the flag ever dropped, the resume would fail loudly
+	 * instead of sweeping whatever else that directory holds into the adoption's
+	 * commit.
+	 */
+	@Test
+	void refusesADirectoryEntryThatNamesNoFileTheAdoptionWrites(@TempDir Path existingWorkspace)
+			throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git", "?? .claude/");
+
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
+
+		assertTrue(failure.getMessage().contains(".claude/"), failure.getMessage());
+	}
+
+	/**
+	 * One unrelated file among the adoption's own still stops the run, so the check
+	 * is not weakened into "some of this is mine".
+	 */
+	@Test
+	void refusesReusedCheckoutMixingTheAdoptionsChangesWithSomebodyElses(@TempDir Path existingWorkspace)
+			throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
+				"?? CLAUDE.md" + System.lineSeparator() + "?? .claude/settings.json" + System.lineSeparator()
+						+ "?? .claude/scratch.md");
+
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
+
+		assertTrue(failure.getMessage().contains(".claude/scratch.md"), failure.getMessage());
+		assertFalse(failure.getMessage().contains("settings.json"), failure.getMessage());
+	}
+
+	/** A clean checkout reports nothing, and the blank transcript names no changed path. */
+	@Test
+	void readsAnEmptyStatusAsACleanCheckout(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
+				System.lineSeparator() + "   " + System.lineSeparator());
+
+		step.execute(existing, runner);
+
+		assertEquals(3, runner.count());
+	}
+
+	/** Staged and unstaged forms of the adoption's own files carry different status letters. */
+	@Test
+	void readsEveryStatusLetterTheAdoptionsOwnFilesArriveWith(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git", String.join(
+				System.lineSeparator(),
+				"A  CLAUDE.md",
+				"M  pom.xml",
+				" M AGENTS.md",
+				"MM .mcp.json",
+				"?? .claude/settings.json"));
 
 		step.execute(existing, runner);
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystemTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystemTest.java
@@ -30,6 +30,42 @@ class FallbackBuildSystemTest {
 		assertEquals(List.of("sh", ".github/claude-md-guard.sh"), buildSystem.verifyCommand(directory));
 	}
 
+	/**
+	 * The guard's shell is a tool like any other, so it is probed before the adoption
+	 * spends a clone and a claude init on a checkout it could not have verified.
+	 */
+	@Test
+	void probesTheShellRatherThanAssumingEveryHostHasOne(@TempDir Path directory) {
+		assertEquals(List.of("sh", "-c", "exit 0"), buildSystem.toolProbe(directory).orElseThrow());
+	}
+
+	/** {@code sh --version} exits non-zero under dash, so the probe must not ask for one. */
+	@Test
+	void probesWithSomethingEveryPosixShellAnswers(@TempDir Path directory) {
+		assertFalse(buildSystem.toolProbe(directory).orElseThrow().contains("--version"));
+	}
+
+	@Test
+	void probesAndVerifiesWithTheOneShell(@TempDir Path directory) {
+		assertEquals(buildSystem.verifyCommand(directory).get(0),
+				buildSystem.toolProbe(directory).orElseThrow().get(0));
+	}
+
+	/** Nothing here is installable under the build system's own name. */
+	@Test
+	void advisesAboutAShellRatherThanAboutItself() {
+		String advice = buildSystem.toolAdvice();
+		assertTrue(advice.contains("sh"), advice);
+		assertFalse(advice.contains(buildSystem.name()), advice);
+	}
+
+	/** The script the verification runs is the one the workflow installs, not a second copy. */
+	@Test
+	void verifiesTheScriptTheGuardInstalls(@TempDir Path directory) {
+		buildSystem.install(directory);
+		assertTrue(Files.isRegularFile(directory.resolve(buildSystem.verifyCommand(directory).get(1))));
+	}
+
 	@Test
 	void installWritesTheWorkflowGuard(@TempDir Path directory) {
 		assertTrue(buildSystem.install(directory));

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestStepTest.java
@@ -91,6 +91,25 @@ class PullRequestStepTest {
 		assertFalse(runner.commandAt(1).contains("--repo"));
 	}
 
+	/**
+	 * A self-hosted GitHub reached on its own port names an owner like any other host.
+	 * Reading the port as a path segment left the URL apparently ownerless, so the
+	 * flag was dropped and {@code gh} was left to infer the repository from a remote
+	 * that an {@code insteadOf} rewrite or a proxied clone can make unreadable —
+	 * failing the last step of an otherwise complete adoption.
+	 */
+	@Test
+	void namesTheRepositoryOfAHostReachedOnAPort() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);
+		AdoptionContext ported = new AdoptionContext("https://ghe.example.com:8443/adamw7/tools.git",
+				Path.of("/tmp/workspace"));
+
+		new PullRequestStep().execute(ported, runner);
+
+		assertTrue(runner.commandAt(0).containsAll(List.of("--repo", "adamw7/tools")), runner.commandAt(0).toString());
+		assertTrue(runner.commandAt(1).containsAll(List.of("--repo", "adamw7/tools")), runner.commandAt(1).toString());
+	}
+
 	@Test
 	void usesConfiguredTitleAndBody() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::noOpenPullRequest);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
@@ -62,6 +62,24 @@ class ToolchainStepTest {
 		assertDoesNotThrow(() -> new ToolchainStep().execute(context, runner));
 	}
 
+	/**
+	 * The stronger, repository-scoped question is asked of a self-hosted GitHub on its
+	 * own port too. Reading the port as a path segment left the URL apparently
+	 * ownerless, so the step fell back to {@code gh api user} — the user-scoped call a
+	 * GitHub App installation token is refused by, and the very credential the ported
+	 * enterprise host is most likely to be driven with.
+	 */
+	@Test
+	void asksAboutTheRepositoryOfAHostReachedOnAPort() {
+		AdoptionContext ported = new AdoptionContext("https://ghe.example.com:8443/adamw7/tools.git",
+				Path.of("/tmp/workspace"));
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+
+		new ToolchainStep().execute(ported, runner);
+
+		assertEquals(List.of("gh", "api", "repos/adamw7/tools"), runner.commandAt(3));
+	}
+
 	/** A token GitHub answers, but not for this repository, cannot open the pull request either. */
 	@Test
 	void aTokenThatCannotSeeTheRepositoryAbortsTheAdoption() {


### PR DESCRIPTION
Each of these made an adoption fail on input the pipeline is documented to
handle, and each is now pinned by tests.

A resumed adoption was refused for its own work. CloneStep asks
`git status --porcelain` whether a reused checkout carries anything but the
adoption's own paths, and compares each reported path against the files
AdoptionAssets names. git collapses a wholly-untracked directory into one
entry, so the `.claude/` the adoption had just created came back as the single
path `.claude/` — not a file the adoption writes — and the resume the step
promises was refused. That is the ordinary case, not a corner of one: a
repository being adopted has no `.claude/` yet, and the fallback guard's
`.github/` is often new too. The status is now asked with
`--untracked-files=all`.

A clone URL with a port named no owner. repositorySlug splits on ':' as well as
'/' so the scp-like form's path separator is read as one, which made the port
of `https://ghe.example.com:8443/owner/repo` a path segment: the host check
landed on `8443` and the URL was reported as naming no owner. `gh` then lost
its `--repo` and was left to infer the repository from a remote an insteadOf
rewrite can make unreadable, ToolchainStep fell back to the user-scoped probe a
GitHub App installation token is refused by, and CliArguments rejected the URL
outright as a workspace mistaken for a repository. A port is now dropped before
the split, but only from a URL carrying a scheme — the scp-like form cannot have
one, so its ':' still separates a path even before an all-digit owner.
isSameRepositoryAs deliberately keeps reading the port as a segment: two ports
on one host are two servers, and that comparison may only err towards refusing.

The fallback guard's shell went unprobed. FallbackBuildSystem answered "no tool
to check" on the grounds that every platform provides `sh`, but a stock Windows
PATH does not — Git for Windows keeps its sh.exe under usr/bin unless the
operator opted into the Unix tools. The adoption ran to VerifyStep, past the
clone, the claude init, and both commits, before failing on a shell
BuildToolchainStep exists to catch at the second step. It now probes with
`sh -c 'exit 0'` rather than `--version`, which dash exits non-zero for. The
remedy text moves to BuildSystem.toolAdvice so a build-less repository is told
to find a shell instead of to "install github-actions on the PATH".

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R7DWRFhp4AJSGiouM5Ftak