### PR TITLE
fix(adopt): four defects that made the conformer disagree with the rule it must satisfy

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -21,9 +21,9 @@ import java.util.stream.IntStream;
  * <p>The reshape is deterministic and conservative: a near-miss heading is
  * <em>renamed</em> in place so its body survives, only a genuinely absent section
  * is appended, and a required section left empty gets a stub body because the rule
- * fails an empty section just as it fails a missing one. Fenced code is left
- * alone, mirroring how the rule matches, and reshaping an already-conforming
- * document is a no-op.
+ * fails an empty section just as it fails a missing one. Fenced code and
+ * commented-out text are left alone, mirroring how the rule matches, and reshaping
+ * an already-conforming document is a no-op.
  */
 public class ClaudeMdConformer {
 
@@ -49,7 +49,19 @@ public class ClaudeMdConformer {
 	private static final char BACKTICK = '`';
 	private static final char TILDE = '~';
 	private static final int MIN_FENCE_LENGTH = 3;
+	private static final String COMMENT_START = "<!--";
+	private static final String COMMENT_END = "-->";
 	private static final String STUB_BODY = "See [AGENTS.md](AGENTS.md).";
+
+	/**
+	 * One to six {@code #} characters, then whitespace and any text, or nothing at
+	 * all — the ATX heading the rule recognises. Reading a heading any more loosely
+	 * than the rule does makes the reshape act on prose the rule holds to be body: a
+	 * {@code #1 rule: run mvn install} was taken for a level-one heading that ended
+	 * the section above it, so a section that already had a body was given a stub in
+	 * front of the prose it already carried.
+	 */
+	private static final Pattern ATX_HEADING = Pattern.compile("#{1,6}(\\s.*)?");
 
 	/** The blank lines the reshape may leave at the end, dropped so the document keeps a single one. */
 	private static final Pattern TRAILING_BLANK_LINES = Pattern.compile("\\n\\s*+\\z");
@@ -61,6 +73,7 @@ public class ClaudeMdConformer {
 	public String conform(String content) {
 		List<String> lines = splitLines(content);
 		closeUnterminatedFence(lines);
+		closeUnterminatedComment(lines);
 		ensureTitle(lines);
 		canonicalizeHeadings(lines);
 		ensureRequiredSections(lines);
@@ -82,6 +95,24 @@ public class ClaudeMdConformer {
 		Delimiter open = scanFences(lines).openAtEnd();
 		if (open != null) {
 			lines.add(open.closing());
+		}
+	}
+
+	/**
+	 * Closes an HTML comment the document opened and never closed, for the same
+	 * reason {@link #closeUnterminatedFence} closes a fence: everything appended
+	 * below has to land outside the block. A section appended inside an open comment
+	 * is inert text the rule does not see, so the adoption would fail its own
+	 * {@link VerifyStep} on a section it had just added. A document whose comments
+	 * balance is returned untouched, keeping the reshape idempotent.
+	 *
+	 * <p>Fences are closed first, because a comment inside a fenced code block is
+	 * sample text rather than a comment — the same precedence the rule reads them
+	 * with.
+	 */
+	private void closeUnterminatedComment(List<String> lines) {
+		if (scanComments(lines, scanFences(lines).mask()).openAtEnd()) {
+			lines.add(COMMENT_END);
 		}
 	}
 
@@ -112,7 +143,7 @@ public class ClaudeMdConformer {
 	 * required section.
 	 */
 	private Set<Integer> reservedHeadings(Outline outline) {
-		return outline.matching(line -> REQUIRED_SECTIONS.contains(line.strip()))
+		return outline.structural(line -> REQUIRED_SECTIONS.contains(line.strip()))
 				.boxed()
 				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
@@ -129,7 +160,7 @@ public class ClaudeMdConformer {
 	}
 
 	private int firstNearMatch(Outline outline, String required, Set<Integer> claimed) {
-		return outline.matching(line -> isNearMatch(line.strip(), required))
+		return outline.structural(line -> isNearMatch(line.strip(), required))
 				.filter(index -> !claimed.contains(index))
 				.findFirst()
 				.orElse(-1);
@@ -189,23 +220,25 @@ public class ClaudeMdConformer {
 	}
 
 	private static boolean isHeading(String stripped) {
-		return stripped.startsWith("#");
+		return ATX_HEADING.matcher(stripped).matches();
 	}
 
 	/**
-	 * The document as the reshape reads it: the lines themselves, and which of them
-	 * sit inside a code fence. The two travel together because every search the
-	 * reshape makes is "outside fences", and a mask taken from lines other than the
-	 * ones it is applied to would quietly mis-answer — so a reshape that inserts or
-	 * removes lines takes a fresh outline rather than carrying this one on.
+	 * The document as the reshape reads it: the lines themselves, which of them sit
+	 * inside a code fence, and which sit inside an HTML comment. The three travel
+	 * together because every search the reshape makes is against one of those masks,
+	 * and a mask taken from lines other than the ones it is applied to would quietly
+	 * mis-answer — so a reshape that inserts or removes lines takes a fresh outline
+	 * rather than carrying this one on.
 	 *
-	 * <p>Renaming a line in place keeps the outline valid, since the mask is indexed
-	 * by line number and the count has not moved.
+	 * <p>Renaming a line in place keeps the outline valid, since the masks are
+	 * indexed by line number and the count has not moved.
 	 */
-	private record Outline(List<String> lines, boolean[] fence) {
+	private record Outline(List<String> lines, boolean[] fence, boolean[] comment) {
 
 		static Outline of(List<String> lines) {
-			return new Outline(lines, scanFences(lines).mask());
+			boolean[] fence = scanFences(lines).mask();
+			return new Outline(lines, fence, scanComments(lines, fence).mask());
 		}
 
 		/** The indices of the lines outside code fences whose text matches, in document order. */
@@ -213,9 +246,21 @@ public class ClaudeMdConformer {
 			return IntStream.range(0, lines.size()).filter(index -> !fence[index] && match.test(lines.get(index)));
 		}
 
-		/** @return the index of the heading outside code fences, or {@code -1} when absent */
+		/**
+		 * The indices of the lines that can carry document structure — outside code
+		 * fences and outside HTML comments alike — whose text matches. A heading is
+		 * only ever looked for, and only ever renamed, on one of these, because that
+		 * is where the rule recognises one: a section commented out with
+		 * {@code <!-- ... -->} is inert text, and counting it left the real section
+		 * unwritten while the rule went on demanding it.
+		 */
+		IntStream structural(Predicate<String> match) {
+			return matching(match).filter(index -> !comment[index]);
+		}
+
+		/** @return the index of the heading outside code fences and comments, or {@code -1} when absent */
 		int indexOfHeading(String heading) {
-			return matching(line -> line.strip().equals(heading)).findFirst().orElse(-1);
+			return structural(line -> line.strip().equals(heading)).findFirst().orElse(-1);
 		}
 
 		/**
@@ -236,9 +281,20 @@ public class ClaudeMdConformer {
 		boolean hasBody(int headingIndex) {
 			int level = headingLevel(lines.get(headingIndex).strip());
 			return IntStream.range(headingIndex + 1, lines.size())
-					.filter(index -> fence[index] || !lines.get(index).isBlank())
+					.filter(this::decidesBody)
 					.limit(1)
 					.anyMatch(index -> fence[index] || isBodyLine(lines.get(index).strip(), level));
+		}
+
+		/**
+		 * Whether the line settles the question of the section's body. A blank line
+		 * does not, and neither does a commented-out one: a section whose only content
+		 * is inside an HTML comment reads as empty to the rule, which is what commenting
+		 * it out meant, so the reshape has to give it a stub rather than conclude it
+		 * already has a body and leave the adoption to fail its own {@link VerifyStep}.
+		 */
+		private boolean decidesBody(int index) {
+			return fence[index] || (!comment[index] && !lines.get(index).isBlank());
 		}
 	}
 
@@ -282,6 +338,50 @@ public class ClaudeMdConformer {
 	 *                  document's fences balance
 	 */
 	private record Fences(boolean[] mask, Delimiter openAtEnd) {
+	}
+
+	/**
+	 * The outcome of reading the document's HTML comments: which lines are commented
+	 * out, and whether one is still open once the last line has been read.
+	 *
+	 * @param openAtEnd whether the document left a comment unterminated
+	 */
+	private record Comments(boolean[] mask, boolean openAtEnd) {
+	}
+
+	/**
+	 * Reads which lines an HTML comment spans. A comment that opens and closes on one
+	 * line masks nothing — {@code <!-- ## Testing -->} is not a heading to begin with
+	 * — while a block comment hides the lines it spans from every heading search.
+	 * This mirrors {@code MarkdownDocument} in the {@code claude-code-enforcer}
+	 * module, as {@link Delimiter} does; keep the two in sync.
+	 *
+	 * @param fence the fence mask, because a comment inside a fenced code block is
+	 *              sample text rather than a comment: the fence wins
+	 */
+	private static Comments scanComments(List<String> lines, boolean[] fence) {
+		boolean[] mask = new boolean[lines.size()];
+		boolean open = false;
+		for (int index = 0; index < lines.size(); index++) {
+			open = applyComment(lines.get(index).strip(), open, fence[index], mask, index);
+		}
+		return new Comments(mask, open);
+	}
+
+	/**
+	 * Marks whether the line is commented out and returns whether a comment is still
+	 * open after it.
+	 */
+	private static boolean applyComment(String line, boolean open, boolean insideFence, boolean[] mask, int index) {
+		if (insideFence) {
+			return open;
+		}
+		if (open) {
+			mask[index] = true;
+			return !line.contains(COMMENT_END);
+		}
+		mask[index] = line.startsWith(COMMENT_START) && !line.contains(COMMENT_END);
+		return mask[index];
 	}
 
 	private static Fences scanFences(List<String> lines) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -508,6 +508,193 @@ class ClaudeMdConformerTest {
 				&& line.substring(run.length()).isBlank();
 	}
 
+	/**
+	 * A section the generated document had commented out is not a section the rule
+	 * can see, so the reshape has to append the real one. Reading the commented
+	 * heading as the document's own left the required section unwritten, and the rule
+	 * the adoption had just wired in then reported it missing — the adoption failing
+	 * its own verification on a document it had just reshaped to pass it.
+	 */
+	@Test
+	void doesNotTakeAHeadingInsideAnHtmlCommentForASection() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				<!--
+				## Testing
+
+				Removed for now.
+				-->
+
+				Intro.
+				""";
+		String conformed = conformer.conform(generated);
+		assertTrue(structuralLines(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
+				"every required section must be a heading the rule can see:\n" + conformed);
+		assertTrue(conformed.contains("Removed for now."), "the commented-out text keeps its content:\n" + conformed);
+		assertEquals(conformed, conformer.conform(conformed), "a second reshape must not append the sections again");
+	}
+
+	/**
+	 * A near-miss heading inside a comment must not be renamed in place either: the
+	 * rename rewrote text its author had deliberately commented out and still left
+	 * the document without the section, since the rule reads neither as structure.
+	 */
+	@Test
+	void doesNotRenameANearMissHeadingInsideAnHtmlComment() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				<!--
+				## Testing strategy
+
+				Old notes.
+				-->
+
+				Intro.
+				""";
+		String conformed = conformer.conform(generated);
+		assertTrue(conformed.contains("## Testing strategy"), "the commented heading must be left alone:\n" + conformed);
+		assertTrue(structuralLines(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
+				"the real section must still be appended:\n" + conformed);
+	}
+
+	/**
+	 * The rule fails a section whose only content is commented out just as it fails
+	 * an empty one, so a stub is owed here. Counting the comment as a body reported
+	 * the section as satisfied and the adoption failed its own verification.
+	 */
+	@Test
+	void givesASectionWhoseOnlyBodyIsAnHtmlCommentAStub() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				## Testing
+
+				<!--
+				Nothing yet.
+				-->
+
+				## Project
+
+				A repo.
+				""";
+		String conformed = conformer.conform(generated);
+		assertTrue(hasStructuralBody(conformed, "## Testing"),
+				"a section whose only content is commented out needs a stub:\n" + conformed);
+	}
+
+	/**
+	 * An unterminated comment swallows everything below it, so the sections appended
+	 * there were as invisible to the rule as the ones appended below an unterminated
+	 * fence — and as invisible to the next run's own check for them, which appended a
+	 * second unreachable copy of the whole skeleton.
+	 */
+	@Test
+	void closesAnUnterminatedHtmlCommentSoAppendedSectionsStayDocumentStructure() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				<!-- work in progress
+				## Testing
+				""";
+		String conformed = conformer.conform(generated);
+		assertTrue(structuralLines(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
+				"every appended section must be a heading, not commented-out text:\n" + conformed);
+		assertEquals(conformed, conformer.conform(conformed), "a second reshape must not append the sections again");
+	}
+
+	/** A comment inside a fenced code block is sample text, so the fence wins — as it does for the rule. */
+	@Test
+	void leavesAHeadingBelowACommentInsideAFenceAsDocumentStructure() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				```markdown
+				<!--
+				```
+
+				## Testing
+
+				JUnit 5.
+				""";
+		String conformed = conformer.conform(generated);
+		assertTrue(hasStructuralBody(conformed, "## Testing"),
+				"the section below the fence is structure, not a comment:\n" + conformed);
+		assertFalse(conformed.contains("## Testing\n\n" + "See [AGENTS.md](AGENTS.md)."),
+				"the section already had a body:\n" + conformed);
+	}
+
+	/**
+	 * A line that merely starts with a hash is prose to the rule, so the section it
+	 * sits in already has a body. Reading it as a shallower heading ended the section
+	 * above it, and a stub was inserted in front of the content the section carried.
+	 */
+	@Test
+	void treatsALineThatMerelyStartsWithAHashAsSectionBody() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				## Testing
+
+				#1 rule: run mvn install every time.
+
+				## Project
+
+				A repo.
+				""";
+		String conformed = conformer.conform(generated);
+		assertFalse(conformed.contains("## Testing\n\n" + "See [AGENTS.md](AGENTS.md)."),
+				"the section already had a body and needs no stub:\n" + conformed);
+		assertTrue(conformed.contains("#1 rule: run mvn install every time."),
+				"the prose keeps its place:\n" + conformed);
+	}
+
+	/**
+	 * The document's lines that can carry structure, read the way the enforcer's
+	 * {@code MarkdownDocument} reads them: outside code fences and outside HTML
+	 * comments alike. The counterpart of {@link #linesOutsideFences} for the tests
+	 * that ask what the rule would recognise as a heading.
+	 */
+	private List<String> structuralLines(String content) {
+		List<String> structural = new ArrayList<>();
+		boolean open = false;
+		for (String line : linesOutsideFences(content)) {
+			open = collectStructural(structural, line, open);
+		}
+		return structural;
+	}
+
+	/** Records the line unless a comment covers it, and answers whether one is still open after it. */
+	private boolean collectStructural(List<String> structural, String line, boolean open) {
+		if (open) {
+			return !line.contains("-->");
+		}
+		boolean opens = line.startsWith("<!--") && !line.contains("-->");
+		addUnlessCode(structural, line, opens);
+		return opens;
+	}
+
+	/** Whether the section carries a body the rule would count: prose outside fences and comments. */
+	private boolean hasStructuralBody(String content, String section) {
+		List<String> lines = structuralLines(content);
+		int start = lines.indexOf(section);
+		return start >= 0 && lines.stream().skip(start + 1L).dropWhile(String::isEmpty).findFirst()
+				.filter(line -> !line.startsWith("## ")).isPresent();
+	}
+
 	/** The leading run of fence characters a line declares, or {@code null} when it declares none. */
 	private String fenceRun(String line) {
 		if (line.isEmpty() || (line.charAt(0) != '`' && line.charAt(0) != '~')) {


### PR DESCRIPTION
ClaudeMdConformer reshapes the generated CLAUDE.md so the claudeMdFormat rule
EnforcerStep wires in passes. It duplicates that rule's reading of a Markdown
document, and the two had drifted: the conformer read HTML comments as document
structure, and read any line starting with a hash as a heading. Each divergence
made the reshape produce a document the rule rejects, so the adoption failed its
own VerifyStep on a file it had just reshaped to pass it.

- A required heading inside a block HTML comment was taken for the section the
  document already had, so the real one was never appended and the rule reported
  it missing.
- A section whose only body was an HTML comment was taken for a section with a
  body, so it got no stub and the rule reported it empty.
- A near-miss heading inside a block comment was renamed in place, rewriting text
  its author had deliberately commented out and still leaving the section absent.
- A line that merely starts with a hash — "#1 rule: run mvn install" — was read
  as a level-one heading that ended the section above it, so a stub was inserted
  in front of the body that section already carried. The rule reads it as prose.

Mirrors MarkdownDocument's comment mask and ATX heading pattern, and closes an
unterminated comment as the reshape already closed an unterminated fence, so
appended sections stay outside the block.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017nUSLg181pCUG1ctNJZNNi