### PR TITLE
fix(claude-code-enforcer): four defects in how a document and a hook are read

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.settings;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.IntPredicate;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -67,6 +68,22 @@ final class CommandTokens {
 	 */
 	private static final Pattern ASSIGNMENT = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*=.*");
 
+	/**
+	 * The shell reserved words, which structure a command rather than name a program.
+	 * A hook that runs its script only under a condition writes
+	 * {@code if [ -n "$CI" ]; then .claude/hooks/session-start.sh; fi}, and reading
+	 * the first word of each segment blindly took {@code then} for the program — so
+	 * the script went unresolved, and {@code reportUnreferencedScripts} reported a
+	 * script the hook really does run as referenced by nothing. A shell skips over
+	 * these the same way it skips a {@code VAR=value} prefix, and so does this: the
+	 * word after them is what runs.
+	 */
+	private static final Set<String> RESERVED_WORDS = Set.of(
+			"if", "then", "elif", "else", "fi",
+			"for", "while", "until", "do", "done",
+			"case", "in", "esac",
+			"{", "}", "!");
+
 	private CommandTokens() {
 	}
 
@@ -96,12 +113,17 @@ final class CommandTokens {
 
 	/** The program of one segment, and the script it hands on when that program is an interpreter. */
 	private static Stream<String> candidatesIn(List<String> tokens) {
-		List<String> words = tokens.stream().dropWhile(token -> ASSIGNMENT.matcher(token).matches()).toList();
+		List<String> words = tokens.stream().dropWhile(CommandTokens::isPrefix).toList();
 		if (words.isEmpty()) {
 			return Stream.empty();
 		}
 		String program = words.getFirst();
 		return Stream.concat(Stream.of(program), interpretedScript(program, words.subList(1, words.size())).stream());
+	}
+
+	/** True for a word that precedes the program rather than being it: an assignment or a reserved word. */
+	private static boolean isPrefix(String token) {
+		return ASSIGNMENT.matcher(token).matches() || RESERVED_WORDS.contains(token);
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -35,6 +35,12 @@ import java.util.stream.Collectors;
  * kebab-case convention it follows, a quoted {@code model} miss its whitelist, and
  * every description count two characters it does not have.
  * <p>
+ * A trailing comment is not part of the value. YAML ends a plain scalar at a
+ * {@code #} that follows whitespace outside quotes, so {@code name: git-commit # the
+ * commit helper} declares {@code git-commit}. Reading the note as part of the value
+ * failed a name over the kebab-case convention it follows and made every such
+ * description count characters Claude Code never sees.
+ * <p>
  * A key declared twice yields its <em>last</em> declaration, which is the one a YAML
  * loader keeps and so the one Claude Code acts on. Reading the first instead
  * validated a value the tool never sees — a second {@code description:} could
@@ -46,7 +52,10 @@ import java.util.stream.Collectors;
 public final class FrontMatter {
 
 	private static final String DELIMITER = "---";
+	private static final char NONE = 0;
 	private static final char KEY_VALUE_SEPARATOR = ':';
+	private static final char COMMENT_START = '#';
+	private static final char ESCAPE = '\\';
 	private static final char DOUBLE_QUOTE = '"';
 	private static final char SINGLE_QUOTE = '\'';
 	private static final String ESCAPED_DOUBLE_QUOTE = "\\\"";
@@ -98,7 +107,7 @@ public final class FrontMatter {
 		if (index < 0) {
 			return Optional.empty();
 		}
-		String declared = valueOf(lines.get(index), key);
+		String declared = withoutComment(valueOf(lines.get(index), key));
 		return Optional.of(isBlockScalar(declared) ? folded(index + 1) : unquoted(declared));
 	}
 
@@ -188,6 +197,40 @@ public final class FrontMatter {
 	private String valueOf(String line, String key) {
 		String stripped = line.strip();
 		return stripped.substring((key + KEY_VALUE_SEPARATOR).length()).strip();
+	}
+
+	/**
+	 * The value with a trailing YAML comment removed. A {@code #} that opens a
+	 * comment stands outside quotes and follows whitespace, which is what separates
+	 * the note in {@code name: git-commit # the commit helper} from the value in
+	 * {@code version: 1.0#2}. Keeping the note made a name break the kebab-case
+	 * convention it follows and a description count characters a YAML loader — and
+	 * so Claude Code — never reads.
+	 */
+	private static String withoutComment(String value) {
+		char quote = NONE;
+		for (int i = 0; i < value.length(); i++) {
+			char character = value.charAt(i);
+			if (quote != NONE) {
+				i += isEscape(quote, character) ? 1 : 0;
+				quote = character == quote ? NONE : quote;
+			} else if (character == DOUBLE_QUOTE || character == SINGLE_QUOTE) {
+				quote = character;
+			} else if (character == COMMENT_START && startsComment(value, i)) {
+				return value.substring(0, i).strip();
+			}
+		}
+		return value;
+	}
+
+	/** A backslash escapes the next character inside a double-quoted scalar, but not a single-quoted one. */
+	private static boolean isEscape(char quote, char character) {
+		return quote == DOUBLE_QUOTE && character == ESCAPE;
+	}
+
+	/** A {@code #} opens a comment at the start of the value or after whitespace, never mid-token. */
+	private static boolean startsComment(String value, int index) {
+		return index == 0 || Character.isWhitespace(value.charAt(index - 1));
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
@@ -22,13 +22,17 @@ import java.util.regex.Pattern;
  * become the block actually contains at least one {@code key: value} entry, so a
  * lone {@code ---} thematic break is never mistaken for front matter. A document
  * whose front matter already parses, or whose problem is not one of the above, is
- * left untouched.
+ * left untouched, and one that is repaired keeps the line separator it was written
+ * with, so repairing two delimiter lines does not rewrite every other line of a
+ * CRLF file.
  */
 public final class FrontMatterFixer {
 
 	private static final char DASH = '-';
 	private static final int MIN_DELIMITER_DASHES = 3;
 	private static final String CANONICAL_DELIMITER = "---";
+	private static final String CARRIAGE_RETURN = "\r";
+	private static final String LINE_FEED = "\n";
 	/**
 	 * A {@code key:} or {@code key: value} entry. The key is a single identifier —
 	 * {@code name}, {@code description}, {@code allowed-tools} — with no spaces in
@@ -137,11 +141,25 @@ public final class FrontMatterFixer {
 	}
 
 	private static String render(List<String> lines, String original) {
-		String joined = String.join("\n", lines);
-		return endsWithNewline(original) ? joined + "\n" : joined;
+		String separator = separatorOf(original);
+		String joined = String.join(separator, lines);
+		return endsWithNewline(original) ? joined + separator : joined;
+	}
+
+	/**
+	 * The line separator the document is already written with. Rebuilding it with
+	 * {@code \n} regardless rewrote every line of a CRLF file to repair its two
+	 * delimiter lines, turning a two-line fix into a whole-file diff on Windows.
+	 */
+	private static String separatorOf(String content) {
+		int carriageReturn = content.indexOf(CARRIAGE_RETURN);
+		if (carriageReturn < 0) {
+			return LINE_FEED;
+		}
+		return content.startsWith(LINE_FEED, carriageReturn + 1) ? CARRIAGE_RETURN + LINE_FEED : CARRIAGE_RETURN;
 	}
 
 	private static boolean endsWithNewline(String content) {
-		return content.endsWith("\n") || content.endsWith("\r");
+		return content.endsWith(LINE_FEED) || content.endsWith(CARRIAGE_RETURN);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -3,15 +3,17 @@ package io.github.adamw7.tools.enforcer.text;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * A parsed Markdown document: its lines plus a mask marking which lines belong to
- * a fenced code block. Parsing the mask once, at construction, lets the structural
- * checks share it instead of each rebuilding it.
+ * A parsed Markdown document: its lines plus the masks marking which of them belong
+ * to a fenced code block and which sit inside an HTML comment. Parsing the masks
+ * once, at construction, lets the structural checks share them instead of each
+ * rebuilding them.
  * <p>
  * Headings are recognised on whole lines outside fenced code blocks, so a heading
  * mentioned inside a fence or in prose is not treated as document structure. The
@@ -20,6 +22,11 @@ import java.util.stream.IntStream;
  * characters followed by whitespace or nothing else — so a line that merely starts
  * with a hash, such as {@code #1 rule: run mvn install}, stays prose. Counting it
  * as a heading would end the section it sits in and report that section as empty.
+ * <p>
+ * A heading is also recognised only outside an HTML comment block. A section
+ * commented out with {@code <!-- ... -->} is inert text, not structure, so counting
+ * it would let a document satisfy a required-section check with the very heading its
+ * author had removed.
  * <p>
  * A fence is closed only by a run of the <em>same</em> character, at least as long
  * as the one that opened it, carrying no info string. All three conditions matter,
@@ -36,22 +43,27 @@ public final class MarkdownDocument {
 	private static final char TILDE = '~';
 	private static final int MIN_FENCE_LENGTH = 3;
 	private static final char HEADING_CHAR = '#';
+	private static final String COMMENT_START = "<!--";
+	private static final String COMMENT_END = "-->";
 
 	/** One to six {@code #} characters, then whitespace and any text, or nothing at all. */
 	private static final Pattern ATX_HEADING = Pattern.compile("#{1,6}(\\s.*)?");
 
 	private final List<String> lines;
 	private final boolean[] insideFence;
+	private final boolean[] insideComment;
 
-	private MarkdownDocument(List<String> lines, boolean[] insideFence) {
+	private MarkdownDocument(List<String> lines, boolean[] insideFence, boolean[] insideComment) {
 		this.lines = lines;
 		this.insideFence = insideFence;
+		this.insideComment = insideComment;
 	}
 
-	/** Parses {@code content} into lines and a fenced-code-block mask. */
+	/** Parses {@code content} into lines, a fenced-code-block mask, and an HTML-comment mask. */
 	public static MarkdownDocument parse(String content) {
 		List<String> lines = content.lines().toList();
-		return new MarkdownDocument(lines, fenceMask(lines));
+		boolean[] insideFence = fenceMask(lines);
+		return new MarkdownDocument(lines, insideFence, commentMask(lines, insideFence));
 	}
 
 	public int lineCount() {
@@ -78,14 +90,23 @@ public final class MarkdownDocument {
 		return IntStream.range(0, lines.size()).filter(index -> !insideFence[index]);
 	}
 
+	/**
+	 * The indices of the lines that can carry document structure: outside fenced code
+	 * blocks and outside HTML comments alike. A heading is only recognised on one of
+	 * these.
+	 */
+	private IntStream structuralLines() {
+		return outsideFences().filter(index -> !insideComment[index]);
+	}
+
 	/** True when {@code token} appears on a line outside a fenced code block. */
 	public boolean containsOutsideFences(String token) {
 		return outsideFences().anyMatch(index -> lines.get(index).contains(token));
 	}
 
-	/** The heading lines outside fenced code blocks, in document order. */
+	/** The heading lines outside fenced code blocks and HTML comments, in document order. */
 	public Set<String> headings() {
-		return outsideFences()
+		return structuralLines()
 				.mapToObj(index -> lines.get(index).strip())
 				.filter(MarkdownDocument::isHeading)
 				.collect(Collectors.toCollection(LinkedHashSet::new));
@@ -117,31 +138,45 @@ public final class MarkdownDocument {
 	public List<String> headingsInOrder(List<String> wanted) {
 		Set<String> required = new LinkedHashSet<>(wanted);
 		List<String> ordered = new ArrayList<>();
-		outsideFences().mapToObj(index -> lines.get(index).strip())
+		structuralLines().mapToObj(index -> lines.get(index).strip())
 				.filter(required::remove)
 				.forEach(ordered::add);
 		return ordered;
 	}
 
 	private int headingIndex(String section) {
-		return outsideFences().filter(index -> lines.get(index).strip().equals(section)).findFirst().orElse(-1);
+		return structuralLines().filter(index -> lines.get(index).strip().equals(section)).findFirst().orElse(-1);
 	}
 
 	private boolean hasBodyAt(int headingIndex) {
 		int sectionLevel = headingLevel(lines.get(headingIndex).strip());
 		for (int i = headingIndex + 1; i < lines.size(); i++) {
-			String line = lines.get(i).strip();
-			if (insideFence[i]) {
-				return true;
-			}
-			if (isHeading(line)) {
-				return headingLevel(line) > sectionLevel;
-			}
-			if (!line.isEmpty()) {
-				return true;
+			Optional<Boolean> verdict = bodyVerdict(i, sectionLevel);
+			if (verdict.isPresent()) {
+				return verdict.get();
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Whether the line at {@code index} settles the question of the section's body,
+	 * or empty when it says nothing either way. A blank line does not, and neither
+	 * does a commented-out one: a section whose only content is inside an HTML
+	 * comment reads as empty, which is what commenting it out meant.
+	 */
+	private Optional<Boolean> bodyVerdict(int index, int sectionLevel) {
+		if (insideComment[index]) {
+			return Optional.empty();
+		}
+		if (insideFence[index]) {
+			return Optional.of(Boolean.TRUE);
+		}
+		String line = lines.get(index).strip();
+		if (isHeading(line)) {
+			return Optional.of(headingLevel(line) > sectionLevel);
+		}
+		return line.isEmpty() ? Optional.empty() : Optional.of(Boolean.TRUE);
 	}
 
 	private static boolean isHeading(String line) {
@@ -163,6 +198,39 @@ public final class MarkdownDocument {
 			open = applyFence(lines.get(i).strip(), open, mask, i);
 		}
 		return mask;
+	}
+
+	/**
+	 * Marks the lines an HTML comment spans, so a commented-out section is not read
+	 * as document structure. A comment that opens and closes on one line masks
+	 * nothing — {@code <!-- ## Testing -->} is not a heading to begin with — while a
+	 * block comment hid a required section from the check that exists to demand it
+	 * and satisfied it at the same time. A comment inside a fenced code block is
+	 * sample text, so the fence wins.
+	 */
+	private static boolean[] commentMask(List<String> lines, boolean[] insideFence) {
+		boolean[] mask = new boolean[lines.size()];
+		boolean open = false;
+		for (int i = 0; i < lines.size(); i++) {
+			open = applyComment(lines.get(i).strip(), open, insideFence[i], mask, i);
+		}
+		return mask;
+	}
+
+	/**
+	 * Marks line {@code index} as commented or not and returns whether a comment is
+	 * still open afterwards.
+	 */
+	private static boolean applyComment(String line, boolean open, boolean insideFence, boolean[] mask, int index) {
+		if (insideFence) {
+			return open;
+		}
+		if (open) {
+			mask[index] = true;
+			return !line.contains(COMMENT_END);
+		}
+		mask[index] = line.startsWith(COMMENT_START) && !line.contains(COMMENT_END);
+		return mask[index];
 	}
 
 	/**

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
@@ -319,6 +319,20 @@ class SkillFilesExistRuleTest {
 		assertTrue(exception.getMessage().contains("description exceeds 20 characters"), exception.getMessage());
 	}
 
+	/** A YAML loader ends a plain scalar at the comment, so the name Claude Code reads follows the convention. */
+	@Test
+	void ignoresATrailingCommentOnTheName() {
+		writeString(tempDir.resolve("git-commit").resolve("SKILL.md"), """
+				---
+				name: git-commit # the repository's commit helper
+				description: Generates commit messages.
+				---
+				# git-commit
+				""");
+
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
 	private void createSkill(String name) {
 		Path skillDir = createDirectory(tempDir.resolve(name));
 		writeString(skillDir.resolve("SKILL.md"), """

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -456,4 +456,16 @@ class ClaudeMdFormatRuleTest {
 		return rule;
 	}
 
+	@Test
+	void failsWhenSectionHeadingIsCommentedOut() {
+		// A section removed with an HTML comment is gone from the document, so the
+		// heading inside it must not satisfy the requirement it was written for.
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace(
+				"## Testing\nWrite unit tests for all new logic.\n",
+				"<!--\n## Testing\nWrite unit tests for all new logic.\n-->\n"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing required section heading: ## Testing"),
+				exception.getMessage());
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
@@ -187,4 +187,36 @@ class CommandTokensTest {
 	void doesNotMistakeAValuedFlagForAnAssignment() {
 		assertEquals(List.of("--out=x"), CommandTokens.scriptCandidatesOf("--out=x"));
 	}
+
+	@Test
+	void skipsAReservedWordToReachTheCommandItIntroduces() {
+		assertEquals(List.of("[", "a.sh"),
+				CommandTokens.scriptCandidatesOf("if [ -n \"$CI\" ]; then a.sh; fi"));
+	}
+
+	/**
+	 * The loop variable takes the place of the program in the {@code for} segment,
+	 * which costs nothing: a bare word names no path, so no rule resolves it.
+	 */
+	@Test
+	void readsTheBodyOfALoopRatherThanItsKeyword() {
+		assertEquals(List.of("f", "a.sh"), CommandTokens.scriptCandidatesOf("for f in x; do a.sh; done"));
+	}
+
+	@Test
+	void readsBothBranchesOfAConditional() {
+		assertEquals(List.of("a.sh", "b.sh"),
+				CommandTokens.scriptCandidatesOf("if a.sh; then b.sh; fi"));
+	}
+
+	@Test
+	void yieldsNoProgramForAReservedWordAlone() {
+		assertEquals(List.of(), CommandTokens.scriptCandidatesOf("fi; done; esac"));
+	}
+
+	/** {@code then} names the command that follows it, but a file really called {@code then} is a program. */
+	@Test
+	void stillReadsAReservedWordSpelledAsAPath() {
+		assertEquals(List.of("./then"), CommandTokens.scriptCandidatesOf("./then --flag"));
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -400,6 +400,33 @@ class HooksFormatRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
+	/**
+	 * A hook that guards its script with a condition still runs it. Reading
+	 * {@code then} as the program left the script the hook really does run reported
+	 * as referenced by nothing.
+	 */
+	@Test
+	void treatsAScriptInsideAConditionalAsReferenced() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("if [ -n \\\"$CI\\\" ]; then .claude/hooks/session-start.sh; fi"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setReportUnreferencedScripts(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenAConditionalHookReferencesAMissingScript() {
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("if true; then .claude/hooks/gone.sh; fi"));
+		rule.setProjectDir(tempDir.toFile());
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("references a missing hook script"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+	}
+
 	private HooksFormatRule ruleFor() {
 		HooksFormatRule rule = new HooksFormatRule();
 		rule.setHooksDir(hooksDir().toFile());

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
@@ -156,4 +156,19 @@ class FrontMatterFixerTest {
 		assertTrue(repaired.isPresent());
 		assertEquals("---\nname: reviewer\ndescription: Reviews code.\n---\n", repaired.get());
 	}
+
+	@Test
+	void keepsCarriageReturnLineFeedSeparatorsWhenRepairing() {
+		String content = "---\r\nname: reviewer\r\nBody one.\r\nBody two.\r\n";
+
+		assertEquals(Optional.of("---\r\nname: reviewer\r\n---\r\nBody one.\r\nBody two.\r\n"),
+				FrontMatterFixer.repair(content));
+	}
+
+	@Test
+	void keepsLineFeedSeparatorsWhenRepairing() {
+		String content = "---\nname: reviewer\nBody one.\n";
+
+		assertEquals(Optional.of("---\nname: reviewer\n---\nBody one.\n"), FrontMatterFixer.repair(content));
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -248,4 +248,47 @@ class FrontMatterTest {
 
 		assertEquals(List.of(), frontMatter.duplicateKeys());
 	}
+
+	@Test
+	void dropsATrailingCommentFromAPlainScalar() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\nname: git-commit # the commit helper\n---\n");
+
+		assertEquals(Optional.of("git-commit"), frontMatter.orElseThrow().value("name"));
+	}
+
+	@Test
+	void dropsATrailingCommentAfterAQuotedScalar() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\ndescription: \"a: b\" # note\n---\n");
+
+		assertEquals(Optional.of("a: b"), frontMatter.orElseThrow().value("description"));
+	}
+
+	/** Only whitespace opens a comment, so a hash inside a value stays part of it. */
+	@Test
+	void keepsAHashThatDoesNotFollowWhitespace() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\nname: issue#7\n---\n");
+
+		assertEquals(Optional.of("issue#7"), frontMatter.orElseThrow().value("name"));
+	}
+
+	@Test
+	void keepsAHashInsideQuotes() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\ndescription: \"tag # here\"\n---\n");
+
+		assertEquals(Optional.of("tag # here"), frontMatter.orElseThrow().value("description"));
+	}
+
+	@Test
+	void readsAValueThatIsNothingButACommentAsEmpty() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\nname: # to be decided\n---\n");
+
+		assertEquals(Optional.of(""), frontMatter.orElseThrow().value("name"));
+	}
+
+	@Test
+	void foldsABlockScalarAnnouncedWithATrailingComment() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\ndescription: > # folded\n  one\n  two\n---\n");
+
+		assertEquals(Optional.of("one two"), frontMatter.orElseThrow().value("description"));
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
@@ -201,6 +201,88 @@ class MarkdownDocumentTest {
 		assertEquals(Set.of("# Title", "##"), document.headings());
 	}
 
+	@Test
+	void doesNotTreatAHeadingInsideAnHtmlCommentAsAHeading() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				<!--
+				## Testing
+				Body.
+				-->
+
+				## Maven
+				Body.
+				""");
+
+		assertEquals(Set.of("# Title", "## Maven"), document.headings());
+	}
+
+	@Test
+	void treatsAHeadingAfterAClosedHtmlCommentAsAHeading() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				<!--
+				A note.
+				-->
+
+				## Testing
+				Body.
+				""");
+
+		assertEquals(Set.of("# Title", "## Testing"), document.headings());
+	}
+
+	/** A comment that opens and closes on one line masks nothing, and is no heading either. */
+	@Test
+	void leavesASingleLineHtmlCommentUnmasked() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				<!-- ## Testing -->
+
+				## Maven
+				Body.
+				""");
+
+		assertEquals(Set.of("# Title", "## Maven"), document.headings());
+	}
+
+	@Test
+	void treatsAnHtmlCommentInsideAFenceAsSampleCode() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				```
+				<!--
+				```
+
+				## Maven
+				Body.
+				""");
+
+		assertEquals(Set.of("# Title", "## Maven"), document.headings());
+	}
+
+	@Test
+	void readsASectionWhoseOnlyContentIsCommentedOutAsEmpty() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				## Maven
+				<!--
+				Body.
+				-->
+
+				## Testing
+				Body.
+				""");
+
+		assertFalse(document.hasBody("## Maven"));
+		assertTrue(document.hasBody("## Testing"));
+	}
+
 	/** The indices of the lines the document masks as fenced code, in document order. */
 	private static List<Integer> fencedLines(MarkdownDocument document) {
 		return IntStream.range(0, document.lineCount()).filter(document::isInsideFence).boxed().toList();


### PR DESCRIPTION
Each of these judges configuration by something other than what Claude Code
reads out of it.

CommandTokens read the first word of every operator-separated segment as the
program, so a shell reserved word took the place of the command it introduces:
`if [ -n "$CI" ]; then .claude/hooks/session-start.sh; fi` named `then`, not the
script. The script the hook really does run went unresolved — reported by
`reportUnreferencedScripts` as referenced by nothing, and, when renamed on disk,
not reported missing at all. A reserved word is now skipped the way a
`VAR=value` prefix already was: the word after it is what runs.

FrontMatter kept a trailing YAML comment as part of the value, though a loader
ends a plain scalar at a `#` that follows whitespace outside quotes. A
`name: git-commit # the commit helper` failed both the kebab-case convention it
follows and the match against its own directory, and every such description
counted characters Claude Code never sees. A `#` inside quotes, or mid-token as
in `1.0#2`, is still part of the value.

FrontMatterFixer rebuilt a repaired document with `\n` regardless of what it was
written with, so auto-fixing the two delimiter lines of a CRLF file rewrote every
other line in it. The repair now keeps the document's own separator.

MarkdownDocument read a heading inside an HTML comment block as document
structure, so a section commented out still satisfied the required-section check
its removal should have broken — and, with `enforceSectionOrder`, could report
sections out of order against a heading that is not there. Headings are now
recognised only outside a comment, and a section whose only content is commented
out reads as empty.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01APgnt7nrsMkwczd8TNfkWa