### PR TITLE
test(adopt,claude-code-enforcer): pin more architecture rules with ArchUnit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -445,7 +445,38 @@ longer and carry no timeout.
   `BuildSystem`, `*CommandRunner` to `CommandRunner`, `*Tool` to `McpTool`); the
   only public `static void main` methods are the two `Main` entry points the pom
   names; and no public method declares a checked `IOException`, since the
-  pipeline reports failure with the unchecked `AdoptionException`. A companion
+  pipeline reports failure with the unchecked `AdoptionException`. Four more keep
+  the pipeline assembled in one place and driven by its options alone:
+  `GitHubRepoAdopter` is the only class outside the `step` package that may
+  depend on an `AdoptionStep`, so the command line and the MCP tool cannot drift
+  into adopting a repository two different ways; a `BuildSystem` describes the
+  commands its build tool needs but never depends on `CommandRunner`, leaving the
+  running to the step it answers; `System.getenv` is read only in the `command`
+  package, where resolving an executable on `PATH` is the one thing a run may
+  take from its environment; and `java.util.concurrent`/`Thread` stay there too,
+  since the pipeline is sequential and only pumping a spawned process's output
+  under a timeout needs threads.
+  `EnforcerArchitectureTest` pins, beyond the layering above, what a rule *is*
+  and what it may do while a build runs. What it is: every concrete rule is a
+  public `@Named` type, because maven-enforcer resolves a configured rule through
+  the Sisu index and an unannotated one tests green and then fails the build that
+  configures it with "rule not found"; its `@Named` value is derived from its
+  class name (the simple name minus the `Rule` suffix, decapitalised), which is
+  the string the poms, CLAUDE.md and AGENTS.md all use; every rule carries that
+  suffix, and — since this module trades the `Abstract` prefix for names poms
+  configure — an abstract type here must be a rule base. What it may do: read the
+  project and nothing else. No class depends on `ProcessBuilder`, `Process` or
+  `Runtime`, so `hookCommandsValid` and `permissionsFormat` check the commands a
+  repository asked Claude Code to run without ever running one; none reaches the
+  network (`java.net.http`, `javax.net`, `URL`, `URLConnection`, `Socket`), so the
+  checks work offline and a secret scanner cannot become the leak; and the only
+  classes that write through `java.nio.file.Files` are the three a build asks for
+  — `HtmlReport`, `Baseline`, and `MarkdownText`'s front-matter fix. Two more pin
+  the seams: `..enforcer.text..` stays free of the Maven API, `javax.inject` and
+  Jackson, which is what lets a rule be tested without a Maven session, and
+  `JsonNodes` is the only class depending on `ObjectMapper`, so every JSON rule
+  reads through the one mapper configured for the comments and trailing commas
+  Claude Code's own files allow. A companion
   `TestConventionsArchitectureTest` in the same `...architecture` package
   analyses only the *test* classes (via `ImportOption.OnlyIncludeTests`) and pins
   conventions on the tests themselves: every `@Testable` method must live in a
@@ -457,7 +488,13 @@ longer and carry no timeout.
   step test drives its step through the recording `CommandRunner` rather than
   spawning a real `git`, `claude` or `gh`, and no `*IT` may depend on `PushStep`
   or `PullRequestStep` — the integration tests run against real GitHub
-  repositories, so their pipeline stops at the branch step.
+  repositories, so their pipeline stops at the branch step. In
+  `claude-code-enforcer` it pins two more, both about the one thing there that
+  cannot be fast: `ProcessBuilder` is confined to the `e2e` package, since a rule
+  is unit-tested by calling `execute()` on it, and every `@Testable` method in
+  that package must sit in an `*IT` class — forking Maven belongs to failsafe and
+  the `integration-tests` profile, not to the pull-request build and its
+  120-second budget.
 - **Shared rule libraries.** The rules above that hold for *every* module are
   declared once in the `test-common` module and imported with ArchUnit's
   `ArchTests.in(...)`, so each module's architecture test states only what is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,8 +202,12 @@ paths.
   package and enforce package layering and coding rules — data-source contracts
   must not depend on their implementations, the uniqueness core must not depend
   on its MCP adapter, JDBC stays confined to the `source.db` package, the
-  adoption spawns processes only in its `command` package and only its clone
-  step reads the credentialled clone URL, loggers are
+  adoption spawns processes only in its `command` package, only its clone step
+  reads the credentialled clone URL and only `GitHubRepoAdopter` assembles the
+  pipeline, every enforcer rule is a public `@Named` type whose configured name
+  follows its class name and which neither spawns a process, reaches the network,
+  nor writes outside the report, the baseline and the front-matter fix, loggers
+  are
   `private static final`, abstract types carry an `Abstract` prefix, public
   fields are `final`, mutable static state is `volatile`, fields are never
   `Optional`, date/time uses `java.time` (not the legacy `Date`/`Calendar` API),
@@ -213,7 +217,9 @@ paths.
   conventions on the tests themselves — test methods must sit in `*Test`/`*IT`
   classes, no `@Disabled`, JUnit 5 only, no `System.out`/`err`, and no
   `Thread.sleep`; in `adopt` it also pins that step tests never spawn a real
-  process and the `*IT`s never push or open a pull request. The rules that apply
+  process and the `*IT`s never push or open a pull request, and in
+  `claude-code-enforcer` that only the `e2e` package forks a real Maven build,
+  and only from an `*IT`. The rules that apply
   to every module live once in `test-common` (`CommonCodingConventions`,
   `CommonNamingConventions`, `CommonTestConventions`) and are pulled in with
   `ArchTests.in(...)`, so a module's own test states only what is specific to it.

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
@@ -191,6 +191,38 @@ public class AdoptArchitectureTest {
 					+ "assembling steps is never made to translate an IOException step by step");
 
 	@ArchTest
+	static final ArchRule onlyTheAdopterAssemblesThePipeline = noClasses()
+			.that().resideOutsideOfPackage(STEP_PACKAGE)
+			.and().doNotHaveFullyQualifiedName(ADOPT_PACKAGE + ".GitHubRepoAdopter")
+			.should().dependOnClassesThat().areAssignableTo(AdoptionStep.class)
+			.because("the adopter is the single place the ordered pipeline is built, so the command line "
+					+ "and the MCP tool cannot drift into adopting a repository two different ways");
+
+	@ArchTest
+	static final ArchRule buildSystemsDescribeCommandsRatherThanRunThem = noClasses()
+			.that().areAssignableTo(BuildSystem.class)
+			.should().dependOnClassesThat().areAssignableTo(CommandRunner.class)
+			.because("a BuildSystem answers what a project's own build tool is called and how it is "
+					+ "invoked; the step it answers runs it, which is what keeps adding a build tool a "
+					+ "matter of adding a class rather than editing the steps");
+
+	@ArchTest
+	static final ArchRule onlyTheCommandPackageReadsTheEnvironment = noClasses()
+			.that().resideOutsideOfPackage(COMMAND_PACKAGE)
+			.should().callMethod(System.class, "getenv")
+			.orShould().callMethod(System.class, "getenv", String.class)
+			.because("a run is driven by the options it was given, not by the ambient environment; the one "
+					+ "exception is resolving an executable on PATH, which lives behind the command runner");
+
+	@ArchTest
+	static final ArchRule onlyTheCommandPackageNeedsConcurrency = noClasses()
+			.that().resideOutsideOfPackage(COMMAND_PACKAGE)
+			.should().dependOnClassesThat().resideInAPackage("java.util.concurrent..")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.Thread")
+			.because("the adoption is a sequential pipeline whose steps depend on the one before; only "
+					+ "spawning a process needs threads, to pump its output while a timeout runs");
+
+	@ArchTest
 	static final ArchRule packagesAreFreeOfCycles = slices()
 			.matching("io.github.adamw7.tools.adopt.(*)..")
 			.should().beFreeOfCycles();

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
@@ -1,15 +1,29 @@
 package io.github.adamw7.tools.enforcer.architecture;
 
+import static com.tngtech.archunit.core.domain.JavaCall.Predicates.target;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
+import static com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With.owner;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
+import java.nio.file.Files;
+import java.util.Locale;
+
+import javax.inject.Named;
+
+import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchTests;
+import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.test.architecture.CommonCodingConventions;
@@ -19,12 +33,26 @@ import io.github.adamw7.tools.test.architecture.CommonCodingConventions;
  * package structure already follows today: {@code text} is the foundation,
  * {@code rule} builds on it, and the feature packages ({@code definition},
  * {@code doc}, {@code mcp}, {@code settings}) build on {@code rule} without
- * reaching sideways into one another. Only production classes are analysed.
+ * reaching sideways into one another. They also pin what a rule is allowed to
+ * do at build time: read the project, and nothing else — no process, no network,
+ * and no write outside the report, the baseline and the front-matter fix a rule
+ * was asked for. Only production classes are analysed.
  */
 @AnalyzeClasses(packages = EnforcerArchitectureTest.ENFORCER_PACKAGE, importOptions = ImportOption.DoNotIncludeTests.class)
 public class EnforcerArchitectureTest {
 
 	static final String ENFORCER_PACKAGE = "io.github.adamw7.tools.enforcer";
+
+	private static final String RULE_SUFFIX = "Rule";
+	private static final String TEXT_PACKAGE = "..enforcer.text..";
+	private static final String OBJECT_MAPPER = "com.fasterxml.jackson.databind.ObjectMapper";
+	private static final String JSON_NODES = ENFORCER_PACKAGE + ".rule.JsonNodes";
+	private static final String BASELINE = ENFORCER_PACKAGE + ".rule.Baseline";
+	private static final String HTML_REPORT = ENFORCER_PACKAGE + ".rule.HtmlReport";
+	private static final String MARKDOWN_TEXT = ENFORCER_PACKAGE + ".text.MarkdownText";
+	private static final String FILE_MUTATIONS =
+			"write|writeString|newBufferedWriter|newOutputStream|createFile|createDirectory|createDirectories"
+					+ "|delete|deleteIfExists|move|copy";
 
 	@ArchTest
 	static final ArchTests commonCodingConventions = ArchTests.in(CommonCodingConventions.class);
@@ -58,9 +86,120 @@ public class EnforcerArchitectureTest {
 
 	@ArchTest
 	static final ArchRule concreteRulesHonourTheContract = classes()
-			.that().haveSimpleNameEndingWith("Rule")
+			.that().haveSimpleNameEndingWith(RULE_SUFFIX)
 			.and().areNotInterfaces()
 			.and().doNotHaveModifier(JavaModifier.ABSTRACT)
 			.should().beAssignableTo(ClaudeCodeEnforcerRule.class)
 			.because("every concrete *Rule is an enforcer rule and must extend the shared base");
+
+	@ArchTest
+	static final ArchRule concreteRulesAreDiscoverable = classes()
+			.that().areAssignableTo(ClaudeCodeEnforcerRule.class)
+			.and().doNotHaveModifier(JavaModifier.ABSTRACT)
+			.should().beAnnotatedWith(Named.class)
+			.andShould().bePublic()
+			.because("maven-enforcer resolves a configured rule through the Sisu index, which only lists "
+					+ "public @Named types; an unannotated rule compiles and tests green, then fails the "
+					+ "build that configures it with 'rule not found'");
+
+	@ArchTest
+	static final ArchRule rulesCarryTheRuleSuffix = classes()
+			.that().areAssignableTo(ClaudeCodeEnforcerRule.class)
+			.should().haveSimpleNameEndingWith(RULE_SUFFIX)
+			.because("the name a pom configures is derived from the class name, so a rule that dropped the "
+					+ "suffix would be configured as something no reader could predict");
+
+	@ArchTest
+	static final ArchRule ruleNamesFollowTheClassName = classes()
+			.that().areAssignableTo(ClaudeCodeEnforcerRule.class)
+			.and().haveSimpleNameEndingWith(RULE_SUFFIX)
+			.and().doNotHaveModifier(JavaModifier.ABSTRACT)
+			.should(beNamedAfterTheirClass())
+			.because("a pom, CLAUDE.md and AGENTS.md all name a rule by its @Named value, so deriving it "
+					+ "from the class name keeps the one string a reader has to guess guessable");
+
+	@ArchTest
+	static final ArchRule abstractTypesAreNamedRule = classes()
+			.that().areNotInterfaces()
+			.and().areTopLevelClasses()
+			.and().haveModifier(JavaModifier.ABSTRACT)
+			.should().haveSimpleNameEndingWith(RULE_SUFFIX)
+			.because("this module trades the repository-wide Abstract prefix for names the poms configure, "
+					+ "so an abstract type here is a rule base; an abstract helper would need the prefix and "
+					+ "the shared naming convention back");
+
+	@ArchTest
+	static final ArchRule theTextFoundationIsFrameworkFree = noClasses()
+			.that().resideInAPackage(TEXT_PACKAGE)
+			.should().dependOnClassesThat().resideInAnyPackage("org.apache.maven..", "javax.inject..",
+					"com.fasterxml..")
+			.because("text reads and rewrites markdown for whoever asks; keeping the enforcer API, its "
+					+ "injection annotations and its JSON parser out of it is what lets a rule be tested "
+					+ "without a Maven session");
+
+	@ArchTest
+	static final ArchRule oneConfiguredJsonMapper = noClasses()
+			.that().doNotHaveFullyQualifiedName(JSON_NODES)
+			.should().dependOnClassesThat().haveFullyQualifiedName(OBJECT_MAPPER)
+			.because("JsonNodes owns the single mapper configured for the comments and trailing commas "
+					+ "Claude Code's JSON files allow; a rule that built its own would reject a file the "
+					+ "tool itself accepts");
+
+	@ArchTest
+	static final ArchRule rulesDoNotSpawnProcesses = noClasses()
+			.should().dependOnClassesThat().haveFullyQualifiedName("java.lang.ProcessBuilder")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.Process")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.Runtime")
+			.because("hookCommandsValid and permissionsFormat read commands a repository asked Claude Code "
+					+ "to run; the whole point of checking them at build time is that this module never "
+					+ "runs one");
+
+	@ArchTest
+	static final ArchRule rulesDoNotReachTheNetwork = noClasses()
+			.should().dependOnClassesThat().resideInAnyPackage("java.net.http..", "javax.net..")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.net.URL")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.net.URLConnection")
+			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.net.Socket")
+			.because("the rules scan a working copy for secrets and malformed configuration, so they must "
+					+ "stay offline: a build behind a firewall runs them, and a check that could send what "
+					+ "it reads would be the leak noSecrets exists to prevent")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule rulesDoNotWriteToTheProjectTheyCheck = noClasses()
+			.that().doNotHaveFullyQualifiedName(BASELINE)
+			.and().doNotHaveFullyQualifiedName(HTML_REPORT)
+			.and().doNotHaveFullyQualifiedName(MARKDOWN_TEXT)
+			.should().callMethodWhere(target(owner(type(Files.class))).and(target(nameMatching(FILE_MUTATIONS))))
+			.because("a check reports what it found; the three places that write are the ones a build asked "
+					+ "for — the HTML report, the recorded baseline, and the front-matter fix")
+			.allowEmptyShould(true);
+
+	/**
+	 * Holds a rule's {@code @Named} value to the name derived from its class:
+	 * the simple name without its {@code Rule} suffix, decapitalised. Rules
+	 * lacking the annotation are left to {@link #concreteRulesAreDiscoverable},
+	 * which reports the missing annotation as the real problem.
+	 */
+	private static ArchCondition<JavaClass> beNamedAfterTheirClass() {
+		return new ArchCondition<>("be named after their class") {
+
+			@Override
+			public void check(JavaClass rule, ConditionEvents events) {
+				rule.tryGetAnnotationOfType(Named.class)
+						.ifPresent(named -> events.add(matches(rule, named.value())));
+			}
+
+			private SimpleConditionEvent matches(JavaClass rule, String configuredName) {
+				String expected = nameDerivedFrom(rule.getSimpleName());
+				return new SimpleConditionEvent(rule, expected.equals(configuredName),
+						rule.getName() + " is configured as <" + configuredName + "> instead of <" + expected + ">");
+			}
+		};
+	}
+
+	private static String nameDerivedFrom(String simpleName) {
+		String withoutSuffix = simpleName.substring(0, simpleName.length() - RULE_SUFFIX.length());
+		return withoutSuffix.substring(0, 1).toLowerCase(Locale.ROOT) + withoutSuffix.substring(1);
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/TestConventionsArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/TestConventionsArchitectureTest.java
@@ -1,24 +1,49 @@
 package io.github.adamw7.tools.enforcer.architecture;
 
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchTests;
+import com.tngtech.archunit.lang.ArchRule;
 
 import io.github.adamw7.tools.test.architecture.CommonTestConventions;
 
 /**
  * Applies the shared {@link CommonTestConventions} to the enforcer module's own
  * test code, so the constraints that keep the unit suite fast and honest cannot
- * be bypassed by how a test is written. Unlike the production architecture
- * rules, this class analyses only the test classes via
- * {@link ImportOption.OnlyIncludeTests}.
+ * be bypassed by how a test is written, plus the two rules this module needs for
+ * itself: a real Maven build belongs to the {@code e2e} package, and only to an
+ * integration test there. Unlike the production architecture rules, this class
+ * analyses only the test classes via {@link ImportOption.OnlyIncludeTests}.
  */
 @AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
 public class TestConventionsArchitectureTest {
 
 	static final String TEST_PACKAGE = "io.github.adamw7.tools.enforcer";
 
+	private static final String E2E_PACKAGE = "..enforcer.e2e..";
+	private static final String TESTABLE_ANNOTATION = "org.junit.platform.commons.annotation.Testable";
+
 	@ArchTest
 	static final ArchTests commonTestConventions = ArchTests.in(CommonTestConventions.class);
+
+	@ArchTest
+	static final ArchRule onlyTheEndToEndSupportRunsARealBuild = noClasses()
+			.that().resideOutsideOfPackage(E2E_PACKAGE)
+			.should().dependOnClassesThat().haveFullyQualifiedName("java.lang.ProcessBuilder")
+			.because("a rule is unit-tested by calling execute() on it; forking Maven is what the e2e "
+					+ "package exists for, and it is the one thing here that cannot fit the 5-second "
+					+ "per-test timeout");
+
+	@ArchTest
+	static final ArchRule realBuildsRunAsIntegrationTests = methods()
+			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
+			.and().areDeclaredInClassesThat().resideInAPackage(E2E_PACKAGE)
+			.should().beDeclaredInClassesThat().haveSimpleNameEndingWith("IT")
+			.because("the e2e tests run real Maven builds, so they belong to failsafe and the "
+					+ "integration-tests profile; named *Test they would run in every pull request build "
+					+ "and blow its 120-second budget");
 }


### PR DESCRIPTION
Adopt gains four rules that keep the pipeline assembled in one place and
driven by its options alone: only GitHubRepoAdopter may depend on an
AdoptionStep outside the step package, a BuildSystem describes commands
rather than depending on CommandRunner, and both System.getenv and
java.util.concurrent/Thread stay inside the command package.

The enforcer gains rules for what a rule is — public, @Named, named after
its class, carrying the Rule suffix that this module's Abstract-prefix
exemption trades for — and for what it may do while a build runs: no
process, no network, and no Files write outside HtmlReport, Baseline and
MarkdownText's front-matter fix. Two more pin the seams: the text package
stays free of the Maven API, javax.inject and Jackson, and JsonNodes is
the only class depending on ObjectMapper.

Its test conventions confine ProcessBuilder to the e2e package and require
every @Testable method there to sit in an *IT class, so a real Maven build
never runs under surefire's 5-second timeout or the PR build's 120-second
budget.

Each new rule was verified to fail when its exemption or target is
mutated, so none passes vacuously.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014NuwrcTp2BFZG2Fd5DPrAV