### PR TITLE
docs(skills): cover the uncovered modules and slim solid-principles

### DIFF
--- a/.claude/skills/adopt-pipeline/README.md
+++ b/.claude/skills/adopt-pipeline/README.md
@@ -1,0 +1,42 @@
+# Adopt Pipeline
+
+**Load**: `view .claude/skills/adopt-pipeline/SKILL.md`
+
+---
+
+## Description
+
+Helps Claude work on the `adopt` module: the ordered adoption steps and what each
+one does, the `AdoptionStep` contract, the ArchUnit rules a new step must satisfy
+(no process spawning outside `command`, immutable state, credential masking), the
+CLI flags, and how batch runs isolate failures.
+
+---
+
+## Use Cases
+
+- "Add a step that installs a pre-commit hook during adoption"
+- "Why did the adoption stop at the verify step?"
+- "Run the adoption without pushing" (dry run)
+- "Adopt these five repositories in one run"
+
+---
+
+## Examples
+
+```
+> view .claude/skills/adopt-pipeline/SKILL.md
+> "Add a step that copies a CODEOWNERS file into the checkout"
+→ new *Step in .step, immutable fields, shell out via CommandRunner only,
+  register in GitHubRepoAdopter.defaultSteps, unit-test with a fake runner
+```
+
+---
+
+## Notes / Tips
+
+- A dry run omits `PushStep` and `PullRequestStep` outright — it does not run
+  them in a no-op mode.
+- Only `CloneStep` may read the credentialled clone URL; everything else uses
+  `displayUrl()`.
+- One failing repository must never abort the rest of a batch.

--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: adopt-pipeline
+description: Work on the adopt module — the ordered pipeline that adopts Claude Code into a GitHub repo (toolchain, clone, branch, trust, init, conform, enforcer, verify, push, PR), its step contract, CLI flags and credential masking. Use when adding or changing an adoption step, debugging a run, or when the user says "adopt", "adoption pipeline", "adopt_repo", or "dry run".
+---
+
+# Adopt Pipeline Skill
+
+Change the `adopt` module — a pipeline of small, ordered steps that clones a
+GitHub repository, wires Claude Code into it, and opens a pull request. The
+module's rules are unusually strict because it shells out to `git`, `gh` and
+`claude` against real repositories.
+
+## When to Use
+- Adding, reordering, or changing an `AdoptionStep`
+- Changing what the CLI or the `adopt_repo` MCP tool accepts
+- A run fails at a step and you need to know what that step does
+- The user says "adopt" / "adoption pipeline" / "adopt_repo" / "dry run"
+
+## The pipeline, in order
+`GitHubRepoAdopter.defaultSteps(options)` assembles:
+
+1. `ToolchainStep` — the pipeline's own tools: `git`, `claude`, `gh` (and `gh`
+   is logged in). Fails before any expensive work.
+2. `CloneStep` — clones into the workspace. **The only step allowed to read the
+   credentialled URL.**
+3. `BuildToolchainStep` — the *cloned project's* build tool, checked as soon as
+   the clone reveals which one it is.
+4. `BranchStep` — feature branch (`claude/adopt-claude-code` by default). The
+   default branch is never written to.
+5. `TrustStep` — marks the checkout trusted for Claude Code.
+6. `ClaudeInitStep` → `ClaudeMdConformanceStep` → `CommitStep` — generate
+   `CLAUDE.md`, conform it (plus a companion `AGENTS.md`) so it satisfies the
+   guard about to be wired in, commit.
+7. `EnforcerStep` → `CommitStep` — wire the build-tool-aware guard in and commit.
+8. *(optional)* `AssetsStep` → `CommitStep` — starter config assets, on `--assets`.
+9. `VerifyStep` — proves the guard passes on the generated file.
+10. `PushStep` → `PullRequestStep` — **omitted entirely on a dry run**, so the
+    report says what a dry run really did rather than listing steps that
+    pretended to run.
+
+The three build-system-aware steps (`BuildToolchainStep`, `EnforcerStep`,
+`VerifyStep`) share one `BuildSystems.defaults(...)` list, so the guard that is
+wired in is the guard that is verified with the tool that was probed
+(`MavenBuildSystem`, `GradleBuildSystem`, `FallbackBuildSystem`).
+
+## The step contract
+```java
+public interface AdoptionStep {
+    String name();
+    void execute(AdoptionContext context, CommandRunner runner);
+    default void execute(AdoptionContext context, CommandRunner runner, AdoptionReport report) {
+        execute(context, runner);   // most steps have nothing to report
+    }
+}
+```
+Implement the three-argument variant only when the step contributes a fact to
+the report (e.g. `PullRequestStep` and the PR URL).
+
+### Adding a step — the checklist ArchUnit enforces
+- Class name **ends with `Step`** and lives in `…adopt.step`.
+- **Never spawn a process yourself.** `ProcessBuilder`/`Runtime` are confined to
+  the `command` package; a step shells out only through `CommandRunner`.
+  `AbstractCommandStep` is the usual base.
+- Fields are **immutable** (step state is final).
+- A step must not depend on `GitHubRepoAdopter` — the pipeline knows its steps,
+  not the other way round.
+- Only `CloneStep` may touch `AdoptionContext#repositoryUrl()`; everything else
+  logs `displayUrl()`. `Redaction` masks credentials in every log, message and
+  report — keep it that way.
+- Register the step in `GitHubRepoAdopter.defaultSteps` (or the optional list it
+  belongs to), and unit-test it with a fake `CommandRunner`.
+
+## Batch runs and failure isolation
+One run adopts a list of repositories: repeatable `--repo <url>`, `--repos
+<file>`, or `repository_urls` on the MCP tool. Each gets its own checkout
+(claimed inside its own adoption via `Checkouts`) and its own `AdoptionReport`,
+and **a repository that fails does not stop the rest** — a malformed URL
+included. Preserve that when changing `BatchAdoption` or `Failures`.
+
+## CLI flags
+`--repo`, `--repos`, `--workspace`, `--branch`, `--title`, `--body`,
+`--reviewer`, `--label`, `--assignee`, `--draft`, `--assets`, `--dry-run`,
+`--rule-version`, `--timeout <minutes>`, `--report <file>`, `--help`. They build
+an `AdoptionOptions` (wrapping `PullRequestOptions`) that both entry points —
+`Main` and the MCP `AdoptTool` — hand to the pipeline factory.
+
+## Testing
+- Step tests use a fake `CommandRunner`: **a test must never spawn a real
+  process** (pinned by `TestConventionsArchitectureTest`).
+- `MultiRepoAdoptionIT` clones real sample repositories to prove each gets its
+  own checkout, and **stops at the branch step** — the `*IT`s never push and
+  never open a pull request. Keep that invariant when extending them.
+- Run them with `mvn -P integration-tests verify` (the profile is declared in
+  `adopt`'s own pom).
+
+## References
+- `CLAUDE.md` / `AGENTS.md` — *Claude Code adoption* (source of truth)
+- `adopt/.../GitHubRepoAdopter.java` — the assembled pipeline
+- `adopt/.../architecture/AdoptArchitectureTest.java` — the rules above, as tests
+- `adopt/.../mcp/MCP_USAGE.md` — the `adopt_repo` tool

--- a/.claude/skills/context-finder/README.md
+++ b/.claude/skills/context-finder/README.md
@@ -1,0 +1,42 @@
+# Context Finder
+
+**Load**: `view .claude/skills/context-finder/SKILL.md`
+
+---
+
+## Description
+
+Helps Claude use the `code/context` module: the `Context` contract, the
+name-based `Finder` vs the `PackageAwareFinder`, `ProjectSources` loading,
+`BudgetedContext` with a `TokenEstimator`, the project-tree builder and its
+serializers, and the three MCP tools over them.
+
+---
+
+## Use Cases
+
+- "Which classes does `KeyFinder.java` depend on, two levels deep?"
+- "Render this project as a Mermaid dependency graph"
+- "Fit this context into an 8k budget"
+- "Add Scala support / a new serializer"
+
+---
+
+## Examples
+
+```
+> view .claude/skills/context-finder/SKILL.md
+> "Assemble the context for KeyFinder within a 5000-token budget"
+→ ProjectSources.load(root) → new BudgetedContext(new Finder(containers),
+  new SubwordTokenEstimator(), 5000).find(root, depth)
+```
+
+---
+
+## Notes / Tips
+
+- Use `PackageAwareFinder` when simple names collide; `Finder` is faster when
+  they don't.
+- Budgeting relies on breadth-first order — don't re-sort the result before
+  trimming.
+- The core stays free of the `mcp` package; ArchUnit fails the build otherwise.

--- a/.claude/skills/context-finder/SKILL.md
+++ b/.claude/skills/context-finder/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: context-finder
+description: Assemble gen-AI context with the code/context module — the class-usage finders (name-based vs package-aware), the project-tree builder and its serializers, token estimation and budgeting, and the project_tree/find_context/estimate_tokens MCP tools. Use when gathering the classes a file depends on, scanning a project into a tree, sizing context for a model, or when the user says "find context", "project tree", or "estimate tokens".
+---
+
+# Context Finder Skill
+
+Use `code/context` to answer "which classes does this file actually need?" and
+"how many tokens will that cost?" — the module behind the `project_tree`,
+`find_context` and `estimate_tokens` MCP tools.
+
+## When to Use
+- Collecting the dependency closure of a source file to feed a model
+- Scanning a project into a tree of folders, files and class dependencies
+- Sizing or trimming context against a token budget
+- Adding a language, a serializer, or a resolution strategy
+- The user says "find context" / "project tree" / "estimate tokens"
+
+## The core contract
+```java
+public interface Context {
+    Set<ClassContainer> find(ClassContainer root, int depth);
+}
+```
+A `ClassContainer` is just a `className` (the file name) plus its
+`originalCode`. `depth` bounds a breadth-first expansion, so nearest
+dependencies come first — which is what makes budgeting meaningful.
+
+Load a project's sources with `new ProjectSources(Language.JAVA).load(root)`,
+which returns `Map<Path, ClassContainer>`. Languages: `JAVA` (`.java`),
+`KOTLIN` (`.kt`), `SCALA` (`.scala`).
+
+## Pick the right finder
+| Finder | Resolves by | Use when |
+|---|---|---|
+| `Finder` | simple file name, indexed once at construction | one class per simple name; fastest |
+| `PackageAwareFinder` | `package` + `import` declarations | two classes share a simple name in different packages |
+
+`PackageAwareFinder` prefers, in order: an explicit import, the referencing
+file's own package, a wildcard import, then a sole project-wide candidate — and
+leaves a genuinely ambiguous reference **unresolved rather than guessed**. Both
+strip comments and string/character literals before matching, so a class name
+mentioned in a comment is not reported as a dependency. The
+`package`/`import` grammar is shared by all three languages.
+
+## Budgeting
+`BudgetedContext` decorates any `Context`: it keeps the delegate's breadth-first
+order and accepts containers until the next one would exceed the budget, so you
+keep the highest-priority prefix of the graph.
+
+```java
+Context context = new BudgetedContext(new Finder(containers), new SubwordTokenEstimator(), 8_000);
+```
+Estimators implement `TokenEstimator`: `SubwordTokenEstimator` (respects word
+and symbol boundaries — the better default) and `HeuristicTokenEstimator`.
+
+## Project tree
+`ProjectTreeBuilder(contextFactory, language, depth).build(root)` returns a
+`ProjectTreeNode`. Serialize with a `ProjectTreeSerializer`:
+`ProjectTreeJsonSerializer` (the MCP default), `…Markdown…`, `…Dot…` (Graphviz),
+`…Mermaid…`, or print with `ProjectTreePrinter`. The builder takes a
+`ContextFactory`, so a different finder can be substituted without touching the
+builder — add a serializer or a factory rather than branching inside the
+builder.
+
+## MCP tools
+`project_tree`, `find_context` and `estimate_tokens` are the adapter over the
+above, in `…context.mcp`. `PathPolicy` confines them to allowed directories.
+**The core must never depend on the `mcp` package** — ArchUnit pins it. See the
+`mcp-server` skill before changing a tool, and update
+`code/context/.../mcp/MCP_USAGE.md` in the same change.
+
+## Adding to this module
+- New language → add to `Language` with its extension; the finders follow.
+- New output format → implement `ProjectTreeSerializer`, don't extend the tree.
+- New resolution strategy → extend `AbstractFinder` and supply
+  `findDirectDependencies`; traversal and depth-bounding are inherited.
+
+## References
+- `code/context/.../mcp/MCP_USAGE.md` — the three tools and their parameters
+- `README.md` — *Context engineering* worked examples
+- `.claude/skills/mcp-server/SKILL.md` — for the adapter side

--- a/.claude/skills/data-sources/SKILL.md
+++ b/.claude/skills/data-sources/SKILL.md
@@ -64,6 +64,18 @@ The checker consumes a `ColumnarDataSource`, asks whether the given columns form
 a key, and searches for a smaller one. `InMemory…` runs recursive passes over a
 single load; `NoMemory…` re-reads the source per pass for a tiny heap.
 
+## Data structures (`data.structure`)
+Open-addressing collections with double hashing, for when `HashMap`'s per-entry
+node allocation is what hurts:
+- `OpenAddressingMap<K, V>` / `OpenAddressingSet<E>` — implement `Map` / `Set`.
+- `IntKeyOpenAddressingMap<V>` — primitive `int[]` keys, so lookups and inserts
+  never box. It deliberately does **not** implement `Map` (that contract is
+  defined over `Object` keys and would reintroduce the boxing it exists to
+  avoid), and mirrors the map operations with primitive keys instead.
+- All three store a `null` value faithfully and report it from `containsKey`;
+  only `get` cannot tell a stored `null` from an absent key. **None is
+  thread-safe.**
+
 ## Adding a new source
 Implement `IterableDataSource` (five methods; `nextRows` is a default). If it can
 report its columns, also implement `ColumnarDataSource` so schema-dependent

--- a/.claude/skills/doc-contract/README.md
+++ b/.claude/skills/doc-contract/README.md
@@ -1,0 +1,41 @@
+# Doc Contract
+
+**Load**: `view .claude/skills/doc-contract/SKILL.md`
+
+---
+
+## Description
+
+Helps Claude keep `CLAUDE.md`, `AGENTS.md`, `README.md` and the `.claude`
+configuration inside the contract the enforcer rules validate: required
+headings, the 32 KB context budget, the module map, the facts pinned across
+documents, and the skill front-matter conventions.
+
+---
+
+## Use Cases
+
+- "Add a new module to the reactor" (three files must change together)
+- "Bump the project to Java 26"
+- "`-DenforceClaudeMd` fails with moduleMapConsistency"
+- "Document this feature — where does it go?"
+
+---
+
+## Examples
+
+```
+> view .claude/skills/doc-contract/SKILL.md
+> "I added a `graph` module — the doc check is red"
+→ mention it in the CLAUDE.md module map AND AGENTS.md "Module layout",
+  then mvn -pl claude-code-enforcer -am install && mvn -N validate -DenforceClaudeMd
+```
+
+---
+
+## Notes / Tips
+
+- AGENTS.md wins over CLAUDE.md; CLAUDE.md is a budgeted summary.
+- A required heading with an empty body fails just like a missing one.
+- Skill directory name must equal the front-matter `name`, and descriptions must
+  be unique across all skills.

--- a/.claude/skills/doc-contract/SKILL.md
+++ b/.claude/skills/doc-contract/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: doc-contract
+description: Keep CLAUDE.md, AGENTS.md and README.md satisfying the enforced documentation contract — required headings, the 32 KB context budget, the module map, and the facts pinned across documents. Use when adding a module, editing any of those files, bumping the Java version, or when the user says "the doc check fails", "moduleMapConsistency", or "context budget".
+---
+
+# Doc Contract Skill
+
+In this repository the documentation is a build artifact: `CLAUDE.md`,
+`AGENTS.md` and `README.md` are validated by the `claude-code-enforcer` rules,
+and a `-DenforceClaudeMd` build fails when they drift. Edit them with the rules
+in mind rather than discovering them in CI.
+
+## When to Use
+- Adding or removing a Maven module
+- Editing `CLAUDE.md`, `AGENTS.md` or `README.md`
+- Changing the Java version, or the protobuf major version
+- The user says "the doc check fails" / "moduleMapConsistency" / "context budget"
+
+## Who is the source of truth
+`AGENTS.md` is the single source of truth. `CLAUDE.md` is a **quick-reference
+summary** that defers to it — it is loaded into every session, so
+`contextBudget` caps it at **32 KB**. New detail belongs in `AGENTS.md` or in a
+skill, not in `CLAUDE.md`.
+
+## Required structure
+
+| Document | Title | Required `##` sections |
+|---|---|---|
+| `CLAUDE.md` | `# CLAUDE.md` | Project · Java version · Maven · Principles for Java Development · Testing · Dependencies |
+| `AGENTS.md` | `# AGENTS.md` | Project overview · Module layout · Environment & toolchain · Build, test, and run · Code style & conventions · Releasing · Pull requests & commits |
+
+Also checked: the title must be the **first non-blank line**; a required section
+must have a **non-empty body** (a heading with nothing under it fails);
+`CLAUDE.md` must reference `AGENTS.md`; and `memoryImports` validates the
+`@`-import graph.
+
+## The consistency rules — what must change together
+
+- **`moduleMapConsistency`** — every `<module>` in the root `pom.xml` must be
+  mentioned in **both** `CLAUDE.md` and `AGENTS.md`. Adding a module means
+  editing three files in one commit: the pom, the module map in `CLAUDE.md`, and
+  *Module layout* in `AGENTS.md`.
+- **`crossDocConsistency`** — the `Java (\d+)` pattern must read the same in
+  `CLAUDE.md` and `AGENTS.md`. A JDK bump touches both.
+- **`readmeConsistency`** — the `proto(\d)` pattern must agree between
+  `README.md` and `AGENTS.md`.
+- **`contextBudget`** — `CLAUDE.md` ≤ 32 KB.
+- **`noSecrets`** — no credentials in `.claude/settings.json`, `.mcp.json`, or
+  `.claude/hooks`.
+
+## Skills, settings and hooks are checked too
+- `skillFilesExist` — each directory under `.claude/skills` needs a non-empty
+  `SKILL.md` opening with YAML front matter carrying `name` and `description`.
+  The `name` must be **lower-case kebab-case, ≤ 64 chars, and equal to the
+  directory name**; an unknown front-matter key is reported (it catches
+  `descripton`).
+- `uniqueNames` / `uniqueDescriptions` — two definitions may not share a name or
+  a description (compared case- and whitespace-insensitively). Claude routes by
+  description, so duplicates make one skill shadow another. Write a description
+  that says *what it covers* **and** *when to use it*, with the trigger phrases.
+- `settingsJsonValid`, `permissionsFormat`, `hookCommandsValid`, `hooksFormat`,
+  `localSettingsIgnored` — `.claude/settings.json`, the hook scripts, and the
+  `.claude/settings.local.json` entry in `.gitignore` (removing that entry fails
+  the build).
+
+## Running the check
+```bash
+mvn -pl claude-code-enforcer -am install   # publish the rule locally first
+mvn -N validate -DenforceClaudeMd          # root-only doc check, seconds
+```
+The check is opt-in; only `.github/workflows/maven.yml` runs it in CI
+(`mvn -B package -DenforceClaudeMd`).
+
+## Checklist for a doc change
+1. Put the detail in `AGENTS.md`; summarise in `CLAUDE.md` only if a session
+   needs it every time.
+2. Adding a module? Update the root pom, the `CLAUDE.md` module map, and
+   `AGENTS.md` *Module layout* together.
+3. Changing a pinned fact (Java version, protobuf major)? Change it everywhere
+   the pattern appears.
+4. Adding a skill? Directory name = front-matter `name`; unique description.
+5. Re-run the two commands above before committing.
+
+## References
+- `AGENTS.md` — *CLAUDE.md enforcement* (full rule catalogue)
+- `docs/adr/0010-documentation-as-enforced-contract.md` — why this exists
+- Root `pom.xml` — the `claude-md-enforce` profile's `<rules>` block

--- a/.claude/skills/enforcer-rules/README.md
+++ b/.claude/skills/enforcer-rules/README.md
@@ -1,0 +1,42 @@
+# Enforcer Rules
+
+**Load**: `view .claude/skills/enforcer-rules/SKILL.md`
+
+---
+
+## Description
+
+Helps Claude write, test and wire a `claude-code-enforcer` rule: the base class
+contract, the one-directional package layering, the two-phase build a
+maven-enforcer rule needs, and the `severity` / `reportFile` / `baselineFile`
+options every rule inherits.
+
+---
+
+## Use Cases
+
+- "Add a rule that checks X in CLAUDE.md"
+- "Why does `-DenforceClaudeMd` fail?"
+- "Gate this new rule without fixing the backlog first"
+- "Wire the sub-agent rule into the build"
+
+---
+
+## Examples
+
+```
+> view .claude/skills/enforcer-rules/SKILL.md
+> "Add an enforcer rule that fails when a skill has no README.md"
+→ new *Rule extends ClaudeCodeEnforcerRule in .definition, collect violations,
+  report(...), test with TestFiles + @TempDir, wire under claude-md-enforce
+```
+
+---
+
+## Notes / Tips
+
+- Always `mvn -pl claude-code-enforcer -am install` before re-running the check —
+  otherwise the old rule JAR is what runs.
+- Collect every violation and report them together; never throw on the first.
+- Feature packages may not depend on each other — push shared logic into `rule`
+  or `text`.

--- a/.claude/skills/enforcer-rules/SKILL.md
+++ b/.claude/skills/enforcer-rules/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: enforcer-rules
+description: Write, test and wire a claude-code-enforcer rule — the custom maven-enforcer rules that fail the build when CLAUDE.md, AGENTS.md, README.md or the .claude configuration is malformed. Use when adding or changing a rule, when configuring severity/reportFile/baselineFile, or when the user says "enforcer rule", "the doc check fails", or "wire a rule into the pom".
+---
+
+# Enforcer Rules Skill
+
+Add or change a rule in `claude-code-enforcer`, the module of custom
+`maven-enforcer-plugin` rules that guard this repository's agent-facing files.
+Every rule follows the same shape, so getting the shape right is most of the
+work.
+
+## When to Use
+- Adding a new enforcer rule, or changing what an existing one accepts
+- Wiring a rule into the root `pom.xml`, or setting `severity` / `reportFile` /
+  `baselineFile`
+- A `-DenforceClaudeMd` build fails and you need to know which rule spoke
+- The user says "enforcer rule" / "the doc check fails" / "wire a rule"
+
+## The two-phase build (there is no shortcut)
+A maven-enforcer rule must be resolvable as a JAR *before* the build that uses
+it runs, so a change to a rule needs two commands:
+
+```bash
+mvn -pl claude-code-enforcer -am install   # 1. publish the rule locally
+mvn -N validate -DenforceClaudeMd          # 2. quick root-only doc check
+```
+
+Skipping step 1 runs the *previous* rule against your new expectations. The
+check is opt-in (`claude-md-enforce` profile, activated by `-DenforceClaudeMd`),
+so ordinary builds are unaffected; `.github/workflows/maven.yml` is the only
+workflow that opts in.
+
+## Anatomy of a rule
+
+```java
+@Named("myNewRule")                                  // the pom's <myNewRule> element
+public class MyNewRule extends ClaudeCodeEnforcerRule {
+
+    private File someFile;                           // injected from the configuration
+
+    @Override
+    public void execute() throws EnforcerRuleException {
+        requireDocument(someFile, "someFile");       // build-setup checks first
+        String content = requireContent(someFile, "someFile");
+        List<String> violations = new ArrayList<>();
+        // ... collect every problem, never stop at the first ...
+        report("What went wrong, in one line:", violations);
+    }
+
+    void setSomeFile(File someFile) {                // package-private setter per parameter
+        this.someFile = someFile;
+    }
+}
+```
+
+Rules that check a property across *every* definition (skills, sub-agents,
+commands) extend `MultiDefinitionRule` instead and call `forEachDefinition(...)`
+— it already owns `commandsDir` / `agentsDir` / `skillsDir` traversal, where a
+skill is a directory holding a `SKILL.md`.
+
+### What the base class gives you (don't reimplement it)
+| Member | Use it for |
+|---|---|
+| `report(header, violations)` | The single exit point: baseline filtering, HTML report, warn-vs-fail |
+| `requireConfigured` / `requireExists` / `requireDocument` | Missing parameter or file — always fails, whatever the severity |
+| `requireContent` | Read a required file and fail when blank |
+| `howToFix()` | Override to give the HTML report rule-specific remediation steps |
+
+Shared configuration every rule inherits: `severity` (`error` default, `warn`
+logs only), `reportFile` (self-contained HTML), `baselineFile` +
+`writeBaseline` (`-Dclaude.enforcer.writeBaseline=true` records current
+violations so a new rule can be gated without clearing the backlog first), and
+`baseDir` for the baseline's `${basedir}` token.
+
+## Rules the module's own ArchUnit tests pin
+- **Layering is one-directional**: `text` depends on nothing; `rule` may use
+  `text`; the feature packages (`definition`, `doc`, `mcp`, `secret`,
+  `settings`) may use `rule` and `text` — **never each other**. Shared logic
+  goes down into `text` or `rule`, not sideways.
+- Every concrete `*Rule` must extend `ClaudeCodeEnforcerRule`.
+- Packages stay free of cycles, plus the repo-wide `CommonCodingConventions`.
+
+## Collect, then report
+Report *all* violations together, not the first one. A rule that throws mid-scan
+makes a contributor fix one problem per build. Build a `List<String>` and hand it
+to `report(...)`.
+
+## Testing a rule
+- Tests live beside the rule (`…/enforcer/<package>/MyNewRuleTest.java`) and lay
+  out fixtures in a `@TempDir` with the `TestFiles` helpers
+  (`writeString`, `writeBytes`, `createDirectory`) — they wrap `IOException`
+  unchecked so a fixture reads as one expression.
+- Assert on the *message*, not just the throw: check
+  `EnforcerRuleException#getMessage()` names the offending file and value.
+- `CapturingLogger` lets a test assert what `severity=warn` logged instead of
+  threw.
+- Cover: passes when correct, fails per violation kind, passes on an empty
+  directory, and the always-fails build-setup cases (missing parameter/file).
+
+## Wiring it into the root pom
+Add the `@Named` element under the `claude-md-enforce` profile's `<rules>` block
+in the root `pom.xml`, with one child per parameter:
+
+```xml
+<myNewRule>
+    <someFile>${project.basedir}/CLAUDE.md</someFile>
+</myNewRule>
+```
+
+Then document it in the `## CLAUDE.md enforcement` sections of `CLAUDE.md` and
+`AGENTS.md` — that list is the rule catalogue contributors read.
+
+**A rule whose definition directory must exist can only be wired once the
+directory does.** `subAgentFormat` (`.claude/agents`) and `commandFormat`
+(`.claude/commands`) ship but are deliberately unwired here, because a
+configured-but-absent directory is treated as a build-setup mistake. Add the
+directory and the wiring in the same change. `pluginFormat`, `mcpServersValid`
+and `mcpConfigFormat` differ — they pass on the absent file and start enforcing
+the moment one appears.
+
+## References
+- `AGENTS.md` — *CLAUDE.md enforcement* (source of truth, full rule catalogue)
+- `claude-code-enforcer/.../rule/ClaudeCodeEnforcerRule.java` — the base contract
+- `claude-code-enforcer/.../architecture/EnforcerArchitectureTest.java` — layering
+- Root `pom.xml` — the `claude-md-enforce` profile

--- a/.claude/skills/mcp-server/README.md
+++ b/.claude/skills/mcp-server/README.md
@@ -1,0 +1,40 @@
+# MCP Server
+
+**Load**: `view .claude/skills/mcp-server/SKILL.md`
+
+---
+
+## Description
+
+Helps Claude add or change an MCP tool or server on the shared `mcp-common`
+scaffolding: the `McpTool` SPI, transport-neutral `ToolDefinition` /
+`ToolResult`, `ToolArguments` parsing, the three transports, path confinement,
+the `MCP_USAGE.md` convention and the `*IT` tests.
+
+---
+
+## Use Cases
+
+- "Expose the key finder over MCP"
+- "Add a `format` argument to the project_tree tool"
+- "Run the MCP server over HTTP instead of stdio"
+
+---
+
+## Examples
+
+```
+> view .claude/skills/mcp-server/SKILL.md
+> "Add an estimate_rows tool to the uniqueness server"
+→ implement McpTool (ToolDefinition + apply), parse with ToolArguments,
+  register in McpConfiguration.tools(), update MCP_USAGE.md, add a unit test
+```
+
+---
+
+## Notes / Tips
+
+- A tool must not import the MCP SDK — the scaffolding translates the SPI types.
+- Thrown `RuntimeException`s already become error results; don't wrap for the
+  protocol.
+- The `integration-tests` profile is declared per module, not in the root pom.

--- a/.claude/skills/mcp-server/SKILL.md
+++ b/.claude/skills/mcp-server/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: mcp-server
+description: Add or change an MCP tool or server on this repo's shared mcp-common scaffolding — the McpTool SPI, transport-neutral ToolDefinition/ToolResult, the three transports, path confinement, MCP_USAGE.md and the *IT tests. Use when exposing functionality over MCP, wiring a new server, or when the user says "MCP tool", "MCP server", "stdio transport", or "streamable HTTP".
+---
+
+# MCP Server Skill
+
+Expose functionality over the Model Context Protocol using `mcp-common`, the
+shared scaffolding behind all three servers here (`data` uniqueness,
+`code/context`, `adopt`). Transport, registration and error handling are already
+solved — a new tool writes none of that.
+
+## When to Use
+- Adding a tool to an existing MCP server, or standing a new server up
+- Changing a tool's input schema or its result
+- The user says "MCP tool" / "MCP server" / "stdio transport" / "streamable HTTP"
+
+## The SPI — a tool never mentions the MCP SDK
+```java
+public class MyTool implements McpTool {   // Function<Map<String,Object>, ToolResult>
+
+    @Override
+    public ToolDefinition getToolDefinition() {
+        return new ToolDefinition("my_tool", "What it does, for the model.",
+                Map.of("type", "object",
+                       "properties", Map.of("path", Map.of("type", "string")),
+                       "required", List.of("path")));
+    }
+
+    @Override
+    public ToolResult apply(Map<String, Object> arguments) {
+        String path = ToolArguments.requiredString(arguments, "path");
+        return ToolResult.success(answer);          // or ToolResult.error(message)
+    }
+}
+```
+
+- `ToolDefinition` (name, description, JSON-schema map) and `ToolResult`
+  (`success` / `error`) are the SPI's **own transport-neutral types**;
+  `AbstractMcpConfiguration` translates them into the SDK's `Tool` and
+  `CallToolResult`. Do not import `io.modelcontextprotocol` from a tool.
+- Parse arguments with `ToolArguments`: `requiredString`, `requiredInt`,
+  `optionalString`, `optionalBoolean`, `optionalInt`, `optionalBoundedInt` —
+  don't hand-roll casts out of the map.
+- **Don't catch-and-wrap for the protocol's sake.** `AbstractMcpConfiguration`
+  turns any thrown `RuntimeException` into an error `ToolResult` naming the
+  tool, so a bad argument reaches the client as an actionable tool error. Throw
+  a clear exception; return `ToolResult.error` when the failure is expected.
+
+## The server
+```java
+@Configuration
+public class McpConfiguration extends AbstractMcpConfiguration {
+    @Override protected String serverName() { return "my-server"; }
+    @Override protected List<McpTool> tools() { return List.of(new MyTool()); }
+}
+```
+That is the whole server. The base class supplies all three transports, selected
+with `--transport.mode`:
+
+| Mode | Value | Endpoint |
+|---|---|---|
+| stdio (default) | `stdio` | — |
+| streamable HTTP | `streamable-http` | `/mcp` |
+| stateless HTTP | `stateless-http` | `/mcp`, no session kept |
+
+A `Main.java` Spring Boot entry point sits next to the configuration
+(`entryPointsAreNamedMain` is an ArchUnit rule in `adopt`).
+
+## Rules that bite
+- **Confine file access.** A server that reads paths from a client must clamp
+  them to a configured base directory before returning any tool — the uniqueness
+  server does this in `tools()` via `PathValidator.setAllowedBaseDir`, defaulting
+  to the working directory, so a client cannot steer it at `/etc/passwd`.
+- **The core must not depend on its MCP adapter.** ArchUnit pins this in every
+  module: the uniqueness/context/adoption logic knows nothing about `mcp`, and
+  only the `mcp` package may see Spring or the scaffolding. Put the adapter in
+  `…/mcp`, keep the logic outside it.
+- Log through log4j2 — no `System.out`, which would corrupt the stdio transport
+  anyway.
+
+## Document and test it
+- Every server has an `MCP_USAGE.md` **next to its `mcp` package**, listing each
+  tool, its parameters and example calls. Update it in the same change as the
+  tool — it is the file users configure their client from.
+- The servers are covered by `*IT` tests over real HTTP, gated behind the
+  `integration-tests` profile: `mvn -P integration-tests verify`. The profile is
+  declared **per module** (`data`, `code/context`, `adopt`) — a new module's
+  `*IT`s do not run until that module gets its own copy.
+- Unit-test the tool directly as a function: build the argument map, assert on
+  the `ToolResult` text and `isError`.
+
+## References
+- `mcp-common/.../AbstractMcpConfiguration.java` — transports and registration
+- `data/.../uniqueness/mcp/` — the smallest complete example
+- `docs/adr/0009-mcp-servers-on-spring-boot.md` — why Spring Boot
+- The three `MCP_USAGE.md` files — the user-facing contract

--- a/.claude/skills/solid-principles/README.md
+++ b/.claude/skills/solid-principles/README.md
@@ -1,12 +1,16 @@
 # SOLID Principles
 
 **Load**: `view .claude/skills/solid-principles/SKILL.md`
+**Worked examples**: `view .claude/skills/solid-principles/examples.md`
 
 ---
 
 ## Description
 
-SOLID principles checklist with detailed Java examples. Each principle includes violation examples, refactored solutions, and detection patterns.
+SOLID checklist grounded in this repository: detection heuristics and the
+refactoring that fixes each violation, with the real examples from `data`,
+`adopt`, `code/context` and `mcp-common`. Full before/after code lives in
+`examples.md`, loaded only when a worked example is needed.
 
 ---
 
@@ -26,7 +30,7 @@ SOLID principles checklist with detailed Java examples. Each principle includes 
 ```
 > view .claude/skills/solid-principles/SKILL.md
 > "Review this UserService for SOLID principles"
-→ Identifies SRP violation, suggests extraction of validation and notification
+→ Identifies the SRP violation, suggests extracting validation and notification
 ```
 
 ---
@@ -43,11 +47,21 @@ SOLID principles checklist with detailed Java examples. Each principle includes 
 
 ---
 
+## Notes / Tips
+
+- `ColumnarDataSource` vs `IterableDataSource` is this repo's ISP in one line —
+  don't widen a contract to silence a compile error.
+- A field must never be `Optional` here (ArchUnit); as a return type it's fine.
+- Wiring is plain constructor injection — no Spring or CDI outside the MCP
+  adapters.
+
+---
+
 ## Related Skills
 
-- `design-patterns` - Implementation patterns
-- `clean-code` - DRY, KISS, YAGNI
-- `java-code-review` - Full review checklist
+- `java-code-review` — the full review checklist, led by the enforced rules
+- `testing-conventions` — the network-off tests these abstractions enable
+- `data-sources` — the schema contract used as the ISP example
 
 ---
 

--- a/.claude/skills/solid-principles/SKILL.md
+++ b/.claude/skills/solid-principles/SKILL.md
@@ -1,640 +1,147 @@
 ---
 name: solid-principles
-description: SOLID principles checklist with Java examples. Use when reviewing classes, refactoring code, or when user asks about Single Responsibility, Open/Closed, Liskov, Interface Segregation, or Dependency Inversion.
+description: Apply and review SOLID in this repo's Java — the detection heuristics per principle, the refactoring that fixes each one, and the real examples in data, adopt, context and mcp-common. Use when reviewing class design, refactoring a large class, or when the user says "check SOLID", "is this class doing too much?", or names one of the five principles.
 ---
 
 # SOLID Principles Skill
 
-Review and apply SOLID principles in Java code.
+Review and apply SOLID in the `tools` reactor. The heuristics below are the fast
+path; long before/after code lives in **`examples.md`** next to this file — load
+it only when a worked example would actually help.
 
 ## When to Use
 - User says "check SOLID" / "SOLID review" / "is this class doing too much?"
-- Reviewing class design
-- Refactoring large classes
-- Code review focusing on design
+- Reviewing class design or refactoring a large class
+- Choosing where a new abstraction belongs
 
----
-
-## Quick Reference
+## Quick reference
 
 | Letter | Principle | One-liner |
 |--------|-----------|-----------|
 | **S** | Single Responsibility | One class = one reason to change |
 | **O** | Open/Closed | Open for extension, closed for modification |
 | **L** | Liskov Substitution | Subtypes must be substitutable for base types |
-| **I** | Interface Segregation | Many specific interfaces > one general interface |
+| **I** | Interface Segregation | Many specific interfaces beat one general one |
 | **D** | Dependency Inversion | Depend on abstractions, not concretions |
 
 ---
 
-## S - Single Responsibility Principle (SRP)
+## S — Single Responsibility
+> One reason to change.
 
-> "A class should have only one reason to change."
+**Detect**: imports from unrelated domains · a name containing "And", "Manager"
+or "Handler" · methods that use none of the fields · you cannot describe the
+class in one sentence without "and".
 
-### Violation
+**Fix**: Extract Class / Move Method.
 
-```java
-// ❌ BAD: UserService does too much
-public class UserService {
-
-    public User createUser(String name, String email) {
-        // validation logic
-        if (email == null || !email.contains("@")) {
-            throw new IllegalArgumentException("Invalid email");
-        }
-
-        // persistence logic
-        User user = new User(name, email);
-        entityManager.persist(user);
-
-        // notification logic
-        String subject = "Welcome!";
-        String body = "Hello " + name;
-        emailClient.send(email, subject, body);
-
-        // audit logic
-        auditLog.log("User created: " + email);
-
-        return user;
-    }
-}
-```
-
-**Problems:**
-- Validation changes? Modify UserService
-- Email template changes? Modify UserService
-- Audit format changes? Modify UserService
-- Hard to test each concern separately
-
-### Refactored
-
-```java
-// ✅ GOOD: Each class has one responsibility
-
-public class UserValidator {
-    public void validate(String name, String email) {
-        if (email == null || !email.contains("@")) {
-            throw new ValidationException("Invalid email");
-        }
-    }
-}
-
-public class UserRepository {
-    public User save(User user) {
-        entityManager.persist(user);
-        return user;
-    }
-}
-
-public class WelcomeEmailSender {
-    public void sendWelcome(User user) {
-        String subject = "Welcome!";
-        String body = "Hello " + user.getName();
-        emailClient.send(user.getEmail(), subject, body);
-    }
-}
-
-public class UserAuditLogger {
-    public void logCreation(User user) {
-        auditLog.log("User created: " + user.getEmail());
-    }
-}
-
-public class UserService {
-    private final UserValidator validator;
-    private final UserRepository repository;
-    private final WelcomeEmailSender emailSender;
-    private final UserAuditLogger auditLogger;
-
-    public User createUser(String name, String email) {
-        validator.validate(name, email);
-        User user = repository.save(new User(name, email));
-        emailSender.sendWelcome(user);
-        auditLogger.logCreation(user);
-        return user;
-    }
-}
-```
-
-### How to Detect SRP Violations
-
-- Class has many `import` statements from different domains
-- Class name contains "And" or "Manager" or "Handler" (often)
-- Methods operate on unrelated data
-- Changes in one area require touching unrelated methods
-- Hard to name the class concisely
-
-### Quick Check Questions
-
-1. Can you describe the class purpose in one sentence without "and"?
-2. Would different stakeholders request changes to this class?
-3. Are there methods that don't use most of the class fields?
+**Here**: an `AdoptionStep` is one stage of the adoption and nothing else;
+`ClaudeCodeEnforcerRule.report(...)` is the one exit point every enforcer rule
+funnels its violations through; the uniqueness core knows nothing about its MCP
+adapter (ArchUnit fails the build if it learns).
 
 ---
 
-## O - Open/Closed Principle (OCP)
+## O — Open/Closed
+> New behaviour arrives as a new class, not an edit to an old one.
 
-> "Software entities should be open for extension, but closed for modification."
+**Detect**: an `if/else` or `switch` on a type or status that keeps growing ·
+adding a feature means editing a core class.
 
-### Violation
+**Fix**: Strategy, Template Method, Decorator, Factory.
 
-```java
-// ❌ BAD: Must modify class to add new discount type
-public class DiscountCalculator {
-
-    public double calculate(Order order, String discountType) {
-        if (discountType.equals("PERCENTAGE")) {
-            return order.getTotal() * 0.1;
-        } else if (discountType.equals("FIXED")) {
-            return 50.0;
-        } else if (discountType.equals("LOYALTY")) {
-            return order.getTotal() * order.getCustomer().getLoyaltyRate();
-        }
-        // Every new discount type = modify this class
-        return 0;
-    }
-}
-```
-
-### Refactored
-
-```java
-// ✅ GOOD: Add new discounts without modifying existing code
-
-public interface DiscountStrategy {
-    double calculate(Order order);
-    boolean supports(String discountType);
-}
-
-public class PercentageDiscount implements DiscountStrategy {
-    @Override
-    public double calculate(Order order) {
-        return order.getTotal() * 0.1;
-    }
-
-    @Override
-    public boolean supports(String discountType) {
-        return "PERCENTAGE".equals(discountType);
-    }
-}
-
-public class FixedDiscount implements DiscountStrategy {
-    @Override
-    public double calculate(Order order) {
-        return 50.0;
-    }
-
-    @Override
-    public boolean supports(String discountType) {
-        return "FIXED".equals(discountType);
-    }
-}
-
-public class LoyaltyDiscount implements DiscountStrategy {
-    @Override
-    public double calculate(Order order) {
-        return order.getTotal() * order.getCustomer().getLoyaltyRate();
-    }
-
-    @Override
-    public boolean supports(String discountType) {
-        return "LOYALTY".equals(discountType);
-    }
-}
-
-// New discount? Just add new class, no modification needed
-public class SeasonalDiscount implements DiscountStrategy {
-    @Override
-    public double calculate(Order order) {
-        return order.getTotal() * 0.2;
-    }
-
-    @Override
-    public boolean supports(String discountType) {
-        return "SEASONAL".equals(discountType);
-    }
-}
-
-public class DiscountCalculator {
-    private final List<DiscountStrategy> strategies;
-
-    public DiscountCalculator(List<DiscountStrategy> strategies) {
-        this.strategies = strategies;
-    }
-
-    public double calculate(Order order, String discountType) {
-        return strategies.stream()
-            .filter(s -> s.supports(discountType))
-            .findFirst()
-            .map(s -> s.calculate(order))
-            .orElse(0.0);
-    }
-}
-```
-
-### How to Detect OCP Violations
-
-- `if/else` or `switch` on type/status that grows over time
-- Enum-based dispatching with frequent new values
-- Changes require modifying core classes
-
-### Common OCP Patterns
-
-| Pattern | Use When |
-|---------|----------|
-| Strategy | Multiple algorithms for same operation |
-| Template Method | Same structure, different steps |
-| Decorator | Add behavior dynamically |
-| Factory | Create objects without specifying class |
+**Here**: `GitHubRepoAdopter` composes a `List<AdoptionStep>`, so a new stage is
+a new step, not a branch; a new tree output format is a new
+`ProjectTreeSerializer`; `BudgetedContext` decorates any `Context` instead of
+teaching `Finder` about budgets; `AbstractFinder` template-methods the
+depth-bounded traversal and lets subclasses supply only
+`findDirectDependencies`.
 
 ---
 
-## L - Liskov Substitution Principle (LSP)
+## L — Liskov Substitution
+> A subtype may not surprise a caller holding the base type.
 
-> "Subtypes must be substitutable for their base types."
+**Detect**: a subclass throwing where the parent doesn't · returning `null`
+where the parent returns a value · `instanceof` checks before calling a method ·
+empty or `UnsupportedOperationException` overrides.
 
-### Violation
+**Fix**: composition over inheritance, or extract a narrower interface.
 
-```java
-// ❌ BAD: Square violates Rectangle contract
-public class Rectangle {
-    protected int width;
-    protected int height;
-
-    public void setWidth(int width) {
-        this.width = width;
-    }
-
-    public void setHeight(int height) {
-        this.height = height;
-    }
-
-    public int getArea() {
-        return width * height;
-    }
-}
-
-public class Square extends Rectangle {
-    @Override
-    public void setWidth(int width) {
-        this.width = width;
-        this.height = width;  // Violates expected behavior!
-    }
-
-    @Override
-    public void setHeight(int height) {
-        this.width = height;  // Violates expected behavior!
-        this.height = height;
-    }
-}
-
-// This test fails for Square!
-void testRectangle(Rectangle r) {
-    r.setWidth(5);
-    r.setHeight(4);
-    assert r.getArea() == 20;  // Square returns 16!
-}
-```
-
-### Refactored
-
-```java
-// ✅ GOOD: Separate abstractions
-
-public interface Shape {
-    int getArea();
-}
-
-public class Rectangle implements Shape {
-    private final int width;
-    private final int height;
-
-    public Rectangle(int width, int height) {
-        this.width = width;
-        this.height = height;
-    }
-
-    @Override
-    public int getArea() {
-        return width * height;
-    }
-}
-
-public class Square implements Shape {
-    private final int side;
-
-    public Square(int side) {
-        this.side = side;
-    }
-
-    @Override
-    public int getArea() {
-        return side * side;
-    }
-}
-```
-
-### LSP Rules
-
-| Rule | Meaning |
-|------|---------|
-| Preconditions | Subclass cannot strengthen (require more) |
-| Postconditions | Subclass cannot weaken (promise less) |
-| Invariants | Subclass must maintain parent's invariants |
-| History | Subclass cannot modify inherited state unexpectedly |
-
-### How to Detect LSP Violations
-
-- Subclass throws exception parent doesn't
-- Subclass returns null where parent returns object
-- Subclass ignores or overrides parent behavior unexpectedly
-- `instanceof` checks before calling methods
-- Empty or throwing implementations of interface methods
-
-### Quick Check
-
-```java
-// If you see this, LSP might be violated
-if (bird instanceof Penguin) {
-    // don't call fly()
-} else {
-    bird.fly();
-}
-```
+**Here**: the repo prefers immutable, constructor-set state — step fields are
+final by an ArchUnit rule — which removes the classic setter-based LSP traps
+before they start.
 
 ---
 
-## I - Interface Segregation Principle (ISP)
+## I — Interface Segregation
+> A client should not be forced to depend on methods it does not use.
 
-> "Clients should not be forced to depend on interfaces they do not use."
+**Detect**: a fat interface (10+ methods) · implementations with empty bodies ·
+different clients using disjoint subsets.
 
-### Violation
+**Fix**: split by role; combine at the implementation.
 
-```java
-// ❌ BAD: Fat interface forces unnecessary implementations
-public interface Worker {
-    void work();
-    void eat();
-    void sleep();
-    void attendMeeting();
-    void writeReport();
-}
-
-// Robot can't eat or sleep!
-public class Robot implements Worker {
-    @Override public void work() { /* OK */ }
-    @Override public void eat() { /* Can't eat! */ }
-    @Override public void sleep() { /* Can't sleep! */ }
-    @Override public void attendMeeting() { /* OK */ }
-    @Override public void writeReport() { /* Maybe */ }
-}
-
-// Intern doesn't attend meetings or write reports
-public class Intern implements Worker {
-    @Override public void work() { /* OK */ }
-    @Override public void eat() { /* OK */ }
-    @Override public void sleep() { /* OK */ }
-    @Override public void attendMeeting() { /* Not allowed! */ }
-    @Override public void writeReport() { /* Not expected! */ }
-}
-```
-
-### Refactored
-
-```java
-// ✅ GOOD: Segregated interfaces
-
-public interface Workable {
-    void work();
-}
-
-public interface Feedable {
-    void eat();
-    void sleep();
-}
-
-public interface Manageable {
-    void attendMeeting();
-    void writeReport();
-}
-
-// Combine what you need
-public class Employee implements Workable, Feedable, Manageable {
-    @Override public void work() { /* ... */ }
-    @Override public void eat() { /* ... */ }
-    @Override public void sleep() { /* ... */ }
-    @Override public void attendMeeting() { /* ... */ }
-    @Override public void writeReport() { /* ... */ }
-}
-
-public class Robot implements Workable {
-    @Override public void work() { /* ... */ }
-    // No unnecessary methods!
-}
-
-public class Intern implements Workable, Feedable {
-    @Override public void work() { /* ... */ }
-    @Override public void eat() { /* ... */ }
-    @Override public void sleep() { /* ... */ }
-    // No meeting/report methods!
-}
-```
-
-### How to Detect ISP Violations
-
-- Implementations with empty methods or `throw new UnsupportedOperationException()`
-- Interface has 10+ methods
-- Different clients use completely different subsets of methods
-- Changes to interface affect unrelated implementations
-
-### Java Standard Library Violations
-
-```java
-// java.util.List has many methods - but this is acceptable for collections
-// However, be careful with your own interfaces!
-
-// ❌ This interface is too fat for most use cases
-public interface Repository<T> {
-    T findById(Long id);
-    List<T> findAll();
-    T save(T entity);
-    void delete(T entity);
-    void deleteById(Long id);
-    List<T> findByExample(T example);
-    Page<T> findAll(Pageable pageable);
-    List<T> findAllById(Iterable<Long> ids);
-    long count();
-    boolean existsById(Long id);
-    // ... 20 more methods
-}
-
-// ✅ Better: Split by use case
-public interface ReadRepository<T> {
-    Optional<T> findById(Long id);
-    List<T> findAll();
-}
-
-public interface WriteRepository<T> {
-    T save(T entity);
-    void delete(T entity);
-}
-```
+**Here — the canonical example.** `IterableDataSource` is the forward-only
+contract (`open`, `nextRow`, `hasMoreData`, `reset`); `ColumnarDataSource
+extends IterableDataSource` adds `getColumnNames()` for sources whose schema is
+known up front. Forward-only JSON/YAML/TOON iterables deliberately **do not**
+implement the columnar contract, so the uniqueness check — which depends on the
+narrower type — can never be handed a source that would answer `null`. Don't
+widen a contract to silence a compile error; that error is the design working.
 
 ---
 
-## D - Dependency Inversion Principle (DIP)
+## D — Dependency Inversion
+> High-level and low-level both depend on the abstraction.
 
-> "High-level modules should not depend on low-level modules. Both should depend on abstractions."
+**Detect**: `new ConcreteClass()` inside business logic · imports of
+implementation packages · tests that need a database or the network.
 
-### Violation
+**Fix**: constructor injection, an interface owned by the caller's side.
 
-```java
-// ❌ BAD: High-level depends on low-level directly
-public class OrderService {
-    private MySqlOrderRepository repository;  // Concrete class!
-    private SmtpEmailSender emailSender;      // Concrete class!
+**Here**: steps shell out through the `CommandRunner` interface, never
+`ProcessBuilder`, so tests pass a fake runner and never spawn a process; MCP
+tools implement `McpTool` and never touch the SDK; `ProjectTreeBuilder` takes a
+`ContextFactory` so the finder can be swapped without touching the builder.
 
-    public OrderService() {
-        this.repository = new MySqlOrderRepository();  // Hard dependency
-        this.emailSender = new SmtpEmailSender();      // Hard dependency
-    }
-
-    public void createOrder(Order order) {
-        repository.save(order);
-        emailSender.send(order.getCustomerEmail(), "Order confirmed");
-    }
-}
-```
-
-**Problems:**
-- Cannot test without real MySQL database
-- Cannot swap email provider
-- OrderService knows about MySQL, SMTP details
-
-### Refactored
-
-```java
-// ✅ GOOD: Depend on abstractions
-
-// Abstractions (interfaces)
-public interface OrderRepository {
-    void save(Order order);
-    Optional<Order> findById(Long id);
-}
-
-public interface NotificationSender {
-    void send(String recipient, String message);
-}
-
-// High-level module depends on abstractions
-public class OrderService {
-    private final OrderRepository repository;
-    private final NotificationSender notificationSender;
-
-    // Dependencies injected
-    public OrderService(OrderRepository repository,
-                        NotificationSender notificationSender) {
-        this.repository = repository;
-        this.notificationSender = notificationSender;
-    }
-
-    public void createOrder(Order order) {
-        repository.save(order);
-        notificationSender.send(order.getCustomerEmail(), "Order confirmed");
-    }
-}
-
-// Low-level modules implement abstractions
-public class MySqlOrderRepository implements OrderRepository {
-    @Override
-    public void save(Order order) { /* MySQL specific */ }
-
-    @Override
-    public Optional<Order> findById(Long id) { /* MySQL specific */ }
-}
-
-public class SmtpEmailSender implements NotificationSender {
-    @Override
-    public void send(String recipient, String message) { /* SMTP specific */ }
-}
-
-// Easy to test with mocks!
-public class InMemoryOrderRepository implements OrderRepository {
-    private Map<Long, Order> orders = new HashMap<>();
-
-    @Override
-    public void save(Order order) {
-        orders.put(order.getId(), order);
-    }
-
-    @Override
-    public Optional<Order> findById(Long id) {
-        return Optional.ofNullable(orders.get(id));
-    }
-}
-```
-
-### DIP in this repo (plain constructor injection — no framework)
-
-`tools` is a plain Maven library: **there is no Spring / CDI here.** Wire
-dependencies by hand through the constructor and pass a test double in tests —
-exactly how the `data` sources and the MCP servers are assembled.
-
-```java
-// Production wiring — the caller supplies the concretions
-OrderService service = new OrderService(
-    new MySqlOrderRepository(),
-    new SmtpEmailSender());
-
-// Test wiring — swap in in-memory / fake implementations, no network needed
-OrderService service = new OrderService(
-    new InMemoryOrderRepository(),
-    recordingNotificationSender);
-```
-
-> Repo caveat: `Optional` is fine as a **return type** (e.g.
-> `Optional<Order> findById(...)`), but a **field must never be `Optional`** —
-> an ArchUnit rule fails the build on `Optional` fields. Hold the value itself
-> and null-check it.
-
-### How to Detect DIP Violations
-
-- `new ConcreteClass()` inside business logic
-- Import statements include implementation packages (e.g., `com.mysql`, `org.apache.http`)
-- Cannot easily swap implementations
-- Tests require real infrastructure (database, network)
+**Wiring is plain constructor injection** — no Spring or CDI outside the MCP
+adapters. Pass concretions from the caller; pass fakes from the test. That is
+what makes the network-off unit tests possible.
 
 ---
 
-## SOLID Review Checklist
+## Repo rules that interact with these
 
-When reviewing code, check:
+- **A field must never be `Optional`** (ArchUnit). `Optional` as a *return type*
+  is fine — hold the value and null-check it in a field.
+- **Abstract types carry an `Abstract` prefix** (`AbstractFinder`,
+  `AbstractCommandStep`), public fields are `final`, mutable static state is
+  `volatile`.
+- **No `continue` or `break`** anywhere — a loop that wants one usually wants a
+  stream or an extracted method, which tends to improve the design anyway.
+- Packages must stay free of cycles; a "shared" class pulled sideways between
+  packages is a layering smell before it is a SOLID one.
+
+## Review checklist
 
 | Principle | Question |
 |-----------|----------|
-| **SRP** | Does this class have more than one reason to change? |
-| **OCP** | Will adding a new type/feature require modifying this class? |
-| **LSP** | Can subclasses be used wherever parent is expected? |
-| **ISP** | Are there empty or throwing method implementations? |
-| **DIP** | Does high-level code depend on concrete implementations? |
-
----
-
-## Common Refactoring Patterns
+| **SRP** | More than one reason to change? |
+| **OCP** | Will the next feature require editing this class? |
+| **LSP** | Can every subtype stand in for the base type? |
+| **ISP** | Any empty or throwing implementations? |
+| **DIP** | Does high-level code name a concrete implementation? |
 
 | Violation | Refactoring |
 |-----------|-------------|
-| SRP - God class | Extract Class, Move Method |
-| OCP - Type switching | Strategy Pattern, Factory |
-| LSP - Broken inheritance | Composition over Inheritance, Extract Interface |
-| ISP - Fat interface | Split Interface, Role Interface |
-| DIP - Hard dependencies | Dependency Injection, Abstract Factory |
+| SRP — god class | Extract Class, Move Method |
+| OCP — type switching | Strategy, Factory |
+| LSP — broken inheritance | Composition, Extract Interface |
+| ISP — fat interface | Split Interface, Role Interface |
+| DIP — hard dependency | Constructor injection, Abstract Factory |
 
----
-
-## Related Skills
-
-- `java-code-review` - Comprehensive review checklist (leads with the repo's
-  ArchUnit-enforced rules)
-- `testing-conventions` - Writing the fast, network-off, DI-friendly tests these
-  abstractions make possible
+## Related
+- `examples.md` (this directory) — full before/after code per principle
+- `java-code-review` — the wider review checklist, led by the enforced rules
+- `testing-conventions` — the fast, network-off tests these abstractions enable

--- a/.claude/skills/solid-principles/examples.md
+++ b/.claude/skills/solid-principles/examples.md
@@ -1,0 +1,429 @@
+# SOLID — worked examples
+
+Long before/after examples for each principle. Load this only when the summary
+in `SKILL.md` isn't enough; the checklists there are the fast path.
+
+---
+
+## S — Single Responsibility
+
+### Violation
+
+```java
+// ❌ BAD: UserService does too much
+public class UserService {
+
+    public User createUser(String name, String email) {
+        // validation logic
+        if (email == null || !email.contains("@")) {
+            throw new IllegalArgumentException("Invalid email");
+        }
+
+        // persistence logic
+        User user = new User(name, email);
+        entityManager.persist(user);
+
+        // notification logic
+        String subject = "Welcome!";
+        String body = "Hello " + name;
+        emailClient.send(email, subject, body);
+
+        // audit logic
+        auditLog.log("User created: " + email);
+
+        return user;
+    }
+}
+```
+
+**Problems:** validation, email template and audit format each give the class a
+separate reason to change, and no concern can be tested on its own.
+
+### Refactored
+
+```java
+// ✅ GOOD: Each class has one responsibility
+
+public class UserValidator {
+    public void validate(String name, String email) {
+        if (email == null || !email.contains("@")) {
+            throw new ValidationException("Invalid email");
+        }
+    }
+}
+
+public class UserRepository {
+    public User save(User user) {
+        entityManager.persist(user);
+        return user;
+    }
+}
+
+public class WelcomeEmailSender {
+    public void sendWelcome(User user) {
+        emailClient.send(user.getEmail(), "Welcome!", "Hello " + user.getName());
+    }
+}
+
+public class UserAuditLogger {
+    public void logCreation(User user) {
+        auditLog.log("User created: " + user.getEmail());
+    }
+}
+
+public class UserService {
+    private final UserValidator validator;
+    private final UserRepository repository;
+    private final WelcomeEmailSender emailSender;
+    private final UserAuditLogger auditLogger;
+
+    public User createUser(String name, String email) {
+        validator.validate(name, email);
+        User user = repository.save(new User(name, email));
+        emailSender.sendWelcome(user);
+        auditLogger.logCreation(user);
+        return user;
+    }
+}
+```
+
+---
+
+## O — Open/Closed
+
+### Violation
+
+```java
+// ❌ BAD: Must modify the class to add a new discount type
+public class DiscountCalculator {
+
+    public double calculate(Order order, String discountType) {
+        if (discountType.equals("PERCENTAGE")) {
+            return order.getTotal() * 0.1;
+        } else if (discountType.equals("FIXED")) {
+            return 50.0;
+        } else if (discountType.equals("LOYALTY")) {
+            return order.getTotal() * order.getCustomer().getLoyaltyRate();
+        }
+        return 0;
+    }
+}
+```
+
+### Refactored
+
+```java
+// ✅ GOOD: Add new discounts without modifying existing code
+
+public interface DiscountStrategy {
+    double calculate(Order order);
+    boolean supports(String discountType);
+}
+
+public class PercentageDiscount implements DiscountStrategy {
+    @Override
+    public double calculate(Order order) {
+        return order.getTotal() * 0.1;
+    }
+
+    @Override
+    public boolean supports(String discountType) {
+        return "PERCENTAGE".equals(discountType);
+    }
+}
+
+public class LoyaltyDiscount implements DiscountStrategy {
+    @Override
+    public double calculate(Order order) {
+        return order.getTotal() * order.getCustomer().getLoyaltyRate();
+    }
+
+    @Override
+    public boolean supports(String discountType) {
+        return "LOYALTY".equals(discountType);
+    }
+}
+
+// A new discount is a new class, not an edit to an existing one
+public class SeasonalDiscount implements DiscountStrategy {
+    @Override
+    public double calculate(Order order) {
+        return order.getTotal() * 0.2;
+    }
+
+    @Override
+    public boolean supports(String discountType) {
+        return "SEASONAL".equals(discountType);
+    }
+}
+
+public class DiscountCalculator {
+    private final List<DiscountStrategy> strategies;
+
+    public DiscountCalculator(List<DiscountStrategy> strategies) {
+        this.strategies = strategies;
+    }
+
+    public double calculate(Order order, String discountType) {
+        return strategies.stream()
+            .filter(strategy -> strategy.supports(discountType))
+            .findFirst()
+            .map(strategy -> strategy.calculate(order))
+            .orElse(0.0);
+    }
+}
+```
+
+| Pattern | Use when |
+|---------|----------|
+| Strategy | Multiple algorithms for the same operation |
+| Template Method | Same structure, different steps |
+| Decorator | Add behaviour around an existing implementation |
+| Factory | Create objects without naming the concrete class |
+
+---
+
+## L — Liskov Substitution
+
+### Violation
+
+```java
+// ❌ BAD: Square violates the Rectangle contract
+public class Rectangle {
+    protected int width;
+    protected int height;
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public int getArea() {
+        return width * height;
+    }
+}
+
+public class Square extends Rectangle {
+    @Override
+    public void setWidth(int width) {
+        this.width = width;
+        this.height = width;  // breaks the caller's expectation
+    }
+
+    @Override
+    public void setHeight(int height) {
+        this.width = height;
+        this.height = height;
+    }
+}
+
+// Passes for Rectangle, fails for Square (16, not 20)
+void testRectangle(Rectangle rectangle) {
+    rectangle.setWidth(5);
+    rectangle.setHeight(4);
+    assert rectangle.getArea() == 20;
+}
+```
+
+### Refactored
+
+```java
+// ✅ GOOD: Separate abstractions, immutable state
+
+public interface Shape {
+    int getArea();
+}
+
+public class Rectangle implements Shape {
+    private final int width;
+    private final int height;
+
+    public Rectangle(int width, int height) {
+        this.width = width;
+        this.height = height;
+    }
+
+    @Override
+    public int getArea() {
+        return width * height;
+    }
+}
+
+public class Square implements Shape {
+    private final int side;
+
+    public Square(int side) {
+        this.side = side;
+    }
+
+    @Override
+    public int getArea() {
+        return side * side;
+    }
+}
+```
+
+| Rule | Meaning |
+|------|---------|
+| Preconditions | A subtype cannot require more |
+| Postconditions | A subtype cannot promise less |
+| Invariants | A subtype must maintain the parent's invariants |
+| History | A subtype cannot mutate inherited state unexpectedly |
+
+---
+
+## I — Interface Segregation
+
+### Violation
+
+```java
+// ❌ BAD: A fat interface forces meaningless implementations
+public interface Worker {
+    void work();
+    void eat();
+    void sleep();
+    void attendMeeting();
+    void writeReport();
+}
+
+public class Robot implements Worker {
+    @Override public void work() { /* OK */ }
+    @Override public void eat() { /* cannot */ }
+    @Override public void sleep() { /* cannot */ }
+    @Override public void attendMeeting() { /* OK */ }
+    @Override public void writeReport() { /* maybe */ }
+}
+```
+
+### Refactored
+
+```java
+// ✅ GOOD: Segregated interfaces, combined where needed
+
+public interface Workable {
+    void work();
+}
+
+public interface Feedable {
+    void eat();
+    void sleep();
+}
+
+public interface Manageable {
+    void attendMeeting();
+    void writeReport();
+}
+
+public class Employee implements Workable, Feedable, Manageable { /* ... */ }
+
+public class Robot implements Workable {
+    @Override public void work() { /* ... */ }
+}
+
+public class Intern implements Workable, Feedable { /* ... */ }
+```
+
+Splitting a repository interface by use case is the same move:
+
+```java
+// ✅ Better than one 20-method Repository<T>
+public interface ReadRepository<T> {
+    Optional<T> findById(Long id);
+    List<T> findAll();
+}
+
+public interface WriteRepository<T> {
+    T save(T entity);
+    void delete(T entity);
+}
+```
+
+---
+
+## D — Dependency Inversion
+
+### Violation
+
+```java
+// ❌ BAD: The high-level module names its low-level collaborators
+public class OrderService {
+    private MySqlOrderRepository repository;
+    private SmtpEmailSender emailSender;
+
+    public OrderService() {
+        this.repository = new MySqlOrderRepository();
+        this.emailSender = new SmtpEmailSender();
+    }
+
+    public void createOrder(Order order) {
+        repository.save(order);
+        emailSender.send(order.getCustomerEmail(), "Order confirmed");
+    }
+}
+```
+
+**Problems:** cannot be tested without a real database, cannot swap the email
+provider, and it knows MySQL and SMTP details it has no business knowing.
+
+### Refactored
+
+```java
+// ✅ GOOD: Both sides depend on abstractions
+
+public interface OrderRepository {
+    void save(Order order);
+    Optional<Order> findById(Long id);
+}
+
+public interface NotificationSender {
+    void send(String recipient, String message);
+}
+
+public class OrderService {
+    private final OrderRepository repository;
+    private final NotificationSender notificationSender;
+
+    public OrderService(OrderRepository repository, NotificationSender notificationSender) {
+        this.repository = repository;
+        this.notificationSender = notificationSender;
+    }
+
+    public void createOrder(Order order) {
+        repository.save(order);
+        notificationSender.send(order.getCustomerEmail(), "Order confirmed");
+    }
+}
+
+public class MySqlOrderRepository implements OrderRepository { /* MySQL specific */ }
+
+public class SmtpEmailSender implements NotificationSender { /* SMTP specific */ }
+
+// The test double needs no infrastructure
+public class InMemoryOrderRepository implements OrderRepository {
+    private final Map<Long, Order> orders = new HashMap<>();
+
+    @Override
+    public void save(Order order) {
+        orders.put(order.getId(), order);
+    }
+
+    @Override
+    public Optional<Order> findById(Long id) {
+        return Optional.ofNullable(orders.get(id));
+    }
+}
+```
+
+Wiring, in this repo, is plain constructor injection — there is no Spring or CDI
+outside the MCP adapters:
+
+```java
+// Production
+OrderService service = new OrderService(new MySqlOrderRepository(), new SmtpEmailSender());
+
+// Test
+OrderService service = new OrderService(new InMemoryOrderRepository(), recordingSender);
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,11 +256,12 @@ asked.**
 
 ## Agent configuration
 
-- `.claude/skills/` holds seven project skills that carry the detail this file
-  only summarises: `data-sources`, `git-commit`, `java-code-review`,
-  `maven-conventions`, `protogen`, `solid-principles`, and
-  `testing-conventions`. Prefer loading the relevant skill over re-deriving a
-  convention.
+- `.claude/skills/` holds twelve project skills that carry the detail this file
+  only summarises — per module: `data-sources`, `context-finder`, `protogen`,
+  `adopt-pipeline`, `mcp-server`, `enforcer-rules`; across the repo:
+  `doc-contract`, `git-commit`, `java-code-review`, `maven-conventions`,
+  `solid-principles`, and `testing-conventions`. Prefer loading the relevant
+  skill over re-deriving a convention.
 - `.claude/settings.json` allows the `mvn` and archive-inspection Bash commands
   and wires the `SessionStart` hook; `.claude/hooks/session-start.sh` provisions
   the JDK and warms the Maven cache in web/remote sessions.


### PR DESCRIPTION
Five modules had no skill, so their conventions had to be re-derived from
AGENTS.md or the code every session: adopt-pipeline (step contract, the
ArchUnit rules a new step must satisfy, batch failure isolation),
enforcer-rules (the base-class contract, package layering, the two-phase
build a maven-enforcer rule needs), mcp-server (the McpTool SPI, transports,
MCP_USAGE.md), context-finder (finders, budgeting, tree serializers) and
doc-contract (what must change together for the enforced doc rules to pass).

solid-principles was 640 lines of generic examples loaded in full for a
one-line answer. The worked before/after code moves to examples.md and the
skill keeps detection heuristics, the fixes, and this repo's real examples
(ColumnarDataSource for ISP, AdoptionStep for OCP, CommandRunner for DIP).
Its README also pointed at two skills that do not exist.

Also notes the open-addressing structures in data-sources and updates the
skill list in CLAUDE.md.

Verified with mvn -N validate -DenforceClaudeMd: all 19 rules pass,
including skillFilesExist, uniqueNames and uniqueDescriptions.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0135pz8DdoRrRkC8d23DGrYB