### PR TITLE
fix(adopt): a rename past the reuse guard and a blank value reaching gh

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -4,6 +4,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -132,8 +133,9 @@ public class CloneStep extends AbstractCommandStep {
 
 	/**
 	 * The changed paths the adoption does not own. A rename is reported as
-	 * {@code old -> new} and a path carrying a space or a quote is reported quoted, so
-	 * both are reduced to the path git would act on before it is compared.
+	 * {@code old -> new} and names two of them, and a path carrying a space or a quote
+	 * is reported quoted, so every entry is reduced to the paths git would act on
+	 * before they are compared.
 	 */
 	private List<String> unrelatedChanges(AdoptionContext context, CommandRunner runner) {
 		CommandResult result = runner.run(context.repositoryDirectory(),
@@ -145,15 +147,28 @@ public class CloneStep extends AbstractCommandStep {
 		}
 		return result.output().lines()
 				.filter(line -> STATUS_ENTRY.matcher(line).matches())
-				.map(this::changedPath)
+				.flatMap(this::changedPaths)
 				.filter(path -> !AdoptionAssets.WRITTEN_PATHS.contains(path))
 				.toList();
 	}
 
-	private String changedPath(String statusLine) {
+	/**
+	 * The paths one entry changes. A rename or a copy is reported as
+	 * {@code old -> new} and changes <em>both</em> sides, so both are asked about:
+	 * reading only the destination waved the whole entry through whenever that
+	 * destination happened to be a path the adoption writes, and a
+	 * {@code git mv docs/CLAUDE.md CLAUDE.md} a contributor had staged was then swept
+	 * into {@link CommitStep}'s {@code git add -A} and pushed to the feature branch —
+	 * the very outcome this guard exists to prevent. A plain entry names one path.
+	 */
+	private Stream<String> changedPaths(String statusLine) {
 		String path = statusLine.substring(STATUS_PREFIX);
 		int rename = path.lastIndexOf(RENAME_ARROW);
-		return unquoted(rename < 0 ? path : path.substring(rename + RENAME_ARROW.length()));
+		if (rename < 0) {
+			return Stream.of(unquoted(path));
+		}
+		return Stream.of(unquoted(path.substring(0, rename)),
+				unquoted(path.substring(rename + RENAME_ARROW.length())));
 	}
 
 	private String unquoted(String path) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
@@ -15,6 +15,15 @@ import io.github.adamw7.tools.adopt.Text;
  * and the MCP tool map their arguments straight in and no {@code null} can reach
  * {@code gh}'s arguments.
  *
+ * <p>Each list entry is stripped, and a blank one is dropped rather than carried:
+ * every entry becomes an argument of its own — {@code gh pr create --reviewer
+ * <entry>} — so a blank one reached {@code gh} as an empty argument and failed the
+ * adoption at its very last step, with the branch already pushed. The MCP tool
+ * already read its arguments this way; doing it here rather than at each entry
+ * point is what keeps the command line from disagreeing with it about what an
+ * omitted value means. Duplicates are left alone, as {@code gh} treats naming a
+ * reviewer twice as naming them once.
+ *
  * @param title     the pull request's title, or blank for {@value #DEFAULT_TITLE}
  * @param body      the pull request's body, or blank for the adoption's own
  * @param reviewers the users to request a review from, empty to request nobody
@@ -32,9 +41,14 @@ public record PullRequestOptions(String title, String body, List<String> reviewe
 	public PullRequestOptions {
 		title = orDefault(title, DEFAULT_TITLE);
 		body = orDefault(body, DEFAULT_BODY);
-		reviewers = List.copyOf(reviewers);
-		labels = List.copyOf(labels);
-		assignees = List.copyOf(assignees);
+		reviewers = supplied(reviewers);
+		labels = supplied(labels);
+		assignees = supplied(assignees);
+	}
+
+	/** @return the entries that name something, stripped — the rule {@link Text} defines for every optional input */
+	private static List<String> supplied(List<String> values) {
+		return values.stream().filter(Text::isPresent).map(String::strip).toList();
 	}
 
 	/** The adoption's own title and body, requesting nobody and not a draft. */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -194,6 +194,23 @@ class CliArgumentsTest {
 		assertTrue(options.draft());
 	}
 
+	/**
+	 * A blank value counts as not supplied for every other optional input, and the
+	 * MCP tool already read its own lists that way. The command line adds what it was
+	 * given without reading it, so a {@code --reviewer ""} used to reach {@code gh}
+	 * as an empty argument and fail the last step of an otherwise complete adoption.
+	 */
+	@Test
+	void dropsBlankRepeatableFlagValues() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL,
+				"--reviewer", "", "--reviewer", "octocat",
+				"--label", "   ", "--assignee", " adamw7 " });
+		PullRequestOptions options = cli.pullRequestOptions();
+		assertEquals(List.of("octocat"), options.reviewers());
+		assertEquals(List.of(), options.labels());
+		assertEquals(List.of("adamw7"), options.assignees());
+	}
+
 	@Test
 	void parsesAssetsAndReportFlags() {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--assets", "--report", "/tmp/report.json" });

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -359,6 +359,50 @@ class CloneStepTest {
 		assertFalse(failure.getMessage().contains("->"), failure.getMessage());
 	}
 
+	/**
+	 * A rename changes the path it starts at as much as the one it ends at. Reading
+	 * only the destination waved the whole entry through whenever that destination
+	 * was a path the adoption writes, so a contributor's staged
+	 * {@code git mv docs/CLAUDE.md CLAUDE.md} was swept into the adoption's commit
+	 * and pushed — which is what this guard exists to prevent.
+	 */
+	@Test
+	void refusesRenameOntoAnAdoptionPathBecauseItsSourceIsUnrelated(@TempDir Path existingWorkspace)
+			throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
+				"R  docs/CLAUDE.md -> CLAUDE.md");
+
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
+
+		assertTrue(failure.getMessage().contains("docs/CLAUDE.md"), failure.getMessage());
+	}
+
+	/** A copy leaves its source in place but is reported the same way, so it is read the same way. */
+	@Test
+	void refusesCopyOntoAnAdoptionPathBecauseItsSourceIsUnrelated(@TempDir Path existingWorkspace)
+			throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
+				"C  Feature.java -> pom.xml");
+
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
+
+		assertTrue(failure.getMessage().contains("Feature.java"), failure.getMessage());
+	}
+
+	/** Both sides being the adoption's own is a resume, not a contributor's work in progress. */
+	@Test
+	void resumesWhenBothSidesOfARenameAreTheAdoptionsOwn(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
+				"R  AGENTS.md -> CLAUDE.md");
+
+		step.execute(existing, runner);
+
+		assertEquals(3, runner.count());
+	}
+
 	/** A status that cannot be read cannot show the checkout to be free of other work. */
 	@Test
 	void refusesReusedCheckoutWhoseStatusCannotBeRead(@TempDir Path existingWorkspace) throws IOException {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestOptionsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestOptionsTest.java
@@ -62,6 +62,52 @@ class PullRequestOptionsTest {
 		assertEquals(List.of("octocat"), options.reviewers());
 	}
 
+	/**
+	 * Every list entry becomes an argument of its own — {@code gh pr create
+	 * --reviewer <entry>} — so a blank one reached {@code gh} as an empty argument
+	 * and failed the adoption at its last step, with the branch already pushed. The
+	 * command line adds what it was given without reading it, so the rule belongs
+	 * here, where the MCP tool's own stripping already agreed with it.
+	 */
+	@Test
+	void dropsBlankListEntriesSoNoneReachesGhAsAnEmptyArgument() {
+		PullRequestOptions options = new PullRequestOptions(null, null, List.of("", "octocat"),
+				List.of("   ", "automation"), List.of("\t", "adamw7"), false);
+		assertEquals(List.of("octocat"), options.reviewers());
+		assertEquals(List.of("automation"), options.labels());
+		assertEquals(List.of("adamw7"), options.assignees());
+	}
+
+	@Test
+	void stripsListEntries() {
+		PullRequestOptions options = new PullRequestOptions(null, null, List.of("  octocat  "),
+				List.of("  automation  "), List.of("  adamw7  "), false);
+		assertEquals(List.of("octocat"), options.reviewers());
+		assertEquals(List.of("automation"), options.labels());
+		assertEquals(List.of("adamw7"), options.assignees());
+	}
+
+	/** A list of nothing but blanks requests nobody, exactly as an omitted one does. */
+	@Test
+	void requestsNobodyWhenEveryEntryIsBlank() {
+		PullRequestOptions options = new PullRequestOptions(null, null, List.of(" "), List.of(""),
+				List.of("  "), false);
+		assertTrue(options.reviewers().isEmpty());
+		assertTrue(options.labels().isEmpty());
+		assertTrue(options.assignees().isEmpty());
+	}
+
+	/**
+	 * {@code gh} treats naming a reviewer twice as naming them once, so a repeated
+	 * {@code --reviewer} is left alone rather than being second-guessed here.
+	 */
+	@Test
+	void keepsRepeatedEntriesAsTheyWereGiven() {
+		PullRequestOptions options = new PullRequestOptions(null, null, List.of("octocat", "octocat"),
+				List.of(), List.of(), false);
+		assertEquals(List.of("octocat", "octocat"), options.reviewers());
+	}
+
 	private PullRequestOptions options(String title, String body) {
 		return new PullRequestOptions(title, body, List.of(), List.of(), List.of(), false);
 	}


### PR DESCRIPTION
Two defects found while auditing `adopt`, each confirmed by driving the real code before and after the fix.

## 1. `CloneStep`'s reuse guard ignored the source side of a rename

`CloneStep` refuses to reuse a checkout carrying uncommitted work that is not the adoption's, because `CommitStep` stages the whole tree with `git add -A` and would push it to the feature branch.

A rename is reported by git as `old -> new` and changes **both** sides, but `changedPath` reduced the entry to its destination alone before comparing it against `AdoptionAssets.WRITTEN_PATHS`. When that destination happened to be a path the adoption writes, the whole entry was waved through — the deletion of the source included.

Driving the real `CloneStep` with a scripted git, before:

```
REFUSED    rename OF an owned file      R  CLAUDE.md -> NOTES.md
ACCEPTED   rename INTO an owned file    R  Feature.java -> CLAUDE.md
ACCEPTED   copy INTO an owned file      C  Feature.java -> pom.xml
```

A contributor's staged `git mv docs/CLAUDE.md CLAUDE.md` was enough: the move was swept into the adoption's commit and offered for review as part of adopting Claude Code, which is the outcome this guard exists to prevent. `CLAUDE.md`, `pom.xml`, `AGENTS.md`, `build.gradle` and the rest of `WRITTEN_PATHS` are all reachable destinations.

Both sides are now asked about. A copy, which git reports the same way, is read the same way. A rename whose two sides are *both* the adoption's own still resumes.

## 2. Blank `--reviewer`/`--label`/`--assignee` values reached `gh` verbatim

Every list entry becomes an argument of its own — `gh pr create --reviewer <entry>` — so a blank one reached `gh` as an empty argument and failed the last step of an otherwise complete adoption, with the branch already pushed.

`PullRequestOptions` only did `List.copyOf`, so the command line passed through whatever it was handed:

```
--reviewer ""    -> reviewers=[""]
--reviewer "  "  -> reviewers=["  "]
```

The MCP tool did not have this problem: `AdoptTool.texts()` already stripped its lists and dropped their blank entries. That contradicted the invariant both `AdoptionOptions` and `PullRequestOptions` state in their javadoc — that the two entry points cannot drift apart on what an omitted value means.

The rule moves into the record both entry points build, so neither can forget it. Repeated entries are deliberately left alone, since `gh` treats naming a reviewer twice as naming them once, and the MCP tool does not de-duplicate either.

## Testing

- 5 new unit tests: rename/copy onto an adoption path refused and naming the source, a rename with both sides owned still resuming, blank list entries dropped, list entries stripped, repeated entries kept, and the same end-to-end through `CliArguments`.
- Full suite green: `mvn -pl adopt -am test` — 672 tests, 0 failures.
- `mvn -N validate -DenforceClaudeMd` passes; `javadoc:javadoc` generates cleanly.

## Audited and found clean

Recorded here so the same ground is not re-covered:

- **`ClaudeMdConformer` against the rule it must satisfy.** Ran the conformer's output through the enforcer's own `MarkdownDocument`/`ClaudeMdFormatRule` reader across 19 inputs — unterminated fences and comments, tilde and four-backtick fences, commented-out sections, an `AGENTS.md` reference visible only inside a comment or a fence, CRLF, missing title, title inside a fence, `#1 rule:` prose, all six headings as near-misses, a required heading as the last line. All conform, all idempotent.
- **`PomDocument`/`PomEnforcerInstaller` splicing.** 14 POM shapes — existing enforcer with and without `dependencies`/`executions`, `<plugins/>`, empty `<build>`, comments containing markup, `>` inside an attribute value, CRLF, tab indentation, rule already wired in a profile, enforcer only in `pluginManagement`. Every result parses, wires the rule exactly once, and is idempotent.
- **`RepositoryUrl` and `Redaction`.** Ports, scp-form, `ssh://` with userinfo, `user:1234@host:8443`, `.GIT`, trailing slash, all-digit owners, `p@ss@host` passwords, an email address beside a URL. Correct throughout; no credential leaked in any form tried.

---
_Generated by [Claude Code](https://claude.ai/code/session_0192TYciirBJgR1tSqKYLu9M)_