### PR TITLE
build(adopt,pitest): gate the mutation score and hold the conformer to its rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":dependencyDashboard"
+  ],
+  "timezone": "UTC",
+  "schedule": [
+    "before 06:00 on monday"
+  ],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "rebaseWhen": "conflicted",
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
+  "osvVulnerabilityAlerts": false,
+  "packageRules": [
+    {
+      "description": "This project's own modules resolve inside the reactor at ${revision}; there is no released version for Renovate to raise.",
+      "matchPackageNames": [
+        "io.github.adamw7:**"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Every Maven plugin version lives in the root pom's pluginManagement, so one grouped PR is the whole change.",
+      "groupName": "maven plugins",
+      "matchPackageNames": [
+        "org.apache.maven.plugins:**",
+        "org.apache.maven.plugin-tools:**",
+        "org.codehaus.mojo:**",
+        "dev.dimlight:shellcheck-maven-plugin",
+        "io.github.ascopes:protobuf-maven-plugin",
+        "org.sonatype.central:central-publishing-maven-plugin"
+      ]
+    },
+    {
+      "description": "The quality gates move together: a JaCoCo or PIT bump changes what the coverage and pitest profiles enforce.",
+      "groupName": "coverage and mutation tooling",
+      "matchPackageNames": [
+        "org.jacoco:**",
+        "org.pitest:**"
+      ]
+    },
+    {
+      "description": "Test libraries land as one reviewable change rather than four.",
+      "groupName": "test libraries",
+      "matchPackageNames": [
+        "org.junit.jupiter:**",
+        "org.junit.platform:**",
+        "org.mockito:**",
+        "com.tngtech.archunit:**",
+        "org.jsoup:jsoup"
+      ]
+    },
+    {
+      "description": "protobuf-java and the protoc the plugin runs share one property; letting them drift apart cost two minor versions once already.",
+      "groupName": "protobuf toolchain",
+      "matchPackageNames": [
+        "com.google.protobuf:**"
+      ]
+    },
+    {
+      "description": "A Maven 4 API is wired in on purpose while the build itself is pinned to Maven 3.9.x, so a major move here is a deliberate one.",
+      "matchPackageNames": [
+        "org.apache.maven:maven-plugin-api",
+        "org.apache.maven:maven-model",
+        "org.apache.maven:maven-artifact"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "A major bump of the framework the three MCP servers boot on is a change to review on its own.",
+      "matchPackageNames": [
+        "org.springframework.boot:**"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -563,9 +563,35 @@ longer and carry no timeout.
   base 5 s), because JaCoCo's bytecode instrumentation slows first-use
   class-loading.
 - **Mutation testing** is the opt-in `pitest` profile (PIT + JUnit 5):
-  `mvn -Ppitest install` writes HTML/XML reports to `**/target/pit-reports/`. It
-  excludes `*IT` integration tests and does not fail when a class has no
-  mutations. Run it with `install` (or any phase past `package`), not with
+  `mvn -Ppitest install` writes HTML/XML reports to `**/target/pit-reports/` and
+  **fails the build** when a module's mutation score drops below its
+  `pitest.mutationThreshold`. The root pom sets the floor (**80**); a module that
+  scores well above it raises its own bar in its `<properties>`:
+
+  | Module | Threshold | Measured when set |
+  | --- | --- | --- |
+  | `code/context` | 92 | 95% |
+  | `adopt` | 88 | 91% |
+  | `claude-code-enforcer` | 88 | 91% |
+  | `code/protogen-maven-plugin` | 84 | 87% |
+  | `data` | 82 | 86% |
+  | `mcp-common` | 80 (the floor) | 84% |
+
+  Each number sits a few points under the measured score, so an equivalent
+  refactor — or a timed-out mutant, which PIT counts as killed — cannot turn a
+  green build red on its own. **Ratchet a threshold up** once a module's score
+  has settled above it; never down to make a red build pass. Two modules opt out
+  entirely with `pitest.skip` (beside the `jacoco.skip` they already set, for the
+  same reason): `grpc-example` and `code/protogen-maven-plugin-test` hold no
+  hand-written production Java, only protobuf and gRPC classes generated from
+  their `.proto` files, so PIT scored them at 14% and 10% while measuring a
+  generator's output rather than anybody's tests. The generator itself is mutated
+  in `protogen-maven-plugin`, which is where the logic under test lives.
+
+  The profile excludes `*IT` integration tests and does not fail when a class has
+  no mutations; PIT skips a module with no production code or no tests outright,
+  so a threshold never applies to one. Run it with `install` (or any phase past
+  `package`), not with
   `test`: PIT is bound to the `test` phase either way, but a `test`-only reactor
   build never packages `mcp-common`, so the `data` module's `requires
   tools.mcp.common` — an automatic module name derived from that **jar**'s file
@@ -584,7 +610,7 @@ manually, or on a release.
 | `integration-tests.yml` | daily | `mvn -P integration-tests verify` (MCP streamable-HTTP integration tests, the `adopt` multi-repository adoption against real GitHub URLs, and the enforcer's end-to-end Maven builds). |
 | `codeql.yml` | weekly (Saturdays) | CodeQL security/static analysis for Java (autobuild). |
 | `coverage.yml` | weekly (Saturdays) | `mvn verify -Pcoverage`, uploads JaCoCo reports as an artifact. |
-| `pitest.yml` | weekly (Sundays); manual | `mvn install -Ppitest`, uploads PIT mutation reports as an artifact. |
+| `pitest.yml` | weekly (Sundays); manual | `mvn install -Ppitest`, which **fails** if a module's mutation score falls below its `pitest.mutationThreshold`, and uploads PIT mutation reports as an artifact. |
 | `maven-windows.yml` | weekly (Sundays); manual | `mvn install` on a `windows-latest` runner, to catch platform-specific regressions the Linux build would miss. |
 | `docker.yml` | weekly (Saturdays); on GitHub release; manual dispatch | `mvn -B package`, then builds `assembly/Dockerfile` for `linux/amd64`, **runs** it against a sample CSV to prove `SampleApp` launches and logs, and scans it with Trivy (failing on fixable HIGH/CRITICAL findings). Only on a release does it push a `linux/amd64,linux/arm64` image to GHCR, tagged with the release version and `latest`, with SBOM and provenance. Deliberately **not** on pull requests — the image build costs minutes per review for a packaging path that changes rarely, so dispatch it by hand when touching `assembly` or the Dockerfile. |
 | `maven-publish.yml` | on GitHub release | Deploys to **GitHub Packages** (`-P github-packages`). See "Releasing". |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,8 @@ mvn -pl data -am test             # tests for a single module
 mvn -B package                    # build without installing (what CI runs)
 mvn -P integration-tests verify   # integration tests (*IT): MCP servers, real-GitHub adoption, enforcer builds
 mvn -Pcoverage verify             # JaCoCo coverage (fails under 80% instruction or branch)
-mvn -Ppitest install              # PIT mutation testing (needs a phase past package)
+mvn -Ppitest install              # PIT mutation testing (fails under the module's
+                                  # pitest.mutationThreshold; needs a phase past package)
 ```
 
 **Always pair `-pl` with `-am`.** `mvn -pl data test` fails before compiling:

--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -11,6 +11,12 @@
 	<packaging>jar</packaging>
 	<name>Claude Code repository adoption</name>
 	<description>Adopts Claude Code into a GitHub repository: clones it, runs claude init to generate CLAUDE.md, commits and pushes, then wires the claude-code-enforcer into the project build.</description>
+	<properties>
+		<!-- Mutation-score floor for this module, a few points under the 91% it
+		     measures today so an equivalent refactor cannot turn the build red.
+		     See the root pom's pitest.mutationThreshold. -->
+		<pitest.mutationThreshold>88</pitest.mutationThreshold>
+	</properties>
 	<build>
 		<resources>
 			<!-- Default resources copied verbatim: log4j2.properties carries ${...}
@@ -123,6 +129,28 @@
 		<dependency>
 			<groupId>com.tngtech.archunit</groupId>
 			<artifactId>archunit-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- Test scope only, so the pipeline stays a plain library that ships no
+		     enforcer rule: ClaudeMdConformerContractTest runs the real
+		     claudeMdFormat rule over the conformer's output, which is the only way
+		     the two can be held to the one contract they both spell out. A compile
+		     dependency would drag the maven-enforcer API into every consumer of
+		     adopt for a check that belongs to this module's tests. -->
+		<dependency>
+			<groupId>io.github.adamw7</groupId>
+			<artifactId>tools.claude-code-enforcer</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- The rule's execute() declares EnforcerRuleException, so the test that
+		     calls it needs the API on its classpath. It is managed as `provided`
+		     for the enforcer module, which maven-enforcer supplies at build time
+		     and which therefore does not travel with the rule jar; narrowed to
+		     `test` here so it stays off adopt's own compile classpath. -->
+		<dependency>
+			<groupId>org.apache.maven.enforcer</groupId>
+			<artifactId>enforcer-api</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -32,7 +32,13 @@ public class ClaudeMdConformer {
 	 * claude-code-enforcer module: the title, the AGENTS.md reference, and the
 	 * required section headings the wired-in claudeMdFormat rule checks for. They
 	 * are duplicated here rather than imported because the adopt module does not
-	 * depend on the enforcer module; keep the two in sync.
+	 * depend on the enforcer module — a pipeline that shipped an enforcer rule
+	 * would force the maven-enforcer API on every consumer.
+	 *
+	 * The copy is not trusted to stay in step: ClaudeMdConformerContractTest runs
+	 * the real rule over this class's output, on a test-scoped dependency, so a
+	 * rule that asks for one more section fails this module's build rather than
+	 * some adopted repository's.
 	 */
 	static final String TITLE = "# CLAUDE.md";
 	static final String AGENTS_REFERENCE = "AGENTS.md";
@@ -304,8 +310,9 @@ public class ClaudeMdConformer {
 	 * delimiter, such as the {@code java} of {@code ```java}.
 	 *
 	 * <p>This mirrors {@code MarkdownDocument} in the {@code claude-code-enforcer}
-	 * module, the reader the wired-in {@code claudeMdFormat} rule uses; keep the two
-	 * in sync, as with {@link #REQUIRED_SECTIONS}. Reading fences any more loosely
+	 * module, the reader the wired-in {@code claudeMdFormat} rule uses, and is held
+	 * to it by the same contract test as {@link #REQUIRED_SECTIONS}. Reading fences
+	 * any more loosely
 	 * than the rule does makes the reshape act on lines the rule holds to be code: a
 	 * {@code ## Testing} inside a code sample was taken for the section the document
 	 * already had, so the real one was never appended and the adoption failed its own

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
@@ -1,0 +1,283 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.doc.ClaudeMdFormatRule;
+
+/**
+ * Holds {@link ClaudeMdConformer} to the rule it exists to satisfy, by running
+ * the real {@code claudeMdFormat} rule over its output instead of a copy of what
+ * that rule is believed to want.
+ * <p>
+ * The conformer spells out the contract a second time — the title, the
+ * {@code AGENTS.md} reference, the required sections, and the fence and comment
+ * reading that decides which of them count. It has to, because the pipeline is a
+ * plain library that must not ship an enforcer rule, so the constants cannot be
+ * imported. What it must not do is drift: a rule that asks for one more section,
+ * or reads a fence one notch differently, turns every adoption into a run that
+ * conforms a document its own {@link VerifyStep} then rejects — on someone else's
+ * repository, after the branch has been pushed.
+ * <p>
+ * Each case first asserts the raw fixture is rejected, so a conformer that
+ * quietly stopped reshaping could not pass this test by doing nothing.
+ *
+ * @see ClaudeMdFormatRule#validating(java.io.File)
+ */
+class ClaudeMdConformerContractTest {
+
+	private final ClaudeMdConformer conformer = new ClaudeMdConformer();
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void renamesNearMissHeadingsIntoOnesTheRuleAccepts() {
+		String generated = """
+				# CLAUDE.md
+
+				## Project purpose
+
+				A security playground.
+
+				## Java version
+
+				Java 25.
+
+				## Maven module structure
+
+				Root pom is packaging=pom.
+
+				## Principles for Java development
+
+				SOLID.
+
+				## Testing
+
+				JUnit 5.
+
+				## Dependencies
+
+				Existing only.
+				""";
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformer.conform(generated));
+	}
+
+	@Test
+	void appendsTheSectionsAGeneratedDocumentNeverHad() {
+		String generated = """
+				# CLAUDE.md
+
+				## Overview
+
+				A small command line utility.
+
+				## Build
+
+				Run `mvn install`.
+				""";
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformer.conform(generated));
+	}
+
+	@Test
+	void conformsADocumentThatIsNothingButATitle() {
+		String generated = "# my-project\n";
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformer.conform(generated));
+	}
+
+	/**
+	 * Both readers hold a heading inside a fence to be code, so the section is
+	 * absent for the rule and has to be appended rather than counted.
+	 */
+	@Test
+	void appendsASectionThatAppearsOnlyInsideACodeFence() {
+		String generated = """
+				# CLAUDE.md
+
+				See [AGENTS.md](AGENTS.md) for the full guide.
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Run `mvn install`.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Dependencies
+
+				Existing only.
+
+				A section skeleton looks like this:
+
+				```markdown
+				## Testing
+
+				Write unit tests for all new logic.
+				```
+				""";
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformer.conform(generated));
+	}
+
+	/** A section removed with an HTML comment is gone for both readers alike. */
+	@Test
+	void appendsASectionThatWasCommentedOut() {
+		String generated = """
+				# CLAUDE.md
+
+				See [AGENTS.md](AGENTS.md) for the full guide.
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Run `mvn install`.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				<!--
+				## Testing
+
+				Write unit tests for all new logic.
+				-->
+
+				## Dependencies
+
+				Existing only.
+				""";
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformer.conform(generated));
+	}
+
+	/**
+	 * An unterminated fence swallows every heading that follows it, so the rule
+	 * reports those sections missing. Closing the fence keeps the swallowed lines
+	 * code, which is what they read as — the sections come back because they are
+	 * appended after it, not because the fence was reinterpreted.
+	 */
+	@Test
+	void conformsADocumentLeftInsideAnOpenCodeFence() {
+		String generated = """
+				# CLAUDE.md
+
+				See [AGENTS.md](AGENTS.md) for the full guide.
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				```bash
+				mvn install
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Testing
+
+				JUnit 5.
+
+				## Dependencies
+
+				Existing only.
+				""";
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformer.conform(generated));
+	}
+
+	@Test
+	void leavesADocumentThatAlreadySatisfiesTheRuleAcceptable() {
+		String conforming = """
+				# CLAUDE.md
+
+				See [AGENTS.md](AGENTS.md) for the full agent guide.
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Run `mvn install`.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Testing
+
+				JUnit 5.
+
+				## Dependencies
+
+				Ask before adding a new one.
+				""";
+
+		assertRuleAccepts(conforming);
+		assertRuleAccepts(conformer.conform(conforming));
+	}
+
+	private void assertRuleAccepts(String content) {
+		assertDoesNotThrow(ruleFor(content)::execute, "the conformed document must satisfy claudeMdFormat:\n" + content);
+	}
+
+	private void assertRuleRejects(String content) {
+		assertThrows(EnforcerRuleException.class, ruleFor(content)::execute,
+				"the fixture must start out failing claudeMdFormat, or it proves nothing:\n" + content);
+	}
+
+	private ClaudeMdFormatRule ruleFor(String content) {
+		Path file = tempDir.resolve("CLAUDE.md");
+		try {
+			Files.writeString(file, content);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not write " + file, e);
+		}
+		return ClaudeMdFormatRule.validating(file.toFile());
+	}
+}

--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -11,6 +11,12 @@
 	<packaging>jar</packaging>
 	<name>CLAUDE.md enforcer rule</name>
 	<description>Custom maven-enforcer rule that validates CLAUDE.md documents for structure and naming conventions during the build.</description>
+	<properties>
+		<!-- Mutation-score floor for this module, a few points under the 91% it
+		     measures today so an equivalent refactor cannot turn the build red.
+		     See the root pom's pitest.mutationThreshold. -->
+		<pitest.mutationThreshold>88</pitest.mutationThreshold>
+	</properties>
 	<profiles>
 		<profile>
 			<id>integration-tests</id>

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
@@ -33,6 +33,24 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 		super("CLAUDE.md", REQUIRED_SECTIONS);
 	}
 
+	/**
+	 * The rule configured exactly as a build wires it — the file to check and
+	 * nothing else — for a caller outside this package that has to prove a
+	 * {@code CLAUDE.md} it produced satisfies the check it is about to wire in.
+	 * The adopt module's conformer is written against this contract and duplicates
+	 * its constants, so its tests run the real rule over the real output rather
+	 * than trusting a copy to have stayed in step.
+	 *
+	 * @param claudeMdFile the {@code CLAUDE.md} to validate
+	 * @return a rule that validates {@code claudeMdFile} with the default title and
+	 *         required sections, every optional check left off
+	 */
+	public static ClaudeMdFormatRule validating(File claudeMdFile) {
+		ClaudeMdFormatRule rule = new ClaudeMdFormatRule();
+		rule.setClaudeMdFile(claudeMdFile);
+		return rule;
+	}
+
 	@Override
 	protected File documentFile() {
 		return claudeMdFile;

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -11,6 +11,12 @@
 	<packaging>jar</packaging>
 	<name>Context engineering</name>
 	<description>Fast, regex-based finder that builds the tree of classes used by a given class and assembles context for gen-AI agents, exposed over an MCP server.</description>
+	<properties>
+		<!-- Mutation-score floor for this module, a few points under the 95% it
+		     measures today so an equivalent refactor cannot turn the build red.
+		     See the root pom's pitest.mutationThreshold. -->
+		<pitest.mutationThreshold>92</pitest.mutationThreshold>
+	</properties>
 	<build>
 		<plugins>
 			<plugin>

--- a/code/protogen-maven-plugin-test/pom.xml
+++ b/code/protogen-maven-plugin-test/pom.xml
@@ -13,8 +13,14 @@
 	<description>Integration test module that exercises the protogen-maven-plugin by generating and compiling protobuf builders end to end.</description>
 	<properties>
 		<!-- This module only exercises generated protobuf classes, so the
-		     instruction-coverage gate is not meaningful here. -->
+		     instruction-coverage gate is not meaningful here. The mutation gate is
+		     not meaningful for the same reason, and for a sharper one: every class
+		     here was written by protoc and the plugin, so PIT scored the module at
+		     10% — 3406 of its 4122 mutants uncovered — measuring a generator's
+		     output rather than anybody's tests. The generator itself is mutated in
+		     protogen-maven-plugin. -->
 		<jacoco.skip>true</jacoco.skip>
+		<pitest.skip>true</pitest.skip>
 		<!-- An integration-test harness for the protogen-maven-plugin, not a
 		     reusable library: it has no main Java sources (only src/main/proto),
 		     so its -sources.jar is empty and Central validation rejects it. Keep

--- a/code/protogen-maven-plugin/pom.xml
+++ b/code/protogen-maven-plugin/pom.xml
@@ -11,6 +11,12 @@
 	<packaging>maven-plugin</packaging>
 	<name>protogen-maven-plugin</name>
 	<description>Maven plugin that generates fluent, type-safe builders for protobuf-generated message classes during the generate-sources phase.</description>
+	<properties>
+		<!-- Mutation-score floor for this module, a few points under the 87% it
+		     measures today so an equivalent refactor cannot turn the build red.
+		     See the root pom's pitest.mutationThreshold. -->
+		<pitest.mutationThreshold>84</pitest.mutationThreshold>
+	</properties>
 	<build>
 		<plugins>
 			<!-- Expose the mockito-core jar path so it can be pre-loaded as a Java

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -11,6 +11,12 @@
 	<packaging>jar</packaging>
 	<name>Tooling for data</name>
 	<description>Data sources (CSV, GZip, JDBC, Parquet; in-memory and iterative), a uniqueness-checking tool, data structures, and an MCP server exposing the uniqueness checker.</description>
+	<properties>
+		<!-- Mutation-score floor for this module, a few points under the 86% it
+		     measures today so an equivalent refactor cannot turn the build red.
+		     See the root pom's pitest.mutationThreshold. -->
+		<pitest.mutationThreshold>82</pitest.mutationThreshold>
+	</properties>
 	<build>
 		<plugins>
 			<!-- Expose the mockito-core jar path (it arrives transitively through

--- a/docs/adr/0005-renovate-dependency-updates.md
+++ b/docs/adr/0005-renovate-dependency-updates.md
@@ -1,6 +1,6 @@
 # 5. Renovate for routine dependency version updates
 
-- **Status:** Proposed (decided; pending implementation)
+- **Status:** Accepted
 - **Date:** 2026-07-16
 - **Deciders:** Project maintainers
 - **Tags:** dependencies, automation, ci
@@ -8,9 +8,9 @@
 - **Superseded by:** —
 
 Refines the "keep dependencies current" pillar of
-[ADR 0002](0002-security-policy-and-supply-chain-posture.md). This record stays
-`Proposed` until the Renovate configuration lands and the app is enabled (see
-*Implementation status* below); it flips to `Accepted` at that point.
+[ADR 0002](0002-security-policy-and-supply-chain-posture.md). The decision is in
+force: the app is enabled and `.github/renovate.json` is committed (see
+*Implementation status* below).
 
 ## Context
 
@@ -42,12 +42,34 @@ own security remediation — that is Dependabot's role
 
 ### Implementation status
 
-This ADR records the decision. The Renovate configuration itself
-(`renovate.json` / `.github/renovate.json`, e.g. extending `config:recommended`
-with a schedule and grouping) is **not yet committed** and is a follow-up. Enabling
-the Renovate GitHub App on the repository is a prerequisite. Until that config
-lands, this ADR stays `Proposed`: the decision is made but not yet in force. The
-status flips to `Accepted` when the config is committed and the app is enabled.
+In force. The Renovate GitHub App is enabled on the repository and has been
+opening pull requests against the root pom for some time; the configuration now
+lives in [`.github/renovate.json`](../../.github/renovate.json). Until that file
+landed the app ran on its own defaults, which is why its earlier pull requests
+arrived ungrouped and unscheduled.
+
+The committed configuration extends `config:recommended` and adds only what this
+repository's shape calls for:
+
+- **`schedule` (Monday before 06:00 UTC) with concurrency limits** — batches the
+  noise the *Consequences* section anticipates into one weekly window.
+- **`vulnerabilityAlerts: { enabled: false }` and `osvVulnerabilityAlerts: false`**
+  — the division of labour above, expressed as configuration rather than
+  convention: Renovate declines security-driven bumps so Dependabot
+  ([ADR 0006](0006-dependabot-security-updates.md)) owns them without a duplicate
+  pull request.
+- **Grouping by what moves together** — Maven plugins, the coverage and mutation
+  tooling, the test libraries, and the protobuf toolchain each land as one pull
+  request, since every version they touch lives in the same two root-pom blocks.
+- **`dependencyDashboardApproval` on two major bumps** — the Maven API
+  (deliberately a Maven 4 artifact while the build is pinned to Maven 3.9.x) and
+  Spring Boot, which hosts the three MCP servers. Both stay visible on the
+  dashboard rather than arriving unannounced.
+- **This project's own `io.github.adamw7` modules disabled** — they resolve inside
+  the reactor at `${revision}`, so there is no release for Renovate to raise.
+
+Validate a change to that file with
+`npx --package renovate renovate-config-validator` before committing it.
 
 ## Consequences
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,7 +55,7 @@ decision, add a new ADR that supersedes it and set both records' `Supersedes` /
 | [0002](0002-security-policy-and-supply-chain-posture.md) | Security policy and supply-chain posture | Accepted | 2026-07-16 |
 | [0003](0003-require-tls-1.3.md) | Require TLS 1.3+ for HTTPS transports | Accepted | 2026-07-16 |
 | [0004](0004-codeql-code-scanning.md) | CodeQL static analysis for code scanning | Accepted | 2026-07-16 |
-| [0005](0005-renovate-dependency-updates.md) | Renovate for routine dependency version updates | Proposed | 2026-07-16 |
+| [0005](0005-renovate-dependency-updates.md) | Renovate for routine dependency version updates | Accepted | 2026-07-16 |
 | [0006](0006-dependabot-security-updates.md) | Dependabot for security-alert updates | Proposed | 2026-07-16 |
 | [0007](0007-duckdb-parquet-data-source.md) | DuckDB (JDBC) as the Parquet read engine | Accepted | 2026-07-16 |
 | [0008](0008-log4j2-logging.md) | log4j2 as the logging backend | Accepted | 2026-07-16 |

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -13,8 +13,12 @@
 	<description>End-to-end gRPC example demonstrating the protogen-generated, compile-time-safe protobuf builders in a working service.</description>
 	<properties>
 		<!-- This module only exercises generated protobuf/gRPC classes, so the
-		     instruction-coverage gate is not meaningful here. -->
+		     instruction-coverage gate is not meaningful here. The mutation gate is
+		     not meaningful for the same reason: with no hand-written production
+		     Java at all, PIT scored the module at 14% — 615 of its 776 mutants
+		     uncovered — measuring protoc's output rather than anybody's tests. -->
 		<jacoco.skip>true</jacoco.skip>
+		<pitest.skip>true</pitest.skip>
 		<!-- An example, not a reusable library, so keep it out of both
 		     publications: the GitHub Packages deployment maven-deploy-plugin
 		     performs on `mvn deploy`, and the Maven Central bundle the root pom's

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,29 @@
 		     that never returns is caught by forkedProcessTimeoutInSeconds. The
 		     coverage profile raises it because JaCoCo instrumentation slows setup. -->
 		<unit.test.lifecycle.timeout>10 s</unit.test.lifecycle.timeout>
+		<!-- Minimum mutation score (percent of mutants killed) the pitest profile
+		     enforces, so the weekly run fails on a regression instead of merely
+		     recording one in an artifact nobody opens. This is the floor, sized on
+		     the weakest module at the time it was introduced (mcp-common, 84%); a
+		     module scoring comfortably above it raises the bar in its own
+		     <properties>, which is what makes the gate mean something module by
+		     module. Each number sits a few points under the measured score, so an
+		     equivalent refactor — or a timed-out mutant, which PIT counts as
+		     killed — cannot turn a green build red on its own. Ratchet a number up
+		     once a module's score has settled above it; never down to make a red
+		     build pass. PIT skips a module with no production code or no tests
+		     entirely, so the threshold never applies to one. -->
+		<pitest.mutationThreshold>80</pitest.mutationThreshold>
+		<!-- Whether the pitest profile skips this module. Mutating code nobody
+		     wrote says nothing about the tests: the two modules that opt out hold
+		     no hand-written production Java at all, only protobuf and gRPC classes
+		     generated from their .proto files, and PIT scored them at 10% and 14%
+		     purely because a generator's output has no unit tests aimed at it. The
+		     plugin that generates those builders is itself mutated, in
+		     protogen-maven-plugin, which is where the logic under test lives. A
+		     module that grows hand-written production code should clear this flag
+		     and take a threshold instead. -->
+		<pitest.skip>false</pitest.skip>
 		<!-- Whole-fork wall-clock cap (seconds). JUnit's per-method timeout only
 		     reports after a method returns; it cannot unwedge a thread that never
 		     yields (deadlock, non-daemon thread that never dies). Surefire kills the
@@ -800,8 +823,10 @@
 								<outputFormat>HTML</outputFormat>
 								<outputFormat>XML</outputFormat>
 							</outputFormats>
+							<skip>${pitest.skip}</skip>
 							<timestampedReports>false</timestampedReports>
 							<failWhenNoMutations>false</failWhenNoMutations>
+							<mutationThreshold>${pitest.mutationThreshold}</mutationThreshold>
 							<excludedTestClasses>
 								<excludedTestClass>*IT</excludedTestClass>
 							</excludedTestClasses>


### PR DESCRIPTION
Three gaps where a check existed on paper but could not fail a build.

adopt's ClaudeMdConformer restates the contract that claude-code-enforcer's
claudeMdFormat rule enforces — the title, the AGENTS.md reference, the required
sections, and the fence and comment reading that decides which of them count —
because the pipeline must not ship an enforcer rule. Nothing held the copy in
step, and a drift turns every adoption into a run that conforms a document its
own VerifyStep then rejects, on someone else's repository. Add a test-scoped
dependency and ClaudeMdConformerContractTest, which runs the real rule over the
conformer's output; each case first asserts the raw fixture is rejected, so a
conformer that stopped reshaping could not pass by doing nothing. The rule gains
a validating(File) factory as the seam, keeping its file setter package-private.

The pitest profile carried no mutationThreshold and failWhenNoMutations=false,
so the weekly run could only upload an artifact — a score could rot to zero and
CI stayed green. Add a per-module threshold, a floor of 80 in the root pom with
each module raising its own bar a few points under the score it measures today
(context 92, adopt 88, enforcer 88, protogen 84, data 82). grpc-example and
protogen-maven-plugin-test opt out with pitest.skip, beside the jacoco.skip they
already set for the same reason: neither holds hand-written production Java, so
PIT scored them at 14% and 10% while measuring protoc's output.

ADR 0005 still read Proposed and said no Renovate configuration was committed,
while the app has been opening pull requests against the root pom for months —
on its own defaults, ungrouped and unscheduled. Commit .github/renovate.json
(schedule, grouping by what moves together, this project's own modules disabled)
and flip the ADR to Accepted. vulnerabilityAlerts is disabled there, which turns
the Renovate/Dependabot division of labour ADR 0002 describes into configuration
rather than convention.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QvoYzn7niwee6gRDrdVJVe