### PR TITLE
docs: record that -T1.5C does not beat the -T1C build default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,6 +328,18 @@ well beyond its ~0.7s dedicated-core cost (measured up to ~3.9s), which is why
 the per-test timeout is sized at 5 s rather than a tighter bound — see *Testing,
 coverage & mutation testing*. Override with `-T1` for a fully serial build.
 
+**Do not raise the thread count above `-T1C`.** Oversubscribing was measured and
+does not pay: on a 4-core machine, 10 alternating `mvn -B clean package` runs per
+setting put `-T1C` at a 50.8 s median and `-T1.5C` (6 threads) at 51.5 s, with
+`-T1C` faster in 58 of 100 pairwise comparisons. Every module got individually
+slower under the extra threads — `data` 32.3 s → 35.6 s, `protogen-maven-plugin`
+34.5 s → 37.6 s, `adopt` 25.0 s → 30.3 s — and the wider overlap only just
+cancelled that out. Two things cap the gain: the reactor already sums ~161 s of
+module work into ~50 s of wall clock (3.2x on 4 cores, near saturation), and the
+critical path is pinned by a single ~35 s module, which no thread count shortens.
+The extra contention also eats into the margin the 5 s per-test timeout is sized
+against, so a higher count buys flaky tests rather than speed.
+
 **Shellcheck.** The root pom lints `scripts/**/*.sh` with
 `dev.dimlight:shellcheck-maven-plugin` (`check` goal). It is configured with
 `<binaryResolutionMethod>embedded</binaryResolutionMethod>`, so the `shellcheck`


### PR DESCRIPTION
Benchmarked whether raising the reactor thread count above the `-T1C` in `.mvn/maven.config` speeds the build up. It does not, so this PR records the measurement in AGENTS.md rather than changing the setting.

## Method

4-core machine, JDK 25, Maven 3.9.11. Local repo warmed first, then `mvn -B clean package` (full build with tests) run **10 times per setting, alternating A/B** to cancel out drift. `-T1C` = 4 threads, `-T1.5C` = 6; the CLI `-T` was verified to override the value in `.mvn/maven.config`. All 20 runs exited 0.

## Results

|         | n  | mean   | median    | min    | max    | sd    |
| ------- | -- | ------ | --------- | ------ | ------ | ----- |
| `-T1C`   | 10 | 52.8 s | **50.8 s** | 49.3 s | 60.0 s | 3.5 s |
| `-T1.5C` | 10 | 52.3 s | 51.5 s    | 50.3 s | 55.7 s | 1.8 s |

`-T1.5C` holds a 0.5 s (1%) edge on the mean, but that comes entirely from three cold-start outliers in the `-T1C` samples. On the median `-T1C` wins by 0.7 s, and it is faster in **58 of 100** pairwise comparisons.

Per-module wall times were uniformly worse under the extra threads (same run number):

| module                  | `-T1C`   | `-T1.5C` |
| ----------------------- | ------- | ------- |
| `data`                    | 32.3 s  | 35.6 s  |
| `protogen-maven-plugin`   | 34.5 s  | 37.6 s  |
| `adopt`                   | 25.0 s  | 30.3 s  |

Two things cap the gain: the reactor already sums ~161 s of module work into ~50 s of wall clock (3.2x on 4 cores, near saturation), and the critical path is pinned by a single ~35 s module that no thread count shortens. The added contention also eats into the margin the 5 s per-test surefire timeout is sized against, so a higher count buys flaky tests rather than speed.

## Changes

- `AGENTS.md` — one paragraph in the parallel-builds section of *Build, test, and run*, next to the existing `-T1C` description.

No build or configuration files are touched; `.mvn/maven.config` keeps `-T1C`.

## Verification

`mvn -B -N validate -DenforceClaudeMd` passes — all 19 doc rules green, including `contextBudget` and `crossDocConsistency`.

## Caveat

Measured on a 4-core machine, where `1C` → `1.5C` is 4 → 6 threads; GitHub's runners have a different core count. The build finishes in ~50 s locally under either setting, against CI's 120 s cap.

---
_Generated by [Claude Code](https://claude.ai/code/session_0174eWu76LdQvSWWewhnZLdm)_