### PR TITLE
fix(claude-code-enforcer): six false-positive defects that failed valid configuration

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.definition;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.inject.Named;
 
@@ -56,8 +57,19 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 		report("Command files are not well formed:", violations);
 	}
 
+	/**
+	 * A command that cannot be decoded as text is reported rather than read. The rule
+	 * scans a directory whose contents it does not control, and an
+	 * {@link java.io.UncheckedIOException} escaping here would abort the build as an
+	 * internal error instead of reporting the malformed command it exists to catch.
+	 */
 	private void collectCommandViolations(File command, List<String> violations) {
-		String content = MarkdownText.read(command, DEFINITION);
+		Optional<String> text = MarkdownText.readIfText(command);
+		if (text.isEmpty()) {
+			violations.add("Command definition cannot be read as text: " + command);
+			return;
+		}
+		String content = text.get();
 		if (content.isBlank()) {
 			violations.add("Command definition is empty: " + command);
 			return;

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -73,8 +73,20 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 		}
 	}
 
+	/**
+	 * A {@code SKILL.md} that cannot be decoded as text is reported rather than read.
+	 * The rule scans a directory whose contents it does not control, and an
+	 * {@link java.io.UncheckedIOException} escaping here would abort the build as an
+	 * internal error instead of reporting the malformed skill it exists to catch —
+	 * and would take the remaining skills' violations down with it.
+	 */
 	private void collectContentViolations(File skillDirectory, File skillFile, List<String> violations) {
-		String content = MarkdownText.read(skillFile, SKILL_FILE_NAME);
+		Optional<String> text = MarkdownText.readIfText(skillFile);
+		if (text.isEmpty()) {
+			violations.add(SKILL_FILE_NAME + " cannot be read as text: " + skillFile);
+			return;
+		}
+		String content = text.get();
 		if (content.isBlank()) {
 			violations.add(SKILL_FILE_NAME + " is empty: " + skillFile);
 			return;

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -58,8 +58,20 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 		report("Sub-agent files are not well formed:", violations);
 	}
 
+	/**
+	 * A definition that cannot be decoded as text is reported rather than read. The
+	 * rule scans a directory whose contents it does not control, and an
+	 * {@link java.io.UncheckedIOException} escaping here would abort the build as an
+	 * internal error instead of reporting the malformed definition it exists to
+	 * catch.
+	 */
 	private void collectDefinitionViolations(File definition, List<String> violations) {
-		String content = MarkdownText.read(definition, DEFINITION);
+		Optional<String> text = MarkdownText.readIfText(definition);
+		if (text.isEmpty()) {
+			violations.add("Sub-agent definition cannot be read as text: " + definition);
+			return;
+		}
+		String content = text.get();
 		if (content.isBlank()) {
 			violations.add("Sub-agent definition is empty: " + definition);
 			return;

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRule.java
@@ -43,12 +43,18 @@ public class UniqueDescriptionsRule extends MultiDefinitionRule {
 				.ifPresent(text -> descriptions.add(normalize(text), text, source.toString()));
 	}
 
+	/**
+	 * A definition that cannot be decoded as text declares no description here. The
+	 * format rules report the unreadable file; an
+	 * {@link java.io.UncheckedIOException} escaping this rule would abort the build
+	 * as an internal error instead.
+	 */
 	private Optional<String> descriptionOf(File definitionFile) {
 		if (!definitionFile.isFile()) {
 			return Optional.empty();
 		}
-		String content = MarkdownText.read(definitionFile, "definition");
-		return FrontMatter.parse(content)
+		return MarkdownText.readIfText(definitionFile)
+				.flatMap(FrontMatter::parse)
 				.flatMap(frontMatter -> frontMatter.value(DESCRIPTION_KEY))
 				.filter(value -> !value.isBlank());
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
@@ -30,8 +30,10 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * the rule reads that answer instead of counting hops as it recurses.
  * <p>
  * Imports are recognised the way Claude Code evaluates them: an {@code @} preceded
- * by start-of-line or whitespace and followed by a path, outside fenced code
- * blocks and inline code spans, so {@code `@claude`} in prose is not an import. A
+ * by start-of-line or whitespace and followed by a path — one carrying a directory
+ * separator, an extension, or both — outside fenced code blocks and inline code
+ * spans, so neither {@code `@claude`} nor a bare {@code @claude} in prose is an
+ * import. A
  * home-relative import ({@code @~/...}) does not match the path syntax at all and
  * so is skipped, as is any import the {@code ignored} predicate accepts. A file
  * that cannot be read as text is treated as a leaf rather than a failure, because
@@ -45,6 +47,8 @@ final class ImportGraph {
 
 	private static final Pattern IMPORT = Pattern.compile("(?<=^|\\s)@([A-Za-z0-9_./-]+)");
 	private static final Pattern TRAILING_DOTS = Pattern.compile("\\.+$");
+	private static final char PATH_SEPARATOR = '/';
+	private static final char EXTENSION_SEPARATOR = '.';
 
 	private final Map<Path, List<Reference>> references = new LinkedHashMap<>();
 	private final Map<Path, Integer> hops = new LinkedHashMap<>();
@@ -128,6 +132,7 @@ final class ImportGraph {
 		return IMPORT.matcher(MarkdownText.withoutCodeSpans(line))
 				.results()
 				.map(match -> withoutTrailingDots(match.group(1)))
+				.filter(ImportGraph::isPath)
 				.filter(imported -> !ignored.test(imported))
 				.map(imported -> new Reference(imported, resolve(file, imported)));
 	}
@@ -135,6 +140,19 @@ final class ImportGraph {
 	/** Drops sentence punctuation, so "see @docs/setup.md." imports {@code docs/setup.md}. */
 	private String withoutTrailingDots(String imported) {
 		return TRAILING_DOTS.matcher(imported).replaceAll("");
+	}
+
+	/**
+	 * True when the token names a path rather than a bare word: it carries a
+	 * directory separator, an extension, or both. An import is a path — Claude Code
+	 * loads a file by it — so {@code @docs/setup} and {@code @AGENTS.md} are imports
+	 * while the {@code @claude} of a mention workflow and the {@code @adamw7} of a
+	 * GitHub handle are prose. Reading those as imports failed the build over files
+	 * the author never meant to name, which no amount of backticking their every
+	 * occurrence could be relied on to prevent.
+	 */
+	private static boolean isPath(String imported) {
+		return imported.indexOf(PATH_SEPARATOR) >= 0 || imported.indexOf(EXTENSION_SEPARATOR) >= 0;
 	}
 
 	private File resolve(File file, String imported) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -32,8 +32,10 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
  * violation depending on the order the imports happen to be written in.
  * <p>
  * Imports are recognised the way Claude Code evaluates them: an {@code @} preceded
- * by start-of-line or whitespace and followed by a path, outside fenced code
- * blocks and inline code spans, so {@code `@claude`} in prose is not an import. A
+ * by start-of-line or whitespace and followed by a path — one carrying a directory
+ * separator, an extension, or both — outside fenced code blocks and inline code
+ * spans, so neither {@code `@claude`} nor a bare {@code @claude} in prose is an
+ * import. A
  * home-relative import ({@code @~/...}) points at machine-specific state a build
  * cannot see and is skipped, as is any import listed in {@code ignoredImports}.
  * Each file is scanned once; all problems found are reported together.

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -35,7 +35,13 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  */
 public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 
-	private static final Pattern MARKDOWN_LINK = Pattern.compile("\\[[^\\]]*\\]\\(([^)]+)\\)");
+	/**
+	 * A Markdown link, whose destination may carry one level of balanced parentheses
+	 * — {@code [img](assets/logo(1).png)} — as Markdown allows. Stopping at the first
+	 * closing parenthesis truncated such a target and reported the half of it that
+	 * naturally does not exist as a missing file.
+	 */
+	private static final Pattern MARKDOWN_LINK = Pattern.compile("\\[[^\\]]*\\]\\(((?:[^()]|\\([^()]*\\))+)\\)");
 	private static final Pattern EXTERNAL_REFERENCE = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+.-]*:.*");
 
 	private final String documentName;

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
@@ -2,15 +2,18 @@ package io.github.adamw7.tools.enforcer.settings;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.IntPredicate;
+import java.util.regex.Pattern;
 
 /**
  * Splits a hook command into the tokens a shell would see. Both hook rules need
  * this to find the script paths inside a command, so the splitting lives here
  * rather than in each of them.
  * <p>
- * Splitting is on whitespace and on the shell separators {@code ;}, {@code &} and
- * {@code |}, all <em>outside</em> quotes. Whitespace alone is not enough: a command
+ * Splitting is on whitespace and on the shell separators {@code ;}, {@code &},
+ * {@code |}, a newline, and the {@code (}/{@code )} of a subshell, all
+ * <em>outside</em> quotes. Whitespace alone is not enough: a command
  * chaining two hooks as {@code hook-a.sh; hook-b.sh} leaves the semicolon glued to
  * the first path, and the rules would then report a script that is really there as
  * missing. Quoting is honoured because a hook script path containing a space is
@@ -30,8 +33,25 @@ final class CommandTokens {
 	private static final char DOUBLE_QUOTE = '"';
 	private static final char SINGLE_QUOTE = '\'';
 
-	/** The shell operators that end a token just as whitespace does. */
-	private static final String OPERATORS = ";&|";
+	/**
+	 * The shell operators that end a token just as whitespace does, and that end one
+	 * command and begin the next. A newline is one of them: a hook command written
+	 * across several lines runs one program per line, and reading only the first
+	 * would leave the rest of its scripts unresolved — and, with
+	 * {@code reportUnreferencedScripts}, report a script the hook really does run as
+	 * referenced by nothing. The parentheses of a subshell are operators for the
+	 * same reason, and because gluing one to the path inside it invents a program
+	 * named {@code (script.sh)} that no file can match.
+	 */
+	private static final String OPERATORS = ";&|\n\r()";
+
+	/**
+	 * A {@code VAR=value} prefix, which sets a variable for the command that follows
+	 * rather than naming a program of its own. A shell skips over every such
+	 * assignment to find what it runs, so reading the first token blindly would take
+	 * {@code FOO=bar} for the program and leave the real script unresolved.
+	 */
+	private static final Pattern ASSIGNMENT = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*=.*");
 
 	private CommandTokens() {
 	}
@@ -43,7 +63,8 @@ final class CommandTokens {
 
 	/**
 	 * The program each command in the string runs: the first token of every
-	 * {@code ;}/{@code &}/{@code |}-separated segment, in order.
+	 * operator-separated segment that is not a {@code VAR=value} assignment, in
+	 * order.
 	 * <p>
 	 * A hook chaining two scripts runs two programs, and only a program is a script
 	 * the rules may resolve as a bare relative path. An argument is not, however much
@@ -54,9 +75,14 @@ final class CommandTokens {
 	static List<String> programsOf(String command) {
 		return split(command, CommandTokens::isOperator).stream()
 				.map(CommandTokens::of)
-				.filter(tokens -> !tokens.isEmpty())
-				.map(List::getFirst)
+				.map(CommandTokens::programOf)
+				.flatMap(Optional::stream)
 				.toList();
+	}
+
+	/** The token a shell would run: the first that is not a leading {@code VAR=value} assignment. */
+	private static Optional<String> programOf(List<String> tokens) {
+		return tokens.stream().dropWhile(token -> ASSIGNMENT.matcher(token).matches()).findFirst();
 	}
 
 	/** Splits on every {@code separator} character outside quotes, dropping the empty pieces. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -25,11 +25,22 @@ import java.util.stream.Collectors;
  * definition claiming the same one-character description and escape any length cap.
  * The fold joins the continuation lines with single spaces, which is all the
  * length, blankness, and uniqueness checks need.
+ * <p>
+ * A value wrapped in matching quotes yields the text inside them, because that is
+ * the value YAML declares and the one Claude Code reads. Quoting is not decoration:
+ * a description containing {@code : } has to be quoted to parse at all. Returning
+ * the quotes as part of the value made a {@code name: "git-commit"} fail the
+ * kebab-case convention it follows, a quoted {@code model} miss its whitelist, and
+ * every description count two characters it does not have.
  */
 public final class FrontMatter {
 
 	private static final String DELIMITER = "---";
 	private static final char KEY_VALUE_SEPARATOR = ':';
+	private static final char DOUBLE_QUOTE = '"';
+	private static final char SINGLE_QUOTE = '\'';
+	private static final String ESCAPED_DOUBLE_QUOTE = "\\\"";
+	private static final String ESCAPED_SINGLE_QUOTE = "''";
 
 	/** A block scalar header: {@code >} or {@code |} with optional indentation and chomping indicators. */
 	private static final Pattern BLOCK_SCALAR = Pattern.compile("[>|][0-9+-]*");
@@ -67,8 +78,9 @@ public final class FrontMatter {
 
 	/**
 	 * The trimmed value declared for {@code key}, or empty when the key is absent.
-	 * A present key with no value yields an empty string, not an empty optional, and
-	 * a block scalar yields its folded continuation lines rather than the indicator.
+	 * A present key with no value yields an empty string, not an empty optional, a
+	 * block scalar yields its folded continuation lines rather than the indicator,
+	 * and a quoted scalar yields the text inside its quotes.
 	 */
 	public Optional<String> value(String key) {
 		int index = indexOfEntry(key);
@@ -76,7 +88,7 @@ public final class FrontMatter {
 			return Optional.empty();
 		}
 		String declared = valueOf(lines.get(index), key);
-		return Optional.of(isBlockScalar(declared) ? folded(index + 1) : declared);
+		return Optional.of(isBlockScalar(declared) ? folded(index + 1) : unquoted(declared));
 	}
 
 	/** The declared keys, in document order, without their trailing colon. */
@@ -153,6 +165,37 @@ public final class FrontMatter {
 	private String valueOf(String line, String key) {
 		String stripped = line.strip();
 		return stripped.substring((key + KEY_VALUE_SEPARATOR).length()).strip();
+	}
+
+	/**
+	 * The text inside a scalar's matching quotes, with the escape each quoting style
+	 * uses resolved, or the value unchanged when it is not quoted.
+	 */
+	private static String unquoted(String value) {
+		if (isWrapped(value, DOUBLE_QUOTE, ESCAPED_DOUBLE_QUOTE)) {
+			return interiorOf(value).replace(ESCAPED_DOUBLE_QUOTE, String.valueOf(DOUBLE_QUOTE));
+		}
+		if (isWrapped(value, SINGLE_QUOTE, ESCAPED_SINGLE_QUOTE)) {
+			return interiorOf(value).replace(ESCAPED_SINGLE_QUOTE, String.valueOf(SINGLE_QUOTE));
+		}
+		return value;
+	}
+
+	/**
+	 * True when {@code quote} opens and closes the whole value and appears inside it
+	 * only as {@code escaped}. An unescaped inner quote means the outer two are not a
+	 * pair — {@code "a" and "b"} opens and closes twice — and stripping them would
+	 * hand back text the author never wrote.
+	 */
+	private static boolean isWrapped(String value, char quote, String escaped) {
+		if (value.length() < 2 || value.charAt(0) != quote || value.charAt(value.length() - 1) != quote) {
+			return false;
+		}
+		return interiorOf(value).replace(escaped, "").indexOf(quote) < 0;
+	}
+
+	private static String interiorOf(String value) {
+		return value.substring(1, value.length() - 1);
 	}
 
 	private static int indexOfDelimiter(List<String> lines, int from) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.definition;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -176,6 +177,14 @@ class CommandFormatRuleTest {
 
 		assertDoesNotThrow(rule::execute);
 		assertTrue(readString(file).contains("---\nReview the diff."), readString(file));
+	}
+
+	@Test
+	void reportsACommandThatCannotBeReadAsText() {
+		writeBytes(tempDir.resolve("binary.md"), new byte[] { (byte) 0xC3, (byte) 0x28 });
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("cannot be read as text"), exception.getMessage());
 	}
 
 	private CommandFormatRule ruleFor(Path commandsDir) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.definition;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -255,6 +256,30 @@ class SkillFilesExistRuleTest {
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
 		assertTrue(exception.getMessage().contains("exceeds 20 characters"), exception.getMessage());
+	}
+
+	/** Quoting a value is ordinary YAML, so the name inside the quotes is the one checked. */
+	@Test
+	void acceptsAQuotedName() {
+		Path skillDir = createDirectory(tempDir.resolve("git-commit"));
+		writeString(skillDir.resolve("SKILL.md"), """
+				---
+				name: "git-commit"
+				description: "Commits. Use when: committing."
+				---
+				# git-commit
+				""");
+
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
+	@Test
+	void reportsASkillFileThatCannotBeReadAsText() {
+		Path skillDir = createDirectory(tempDir.resolve("binary"));
+		writeBytes(skillDir.resolve("SKILL.md"), new byte[] { (byte) 0xC3, (byte) 0x28 });
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("cannot be read as text"), exception.getMessage());
 	}
 
 	private void createSkill(String name) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.definition;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -167,6 +168,31 @@ class SubAgentFormatRuleTest {
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
 		assertTrue(exception.getMessage().contains("front matter"), exception.getMessage());
+	}
+
+	/** Quoting a value is ordinary YAML, so the name inside the quotes is the one checked. */
+	@Test
+	void acceptsAQuotedNameAndModel() {
+		writeString(tempDir.resolve("reviewer.md"), """
+				---
+				name: "reviewer"
+				description: "Reviews code. Use when: reviewing."
+				model: "opus"
+				---
+				# Reviewer
+				""");
+		SubAgentFormatRule rule = ruleFor(tempDir);
+		rule.setAllowedModels(List.of("opus"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void reportsADefinitionThatCannotBeReadAsText() {
+		writeBytes(tempDir.resolve("binary.md"), new byte[] { (byte) 0xC3, (byte) 0x28 });
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("cannot be read as text"), exception.getMessage());
 	}
 
 	private void createAgent(String name, String model) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.enforcer.definition;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -150,6 +151,25 @@ class UniqueDescriptionsRuleTest {
 				---
 				# %s
 				""".formatted(name, description, name));
+	}
+
+	/** The format rules report the unreadable file; this one must not abort the build over it. */
+	@Test
+	void skipsADefinitionThatCannotBeReadAsText() {
+		writeAgent("reviewer", "Reviews code.");
+		writeBytes(agentsDir().resolve("binary.md"), new byte[] { (byte) 0xC3, (byte) 0x28 });
+
+		assertDoesNotThrow(agentsRule()::execute);
+	}
+
+	/** A quoted description is the same description as its unquoted spelling. */
+	@Test
+	void comparesAQuotedDescriptionByItsText() {
+		writeAgent("reviewer", "Reviews code.");
+		writeAgent("checker", "\"Reviews code.\"");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, agentsRule()::execute);
+		assertTrue(exception.getMessage().contains("checker.md"), exception.getMessage());
 	}
 
 	private UniqueDescriptionsRule agentsRule() {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -350,6 +350,28 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
+	void resolvesAReferenceWhosePathCarriesParentheses() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+		writeString(tempDir.resolve("assets/logo(1).png"), "binary");
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nSee ![logo](assets/logo(1).png).\n");
+		rule.setValidateFileReferences(true);
+
+		// Stopping at the first closing parenthesis truncated the target and reported
+		// the half of it that naturally does not exist.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void stillReportsTheSecondLinkOnALineAsMissing() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n[a](AGENTS.md) and [b](absent.md).\n");
+		rule.setValidateFileReferences(true);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing file: absent.md"), exception.getMessage());
+	}
+
+	@Test
 	void ignoresExternalLinksWhenValidatingReferences() {
 		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nSee [site](https://example.com) and [top](#project).\n");

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
@@ -235,6 +235,21 @@ class ImportGraphTest {
 		assertFalse(roundabout.getPath().equals(ImportGraph.normalized(roundabout).toString()));
 	}
 
+	@Test
+	void readsNoImportFromABareWordCarryingNeitherSeparatorNorExtension() {
+		File root = write("CLAUDE.md", "An @claude-mention workflow, opened by @adamw7.\n");
+
+		assertEquals(List.of(), graphFrom(root).importsOf(root));
+	}
+
+	@Test
+	void stillReadsAnImportNamedOnlyByItsExtension() {
+		write("AGENTS.md", "# Agents\n");
+		File root = write("CLAUDE.md", "See @AGENTS.md for the rest.\n");
+
+		assertEquals(List.of("AGENTS.md"), textOf(graphFrom(root).importsOf(root)));
+	}
+
 	private ImportGraph graphFrom(File root) {
 		return ImportGraph.from(root, NOTHING_IGNORED, unreadable::add);
 	}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
@@ -71,6 +71,12 @@ class MemoryImportsRuleTest {
 		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nan `@claude`-mention workflow\n")::execute);
 	}
 
+	/** A mention is a word, not a path, so it names no file the build could be failed over. */
+	@Test
+	void ignoresABareMentionThatNamesNoPath() {
+		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nAn @claude-mention workflow, opened by @adamw7.\n")::execute);
+	}
+
 	@Test
 	void ignoresTokensNotPrecededByWhitespace() {
 		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nMail adam@example.com about it.\n")::execute);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
@@ -115,4 +115,46 @@ class CommandTokensTest {
 	void doesNotSplitASegmentOnAQuotedOperator() {
 		assertEquals(List.of("run.sh", "b.sh"), CommandTokens.programsOf("run.sh \"a;b\"; b.sh"));
 	}
+
+	/** A hook written across several lines runs one program per line, not one in total. */
+	@Test
+	void readsAProgramFromEveryLineOfAMultiLineCommand() {
+		assertEquals(List.of("a.sh", "b.sh"), CommandTokens.programsOf("a.sh --flag\nb.sh"));
+	}
+
+	@Test
+	void readsAProgramFromEveryLineSeparatedByACarriageReturn() {
+		assertEquals(List.of("a.sh", "b.sh"), CommandTokens.programsOf("a.sh\r\nb.sh"));
+	}
+
+	@Test
+	void readsTheProgramOfASubshellWithoutItsParentheses() {
+		assertEquals(List.of("a.sh"), CommandTokens.programsOf("(a.sh --flag)"));
+	}
+
+	@Test
+	void splitsOnParenthesesSoTheyDoNotStayGluedToAPath() {
+		assertEquals(List.of("a.sh"), CommandTokens.of("(a.sh)"));
+	}
+
+	@Test
+	void skipsAVariableAssignmentToReachTheProgramItPrefixes() {
+		assertEquals(List.of("a.sh"), CommandTokens.programsOf("FOO=bar a.sh"));
+	}
+
+	@Test
+	void skipsEveryLeadingAssignmentOfACommand() {
+		assertEquals(List.of("a.sh"), CommandTokens.programsOf("FOO=bar BAZ=1 a.sh --flag"));
+	}
+
+	@Test
+	void yieldsNoProgramForAnAssignmentAlone() {
+		assertEquals(List.of(), CommandTokens.programsOf("FOO=bar"));
+	}
+
+	/** A flag written as {@code --out=x} is an argument, and never the program of its segment. */
+	@Test
+	void doesNotMistakeAValuedFlagForAnAssignment() {
+		assertEquals(List.of("--out=x"), CommandTokens.programsOf("--out=x"));
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.settings;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -371,6 +372,37 @@ class HookCommandsValidRuleTest {
 		return """
 				{ "hooks": { "SessionStart": [ { "hooks": [ { "type": "command", "command": "%s" } ] } ] } }
 				""".formatted(command);
+	}
+
+	/** Every line of a multi-line hook runs a script, so a missing one on any line is reported. */
+	@Test
+	void checksTheScriptOnEveryLineOfAMultiLineCommand() {
+		writeString(tempDir.resolve("hooks/present.sh"), "#!/bin/sh\n");
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("hooks/present.sh\\nhooks/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+		assertFalse(exception.getMessage().contains("present.sh"), exception.getMessage());
+	}
+
+	@Test
+	void readsTheScriptAVariableAssignmentPrefixes() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("LOG_LEVEL=debug hooks/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+	}
+
+	/** The parentheses belong to the shell, not to the path, so no file is named by them. */
+	@Test
+	void doesNotReadASubshellsParenthesesAsPartOfItsScript() {
+		writeString(tempDir.resolve("hooks/present.sh"), "#!/bin/sh\n");
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("(hooks/present.sh)"));
+		rule.setProjectDir(tempDir.toFile());
+
+		assertDoesNotThrow(rule::execute);
 	}
 
 	private HookCommandsValidRule ruleFor(String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -340,6 +340,38 @@ class HooksFormatRuleTest {
 				.toList();
 	}
 
+	/** A hook written across two lines runs both scripts, so neither is unreferenced. */
+	@Test
+	void countsEveryLineOfAMultiLineCommandAsAReference() {
+		writeScript("a.sh", "#!/bin/sh\necho a\n", true);
+		writeScript("b.sh", "#!/bin/sh\necho b\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing(".claude/hooks/a.sh\\n.claude/hooks/b.sh"));
+		rule.setReportUnreferencedScripts(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void countsAScriptPrefixedByAVariableAssignmentAsAReference() {
+		writeScript("a.sh", "#!/bin/sh\necho a\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("LOG_LEVEL=debug .claude/hooks/a.sh"));
+		rule.setReportUnreferencedScripts(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void countsAScriptRunInASubshellAsAReference() {
+		writeScript("a.sh", "#!/bin/sh\necho a\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("(.claude/hooks/a.sh)"));
+		rule.setReportUnreferencedScripts(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
 	private HooksFormatRule ruleFor() {
 		HooksFormatRule rule = new HooksFormatRule();
 		rule.setHooksDir(hooksDir().toFile());

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -167,4 +167,50 @@ class FrontMatterTest {
 
 		assertEquals(Optional.of("a | b"), frontMatter.value("description"));
 	}
+
+	@Test
+	void readsADoubleQuotedValueWithoutItsQuotes() {
+		FrontMatter frontMatter = FrontMatter.parse("---\nname: \"git-commit\"\n---\n").orElseThrow();
+
+		assertEquals(Optional.of("git-commit"), frontMatter.value("name"));
+	}
+
+	@Test
+	void readsASingleQuotedValueWithoutItsQuotes() {
+		FrontMatter frontMatter = FrontMatter.parse("---\nname: 'git-commit'\n---\n").orElseThrow();
+
+		assertEquals(Optional.of("git-commit"), frontMatter.value("name"));
+	}
+
+	/** A description carrying a {@code : } has to be quoted to parse as YAML at all. */
+	@Test
+	void readsAQuotedDescriptionCarryingAColon() {
+		FrontMatter frontMatter = FrontMatter.parse("---\ndescription: \"Use when: committing.\"\n---\n")
+				.orElseThrow();
+
+		assertEquals(Optional.of("Use when: committing."), frontMatter.value("description"));
+	}
+
+	@Test
+	void resolvesTheEscapeOfEachQuotingStyle() {
+		assertEquals(Optional.of("a \" b"),
+				FrontMatter.parse("---\ndescription: \"a \\\" b\"\n---\n").orElseThrow().value("description"));
+		assertEquals(Optional.of("it's"),
+				FrontMatter.parse("---\ndescription: 'it''s'\n---\n").orElseThrow().value("description"));
+	}
+
+	/** The outer quotes of {@code "a" and "b"} are two pairs, not one wrapping the value. */
+	@Test
+	void keepsQuotesThatDoNotWrapTheWholeValue() {
+		FrontMatter frontMatter = FrontMatter.parse("---\ndescription: \"a\" and \"b\"\n---\n").orElseThrow();
+
+		assertEquals(Optional.of("\"a\" and \"b\""), frontMatter.value("description"));
+	}
+
+	@Test
+	void readsAnEmptyQuotedValueAsBlank() {
+		FrontMatter frontMatter = FrontMatter.parse("---\ndescription: \"\"\n---\n").orElseThrow();
+
+		assertEquals(Optional.of(""), frontMatter.value("description"));
+	}
 }


### PR DESCRIPTION
Each of these fails a build over configuration Claude Code accepts, or lets a
real problem through:

- CommandTokens read only the first program of a hook command, so a newline
  never ended one command and began the next. A hook written across several
  lines had every line after the first taken for arguments: its scripts went
  unchecked, and reportUnreferencedScripts named a script the hook really does
  run as referenced by nothing. Newline now separates commands, as do the
  parentheses of a subshell, which were otherwise glued to the path inside them
  and resolved as a file named "(script.sh)".
- A VAR=value prefix was read as the program it precedes, leaving the real
  script unresolved. Leading assignments are now skipped, as a shell skips them.
- FrontMatter returned a quoted scalar with its quotes, so name: "git-commit"
  failed the kebab-case convention it follows, a quoted model missed its
  whitelist, and every description counted two characters it does not have.
  Quoting is not decoration: a description carrying ": " must be quoted to parse
  as YAML at all.
- The definition rules read a file with MarkdownText.read, so an undecodable
  SKILL.md, sub-agent, or command aborted the build with an UncheckedIOException
  instead of reporting the malformed definition — and took the remaining
  definitions' violations with it. They now report it, as the rules scanning
  directories already did.
- A Markdown link destination stopped at the first closing parenthesis, so
  [logo](assets/logo(1).png) reported the truncated half as a missing file.
- A bare @word was read as a memory import, so "an @claude-mention workflow" or
  a GitHub handle in prose failed the build over a file nobody named. An import
  is a path, so one must now carry a separator, an extension, or both.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BNvHBQ1cxtVJ2mRD5oXjQS