### PR TITLE
fix(adopt): bound captured command output and name each commit step

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,8 +895,11 @@ repository URL; a first positional that names no repository owner while the flag
 named repositories is rejected, since that is the workspace this reading invites.
 Two repositories that would clone into the same directory — `owner/tools` and
 `other-owner/tools`, or one repository named both with and without its `.git`
-suffix — are rejected before anything is cloned rather than adopted on top of each
-other:
+suffix — are refused rather than adopted on top of each other. The refusal belongs
+to the repository that raised it: each one claims its checkout directory inside its
+own adoption, so the second is recorded as *its* failure and the repositories
+around it are still adopted, rather than the whole batch aborting before its first
+clone:
 
 ```bash
 mvn -pl adopt exec:java \
@@ -931,6 +934,13 @@ single-repository run writes unwrapped:
 }
 ```
 
+`--assets` commits a set of starter Claude Code configuration files alongside the
+generated `CLAUDE.md`: an `AGENTS.md` pointer, a `.claude/settings.json` that
+denies reads of obvious secret files and wires a `.claude/hooks/session-start.sh`
+stub, a starter `.mcp.json`, and a GitHub Actions workflow answering `@claude`
+mentions. None of them ever overwrites a file the repository already carries, so
+the flag is safe on a project that has configured some of them already.
+
 The `claude-code-enforcer` version a Maven project's `pom.xml` is made to depend
 on defaults to the version of the `tools` build running the adoption;
 `--rule-version <version>` pins a different one. A `-SNAPSHOT` is refused either
@@ -961,14 +971,18 @@ The report is a parameter rather than a return value alone, so a run that fails
 part-way still leaves the caller holding the steps that did complete and the
 reason it stopped.
 
-`BatchAdoption` wraps that pipeline to work through a list of repositories, one
-`AdoptionContext` at a time, and answers with an `AdoptionRun` (the context and
-its report) per repository — a failing repository is recorded rather than
-allowed to abandon the rest:
+`BatchAdoption` wraps that pipeline to work through a list of repository URLs,
+handing each to a `Checkouts` that gives it its own directory under the run's
+shared workspace, and answers with an `AdoptionRun` (the redacted URL, the branch,
+and the report) per repository — a failing repository is recorded rather than
+allowed to abandon the rest. The context is claimed inside each repository's own
+adoption rather than for the whole run up front, so a URL that names no repository
+is that repository's recorded failure too:
 
 ```java
 GitHubRepoAdopter adopter = GitHubRepoAdopter.withDefaultPipeline(runner, AdoptionOptions.defaults());
-List<AdoptionRun> runs = new BatchAdoption(adopter::adopt).adoptAll(contexts);
+Checkouts checkouts = new Checkouts(workspace, AdoptionContext.DEFAULT_BRANCH);
+List<AdoptionRun> runs = new BatchAdoption(adopter::adopt).adoptAll(repositoryUrls, checkouts);
 ```
 
 The default pipeline runs these steps in order:
@@ -1009,9 +1023,21 @@ The default pipeline runs these steps in order:
    (`claude -p /init` by default; the invocation is configurable because the
    flags differ between environments) so it generates a `CLAUDE.md`, aborting if
    the file did not appear.
-7. **`CommitStep`** — commits the generated `CLAUDE.md` (`Adopt Claude Code: add
-   CLAUDE.md`).
-8. **`EnforcerStep`** — detects the checkout's build system and wires the
+7. **`ClaudeMdConformanceStep`** — reshapes that generated file so it satisfies
+   the `claudeMdFormat` rule the next step is about to wire in, and writes the
+   companion `AGENTS.md` the rule's reference has to resolve to. Without it the
+   adoption fails its own `VerifyStep`: a generic `claude init` writes natural,
+   project-specific headings and no `AGENTS.md` reference, while the rule demands
+   a fixed set of whole-line headings plus that reference. The reshape is
+   deterministic and conservative — a near-miss heading is *renamed in place* so
+   its body survives, only a genuinely absent section is appended, a required
+   section left empty gets a stub body because the rule fails an empty section
+   just as it fails a missing one, and fenced code and commented-out text are left
+   alone, mirroring how the rule matches. Reshaping an already-conforming document
+   is a no-op, so a re-adoption leaves the file untouched.
+8. **`CommitStep`** — commits the generated `CLAUDE.md` and its companion
+   (`Adopt Claude Code: add CLAUDE.md`), reported as `commit:claude-md`.
+9. **`EnforcerStep`** — detects the checkout's build system and wires the
    `CLAUDE.md` guard into it. A Maven project has the `claude-code-enforcer` added
    to its root `pom.xml` via `PomEnforcerInstaller` (the edit is done on the JDK's
    DOM — no third-party XML library — is namespace-aware, and is idempotent); a
@@ -1032,18 +1058,22 @@ The default pipeline runs these steps in order:
    the edited DOM out whole would normalise details a DOM does not record,
    collapsing a start tag spread over several lines and rewriting `<rule />` as
    `<rule/>`, turning a fourteen-line addition into a diff across the file.
-9. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
-   build`).
-10. **`VerifyStep`** — runs the detected build system's verification (a
+10. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
+   build`), reported as `commit:guard`.
+11. **`AssetsStep` → `CommitStep`** — *only on `--assets`* (`assets` on the MCP
+   tool): installs the starter configuration files described above and commits
+   them (`commit:assets`). Each asset is installed independently and never
+   overwrites an existing file, so the pair is idempotent.
+12. **`VerifyStep`** — runs the detected build system's verification (a
    non-recursive `mvn -N validate` for Maven, the `enforceClaudeMd` task for
    Gradle, the `.github/claude-md-guard.sh` script for the fallback) so the
    freshly wired guard actually executes against the generated `CLAUDE.md`,
    failing the adoption locally if the file is missing or malformed rather than
    after the pull request lands.
-11. **`PushStep`** — pushes the feature branch to origin and sets its upstream
+13. **`PushStep`** — pushes the feature branch to origin and sets its upstream
     (`git push -u origin <branch>`). Left out of a `--dry-run` pipeline, together
     with the step below it.
-12. **`PullRequestStep`** — opens a pull request from the branch with
+14. **`PullRequestStep`** — opens a pull request from the branch with
    `gh pr create`, targeting the repository's default branch as the base. The
    pull request metadata is supplied through `PullRequestOptions` — title, body,
    and optional reviewers, labels, and assignees to request, plus whether to open

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -85,16 +85,16 @@ public class GitHubRepoAdopter {
 				new TrustStep(),
 				new ClaudeInitStep(),
 				new ClaudeMdConformanceStep(),
-				new CommitStep("Adopt Claude Code: add CLAUDE.md"),
+				new CommitStep("Adopt Claude Code: add CLAUDE.md", "claude-md"),
 				new EnforcerStep(buildSystems),
-				new CommitStep("Add claude-code-enforcer to the build"));
+				new CommitStep("Add claude-code-enforcer to the build", "guard"));
 	}
 
 	private static List<AdoptionStep> assetSteps(AdoptionOptions options) {
 		if (!options.includeAssets()) {
 			return List.of();
 		}
-		return List.of(new AssetsStep(), new CommitStep("Add Claude Code configuration assets"));
+		return List.of(new AssetsStep(), new CommitStep("Add Claude Code configuration assets", "assets"));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/BoundedTranscript.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/BoundedTranscript.java
@@ -1,0 +1,147 @@
+package io.github.adamw7.tools.adopt.command;
+
+/**
+ * A command's captured output, bounded so a talkative child cannot cost the
+ * adoption unbounded memory. The beginning and the end are kept and the middle is
+ * dropped, because that is where a command says what it was asked to do and how it
+ * went: the invocation and its first errors are at the top, the failure that
+ * stopped it at the bottom, and the thousands of progress lines between them are
+ * what a transcript grows by.
+ *
+ * <p>Bounding it here rather than at the caller matters because the transcript does
+ * not stop at the log. {@link io.github.adamw7.tools.adopt.step.AbstractCommandStep}
+ * puts a failing command's whole output into the {@link
+ * io.github.adamw7.tools.adopt.AdoptionException} it raises, which becomes the
+ * {@code failure} field of the JSON report written to disk and answered to MCP
+ * clients — so an unbounded transcript is an unbounded response, held in memory for
+ * as long as the command's timeout allows.
+ *
+ * <p>A transcript that fits is answered verbatim, byte for byte, so the common case
+ * keeps the child's own line terminators and its trailing newline. Only one that
+ * overflowed is cut, and then <em>only at line boundaries</em>: a clone URL's
+ * credentials are masked by {@link io.github.adamw7.tools.adopt.Redaction} matching
+ * the user information that follows a {@code ://}, so a cut through the middle of
+ * such a URL would leave the token behind with nothing left to recognise it by.
+ * Cutting whole lines cannot split one. A region carrying no line feed at all is
+ * therefore dropped whole rather than cut mid-line.
+ */
+final class BoundedTranscript {
+
+	/** Kept from the start of the output: the command's invocation and its first errors. */
+	static final int DEFAULT_HEAD_LIMIT = 64 * 1024;
+
+	/** Kept from the end of the output, at minimum: the failure that stopped the command. */
+	static final int DEFAULT_TAIL_LIMIT = 64 * 1024;
+
+	private static final char LINE_FEED = '\n';
+
+	private final int headLimit;
+	private final int tailLimit;
+
+	private final StringBuilder head = new StringBuilder();
+
+	/**
+	 * The end of the output, held as two windows that are retired whole. Sliding a
+	 * buffer of the last {@link #tailLimit} characters would shift it once per
+	 * character read; rotating a filled window costs nothing per character and keeps
+	 * between {@code tailLimit} and twice that much, which is bounded just the same.
+	 */
+	private StringBuilder previousWindow = new StringBuilder();
+	private StringBuilder currentWindow = new StringBuilder();
+
+	/** Characters retired with a window, and so no longer recoverable. */
+	private long dropped;
+
+	BoundedTranscript() {
+		this(DEFAULT_HEAD_LIMIT, DEFAULT_TAIL_LIMIT);
+	}
+
+	BoundedTranscript(int headLimit, int tailLimit) {
+		this.headLimit = requirePositive(headLimit, "headLimit");
+		this.tailLimit = requirePositive(tailLimit, "tailLimit");
+	}
+
+	/**
+	 * Appends the first {@code length} characters of {@code buffer}. Synchronized
+	 * because the reader thread appends while {@link #text()} may already be reading:
+	 * {@link StreamGobbler} bounds its wait for that thread, so a descendant holding
+	 * the pipe open leaves the two genuinely concurrent.
+	 */
+	synchronized void append(char[] buffer, int length) {
+		int intoHead = Math.min(headLimit - head.length(), length);
+		head.append(buffer, 0, intoHead);
+		appendToTail(buffer, intoHead, length - intoHead);
+	}
+
+	/** @return everything captured, or the kept regions and a count of what was dropped */
+	synchronized String text() {
+		String tail = previousWindow.toString() + currentWindow;
+		return dropped == 0 ? head + tail : elided(tail);
+	}
+
+	/**
+	 * A run at least as long as the whole tail makes both windows redundant — its own
+	 * last {@link #tailLimit} characters are the end of the output — so it replaces
+	 * them rather than being appended to one. Without that, a caller reading the
+	 * stream in one go would land the entire output in a single window, and the
+	 * rotation below would never have anything to drop.
+	 */
+	private void appendToTail(char[] buffer, int offset, int length) {
+		if (length >= tailLimit) {
+			replaceWindows(buffer, offset, length);
+		} else {
+			currentWindow.append(buffer, offset, length);
+			rotateWhenFull();
+		}
+	}
+
+	private void replaceWindows(char[] buffer, int offset, int length) {
+		dropped += previousWindow.length() + currentWindow.length() + (length - tailLimit);
+		previousWindow = new StringBuilder();
+		currentWindow = new StringBuilder().append(buffer, offset + length - tailLimit, tailLimit);
+	}
+
+	private void rotateWhenFull() {
+		if (currentWindow.length() < tailLimit) {
+			return;
+		}
+		dropped += previousWindow.length();
+		previousWindow = currentWindow;
+		currentWindow = new StringBuilder();
+	}
+
+	/**
+	 * Both kept regions are cut back to a line boundary before they are joined, so
+	 * neither ends nor begins mid-line. The count names every character left out —
+	 * the ones dropped as the output arrived, and the partial lines trimmed here.
+	 */
+	private String elided(String tail) {
+		String keptHead = throughLastLine(head.toString());
+		String keptTail = fromFirstLine(tail);
+		long omitted = dropped + (head.length() - keptHead.length()) + (tail.length() - keptTail.length());
+		return keptHead + elision(omitted) + keptTail;
+	}
+
+	/** @return the text up to and including its last line feed, or empty when it carries none */
+	private static String throughLastLine(String text) {
+		int lastLineFeed = text.lastIndexOf(LINE_FEED);
+		return lastLineFeed < 0 ? "" : text.substring(0, lastLineFeed + 1);
+	}
+
+	/** @return the text after its first line feed, or empty when it carries none */
+	private static String fromFirstLine(String text) {
+		int firstLineFeed = text.indexOf(LINE_FEED);
+		return firstLineFeed < 0 ? "" : text.substring(firstLineFeed + 1);
+	}
+
+	private static String elision(long omitted) {
+		return "[... " + omitted + " characters of output omitted ...]" + System.lineSeparator();
+	}
+
+	private static int requirePositive(int limit, String field) {
+		if (limit <= 0) {
+			throw new IllegalArgumentException(field + " must be positive but was " + limit);
+		}
+		return limit;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/StreamGobbler.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
@@ -19,9 +18,12 @@ import org.apache.logging.log4j.Logger;
  * still recovered.
  *
  * <p>The stream is copied verbatim, so the transcript keeps the child's own line
- * terminators rather than a re-joined approximation. {@link #output()} bounds its
- * wait for the reader thread, because a descendant the child spawned can keep the
- * pipe open after the child itself has exited.
+ * terminators rather than a re-joined approximation — up to the bound
+ * {@link BoundedTranscript} holds it to, past which the middle of a very long
+ * transcript is dropped rather than the adoption growing with whatever the child
+ * chose to print. {@link #output()} bounds its wait for the reader thread, because
+ * a descendant the child spawned can keep the pipe open after the child itself has
+ * exited.
  */
 final class StreamGobbler {
 
@@ -34,10 +36,13 @@ final class StreamGobbler {
 	 */
 	static final Duration JOIN_TIMEOUT = Duration.ofSeconds(5);
 
+	/** How much is read from the stream at a time, before being appended to the transcript. */
+	private static final int BUFFER_SIZE = 8 * 1024;
+
 	private final Thread thread;
 
-	/** Written by the reader thread and read by {@link #output()}, so its buffer must be synchronized. */
-	private final StringWriter output = new StringWriter();
+	/** Written by the reader thread and read by {@link #output()}, so its appends are synchronized. */
+	private final BoundedTranscript output = new BoundedTranscript();
 
 	private StreamGobbler(InputStream stream) {
 		this.thread = new Thread(() -> drain(stream), "adopt-stream-gobbler");
@@ -58,7 +63,7 @@ final class StreamGobbler {
 	 */
 	String output() {
 		join();
-		return output.toString();
+		return output.text();
 	}
 
 	private void join() {
@@ -79,9 +84,23 @@ final class StreamGobbler {
 	 */
 	private void drain(InputStream stream) {
 		try (Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
-			reader.transferTo(output);
+			transfer(reader);
 		} catch (IOException e) {
 			log.debug("Stopped reading the command's output before end-of-stream", e);
+		}
+	}
+
+	/**
+	 * Reads in fixed chunks rather than with {@link Reader#transferTo}, which would
+	 * need a {@link java.io.Writer} to append to and so give up the bound
+	 * {@link BoundedTranscript} exists to keep.
+	 */
+	private void transfer(Reader reader) throws IOException {
+		char[] buffer = new char[BUFFER_SIZE];
+		int read = reader.read(buffer);
+		while (read >= 0) {
+			output.append(buffer, read);
+			read = reader.read(buffer);
 		}
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
@@ -85,7 +85,9 @@ This creates an executable JAR in `adopt/target/tools.adopt-{version}.jar`.
   command may run before it is killed. Defaults to 10, and is bounded to a day —
   this server is long-lived, so a command it could never reclaim is refused
 
-**Returns** a JSON report:
+**Returns** a JSON report. Each commit the adoption makes is named for what it
+commits (`commit:claude-md`, `commit:guard`, `commit:assets`), so a run that
+stopped part-way says which of them landed:
 
 ```json
 {
@@ -95,8 +97,8 @@ This creates an executable JAR in `adopt/target/tools.adopt-{version}.jar`.
   "succeeded" : true,
   "failure" : null,
   "completedSteps" : [ "toolchain", "clone", "build-toolchain", "branch", "trust",
-    "claude-init", "conform", "commit", "enforcer", "commit", "verify", "push",
-    "pull-request" ]
+    "claude-init", "conform", "commit:claude-md", "enforcer", "commit:guard",
+    "verify", "push", "pull-request" ]
 }
 ```
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.Text;
 import io.github.adamw7.tools.adopt.command.CommandLine;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
@@ -22,6 +23,12 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * aborts with "Author identity unknown". Each missing identity is supplied for the
  * commit alone with a {@code -c} override, so an identity the checkout already
  * configures stays in force.
+ *
+ * <p>The pipeline runs this step two or three times, so each one is qualified with
+ * what it commits. A report whose {@code completedSteps} read {@code commit} three
+ * times said only how far the run got by counting; qualified, it says which of the
+ * adoption's commits landed — the reading that matters for a run that stopped
+ * part-way, which is the only kind of report anyone reads closely.
  */
 public class CommitStep extends AbstractCommandStep {
 
@@ -30,15 +37,30 @@ public class CommitStep extends AbstractCommandStep {
 	static final String FALLBACK_NAME = "Claude Code Adopt";
 	static final String FALLBACK_EMAIL = "claude-code-adopt@users.noreply.github.com";
 
-	private final String message;
+	/** The step name an unqualified commit reports, and the prefix a qualified one carries. */
+	static final String NAME = "commit";
 
+	private final String message;
+	private final String name;
+
+	/** A commit that reports itself as the bare {@value #NAME}. */
 	public CommitStep(String message) {
+		this(message, null);
+	}
+
+	/**
+	 * @param message   the commit message
+	 * @param qualifier what this commit is for, reported as {@code commit:<qualifier>};
+	 *                  blank or {@code null} for a commit that names only itself
+	 */
+	public CommitStep(String message, String qualifier) {
 		this.message = message;
+		this.name = Text.isPresent(qualifier) ? NAME + ":" + qualifier.strip() : NAME;
 	}
 
 	@Override
 	public String name() {
-		return "commit";
+		return name;
 	}
 
 	@Override

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -144,14 +144,15 @@ class GitHubRepoAdopterTest {
 	@Test
 	void defaultPipelineBranchesCommitsPushesAndOpensAPullRequest() {
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
-				"commit", "enforcer", "commit", "verify", "push", "pull-request"),
+				"commit:claude-md", "enforcer", "commit:guard", "verify", "push", "pull-request"),
 				stepNames(AdoptionOptions.defaults()));
 	}
 
 	@Test
 	void defaultPipelineWithAssetsInstallsAndCommitsThemBeforeVerification() {
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
-				"commit", "enforcer", "commit", "assets", "commit", "verify", "push", "pull-request"),
+				"commit:claude-md", "enforcer", "commit:guard", "assets", "commit:assets", "verify", "push",
+				"pull-request"),
 				stepNames(withAssets()));
 	}
 
@@ -164,14 +165,15 @@ class GitHubRepoAdopterTest {
 	@Test
 	void aDryRunPipelineStopsAtTheVerification() {
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
-				"commit", "enforcer", "commit", "verify"), stepNames(dryRun()));
+				"commit:claude-md", "enforcer", "commit:guard", "verify"), stepNames(dryRun()));
 	}
 
 	@Test
 	void aDryRunPipelineStillInstallsTheAssetsWhenAskedFor() {
 		AdoptionOptions options = new AdoptionOptions(PullRequestOptions.defaults(), true, null, true, null);
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
-				"commit", "enforcer", "commit", "assets", "commit", "verify"), stepNames(options));
+				"commit:claude-md", "enforcer", "commit:guard", "assets", "commit:assets", "verify"),
+				stepNames(options));
 	}
 
 	private List<String> stepNames(AdoptionOptions options) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/BoundedTranscriptTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/BoundedTranscriptTest.java
@@ -1,0 +1,154 @@
+package io.github.adamw7.tools.adopt.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.Redaction;
+
+class BoundedTranscriptTest {
+
+	private static final String CREDENTIALLED_URL = "https://x-access-token:SECRET@github.com/owner/repo.git";
+
+	@Test
+	void returnsEmptyWhenNothingWasAppended() {
+		assertEquals("", new BoundedTranscript().text());
+	}
+
+	/**
+	 * The common case must stay byte-for-byte what the child printed, terminators and
+	 * trailing newline included: a transcript that fits is not a transcript that was
+	 * reassembled.
+	 */
+	@Test
+	void returnsShortOutputVerbatim() {
+		String text = "first\r\nsecond\nthird\n";
+		assertEquals(text, transcriptOf(new BoundedTranscript(), text));
+	}
+
+	@Test
+	void keepsAppendingAcrossSeveralChunks() {
+		BoundedTranscript transcript = new BoundedTranscript();
+		append(transcript, "first\n");
+		append(transcript, "second\n");
+		assertEquals("first\nsecond\n", transcript.text());
+	}
+
+	/**
+	 * The bound has to hold however the stream is read: a caller appending the whole
+	 * output at once must be cut just as one appending it chunk by chunk is.
+	 */
+	@Test
+	void keepsTheBeginningAndTheEndWhenTheOutputArrivesInChunks() {
+		BoundedTranscript transcript = new BoundedTranscript(16, 16);
+		append(transcript, "head\n");
+		appendRepeatedly(transcript, "filler\n", 4000);
+		append(transcript, "tail\n");
+
+		String text = transcript.text();
+		assertTrue(text.startsWith("head\n"), text);
+		assertTrue(text.endsWith("tail\n"), text);
+		assertTrue(text.contains("characters of output omitted"), text);
+	}
+
+	@Test
+	void keepsTheBeginningAndTheEndOfAnOverflowingTranscript() {
+		String text = transcriptOf(new BoundedTranscript(16, 16), "head\n" + filler(4000) + "tail\n");
+
+		assertTrue(text.startsWith("head\n"), text);
+		assertTrue(text.endsWith("tail\n"), text);
+	}
+
+	@Test
+	void namesHowMuchWasOmitted() {
+		String input = "head\n" + filler(4000) + "tail\n";
+		String text = transcriptOf(new BoundedTranscript(16, 16), input);
+
+		assertTrue(text.contains("characters of output omitted"), text);
+		assertTrue(text.length() < input.length() / 10, "the middle must not survive: kept " + text.length());
+	}
+
+	/**
+	 * The bound is what makes the transcript safe to carry into an exception message
+	 * and from there into the JSON report, so it has to hold for output far larger
+	 * than the limits rather than merely for output a little over them.
+	 */
+	@Test
+	void boundsTheTextItKeepsWhateverTheChildPrints() {
+		BoundedTranscript transcript = new BoundedTranscript(1024, 1024);
+		appendRepeatedly(transcript, "a line of noise from a very talkative command\n", 40_000);
+
+		int kept = transcript.text().length();
+		assertTrue(kept < 1024 + 2 * 1024 + 256, "the head, both tail windows, and the marker, but no more: " + kept);
+	}
+
+	/**
+	 * Credentials are masked by {@link Redaction} recognising the user information
+	 * that follows a {@code ://}, so a cut through the middle of a clone URL would
+	 * strand the token with nothing left to recognise it by. Cutting whole lines is
+	 * what keeps that from happening — here the head limit falls inside the token
+	 * itself.
+	 */
+	@Test
+	void neverCutsThroughACredentialledUrl() {
+		int insideTheToken = "keep\n".length() + "https://x-access-token:SEC".length();
+		String text = transcriptOf(new BoundedTranscript(insideTheToken, 16),
+				"keep\n" + CREDENTIALLED_URL + "\n" + filler(4000) + "tail\n");
+
+		assertFalse(text.contains("SECRET"), text);
+		assertFalse(text.contains("github.com"), text);
+		assertTrue(text.startsWith("keep\n"), text);
+	}
+
+	/** A transcript that fits is untouched, so the caller's redaction still has a whole URL to mask. */
+	@Test
+	void leavesAnIntactUrlForTheCallerToRedact() {
+		String text = transcriptOf(new BoundedTranscript(), "fatal: could not read Username for '"
+				+ CREDENTIALLED_URL + "'\n");
+
+		assertTrue(text.contains("SECRET"), text);
+		assertEquals("fatal: could not read Username for 'https://***@github.com/owner/repo.git'\n",
+				Redaction.of(text));
+	}
+
+	/**
+	 * A region carrying no line feed cannot be cut at one, so it is dropped whole
+	 * rather than trimmed mid-line — the one reading that cannot split a URL.
+	 */
+	@Test
+	void dropsAKeptRegionThatCarriesNoLineFeed() {
+		String text = transcriptOf(new BoundedTranscript(16, 16), "a".repeat(4000));
+
+		assertFalse(text.contains("aaa"), text);
+		assertTrue(text.contains("characters of output omitted"), text);
+	}
+
+	@Test
+	void rejectsNonPositiveLimits() {
+		assertThrows(IllegalArgumentException.class, () -> new BoundedTranscript(0, 16));
+		assertThrows(IllegalArgumentException.class, () -> new BoundedTranscript(16, -1));
+	}
+
+	private static String transcriptOf(BoundedTranscript transcript, String text) {
+		append(transcript, text);
+		return transcript.text();
+	}
+
+	private static void append(BoundedTranscript transcript, String text) {
+		transcript.append(text.toCharArray(), text.length());
+	}
+
+	private static void appendRepeatedly(BoundedTranscript transcript, String line, int times) {
+		char[] buffer = line.toCharArray();
+		for (int written = 0; written < times; written++) {
+			transcript.append(buffer, buffer.length);
+		}
+	}
+
+	private static String filler(int lines) {
+		return ("filler\n").repeat(lines);
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
@@ -55,6 +56,33 @@ class CommitStepTest {
 	void commitFailureAborts() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::genuineCommitFailure);
 		assertThrows(AdoptionException.class, () -> new CommitStep("msg").execute(context, runner));
+	}
+
+	@Test
+	void reportsTheBareNameWhenUnqualified() {
+		assertEquals("commit", new CommitStep("msg").name());
+		assertEquals("commit", new CommitStep("msg", " ").name());
+		assertEquals("commit", new CommitStep("msg", null).name());
+	}
+
+	/**
+	 * The pipeline runs this step two or three times, so a report's
+	 * {@code completedSteps} has to say which of the adoption's commits landed rather
+	 * than repeating one name.
+	 */
+	@Test
+	void qualifiesTheStepNameWithWhatItCommits() {
+		assertEquals("commit:claude-md", new CommitStep("msg", "claude-md").name());
+		assertEquals("commit:guard", new CommitStep("msg", "  guard  ").name());
+	}
+
+	/** The qualified name is what a failing commit reports, so the failure names the same step. */
+	@Test
+	void namesTheQualifiedStepInAFailure() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::genuineCommitFailure);
+		AdoptionException failure = assertThrows(AdoptionException.class,
+				() -> new CommitStep("msg", "guard").execute(context, runner));
+		assertTrue(failure.getMessage().startsWith("commit:guard failed"), failure.getMessage());
 	}
 
 	private CommandResult stagedChanges(List<String> command) {


### PR DESCRIPTION
Three findings from a review of the adopt module.

A command's merged transcript was accumulated whole in a StringWriter, and
AbstractCommandStep puts a failing command's entire output into the
AdoptionException it raises — which becomes the `failure` field of the JSON
report written to disk and answered to MCP clients. A talkative child therefore
cost unbounded memory and an unbounded response, held for as long as its timeout
allowed. BoundedTranscript keeps the start and the end and drops the middle,
cutting only at line boundaries so Redaction can never be defeated by a clone
URL split across the cut. A transcript that fits is still answered verbatim.

CommitStep runs two or three times per pipeline and reported "commit" each time,
so a report that stopped part-way could not say which of the adoption's commits
had landed. Each is now qualified: commit:claude-md, commit:guard, commit:assets.

README.md had drifted from the code: the BatchAdoption example used the old
adoptAll(contexts) signature, AdoptionRun was described as carrying the context,
a colliding checkout was said to be rejected before anything is cloned (it is
now that repository's own recorded failure), and the numbered pipeline omitted
ClaudeMdConformanceStep and AssetsStep — with --assets undocumented entirely,
though AGENTS.md, CLAUDE.md and MCP_USAGE.md all covered it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GtRzkQfsB8nd5mSKh9FCk2