### PR TITLE
test(claude-code-enforcer): run the rules through real Maven builds

### DIFF
--- a/.claude/skills/enforcer-rules/SKILL.md
+++ b/.claude/skills/enforcer-rules/SKILL.md
@@ -98,6 +98,23 @@ to `report(...)`.
 - Cover: passes when correct, fails per violation kind, passes on an empty
   directory, and the always-fails build-setup cases (missing parameter/file).
 
+**A unit test cannot prove the rule runs.** It calls the setters itself, so it
+skips artifact resolution, `@Named` discovery, and Plexus binding — the ways a
+correct rule never runs at all. The `*IT`s in `…/enforcer/e2e` run real Maven
+builds and cover that seam; extend them alongside a new rule:
+`RuleConfiguration.complete()` must configure it with **every** parameter it
+accepts (that fixture is checked against the compiled classes, so a rule or
+parameter left out fails `EnforcerRuleBuildIT`), and `RepositoryEnforcementIT`
+compares the shipped catalogue against the root pom's profile. Run them with
+`mvn -pl claude-code-enforcer -am -P integration-tests verify`.
+
+**Naming trap for a `List<String>` parameter.** Plexus infers a configured
+list's element type from the *child element name*, trying the rule's own package
+first, so a class matching the capitalised child name — `SecretPattern` for
+`<secretPatterns><secretPattern>` — wins over `String` and the build fails
+trying to instantiate it. Keep helper names clear of the singular of any list
+parameter in the same package (hence `CredentialPattern`).
+
 ## Wiring it into the root pom
 Add the `@Named` element under the `claude-md-enforce` profile's `<rules>` block
 in the root `pom.xml`, with one child per parameter:
@@ -123,4 +140,5 @@ the moment one appears.
 - `AGENTS.md` — *CLAUDE.md enforcement* (source of truth, full rule catalogue)
 - `claude-code-enforcer/.../rule/ClaudeCodeEnforcerRule.java` — the base contract
 - `claude-code-enforcer/.../architecture/EnforcerArchitectureTest.java` — layering
+- `claude-code-enforcer/.../e2e/EnforcerRuleBuildIT.java` — the pom-to-rule seam
 - Root `pom.xml` — the `claude-md-enforce` profile

--- a/.claude/skills/mcp-server/SKILL.md
+++ b/.claude/skills/mcp-server/SKILL.md
@@ -85,8 +85,9 @@ A `Main.java` Spring Boot entry point sits next to the configuration
   tool — it is the file users configure their client from.
 - The servers are covered by `*IT` tests over real HTTP, gated behind the
   `integration-tests` profile: `mvn -P integration-tests verify`. The profile is
-  declared **per module** (`data`, `code/context`, `adopt`) — a new module's
-  `*IT`s do not run until that module gets its own copy.
+  declared **per module** (`data`, `code/context`, `adopt`,
+  `claude-code-enforcer`) — a new module's `*IT`s do not run until that module
+  gets its own copy.
 - Unit-test the tool directly as a function: build the argument map, assert on
   the `ToolResult` text and `isError`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,7 +467,8 @@ longer and carry no timeout.
   one library, not six tests; an exemption means a module not importing a
   library, which stays visible in that module's test.
 - **Integration tests** are gated behind the `integration-tests` profile
-  (defined in `data`, `code/context`, and `adopt`) and are the tests that need
+  (defined in `data`, `code/context`, `adopt`, and `claude-code-enforcer`) and are
+  the tests that need
   something real: `mvn -P integration-tests verify`. Test classes ending in `IT`
   belong to this profile. `data` and `code/context` exercise their MCP servers
   over streamable HTTP; `adopt`'s `MultiRepoAdoptionIT` runs a multi-repository
@@ -483,6 +484,35 @@ longer and carry no timeout.
   over the network, a host with a git `url.<base>.insteadOf` rewrite records the
   rewritten remote, so the test identifies each checkout by the
   `owner/repository` its `origin` names rather than by the URL it was given.
+- **The enforcer's end-to-end tests** (`claude-code-enforcer`, package
+  `...enforcer.e2e`) run *real Maven builds*, because everything between a pom and
+  a rule's `execute()` is what a unit test assumes: Maven resolving the rule jar,
+  Sisu finding the class behind a `@Named` element, and Plexus binding each
+  configuration element to a field. A rule can be correct and still never run — a
+  misspelled parameter fails the build outright, a misspelled rule name never runs
+  at all — and none of that is visible from inside the rule. `EnforcerRuleBuildIT`
+  builds a throwaway project (`FixtureProject`) laid out like an adopted
+  repository and enforces `RuleConfiguration.complete()`, which configures **every**
+  shipped rule with **every** parameter it accepts; the configuration is held
+  against the compiled classes (`ShippedRules`, by reflection) so a new rule or
+  parameter that no fixture addresses is named rather than silently unexercised.
+  The same class pins the shared behaviours across the Maven boundary:
+  collect-then-report, `severity=warn` going green while still logging,
+  the HTML `reportFile` landing on disk, a `baselineFile` suppressing recorded
+  violations until a new one appears, and the build-setup checks that fail whatever
+  the severity. `RepositoryEnforcementIT` runs the repository's own
+  `mvn -N validate -DenforceClaudeMd`, checks every rule the
+  `claude-md-enforce` profile wires reported a pass, holds the shipped catalogue
+  against that profile (`subAgentFormat` and `commandFormat` are the documented
+  exemptions), and then breaks a *copy* of the repository — a skill losing its
+  `SKILL.md`, the two agent documents disagreeing about the Java version — to prove
+  the wiring bites. Two mechanics are worth knowing before changing them: the
+  `*IT`s run at `integration-test`, *before* this module is installed, so they
+  publish the freshly packaged jar into the local repository themselves
+  (`install-file`, with the flattened pom so the rule's own dependencies come with
+  it); and a forked test JVM cannot work out where Maven, the local repository or
+  that jar are, so the module's `integration-tests` profile passes each in as an
+  `enforcer.it.*` system property that `BuildEnvironment` reads.
 - **Coverage** is the opt-in `coverage` profile (JaCoCo): `mvn -Pcoverage verify`
   produces reports at `**/target/site/jacoco/` and **fails the build** if a
   bundle's instruction **or** branch coverage drops below **80%** (two
@@ -509,7 +539,7 @@ manually, or on a release.
 | Workflow | Trigger | What it runs |
 | --- | --- | --- |
 | `maven.yml` | push, PR → `main` | Installs the enforcer rule, then `mvn -B package -DenforceClaudeMd` on JDK 25 — the **only** workflow that runs the CLAUDE.md/AGENTS.md checks. The build step is capped at **120 s** (`timeout-minutes: 2` plus a wall-clock check). |
-| `integration-tests.yml` | daily | `mvn -P integration-tests verify` (MCP streamable-HTTP integration tests, and the `adopt` multi-repository adoption against real GitHub URLs). |
+| `integration-tests.yml` | daily | `mvn -P integration-tests verify` (MCP streamable-HTTP integration tests, the `adopt` multi-repository adoption against real GitHub URLs, and the enforcer's end-to-end Maven builds). |
 | `codeql.yml` | weekly (Saturdays) | CodeQL security/static analysis for Java (autobuild). |
 | `coverage.yml` | weekly (Saturdays) | `mvn verify -Pcoverage`, uploads JaCoCo reports as an artifact. |
 | `pitest.yml` | weekly (Sundays); manual | `mvn install -Ppitest`, uploads PIT mutation reports as an artifact. |
@@ -723,6 +753,18 @@ delimiter — the rule rewrites the file in place and continues against the
 corrected content instead of failing. The repair is conservative: it only acts
 when the document opens with a dashes line enclosing real `key: value` entries, so
 a lone `---` thematic break is never mistaken for front matter.
+
+A `List<String>` parameter carries a trap worth knowing before naming a helper
+class. Plexus infers a configured list's element type from the **child element
+name**, trying the rule's own package first, so a class whose name matches the
+capitalised child name — `SecretPattern` for
+`<secretPatterns><secretPattern>…</secretPattern></secretPatterns>` — is chosen
+over `String` and the build fails trying to instantiate it. The parameter then
+works in a unit test, which calls the setter directly, and not in the builds it
+exists for. Keep a helper's name clear of the singular of any list parameter in
+its package: the credential shapes `noSecrets` scans for are a
+`CredentialPattern` for exactly this reason, and `EnforcerRuleBuildIT`, which
+configures every parameter from a pom, is what catches a reintroduction.
 
 The check is **opt-in**: the `claude-md-enforce` profile activates only when the
 `enforceClaudeMd` property is set (`-DenforceClaudeMd`). This keeps every other

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ mvn install                       # faster incremental build
 mvn -pl data -am install          # one module plus the modules it depends on
 mvn -pl data -am test             # tests for a single module
 mvn -B package                    # build without installing (what CI runs)
-mvn -P integration-tests verify   # integration tests (*IT): MCP servers, real-GitHub adoption
+mvn -P integration-tests verify   # integration tests (*IT): MCP servers, real-GitHub adoption, enforcer builds
 mvn -Pcoverage verify             # JaCoCo coverage (fails under 80% instruction or branch)
 mvn -Ppitest install              # PIT mutation testing (needs a phase past package)
 ```
@@ -217,13 +217,17 @@ paths.
   `ArchTests.in(...)`, so a module's own test states only what is specific to it.
   Keep new code within these rules.
 - **Integration tests** (`*IT`) are gated behind the `integration-tests` profile
-  and cover what needs something real: the MCP servers over HTTP, and `adopt`'s
+  and cover what needs something real: the MCP servers over HTTP; `adopt`'s
   `MultiRepoAdoptionIT`, which clones real GitHub sample repositories to prove a
-  batch gives each repository its own checkout. It stops at the branch step, so
-  it never pushes or opens a pull request. The profile is declared per module —
-  in `data`, `code/context`, and `adopt`, each wiring `maven-failsafe-plugin` —
-  not in the root pom, so a new module's `*IT`s stay unrun until that module
-  gets its own copy. See *Testing* in AGENTS.md.
+  batch gives each repository its own checkout (it stops at the branch step, so
+  it never pushes or opens a pull request); and `claude-code-enforcer`'s
+  `EnforcerRuleBuildIT`/`RepositoryEnforcementIT`, which run real Maven builds so
+  the pom-to-rule seam a unit test skips — artifact resolution, `@Named`
+  discovery, parameter binding — is exercised, and this repository's own wired
+  configuration is proved to catch a regression. The profile is declared per
+  module — in `data`, `code/context`, `adopt`, and `claude-code-enforcer`, each
+  wiring `maven-failsafe-plugin` — not in the root pom, so a new module's `*IT`s
+  stay unrun until that module gets its own copy. See *Testing* in AGENTS.md.
 
 ## Continuous integration and commits
 

--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -11,6 +11,44 @@
 	<packaging>jar</packaging>
 	<name>CLAUDE.md enforcer rule</name>
 	<description>Custom maven-enforcer rule that validates CLAUDE.md documents for structure and naming conventions during the build.</description>
+	<profiles>
+		<profile>
+			<id>integration-tests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<executions>
+							<execution>
+								<goals>
+									<goal>integration-test</goal>
+									<goal>verify</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<!-- The *IT tests run real Maven builds against the rule jar
+							     this module has just packaged, which a forked test JVM
+							     cannot locate on its own: the local repository may have
+							     been relocated with -Dmaven.repo.local, and the jar's
+							     name comes from the build's finalName. Only the build
+							     knows all of that, so it hands each fact over rather
+							     than letting a test guess. -->
+							<systemPropertyVariables>
+								<enforcer.it.mavenHome>${maven.home}</enforcer.it.mavenHome>
+								<enforcer.it.localRepository>${settings.localRepository}</enforcer.it.localRepository>
+								<enforcer.it.version>${project.version}</enforcer.it.version>
+								<enforcer.it.jar>${project.build.directory}/${project.build.finalName}.jar</enforcer.it.jar>
+								<enforcer.it.pom>${project.basedir}/.flattened-pom.xml</enforcer.it.pom>
+								<enforcer.it.repositoryRoot>${project.basedir}/..</enforcer.it.repositoryRoot>
+							</systemPropertyVariables>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<!-- flatten-maven-plugin is inherited from the root pom, which flattens the
 	     CI-friendly ${revision} out of every module's pom. This module needs it
 	     because it is consumed as a maven-enforcer-plugin dependency resolved

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/CredentialPattern.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/CredentialPattern.java
@@ -9,15 +9,22 @@ import java.util.regex.Pattern;
  * configuration — API keys pasted into an {@code env} block or a hook script —
  * and each carries a human-readable name so a violation says what kind of
  * secret it looks like without echoing the secret itself.
+ * <p>
+ * Deliberately <em>not</em> named after the {@code secretPatterns} parameter it
+ * serves. Plexus resolves the element type of a configured list from the child
+ * element name, trying the rule's own package first, so a class called
+ * {@code SecretPattern} would capture every {@code <secretPattern>} element a pom
+ * writes and fail the build trying to instantiate it — leaving the parameter
+ * configurable in a unit test but not in the builds it exists for.
  */
-record SecretPattern(String name, Pattern pattern) {
+record CredentialPattern(String name, Pattern pattern) {
 
-	static SecretPattern of(String name, String regex) {
-		return new SecretPattern(name, Pattern.compile(regex));
+	static CredentialPattern of(String name, String regex) {
+		return new CredentialPattern(name, Pattern.compile(regex));
 	}
 
 	/** The built-in credential shapes, scanned unless {@code useDefaultPatterns} is switched off. */
-	static List<SecretPattern> defaults() {
+	static List<CredentialPattern> defaults() {
 		return List.of(
 				of("Anthropic API key", "sk-ant-[A-Za-z0-9_-]{16,}"),
 				of("AWS access key ID", "(?<![A-Z0-9])AKIA[0-9A-Z]{16}(?![A-Z0-9])"),

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
@@ -53,7 +53,7 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 
 	@Override
 	public void execute() throws EnforcerRuleException {
-		List<SecretPattern> patterns = patterns();
+		List<CredentialPattern> patterns = patterns();
 		ScanTargets targets = new ScanTargets(files, directories);
 		targets.requireConfigured();
 		requirePatterns(patterns);
@@ -73,25 +73,25 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 				"Re-run the build to confirm no secrets remain.");
 	}
 
-	private void requirePatterns(List<SecretPattern> patterns) throws EnforcerRuleException {
+	private void requirePatterns(List<CredentialPattern> patterns) throws EnforcerRuleException {
 		if (patterns.isEmpty()) {
 			throw new EnforcerRuleException(
 					"Configure secretPatterns or leave useDefaultPatterns enabled, so there is something to scan for");
 		}
 	}
 
-	private Stream<String> scan(File file, List<SecretPattern> patterns) {
+	private Stream<String> scan(File file, List<CredentialPattern> patterns) {
 		List<String> lines = readTextLines(file);
 		return IntStream.range(0, lines.size())
 				.boxed()
 				.flatMap(index -> scanLine(file, lines.get(index), index + 1, patterns));
 	}
 
-	private Stream<String> scanLine(File file, String line, int lineNumber, List<SecretPattern> patterns) {
+	private Stream<String> scanLine(File file, String line, int lineNumber, List<CredentialPattern> patterns) {
 		return patterns.stream().flatMap(pattern -> matches(file, line, lineNumber, pattern));
 	}
 
-	private Stream<String> matches(File file, String line, int lineNumber, SecretPattern pattern) {
+	private Stream<String> matches(File file, String line, int lineNumber, CredentialPattern pattern) {
 		return pattern.pattern().matcher(line)
 				.results()
 				.map(match -> file + " line " + lineNumber + " contains what looks like a " + pattern.name()
@@ -112,10 +112,10 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 		return content.map(text -> text.lines().toList()).orElseGet(List::of);
 	}
 
-	private List<SecretPattern> patterns() throws EnforcerRuleException {
-		List<SecretPattern> patterns = new ArrayList<>();
+	private List<CredentialPattern> patterns() throws EnforcerRuleException {
+		List<CredentialPattern> patterns = new ArrayList<>();
 		if (useDefaultPatterns) {
-			patterns.addAll(SecretPattern.defaults());
+			patterns.addAll(CredentialPattern.defaults());
 		}
 		List<String> configured = secretPatterns != null ? secretPatterns : List.of();
 		for (String regex : configured) {
@@ -129,9 +129,9 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 	 * mistake, so it fails with a message naming it rather than letting a
 	 * {@link PatternSyntaxException} escape as an internal build error.
 	 */
-	private SecretPattern compiled(String regex) throws EnforcerRuleException {
+	private CredentialPattern compiled(String regex) throws EnforcerRuleException {
 		try {
-			return SecretPattern.of(regex, regex);
+			return CredentialPattern.of(regex, regex);
 		} catch (PatternSyntaxException e) {
 			throw new EnforcerRuleException(
 					"secretPattern '" + regex + "' is not a valid regular expression: " + e.getDescription());

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/BuildEnvironment.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/BuildEnvironment.java
@@ -1,0 +1,122 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+
+/**
+ * Where the outer build put the things an end-to-end test needs: the Maven that
+ * is running, the local repository it resolves from, and the rule jar plus
+ * flattened pom this module has just produced. None of that can be worked out
+ * from inside a forked test JVM — the local repository may have been relocated
+ * with {@code -Dmaven.repo.local}, and the jar's name comes from the build's
+ * {@code finalName} — so the {@code integration-tests} profile passes each one in
+ * as a system property and this class reads them.
+ * <p>
+ * A missing property means the {@code *IT}s were run outside that profile, which
+ * is a build-setup mistake rather than a failed expectation, so it is reported as
+ * an {@link IllegalStateException} naming the property.
+ */
+final class BuildEnvironment {
+
+	private static final String MAVEN_HOME = "enforcer.it.mavenHome";
+	private static final String LOCAL_REPOSITORY = "enforcer.it.localRepository";
+	private static final String VERSION = "enforcer.it.version";
+	private static final String JAR = "enforcer.it.jar";
+	private static final String POM = "enforcer.it.pom";
+	private static final String REPOSITORY_ROOT = "enforcer.it.repositoryRoot";
+
+	static final String GROUP_ID = "io.github.adamw7";
+	static final String ARTIFACT_ID = "tools.claude-code-enforcer";
+
+	private final Path mavenExecutable;
+	private final Path localRepository;
+	private final String version;
+	private final Path jar;
+	private final Path pom;
+	private final Path repositoryRoot;
+
+	BuildEnvironment() {
+		this.mavenExecutable = mavenExecutableIn(directory(MAVEN_HOME));
+		this.localRepository = directory(LOCAL_REPOSITORY);
+		this.version = property(VERSION);
+		this.jar = file(JAR);
+		this.pom = file(POM);
+		this.repositoryRoot = directory(REPOSITORY_ROOT);
+	}
+
+	Path mavenExecutable() {
+		return mavenExecutable;
+	}
+
+	Path localRepository() {
+		return localRepository;
+	}
+
+	/** The version of the rule jar under test, which every fixture pom depends on. */
+	String version() {
+		return version;
+	}
+
+	/** The jar this module's {@code package} phase produced, published before the first fixture build. */
+	Path jar() {
+		return jar;
+	}
+
+	/**
+	 * The flattened pom that goes with {@link #jar()}. Installing the jar with it
+	 * rather than with a generated pom is what gives a fixture build the rule's own
+	 * dependencies — Jackson above all — on the enforcer plugin's class path.
+	 */
+	Path pom() {
+		return pom;
+	}
+
+	/** The repository this module sits in, whose own configuration one of the {@code *IT}s enforces. */
+	Path repositoryRoot() {
+		return repositoryRoot;
+	}
+
+	/**
+	 * The launcher rather than the wrapper script name alone, because a test starts
+	 * a process directly instead of going through a shell that would resolve
+	 * {@code mvn} on the {@code PATH}.
+	 */
+	private static Path mavenExecutableIn(Path mavenHome) {
+		String launcher = isWindows() ? "mvn.cmd" : "mvn";
+		Path executable = mavenHome.resolve("bin").resolve(launcher);
+		if (!Files.isRegularFile(executable)) {
+			throw new IllegalStateException("No Maven launcher at " + executable);
+		}
+		return executable;
+	}
+
+	private static boolean isWindows() {
+		return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("windows");
+	}
+
+	private static Path file(String name) {
+		Path path = Path.of(property(name));
+		if (!Files.isRegularFile(path)) {
+			throw new IllegalStateException("The " + name + " property does not name a file: " + path);
+		}
+		return path;
+	}
+
+	private static Path directory(String name) {
+		Path path = Path.of(property(name));
+		if (!Files.isDirectory(path)) {
+			throw new IllegalStateException("The " + name + " property does not name a directory: " + path);
+		}
+		return path.toAbsolutePath().normalize();
+	}
+
+	private static String property(String name) {
+		String value = System.getProperty(name);
+		if (value == null || value.isBlank()) {
+			throw new IllegalStateException("The " + name + " system property is not set; run the integration tests "
+					+ "with the integration-tests profile, which passes it in");
+		}
+		return value;
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/BuildOutcome.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/BuildOutcome.java
@@ -1,0 +1,29 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+/**
+ * What a Maven build said and whether it passed — the whole of what an end-to-end
+ * test can observe, since a fixture build runs in its own process.
+ *
+ * @param exitCode the process exit code, zero when the build succeeded
+ * @param output   the merged standard output and standard error of the build
+ */
+record BuildOutcome(int exitCode, String output) {
+
+	boolean succeeded() {
+		return exitCode == 0;
+	}
+
+	boolean mentions(String text) {
+		return output.contains(text);
+	}
+
+	/**
+	 * The whole build log, for the {@code assert*} message of a test that did not get
+	 * the outcome it expected. A failure here is nearly always explained by a line of
+	 * that log, and the test process cannot print it — so it is carried into the
+	 * assertion instead.
+	 */
+	String describe() {
+		return "the build exited with " + exitCode + " and said:" + System.lineSeparator() + output;
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/EnforcerRuleBuildIT.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/EnforcerRuleBuildIT.java
@@ -1,0 +1,265 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Runs the shipped rules the way a project meets them: as elements of a
+ * {@code pom.xml}, evaluated by a real maven-enforcer-plugin, in a real Maven
+ * build, against a real directory of files.
+ *
+ * <p>The unit tests construct each rule, call its setters and invoke
+ * {@code execute()}. Everything between the pom and that call is theirs to assume:
+ * that Maven can resolve the rule jar, that Sisu finds the class behind a
+ * {@code @Named} element, that Plexus binds {@code <maxLineLength>} to the field
+ * of that name, and that a violation collected in a list comes back out as a
+ * failed build rather than a passed one. Each of those is a way a rule can be
+ * correct and still never run — a misspelled parameter fails the build outright, a
+ * misspelled <em>rule</em> name never runs at all — and none of them is observable
+ * from inside the rule.
+ *
+ * <p>What is asserted here is therefore the seam, not the rules' logic: that the
+ * whole catalogue binds ({@link #theCompleteConfigurationAddressesEveryRuleAndParameterTheModuleShips}
+ * pins the fixture to the classes so a new rule cannot quietly skip this), that a
+ * well-formed project passes every one of them, and that the shared behaviours the
+ * base class offers — collect-then-report, {@code severity=warn}, the HTML report,
+ * the baseline, and the build-setup checks that fail whatever the severity —
+ * survive the crossing into Maven.
+ *
+ * <p>Each build takes about a second against the local repository the outer build
+ * already populated, and the rule jar it resolves is the one this module has just
+ * packaged, published into that repository by {@link #publishTheRuleUnderTest()}.
+ */
+class EnforcerRuleBuildIT {
+
+	/** Only the sections a well-formed CLAUDE.md needs are gone, so the rule has several things to say at once. */
+	private static final String MALFORMED_CLAUDE_MD = """
+			# CLAUDE.md
+
+			## Project
+
+			A fixture that has lost most of its structure.
+			""";
+
+	/** Adds a violation to {@link #MALFORMED_CLAUDE_MD} without disturbing the ones already there. */
+	private static final String WRONGLY_TITLED_CLAUDE_MD = """
+			# Claude instructions
+
+			## Project
+
+			A fixture that has lost most of its structure.
+			""";
+
+	private static final String MISSING_SECTION = "CLAUDE.md is missing required section heading: ";
+	private static final String MISSING_AGENTS_REFERENCE = "CLAUDE.md must reference AGENTS.md";
+	private static final String WRONG_TITLE = "CLAUDE.md must start with the '# CLAUDE.md' title heading";
+
+	private static BuildEnvironment environment;
+	private static MavenBuild maven;
+	private static String enforcerPluginVersion;
+
+	@TempDir
+	Path workspace;
+
+	@BeforeAll
+	static void publishTheRuleUnderTest() {
+		environment = new BuildEnvironment();
+		RepositoryPom repositoryPom = new RepositoryPom(environment.repositoryRoot());
+		enforcerPluginVersion = repositoryPom.pluginVersion("maven-enforcer-plugin");
+		maven = new MavenBuild(environment);
+		maven.publishRuleUnderTest(repositoryPom.pluginVersion("maven-install-plugin"));
+	}
+
+	/**
+	 * The fixture is held against the compiled classes rather than a list someone
+	 * remembered to update: a rule added to the module, or a parameter added to a
+	 * rule, that no fixture configures is named here instead of quietly going
+	 * unexercised by every test below.
+	 */
+	@Test
+	void theCompleteConfigurationAddressesEveryRuleAndParameterTheModuleShips() {
+		Map<String, Class<?>> shipped = ShippedRules.byName();
+		RuleConfiguration configuration = RuleConfiguration.complete();
+
+		assertEquals(shipped.keySet(), configuration.ruleNames(),
+				"every shipped rule must be configured by the end-to-end fixture");
+		shipped.forEach((name, rule) -> assertEquals(ShippedRules.parametersOf(rule),
+				configuration.parametersOf(name), () -> "the fixture must configure every parameter of " + name));
+	}
+
+	/**
+	 * The catalogue in one build: twenty-odd rules, each configured with every
+	 * parameter it accepts, against a project laid out the way an adopted repository
+	 * is. A green build here is what proves each {@code @Named} name resolves to a
+	 * rule class and each configuration element to a field — Maven fails outright on
+	 * an element it cannot bind — and each rule is checked to have actually run,
+	 * since a rule that is never reached also never fails.
+	 */
+	@Test
+	void aWellFormedProjectPassesEveryRuleInARealMavenBuild() {
+		FixtureProject project = wellFormedProject().enforcing(RuleConfiguration.complete().xml());
+
+		BuildOutcome outcome = validate(project);
+
+		assertTrue(outcome.succeeded(), outcome::describe);
+		for (String name : ShippedRules.byName().keySet()) {
+			assertTrue(outcome.mentions("(" + name + ") passed"),
+					() -> name + " did not report a pass: " + outcome.describe());
+		}
+	}
+
+	/**
+	 * A rule collects every problem before reporting, so one build tells a
+	 * contributor everything that is wrong with the document. That is worth little if
+	 * the grouped message is truncated on its way through Maven, so all six
+	 * violations are looked for in the failed build's own output.
+	 */
+	@Test
+	void aMalformedDocumentFailsTheBuildListingEveryViolationAtOnce() {
+		FixtureProject project = malformedProject(claudeMdRule());
+
+		BuildOutcome outcome = validate(project);
+
+		assertFalse(outcome.succeeded(), outcome::describe);
+		assertTrue(outcome.mentions(MISSING_AGENTS_REFERENCE), outcome::describe);
+		for (String section : Set.of("## Java version", "## Maven", "## Principles for Java Development",
+				"## Testing", "## Dependencies")) {
+			assertTrue(outcome.mentions(MISSING_SECTION + section), outcome::describe);
+		}
+	}
+
+	/**
+	 * The severity switch exists so a team can adopt a rule before it is allowed to
+	 * break the build, which is only true if the build really does go green while the
+	 * violations are still visible in its log.
+	 */
+	@Test
+	void severityWarnKeepsTheBuildGreenAndStillLogsTheViolations() {
+		FixtureProject project = malformedProject(claudeMdRule("<severity>warn</severity>"));
+
+		BuildOutcome outcome = validate(project);
+
+		assertTrue(outcome.succeeded(), outcome::describe);
+		assertTrue(outcome.mentions("[WARNING] CLAUDE.md is not well formed:"), outcome::describe);
+		assertTrue(outcome.mentions(MISSING_SECTION + "## Dependencies"), outcome::describe);
+	}
+
+	/**
+	 * The HTML report is written for a CI job to publish as an artifact, so what
+	 * matters is that a real build leaves it on disk, at the configured path, holding
+	 * both what failed and how to fix it.
+	 */
+	@Test
+	void aConfiguredReportFileIsWrittenWhereACiJobCanPublishIt() {
+		FixtureProject project = malformedProject(
+				claudeMdRule("<reportFile>${project.basedir}/target/enforcer-report.html</reportFile>"));
+
+		BuildOutcome outcome = validate(project);
+
+		assertFalse(outcome.succeeded(), outcome::describe);
+		Path report = project.path("target/enforcer-report.html");
+		assertTrue(Files.isRegularFile(report), () -> "no report at " + report + ": " + outcome.describe());
+		String html = project.read("target/enforcer-report.html");
+		assertTrue(html.contains(MISSING_SECTION + "## Dependencies"), html);
+		assertTrue(html.contains("How to fix"), html);
+	}
+
+	/**
+	 * A baseline lets a rule be switched on over a backlog: the violations recorded
+	 * once are suppressed, and only a new one fails the build. All three of those
+	 * steps are builds — recording, passing with the backlog still in place, and
+	 * failing on what was added afterwards — so all three are run here, against one
+	 * baseline file the way a repository keeps one.
+	 */
+	@Test
+	void aBaselineSuppressesTheRecordedViolationsUntilANewOneAppears() {
+		FixtureProject project = malformedProject(claudeMdRule(
+				"<baselineFile>${project.basedir}/enforcer-baseline.txt</baselineFile>",
+				"<baseDir>${project.basedir}</baseDir>"));
+
+		BuildOutcome recording = maven.run(project.root(), "-N", "validate",
+				"-Dclaude.enforcer.writeBaseline=true");
+		assertTrue(recording.succeeded(), recording::describe);
+		assertTrue(Files.isRegularFile(project.path("enforcer-baseline.txt")), recording::describe);
+
+		BuildOutcome suppressed = validate(project);
+		assertTrue(suppressed.succeeded(), suppressed::describe);
+		assertTrue(suppressed.mentions("violation(s) suppressed by the baseline"), suppressed::describe);
+
+		project.write("CLAUDE.md", WRONGLY_TITLED_CLAUDE_MD);
+		BuildOutcome regressed = validate(project);
+		assertFalse(regressed.succeeded(), regressed::describe);
+		assertTrue(regressed.mentions(WRONG_TITLE), regressed::describe);
+		assertFalse(regressed.mentions(MISSING_SECTION + "## Dependencies"),
+				() -> "a violation the baseline accepted must not be reported again: " + regressed.describe());
+	}
+
+	/**
+	 * A document that is not there is a build-setup mistake, not a document-quality
+	 * one, so it must fail even where the project asked for warnings only — otherwise
+	 * a mistyped path would silently switch the check off and the build would stay
+	 * green for as long as nobody looked.
+	 */
+	@Test
+	void aMissingDocumentFailsTheBuildEvenWhenSeverityIsWarn() {
+		FixtureProject project = project().enforcing(claudeMdRule("<severity>warn</severity>"));
+
+		BuildOutcome outcome = validate(project);
+
+		assertFalse(outcome.succeeded(), outcome::describe);
+		assertTrue(outcome.mentions("CLAUDE.md does not exist at"), outcome::describe);
+	}
+
+	/**
+	 * The other way a check can silently stop running: a parameter spelled almost
+	 * right. Maven refuses to bind it, and it must stay that way — a
+	 * {@code maxLineLenght} that were ignored would leave a project believing its
+	 * line-length budget was enforced.
+	 */
+	@Test
+	void aMisspelledParameterFailsTheBuildRatherThanSilentlyDisablingTheCheck() {
+		FixtureProject project = wellFormedProject().enforcing(claudeMdRule("<maxLineLenght>80</maxLineLenght>"));
+
+		BuildOutcome outcome = validate(project);
+
+		assertFalse(outcome.succeeded(), outcome::describe);
+		assertTrue(outcome.mentions("Cannot find 'maxLineLenght'"), outcome::describe);
+	}
+
+	private BuildOutcome validate(FixtureProject project) {
+		return maven.run(project.root(), "-N", "validate");
+	}
+
+	private FixtureProject project() {
+		return new FixtureProject(workspace, environment, enforcerPluginVersion);
+	}
+
+	private FixtureProject wellFormedProject() {
+		return project().layOutWellFormedProject();
+	}
+
+	/** A project whose only problem is its CLAUDE.md, so one rule has everything to say. */
+	private FixtureProject malformedProject(String rulesXml) {
+		return wellFormedProject().write("CLAUDE.md", MALFORMED_CLAUDE_MD).enforcing(rulesXml);
+	}
+
+	/** The document rule alone, plus whatever shared configuration the test is about. */
+	private String claudeMdRule(String... sharedConfiguration) {
+		return """
+									<claudeMdFormat>
+										<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
+										%s
+									</claudeMdFormat>
+				""".formatted(String.join(System.lineSeparator(), sharedConfiguration));
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/FixtureProject.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/FixtureProject.java
@@ -1,0 +1,321 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+
+import java.nio.file.Path;
+
+/**
+ * A throwaway project laid out the way a repository that has adopted Claude Code
+ * is: the two agent documents, a README, the {@code .claude} configuration with a
+ * skill, a sub-agent, a command, settings and a hook, an {@code .mcp.json}, a
+ * plugin manifest and a {@code .gitignore} — plus the pom that runs the rules
+ * against them.
+ * <p>
+ * Everything is well formed to begin with, so a test states its case by breaking
+ * exactly one thing and watching the build react. Rule parameters are written into
+ * the pom as {@code ${project.basedir}} paths, as a real project writes them, which
+ * is what puts Maven's own interpolation between the configuration and the rule.
+ */
+final class FixtureProject {
+
+	private static final String CLAUDE_MD = """
+			# CLAUDE.md
+
+			Guidance for agents working in this fixture, which defers to
+			[AGENTS.md](AGENTS.md) as the single source of truth.
+
+			@docs/imported.md
+			@ignored/never-loaded.md
+
+			## Project
+
+			A fixture reactor of two modules, alpha and beta.
+
+			## Java version
+
+			Java 25.
+
+			## Maven
+
+			Build with `mvn install` from the fixture root.
+
+			## Principles for Java Development
+
+			SOLID principles, clean code, short methods.
+
+			## Testing
+
+			Unit tests for all new logic, and integration tests for what needs
+			something real.
+
+			## Dependencies
+
+			Use the existing dependencies; ask before adding one.
+			""";
+
+	private static final String AGENTS_MD = """
+			# AGENTS.md
+
+			The source of truth for this fixture, summarised in
+			[CLAUDE.md](CLAUDE.md).
+
+			## Project overview
+
+			A fixture project the enforcer end-to-end tests build. Java 25, proto3.
+
+			## Module layout
+
+			The reactor holds two modules: alpha and beta.
+
+			## Environment & toolchain
+
+			Java 25 and Maven.
+
+			## Build, test, and run
+
+			`mvn install` builds and tests everything.
+
+			## Code style & conventions
+
+			Match the surrounding code.
+
+			## Releasing
+
+			Tag a release and let the pipeline publish it.
+
+			## Pull requests & commits
+
+			Conventional commit messages and focused changes.
+			""";
+
+	private static final String README_MD = """
+			# Fixture
+
+			A fixture project that generates proto3 messages. See
+			[AGENTS.md](AGENTS.md) for the details.
+			""";
+
+	private static final String IMPORTED_MD = """
+			# Imported memory
+
+			Context that CLAUDE.md pulls in with a memory import.
+			""";
+
+	private static final String GITIGNORE = """
+			target/
+			.claude/settings.local.json
+			""";
+
+	/**
+	 * The reactor whose modules the docs must document. It is a plain file the
+	 * module-map rule reads rather than a pom any build runs, which is why it can
+	 * name modules that have no directory — including the one the rule is configured
+	 * to ignore.
+	 */
+	private static final String REACTOR_POM = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+				<modelVersion>4.0.0</modelVersion>
+				<groupId>io.github.adamw7.enforcer.e2e</groupId>
+				<artifactId>reactor</artifactId>
+				<version>1.0</version>
+				<packaging>pom</packaging>
+				<modules>
+					<module>alpha</module>
+					<module>nested/beta</module>
+					<module>gamma</module>
+				</modules>
+			</project>
+			""";
+
+	private static final String SETTINGS_JSON = """
+			{
+			  "permissions": {
+			    "allow": ["Bash(mvn *)", "Read"],
+			    "deny": ["Bash(rm *)"]
+			  },
+			  "hooks": {
+			    "SessionStart": [
+			      {
+			        "hooks": [
+			          {
+			            "type": "command",
+			            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+			          }
+			        ]
+			      }
+			    ]
+			  }
+			}
+			""";
+
+	private static final String SESSION_START_HOOK = """
+			#!/usr/bin/env bash
+			set -euo pipefail
+			echo "fixture session start"
+			""";
+
+	private static final String SKILL_MD = """
+			---
+			name: sample-skill
+			description: Explains the fixture project to an agent that opens it.
+			---
+
+			# Sample skill
+
+			Body of the skill.
+			""";
+
+	private static final String SUB_AGENT_MD = """
+			---
+			name: sample-agent
+			description: Reviews the fixture project on request.
+			model: sonnet
+			---
+
+			Instructions for the sub-agent.
+			""";
+
+	private static final String COMMAND_MD = """
+			---
+			description: Builds the fixture project from the repository root.
+			model: sonnet
+			---
+
+			Run the build.
+			""";
+
+	private static final String PLUGIN_JSON = """
+			{
+			  "name": "sample-plugin",
+			  "version": "1.0.0",
+			  "description": "A plugin manifest the fixture ships."
+			}
+			""";
+
+	private static final String MCP_JSON = """
+			{
+			  "mcpServers": {
+			    "remote": {
+			      "type": "http",
+			      "url": "https://example.invalid/mcp",
+			      "headers": { "X-Fixture": "sample" }
+			    },
+			    "local": {
+			      "type": "stdio",
+			      "command": "java",
+			      "args": ["-jar", "server.jar"],
+			      "env": { "MODE": "fixture" }
+			    }
+			  }
+			}
+			""";
+
+	/**
+	 * The build itself. The rule jar is a plugin dependency rather than a project
+	 * dependency, because that is the only class path a maven-enforcer rule is loaded
+	 * from, and the whole configuration sits in one {@code validate}-phase execution
+	 * so a fixture build costs a second.
+	 */
+	private static final String POM_TEMPLATE = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+				<modelVersion>4.0.0</modelVersion>
+				<groupId>io.github.adamw7.enforcer.e2e</groupId>
+				<artifactId>fixture</artifactId>
+				<version>1.0</version>
+				<packaging>pom</packaging>
+				<build>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-enforcer-plugin</artifactId>
+							<version>%s</version>
+							<dependencies>
+								<dependency>
+									<groupId>%s</groupId>
+									<artifactId>%s</artifactId>
+									<version>%s</version>
+								</dependency>
+							</dependencies>
+							<executions>
+								<execution>
+									<id>enforce-claude-code</id>
+									<phase>validate</phase>
+									<goals>
+										<goal>enforce</goal>
+									</goals>
+									<configuration>
+										<rules>
+			%s
+										</rules>
+									</configuration>
+								</execution>
+							</executions>
+						</plugin>
+					</plugins>
+				</build>
+			</project>
+			""";
+
+	private final Path root;
+	private final BuildEnvironment environment;
+	private final String enforcerPluginVersion;
+
+	FixtureProject(Path root, BuildEnvironment environment, String enforcerPluginVersion) {
+		this.root = root;
+		this.environment = environment;
+		this.enforcerPluginVersion = enforcerPluginVersion;
+	}
+
+	Path root() {
+		return root;
+	}
+
+	Path path(String relativePath) {
+		return root.resolve(relativePath);
+	}
+
+	String read(String relativePath) {
+		return readString(path(relativePath));
+	}
+
+	FixtureProject write(String relativePath, String content) {
+		writeString(path(relativePath), content);
+		return this;
+	}
+
+	/** Every file the shipped rules look at, all of them well formed. */
+	FixtureProject layOutWellFormedProject() {
+		write("CLAUDE.md", CLAUDE_MD);
+		write("AGENTS.md", AGENTS_MD);
+		write("README.md", README_MD);
+		write("docs/imported.md", IMPORTED_MD);
+		write(".gitignore", GITIGNORE);
+		write("reactor-pom.xml", REACTOR_POM);
+		write(".claude/settings.json", SETTINGS_JSON);
+		writeHook();
+		write(".claude/skills/sample-skill/SKILL.md", SKILL_MD);
+		write(".claude/agents/sample-agent.md", SUB_AGENT_MD);
+		write(".claude/commands/sample-command.md", COMMAND_MD);
+		write(".claude-plugin/plugin.json", PLUGIN_JSON);
+		write(".mcp.json", MCP_JSON);
+		return this;
+	}
+
+	/** Writes the pom that runs {@code rulesXml}, and returns the project to build. */
+	FixtureProject enforcing(String rulesXml) {
+		write("pom.xml", POM_TEMPLATE.formatted(enforcerPluginVersion, BuildEnvironment.GROUP_ID,
+				BuildEnvironment.ARTIFACT_ID, environment.version(), rulesXml));
+		return this;
+	}
+
+	/**
+	 * A hook is a script Claude Code runs, so the executable bit is part of being well
+	 * formed and the rule that checks it needs the fixture to carry one.
+	 */
+	private void writeHook() {
+		Path hook = path(".claude/hooks/session-start.sh");
+		writeString(hook, SESSION_START_HOOK);
+		hook.toFile().setExecutable(true);
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/MavenBuild.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/MavenBuild.java
@@ -1,0 +1,157 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Runs a real Maven build in a real process, which is the only way to observe an
+ * enforcer rule the way a contributor meets it. A unit test constructs a rule and
+ * calls {@code execute()} on it directly; everything between the pom and that call
+ * — Maven resolving the rule jar, Sisu finding the class behind a {@code @Named}
+ * element, and Plexus binding each configuration element to a field — is skipped,
+ * and each of those is a way a rule can be perfectly correct and still never run.
+ * <p>
+ * Builds are launched from the Maven that is running the outer build and are
+ * pointed at its local repository, so a fixture resolves the plugins and
+ * dependencies already downloaded for this build rather than reaching for the
+ * network. Standard output and error are merged into a temporary log outside the
+ * project directory — a build must never leave a file in the repository it was
+ * pointed at — and returned as the {@link BuildOutcome}.
+ */
+final class MavenBuild {
+
+	/**
+	 * Far above the second or two a fixture build takes, since it only has to fail a
+	 * build that has stopped responding rather than one that is merely slow: the
+	 * first run in a cold environment may still be downloading the install plugin.
+	 */
+	private static final long TIMEOUT_MINUTES = 5;
+
+	private static final String INSTALL_PLUGIN = "org.apache.maven.plugins:maven-install-plugin";
+
+	private final BuildEnvironment environment;
+
+	MavenBuild(BuildEnvironment environment) {
+		this.environment = environment;
+	}
+
+	/**
+	 * Publishes the jar this module has just built into the local repository, so a
+	 * fixture pom can name it as a plugin dependency. A maven-enforcer rule has to be
+	 * resolvable as an artifact before the build that uses it starts, which is why the
+	 * repository documents the doc check as a two-phase build; an {@code *IT} runs at
+	 * {@code integration-test}, before this module is installed, so it publishes the
+	 * jar itself rather than testing whatever an earlier build happened to leave
+	 * behind.
+	 *
+	 * @param installPluginVersion the version the repository pins, rather than the
+	 *                             one Maven's own super-pom defaults to: only the
+	 *                             pinned one is certain to be in the local repository
+	 *                             already, so taking it keeps this off the network
+	 */
+	void publishRuleUnderTest(String installPluginVersion) {
+		Path workingDirectory = temporaryDirectory();
+		BuildOutcome outcome = run(workingDirectory,
+				INSTALL_PLUGIN + ":" + installPluginVersion + ":install-file",
+				"-Dfile=" + environment.jar(),
+				"-DpomFile=" + environment.pom());
+		delete(workingDirectory);
+		if (!outcome.succeeded()) {
+			throw new IllegalStateException("Could not publish " + environment.jar() + ": " + outcome.describe());
+		}
+	}
+
+	/**
+	 * Runs Maven in {@code directory} with the given arguments. Batch mode keeps the
+	 * log free of progress animations a test would have to parse around, and the
+	 * explicit local repository makes the fixture build resolve from the same place
+	 * as the build that started it.
+	 */
+	BuildOutcome run(Path directory, String... arguments) {
+		List<String> command = new ArrayList<>(List.of(
+				environment.mavenExecutable().toString(),
+				"-B",
+				"--no-transfer-progress",
+				"-Dmaven.repo.local=" + environment.localRepository()));
+		command.addAll(List.of(arguments));
+		return execute(directory, command);
+	}
+
+	private BuildOutcome execute(Path directory, List<String> command) {
+		Path log = temporaryFile();
+		try {
+			Process process = new ProcessBuilder(command)
+					.directory(directory.toFile())
+					.redirectErrorStream(true)
+					.redirectOutput(log.toFile())
+					.start();
+			return new BuildOutcome(exitCodeOf(process, command), read(log));
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not run " + command, e);
+		} finally {
+			delete(log);
+		}
+	}
+
+	/**
+	 * A build that never returns would otherwise hang the whole test run until
+	 * surefire's fork timeout kills it, taking the log with it, so it is killed here
+	 * and reported as what it is.
+	 */
+	private int exitCodeOf(Process process, List<String> command) {
+		try {
+			if (!process.waitFor(TIMEOUT_MINUTES, TimeUnit.MINUTES)) {
+				process.destroyForcibly();
+				throw new IllegalStateException(command + " did not finish within " + TIMEOUT_MINUTES + " minutes");
+			}
+			return process.exitValue();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("Interrupted while waiting for " + command, e);
+		}
+	}
+
+	/**
+	 * Decoded leniently: Maven writes the platform's encoding, and a byte that does
+	 * not decode is noise in a log, never a reason to fail a test that has an
+	 * assertion of its own to make.
+	 */
+	private String read(Path log) {
+		try {
+			return new String(Files.readAllBytes(log), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read the build log " + log, e);
+		}
+	}
+
+	private Path temporaryFile() {
+		try {
+			return Files.createTempFile("enforcer-e2e", ".log");
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create a build log", e);
+		}
+	}
+
+	/** A directory with no pom in it, so a project-free goal is not handed a project. */
+	private Path temporaryDirectory() {
+		try {
+			return Files.createTempDirectory("enforcer-e2e");
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create a working directory", e);
+		}
+	}
+
+	private void delete(Path path) {
+		try {
+			Files.deleteIfExists(path);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not delete " + path, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RepositoryEnforcementIT.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RepositoryEnforcementIT.java
@@ -1,0 +1,227 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+import static java.nio.file.StandardCopyOption.COPY_ATTRIBUTES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Enforces this repository's own documentation contract the way
+ * {@code .github/workflows/maven.yml} does — {@code mvn -N validate
+ * -DenforceClaudeMd}, with the rules wired in the root pom's
+ * {@code claude-md-enforce} profile — and then breaks that repository to prove the
+ * wiring bites.
+ *
+ * <p>{@link EnforcerRuleBuildIT} builds a fixture project, so it proves the rules
+ * work; it says nothing about the configuration this repository actually ships. A
+ * rule can be flawless and still guard nothing here: pointed at the wrong path,
+ * left out of the profile, or written down in a document that no longer matches
+ * the module list. The three things asserted here are exactly those — that the
+ * wired configuration passes today, that every shipped rule is either wired or
+ * deliberately left out, and that a regression in the repository's own files is
+ * caught rather than waved through.
+ *
+ * <p>The two regression tests work on a copy in a temporary directory. Breaking
+ * the checkout the build is running from and putting it back would leave a
+ * developer with a modified working tree if the test failed halfway; the copy
+ * carries the same files, so the rules see the same repository.
+ */
+class RepositoryEnforcementIT {
+
+	/**
+	 * Everything the wired rules read: the root pom they take the module map from,
+	 * the three documents, the gitignore, and the whole agent configuration.
+	 */
+	private static final List<String> ENFORCED_PATHS = List.of(
+			"pom.xml", "CLAUDE.md", "AGENTS.md", "README.md", ".gitignore", ".claude");
+
+	/**
+	 * The rules that ship unwired on purpose. Both take a definition directory that
+	 * must exist when configured, so wiring one before the repository has the
+	 * directory would fail the build as a setup mistake; they are wired the day the
+	 * directory is added.
+	 */
+	private static final Set<String> DELIBERATELY_UNWIRED = Set.of("subAgentFormat", "commandFormat");
+
+	private static BuildEnvironment environment;
+	private static MavenBuild maven;
+	private static RepositoryPom repositoryPom;
+
+	@TempDir
+	Path copy;
+
+	@BeforeAll
+	static void publishTheRuleUnderTest() {
+		environment = new BuildEnvironment();
+		repositoryPom = new RepositoryPom(environment.repositoryRoot());
+		maven = new MavenBuild(environment);
+		maven.publishRuleUnderTest(repositoryPom.pluginVersion("maven-install-plugin"));
+	}
+
+	/**
+	 * The check the pull-request workflow runs, run against the checkout it is being
+	 * run from. Each wired rule is confirmed to have reported a pass, because a rule
+	 * that silently never ran would leave this test green while guarding nothing.
+	 */
+	@Test
+	void theRepositoryPassesTheContractItShipsWith() {
+		BuildOutcome outcome = enforce(environment.repositoryRoot());
+
+		assertTrue(outcome.succeeded(), outcome::describe);
+		for (String name : repositoryPom.wiredRuleNames()) {
+			assertTrue(outcome.mentions("(" + name + ") passed"),
+					() -> name + " is wired but did not report a pass: " + outcome.describe());
+		}
+	}
+
+	/**
+	 * A rule nobody wires guards nothing, and the two that ship unwired do so for a
+	 * documented reason. Comparing the shipped catalogue against the profile turns
+	 * "someone forgot to wire it" into a failure, and equally stops the exemption
+	 * list from quietly growing.
+	 */
+	@Test
+	void everyShippedRuleIsWiredIntoTheBuildOrDeliberatelyLeftOut() {
+		Set<String> shipped = ShippedRules.byName().keySet();
+		Set<String> wired = repositoryPom.wiredRuleNames();
+
+		assertTrue(shipped.containsAll(wired),
+				() -> "the profile wires rules this module does not ship: " + difference(wired, shipped));
+		assertEquals(DELIBERATELY_UNWIRED, difference(shipped, wired),
+				"a shipped rule is either wired into the claude-md-enforce profile or a documented exemption");
+	}
+
+	/**
+	 * The rule that would notice a skill losing its definition is wired at
+	 * {@code ${project.basedir}/.claude/skills}, which is a claim about a path that
+	 * no unit test can check. Removing a real {@code SKILL.md} from the copy is what
+	 * proves the wired path is the one the skills are actually under.
+	 */
+	@Test
+	void theWiredConfigurationCatchesASkillThatLostItsDefinition() {
+		Path repository = copyOfRepository();
+		Path skill = firstSkillIn(repository);
+		delete(skill.resolve("SKILL.md"));
+
+		BuildOutcome outcome = enforce(repository);
+
+		assertFalse(outcome.succeeded(), outcome::describe);
+		assertTrue(outcome.mentions("(skillFilesExist) failed"), outcome::describe);
+		assertTrue(outcome.mentions("Missing SKILL.md in skill directory: "), outcome::describe);
+		assertTrue(outcome.mentions(skill.getFileName().toString()), outcome::describe);
+	}
+
+	/**
+	 * The cross-document rule is the one wired with two paths at once, and the fact
+	 * it pins — the Java version — is the one most likely to be bumped in one
+	 * document and forgotten in the other. Bumping it in the copy's CLAUDE.md alone
+	 * is that mistake, made on purpose.
+	 */
+	@Test
+	void theWiredConfigurationCatchesTheAgentDocumentsContradictingEachOther() {
+		Path repository = copyOfRepository();
+		Path claudeMd = repository.resolve("CLAUDE.md");
+		write(claudeMd, read(claudeMd).replace("Java 25", "Java 21"));
+
+		BuildOutcome outcome = enforce(repository);
+
+		assertFalse(outcome.succeeded(), outcome::describe);
+		assertTrue(outcome.mentions("(crossDocConsistency) failed"), outcome::describe);
+		assertTrue(outcome.mentions("captured"), outcome::describe);
+	}
+
+	private BuildOutcome enforce(Path repository) {
+		return maven.run(repository, "-N", "validate", "-DenforceClaudeMd");
+	}
+
+	/** The repository as the wired rules see it: only the files they are pointed at. */
+	private Path copyOfRepository() {
+		for (String path : ENFORCED_PATHS) {
+			copyTree(environment.repositoryRoot().resolve(path), copy.resolve(path));
+		}
+		return copy;
+	}
+
+	/**
+	 * Chosen by name rather than named outright, so renaming a skill does not rename
+	 * it here too; sorted, so a failure reports the same skill on every run.
+	 */
+	private Path firstSkillIn(Path repository) {
+		Path skills = repository.resolve(".claude/skills");
+		try (Stream<Path> directories = Files.list(skills)) {
+			return directories.filter(Files::isDirectory).min(Comparator.comparing(Path::getFileName))
+					.orElseThrow(() -> new IllegalStateException("There are no skills under " + skills));
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not list " + skills, e);
+		}
+	}
+
+	/**
+	 * Copied with the file attributes, because one of the things the wired rules
+	 * check is that a hook script is executable — a copy that dropped the mode bits
+	 * would fail for a reason the repository is not guilty of.
+	 */
+	private void copyTree(Path source, Path target) {
+		try (Stream<Path> tree = Files.walk(source)) {
+			for (Path path : tree.toList()) {
+				copyOne(path, target.resolve(source.relativize(path).toString()));
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not copy " + source, e);
+		}
+	}
+
+	private void copyOne(Path source, Path target) throws IOException {
+		if (Files.isDirectory(source)) {
+			Files.createDirectories(target);
+		} else {
+			Files.createDirectories(target.getParent());
+			Files.copy(source, target, COPY_ATTRIBUTES);
+		}
+	}
+
+	private String read(Path file) {
+		try {
+			return Files.readString(file);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read " + file, e);
+		}
+	}
+
+	private void write(Path file, String content) {
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+	}
+
+	private void delete(Path file) {
+		try {
+			Files.delete(file);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not delete " + file, e);
+		}
+	}
+
+	/** What is in {@code all} but not in {@code some}, sorted so a failure message is stable. */
+	private Set<String> difference(Set<String> all, Set<String> some) {
+		Set<String> difference = new TreeSet<>(all);
+		difference.removeAll(some);
+		return difference;
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RepositoryPom.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RepositoryPom.java
@@ -1,0 +1,112 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+import org.jsoup.select.Elements;
+
+/**
+ * The repository's own root {@code pom.xml}, read as the configuration under test
+ * rather than as a build file. Two facts are taken from it: the plugin versions a
+ * fixture build must use, so an end-to-end test exercises the same
+ * maven-enforcer-plugin the repository does rather than a version of its own, and
+ * the set of rules the {@code claude-md-enforce} profile actually wires — the
+ * catalogue a contributor's build runs, which is what
+ * {@link RepositoryEnforcementIT} holds against the rules this module ships.
+ */
+final class RepositoryPom {
+
+	private static final String ENFORCE_PROFILE = "claude-md-enforce";
+
+	private final Document pom;
+	private final Path file;
+
+	RepositoryPom(Path repositoryRoot) {
+		this.file = repositoryRoot.resolve("pom.xml");
+		this.pom = parse(file);
+	}
+
+	/**
+	 * The version pinned for {@code artifactId} under {@code pluginManagement}, where
+	 * this repository keeps every plugin version.
+	 */
+	String pluginVersion(String artifactId) {
+		for (Element plugin : pom.select("pluginManagement > plugins > plugin")) {
+			if (artifactId.equals(textOf(plugin, "artifactId"))) {
+				return required(textOf(plugin, "version"), artifactId + " has no version in " + file);
+			}
+		}
+		throw new IllegalStateException(artifactId + " is not managed in " + file);
+	}
+
+	/**
+	 * The rule names the doc check is wired with, in pom order. Each is the name of a
+	 * configuration element, which is also the {@code @Named} name of the rule class
+	 * behind it — the whole point of the comparison this feeds.
+	 */
+	Set<String> wiredRuleNames() {
+		Set<String> names = new LinkedHashSet<>();
+		for (Element rule : enforceProfileRules().children()) {
+			names.add(rule.tagName());
+		}
+		return names;
+	}
+
+	/**
+	 * Scoped to the {@code claude-md-enforce} profile on purpose: the root pom
+	 * carries other {@code <rules>} blocks — the standing enforcer checks, the
+	 * coverage limits — and picking the first one found would compare the doc-check
+	 * catalogue against something else entirely.
+	 */
+	private Element enforceProfileRules() {
+		for (Element profile : pom.select("profiles > profile")) {
+			if (ENFORCE_PROFILE.equals(textOf(profile, "id"))) {
+				Elements rules = profile.select("rules");
+				return required(rules.first(), "The " + ENFORCE_PROFILE + " profile has no rules in " + file);
+			}
+		}
+		throw new IllegalStateException("There is no " + ENFORCE_PROFILE + " profile in " + file);
+	}
+
+	/**
+	 * The text of a <em>direct</em> child element, or null when there is none. Direct
+	 * rather than descendant, so a plugin's own {@code artifactId} is not confused
+	 * with one nested in its {@code dependencies}.
+	 */
+	private String textOf(Element parent, String tagName) {
+		for (Element child : parent.children()) {
+			if (child.tagName().equals(tagName)) {
+				return child.text().strip();
+			}
+		}
+		return null;
+	}
+
+	private <T> T required(T value, String message) {
+		if (value == null) {
+			throw new IllegalStateException(message);
+		}
+		return value;
+	}
+
+	/**
+	 * Parsed with the XML parser rather than the HTML one, which lower-cases tag
+	 * names — a rule element such as {@code claudeMdFormat} would come back as
+	 * {@code claudemdformat} and match no rule.
+	 */
+	private static Document parse(Path file) {
+		try {
+			return Jsoup.parse(file.toFile(), StandardCharsets.UTF_8.name(), "", Parser.xmlParser());
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read " + file, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
@@ -1,0 +1,290 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+
+/**
+ * A {@code <rules>} block as a pom writes one, and what it says about itself.
+ * <p>
+ * {@link #complete()} configures every rule this module ships with every parameter
+ * that rule accepts — the whole surface a project can address the enforcer through.
+ * Maven refuses an element it cannot bind ("Cannot find 'x' in class …"), so a
+ * build that gets through this configuration has proved that each
+ * {@code @Named} name resolves to a rule and each element resolves to a field. The
+ * block reads itself back through the same XML it hands Maven, which is what lets
+ * a test compare it against the shipped rules without a second, hand-kept list to
+ * drift.
+ */
+final class RuleConfiguration {
+
+	private static final String COMPLETE = """
+								<claudeMdFormat>
+									<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
+									<titleHeading># CLAUDE.md</titleHeading>
+									<requiredSections>
+										<requiredSection>## Project</requiredSection>
+										<requiredSection>## Java version</requiredSection>
+										<requiredSection>## Maven</requiredSection>
+										<requiredSection>## Principles for Java Development</requiredSection>
+										<requiredSection>## Testing</requiredSection>
+										<requiredSection>## Dependencies</requiredSection>
+									</requiredSections>
+									<forbiddenTokens>
+										<forbiddenToken>TODO</forbiddenToken>
+									</forbiddenTokens>
+									<enforceSectionOrder>true</enforceSectionOrder>
+									<maxLineLength>100</maxLineLength>
+									<validateFileReferences>true</validateFileReferences>
+									<referenceBaseDir>${project.basedir}</referenceBaseDir>
+								</claudeMdFormat>
+								<agentsMdFormat>
+									<agentsMdFile>${project.basedir}/AGENTS.md</agentsMdFile>
+									<titleHeading># AGENTS.md</titleHeading>
+									<requiredSections>
+										<requiredSection>## Project overview</requiredSection>
+										<requiredSection>## Module layout</requiredSection>
+										<requiredSection>## Environment &amp; toolchain</requiredSection>
+										<requiredSection>## Build, test, and run</requiredSection>
+										<requiredSection>## Code style &amp; conventions</requiredSection>
+										<requiredSection>## Releasing</requiredSection>
+										<requiredSection>## Pull requests &amp; commits</requiredSection>
+									</requiredSections>
+									<forbiddenTokens>
+										<forbiddenToken>TODO</forbiddenToken>
+									</forbiddenTokens>
+									<enforceSectionOrder>true</enforceSectionOrder>
+									<maxLineLength>100</maxLineLength>
+									<validateFileReferences>true</validateFileReferences>
+									<referenceBaseDir>${project.basedir}</referenceBaseDir>
+								</agentsMdFormat>
+								<crossDocConsistency>
+									<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
+									<agentsMdFile>${project.basedir}/AGENTS.md</agentsMdFile>
+									<consistentPatterns>
+										<consistentPattern>Java (\\d+)</consistentPattern>
+									</consistentPatterns>
+								</crossDocConsistency>
+								<readmeConsistency>
+									<readmeFile>${project.basedir}/README.md</readmeFile>
+									<agentDocFile>${project.basedir}/AGENTS.md</agentDocFile>
+									<consistentPatterns>
+										<consistentPattern>proto(\\d)</consistentPattern>
+									</consistentPatterns>
+								</readmeConsistency>
+								<memoryImports>
+									<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
+									<maxDepth>3</maxDepth>
+									<ignoredImports>
+										<ignoredImport>ignored/never-loaded.md</ignoredImport>
+									</ignoredImports>
+								</memoryImports>
+								<moduleMapConsistency>
+									<pomFile>${project.basedir}/reactor-pom.xml</pomFile>
+									<docFiles>
+										<docFile>${project.basedir}/CLAUDE.md</docFile>
+										<docFile>${project.basedir}/AGENTS.md</docFile>
+									</docFiles>
+									<ignoredModules>
+										<ignoredModule>gamma</ignoredModule>
+									</ignoredModules>
+								</moduleMapConsistency>
+								<contextBudget>
+									<files>
+										<file>${project.basedir}/CLAUDE.md</file>
+									</files>
+									<directories>
+										<directory>${project.basedir}/.claude/skills</directory>
+									</directories>
+									<maxBytes>32768</maxBytes>
+									<maxLines>500</maxLines>
+									<maxTokens>8192</maxTokens>
+								</contextBudget>
+								<skillFilesExist>
+									<skillsDir>${project.basedir}/.claude/skills</skillsDir>
+									<requiredKeys>
+										<requiredKey>name</requiredKey>
+										<requiredKey>description</requiredKey>
+									</requiredKeys>
+									<allowedFrontMatterKeys>
+										<allowedFrontMatterKey>name</allowedFrontMatterKey>
+										<allowedFrontMatterKey>description</allowedFrontMatterKey>
+									</allowedFrontMatterKeys>
+									<maxDescriptionLength>200</maxDescriptionLength>
+									<autoFix>false</autoFix>
+								</skillFilesExist>
+								<subAgentFormat>
+									<agentsDir>${project.basedir}/.claude/agents</agentsDir>
+									<requiredKeys>
+										<requiredKey>name</requiredKey>
+										<requiredKey>description</requiredKey>
+									</requiredKeys>
+									<allowedModels>
+										<allowedModel>sonnet</allowedModel>
+										<allowedModel>opus</allowedModel>
+									</allowedModels>
+									<autoFix>false</autoFix>
+								</subAgentFormat>
+								<commandFormat>
+									<commandsDir>${project.basedir}/.claude/commands</commandsDir>
+									<allowedFrontMatterKeys>
+										<allowedFrontMatterKey>description</allowedFrontMatterKey>
+										<allowedFrontMatterKey>model</allowedFrontMatterKey>
+									</allowedFrontMatterKeys>
+									<allowedModels>
+										<allowedModel>sonnet</allowedModel>
+										<allowedModel>opus</allowedModel>
+									</allowedModels>
+									<autoFix>false</autoFix>
+								</commandFormat>
+								<uniqueNames>
+									<commandsDir>${project.basedir}/.claude/commands</commandsDir>
+									<agentsDir>${project.basedir}/.claude/agents</agentsDir>
+									<skillsDir>${project.basedir}/.claude/skills</skillsDir>
+								</uniqueNames>
+								<uniqueDescriptions>
+									<commandsDir>${project.basedir}/.claude/commands</commandsDir>
+									<agentsDir>${project.basedir}/.claude/agents</agentsDir>
+									<skillsDir>${project.basedir}/.claude/skills</skillsDir>
+								</uniqueDescriptions>
+								<pluginFormat>
+									<pluginFile>${project.basedir}/.claude-plugin/plugin.json</pluginFile>
+									<requiredKeys>
+										<requiredKey>name</requiredKey>
+									</requiredKeys>
+									<allowedKeys>
+										<allowedKey>name</allowedKey>
+										<allowedKey>version</allowedKey>
+										<allowedKey>description</allowedKey>
+									</allowedKeys>
+								</pluginFormat>
+								<settingsJsonValid>
+									<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
+									<requiredPermissions>
+										<requiredPermission>Bash(mvn *)</requiredPermission>
+									</requiredPermissions>
+									<forbiddenPermissions>
+										<forbiddenPermission>Bash(*)</forbiddenPermission>
+									</forbiddenPermissions>
+								</settingsJsonValid>
+								<permissionsFormat>
+									<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
+									<allowedTools>
+										<allowedTool>Bash</allowedTool>
+										<allowedTool>Read</allowedTool>
+									</allowedTools>
+									<forbiddenEntryPatterns>
+										<forbiddenEntryPattern>Bash\\(\\*\\)</forbiddenEntryPattern>
+									</forbiddenEntryPatterns>
+								</permissionsFormat>
+								<hookCommandsValid>
+									<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
+									<projectDir>${project.basedir}</projectDir>
+									<allowedEvents>
+										<allowedEvent>SessionStart</allowedEvent>
+									</allowedEvents>
+									<validateScriptReferences>true</validateScriptReferences>
+								</hookCommandsValid>
+								<hooksFormat>
+									<hooksDir>${project.basedir}/.claude/hooks</hooksDir>
+									<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
+									<projectDir>${project.basedir}</projectDir>
+									<allowedExtensions>
+										<allowedExtension>sh</allowedExtension>
+									</allowedExtensions>
+									<requireShebang>true</requireShebang>
+									<requireExecutable>true</requireExecutable>
+									<reportUnreferencedScripts>true</reportUnreferencedScripts>
+								</hooksFormat>
+								<localSettingsIgnored>
+									<gitignoreFile>${project.basedir}/.gitignore</gitignoreFile>
+									<ignoredPaths>
+										<ignoredPath>.claude/settings.local.json</ignoredPath>
+									</ignoredPaths>
+								</localSettingsIgnored>
+								<noSecrets>
+									<files>
+										<file>${project.basedir}/.claude/settings.json</file>
+										<file>${project.basedir}/.mcp.json</file>
+									</files>
+									<directories>
+										<directory>${project.basedir}/.claude/hooks</directory>
+									</directories>
+									<secretPatterns>
+										<secretPattern>XKEY-[0-9a-f]{16}</secretPattern>
+									</secretPatterns>
+									<useDefaultPatterns>true</useDefaultPatterns>
+								</noSecrets>
+								<mcpServersValid>
+									<mcpFile>${project.basedir}/.mcp.json</mcpFile>
+									<requiredServers>
+										<requiredServer>remote</requiredServer>
+									</requiredServers>
+									<forbiddenServers>
+										<forbiddenServer>deprecated</forbiddenServer>
+									</forbiddenServers>
+									<allowedTypes>
+										<allowedType>stdio</allowedType>
+										<allowedType>http</allowedType>
+										<allowedType>sse</allowedType>
+									</allowedTypes>
+								</mcpServersValid>
+								<mcpConfigFormat>
+									<mcpFile>${project.basedir}/.mcp.json</mcpFile>
+									<requireHttps>true</requireHttps>
+								</mcpConfigFormat>
+			""";
+
+	private final String xml;
+
+	RuleConfiguration(String xml) {
+		this.xml = xml;
+	}
+
+	/** Every shipped rule, with every parameter it accepts, against the well-formed fixture. */
+	static RuleConfiguration complete() {
+		return new RuleConfiguration(COMPLETE);
+	}
+
+	String xml() {
+		return xml;
+	}
+
+	/** The rules this block configures, by the name the pom addresses each one with. */
+	Set<String> ruleNames() {
+		Set<String> names = new LinkedHashSet<>();
+		for (Element rule : rules().children()) {
+			names.add(rule.tagName());
+		}
+		return names;
+	}
+
+	/** The parameters this block sets on one rule, by the element name each is written as. */
+	Set<String> parametersOf(String ruleName) {
+		Set<String> parameters = new LinkedHashSet<>();
+		for (Element rule : rules().children()) {
+			addParameters(rule, ruleName, parameters);
+		}
+		return parameters;
+	}
+
+	private void addParameters(Element rule, String ruleName, Set<String> parameters) {
+		if (rule.tagName().equals(ruleName)) {
+			for (Element parameter : rule.children()) {
+				parameters.add(parameter.tagName());
+			}
+		}
+	}
+
+	/**
+	 * Parsed with the XML parser, which preserves the case of a tag name; the HTML
+	 * one would fold {@code claudeMdFormat} to lower case and match no rule.
+	 */
+	private Element rules() {
+		return Jsoup.parse("<rules>" + xml + "</rules>", "", Parser.xmlParser())
+				.selectFirst("rules");
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/ShippedRules.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/ShippedRules.java
@@ -1,0 +1,114 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.inject.Named;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+
+/**
+ * The rules this module ships, discovered from the compiled classes rather than
+ * listed by hand, together with the configuration parameters each one exposes.
+ * <p>
+ * An end-to-end test that named its rules in a literal list would go on passing
+ * after a new rule was added and never exercised, which is exactly the rule most
+ * likely to be misconfigured. Deriving the catalogue from the classes turns that
+ * silence into a failure: a rule, or a parameter, that no fixture configures is
+ * reported by name.
+ */
+final class ShippedRules {
+
+	private static final String ENFORCER_PACKAGE = "io.github.adamw7.tools.enforcer";
+	private static final String SETTER_PREFIX = "set";
+
+	private ShippedRules() {
+	}
+
+	/**
+	 * Every concrete rule by the {@code @Named} name a pom configures it with, sorted
+	 * so a failure reads the same way twice.
+	 */
+	static Map<String, Class<?>> byName() {
+		Map<String, Class<?>> rules = new TreeMap<>();
+		for (JavaClass candidate : importedClasses()) {
+			addRule(candidate, rules);
+		}
+		if (rules.isEmpty()) {
+			throw new IllegalStateException("No enforcer rules were found in " + ENFORCER_PACKAGE
+					+ "; the compiled classes are not on the test class path");
+		}
+		return rules;
+	}
+
+	/**
+	 * The parameters {@code rule} accepts: the setters it and its rule-specific bases
+	 * declare, named as a pom names them. The walk stops at
+	 * {@link ClaudeCodeEnforcerRule} because the parameters it declares — severity,
+	 * the report file, the baseline — belong to every rule alike and are exercised on
+	 * their own rather than once per rule.
+	 */
+	static Set<String> parametersOf(Class<?> rule) {
+		Set<String> parameters = new LinkedHashSet<>();
+		for (Class<?> type = rule; type != ClaudeCodeEnforcerRule.class; type = type.getSuperclass()) {
+			addParameters(type, parameters);
+		}
+		return parameters;
+	}
+
+	private static void addRule(JavaClass candidate, Map<String, Class<?>> rules) {
+		if (isConcreteRule(candidate)) {
+			Class<?> rule = candidate.reflect();
+			rules.put(rule.getAnnotation(Named.class).value(), rule);
+		}
+	}
+
+	private static boolean isConcreteRule(JavaClass candidate) {
+		return candidate.isAssignableTo(ClaudeCodeEnforcerRule.class)
+				&& !candidate.getModifiers().contains(JavaModifier.ABSTRACT)
+				&& candidate.isAnnotatedWith(Named.class);
+	}
+
+	private static void addParameters(Class<?> type, Set<String> parameters) {
+		for (Method method : type.getDeclaredMethods()) {
+			addParameter(method, parameters);
+		}
+	}
+
+	private static void addParameter(Method method, Set<String> parameters) {
+		if (isSetter(method)) {
+			parameters.add(uncapitalized(method.getName().substring(SETTER_PREFIX.length())));
+		}
+	}
+
+	private static boolean isSetter(Method method) {
+		return method.getName().startsWith(SETTER_PREFIX)
+				&& method.getParameterCount() == 1
+				&& !Modifier.isStatic(method.getModifiers())
+				&& !method.isSynthetic();
+	}
+
+	private static String uncapitalized(String name) {
+		return name.substring(0, 1).toLowerCase(Locale.ROOT) + name.substring(1);
+	}
+
+	/**
+	 * Production classes only: the test classes on the same class path include this
+	 * package's own helpers, and importing them would only slow the scan down.
+	 */
+	private static Iterable<JavaClass> importedClasses() {
+		return new ClassFileImporter()
+				.withImportOption(new ImportOption.DoNotIncludeTests())
+				.importPackages(ENFORCER_PACKAGE);
+	}
+}

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -539,7 +539,7 @@ flowchart TB
         end
 
         subgraph secRules ["secret"]
-            secrets["<b>NoSecretsRule / SecretPattern</b>"]
+            secrets["<b>NoSecretsRule / CredentialPattern</b>"]
         end
 
         subgraph textSupport ["text — parsing support"]


### PR DESCRIPTION
A unit test constructs a rule, calls its setters and invokes execute(), so
everything between a pom and that call is assumed: artifact resolution,
@Named discovery, and Plexus binding each element to a field. A rule can be
correct and still never run, and none of that is visible from inside it.

EnforcerRuleBuildIT builds a throwaway project and enforces every shipped
rule with every parameter it accepts — the configuration is checked against
the compiled classes, so a new rule or parameter cannot skip it — and pins
the shared behaviours across the Maven boundary: collect-then-report,
severity=warn, the HTML report, the baseline, and the build-setup checks
that fail whatever the severity. RepositoryEnforcementIT runs this
repository's own doc check, holds the shipped catalogue against the wired
profile, and breaks a copy of the repository to prove the wiring bites.

The first run found one: noSecrets could not take custom patterns from a
pom at all. Plexus infers a list's element type from the child element
name, trying the rule's own package first, so <secretPattern> resolved to
the SecretPattern record and the build failed instantiating it. Renamed to
CredentialPattern, which the unit tests could never have caught.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AnuKzQUpPgDj15ufv7fkoz