### PR TITLE
fix(adopt): three defects that refused a resume and leaked a token

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ tools (root pom, packaging=pom)
 │   ├── protogen-maven-plugin       # the proto2 builder-generating Maven plugin
 │   ├── protogen-maven-plugin-test  # integration tests / use cases for the plugin
 │   └── context                     # regex-based class-usage context finder
-├── adopt                       # adopts Claude Code into a GitHub repo (clone, build-tool check, branch, trust, init, enforcer, verify, push, PR)
+├── adopt                       # adopts Claude Code into a GitHub repo (clone, build-tool check, branch, trust, init, conform, enforcer, verify, push, PR)
 ├── grpc-example                # end-to-end gRPC example with compile-time-safe builders
 ├── assembly                    # runnable SampleApp distribution: launcher jar + lib/
 │                               #   (mainClass: io.github.adamw7.tools.data.SampleApp)

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -301,11 +301,19 @@ public final class CliArguments {
 	 * run whose only repository is the positional has nothing else it could be. A
 	 * local path really is adoptable — only a URL with a host names an owner — so a
 	 * batch of local repositories names them all with {@code --repo}.
+	 *
+	 * <p>The argument is named through {@link Redaction}, as every other message the
+	 * adoption raises about a URL is. A URL naming no owner can still carry
+	 * credentials — {@code https://x-access-token:TOKEN@github.com/repo}, whose
+	 * userinfo and host collapse into one segment where the owner should be — and this
+	 * message is the last thing a run prints before it stops, so reporting the
+	 * argument verbatim wrote the token to the operator's terminal and to whatever
+	 * captured it.
 	 */
 	private void requirePositionalNamesARepository() {
 		if (positionalUrl != null && flagsNamedARepository && namesNoOwner(positionalUrl)) {
-			throw new IllegalArgumentException("The first argument is read as a repository URL, but " + positionalUrl
-					+ " names no repository owner. Name the workspace with --workspace,"
+			throw new IllegalArgumentException("The first argument is read as a repository URL, but "
+					+ Redaction.of(positionalUrl) + " names no repository owner. Name the workspace with --workspace,"
 					+ " or the repository with --repo. " + USAGE);
 		}
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandResult.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandResult.java
@@ -15,7 +15,8 @@ import io.github.adamw7.tools.adopt.Redaction;
  *                 goes through {@link #describe()}
  * @param exitCode the code the command exited with, zero meaning success
  * @param output   the command's standard output and standard error, merged into
- *                 one ordered transcript
+ *                 one ordered transcript — the tool's own text, so anything that
+ *                 outlives the run reports it through {@link #redactedOutput()}
  */
 public record CommandResult(List<String> command, int exitCode, String output) {
 
@@ -25,6 +26,18 @@ public record CommandResult(List<String> command, int exitCode, String output) {
 
 	public String describe() {
 		return describe(command);
+	}
+
+	/**
+	 * The transcript with any clone credentials masked, for the logs, failure
+	 * messages, and JSON report a secret must not reach. A tool handed a
+	 * credentialled clone URL echoes it back when it cannot use it — {@code fatal:
+	 * could not read Username for 'https://...@github.com'} — so the transcript
+	 * carries one as readily as the command does, and masking it here rather than at
+	 * each caller keeps it out of the places a caller would forget.
+	 */
+	public String redactedOutput() {
+		return Redaction.of(output);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
@@ -18,9 +18,11 @@ repository, the branch, the pull request URL, and the completed steps.
 One call can adopt a list of repositories, one after another, sharing the
 workspace and branch name. A repository whose adoption fails does not strand the
 ones behind it: the batch runs to the end and the report says which landed, the
-result being marked as an error when any of them did not. Two repositories of the
-list that would clone into the same directory under the workspace are refused
-before anything is cloned, so neither is adopted on top of the other.
+result being marked as an error when any of them did not. Each repository claims
+its checkout directory inside its own adoption, so a second repository of the list
+that would clone into a directory the first already claimed is that repository's
+recorded failure — never an adoption on top of the first — rather than an abort of
+the whole call.
 
 Because the pipeline shells out to `git`, `claude`, and `gh`, those tools must
 be installed and authenticated on the machine running the MCP server.
@@ -92,8 +94,9 @@ This creates an executable JAR in `adopt/target/tools.adopt-{version}.jar`.
   "pullRequestUrl" : "https://github.com/owner/repo/pull/42",
   "succeeded" : true,
   "failure" : null,
-  "completedSteps" : [ "toolchain", "clone", "branch", "trust", "claude-init",
-    "commit", "enforcer", "commit", "verify", "push", "pull-request" ]
+  "completedSteps" : [ "toolchain", "clone", "build-toolchain", "branch", "trust",
+    "claude-init", "conform", "commit", "enforcer", "commit", "verify", "push",
+    "pull-request" ]
 }
 ```
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractCommandStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractCommandStep.java
@@ -6,7 +6,6 @@ import java.util.Locale;
 import java.util.Optional;
 
 import io.github.adamw7.tools.adopt.AdoptionException;
-import io.github.adamw7.tools.adopt.Redaction;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
@@ -63,6 +62,6 @@ public abstract class AbstractCommandStep implements AdoptionStep {
 	 */
 	private AdoptionException failure(CommandResult result) {
 		return new AdoptionException(name() + " failed (exit " + result.exitCode() + ") running: " + result.describe()
-				+ System.lineSeparator() + Redaction.of(result.output()));
+				+ System.lineSeparator() + result.redactedOutput());
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.Failures;
-import io.github.adamw7.tools.adopt.Redaction;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 
@@ -138,7 +137,7 @@ public class ClaudeInitStep extends AbstractCommandStep {
 			throw new AdoptionException(name() + " completed but " + CLAUDE_MD + " was not found in "
 					+ context.repositoryDirectory() + ". " + CommandResult.describe(claudeCommand)
 					+ " exited " + result.exitCode() + " and said:" + System.lineSeparator()
-					+ Redaction.of(result.output().strip()));
+					+ result.redactedOutput().strip());
 		}
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.adopt.step;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -60,6 +61,23 @@ public class CloneStep extends AbstractCommandStep {
 
 	/** What {@code git status --porcelain} puts between a rename's old and new path. */
 	private static final String RENAME_ARROW = " -> ";
+
+	/**
+	 * One entry of {@code git status --porcelain}: the index and work-tree status
+	 * letters — the alphabet git documents for the format — then the space before the
+	 * path.
+	 *
+	 * <p>The transcript merges the command's standard error into its standard output,
+	 * exactly as {@link #originTranscript} does, so it is not reliably status entries
+	 * and nothing else: a git that warns — about an unreadable system config, or a
+	 * directory it could not open — puts that line in there too. Reading every line as
+	 * an entry took the warning's fourth character onwards for a path, found it among
+	 * no path the adoption writes, and refused the resume this step promises for
+	 * changes the checkout did not have. A line that is not an entry is therefore
+	 * skipped rather than read as one, the same reading {@link #namesThisRepository}
+	 * takes of that transcript's noise.
+	 */
+	private static final Pattern STATUS_ENTRY = Pattern.compile("^[ MTADRCU?!]{2} .+");
 
 	@Override
 	public String name() {
@@ -123,10 +141,10 @@ public class CloneStep extends AbstractCommandStep {
 		if (!result.succeeded()) {
 			throw new AdoptionException(context.repositoryDirectory() + " is a checkout whose status could not be"
 					+ " read, so it cannot be shown to be free of uncommitted work: "
-					+ Redaction.of(result.output().strip()));
+					+ result.redactedOutput().strip());
 		}
 		return result.output().lines()
-				.filter(line -> line.length() > STATUS_PREFIX)
+				.filter(line -> STATUS_ENTRY.matcher(line).matches())
 				.map(this::changedPath)
 				.filter(path -> !AdoptionAssets.WRITTEN_PATHS.contains(path))
 				.toList();
@@ -195,7 +213,7 @@ public class CloneStep extends AbstractCommandStep {
 			throw new AdoptionException(context.repositoryDirectory() + " is a checkout with no '"
 					+ AdoptionContext.REMOTE
 					+ "' remote, so it can be neither confirmed to be " + context.displayUrl() + " nor pushed to it: "
-					+ Redaction.of(result.output().strip()));
+					+ result.redactedOutput().strip());
 		}
 		return result.output();
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -108,7 +108,7 @@ public class PullRequestStep extends AbstractCommandStep {
 		log.info("Opening pull request for branch {}", context.branchName());
 		runTolerating(runner, context.repositoryDirectory(), createCommand(context), TOLERATED_FAILURES)
 				.ifPresentOrElse(
-						result -> log.info("Opened pull request: {}", result.output().strip()),
+						result -> log.info("Opened pull request: {}", result.redactedOutput().strip()),
 						() -> log.info("Nothing to open a pull request for on branch {}; left unchanged",
 								context.branchName()));
 	}
@@ -134,6 +134,13 @@ public class PullRequestStep extends AbstractCommandStep {
 	 * the log of an adoption that went on to create a duplicate needs to see which
 	 * of the two it was.
 	 *
+	 * <p>The transcript is redacted for the same reason
+	 * {@link AbstractCommandStep#runOrFail} redacts the one it fails with: a
+	 * {@code gh} left without a {@code --repo} reads the checkout's remote through
+	 * {@code git}, and a {@code git} that cannot use it echoes the credentialled URL
+	 * back — {@code fatal: could not read Username for 'https://...@github.com'}.
+	 * This warning is written to the log, which outlives the run.
+	 *
 	 * @return the URL of the branch's open pull request, or empty when none is open
 	 *         or {@code gh} could not be queried
 	 */
@@ -141,7 +148,7 @@ public class PullRequestStep extends AbstractCommandStep {
 		CommandResult result = runner.run(context.repositoryDirectory(), listCommand(context));
 		if (!result.succeeded()) {
 			log.warn("Could not ask gh which pull requests are open for branch {} (exit {}): {}",
-					context.branchName(), result.exitCode(), result.output().strip());
+					context.branchName(), result.exitCode(), result.redactedOutput().strip());
 			return Optional.empty();
 		}
 		return extractUrl(result.output());

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -303,6 +303,21 @@ class CliArgumentsTest {
 				() -> CliArguments.parse(new String[] { "--repo", REPO_URL, "/tmp/ws" }));
 	}
 
+	/**
+	 * A URL that names no owner can still carry credentials — the userinfo and the
+	 * host of {@code https://x-access-token:TOKEN@github.com/repo} collapse into the
+	 * one segment where the owner should be — and this refusal is the last thing the
+	 * run prints, so it reports the argument through {@code Redaction} as every other
+	 * message about a URL does.
+	 */
+	@Test
+	void masksTheCredentialsOfARejectedPositional() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> CliArguments
+				.parse(new String[] { "https://x-access-token:SECRET@github.com/repo", "--repo", OTHER_URL }));
+		assertFalse(exception.getMessage().contains("SECRET"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("https://***@github.com/repo"), exception.getMessage());
+	}
+
 	/** A positional URL beside the flags is the documented way to name the first repository. */
 	@Test
 	void acceptsARepositoryPositionalAlongsideTheRepositoryFlags() {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/CommandResultTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/CommandResultTest.java
@@ -45,4 +45,23 @@ class CommandResultTest {
 				List.of("git", "clone", "https://x-access-token:secret@github.com/owner/repo.git", "/tmp/repo"));
 		assertEquals("git clone https://***@github.com/owner/repo.git /tmp/repo", described);
 	}
+
+	/**
+	 * A tool handed a credentialled clone URL echoes it back when it cannot use it, so
+	 * the transcript carries a secret as readily as the command does — and the
+	 * transcript is what the failure messages and the warnings quote.
+	 */
+	@Test
+	void masksTheCredentialsAToolEchoedBackInItsTranscript() {
+		CommandResult result = new CommandResult(List.of("git", "fetch"), 128,
+				"fatal: could not read Username for 'https://x-access-token:secret@github.com'");
+		assertEquals("fatal: could not read Username for 'https://***@github.com'", result.redactedOutput());
+	}
+
+	/** A transcript carrying no credentials reads as the tool wrote it. */
+	@Test
+	void leavesATranscriptWithoutCredentialsAlone() {
+		assertEquals("nothing to commit", new CommandResult(List.of("git", "commit"), 1, "nothing to commit")
+				.redactedOutput());
+	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -372,6 +372,41 @@ class CloneStepTest {
 		assertTrue(failure.getMessage().contains("status could not be read"), failure.getMessage());
 	}
 
+	/**
+	 * The runner merges standard error into the transcript, so a git that warns puts
+	 * that line among the status entries. Read as an entry it named a path the
+	 * adoption does not write, and the resume this step promises was refused for
+	 * changes the checkout never had.
+	 */
+	@Test
+	void resumesReusedCheckoutWhoseStatusWarnedOnStandardError(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git", String.join(
+				System.lineSeparator(),
+				"warning: unable to access '/etc/gitconfig': Permission denied",
+				"?? CLAUDE.md"));
+
+		step.execute(existing, runner);
+
+		assertEquals(3, runner.count());
+	}
+
+	/** A warning is skipped, not read as a change — but a real entry beside it still stops the run. */
+	@Test
+	void refusesReusedCheckoutWhoseWarnedStatusAlsoNamesSomebodyElsesWork(@TempDir Path existingWorkspace)
+			throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git", String.join(
+				System.lineSeparator(),
+				"warning: could not open directory 'vendor/': Permission denied",
+				" M src/Main.java"));
+
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
+
+		assertTrue(failure.getMessage().contains("src/Main.java"), failure.getMessage());
+		assertFalse(failure.getMessage().contains("warning"), failure.getMessage());
+	}
+
 	@Test
 	void isNamedClone() {
 		assertEquals("clone", step.name());


### PR DESCRIPTION
Each of these made the pipeline misbehave on input it is documented to handle,
and each is now pinned by a test.

A resumed adoption was refused for a git warning. CloneStep asks
`git status --porcelain` whether a reused checkout carries anything but the
adoption's own paths, and read every line of the answer as a status entry. The
runner merges standard error into the transcript, so a git that warns — about an
unreadable system config, a directory it could not open — puts that line in there
too: its fourth character onwards was taken for a changed path, found among no
path the adoption writes, and the resume the step promises was refused for
changes the checkout never had. This is the same defect already fixed for the
origin query beside it, whose transcript is read line by line precisely because
noise shares it. A line that is not a porcelain entry is now skipped rather than
read as one; a real entry beside the warning still stops the run.

A rejected positional reported its credentials. CliArguments refuses a first
positional that names no repository owner when the flags already named
repositories, and named the argument verbatim. A URL naming no owner can still
carry one — the userinfo and host of
`https://x-access-token:TOKEN@github.com/repo` collapse into the single segment
where the owner should be — so the message the run stops on wrote the token to
the terminal and to whatever captured it. It goes through Redaction now, as every
other message about a URL does.

A command's transcript reached the log unmasked. PullRequestStep logged the raw
output of a `gh pr list` it could not run and of the `gh pr create` it did; a
`gh` left without a `--repo` reads the checkout's remote through git, which
echoes a credentialled clone URL back when it cannot use it. Rather than adding
the call at each site, CommandResult grows `redactedOutput()` beside the
`describe()` that already masks the command, and the steps that quote a
transcript take it — so the masking is structural instead of remembered.

Also corrects two stale facts in the module's docs: the MCP tool's sample
`completedSteps` omitted `build-toolchain` and `conform`, and its batch note
still claimed a colliding checkout is refused before anything is cloned, which
moved into each repository's own adoption so a collision fails that repository
rather than the call. AGENTS.md's module map gains the `conform` step CLAUDE.md's
already lists.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WmdmJ991GeFTqNEZqpGHuZ