### PR TITLE
fix(claude-code-enforcer): four defects that failed valid configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -574,7 +574,9 @@ profile:
   `requiredKeys`). The `name` must be lower-case kebab-case, at most 64
   characters, and match the skill's directory name; the `description` must be
   non-empty and within `maxDescriptionLength`. Setting `allowedFrontMatterKeys`
-  also reports unknown keys, catching typos such as `descripton`.
+  also reports unknown keys, catching typos such as `descripton`. A key declared
+  twice is reported too, and every check reads the last declaration, which is the
+  one a YAML loader keeps and so the one Claude Code acts on.
 - `SubAgentFormatRule` (`subAgentFormat`) applies the same front-matter checks to
   every `*.md` sub-agent definition under a configured `agentsDir`; the `name`
   must match the file name, and an optional `allowedModels` list rejects an
@@ -595,10 +597,14 @@ profile:
   `command` hook also a non-blank `command`). A project-local script command —
   rooted at `$CLAUDE_PROJECT_DIR`, or written as the plain repository-relative
   path Claude Code resolves the same way — is resolved against `projectDir` and
-  must exist on disk; only the program of each chained command is read as a
-  relative script, so an argument that looks like a path is not required to
-  exist. An optional `allowedEvents` list rejects mistyped events and
-  `validateScriptReferences` toggles the script-existence check.
+  must exist on disk. Both spellings are read from the same tokens: the program
+  of each chained command, plus the script an interpreter among them is handed
+  (`bash <script>`). An argument that merely looks like a path is not required to
+  exist whichever way it is spelled, so a hook writing
+  `--out $CLAUDE_PROJECT_DIR/target/log.txt` or creating a directory with
+  `mkdir -p` is not reported as referencing a missing script. An optional
+  `allowedEvents` list rejects mistyped events and `validateScriptReferences`
+  toggles the script-existence check.
 - `HooksFormatRule` (`hooksFormat`) validates the hook scripts under a configured
   `hooksDir` (e.g. `.claude/hooks`): every regular file must be non-empty, start
   with a `#!` shebang (`requireShebang`), and carry the executable bit
@@ -623,8 +629,10 @@ profile:
   an array of strings, `env` and `headers` must be objects whose values are all
   strings, a `url` must be a syntactically valid `http`/`https` URL (and `https`
   only when `requireHttps` is set), and a server must not mix transports by
-  declaring both a `command` and a `url`. Like `mcpServersValid` it treats an
-  absent file as a pass.
+  declaring both a `command` and a `url`. A `url` assembled from an environment
+  variable expansion (`https://${MCP_HOST}/mcp`) is left alone, since only the
+  shell that resolves it knows what it becomes. Like `mcpServersValid` it treats
+  an absent file as a pass.
 - `UniqueNamesRule` (`uniqueNames`) gathers the names of every command,
   sub-agent, and skill from the configured `commandsDir`, `agentsDir`, and
   `skillsDir` (file name for commands and sub-agents, directory name for skills)
@@ -723,7 +731,9 @@ The `claudeMdFormat` and `agentsMdFormat` rules share a `MarkdownFormatRule`
 base class that performs the file-existence, BOM, title, and section checks, and
 offer optional checks switched on from configuration: `forbiddenTokens`,
 `enforceSectionOrder`, `maxLineLength`, and `validateFileReferences` (Markdown
-links to local files must resolve on disk). Every rule extends a common
+links to local files must resolve on disk, read both as written and with their
+percent-escapes decoded, so a link to a real `my doc.md` written `my%20doc.md`
+resolves). Every rule extends a common
 `ClaudeCodeEnforcerRule` base that reports all violations together and supports a
 `severity` of `error` (default, fails the build) or `warn` (logs the same
 violations), so a new rule can be adopted gradually. An optional `reportFile`

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -83,6 +83,7 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 
 	private void collectFrontMatterViolations(File command, FrontMatter frontMatter, List<String> violations) {
 		FrontMatterChecks checks = new FrontMatterChecks(frontMatter, LABEL, command, violations);
+		checks.rejectDuplicateKeys();
 		checks.allowOnlyKeys(allowedFrontMatterKeys);
 		checks.checkDescription(0);
 		checks.checkModel(allowedModels);

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/FrontMatterChecks.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/FrontMatterChecks.java
@@ -46,6 +46,17 @@ final class FrontMatterChecks {
 		}
 	}
 
+	/**
+	 * Reports every key declared more than once. Only the last declaration takes
+	 * effect, so an earlier one is a line the author wrote and Claude Code never
+	 * reads — a second {@code description:} silently replaces the one above it.
+	 */
+	void rejectDuplicateKeys() {
+		for (String key : frontMatter.duplicateKeys()) {
+			violations.add(label + " front matter declares '" + key + ":' more than once in: " + file);
+		}
+	}
+
 	/** Reports every declared key outside the whitelist, which catches a typo such as {@code descripton}. */
 	void allowOnlyKeys(List<String> allowedKeys) {
 		if (allowedKeys == null) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -105,6 +105,7 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 			List<String> violations) {
 		FrontMatterChecks checks = new FrontMatterChecks(frontMatter, SKILL_FILE_NAME, skillFile, violations);
 		checks.requireKeys(Objects.requireNonNullElse(requiredKeys, DEFAULT_REQUIRED_KEYS));
+		checks.rejectDuplicateKeys();
 		checks.allowOnlyKeys(allowedFrontMatterKeys);
 		checks.checkName(skillDirectory.getName());
 		checks.checkDescription(maxDescriptionLength);

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -89,6 +89,7 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 	private void collectFrontMatterViolations(File definition, FrontMatter frontMatter, List<String> violations) {
 		FrontMatterChecks checks = new FrontMatterChecks(frontMatter, LABEL, definition, violations);
 		checks.requireKeys(Objects.requireNonNullElse(requiredKeys, DEFAULT_REQUIRED_KEYS));
+		checks.rejectDuplicateKeys();
 		checks.checkName(DefinitionFiles.baseName(definition));
 		checks.checkDescription(0);
 		checks.checkModel(allowedModels);

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 import javax.inject.Named;
 
@@ -24,7 +25,9 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
  * <li>{@code env} and {@code headers} must be objects whose values are all
  * strings;</li>
  * <li>{@code url} must be a syntactically valid {@code http} or {@code https}
- * URL (and {@code https} only when {@code requireHttps} is set); and</li>
+ * URL (and {@code https} only when {@code requireHttps} is set), unless it is
+ * assembled from an environment variable expansion, which only the shell that
+ * resolves it can judge; and</li>
  * <li>a server must not declare both a {@code command} and a {@code url}, which
  * mixes a stdio and a remote transport in one entry.</li>
  * </ul>
@@ -45,6 +48,9 @@ public class McpConfigFormatRule extends JsonFileRule {
 	private static final String URL_KEY = "url";
 	private static final String HTTP_SCHEME = "http";
 	private static final String HTTPS_SCHEME = "https";
+
+	/** An environment variable expansion, in either spelling Claude Code resolves in {@code .mcp.json}. */
+	private static final Pattern EXPANSION = Pattern.compile("\\$\\{[^}]*\\}|\\$[A-Za-z_][A-Za-z0-9_]*");
 
 	/** The {@code .mcp.json} file to validate. Injected from the rule configuration. */
 	private File mcpFile;
@@ -133,7 +139,7 @@ public class McpConfigFormatRule extends JsonFileRule {
 
 	private void collectUrlViolations(String name, JsonNode server, List<String> violations) {
 		JsonNode url = server.get(URL_KEY);
-		if (url == null || !url.isTextual()) {
+		if (url == null || !url.isTextual() || isExpanded(url.asText())) {
 			return;
 		}
 		String scheme = schemeOf(url.asText());
@@ -144,17 +150,36 @@ public class McpConfigFormatRule extends JsonFileRule {
 		}
 	}
 
+	/**
+	 * True when the URL is assembled at load time from an environment variable, which
+	 * Claude Code expands before it ever reaches a URL parser. Only the shell knows
+	 * what {@code https://${MCP_HOST}/mcp} becomes, so there is nothing here to judge
+	 * — and judging it anyway reported a configuration Claude Code loads happily as
+	 * malformed, against the very advice {@code noSecrets} gives for keeping a
+	 * credential out of the file.
+	 */
+	private boolean isExpanded(String url) {
+		return EXPANSION.matcher(url).find();
+	}
+
 	/** Every violation names the server whose entry is malformed. */
 	private void add(String name, String problem, List<String> violations) {
 		violations.add("mcp.json server '" + name + "' " + problem);
 	}
 
-	/** The {@code http}/{@code https} scheme of a syntactically valid absolute URL, or null otherwise. */
+	/**
+	 * The {@code http}/{@code https} scheme of a syntactically valid absolute URL, or
+	 * null otherwise. Presence of an authority is what makes the URL absolute, read
+	 * from {@link URI#getAuthority()} rather than {@link URI#getHost()}: the latter is
+	 * null for a host name {@code java.net.URI} considers non-compliant, so an
+	 * underscore in it — routine in a container or service name — turned a URL Claude
+	 * Code connects to into a reported malformation.
+	 */
 	private String schemeOf(String url) {
 		try {
 			URI uri = new URI(url);
 			String scheme = uri.getScheme();
-			if (scheme == null || uri.getHost() == null) {
+			if (scheme == null || uri.getAuthority() == null || uri.getAuthority().isBlank()) {
 				return null;
 			}
 			String lower = scheme.toLowerCase(Locale.ROOT);

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -1,6 +1,8 @@
 package io.github.adamw7.tools.enforcer.rule;
 
 import java.io.File;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -261,8 +263,30 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private void addReferenceViolation(String localPath, File baseDir, List<String> violations) {
-		if (localPath != null && !new File(baseDir, localPath).exists()) {
+		if (localPath != null && !resolves(localPath, baseDir)) {
 			violations.add(documentName() + " references a missing file: " + localPath);
+		}
+	}
+
+	/**
+	 * True when the link lands on a file, read both as written and with its
+	 * percent-escapes decoded. A Markdown destination escapes the characters a URL
+	 * cannot carry raw — a space becomes {@code %20} — so a link to a real
+	 * {@code my doc.md} is written {@code my%20doc.md}, and matching only the literal
+	 * spelling reported every such file as missing. Both readings are accepted rather
+	 * than the decoded one alone, so a file whose name genuinely contains a percent
+	 * sign still resolves.
+	 */
+	private boolean resolves(String localPath, File baseDir) {
+		return new File(baseDir, localPath).exists() || new File(baseDir, decoded(localPath)).exists();
+	}
+
+	/** The path with its percent-escapes decoded, or unchanged when they are malformed. */
+	private String decoded(String localPath) {
+		try {
+			return URLDecoder.decode(localPath, StandardCharsets.UTF_8);
+		} catch (IllegalArgumentException e) {
+			return localPath;
 		}
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDir.java
@@ -2,10 +2,9 @@ package io.github.adamw7.tools.enforcer.settings;
 
 import java.io.File;
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 /**
  * Resolves the project-local scripts a hook command runs, against the base
@@ -36,57 +35,47 @@ final class ClaudeProjectDir {
 	}
 
 	/**
-	 * The project-local scripts {@code command} runs: every token rooted at
-	 * {@code $CLAUDE_PROJECT_DIR}, plus the program of each chained command written
-	 * as a plain repository-relative path.
+	 * The project-local scripts {@code command} runs, whichever way each is spelled:
+	 * rooted at {@code $CLAUDE_PROJECT_DIR}, or as the plain repository-relative path
+	 * Claude Code resolves the same way.
 	 * <p>
 	 * Both spellings name the same file — Claude Code runs a hook from the project
 	 * directory, so {@code .claude/hooks/session-start.sh} resolves exactly where
 	 * {@code $CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh} does — and a
-	 * settings.json is as likely to be written either way. Reading only the variable
-	 * left the relative spelling unchecked: a hook pointing at a script that had been
-	 * renamed passed, which is the very failure these rules exist to catch, and
-	 * {@code hooksFormat} reported the script it really did reference as referenced
-	 * by nothing.
+	 * settings.json is as likely to be written either way. They are therefore read
+	 * from the same tokens: the scripts of the command, as
+	 * {@link CommandTokens#scriptCandidatesOf} picks them out. Expanding <em>every</em>
+	 * token that mentioned the variable instead made the two spellings disagree, and
+	 * failed a build over an argument the hook was about to create: a
+	 * {@code mkdir -p "$CLAUDE_PROJECT_DIR/target/logs"} was reported as a missing
+	 * script, while the identical {@code mkdir -p target/logs} passed.
 	 * <p>
 	 * A command that names one script both ways yields it once. The separators are
 	 * normalised before the comparison because the two spellings are assembled
 	 * differently — an expansion keeps the separators the command was written with,
-	 * a relative program is resolved as a {@link File} — and on a platform where
-	 * those disagree the same script would otherwise be reported as two.
+	 * a relative path is resolved as a {@link File} — and on a platform where those
+	 * disagree the same script would otherwise be reported as two.
 	 */
 	List<String> scriptsIn(String command) {
-		return Stream.concat(expandAll(command).stream(), relativePrograms(command).stream())
+		return CommandTokens.scriptCandidatesOf(command).stream()
+				.map(this::resolveScript)
+				.flatMap(Optional::stream)
 				.map(path -> new File(path).getPath())
 				.distinct()
 				.toList();
 	}
 
-	/**
-	 * The paths every {@code $CLAUDE_PROJECT_DIR}-rooted token of {@code command}
-	 * resolves to. A command chains more than one script often enough — an
-	 * {@code &&} between two hooks — that stopping at the first reference would
-	 * leave the rest unchecked.
-	 */
-	List<String> expandAll(String command) {
-		return CommandTokens.of(command).stream().map(this::expand).filter(Objects::nonNull).toList();
+	/** The path a script token resolves to, or empty when it names no file this rule can see. */
+	private Optional<String> resolveScript(String token) {
+		String bare = withoutQuotes(token);
+		if (references(bare)) {
+			return Optional.of(expanded(bare));
+		}
+		return isRelativeScript(bare) ? Optional.of(new File(resolve(), bare).getPath()) : Optional.empty();
 	}
 
 	/**
-	 * Only a program is read as a relative script, never an argument — see
-	 * {@link CommandTokens#programsOf} — so a hook passing a path to the script it
-	 * runs does not have that path required to exist too.
-	 */
-	private List<String> relativePrograms(String command) {
-		return CommandTokens.programsOf(command).stream()
-				.map(this::withoutQuotes)
-				.filter(ClaudeProjectDir::isRelativeScript)
-				.map(program -> new File(resolve(), program).getPath())
-				.toList();
-	}
-
-	/**
-	 * Whether a program names a repository-relative script rather than a tool the
+	 * Whether a token names a repository-relative script rather than a tool the
 	 * shell finds for itself: {@code .claude/hooks/session-start.sh} and
 	 * {@code ./run.sh} do, while {@code bash}, {@code python3}, and {@code npx} name
 	 * no path at all and are looked up on the {@code PATH}. An absolute path, a
@@ -94,17 +83,13 @@ final class ClaudeProjectDir {
 	 * the repository's control — or one only a shell can resolve — so none of them is
 	 * a script this rule may require.
 	 */
-	private static boolean isRelativeScript(String program) {
-		return program.indexOf('/') > 0 && program.indexOf('$') < 0 && !program.startsWith("~")
-				&& !program.startsWith("-");
+	private static boolean isRelativeScript(String token) {
+		return token.indexOf('/') > 0 && token.indexOf('$') < 0 && !token.startsWith("~")
+				&& !token.startsWith("-");
 	}
 
-	/** The path {@code token} resolves to when it references the project dir, else null. */
-	String expand(String token) {
-		String bare = withoutQuotes(token);
-		if (!references(bare)) {
-			return null;
-		}
+	/** The path a project-dir reference expands to, with both spellings of the variable resolved. */
+	private String expanded(String bare) {
 		String root = resolve().getPath();
 		return PLAIN_REFERENCE.matcher(bare.replace(BRACED, root)).replaceAll(Matcher.quoteReplacement(root));
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.IntPredicate;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * Splits a hook command into the tokens a shell would see. Both hook rules need
@@ -22,16 +23,29 @@ import java.util.regex.Pattern;
  * kept on the token, since {@link ClaudeProjectDir} strips them as part of expanding
  * it.
  * <p>
- * {@link #programsOf} answers the narrower question of which tokens a shell would
- * actually <em>run</em>, which is what a rule reading a bare relative path as a
- * script has to go on: only a program can be one, never an argument that happens to
- * look like a path.
+ * {@link #scriptCandidatesOf} answers the narrower question of which tokens name a
+ * file the shell would execute or read as a script, which is what a rule resolving
+ * a path on disk has to go on: a program is one, as is the script an interpreter is
+ * handed, but never an argument that merely happens to look like a path.
  */
 final class CommandTokens {
 
 	private static final char NONE = 0;
 	private static final char DOUBLE_QUOTE = '"';
 	private static final char SINGLE_QUOTE = '\'';
+	private static final char PATH_SEPARATOR = '/';
+	private static final String OPTION_PREFIX = "-";
+	private static final String LONG_OPTION_PREFIX = "--";
+	private static final char INLINE_SCRIPT_FLAG = 'c';
+
+	/**
+	 * The programs that run a script named by their first non-option argument rather
+	 * than being that script themselves. A hook wired as {@code bash <script>} names a
+	 * file that must exist just as plainly as one wired as {@code <script>}, and
+	 * reading only the program would leave it unchecked.
+	 */
+	private static final List<String> INTERPRETERS = List.of(
+			"bash", "sh", "zsh", "dash", "ksh", "python", "python3", "node", "ruby", "perl");
 
 	/**
 	 * The shell operators that end a token just as whitespace does, and that end one
@@ -62,27 +76,59 @@ final class CommandTokens {
 	}
 
 	/**
-	 * The program each command in the string runs: the first token of every
-	 * operator-separated segment that is not a {@code VAR=value} assignment, in
-	 * order.
+	 * The tokens of {@code command} that name a script file: the program each
+	 * operator-separated segment runs, plus the script an interpreter among them is
+	 * handed, in order.
 	 * <p>
-	 * A hook chaining two scripts runs two programs, and only a program is a script
-	 * the rules may resolve as a bare relative path. An argument is not, however much
-	 * it looks like one: a hook invoked as {@code .claude/hooks/build.sh --out
-	 * target/log.txt} names one script and one output file, and requiring the second
-	 * to exist would fail a build over a file the hook is about to write.
+	 * A hook chaining two scripts names two of them, so every segment is read. What is
+	 * deliberately left out is an ordinary argument, however much it looks like a path:
+	 * a hook invoked as {@code .claude/hooks/build.sh --out target/log.txt} names one
+	 * script and one output file, and requiring the second to exist would fail a build
+	 * over a file the hook is about to write. The same goes for the directory of a
+	 * {@code mkdir -p}.
 	 */
-	static List<String> programsOf(String command) {
+	static List<String> scriptCandidatesOf(String command) {
 		return split(command, CommandTokens::isOperator).stream()
 				.map(CommandTokens::of)
-				.map(CommandTokens::programOf)
-				.flatMap(Optional::stream)
+				.flatMap(CommandTokens::candidatesIn)
 				.toList();
 	}
 
-	/** The token a shell would run: the first that is not a leading {@code VAR=value} assignment. */
-	private static Optional<String> programOf(List<String> tokens) {
-		return tokens.stream().dropWhile(token -> ASSIGNMENT.matcher(token).matches()).findFirst();
+	/** The program of one segment, and the script it hands on when that program is an interpreter. */
+	private static Stream<String> candidatesIn(List<String> tokens) {
+		List<String> words = tokens.stream().dropWhile(token -> ASSIGNMENT.matcher(token).matches()).toList();
+		if (words.isEmpty()) {
+			return Stream.empty();
+		}
+		String program = words.getFirst();
+		return Stream.concat(Stream.of(program), interpretedScript(program, words.subList(1, words.size())).stream());
+	}
+
+	/**
+	 * The script an interpreter is handed: its first non-option argument. A segment
+	 * carrying the {@code -c} flag names no file at all — the argument is the script's
+	 * text — so it yields nothing rather than a path that was never meant to be one.
+	 */
+	private static Optional<String> interpretedScript(String program, List<String> arguments) {
+		if (!INTERPRETERS.contains(commandName(program)) || arguments.stream().anyMatch(CommandTokens::isInlineScript)) {
+			return Optional.empty();
+		}
+		return arguments.stream().filter(argument -> !argument.startsWith(OPTION_PREFIX)).findFirst();
+	}
+
+	/**
+	 * True for the {@code -c} flag, alone or inside a cluster of short ones. A shell
+	 * reads {@code -ec} as {@code -e -c} just as it reads {@code -c}, and missing the
+	 * cluster would take the inline script's text for a path on disk.
+	 */
+	private static boolean isInlineScript(String argument) {
+		return argument.startsWith(OPTION_PREFIX) && !argument.startsWith(LONG_OPTION_PREFIX)
+				&& argument.indexOf(INLINE_SCRIPT_FLAG) > 0;
+	}
+
+	/** The program's own name, so an interpreter is recognised however it was spelled on disk. */
+	private static String commandName(String program) {
+		return program.substring(program.lastIndexOf(PATH_SEPARATOR) + 1);
 	}
 
 	/** Splits on every {@code separator} character outside quotes, dropping the empty pieces. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -1,7 +1,9 @@
 package io.github.adamw7.tools.enforcer.text;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -32,6 +34,14 @@ import java.util.stream.Collectors;
  * the quotes as part of the value made a {@code name: "git-commit"} fail the
  * kebab-case convention it follows, a quoted {@code model} miss its whitelist, and
  * every description count two characters it does not have.
+ * <p>
+ * A key declared twice yields its <em>last</em> declaration, which is the one a YAML
+ * loader keeps and so the one Claude Code acts on. Reading the first instead
+ * validated a value the tool never sees — a second {@code description:} could
+ * lengthen a capped one, break a name convention, or collide with another
+ * definition, and every check would still be looking at the line above it.
+ * {@link #duplicateKeys()} reports the duplication itself, since a key written twice
+ * is a mistake whichever value wins.
  */
 public final class FrontMatter {
 
@@ -80,7 +90,8 @@ public final class FrontMatter {
 	 * The trimmed value declared for {@code key}, or empty when the key is absent.
 	 * A present key with no value yields an empty string, not an empty optional, a
 	 * block scalar yields its folded continuation lines rather than the indicator,
-	 * and a quoted scalar yields the text inside its quotes.
+	 * and a quoted scalar yields the text inside its quotes. A key declared more than
+	 * once yields its last declaration, the one a YAML loader keeps.
 	 */
 	public Optional<String> value(String key) {
 		int index = indexOfEntry(key);
@@ -94,6 +105,17 @@ public final class FrontMatter {
 	/** The declared keys, in document order, without their trailing colon. */
 	public List<String> keys() {
 		return lines.stream().map(this::entryKey).flatMap(Optional::stream).toList();
+	}
+
+	/**
+	 * The keys declared more than once, each named once, in the order they first
+	 * appear. Only the last of them takes effect, so the earlier lines say something
+	 * the tool never reads — the front matter equivalent of the duplicated JSON key
+	 * the configuration rules already reject.
+	 */
+	public List<String> duplicateKeys() {
+		Set<String> seen = new LinkedHashSet<>();
+		return keys().stream().filter(key -> !seen.add(key)).distinct().toList();
 	}
 
 	/**
@@ -132,8 +154,9 @@ public final class FrontMatter {
 		return !line.isEmpty() && Character.isWhitespace(line.charAt(0));
 	}
 
+	/** The last line declaring {@code key}, since that is the declaration YAML keeps. */
 	private int indexOfEntry(String key) {
-		for (int i = 0; i < lines.size(); i++) {
+		for (int i = lines.size() - 1; i >= 0; i--) {
 			if (isEntryFor(lines.get(i), key)) {
 				return i;
 			}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
@@ -282,6 +282,43 @@ class SkillFilesExistRuleTest {
 		assertTrue(exception.getMessage().contains("cannot be read as text"), exception.getMessage());
 	}
 
+	/**
+	 * Only the last declaration of a repeated key takes effect, so an earlier one is
+	 * a line the author wrote and Claude Code never reads.
+	 */
+	@Test
+	void failsWhenAKeyIsDeclaredTwice() {
+		writeString(tempDir.resolve("git-commit").resolve("SKILL.md"), """
+				---
+				name: git-commit
+				description: Writes a commit message.
+				description: Writes a commit message, at length.
+				---
+				# git-commit
+				""");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(exception.getMessage().contains("declares 'description:' more than once"), exception.getMessage());
+	}
+
+	/** The cap applies to the declaration that wins, not to the one it replaced. */
+	@Test
+	void measuresTheDescriptionCapAgainstTheLastDeclaration() {
+		writeString(tempDir.resolve("git-commit").resolve("SKILL.md"), """
+				---
+				name: git-commit
+				description: Short.
+				description: Far longer than the cap allows on any reading of it.
+				---
+				# git-commit
+				""");
+		SkillFilesExistRule rule = ruleFor(tempDir);
+		rule.setMaxDescriptionLength(20);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("description exceeds 20 characters"), exception.getMessage());
+	}
+
 	private void createSkill(String name) {
 		Path skillDir = createDirectory(tempDir.resolve(name));
 		writeString(skillDir.resolve("SKILL.md"), """

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -372,6 +372,41 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
+	void resolvesAReferenceWhosePathIsPercentEncoded() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+		writeString(tempDir.resolve("docs/my guide.md"), "# Guide");
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nSee [guide](docs/my%20guide.md).\n");
+		rule.setValidateFileReferences(true);
+
+		// A Markdown destination escapes the characters a URL cannot carry raw, so a
+		// link to a real file with a space in its name is written with %20 and must
+		// not be reported as missing.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void resolvesAReferenceWhosePathReallyContainsAPercentSign() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+		writeString(tempDir.resolve("docs/100%25.md"), "# Percent");
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nSee [pct](docs/100%25.md).\n");
+		rule.setValidateFileReferences(true);
+
+		// Both readings are accepted, so decoding never hides a file whose name
+		// genuinely carries the escape.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void stillReportsAPercentEncodedReferenceThatResolvesToNothing() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nSee [guide](docs/no%20such.md).\n");
+		rule.setValidateFileReferences(true);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing file: docs/no%20such.md"), exception.getMessage());
+	}
+
+	@Test
 	void ignoresExternalLinksWhenValidatingReferences() {
 		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nSee [site](https://example.com) and [top](#project).\n");

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
@@ -208,4 +208,32 @@ class McpConfigFormatRuleTest {
 		return rule;
 	}
 
+	/**
+	 * Claude Code expands an environment variable in {@code .mcp.json} before it ever
+	 * reaches a URL parser, and {@code noSecrets} tells authors to write one there
+	 * rather than a literal credential. Judging the unexpanded text reported a
+	 * configuration Claude Code loads happily as malformed.
+	 */
+	@Test
+	void passesWhenTheUrlIsAssembledFromABracedVariable() {
+		assertDoesNotThrow(ruleFor(
+				"{ \"mcpServers\": { \"r\": { \"type\": \"http\", \"url\": \"https://${MCP_HOST}/mcp\" } } }")::execute);
+	}
+
+	@Test
+	void passesWhenTheUrlIsAssembledFromAPlainVariable() {
+		assertDoesNotThrow(ruleFor(
+				"{ \"mcpServers\": { \"r\": { \"type\": \"http\", \"url\": \"$MCP_BASE/mcp\" } } }")::execute);
+	}
+
+	/**
+	 * {@code java.net.URI} reports no host for a name it considers non-compliant, so
+	 * reading the host turned a container or service name — where an underscore is
+	 * routine — into a reported malformation.
+	 */
+	@Test
+	void passesWhenTheUrlHostCarriesAnUnderscore() {
+		assertDoesNotThrow(ruleFor(
+				"{ \"mcpServers\": { \"r\": { \"type\": \"http\", \"url\": \"https://mcp_gateway:8080/mcp\" } } }")::execute);
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDirTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/ClaudeProjectDirTest.java
@@ -78,9 +78,41 @@ class ClaudeProjectDirTest {
 		assertEquals(List.of(resolved("build.d/build.sh")), scriptsIn("build.d/build.sh --out target/log.txt"));
 	}
 
+	/**
+	 * A hook wired as {@code bash <script>} names a file that must exist just as
+	 * plainly as one wired as {@code <script>}, so the interpreter's script argument
+	 * is resolved even though the interpreter itself is the program.
+	 */
 	@Test
-	void readsNoScriptFromAnInterpretersArgument() {
-		assertEquals(List.of(), scriptsIn("bash " + HOOK));
+	void resolvesTheScriptAnInterpreterIsHanded() {
+		assertEquals(List.of(resolved(HOOK)), scriptsIn("bash " + HOOK));
+	}
+
+	@Test
+	void resolvesTheScriptAnInterpreterIsHandedPastItsOptions() {
+		assertEquals(List.of(resolved(HOOK)), scriptsIn("bash -e " + HOOK));
+	}
+
+	/** The argument of {@code -c} is a script's text, not a path, so it names no file. */
+	@Test
+	void readsNoScriptFromAnInlineShellScript() {
+		assertEquals(List.of(), scriptsIn("bash -c \"" + HOOK + " --flag\""));
+	}
+
+	/**
+	 * The two spellings must agree about what is an argument: expanding every token
+	 * that mentioned the variable required a path the hook was about to create to
+	 * exist already, while the identical relative spelling passed.
+	 */
+	@Test
+	void readsNoScriptFromAnArgumentRootedAtTheProjectVariable() {
+		assertEquals(List.of(resolved("build.d/build.sh")),
+				scriptsIn("build.d/build.sh --out $CLAUDE_PROJECT_DIR/target/log.txt"));
+	}
+
+	@Test
+	void readsNoScriptFromADirectoryTheCommandCreates() {
+		assertEquals(List.of(), scriptsIn("mkdir -p ${CLAUDE_PROJECT_DIR}/target/logs"));
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
@@ -67,69 +67,99 @@ class CommandTokensTest {
 	@Test
 	void readsTheProgramOfASingleCommand() {
 		assertEquals(List.of(".claude/hooks/session-start.sh"),
-				CommandTokens.programsOf(".claude/hooks/session-start.sh"));
+				CommandTokens.scriptCandidatesOf(".claude/hooks/session-start.sh"));
 	}
 
 	@Test
 	void readsTheProgramOfEveryChainedCommand() {
-		assertEquals(List.of("a.sh", "b.sh", "c.sh"), CommandTokens.programsOf("a.sh && b.sh; c.sh --flag"));
+		assertEquals(List.of("a.sh", "b.sh", "c.sh"), CommandTokens.scriptCandidatesOf("a.sh && b.sh; c.sh --flag"));
 	}
 
 	@Test
 	void doesNotReadAnArgumentAsAProgram() {
-		assertEquals(List.of("build.sh"), CommandTokens.programsOf("build.sh --out target/log.txt"));
+		assertEquals(List.of("build.sh"), CommandTokens.scriptCandidatesOf("build.sh --out target/log.txt"));
+	}
+
+	/** An interpreter names a script of its own, so both it and that script are candidates. */
+	@Test
+	void readsBothAnInterpreterAndTheScriptItRuns() {
+		assertEquals(List.of("bash", ".claude/hooks/run.sh"),
+				CommandTokens.scriptCandidatesOf("bash .claude/hooks/run.sh"));
 	}
 
 	@Test
-	void readsAnInterpreterAsTheProgramRatherThanTheScriptItRuns() {
-		assertEquals(List.of("bash"), CommandTokens.programsOf("bash .claude/hooks/run.sh"));
+	void skipsAnInterpretersOptionsToReachItsScript() {
+		assertEquals(List.of("bash", "run.sh"), CommandTokens.scriptCandidatesOf("bash -eu run.sh"));
+	}
+
+	/** The argument of {@code -c} is the script's text rather than a file to look for. */
+	@Test
+	void readsNoScriptFromAnInlineShellScript() {
+		assertEquals(List.of("sh"), CommandTokens.scriptCandidatesOf("sh -c \"run.sh --flag\""));
+	}
+
+	/** A shell reads {@code -ec} as {@code -e -c}, so the inline script is still text. */
+	@Test
+	void readsNoScriptFromAnInlineShellScriptInAFlagCluster() {
+		assertEquals(List.of("bash"), CommandTokens.scriptCandidatesOf("bash -ec \"run.sh --flag\""));
+	}
+
+	@Test
+	void recognisesAnInterpreterNamedByAnAbsolutePath() {
+		assertEquals(List.of("/usr/bin/bash", "run.sh"), CommandTokens.scriptCandidatesOf("/usr/bin/bash run.sh"));
+	}
+
+	/** Only an interpreter hands its argument on; any other program's arguments are its own. */
+	@Test
+	void readsNoScriptFromAnOrdinaryProgramsArgument() {
+		assertEquals(List.of("mkdir"), CommandTokens.scriptCandidatesOf("mkdir -p target/logs"));
 	}
 
 	@Test
 	void keepsAQuotedProgramWithASpaceWhole() {
-		assertEquals(List.of("\"my hook.sh\""), CommandTokens.programsOf("\"my hook.sh\" --flag"));
+		assertEquals(List.of("\"my hook.sh\""), CommandTokens.scriptCandidatesOf("\"my hook.sh\" --flag"));
 	}
 
 	@Test
 	void readsNoProgramFromAQuotedSeparator() {
-		assertEquals(List.of("echo"), CommandTokens.programsOf("echo \"a;b\""));
+		assertEquals(List.of("echo"), CommandTokens.scriptCandidatesOf("echo \"a;b\""));
 	}
 
 	@Test
 	void yieldsNoProgramsForABlankCommand() {
-		assertEquals(List.of(), CommandTokens.programsOf("   "));
+		assertEquals(List.of(), CommandTokens.scriptCandidatesOf("   "));
 	}
 
 	@Test
 	void yieldsNoProgramsForOperatorsAlone() {
-		assertEquals(List.of(), CommandTokens.programsOf("&& ;| "));
+		assertEquals(List.of(), CommandTokens.scriptCandidatesOf("&& ;| "));
 	}
 
 	/** A program is the first token of its own segment, however the operators are spaced. */
 	@Test
 	void readsTheProgramAfterAnOperatorWithNoSurroundingSpace() {
-		assertEquals(List.of("a.sh", "b.sh"), CommandTokens.programsOf("a.sh --flag&&b.sh --flag"));
+		assertEquals(List.of("a.sh", "b.sh"), CommandTokens.scriptCandidatesOf("a.sh --flag&&b.sh --flag"));
 	}
 
 	@Test
 	void doesNotSplitASegmentOnAQuotedOperator() {
-		assertEquals(List.of("run.sh", "b.sh"), CommandTokens.programsOf("run.sh \"a;b\"; b.sh"));
+		assertEquals(List.of("run.sh", "b.sh"), CommandTokens.scriptCandidatesOf("run.sh \"a;b\"; b.sh"));
 	}
 
 	/** A hook written across several lines runs one program per line, not one in total. */
 	@Test
 	void readsAProgramFromEveryLineOfAMultiLineCommand() {
-		assertEquals(List.of("a.sh", "b.sh"), CommandTokens.programsOf("a.sh --flag\nb.sh"));
+		assertEquals(List.of("a.sh", "b.sh"), CommandTokens.scriptCandidatesOf("a.sh --flag\nb.sh"));
 	}
 
 	@Test
 	void readsAProgramFromEveryLineSeparatedByACarriageReturn() {
-		assertEquals(List.of("a.sh", "b.sh"), CommandTokens.programsOf("a.sh\r\nb.sh"));
+		assertEquals(List.of("a.sh", "b.sh"), CommandTokens.scriptCandidatesOf("a.sh\r\nb.sh"));
 	}
 
 	@Test
 	void readsTheProgramOfASubshellWithoutItsParentheses() {
-		assertEquals(List.of("a.sh"), CommandTokens.programsOf("(a.sh --flag)"));
+		assertEquals(List.of("a.sh"), CommandTokens.scriptCandidatesOf("(a.sh --flag)"));
 	}
 
 	@Test
@@ -139,22 +169,22 @@ class CommandTokensTest {
 
 	@Test
 	void skipsAVariableAssignmentToReachTheProgramItPrefixes() {
-		assertEquals(List.of("a.sh"), CommandTokens.programsOf("FOO=bar a.sh"));
+		assertEquals(List.of("a.sh"), CommandTokens.scriptCandidatesOf("FOO=bar a.sh"));
 	}
 
 	@Test
 	void skipsEveryLeadingAssignmentOfACommand() {
-		assertEquals(List.of("a.sh"), CommandTokens.programsOf("FOO=bar BAZ=1 a.sh --flag"));
+		assertEquals(List.of("a.sh"), CommandTokens.scriptCandidatesOf("FOO=bar BAZ=1 a.sh --flag"));
 	}
 
 	@Test
 	void yieldsNoProgramForAnAssignmentAlone() {
-		assertEquals(List.of(), CommandTokens.programsOf("FOO=bar"));
+		assertEquals(List.of(), CommandTokens.scriptCandidatesOf("FOO=bar"));
 	}
 
 	/** A flag written as {@code --out=x} is an argument, and never the program of its segment. */
 	@Test
 	void doesNotMistakeAValuedFlagForAnAssignment() {
-		assertEquals(List.of("--out=x"), CommandTokens.programsOf("--out=x"));
+		assertEquals(List.of("--out=x"), CommandTokens.scriptCandidatesOf("--out=x"));
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -405,6 +405,51 @@ class HookCommandsValidRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
+	/**
+	 * A hook that writes a file names an output path, not a script. Expanding every
+	 * token that mentioned the variable required the path to exist already, so the two
+	 * spellings of the same argument disagreed: this one failed the build while the
+	 * identical {@code --out target/log.txt} passed.
+	 */
+	@Test
+	void passesWhenAnOutputPathIsWrittenWithTheProjectVariable() {
+		writeString(tempDir.resolve("run.sh"), "#!/bin/sh\n");
+		HookCommandsValidRule rule = ruleFor(
+				hooksReferencing("$CLAUDE_PROJECT_DIR/run.sh --out $CLAUDE_PROJECT_DIR/target/log.txt"));
+		rule.setProjectDir(tempDir.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void passesWhenTheHookCreatesTheDirectoryItThenWritesTo() {
+		writeString(tempDir.resolve("run.sh"), "#!/bin/sh\n");
+		HookCommandsValidRule rule = ruleFor(
+				hooksReferencing("mkdir -p ${CLAUDE_PROJECT_DIR}/target/logs && $CLAUDE_PROJECT_DIR/run.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/** An interpreter's script is a file the hook really runs, whichever spelling names it. */
+	@Test
+	void failsWhenTheScriptAnInterpreterIsHandedIsMissing() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("bash $CLAUDE_PROJECT_DIR/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenTheScriptAnInterpreterIsHandedRelativelyIsMissing() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("bash hooks/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+	}
+
 	private HookCommandsValidRule ruleFor(String content) {
 		Path file = tempDir.resolve("settings.json");
 		writeString(file, content);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -170,6 +170,34 @@ class HooksFormatRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
+	/** A hook wired as {@code bash <script>} references that script just as plainly. */
+	@Test
+	void treatsTheScriptAnInterpreterIsHandedAsReferenced() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("bash $CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setReportUnreferencedScripts(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/**
+	 * An output path is an argument whichever spelling names it. Expanding every token
+	 * that mentioned the variable made the hooks directory's own scripts look
+	 * referenced by a path the hook was only about to write.
+	 */
+	@Test
+	void doesNotTreatAVariableRootedArgumentAsAScript() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing(
+				".claude/hooks/session-start.sh --out $CLAUDE_PROJECT_DIR/.claude/hooks/generated.log"));
+		rule.setProjectDir(tempDir.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
 	/** An argument is not a script, so it cannot mark one referenced or be required to exist. */
 	@Test
 	void doesNotTreatAnArgumentThatLooksLikeAPathAsAScript() {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -213,4 +213,39 @@ class FrontMatterTest {
 
 		assertEquals(Optional.of(""), frontMatter.value("description"));
 	}
+
+	/**
+	 * A YAML loader keeps the last declaration of a repeated key, so that is the
+	 * value Claude Code acts on. Reading the first validated a value the tool never
+	 * sees.
+	 */
+	@Test
+	void readsTheLastDeclarationOfARepeatedKey() {
+		FrontMatter frontMatter = FrontMatter.parse("---\ndescription: first\ndescription: second\n---\n")
+				.orElseThrow();
+
+		assertEquals(Optional.of("second"), frontMatter.value("description"));
+	}
+
+	@Test
+	void reportsEachKeyDeclaredMoreThanOnce() {
+		FrontMatter frontMatter = FrontMatter
+				.parse("---\nname: a\ndescription: one\ndescription: two\nname: b\n---\n").orElseThrow();
+
+		assertEquals(List.of("description", "name"), frontMatter.duplicateKeys());
+	}
+
+	@Test
+	void namesARepeatedKeyOnceHoweverOftenItIsDeclared() {
+		FrontMatter frontMatter = FrontMatter.parse("---\nmodel: a\nmodel: b\nmodel: c\n---\n").orElseThrow();
+
+		assertEquals(List.of("model"), frontMatter.duplicateKeys());
+	}
+
+	@Test
+	void reportsNoDuplicateWhenEveryKeyIsDeclaredOnce() {
+		FrontMatter frontMatter = FrontMatter.parse("---\nname: a\ndescription: d\n---\n").orElseThrow();
+
+		assertEquals(List.of(), frontMatter.duplicateKeys());
+	}
 }


### PR DESCRIPTION
Each of these fails a build over a configuration Claude Code reads exactly
as its author meant, or validates a value Claude Code never sees.

hookCommandsValid / hooksFormat resolved *every* token that mentioned
$CLAUDE_PROJECT_DIR as a script that must exist, so the two spellings of the
same argument disagreed: `mkdir -p "$CLAUDE_PROJECT_DIR/target/logs"` was
reported as a missing script while the identical `mkdir -p target/logs`
passed. Both spellings are now read from the same tokens — the program of
each chained command, plus the script an interpreter among them is handed —
which also closes the gap where `bash <script>` left that script unchecked.

FrontMatter read the *first* declaration of a repeated key, while a YAML
loader keeps the last, so a second `description:` could lengthen a capped
one, break a name convention, or collide with another definition with every
check still looking at the line above it. It now reads the last declaration
and reports the duplication itself, matching the duplicate-key detection the
JSON rules already enforce.

mcpConfigFormat rejected a `url` assembled from an environment variable
expansion — the very thing noSecrets tells authors to write instead of a
literal credential — and one whose host carries an underscore, which
java.net.URI reports no host for. An expansion is now left to the shell that
resolves it, and the scheme check reads the authority instead of the host.

claudeMdFormat / agentsMdFormat reported a percent-encoded link destination
as a missing file, though `[guide](docs/my%20guide.md)` is how Markdown
spells a link to a real `docs/my guide.md`. A reference now resolves as
written or with its escapes decoded.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XKt5eaW29qyY7SuatGUqTs