### PR TITLE
feat(context): emit project context as Open Knowledge Format bundles

### DIFF
--- a/.claude/skills/context-finder/SKILL.md
+++ b/.claude/skills/context-finder/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: context-finder
-description: Assemble gen-AI context with the code/context module — the class-usage finders (name-based vs package-aware), the project-tree builder and its serializers, token estimation and budgeting, and the project_tree/find_context/estimate_tokens MCP tools. Use when gathering the classes a file depends on, scanning a project into a tree, sizing context for a model, or when the user says "find context", "project tree", or "estimate tokens".
+description: Assemble gen-AI context with the code/context module — the class-usage finders (name-based vs package-aware), the project-tree builder and its serializers, Open Knowledge Format (OKF) bundles, token estimation and budgeting, and the project_tree/find_context/estimate_tokens/okf_bundle MCP tools. Use when gathering the classes a file depends on, scanning a project into a tree, emitting an OKF bundle, sizing context for a model, or when the user says "find context", "project tree", "OKF", or "estimate tokens".
 ---
 
 # Context Finder Skill
 
 Use `code/context` to answer "which classes does this file actually need?" and
 "how many tokens will that cost?" — the module behind the `project_tree`,
-`find_context` and `estimate_tokens` MCP tools.
+`find_context`, `estimate_tokens` and `okf_bundle` MCP tools.
 
 ## When to Use
 - Collecting the dependency closure of a source file to feed a model
 - Scanning a project into a tree of folders, files and class dependencies
+- Emitting that tree as an Open Knowledge Format bundle
 - Sizing or trimming context against a token budget
 - Adding a language, a serializer, or a resolution strategy
-- The user says "find context" / "project tree" / "estimate tokens"
+- The user says "find context" / "project tree" / "estimate tokens" / "OKF"
 
 ## The core contract
 ```java
@@ -63,9 +64,33 @@ and symbol boundaries — the better default) and `HeuristicTokenEstimator`.
 builder — add a serializer or a factory rather than branching inside the
 builder.
 
+## Open Knowledge Format
+The `…context.okf` package emits the same tree as an **OKF v0.2** bundle — a
+directory of markdown files, not one document:
+
+```java
+OkfBundle bundle = new OkfBundler(Language.JAVA).bundle(tree);
+new OkfBundleWriter().write(bundle, Path.of("target/okf"));
+```
+
+- Every directory → the reserved `index.md` (no frontmatter; only a bundle-root
+  index may carry `okf_version`). Every file → a concept document.
+- `type` is the **one** mandatory frontmatter field; `title`, `description`,
+  `resource`, `tags` are recommended; v0.2 records production as
+  `generated: { by, at }` using the `<producer>/<version>` actor convention.
+- Cross-links use the bundle-relative `/`-prefixed form. A dependency is linked
+  only when its file name identifies exactly one concept — unresolved or
+  ambiguous names stay plain code rather than linking to a guess.
+- `OkfConcept` holds a concept's facts before rendering, so the index entry and
+  the frontmatter carry the same description, as the spec recommends.
+- Adding a frontmatter field → extend `OkfFrontmatter` (fixed render order,
+  every scalar quoted), not the bundler.
+
 ## MCP tools
-`project_tree`, `find_context` and `estimate_tokens` are the adapter over the
-above, in `…context.mcp`. `PathPolicy` confines them to allowed directories.
+`project_tree`, `find_context`, `estimate_tokens` and `okf_bundle` are the
+adapter over the above, in `…context.mcp`. `PathPolicy` confines them to allowed
+directories, and the server is **read-only** — `okf_bundle` returns the bundle as
+JSON rather than writing it, so keep writing on the caller's side.
 **The core must never depend on the `mcp` package** — ArchUnit pins it. See the
 `mcp-server` skill before changing a tool, and update
 `code/context/.../mcp/MCP_USAGE.md` in the same change.
@@ -77,6 +102,8 @@ above, in `…context.mcp`. `PathPolicy` confines them to allowed directories.
   `findDirectDependencies`; traversal and depth-bounding are inherited.
 
 ## References
-- `code/context/.../mcp/MCP_USAGE.md` — the three tools and their parameters
+- `code/context/.../mcp/MCP_USAGE.md` — the four tools and their parameters
+- [OKF v0.2 spec](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+  — conformance rules, frontmatter families, reserved filenames
 - `README.md` — *Context engineering* worked examples
 - `.claude/skills/mcp-server/SKILL.md` — for the adapter side

--- a/.claude/skills/context-finder/SKILL.md
+++ b/.claude/skills/context-finder/SKILL.md
@@ -86,6 +86,15 @@ new OkfBundleWriter().write(bundle, Path.of("target/okf"));
 - Adding a frontmatter field → extend `OkfFrontmatter` (fixed render order,
   every scalar quoted), not the bundler.
 
+Two build-level checks guard this, and a change to the emitter has to keep both
+green:
+- `OkfBundleConformanceTest` (this module) restates the spec's conformance
+  conditions against every emitted bundle. It runs in the ordinary `test` phase,
+  so `mvn test` / `package` / `install` all catch drift.
+- The `okfBundleFormat` enforcer rule checks a bundle already on disk, at
+  `validate` under `-DenforceClaudeMd` — what `.github/workflows/maven.yml` runs
+  on every pull request. See the `enforcer-rules` skill to change it.
+
 ## MCP tools
 `project_tree`, `find_context`, `estimate_tokens` and `okf_bundle` are the
 adapter over the above, in `…context.mcp`. `PathPolicy` confines them to allowed

--- a/.claude/skills/enforcer-rules/SKILL.md
+++ b/.claude/skills/enforcer-rules/SKILL.md
@@ -134,7 +134,15 @@ directory does.** `subAgentFormat` (`.claude/agents`) and `commandFormat`
 configured-but-absent directory is treated as a build-setup mistake. Add the
 directory and the wiring in the same change. `pluginFormat`, `mcpServersValid`
 and `mcpConfigFormat` differ — they pass on the absent file and start enforcing
-the moment one appears.
+the moment one appears. `okfBundleFormat` follows that second pattern for a
+directory: an absent `bundleDir` is a pass, so it is wired here today against a
+bundle this repository does not yet ship.
+
+**A new rule must also be listed in
+`src/main/resources/META-INF/sisu/javax.inject.Named`.** The index is
+hand-maintained; a rule missing from it compiles, unit-tests green, and then
+fails a real build with "Failed to create enforcer rules with name: …". The
+`*IT`s are what catch it.
 
 ## References
 - `AGENTS.md` — *CLAUDE.md enforcement* (source of truth, full rule catalogue)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -638,6 +638,23 @@ profile:
   variable expansion (`https://${MCP_HOST}/mcp`) is left alone, since only the
   shell that resolves it knows what it becomes. Like `mcpServersValid` it treats
   an absent file as a pass.
+- `OkfBundleFormatRule` (`okfBundleFormat`) holds a bundle in Google's Open
+  Knowledge Format at `bundleDir` to the specification's own conformance
+  conditions: every non-reserved `.md` file carries a parseable YAML frontmatter
+  block, every block declares a non-empty `type` (the one mandatory field), and
+  the reserved names keep their structure — an `index.md` carries no frontmatter
+  beyond an `okf_version` at the bundle root, and a `log.md` groups entries under
+  ISO 8601 `YYYY-MM-DD` headings. Where the format defines a closed vocabulary the
+  value is checked too (`status` is `draft`/`stable`/`deprecated`, `stale_after`
+  is a real calendar date, a `generated` mapping names its actor); where it does
+  not, nothing is imposed — a `type` is not registered centrally, so an unknown
+  one passes. `requiredKeys` adds frontmatter keys every concept must declare,
+  `okfVersion` pins the version the bundle root declares, and `requireIndex`
+  demands a listing in every directory holding concepts (off by default, since a
+  consumer must tolerate a missing `index.md`). A bundle is optional, so an absent
+  `bundleDir` is a pass. The producer side is guarded separately: `code/context`'s
+  `OkfBundleConformanceTest` restates the same conditions against every bundle
+  `OkfBundler` emits, and runs in the ordinary `test` phase.
 - `UniqueNamesRule` (`uniqueNames`) gathers the names of every command,
   sub-agent, and skill from the configured `commandsDir`, `agentsDir`, and
   `skillsDir` (file name for commands and sub-agents, directory name for skills)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,14 @@ Maven project. The notable capabilities are:
 - **Context engineering** (`code/context`) — a fast, regex-based finder that
   builds the tree of classes used by a given class, plus a `ProjectTreeBuilder`
   that scans a whole Java project into a tree of folders, files and
-  dependencies, to assemble context for gen-AI agents working with Java code. An
-  **MCP server** (in the `io.github.adamw7.context.mcp` package) exposes the
-  project-tree and context-finder tools over stdio, streamable HTTP or stateless
+  dependencies, to assemble context for gen-AI agents working with Java code.
+  The same tree can also be emitted as a bundle in Google's **Open Knowledge
+  Format** (OKF) v0.2 — a directory of markdown concept documents with YAML
+  frontmatter, in the `io.github.adamw7.context.okf` package — so a consumer that
+  already speaks OKF can take this project's context without knowing anything
+  about the tree behind it. An **MCP server** (in the
+  `io.github.adamw7.context.mcp` package) exposes the project-tree,
+  context-finder and OKF-bundle tools over stdio, streamable HTTP or stateless
   HTTP.
 - **Data** (`data`) — data sources (CSV, GZip, JDBC, Parquet; in-memory and
   iterative loading). Parquet files are read through an in-process DuckDB engine,
@@ -196,7 +201,7 @@ tools (root pom, packaging=pom)
 ├── code
 │   ├── protogen-maven-plugin       # the proto2 builder-generating Maven plugin
 │   ├── protogen-maven-plugin-test  # integration tests / use cases for the plugin
-│   └── context                     # regex-based class-usage context finder
+│   └── context                     # regex-based class-usage context finder + OKF bundles
 ├── adopt                       # adopts Claude Code into a GitHub repo (clone, build-tool check, branch, trust, init, conform, enforcer, verify, push, PR)
 ├── grpc-example                # end-to-end gRPC example with compile-time-safe builders
 ├── assembly                    # runnable SampleApp distribution: launcher jar + lib/
@@ -222,7 +227,7 @@ is `Main.java` and which supports stdio (default), streamable HTTP
   [MCP_USAGE.md](data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md).
 - The context-engineering server in
   `code/context/src/main/java/io/github/adamw7/context/mcp/`, exposing the
-  `project_tree`, `find_context` and `estimate_tokens` tools; see its
+  `project_tree`, `find_context`, `estimate_tokens` and `okf_bundle` tools; see its
   [MCP_USAGE.md](code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md).
 - The adoption server in
   `adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/`, exposing the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,10 @@ run `mvn install` from the repository root. The main capabilities are:
   time** (proto2 `required`, proto3 presence-aware accessors, `oneof`
   discriminators).
 - **Context engineering** (`code/context`) — a regex-based class-usage finder and
-  project-tree builder that assembles context for gen-AI agents, plus an MCP
-  server exposing `project_tree`, `find_context`, and `estimate_tokens`.
+  project-tree builder that assembles context for gen-AI agents, an emitter for
+  Google's Open Knowledge Format (OKF v0.2 bundles of markdown concept documents,
+  in the `okf` package), plus an MCP server exposing `project_tree`,
+  `find_context`, `estimate_tokens`, and `okf_bundle`.
 - **Data** (`data`) — data sources (CSV, GZip, JDBC, Parquet via an in-process
   DuckDB engine, plus forward-only JSON/YAML/TOON), each in in-memory and
   iterative variants. Schema-aware sources implement the narrower

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,10 +295,11 @@ editing them:
   and `memoryImports`, `noSecrets`, `skillFilesExist`, `uniqueNames`,
   `uniqueDescriptions`, `settingsJsonValid`, `permissionsFormat`,
   `hookCommandsValid`, `hooksFormat`, `localSettingsIgnored`, `mcpServersValid`,
-  `mcpConfigFormat`, and `pluginFormat` cover the rest of the agent
-  configuration. The last three validate `.mcp.json` and
-  `.claude-plugin/plugin.json`, which this repository does not ship — they pass
-  on the absent file and start enforcing the moment one is added.
+  `mcpConfigFormat`, `pluginFormat`, and `okfBundleFormat` cover the rest of the
+  agent configuration. The last four validate `.mcp.json`,
+  `.claude-plugin/plugin.json` and an Open Knowledge Format bundle, none of which
+  this repository ships — they pass on the absent file and start enforcing the
+  moment one is added.
 - Two more rules ship but are **not** wired here: `subAgentFormat`
   (`.claude/agents`) and `commandFormat` (`.claude/commands`). Unlike
   `pluginFormat`, a *configured* definition directory must exist — an absent one

--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ consistent and in their expected shape:
   `https` only when `requireHttps` is set), and a server must not mix transports
   by declaring both a `command` and a `url`. Like `mcpServersValid` it treats an
   absent file as a pass.
+- **`okfBundleFormat`** (`OkfBundleFormatRule`) — holds a bundle in Google's
+  [Open Knowledge Format](#open-knowledge-format-bundles) at `bundleDir` to the
+  specification's own conformance conditions: every non-reserved `.md` file
+  carries a parseable YAML front matter block, every block declares a non-empty
+  `type` (the one mandatory field), and the reserved names keep their structure —
+  an `index.md` carries no front matter beyond an `okf_version` at the bundle
+  root, and a `log.md` groups its entries under ISO 8601 `YYYY-MM-DD` headings.
+  Where the format defines a closed vocabulary the value is checked too: a
+  `status` must be `draft`, `stable` or `deprecated`, a `stale_after` must be a
+  real calendar date, and a `generated` mapping must name the actor that produced
+  the concept. Where the format leaves things open, nothing is imposed — `type`
+  values are not registered centrally, so an unknown one is not a violation.
+  Beyond that, `requiredKeys` adds front matter keys every concept must declare,
+  `okfVersion` pins the version the bundle root declares, and `requireIndex`
+  demands a listing in every directory holding concepts (off by default, since a
+  consumer must tolerate a missing `index.md`). A bundle is optional, so an absent
+  `bundleDir` is a pass and the rule starts enforcing the day a bundle is
+  committed.
 - **`hooksFormat`** (`HooksFormatRule`) — validates the hook scripts under a
   configured `hooksDir` (e.g. `.claude/hooks`): every regular file must be
   non-empty, start with a `#!` shebang (`requireShebang`), and carry the
@@ -574,6 +592,19 @@ generated: { by: "tools.code.context/1", at: "2026-08-03T10:15:30Z" }
 
 The `okf_bundle` MCP tool exposes the same mapping; it *returns* the bundle as
 JSON rather than writing it, so the server stays read-only.
+
+Conformance is checked by the build, on both sides of the format:
+
+- **The producer.** `OkfBundleConformanceTest` holds every bundle `OkfBundler`
+  emits to the specification's conformance conditions, restated from the
+  specification rather than read back out of the bundler — a test that asked the
+  bundler what it meant to write would pass however far the output drifted. It
+  runs in the ordinary `test` phase, so `mvn test`, `mvn package` and `mvn
+  install` all catch a drifting emitter without opting into anything.
+- **A bundle on disk.** The
+  [`okfBundleFormat`](#claude-code-files-maven-enforcer) enforcer rule checks a
+  bundle a repository ships, at `validate` under `-DenforceClaudeMd` — the check
+  the pull-request workflow already runs.
 
 ### Token-budget-aware context
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Library of tooling for various purposes.
   - [Scala code context build up](#scala-code-context-build-up)
   - [Project tree](#project-tree)
   - [Output formats](#output-formats)
+  - [Open Knowledge Format bundles](#open-knowledge-format-bundles)
   - [Token-budget-aware context](#token-budget-aware-context)
 - [Data](#data)
   - [Open-addressing map](#open-addressing-map)
@@ -509,6 +510,70 @@ String rendered = serializer.serialize(root);
   [Mermaid](https://mermaid.js.org/syntax/flowchart.html) `flowchart`, which
   renders inline on GitHub, in Markdown viewers and in many gen-AI agent surfaces
   without any external tooling.
+
+### Open Knowledge Format bundles
+
+The formats above render the tree as *one* document. Google's
+[Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+(OKF) takes the other shape: a knowledge bundle is a **directory of markdown
+files with YAML frontmatter**, so an agent can navigate it file by file instead
+of swallowing the whole project at once, and no proprietary runtime is needed to
+read it — if you can `cat` a file, you can read OKF.
+
+`OkfBundler` maps a scanned tree onto that format. Every directory becomes the
+reserved `index.md` listing what it holds, and every file becomes a concept
+document:
+
+```java
+ProjectTreeNode tree = new ProjectTreeBuilder(Language.JAVA, 1).build(root);
+OkfBundle bundle = new OkfBundler(Language.JAVA).bundle(tree);
+new OkfBundleWriter().write(bundle, Path.of("target/okf"));
+```
+
+```
+target/okf
+├── index.md            <- okf_version: "0.2", then the listing
+└── pkg
+    ├── index.md
+    ├── A.java.md
+    └── B.java.md
+```
+
+A concept document names the file in frontmatter and links to what it depends
+on:
+
+```markdown
+---
+type: "Java Source File"
+title: "B.java"
+description: "Java source file with 1 project dependency."
+resource: "pkg/B.java"
+tags: ["source", "java"]
+generated: { by: "tools.code.context/1", at: "2026-08-03T10:15:30Z" }
+---
+
+# Dependencies
+
+* [`A.java`](/pkg/A.java.md)
+```
+
+- **`OkfBundler`** — maps a `ProjectTreeNode` tree onto bundle paths and
+  documents. A dependency is linked only when its file name identifies exactly
+  one concept in the bundle; an unresolved or ambiguous name stays plain code
+  rather than becoming a link to a guess. Links use the bundle-relative
+  (`/`-prefixed) form the specification recommends, which survives a document
+  being moved.
+- **`OkfConcept`** — one concept's facts (type, title, description, resource,
+  tags, dependencies) before they are rendered, so the same description serves
+  both the concept's frontmatter and the `index.md` entry linking to it.
+- **`OkfFrontmatter`** — renders the YAML block. OKF makes exactly one field
+  mandatory, `type`; the rest are recommended, and v0.2 records production as
+  `generated: { by, at }` with the `<producer>/<version>` actor convention.
+- **`OkfBundleWriter`** — writes the bundle out as plain files, ready to be
+  committed to a git repository or mounted into an agent's file system.
+
+The `okf_bundle` MCP tool exposes the same mapping; it *returns* the bundle as
+JSON rather than writing it, so the server stays read-only.
 
 ### Token-budget-aware context
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRule.java
@@ -1,0 +1,330 @@
+package io.github.adamw7.tools.enforcer.okf;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.rule.ScanTargets;
+import io.github.adamw7.tools.enforcer.text.FrontMatter;
+import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * Enforcer rule that fails the build when a bundle in Google's Open Knowledge
+ * Format is not conformant. OKF is what a repository hands an agent, so a
+ * malformed bundle is the same class of problem as a malformed {@code CLAUDE.md}:
+ * the file is still there, the consumer just silently gets less than it should.
+ * <p>
+ * The specification's own conformance conditions are checked unconditionally:
+ * <ul>
+ * <li>every non-reserved {@code .md} file carries a parseable YAML frontmatter
+ * block;</li>
+ * <li>every frontmatter block declares a non-empty {@code type}, the one
+ * mandatory field;</li>
+ * <li>the reserved names keep their defined structure — an {@code index.md}
+ * carries no frontmatter beyond an {@code okf_version} at the bundle root, and a
+ * {@code log.md} groups its entries under ISO 8601 {@code YYYY-MM-DD}
+ * headings.</li>
+ * </ul>
+ * Where the format defines a closed vocabulary the value is checked too: a
+ * {@code status} is {@code draft}, {@code stable} or {@code deprecated}, a
+ * {@code stale_after} is a real calendar date, and a {@code generated} mapping
+ * names the actor that produced the concept. What the specification leaves open
+ * is left open — {@code type} values are not registered centrally, so an unknown
+ * one is not a violation.
+ * <p>
+ * Beyond that, {@code requiredKeys} adds frontmatter keys a project wants on every
+ * concept, {@code okfVersion} pins the version the bundle root declares, and
+ * {@code requireIndex} demands a listing in every directory that holds concepts —
+ * off by default, since a consumer must tolerate a missing {@code index.md}.
+ * <p>
+ * An OKF bundle is optional, so an absent {@code bundleDir} is a pass: the rule
+ * can be wired before a repository emits one and starts enforcing the moment it
+ * does. All problems found are reported together.
+ */
+@Named("okfBundleFormat")
+public class OkfBundleFormatRule extends ClaudeCodeEnforcerRule {
+
+	private static final String INDEX = "index.md";
+	private static final String LOG = "log.md";
+	private static final String MARKDOWN_SUFFIX = ".md";
+	private static final String TYPE_KEY = "type";
+	private static final String STATUS_KEY = "status";
+	private static final String STALE_AFTER_KEY = "stale_after";
+	private static final String GENERATED_KEY = "generated";
+	private static final String OKF_VERSION_KEY = "okf_version";
+	private static final String SEPARATOR = "/";
+
+	private static final Set<String> STATUSES = Set.of("draft", "stable", "deprecated");
+
+	/** An ISO 8601 calendar date, the only form the specification allows for a date. */
+	private static final Pattern ISO_DATE = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
+
+	/** A {@code log.md} entry heading, which the specification defines as a date. */
+	private static final Pattern LOG_DATE_HEADING = Pattern.compile("##\\s+(.*)");
+
+	/** The {@code by} entry of a flow mapping such as {@code { by: agent/1, at: ... }}. */
+	private static final Pattern GENERATED_BY = Pattern.compile("\\bby\\s*:\\s*\\S");
+
+	/** The bundle root to validate. Injected from the rule configuration. */
+	private File bundleDir;
+
+	/** Optional version the bundle root's {@code index.md} must declare, e.g. {@code 0.2}. */
+	private String okfVersion;
+
+	/** Optional frontmatter keys every concept must declare beyond the mandatory {@code type}. */
+	private List<String> requiredKeys;
+
+	/** When true, every directory holding concepts must also carry an {@code index.md}. */
+	private boolean requireIndex;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		requireConfigured(bundleDir, "bundleDir");
+		if (!bundleDir.isDirectory()) {
+			return;
+		}
+		List<File> documents = markdownFiles();
+		List<String> violations = new ArrayList<>();
+		documents.forEach(document -> collectDocumentViolations(document, violations));
+		collectVersionViolations(documents, violations);
+		collectMissingIndexViolations(documents, violations);
+		report("The OKF bundle at " + bundleDir + " is not conformant:", violations);
+	}
+
+	@Override
+	protected List<String> howToFix() {
+		return List.of(
+				"Open each document named above, relative to the bundle root.",
+				"Give every concept document a --- delimited YAML frontmatter block "
+						+ "declaring a non-empty 'type'.",
+				"Keep index.md free of frontmatter, except an okf_version at the bundle root, "
+						+ "and give every log.md heading an ISO 8601 YYYY-MM-DD date.",
+				"Re-run the build to confirm the bundle is conformant.");
+	}
+
+	private List<File> markdownFiles() {
+		return new ScanTargets(List.of(), List.of(bundleDir))
+				.filesInDirectories(path -> path.getFileName().toString().endsWith(MARKDOWN_SUFFIX));
+	}
+
+	private void collectDocumentViolations(File document, List<String> violations) {
+		String name = relativePath(document);
+		Optional<String> content = MarkdownText.readIfText(document);
+		if (content.isEmpty()) {
+			violations.add(name + " could not be read as UTF-8 text");
+			return;
+		}
+		if (isNamed(document, INDEX)) {
+			collectIndexViolations(name, content.get(), violations);
+		} else if (isNamed(document, LOG)) {
+			collectLogViolations(name, content.get(), violations);
+		} else {
+			collectConceptViolations(name, content.get(), violations);
+		}
+	}
+
+	private void collectConceptViolations(String name, String content, List<String> violations) {
+		Optional<FrontMatter> parsed = FrontMatter.parse(content);
+		if (parsed.isEmpty()) {
+			violations.add(name + " has no parseable YAML frontmatter block");
+			return;
+		}
+		FrontMatter frontMatter = parsed.get();
+		collectKeyViolations(name, frontMatter, violations);
+		collectStatusViolations(name, frontMatter, violations);
+		collectDateViolations(name, frontMatter.value(STALE_AFTER_KEY).orElse(null), STALE_AFTER_KEY, violations);
+		collectGeneratedViolations(name, frontMatter, violations);
+	}
+
+	private void collectKeyViolations(String name, FrontMatter frontMatter, List<String> violations) {
+		if (isBlank(frontMatter, TYPE_KEY)) {
+			violations.add(name + " declares no non-empty '" + TYPE_KEY + "', the one mandatory OKF field");
+		}
+		frontMatter.duplicateKeys()
+				.forEach(key -> violations.add(name + " declares '" + key + "' more than once"));
+		requiredKeys().stream()
+				.filter(key -> isBlank(frontMatter, key))
+				.forEach(key -> violations.add(name + " declares no non-empty '" + key + "'"));
+	}
+
+	private void collectStatusViolations(String name, FrontMatter frontMatter, List<String> violations) {
+		String status = frontMatter.value(STATUS_KEY).orElse(null);
+		if (status != null && !STATUSES.contains(status.toLowerCase(Locale.ROOT))) {
+			violations.add(name + " declares an unknown '" + STATUS_KEY + "': " + status
+					+ " (expected draft, stable or deprecated)");
+		}
+	}
+
+	private void collectDateViolations(String name, String value, String key, List<String> violations) {
+		if (value == null || isDate(value)) {
+			return;
+		}
+		violations.add(name + " declares a '" + key + "' that is not an ISO 8601 date: " + value);
+	}
+
+	private void collectGeneratedViolations(String name, FrontMatter frontMatter, List<String> violations) {
+		String generated = frontMatter.value(GENERATED_KEY).orElse(null);
+		if (generated != null && !GENERATED_BY.matcher(generated).find()) {
+			violations.add(name + " declares a '" + GENERATED_KEY + "' without the actor that produced it: "
+					+ generated);
+		}
+	}
+
+	/**
+	 * An {@code index.md} is a listing, not a concept, so it declares no frontmatter
+	 * — with the single exception the specification carves out for the bundle root,
+	 * where an {@code okf_version} may say which version the bundle targets.
+	 */
+	private void collectIndexViolations(String name, String content, List<String> violations) {
+		Optional<FrontMatter> parsed = FrontMatter.parse(content);
+		if (parsed.isEmpty()) {
+			return;
+		}
+		if (!isBundleRootIndex(name)) {
+			violations.add(name + " carries frontmatter; only a bundle-root " + INDEX + " may declare '"
+					+ OKF_VERSION_KEY + "'");
+			return;
+		}
+		unexpectedRootKeys(parsed.get())
+				.forEach(key -> violations.add(name + " declares '" + key + "'; a bundle-root " + INDEX
+						+ " may declare only '" + OKF_VERSION_KEY + "'"));
+	}
+
+	private Set<String> unexpectedRootKeys(FrontMatter frontMatter) {
+		Set<String> keys = new LinkedHashSet<>(frontMatter.keys());
+		keys.remove(OKF_VERSION_KEY);
+		return keys;
+	}
+
+	private void collectLogViolations(String name, String content, List<String> violations) {
+		MarkdownDocument.parse(content).headings().stream()
+				.map(LOG_DATE_HEADING::matcher)
+				.filter(Matcher::matches)
+				.map(matcher -> matcher.group(1).strip())
+				.filter(heading -> !isDate(heading))
+				.forEach(heading -> violations.add(
+						name + " groups entries under '" + heading + "', which is not an ISO 8601 date"));
+	}
+
+	/**
+	 * Checks the version the bundle root declares, only when a project pinned one.
+	 * The declaration itself is optional in OKF, so configuring {@code okfVersion} is
+	 * what turns it into a requirement.
+	 */
+	private void collectVersionViolations(List<File> documents, List<String> violations) {
+		if (okfVersion == null || okfVersion.isBlank()) {
+			return;
+		}
+		File root = documents.stream().filter(document -> isBundleRootIndex(relativePath(document)))
+				.findFirst().orElse(null);
+		if (root == null) {
+			violations.add("The bundle declares no " + INDEX + " at its root, so it cannot declare '"
+					+ OKF_VERSION_KEY + ": " + okfVersion + "'");
+			return;
+		}
+		collectDeclaredVersionViolations(root, violations);
+	}
+
+	private void collectDeclaredVersionViolations(File root, List<String> violations) {
+		String declared = MarkdownText.readIfText(root)
+				.flatMap(FrontMatter::parse)
+				.flatMap(frontMatter -> frontMatter.value(OKF_VERSION_KEY))
+				.orElse("");
+		if (!declared.equals(okfVersion)) {
+			violations.add(relativePath(root) + " declares '" + OKF_VERSION_KEY + ": " + declared
+					+ "' but the build expects " + okfVersion);
+		}
+	}
+
+	/**
+	 * Reports a directory that holds concepts without listing them. A consumer must
+	 * tolerate a missing {@code index.md}, so this is only checked when a project
+	 * opts in with {@code requireIndex}.
+	 */
+	private void collectMissingIndexViolations(List<File> documents, List<String> violations) {
+		if (!requireIndex) {
+			return;
+		}
+		Set<Path> indexed = documents.stream().filter(document -> isNamed(document, INDEX))
+				.map(document -> document.toPath().getParent()).collect(Collectors.toSet());
+		documents.stream()
+				.filter(document -> !isNamed(document, INDEX) && !isNamed(document, LOG))
+				.map(document -> document.toPath().getParent())
+				.distinct()
+				.filter(directory -> !indexed.contains(directory))
+				.forEach(directory -> violations.add(
+						relativeDirectory(directory) + " holds concepts but no " + INDEX));
+	}
+
+	private List<String> requiredKeys() {
+		return requiredKeys != null ? requiredKeys : List.of();
+	}
+
+	private boolean isBlank(FrontMatter frontMatter, String key) {
+		return frontMatter.value(key).orElse("").isBlank();
+	}
+
+	private boolean isNamed(File document, String name) {
+		return document.getName().equals(name);
+	}
+
+	private boolean isBundleRootIndex(String name) {
+		return name.equals(INDEX);
+	}
+
+	private boolean isDate(String value) {
+		if (!ISO_DATE.matcher(value).matches()) {
+			return false;
+		}
+		try {
+			LocalDate.parse(value);
+			return true;
+		} catch (DateTimeParseException e) {
+			return false;
+		}
+	}
+
+	/** Bundle-relative and always {@code /}-separated, so a message reads the same on every platform. */
+	private String relativePath(File document) {
+		return bundleDir.toPath().toAbsolutePath().normalize()
+				.relativize(document.toPath().toAbsolutePath().normalize())
+				.toString().replace(File.separator, SEPARATOR);
+	}
+
+	private String relativeDirectory(Path directory) {
+		String relative = relativePath(directory.toFile());
+		return relative.isEmpty() ? "The bundle root" : relative;
+	}
+
+	void setBundleDir(File bundleDir) {
+		this.bundleDir = bundleDir;
+	}
+
+	void setOkfVersion(String okfVersion) {
+		this.okfVersion = okfVersion;
+	}
+
+	void setRequiredKeys(List<String> requiredKeys) {
+		this.requiredKeys = requiredKeys;
+	}
+
+	void setRequireIndex(boolean requireIndex) {
+		this.requireIndex = requireIndex;
+	}
+}

--- a/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -19,3 +19,4 @@ io.github.adamw7.tools.enforcer.doc.ContextBudgetRule
 io.github.adamw7.tools.enforcer.settings.LocalSettingsIgnoredRule
 io.github.adamw7.tools.enforcer.doc.ModuleMapConsistencyRule
 io.github.adamw7.tools.enforcer.definition.PluginFormatRule
+io.github.adamw7.tools.enforcer.okf.OkfBundleFormatRule

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
@@ -37,6 +37,7 @@ public class EnforcerArchitectureTest {
 			.layer("Definition").definedBy("..enforcer.definition..")
 			.layer("Doc").definedBy("..enforcer.doc..")
 			.layer("Mcp").definedBy("..enforcer.mcp..")
+			.layer("Okf").definedBy("..enforcer.okf..")
 			.layer("Secret").definedBy("..enforcer.secret..")
 			.layer("Settings").definedBy("..enforcer.settings..")
 			.whereLayer("Text").mayNotAccessAnyLayer()
@@ -44,6 +45,7 @@ public class EnforcerArchitectureTest {
 			.whereLayer("Definition").mayOnlyAccessLayers("Rule", "Text")
 			.whereLayer("Doc").mayOnlyAccessLayers("Rule", "Text")
 			.whereLayer("Mcp").mayOnlyAccessLayers("Rule", "Text")
+			.whereLayer("Okf").mayOnlyAccessLayers("Rule", "Text")
 			.whereLayer("Secret").mayOnlyAccessLayers("Rule", "Text")
 			.whereLayer("Settings").mayOnlyAccessLayers("Rule", "Text")
 			.as("text is the foundation, rule builds on it, and the feature packages "

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/FixtureProject.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/FixtureProject.java
@@ -211,6 +211,33 @@ final class FixtureProject {
 			}
 			""";
 
+	/** A bundle-root listing: the one index allowed frontmatter, and only for the version. */
+	private static final String OKF_INDEX = """
+			---
+			okf_version: "0.2"
+			---
+
+			# Files
+
+			* [sample.md](sample.md) - a sample concept.
+			""";
+
+	private static final String OKF_CONCEPT = """
+			---
+			type: "Sample Concept"
+			title: "Sample"
+			description: "A conformant concept the enforcer rule reads."
+			tags: ["fixture"]
+			status: stable
+			stale_after: 2027-01-01
+			generated: { by: "fixture/1", at: "2026-08-03T10:15:30Z" }
+			---
+
+			# Body
+
+			Nothing here depends on anything.
+			""";
+
 	/**
 	 * The build itself. The rule jar is a plugin dependency rather than a project
 	 * dependency, because that is the only class path a maven-enforcer rule is loaded
@@ -299,6 +326,8 @@ final class FixtureProject {
 		write(".claude/commands/sample-command.md", COMMAND_MD);
 		write(".claude-plugin/plugin.json", PLUGIN_JSON);
 		write(".mcp.json", MCP_JSON);
+		write("okf/index.md", OKF_INDEX);
+		write("okf/sample.md", OKF_CONCEPT);
 		return this;
 	}
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
@@ -236,6 +236,14 @@ final class RuleConfiguration {
 									<mcpFile>${project.basedir}/.mcp.json</mcpFile>
 									<requireHttps>true</requireHttps>
 								</mcpConfigFormat>
+								<okfBundleFormat>
+									<bundleDir>${project.basedir}/okf</bundleDir>
+									<okfVersion>0.2</okfVersion>
+									<requiredKeys>
+										<requiredKey>title</requiredKey>
+									</requiredKeys>
+									<requireIndex>true</requireIndex>
+								</okfBundleFormat>
 			""";
 
 	private final String xml;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRuleTest.java
@@ -1,0 +1,309 @@
+package io.github.adamw7.tools.enforcer.okf;
+
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+
+class OkfBundleFormatRuleTest {
+
+	private static final String ROOT_INDEX = """
+			---
+			okf_version: "0.2"
+			---
+
+			# Files
+
+			* [A.java](A.java.md) - Java source file with no project dependencies.
+			""";
+
+	private static final String CONCEPT = """
+			---
+			type: "Java Source File"
+			title: "A.java"
+			description: "Java source file with no project dependencies."
+			generated: { by: "tools.code.context/1", at: "2026-08-03T10:15:30Z" }
+			---
+
+			# Dependencies
+
+			This file depends on no other file in the project.
+			""";
+
+	@TempDir
+	private Path tempDir;
+
+	private Path bundle;
+
+	@BeforeEach
+	void setUp() {
+		bundle = createDirectory(tempDir.resolve("okf"));
+	}
+
+	@Test
+	void passesForAConformantBundle() {
+		writeString(bundle.resolve("index.md"), ROOT_INDEX);
+		writeString(bundle.resolve("A.java.md"), CONCEPT);
+
+		assertDoesNotThrow(rule()::execute);
+	}
+
+	@Test
+	void passesWhenTheBundleIsAbsentSoTheRuleCanBeWiredBeforeOneExists() {
+		OkfBundleFormatRule rule = new OkfBundleFormatRule();
+		rule.setBundleDir(tempDir.resolve("no-bundle-here").toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void passesForAnEmptyBundleDirectory() {
+		assertDoesNotThrow(rule()::execute);
+	}
+
+	@Test
+	void failsWhenNotConfigured() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+				new OkfBundleFormatRule()::execute);
+		assertTrue(exception.getMessage().contains("bundleDir parameter is not configured"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAConceptHasNoFrontmatter() {
+		writeString(bundle.resolve("A.java.md"), "# Dependencies\n\nNone.\n");
+
+		assertTrue(failure().contains("A.java.md has no parseable YAML frontmatter block"));
+	}
+
+	@Test
+	void failsWhenAFrontmatterBlockIsNeverClosed() {
+		writeString(bundle.resolve("A.java.md"), "---\ntype: \"Java Source File\"\n\n# Dependencies\n");
+
+		assertTrue(failure().contains("A.java.md has no parseable YAML frontmatter block"));
+	}
+
+	@Test
+	void failsWhenAConceptDeclaresNoType() {
+		writeString(bundle.resolve("A.java.md"), "---\ntitle: \"A.java\"\n---\n\n# Dependencies\n");
+
+		assertTrue(failure().contains("declares no non-empty 'type', the one mandatory OKF field"));
+	}
+
+	@Test
+	void failsWhenTheTypeIsEmpty() {
+		writeString(bundle.resolve("A.java.md"), "---\ntype: \n---\n\n# Dependencies\n");
+
+		assertTrue(failure().contains("declares no non-empty 'type'"));
+	}
+
+	@Test
+	void failsWhenAKeyIsDeclaredTwice() {
+		writeString(bundle.resolve("A.java.md"),
+				"---\ntype: \"Java Source File\"\ntype: \"Project File\"\n---\n\n# Dependencies\n");
+
+		assertTrue(failure().contains("A.java.md declares 'type' more than once"));
+	}
+
+	@Test
+	void toleratesAnUnknownTypeBecauseOkfRegistersNone() {
+		writeString(bundle.resolve("Recipe.md"), "---\ntype: \"Something Nobody Registered\"\n---\n\n# Body\n");
+
+		assertDoesNotThrow(rule()::execute);
+	}
+
+	@Test
+	void failsWhenAStatusIsOutsideTheSpecifiedVocabulary() {
+		writeString(bundle.resolve("A.java.md"),
+				"---\ntype: \"Java Source File\"\nstatus: \"provisional\"\n---\n\n# Dependencies\n");
+
+		assertTrue(failure().contains("declares an unknown 'status': provisional"));
+	}
+
+	@Test
+	void acceptsEveryStatusTheSpecificationDefines() {
+		writeString(bundle.resolve("a.md"), "---\ntype: \"T\"\nstatus: draft\n---\n\n# Body\n");
+		writeString(bundle.resolve("b.md"), "---\ntype: \"T\"\nstatus: stable\n---\n\n# Body\n");
+		writeString(bundle.resolve("c.md"), "---\ntype: \"T\"\nstatus: deprecated\n---\n\n# Body\n");
+
+		assertDoesNotThrow(rule()::execute);
+	}
+
+	@Test
+	void failsWhenStaleAfterIsNotAnIsoDate() {
+		writeString(bundle.resolve("A.java.md"),
+				"---\ntype: \"Java Source File\"\nstale_after: \"next quarter\"\n---\n\n# Dependencies\n");
+
+		assertTrue(failure().contains("declares a 'stale_after' that is not an ISO 8601 date: next quarter"));
+	}
+
+	@Test
+	void failsWhenStaleAfterIsNotARealCalendarDate() {
+		writeString(bundle.resolve("A.java.md"),
+				"---\ntype: \"Java Source File\"\nstale_after: 2026-13-45\n---\n\n# Dependencies\n");
+
+		assertTrue(failure().contains("not an ISO 8601 date: 2026-13-45"));
+	}
+
+	@Test
+	void failsWhenGeneratedNamesNoActor() {
+		writeString(bundle.resolve("A.java.md"),
+				"---\ntype: \"Java Source File\"\ngenerated: { at: 2026-08-03T10:15:30Z }\n---\n\n# Dependencies\n");
+
+		assertTrue(failure().contains("declares a 'generated' without the actor that produced it"));
+	}
+
+	@Test
+	void failsWhenANestedIndexCarriesFrontmatter() {
+		Path pkg = createDirectory(bundle.resolve("pkg"));
+		writeString(pkg.resolve("index.md"), "---\ntype: \"Listing\"\n---\n\n# Files\n");
+
+		assertTrue(failure().contains("pkg/index.md carries frontmatter"));
+	}
+
+	@Test
+	void failsWhenTheRootIndexDeclaresMoreThanTheVersion() {
+		writeString(bundle.resolve("index.md"), "---\nokf_version: \"0.2\"\ntype: \"Listing\"\n---\n\n# Files\n");
+
+		assertTrue(failure().contains("index.md declares 'type'; a bundle-root index.md may declare only"));
+	}
+
+	@Test
+	void passesForAnIndexWithoutFrontmatter() {
+		writeString(bundle.resolve("index.md"), "# Files\n\n* [A.java](A.java.md) - a file.\n");
+		writeString(bundle.resolve("A.java.md"), CONCEPT);
+
+		assertDoesNotThrow(rule()::execute);
+	}
+
+	@Test
+	void failsWhenALogGroupsEntriesUnderSomethingOtherThanADate() {
+		writeString(bundle.resolve("log.md"), "# Update Log\n\n## last week\n\n* **Update**: something.\n");
+
+		assertTrue(failure().contains("log.md groups entries under 'last week', which is not an ISO 8601 date"));
+	}
+
+	@Test
+	void passesForALogWithIsoDateHeadings() {
+		writeString(bundle.resolve("log.md"), "# Update Log\n\n## 2026-05-22\n\n* **Update**: something.\n");
+
+		assertDoesNotThrow(rule()::execute);
+	}
+
+	@Test
+	void failsWhenTheDeclaredVersionIsNotThePinnedOne() {
+		writeString(bundle.resolve("index.md"), "---\nokf_version: \"0.1\"\n---\n\n# Files\n");
+		OkfBundleFormatRule rule = rule();
+		rule.setOkfVersion("0.2");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("declares 'okf_version: 0.1' but the build expects 0.2"),
+				exception.getMessage());
+	}
+
+	@Test
+	void failsWhenAPinnedVersionHasNoRootIndexToDeclareIt() {
+		writeString(bundle.resolve("A.java.md"), CONCEPT);
+		OkfBundleFormatRule rule = rule();
+		rule.setOkfVersion("0.2");
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("declares no index.md at its root"), exception.getMessage());
+	}
+
+	@Test
+	void doesNotCheckTheVersionWhenNoneIsPinned() {
+		writeString(bundle.resolve("index.md"), "---\nokf_version: \"0.1\"\n---\n\n# Files\n");
+
+		assertDoesNotThrow(rule()::execute);
+	}
+
+	@Test
+	void failsWhenARequiredKeyIsMissing() {
+		writeString(bundle.resolve("A.java.md"), "---\ntype: \"Java Source File\"\n---\n\n# Dependencies\n");
+		OkfBundleFormatRule rule = rule();
+		rule.setRequiredKeys(List.of("title", "description"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("declares no non-empty 'title'"), exception.getMessage());
+		assertTrue(exception.getMessage().contains("declares no non-empty 'description'"), exception.getMessage());
+	}
+
+	@Test
+	void failsWhenADirectoryHoldingConceptsHasNoIndexAndOneIsRequired() {
+		Path pkg = createDirectory(bundle.resolve("pkg"));
+		writeString(pkg.resolve("A.java.md"), CONCEPT);
+		OkfBundleFormatRule rule = rule();
+		rule.setRequireIndex(true);
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("pkg holds concepts but no index.md"), exception.getMessage());
+	}
+
+	@Test
+	void aMissingIndexIsToleratedByDefault() {
+		writeString(bundle.resolve("A.java.md"), CONCEPT);
+
+		assertDoesNotThrow(rule()::execute);
+	}
+
+	@Test
+	void reportsEveryProblemTogetherRatherThanTheFirst() {
+		writeString(bundle.resolve("A.java.md"), "---\ntitle: \"A.java\"\n---\n\n# Dependencies\n");
+		writeString(bundle.resolve("B.java.md"), "# Dependencies\n");
+
+		String message = failure();
+		assertTrue(message.contains("A.java.md declares no non-empty 'type'"), message);
+		assertTrue(message.contains("B.java.md has no parseable YAML frontmatter block"), message);
+	}
+
+	@Test
+	void namesTheDocumentRelativeToTheBundleRoot() {
+		Path pkg = createDirectory(bundle.resolve("pkg"));
+		writeString(pkg.resolve("A.java.md"), "# Dependencies\n");
+
+		assertTrue(failure().contains("pkg/A.java.md has no parseable"));
+	}
+
+	@Test
+	void ignoresFilesThatAreNotMarkdown() {
+		writeString(bundle.resolve("notes.txt"), "no frontmatter here");
+
+		assertDoesNotThrow(rule()::execute);
+	}
+
+	@Test
+	void warnSeverityLogsInsteadOfFailing() {
+		writeString(bundle.resolve("A.java.md"), "# Dependencies\n");
+		CapturingLogger logger = new CapturingLogger();
+		OkfBundleFormatRule rule = rule();
+		rule.setSeverity("warn");
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertEquals(1, logger.warnings().size());
+		assertTrue(logger.warnings().get(0).contains("has no parseable YAML frontmatter block"));
+	}
+
+	private String failure() {
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule()::execute);
+		return exception.getMessage();
+	}
+
+	private OkfBundleFormatRule rule() {
+		OkfBundleFormatRule rule = new OkfBundleFormatRule();
+		rule.setBundleDir(bundle.toFile());
+		return rule;
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -7,7 +7,7 @@ Desktop, Cline, or any other MCP-compatible client.
 
 ## Overview
 
-The server exposes three tools:
+The server exposes four tools:
 
 - **`project_tree`** — scans a Java, Kotlin or Scala project into a tree of
   folders, files and the classes each file depends on, then serialises it as JSON
@@ -17,6 +17,10 @@ The server exposes three tools:
 - **`estimate_tokens`** — estimates the LLM token cost of the context assembled
   for a class (the class itself plus its dependencies), returning a per-class
   breakdown and the total.
+- **`okf_bundle`** — scans the same project into a bundle in Google's
+  [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+  (OKF) v0.2: a directory of markdown concept documents with YAML frontmatter,
+  portable to any consumer that speaks OKF.
 
 ## Architecture
 
@@ -27,7 +31,7 @@ The implementation lives in a package separate from the core finders:
    registers the tools.
 3. **ContextTool.java** — the abstraction every tool implements.
 4. **ProjectTreeTool.java** / **ContextFinderTool.java** / **EstimateTokensTool.java**
-   — the three tools.
+   / **OkfBundleTool.java** — the four tools.
 5. **LanguageArguments.java** — resolves the optional `language` argument; the
    generic argument parsing is shared from `mcp-common`'s `ToolArguments`.
 
@@ -125,6 +129,51 @@ class is reported as an error result.
 }
 ```
 
+### okf_bundle
+
+Scans a project into a bundle in Google's Open Knowledge Format (OKF) v0.2.
+
+**Parameters:**
+
+- `path` (string, required): absolute path to the project root directory
+- `language` (string, optional): `java` (default), `kotlin` or `scala`
+- `depth` (integer, optional): levels of transitive dependencies to resolve (default `1`)
+
+**Returns:** a JSON object with the targeted `okf_version` and a `documents` map
+from each bundle-relative path to that document's markdown. Every directory
+becomes a reserved `index.md` listing what it holds, and every file becomes a
+concept document — YAML frontmatter naming it, then a `# Dependencies` section
+linking to the concepts it relies on. The bundle is **returned, never written**:
+the server stays read-only, so a client cannot use it to create files on the
+host. Write it out with `OkfBundleWriter` on the consumer's side.
+
+**Example:**
+
+```json
+{
+  "path": "/path/to/project",
+  "language": "java",
+  "depth": 1
+}
+```
+
+A returned concept document looks like this:
+
+```markdown
+---
+type: "Java Source File"
+title: "B.java"
+description: "Java source file with 1 project dependency."
+resource: "pkg/B.java"
+tags: ["source", "java"]
+generated: { by: "tools.code.context/1", at: "2026-08-03T10:15:30Z" }
+---
+
+# Dependencies
+
+* [`A.java`](/pkg/A.java.md)
+```
+
 ## Running the Server
 
 ### stdio (default)
@@ -185,7 +234,8 @@ provider supports it, with no code change. See
 
 ## Security
 
-The tools read source files from disk, so access is constrained by design:
+The tools read source files from disk and never write to it, so access is
+constrained by design:
 
 - **Allowed roots.** Every `path` argument is resolved to its real location
   (symlinks followed, `..` collapsed) and must fall within a configured allowed
@@ -242,7 +292,7 @@ The tools read source files from disk, so access is constrained by design:
 
 The server advertises:
 
-- **Tools**: true (`project_tree`, `find_context`, `estimate_tokens`)
+- **Tools**: true (`project_tree`, `find_context`, `estimate_tokens`, `okf_bundle`)
 - **Resources**: false
 - **Prompts**: false
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/McpConfiguration.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/McpConfiguration.java
@@ -13,7 +13,7 @@ import io.github.adamw7.tools.mcp.McpTool;
 
 /**
  * Wires the context-engineering MCP server. It exposes the project-tree,
- * context-finder and token-estimate tools, confined to the configured
+ * context-finder, token-estimate and OKF-bundle tools, confined to the configured
  * {@code context.allowed-roots}; all transport wiring is inherited from
  * {@link AbstractMcpConfiguration}.
  */
@@ -35,6 +35,6 @@ public class McpConfiguration extends AbstractMcpConfiguration {
 		PathPolicy pathPolicy = new PathPolicy(allowedRoots);
 		log.info("Confining MCP file access to allowed roots: {}", pathPolicy.allowedRoots());
 		return List.of(new ProjectTreeTool(pathPolicy), new ContextFinderTool(pathPolicy),
-				new EstimateTokensTool(pathPolicy));
+				new EstimateTokensTool(pathPolicy), new OkfBundleTool(pathPolicy));
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/OkfBundleTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/OkfBundleTool.java
@@ -1,0 +1,86 @@
+package io.github.adamw7.context.mcp;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.github.adamw7.context.Language;
+import io.github.adamw7.context.okf.OkfBundle;
+import io.github.adamw7.context.okf.OkfBundler;
+import io.github.adamw7.context.tree.ProjectTreeBuilder;
+import io.github.adamw7.context.tree.ProjectTreeNode;
+import io.github.adamw7.tools.mcp.ToolArguments;
+import io.github.adamw7.tools.mcp.ToolDefinition;
+import io.github.adamw7.tools.mcp.ToolResult;
+
+/**
+ * MCP tool that scans a Java, Kotlin or Scala project and returns it as a bundle
+ * in Google's Open Knowledge Format — a directory of markdown concept documents
+ * with YAML frontmatter — so an agent that already consumes OKF can take this
+ * project's structure and class dependencies without knowing anything about the
+ * tree behind it.
+ * <p>
+ * The bundle is returned as JSON mapping each bundle-relative path to its
+ * document, rather than written to disk: the server stays read-only, so a client
+ * cannot use it to create files anywhere on the host.
+ */
+public class OkfBundleTool implements ContextTool {
+
+	private static final Logger log = LogManager.getLogger(OkfBundleTool.class.getName());
+
+	private static final int DEFAULT_DEPTH = 1;
+	private static final int MAX_DEPTH = 10;
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private final PathPolicy pathPolicy;
+
+	public OkfBundleTool(PathPolicy pathPolicy) {
+		this.pathPolicy = pathPolicy;
+	}
+
+	private final ToolDefinition toolDefinition = new ToolDefinition("okf_bundle",
+			"Scan a Java, Kotlin or Scala project into an Open Knowledge Format (OKF) bundle of markdown documents",
+			Map.of(
+					"type", "object",
+					"properties", Map.of(
+							"path", Map.of("type", "string",
+									"description", "absolute path to the project root directory"),
+							"language", Map.of("type", "string",
+									"description", "source language: java (default), kotlin or scala"),
+							"depth", Map.of("type", "integer",
+									"description", "how many levels of transitive dependencies to resolve (default 1)")),
+					"required", List.of("path")));
+
+	@Override
+	public ToolDefinition getToolDefinition() {
+		return toolDefinition;
+	}
+
+	@Override
+	public ToolResult apply(Map<String, Object> arguments) {
+		log.info("Calling MCP okf_bundle tool for {}", arguments);
+		return ToolResult.success(buildBundle(arguments));
+	}
+
+	private String buildBundle(Map<String, Object> arguments) {
+		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
+		Language language = LanguageArguments.optionalLanguage(arguments, "language", Language.JAVA);
+		int depth = ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH);
+		ProjectTreeNode tree = new ProjectTreeBuilder(language, depth).build(root);
+		return toJson(new OkfBundler(language).bundle(tree));
+	}
+
+	private String toJson(OkfBundle bundle) {
+		ObjectNode result = MAPPER.createObjectNode();
+		result.put("okf_version", OkfBundle.VERSION);
+		ObjectNode documents = result.putObject("documents");
+		bundle.documents().forEach(document -> documents.put(document.path(), document.content()));
+		return result.toString();
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundle.java
+++ b/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundle.java
@@ -1,0 +1,33 @@
+package io.github.adamw7.context.okf;
+
+import java.util.List;
+
+/**
+ * A knowledge bundle in Google's Open Knowledge Format: a directory tree of
+ * markdown documents that a gen-AI agent can consume without a proprietary
+ * runtime, held in memory as an ordered list of {@link OkfDocument}s so a
+ * producer can hand it to a writer, an archive or an MCP client alike.
+ * <p>
+ * A bundle is conformant when every non-reserved document carries parseable YAML
+ * frontmatter with a non-empty {@code type}, and the reserved {@code index.md}
+ * and {@code log.md} names keep their defined meaning. Bundles built here target
+ * {@link #VERSION}.
+ */
+public class OkfBundle {
+
+	/** The Open Knowledge Format version the documents of this bundle target. */
+	public static final String VERSION = "0.2";
+
+	/** The reserved name of a directory listing, which carries no concept of its own. */
+	public static final String INDEX = "index.md";
+
+	private final List<OkfDocument> documents;
+
+	public OkfBundle(List<OkfDocument> documents) {
+		this.documents = List.copyOf(documents);
+	}
+
+	public List<OkfDocument> documents() {
+		return documents;
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundleWriter.java
+++ b/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundleWriter.java
@@ -1,0 +1,45 @@
+package io.github.adamw7.context.okf;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Materialises an {@link OkfBundle} as a directory tree on disk. The Open
+ * Knowledge Format is deliberately "just files", so a bundle needs no packaging
+ * beyond writing each document at its bundle-relative path — the result can then
+ * be committed to a git repository, archived as a tarball or mounted straight
+ * into an agent's file system.
+ */
+public class OkfBundleWriter {
+
+	private static final Logger log = LogManager.getLogger(OkfBundleWriter.class.getName());
+
+	/**
+	 * Writes every document of the bundle beneath {@code target}, creating the
+	 * directories each one needs.
+	 *
+	 * @return the bundle root that was written to
+	 */
+	public Path write(OkfBundle bundle, Path target) {
+		bundle.documents().forEach(document -> writeDocument(document, target));
+		log.info("Wrote an OKF v{} bundle of {} documents to {}", OkfBundle.VERSION, bundle.documents().size(),
+				target);
+		return target;
+	}
+
+	private void writeDocument(OkfDocument document, Path target) {
+		Path file = target.resolve(document.path());
+		try {
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, document.content(), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to write the OKF document " + file, e);
+		}
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundler.java
+++ b/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundler.java
@@ -1,0 +1,229 @@
+package io.github.adamw7.context.okf;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import io.github.adamw7.context.Language;
+import io.github.adamw7.context.tree.ProjectTreeNode;
+
+/**
+ * Turns a scanned {@link ProjectTreeNode} tree into an {@link OkfBundle}: every
+ * directory becomes a reserved {@code index.md} listing what it holds, and every
+ * file becomes a concept document whose frontmatter names it and whose body links
+ * to the concepts it depends on. The result is the project's structure and its
+ * class dependencies expressed in Google's Open Knowledge Format, so an agent
+ * that already speaks OKF can consume this repository's context without knowing
+ * anything about the tree the finder builds.
+ * <p>
+ * A dependency is linked only when its file name identifies exactly one concept
+ * in the bundle; an ambiguous or unresolved name is rendered as plain code rather
+ * than as a link to a guess. Links use the bundle-relative form the specification
+ * recommends, since it survives a document being moved.
+ */
+public class OkfBundler {
+
+	/** The {@code <producer>/<version>} actor recorded in every concept's {@code generated} field. */
+	public static final String DEFAULT_PRODUCER = "tools.code.context/1";
+
+	private static final String SEPARATOR = "/";
+	private static final String DOCUMENT_SUFFIX = ".md";
+	private static final String DELIMITER = "---";
+	private static final String BULLET = "* ";
+	private static final String DIRECTORIES_HEADING = "# Directories";
+	private static final String FILES_HEADING = "# Files";
+	private static final String EMPTY_HEADING = "# Contents";
+	private static final String EMPTY_BODY = "This directory holds no concepts.";
+
+	private final Language language;
+	private final String producer;
+	private final Clock clock;
+
+	public OkfBundler(Language language) {
+		this(language, DEFAULT_PRODUCER, Clock.systemUTC());
+	}
+
+	public OkfBundler(Language language, String producer, Clock clock) {
+		this.language = language;
+		this.producer = producer;
+		this.clock = clock;
+	}
+
+	public OkfBundle bundle(ProjectTreeNode root) {
+		Map<String, String> conceptPaths = conceptPaths(root);
+		List<OkfDocument> documents = new ArrayList<>();
+		documents.add(index(root, ""));
+		entries(root).forEach(child -> collect(child, "", documents, conceptPaths));
+		return new OkfBundle(documents);
+	}
+
+	private void collect(ProjectTreeNode node, String prefix, List<OkfDocument> documents,
+			Map<String, String> conceptPaths) {
+		if (node.isDirectory()) {
+			collectDirectory(node, prefix + node.name() + SEPARATOR, documents, conceptPaths);
+			return;
+		}
+		documents.add(concept(node, prefix, conceptPaths).render(producer, clock.instant()));
+	}
+
+	private void collectDirectory(ProjectTreeNode directory, String prefix, List<OkfDocument> documents,
+			Map<String, String> conceptPaths) {
+		documents.add(index(directory, prefix));
+		directory.children().forEach(child -> collect(child, prefix, documents, conceptPaths));
+	}
+
+	/**
+	 * Maps each file name to the one concept it identifies. A name carried by more
+	 * than one file is dropped, so a dependency on it stays unlinked instead of
+	 * pointing at whichever file happened to be scanned last.
+	 */
+	private Map<String, String> conceptPaths(ProjectTreeNode root) {
+		Map<String, String> paths = new HashMap<>();
+		Set<String> ambiguous = new HashSet<>();
+		entries(root).forEach(child -> mapConcept(child, "", paths, ambiguous));
+		ambiguous.forEach(paths::remove);
+		return paths;
+	}
+
+	private void mapConcept(ProjectTreeNode node, String prefix, Map<String, String> paths, Set<String> ambiguous) {
+		if (node.isDirectory()) {
+			node.children().forEach(child -> mapConcept(child, prefix + node.name() + SEPARATOR, paths, ambiguous));
+			return;
+		}
+		String previous = paths.put(node.name(), SEPARATOR + prefix + conceptName(node));
+		if (previous != null) {
+			ambiguous.add(node.name());
+		}
+	}
+
+	private OkfConcept concept(ProjectTreeNode node, String prefix, Map<String, String> conceptPaths) {
+		return new OkfConcept(prefix + conceptName(node), type(node), node.name(), describe(node),
+				prefix + node.name(), tags(node), dependencyLinks(node, conceptPaths));
+	}
+
+	private List<String> dependencyLinks(ProjectTreeNode node, Map<String, String> conceptPaths) {
+		return node.dependencies().stream().map(dependency -> link(dependency, conceptPaths)).toList();
+	}
+
+	private String link(String dependency, Map<String, String> conceptPaths) {
+		String target = conceptPaths.get(dependency);
+		if (target == null) {
+			return "`" + dependency + "`";
+		}
+		return "[`" + dependency + "`](" + target + ")";
+	}
+
+	private OkfDocument index(ProjectTreeNode node, String prefix) {
+		StringBuilder builder = new StringBuilder();
+		appendVersion(builder, prefix);
+		appendSection(builder, DIRECTORIES_HEADING, directoryEntries(node));
+		appendSection(builder, FILES_HEADING, fileEntries(node));
+		appendEmptyContents(builder, node);
+		return new OkfDocument(prefix + OkfBundle.INDEX, builder.toString());
+	}
+
+	/**
+	 * A bundle-root index is the one index allowed a frontmatter block, and the one
+	 * place the targeted specification version is declared.
+	 */
+	private void appendVersion(StringBuilder builder, String prefix) {
+		if (!prefix.isEmpty()) {
+			return;
+		}
+		builder.append(DELIMITER).append(System.lineSeparator())
+				.append("okf_version: \"").append(OkfBundle.VERSION).append('"').append(System.lineSeparator())
+				.append(DELIMITER).append(System.lineSeparator())
+				.append(System.lineSeparator());
+	}
+
+	private void appendSection(StringBuilder builder, String heading, List<String> sectionEntries) {
+		if (sectionEntries.isEmpty()) {
+			return;
+		}
+		builder.append(heading).append(System.lineSeparator()).append(System.lineSeparator());
+		sectionEntries.forEach(entry -> builder.append(BULLET).append(entry).append(System.lineSeparator()));
+		builder.append(System.lineSeparator());
+	}
+
+	private void appendEmptyContents(StringBuilder builder, ProjectTreeNode node) {
+		if (!entries(node).isEmpty()) {
+			return;
+		}
+		builder.append(EMPTY_HEADING).append(System.lineSeparator()).append(System.lineSeparator())
+				.append(EMPTY_BODY).append(System.lineSeparator());
+	}
+
+	private List<String> directoryEntries(ProjectTreeNode node) {
+		return entries(node).stream()
+				.filter(ProjectTreeNode::isDirectory)
+				.map(child -> "[" + child.name() + "](" + child.name() + SEPARATOR + ") - " + describe(child))
+				.toList();
+	}
+
+	private List<String> fileEntries(ProjectTreeNode node) {
+		return entries(node).stream()
+				.filter(child -> !child.isDirectory())
+				.map(child -> "[" + child.name() + "](" + conceptName(child) + ") - " + describe(child))
+				.toList();
+	}
+
+	/**
+	 * The children a node contributes to its own index. A file handed in as the
+	 * scanned root is its own single entry, so a one-file scan still yields a
+	 * conformant bundle rather than an empty one.
+	 */
+	private List<ProjectTreeNode> entries(ProjectTreeNode node) {
+		return node.isDirectory() ? node.children() : List.of(node);
+	}
+
+	private String describe(ProjectTreeNode node) {
+		if (node.isDirectory()) {
+			return "Directory holding " + count(node.children().size(), "concept") + ".";
+		}
+		if (isSource(node)) {
+			return displayLanguage() + " source file with "
+					+ count(node.dependencies().size(), "project dependency", "project dependencies") + ".";
+		}
+		return "Project file " + node.name() + ".";
+	}
+
+	private String count(int amount, String singular) {
+		return count(amount, singular, singular + "s");
+	}
+
+	private String count(int amount, String singular, String plural) {
+		if (amount == 0) {
+			return "no " + plural;
+		}
+		return amount + " " + (amount == 1 ? singular : plural);
+	}
+
+	private String type(ProjectTreeNode node) {
+		return isSource(node) ? displayLanguage() + " Source File" : "Project File";
+	}
+
+	private List<String> tags(ProjectTreeNode node) {
+		if (isSource(node)) {
+			return List.of("source", language.name().toLowerCase(Locale.ROOT));
+		}
+		return List.of("file");
+	}
+
+	private boolean isSource(ProjectTreeNode node) {
+		return node.name().endsWith(language.extension());
+	}
+
+	private String displayLanguage() {
+		String name = language.name();
+		return name.charAt(0) + name.substring(1).toLowerCase(Locale.ROOT);
+	}
+
+	private String conceptName(ProjectTreeNode node) {
+		return node.name() + DOCUMENT_SUFFIX;
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/okf/OkfConcept.java
+++ b/code/context/src/main/java/io/github/adamw7/context/okf/OkfConcept.java
@@ -1,0 +1,65 @@
+package io.github.adamw7.context.okf;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * One concept of an {@link OkfBundle} — in this producer's vocabulary, a single
+ * file of the scanned project — described in the terms the Open Knowledge Format
+ * asks for, before it is rendered to markdown. Separating the facts about a
+ * concept from the document they end up in lets the same description serve both
+ * the concept's own frontmatter and the {@code index.md} entry that links to it,
+ * which is what the specification recommends.
+ *
+ * @param path        bundle-relative path of the concept document
+ * @param type        the one mandatory frontmatter field, e.g. {@code Java Source File}
+ * @param title       human-readable name, here the file name
+ * @param description single sentence summarising the concept
+ * @param resource    project-relative path of the file the concept describes
+ * @param tags        cross-cutting categories
+ * @param dependencies rendered markdown for each dependency, linked when the
+ *                     dependency resolves to another concept of the same bundle
+ */
+public record OkfConcept(String path, String type, String title, String description, String resource,
+		List<String> tags, List<String> dependencies) {
+
+	private static final String DEPENDENCIES_HEADING = "# Dependencies";
+	private static final String NO_DEPENDENCIES = "This file depends on no other file in the project.";
+	private static final String BULLET = "* ";
+
+	public OkfConcept {
+		tags = List.copyOf(tags);
+		dependencies = List.copyOf(dependencies);
+	}
+
+	/**
+	 * Renders the concept as a markdown document: the YAML frontmatter, then a
+	 * dependencies section listing the other concepts this file relies on.
+	 */
+	public OkfDocument render(String producer, Instant generatedAt) {
+		StringBuilder builder = new StringBuilder(frontmatter(producer, generatedAt));
+		builder.append(System.lineSeparator()).append(DEPENDENCIES_HEADING).append(System.lineSeparator())
+				.append(System.lineSeparator());
+		appendDependencies(builder);
+		return new OkfDocument(path, builder.toString());
+	}
+
+	private String frontmatter(String producer, Instant generatedAt) {
+		return new OkfFrontmatter(type)
+				.title(title)
+				.description(description)
+				.resource(resource)
+				.tags(tags)
+				.generated(producer, generatedAt)
+				.render();
+	}
+
+	private void appendDependencies(StringBuilder builder) {
+		if (dependencies.isEmpty()) {
+			builder.append(NO_DEPENDENCIES).append(System.lineSeparator());
+			return;
+		}
+		dependencies.forEach(dependency ->
+				builder.append(BULLET).append(dependency).append(System.lineSeparator()));
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/okf/OkfDocument.java
+++ b/code/context/src/main/java/io/github/adamw7/context/okf/OkfDocument.java
@@ -1,0 +1,15 @@
+package io.github.adamw7.context.okf;
+
+/**
+ * One markdown file of an {@link OkfBundle}: where it sits in the bundle and what
+ * it says. The Open Knowledge Format gives a concept its identity through its
+ * path, so carrying the path beside the content lets a bundle be written to disk,
+ * archived or handed to a client without the producer having to remember where
+ * each file belongs.
+ *
+ * @param path    bundle-relative path, always {@code /}-separated and never
+ *                starting with a separator, e.g. {@code tree/ProjectTreeNode.java.md}
+ * @param content the markdown content, YAML frontmatter included
+ */
+public record OkfDocument(String path, String content) {
+}

--- a/code/context/src/main/java/io/github/adamw7/context/okf/OkfFrontmatter.java
+++ b/code/context/src/main/java/io/github/adamw7/context/okf/OkfFrontmatter.java
@@ -1,0 +1,114 @@
+package io.github.adamw7.context.okf;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The YAML frontmatter block that opens every OKF concept document. The Open
+ * Knowledge Format makes exactly one field mandatory — {@code type} — and
+ * recommends {@code title}, {@code description}, {@code resource} and
+ * {@code tags}; v0.2 records how a concept was produced as
+ * {@code generated: { by, at }}. This builder renders that subset in a fixed
+ * order and skips the fields a caller left unset, so callers describe a concept
+ * in domain terms rather than assembling YAML by hand.
+ * <p>
+ * Every scalar is emitted double-quoted, which keeps a colon in a description or
+ * a {@code #} in a path from changing the meaning of the block, and the actor of
+ * {@code generated.by} follows the specification's {@code <producer>/<version>}
+ * convention.
+ */
+public class OkfFrontmatter {
+
+	private static final String DELIMITER = "---";
+	private static final String SEPARATOR = ": ";
+
+	private final String type;
+	private String title;
+	private String description;
+	private String resource;
+	private List<String> tags = List.of();
+	private String generatedBy;
+	private Instant generatedAt;
+
+	public OkfFrontmatter(String type) {
+		if (type == null || type.isBlank()) {
+			throw new IllegalArgumentException("An OKF concept must declare a non-empty type");
+		}
+		this.type = type;
+	}
+
+	public OkfFrontmatter title(String newTitle) {
+		this.title = newTitle;
+		return this;
+	}
+
+	public OkfFrontmatter description(String newDescription) {
+		this.description = newDescription;
+		return this;
+	}
+
+	public OkfFrontmatter resource(String newResource) {
+		this.resource = newResource;
+		return this;
+	}
+
+	public OkfFrontmatter tags(List<String> newTags) {
+		this.tags = List.copyOf(newTags);
+		return this;
+	}
+
+	/**
+	 * Records the actor that produced the concept and when its content last
+	 * changed. The instant is truncated to whole seconds, the granularity the
+	 * specification's ISO 8601 examples use.
+	 */
+	public OkfFrontmatter generated(String actor, Instant when) {
+		this.generatedBy = actor;
+		this.generatedAt = when;
+		return this;
+	}
+
+	public String render() {
+		StringBuilder builder = new StringBuilder();
+		builder.append(DELIMITER).append(System.lineSeparator());
+		appendScalar(builder, "type", type);
+		appendScalar(builder, "title", title);
+		appendScalar(builder, "description", description);
+		appendScalar(builder, "resource", resource);
+		appendTags(builder);
+		appendGenerated(builder);
+		builder.append(DELIMITER).append(System.lineSeparator());
+		return builder.toString();
+	}
+
+	private void appendScalar(StringBuilder builder, String key, String value) {
+		if (value == null || value.isBlank()) {
+			return;
+		}
+		builder.append(key).append(SEPARATOR).append(quote(value)).append(System.lineSeparator());
+	}
+
+	private void appendTags(StringBuilder builder) {
+		if (tags.isEmpty()) {
+			return;
+		}
+		String rendered = tags.stream().map(OkfFrontmatter::quote).collect(Collectors.joining(", ", "[", "]"));
+		builder.append("tags").append(SEPARATOR).append(rendered).append(System.lineSeparator());
+	}
+
+	private void appendGenerated(StringBuilder builder) {
+		if (generatedBy == null || generatedAt == null) {
+			return;
+		}
+		builder.append("generated").append(SEPARATOR)
+				.append("{ by: ").append(quote(generatedBy))
+				.append(", at: ").append(quote(generatedAt.truncatedTo(ChronoUnit.SECONDS).toString()))
+				.append(" }").append(System.lineSeparator());
+	}
+
+	private static String quote(String value) {
+		return '"' + value.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpStatelessHttpIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpStatelessHttpIT.java
@@ -77,7 +77,7 @@ public class McpStatelessHttpIT {
 		McpSchema.ListToolsResult tools = client.listTools();
 
 		Set<String> names = tools.tools().stream().map(McpSchema.Tool::name).collect(Collectors.toSet());
-		assertEquals(Set.of("project_tree", "find_context", "estimate_tokens"), names);
+		assertEquals(Set.of("project_tree", "find_context", "estimate_tokens", "okf_bundle"), names);
 	}
 
 	@Test

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpIT.java
@@ -70,7 +70,7 @@ public class McpStreamableHttpIT {
 		McpSchema.ListToolsResult tools = client.listTools();
 
 		Set<String> names = tools.tools().stream().map(McpSchema.Tool::name).collect(Collectors.toSet());
-		assertEquals(Set.of("project_tree", "find_context", "estimate_tokens"), names);
+		assertEquals(Set.of("project_tree", "find_context", "estimate_tokens", "okf_bundle"), names);
 	}
 
 	@Test
@@ -132,6 +132,22 @@ public class McpStreamableHttpIT {
 		assertTrue(tree.contains("- `A.java`"));
 		assertTrue(tree.contains("- `B.java`"));
 		assertTrue(tree.contains("- depends on: `A.java`"));
+	}
+
+	@Test
+	void okfBundleToolReturnsAConformantBundle() {
+		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("okf_bundle")
+				.arguments(Map.of("path", projectRoot.toString()))
+				.build();
+
+		McpSchema.CallToolResult result = client.callTool(request);
+
+		JsonNode bundle = parse(singleTextResult(result));
+		assertEquals("0.2", bundle.get("okf_version").asText());
+		JsonNode documents = bundle.get("documents");
+		assertTrue(documents.get("index.md").asText().contains("okf_version: \"0.2\""));
+		assertTrue(documents.get("A.java.md").asText().contains("type: \"Java Source File\""));
+		assertTrue(documents.get("B.java.md").asText().contains("[`A.java`](/A.java.md)"));
 	}
 
 	@Test

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/OkfBundleToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/OkfBundleToolTest.java
@@ -1,0 +1,155 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.mcp.ToolResult;
+
+public class OkfBundleToolTest {
+
+	@TempDir
+	Path projectRoot;
+
+	@TempDir
+	Path outsideRoot;
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private OkfBundleTool tool;
+
+	@BeforeEach
+	void setUp() {
+		tool = new OkfBundleTool(new PathPolicy(projectRoot.toString()));
+	}
+
+	@Test
+	void toolDefinitionExposesName() {
+		assertEquals("okf_bundle", tool.getToolDefinition().name());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void toolDefinitionRequiresPath() {
+		List<String> required = (List<String>) tool.getToolDefinition().inputSchema().get("required");
+		assertTrue(required.contains("path"));
+	}
+
+	@Test
+	void returnsTheTargetedSpecificationVersion() throws IOException {
+		writeJava("A", "public class A {}");
+
+		JsonNode bundle = MAPPER.readTree(text(tool.apply(arguments())));
+
+		assertEquals("0.2", bundle.get("okf_version").asText());
+	}
+
+	@Test
+	void returnsOneMarkdownDocumentPerFileBesideTheRootIndex() throws IOException {
+		writeJava("A", "public class A {}");
+		writeJava("B", "public class B { A a; }");
+
+		JsonNode documents = MAPPER.readTree(text(tool.apply(arguments()))).get("documents");
+
+		assertEquals(3, documents.size());
+		assertTrue(documents.has("index.md"));
+		assertTrue(documents.has("A.java.md"));
+		assertTrue(documents.has("B.java.md"));
+	}
+
+	@Test
+	void conceptDocumentsCarryFrontmatterWithAType() throws IOException {
+		writeJava("A", "public class A {}");
+
+		JsonNode documents = MAPPER.readTree(text(tool.apply(arguments()))).get("documents");
+
+		assertTrue(documents.get("A.java.md").asText().startsWith("---"));
+		assertTrue(documents.get("A.java.md").asText().contains("type: \"Java Source File\""));
+	}
+
+	@Test
+	void linksADependencyToTheConceptThatDescribesIt() throws IOException {
+		writeJava("A", "public class A {}");
+		writeJava("B", "public class B { A a; }");
+
+		JsonNode documents = MAPPER.readTree(text(tool.apply(arguments()))).get("documents");
+
+		assertTrue(documents.get("B.java.md").asText().contains("[`A.java`](/A.java.md)"));
+	}
+
+	@Test
+	void honoursTheRequestedLanguage() throws IOException {
+		Files.writeString(projectRoot.resolve("A.kt"), "class A");
+
+		Map<String, Object> arguments = arguments();
+		arguments.put("language", "kotlin");
+
+		JsonNode documents = MAPPER.readTree(text(tool.apply(arguments))).get("documents");
+		assertTrue(documents.get("A.kt.md").asText().contains("type: \"Kotlin Source File\""));
+	}
+
+	@Test
+	void resultIsNotAnError() throws IOException {
+		writeJava("A", "public class A {}");
+		assertFalse(tool.apply(arguments()).isError());
+	}
+
+	@Test
+	void missingPathIsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> tool.apply(new HashMap<>()));
+	}
+
+	@Test
+	void pathOutsideTheAllowedRootIsRejected() {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("path", outsideRoot.toString());
+		assertThrows(SecurityException.class, () -> tool.apply(arguments));
+	}
+
+	@Test
+	void excessiveDepthIsRejected() throws IOException {
+		writeJava("A", "public class A {}");
+		Map<String, Object> arguments = arguments();
+		arguments.put("depth", 99);
+		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
+	}
+
+	@Test
+	void scanningWritesNothingToTheProject() throws IOException {
+		writeJava("A", "public class A {}");
+
+		tool.apply(arguments());
+
+		try (var entries = Files.list(projectRoot)) {
+			assertEquals(List.of("A.java"), entries.map(path -> path.getFileName().toString()).toList());
+		}
+	}
+
+	private Map<String, Object> arguments() {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("path", projectRoot.toString());
+		return arguments;
+	}
+
+	private void writeJava(String className, String body) throws IOException {
+		Files.writeString(projectRoot.resolve(className + ".java"), body);
+	}
+
+	private String text(ToolResult result) {
+		return result.text();
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundleConformanceTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundleConformanceTest.java
@@ -1,0 +1,204 @@
+package io.github.adamw7.context.okf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.context.Language;
+import io.github.adamw7.context.tree.ProjectTreeBuilder;
+import io.github.adamw7.context.tree.ProjectTreeNode;
+
+/**
+ * Holds every bundle the emitter produces to the Open Knowledge Format's own
+ * conformance conditions, restated here from the specification rather than read
+ * back out of {@link OkfBundler}. A test that asked the bundler what it meant to
+ * write would pass however far the output drifted from OKF; these assertions are
+ * the specification's side of the contract, so this is what fails when the two
+ * part company.
+ * <p>
+ * This runs in the ordinary {@code test} phase, so {@code mvn test}, {@code mvn
+ * package} and {@code mvn install} all catch the drift. The
+ * {@code okfBundleFormat} enforcer rule checks a bundle already written to disk;
+ * this checks the producer that writes one.
+ */
+public class OkfBundleConformanceTest {
+
+	private static final String DELIMITER = "---";
+	private static final String INDEX = "index.md";
+	private static final String LOG = "log.md";
+	private static final Pattern TYPE = Pattern.compile("^type:\\s*(.+)$", Pattern.MULTILINE);
+	private static final Pattern OKF_VERSION = Pattern.compile("^okf_version:\\s*\"(.+)\"$", Pattern.MULTILINE);
+	private static final Pattern GENERATED_AT = Pattern.compile("at:\\s*\"([^\"]+)\"");
+	private static final Pattern BUNDLE_LINK = Pattern.compile("]\\((/[^)]+)\\)");
+
+	@TempDir
+	Path projectRoot;
+
+	private final OkfBundler bundler = new OkfBundler(Language.JAVA);
+
+	@Test
+	void everyNonReservedDocumentCarriesFrontmatterDeclaringANonEmptyType() {
+		concepts(bundler.bundle(sampleTree())).forEach(document -> {
+			assertTrue(hasFrontmatter(document.content()),
+					document.path() + " must open with a closed --- frontmatter block");
+			assertFalse(typeOf(document.content()).isBlank(),
+					document.path() + " must declare a non-empty type");
+		});
+	}
+
+	@Test
+	void onlyTheBundleRootIndexCarriesFrontmatterAndOnlyTheVersion() {
+		OkfBundle bundle = bundler.bundle(sampleTree());
+
+		bundle.documents().stream()
+				.filter(document -> document.path().endsWith(INDEX))
+				.forEach(document -> assertIndexConforms(document));
+	}
+
+	@Test
+	void theBundleRootDeclaresTheVersionTheDocumentsTarget() {
+		OkfBundle bundle = bundler.bundle(sampleTree());
+
+		Matcher declared = OKF_VERSION.matcher(documentAt(bundle, INDEX));
+		assertTrue(declared.find(), "the bundle root index must declare okf_version");
+		assertEquals(OkfBundle.VERSION, declared.group(1));
+	}
+
+	@Test
+	void noDocumentUsesAReservedNameForAConcept() {
+		concepts(bundler.bundle(sampleTree())).forEach(document -> {
+			assertFalse(document.path().endsWith("/" + INDEX) || document.path().equals(INDEX),
+					document.path() + " must not take the reserved index name");
+			assertFalse(document.path().endsWith("/" + LOG) || document.path().equals(LOG),
+					document.path() + " must not take the reserved log name");
+		});
+	}
+
+	@Test
+	void everyDocumentPathIsUnique() {
+		List<String> paths = bundler.bundle(sampleTree()).documents().stream().map(OkfDocument::path).toList();
+
+		assertEquals(paths.size(), Set.copyOf(paths).size(), "two documents claimed the same bundle path");
+	}
+
+	@Test
+	void everyBundleRelativeLinkResolvesToADocumentOfTheBundle() {
+		OkfBundle bundle = bundler.bundle(sampleTree());
+		Set<String> paths = new HashSet<>(bundle.documents().stream().map(OkfDocument::path).toList());
+
+		links(bundle).forEach(link -> assertTrue(paths.contains(link.substring(1)),
+				"the link " + link + " points outside the bundle"));
+	}
+
+	@Test
+	void everyProductionTimestampIsAnIsoInstant() {
+		concepts(bundler.bundle(sampleTree())).forEach(document -> {
+			Matcher at = GENERATED_AT.matcher(document.content());
+			assertTrue(at.find(), document.path() + " must record when it was generated");
+			assertEquals(at.group(1), Instant.parse(at.group(1)).toString());
+		});
+	}
+
+	@Test
+	void aBundleScannedFromRealSourcesIsConformantToo() throws IOException {
+		Files.writeString(projectRoot.resolve("A.java"), "public class A {}");
+		Path pkg = Files.createDirectory(projectRoot.resolve("pkg"));
+		Files.writeString(pkg.resolve("B.java"), "public class B { A a; }");
+		Files.writeString(projectRoot.resolve("notes.md"), "plain markdown, not a source file");
+
+		OkfBundle bundle = bundler.bundle(new ProjectTreeBuilder(Language.JAVA, 1).build(projectRoot));
+
+		concepts(bundle).forEach(document -> assertTrue(hasFrontmatter(document.content())
+				&& !typeOf(document.content()).isBlank(), document.path() + " is not conformant"));
+		Set<String> paths = new HashSet<>(bundle.documents().stream().map(OkfDocument::path).toList());
+		links(bundle).forEach(link -> assertTrue(paths.contains(link.substring(1)), link + " is dangling"));
+	}
+
+	private void assertIndexConforms(OkfDocument document) {
+		if (!document.path().equals(INDEX)) {
+			assertFalse(hasFrontmatter(document.content()),
+					document.path() + " is not the bundle root, so it must carry no frontmatter");
+			return;
+		}
+		assertEquals(List.of("okf_version"), frontmatterKeys(document.content()),
+				"a bundle-root index may declare only okf_version");
+	}
+
+	private List<OkfDocument> concepts(OkfBundle bundle) {
+		return bundle.documents().stream().filter(document -> !document.path().endsWith(INDEX)).toList();
+	}
+
+	private List<String> links(OkfBundle bundle) {
+		List<String> found = new ArrayList<>();
+		bundle.documents().forEach(document -> {
+			Matcher matcher = BUNDLE_LINK.matcher(document.content());
+			while (matcher.find()) {
+				found.add(matcher.group(1));
+			}
+		});
+		return found;
+	}
+
+	private String documentAt(OkfBundle bundle, String path) {
+		return bundle.documents().stream()
+				.filter(document -> document.path().equals(path))
+				.map(OkfDocument::content)
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("the bundle holds no document at " + path));
+	}
+
+	/** True when the content opens with a {@code ---} line that a later {@code ---} closes. */
+	private boolean hasFrontmatter(String content) {
+		List<String> lines = content.lines().toList();
+		return !lines.isEmpty() && lines.get(0).strip().equals(DELIMITER)
+				&& lines.subList(1, lines.size()).stream().anyMatch(line -> line.strip().equals(DELIMITER));
+	}
+
+	private List<String> frontmatterKeys(String content) {
+		return frontmatterLines(content).stream()
+				.map(line -> line.substring(0, line.indexOf(':')))
+				.toList();
+	}
+
+	private List<String> frontmatterLines(String content) {
+		List<String> lines = content.lines().toList();
+		return lines.subList(1, lines.size()).stream()
+				.takeWhile(line -> !line.strip().equals(DELIMITER))
+				.filter(line -> line.contains(":"))
+				.toList();
+	}
+
+	private String typeOf(String content) {
+		Matcher matcher = TYPE.matcher(content);
+		return matcher.find() ? matcher.group(1).replace("\"", "").strip() : "";
+	}
+
+	private ProjectTreeNode sampleTree() {
+		ProjectTreeNode root = new ProjectTreeNode("project", ProjectTreeNode.Type.DIRECTORY);
+		ProjectTreeNode pkg = new ProjectTreeNode("pkg", ProjectTreeNode.Type.DIRECTORY);
+		ProjectTreeNode dependency = new ProjectTreeNode("A.java", ProjectTreeNode.Type.FILE);
+		ProjectTreeNode dependent = new ProjectTreeNode("B.java", ProjectTreeNode.Type.FILE);
+		dependent.addDependency("A.java");
+		dependent.addDependency("Library.java");
+		pkg.addChild(dependency);
+		pkg.addChild(dependent);
+		root.addChild(pkg);
+		root.addChild(new ProjectTreeNode("pom.xml", ProjectTreeNode.Type.FILE));
+		root.addChild(new ProjectTreeNode(INDEX, ProjectTreeNode.Type.FILE));
+		return root;
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundleWriterTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundleWriterTest.java
@@ -1,0 +1,66 @@
+package io.github.adamw7.context.okf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class OkfBundleWriterTest {
+
+	@TempDir
+	Path target;
+
+	private final OkfBundleWriter writer = new OkfBundleWriter();
+
+	@Test
+	void writesEveryDocumentAtItsBundleRelativePath() throws IOException {
+		OkfBundle bundle = new OkfBundle(List.of(new OkfDocument("index.md", "root"),
+				new OkfDocument("pkg/A.java.md", "concept")));
+
+		writer.write(bundle, target);
+
+		assertEquals("root", Files.readString(target.resolve("index.md")));
+		assertEquals("concept", Files.readString(target.resolve("pkg/A.java.md")));
+	}
+
+	@Test
+	void createsTheDirectoriesADocumentNeeds() {
+		OkfBundle bundle = new OkfBundle(List.of(new OkfDocument("one/two/three/A.java.md", "deep")));
+
+		writer.write(bundle, target);
+
+		assertTrue(Files.isDirectory(target.resolve("one/two/three")));
+	}
+
+	@Test
+	void returnsTheBundleRootItWroteTo() {
+		assertEquals(target, writer.write(new OkfBundle(List.of()), target));
+	}
+
+	@Test
+	void writesDocumentsAsUtf8() throws IOException {
+		OkfBundle bundle = new OkfBundle(List.of(new OkfDocument("index.md", "wgłębienie")));
+
+		writer.write(bundle, target);
+
+		assertEquals("wgłębienie",
+				new String(Files.readAllBytes(target.resolve("index.md")), StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void reportsAnUnwritableTargetRatherThanFailingSilently() throws IOException {
+		Path file = Files.createFile(target.resolve("occupied"));
+		OkfBundle bundle = new OkfBundle(List.of(new OkfDocument("index.md", "root")));
+
+		assertThrows(UncheckedIOException.class, () -> writer.write(bundle, file));
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundlerTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundlerTest.java
@@ -1,0 +1,250 @@
+package io.github.adamw7.context.okf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.context.Language;
+import io.github.adamw7.context.tree.ProjectTreeNode;
+
+public class OkfBundlerTest {
+
+	private static final Instant PRODUCED_AT = Instant.parse("2026-08-03T10:15:30Z");
+	private static final String PRODUCER = "test-producer/1";
+
+	private final OkfBundler bundler = new OkfBundler(Language.JAVA, PRODUCER,
+			Clock.fixed(PRODUCED_AT, ZoneOffset.UTC));
+
+	@Test
+	void bundleRootIndexDeclaresTheTargetedSpecificationVersion() {
+		OkfBundle bundle = bundler.bundle(directory("project"));
+
+		assertTrue(document(bundle, "index.md").startsWith("---"));
+		assertTrue(document(bundle, "index.md").contains("okf_version: \"0.2\""));
+	}
+
+	@Test
+	void aNestedIndexCarriesNoFrontmatter() {
+		ProjectTreeNode root = directory("project");
+		root.addChild(directory("pkg"));
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertFalse(document(bundle, "pkg/index.md").contains("---"));
+	}
+
+	@Test
+	void everyConceptDocumentDeclaresANonEmptyType() {
+		ProjectTreeNode root = directory("project");
+		ProjectTreeNode pkg = directory("pkg");
+		pkg.addChild(file("A.java"));
+		root.addChild(pkg);
+		root.addChild(file("README.md"));
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		bundle.documents().stream()
+				.filter(document -> !document.path().endsWith(OkfBundle.INDEX))
+				.forEach(document -> {
+					assertTrue(document.content().startsWith("---"), document.path() + " must open with frontmatter");
+					assertTrue(document.content().contains("type: \""), document.path() + " must declare a type");
+				});
+	}
+
+	@Test
+	void filesBecomeConceptDocumentsBesideTheirDirectoryIndex() {
+		ProjectTreeNode root = directory("project");
+		ProjectTreeNode pkg = directory("pkg");
+		pkg.addChild(file("A.java"));
+		root.addChild(pkg);
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertEquals(List.of("index.md", "pkg/index.md", "pkg/A.java.md"),
+				bundle.documents().stream().map(OkfDocument::path).toList());
+	}
+
+	@Test
+	void aDependencyResolvedInTheProjectBecomesABundleRelativeLink() {
+		ProjectTreeNode root = directory("project");
+		ProjectTreeNode pkg = directory("pkg");
+		pkg.addChild(file("A.java"));
+		ProjectTreeNode dependent = file("B.java");
+		dependent.addDependency("A.java");
+		pkg.addChild(dependent);
+		root.addChild(pkg);
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertTrue(document(bundle, "pkg/B.java.md").contains("* [`A.java`](/pkg/A.java.md)"));
+	}
+
+	@Test
+	void aDependencyOutsideTheProjectStaysPlainCode() {
+		ProjectTreeNode root = directory("project");
+		ProjectTreeNode dependent = file("B.java");
+		dependent.addDependency("Library.java");
+		root.addChild(dependent);
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertTrue(document(bundle, "B.java.md").contains("* `Library.java`"));
+		assertFalse(document(bundle, "B.java.md").contains("]("));
+	}
+
+	@Test
+	void anAmbiguousDependencyNameIsNotLinkedToAGuess() {
+		ProjectTreeNode root = directory("project");
+		ProjectTreeNode first = directory("one");
+		first.addChild(file("A.java"));
+		ProjectTreeNode second = directory("two");
+		second.addChild(file("A.java"));
+		ProjectTreeNode dependent = file("B.java");
+		dependent.addDependency("A.java");
+		root.addChild(first);
+		root.addChild(second);
+		root.addChild(dependent);
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertTrue(document(bundle, "B.java.md").contains("* `A.java`"));
+		assertFalse(document(bundle, "B.java.md").contains("]("));
+	}
+
+	@Test
+	void aConceptWithoutDependenciesSaysSo() {
+		ProjectTreeNode root = directory("project");
+		root.addChild(file("A.java"));
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertTrue(document(bundle, "A.java.md").contains("# Dependencies"));
+		assertTrue(document(bundle, "A.java.md").contains("This file depends on no other file in the project."));
+	}
+
+	@Test
+	void anIndexEntryRepeatsTheDescriptionOfTheConceptItLinksTo() {
+		ProjectTreeNode root = directory("project");
+		ProjectTreeNode dependent = file("B.java");
+		dependent.addDependency("Library.java");
+		root.addChild(dependent);
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		String description = "Java source file with 1 project dependency.";
+		assertTrue(document(bundle, "index.md").contains("* [B.java](B.java.md) - " + description));
+		assertTrue(document(bundle, "B.java.md").contains("description: \"" + description + "\""));
+	}
+
+	@Test
+	void anIndexListsItsSubdirectoriesWithATrailingSeparator() {
+		ProjectTreeNode root = directory("project");
+		ProjectTreeNode pkg = directory("pkg");
+		pkg.addChild(file("A.java"));
+		root.addChild(pkg);
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertTrue(document(bundle, "index.md").contains("# Directories"));
+		assertTrue(document(bundle, "index.md").contains("* [pkg](pkg/) - Directory holding 1 concept."));
+	}
+
+	@Test
+	void anEmptyDirectoryStillGetsAConformantIndex() {
+		OkfBundle bundle = bundler.bundle(directory("project"));
+
+		assertEquals(1, bundle.documents().size());
+		assertTrue(document(bundle, "index.md").contains("# Contents"));
+		assertTrue(document(bundle, "index.md").contains("This directory holds no concepts."));
+	}
+
+	@Test
+	void aFileThatIsNotASourceFileIsTypedAsAProjectFile() {
+		ProjectTreeNode root = directory("project");
+		root.addChild(file("pom.xml"));
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertTrue(document(bundle, "pom.xml.md").contains("type: \"Project File\""));
+		assertTrue(document(bundle, "pom.xml.md").contains("tags: [\"file\"]"));
+	}
+
+	@Test
+	void theConfiguredLanguageNamesAndTagsTheConcept() {
+		ProjectTreeNode root = directory("project");
+		root.addChild(file("A.kt"));
+		OkfBundler kotlinBundler = new OkfBundler(Language.KOTLIN, PRODUCER, Clock.fixed(PRODUCED_AT, ZoneOffset.UTC));
+
+		OkfBundle bundle = kotlinBundler.bundle(root);
+
+		assertTrue(document(bundle, "A.kt.md").contains("type: \"Kotlin Source File\""));
+		assertTrue(document(bundle, "A.kt.md").contains("tags: [\"source\", \"kotlin\"]"));
+	}
+
+	@Test
+	void aConceptPointsAtTheProjectFileItDescribes() {
+		ProjectTreeNode root = directory("project");
+		ProjectTreeNode pkg = directory("pkg");
+		pkg.addChild(file("A.java"));
+		root.addChild(pkg);
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertTrue(document(bundle, "pkg/A.java.md").contains("resource: \"pkg/A.java\""));
+	}
+
+	@Test
+	void aScannedFileRootStillYieldsAConformantBundle() {
+		OkfBundle bundle = bundler.bundle(file("A.java"));
+
+		assertEquals(List.of("index.md", "A.java.md"), bundle.documents().stream().map(OkfDocument::path).toList());
+		assertTrue(document(bundle, "index.md").contains("* [A.java](A.java.md)"));
+	}
+
+	@Test
+	void everyConceptRecordsTheProducerAndTheMomentOfProduction() {
+		ProjectTreeNode root = directory("project");
+		root.addChild(file("A.java"));
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertTrue(document(bundle, "A.java.md")
+				.contains("generated: { by: \"" + PRODUCER + "\", at: \"2026-08-03T10:15:30Z\" }"));
+	}
+
+	@Test
+	void aFileNamedLikeAReservedDocumentDoesNotOverwriteTheIndex() {
+		ProjectTreeNode root = directory("project");
+		root.addChild(file(OkfBundle.INDEX));
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertTrue(document(bundle, "index.md").contains("# Files"));
+		assertTrue(document(bundle, "index.md.md").contains("type: \"Project File\""));
+	}
+
+	private String document(OkfBundle bundle, String path) {
+		OkfDocument document = bundle.documents().stream()
+				.filter(candidate -> candidate.path().equals(path))
+				.findFirst()
+				.orElse(null);
+		assertNotNull(document, "the bundle must hold a document at " + path);
+		return document.content();
+	}
+
+	private ProjectTreeNode directory(String name) {
+		return new ProjectTreeNode(name, ProjectTreeNode.Type.DIRECTORY);
+	}
+
+	private ProjectTreeNode file(String name) {
+		return new ProjectTreeNode(name, ProjectTreeNode.Type.FILE);
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/okf/OkfFrontmatterTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/okf/OkfFrontmatterTest.java
@@ -1,0 +1,117 @@
+package io.github.adamw7.context.okf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class OkfFrontmatterTest {
+
+	@Test
+	void rendersTheOnlyMandatoryField() {
+		String rendered = new OkfFrontmatter("Java Source File").render();
+
+		assertTrue(rendered.startsWith("---"));
+		assertTrue(rendered.contains("type: \"Java Source File\""));
+		assertTrue(rendered.trim().endsWith("---"));
+	}
+
+	@Test
+	void rejectsAConceptWithoutAType() {
+		assertThrows(IllegalArgumentException.class, () -> new OkfFrontmatter(" "));
+	}
+
+	@Test
+	void rejectsANullType() {
+		assertThrows(IllegalArgumentException.class, () -> new OkfFrontmatter(null));
+	}
+
+	@Test
+	void skipsTheRecommendedFieldsLeftUnset() {
+		String rendered = new OkfFrontmatter("Project File").render();
+
+		assertFalse(rendered.contains("title"));
+		assertFalse(rendered.contains("description"));
+		assertFalse(rendered.contains("resource"));
+		assertFalse(rendered.contains("tags"));
+		assertFalse(rendered.contains("generated"));
+	}
+
+	@Test
+	void rendersTheRecommendedFields() {
+		String rendered = new OkfFrontmatter("Java Source File")
+				.title("A.java")
+				.description("Java source file with no project dependencies.")
+				.resource("src/A.java")
+				.tags(List.of("source", "java"))
+				.render();
+
+		assertTrue(rendered.contains("title: \"A.java\""));
+		assertTrue(rendered.contains("description: \"Java source file with no project dependencies.\""));
+		assertTrue(rendered.contains("resource: \"src/A.java\""));
+		assertTrue(rendered.contains("tags: [\"source\", \"java\"]"));
+	}
+
+	@Test
+	void recordsTheProducingActorAndTheMomentOfProduction() {
+		String rendered = new OkfFrontmatter("Java Source File")
+				.generated("tools.code.context/1", Instant.parse("2026-08-03T10:15:30Z"))
+				.render();
+
+		assertTrue(rendered.contains(
+				"generated: { by: \"tools.code.context/1\", at: \"2026-08-03T10:15:30Z\" }"));
+	}
+
+	@Test
+	void truncatesTheProductionInstantToWholeSeconds() {
+		String rendered = new OkfFrontmatter("Java Source File")
+				.generated("tools.code.context/1", Instant.parse("2026-08-03T10:15:30.123456Z"))
+				.render();
+
+		assertTrue(rendered.contains("at: \"2026-08-03T10:15:30Z\""));
+	}
+
+	@Test
+	void quotesAValueThatWouldOtherwiseChangeTheMeaningOfTheBlock() {
+		String rendered = new OkfFrontmatter("Project File")
+				.description("Reads a: b # not a comment")
+				.render();
+
+		assertTrue(rendered.contains("description: \"Reads a: b # not a comment\""));
+	}
+
+	@Test
+	void escapesQuotesAndBackslashes() {
+		String rendered = new OkfFrontmatter("Project File").title("a\"b\\c").render();
+
+		assertTrue(rendered.contains("title: \"a\\\"b\\\\c\""));
+	}
+
+	@Test
+	void tagsAreCopiedSoALaterChangeCannotLeakIn() {
+		List<String> tags = new java.util.ArrayList<>(List.of("source"));
+		OkfFrontmatter frontmatter = new OkfFrontmatter("Java Source File").tags(tags);
+		tags.add("leaked");
+
+		assertFalse(frontmatter.render().contains("leaked"));
+	}
+
+	@Test
+	void keepsTheFieldsInTheSpecificationsOrder() {
+		String rendered = new OkfFrontmatter("Java Source File")
+				.title("A.java")
+				.description("A description.")
+				.resource("src/A.java")
+				.tags(List.of("source"))
+				.generated("tools.code.context/1", Instant.parse("2026-08-03T10:15:30Z"))
+				.render();
+
+		assertEquals(List.of("type", "title", "description", "resource", "tags", "generated"),
+				rendered.lines().filter(line -> line.contains(":")).map(line -> line.split(":")[0]).toList());
+	}
+}

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -116,7 +116,7 @@ flowchart TB
 
         subgraph agentTooling ["Agent tooling"]
             context["<b>code/context</b><br/><i>Library + MCP server</i><br/>Class-usage finder + ProjectTreeBuilder"]
-            contextMcp(["🟪 Context MCP server<br/><i>Spring Boot · stdio / HTTP</i><br/>project_tree · find_context · estimate_tokens"])
+            contextMcp(["🟪 Context MCP server<br/><i>Spring Boot · stdio / HTTP</i><br/>project_tree · find_context · estimate_tokens · okf_bundle"])
             adopt["<b>adopt</b><br/><i>CLI + MCP server</i><br/>Adoption pipeline: toolchain → clone →<br/>branch → init → conform → guard →<br/>verify → push → PR"]
             adoptMcp(["🟪 Adopt MCP server<br/><i>Spring Boot · stdio / HTTP</i><br/>adopt_repo"])
         end
@@ -292,6 +292,7 @@ flowchart TB
             treeTool["<b>ProjectTreeTool</b><br/><i>project_tree</i>"]
             finderTool["<b>ContextFinderTool</b><br/><i>find_context</i>"]
             tokenTool["<b>EstimateTokensTool</b><br/><i>estimate_tokens</i>"]
+            okfTool["<b>OkfBundleTool</b><br/><i>okf_bundle</i>"]
         end
 
         subgraph core ["Core"]
@@ -300,6 +301,7 @@ flowchart TB
             treeBuilder["<b>ProjectTreeBuilder</b><br/><i>scans project → tree</i>"]
             treeNode["<b>ProjectTreeNode</b><br/><i>model</i>"]
             serializers["<b>ProjectTree*Serializer</b><br/>JSON · Markdown · DOT ·<br/>Mermaid · printer"]
+            okf["<b>OkfBundler / OkfBundle /<br/>OkfConcept / OkfBundleWriter</b><br/><i>Open Knowledge Format v0.2</i>"]
             tokens["<b>TokenEstimator impls</b><br/>heuristic · subword"]
             sources["<b>ProjectSources / Language</b>"]
         end
@@ -311,8 +313,12 @@ flowchart TB
     mcpMain --> treeTool
     mcpMain --> finderTool
     mcpMain --> tokenTool
+    mcpMain --> okfTool
 
     treeTool --> treeBuilder
+    okfTool --> treeBuilder
+    okfTool --> okf
+    okf --> treeNode
     finderTool --> context_
     finderTool --> finder
     tokenTool --> tokens
@@ -331,7 +337,7 @@ flowchart TB
     classDef comp fill:#85bbf0,stroke:#5d82a8,color:#08427b
     classDef ext fill:#999999,stroke:#6b6b6b,color:#fff
     class agent person
-    class mcpMain,treeTool,finderTool,tokenTool,finder,context_,treeBuilder,treeNode,serializers,tokens,sources comp
+    class mcpMain,treeTool,finderTool,tokenTool,okfTool,finder,context_,treeBuilder,treeNode,serializers,okf,tokens,sources comp
     class projectSrc ext
     style context fill:#f2f7fc,stroke:#438dd5,color:#08427b
     style mcpLayer fill:#eef4ec,stroke:#6b3fa0,color:#46296b

--- a/pom.xml
+++ b/pom.xml
@@ -661,6 +661,14 @@
 										<mcpConfigFormat>
 											<mcpFile>${project.basedir}/.mcp.json</mcpFile>
 										</mcpConfigFormat>
+										<!-- This repository emits OKF bundles rather than
+										     shipping one, so the bundle root is absent and the
+										     rule passes; it starts enforcing the day a bundle
+										     is committed here. -->
+										<okfBundleFormat>
+											<bundleDir>${project.basedir}/okf</bundleDir>
+											<okfVersion>0.2</okfVersion>
+										</okfBundleFormat>
 										<crossDocConsistency>
 											<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
 											<agentsMdFile>${project.basedir}/AGENTS.md</agentsMdFile>


### PR DESCRIPTION
Google's Open Knowledge Format (OKF) packages knowledge for LLM-based
consumers as a directory of markdown files with YAML frontmatter — no
schema registry, no proprietary runtime. That is the same job the context
module already does, in a shape any OKF consumer can read, so a scanned
project tree can now be emitted as a conformant v0.2 bundle.

The new okf package maps a ProjectTreeNode tree onto bundle paths: every
directory becomes the reserved index.md listing what it holds, every file
becomes a concept document whose frontmatter names it and whose body links
to the concepts it depends on. A dependency is linked only when its file
name identifies exactly one concept, so an ambiguous or unresolved name
stays plain code rather than a link to a guess; links use the
bundle-relative form the specification recommends. OkfConcept holds a
concept's facts before rendering, so the index entry and the frontmatter
carry the same description.

The okf_bundle MCP tool returns the bundle as JSON rather than writing it,
keeping the server read-only; OkfBundleWriter materialises it on the
caller's side.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AXRDoAb4PJvCweXqLFiMs1