### PR TITLE
fix(claude-code-enforcer): read commented-out content, YAML comments and undecodable JSON correctly

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
@@ -58,7 +58,7 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 
 	@Override
 	protected void collectAdditionalViolations(MarkdownDocument document, List<String> violations) {
-		if (!document.containsOutsideFences(AGENTS_REFERENCE)) {
+		if (!document.containsOnStructuralLine(AGENTS_REFERENCE)) {
 			violations.add("CLAUDE.md must reference " + AGENTS_REFERENCE + " as the source of truth");
 		}
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
@@ -31,9 +31,11 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * <p>
  * Imports are recognised the way Claude Code evaluates them: an {@code @} preceded
  * by start-of-line or whitespace and followed by a path — one carrying a directory
- * separator, an extension, or both — outside fenced code blocks and inline code
- * spans, so neither {@code `@claude`} nor a bare {@code @claude} in prose is an
- * import. A
+ * separator, an extension, or both — outside fenced code blocks, HTML comments and
+ * inline code spans, so neither {@code `@claude`} nor a bare {@code @claude} in
+ * prose is an import, and neither is one an author commented out: Claude Code never
+ * loads it, so demanding its target exist failed the build over a file the memory
+ * had deliberately stopped importing. A
  * home-relative import ({@code @~/...}) does not match the path syntax at all and
  * so is skipped, as is any import the {@code ignored} predicate accepts. A file
  * that cannot be read as text is treated as a leaf rather than a failure, because
@@ -122,7 +124,7 @@ final class ImportGraph {
 	private List<Reference> referencesIn(File file) {
 		MarkdownDocument document = MarkdownDocument.parse(readSafely(file));
 		return IntStream.range(0, document.lineCount())
-				.filter(index -> !document.isInsideFence(index))
+				.filter(document::carriesStructure)
 				.mapToObj(document::line)
 				.flatMap(line -> lineReferences(file, line))
 				.toList();

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -33,9 +33,9 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
  * <p>
  * Imports are recognised the way Claude Code evaluates them: an {@code @} preceded
  * by start-of-line or whitespace and followed by a path — one carrying a directory
- * separator, an extension, or both — outside fenced code blocks and inline code
- * spans, so neither {@code `@claude`} nor a bare {@code @claude} in prose is an
- * import. A
+ * separator, an extension, or both — outside fenced code blocks, HTML comments and
+ * inline code spans, so neither {@code `@claude`} nor a bare {@code @claude} in
+ * prose is an import, and neither is one an author commented out. A
  * home-relative import ({@code @~/...}) points at machine-specific state a build
  * cannot see and is skipped, as is any import listed in {@code ignoredImports}.
  * Each file is scanned once; all problems found are reported together.

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -3,18 +3,21 @@ package io.github.adamw7.tools.enforcer.rule;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
 /**
  * Base for enforcer rules that validate a single JSON configuration file. It owns
  * the scaffolding every such rule repeats: the file parameter must be configured,
  * the file must exist (unless the subclass treats absence as a pass), be non-empty,
- * and parse as JSON. A parse failure is collected as a violation rather than
- * thrown, so it is reported through the shared {@link #report} path alongside any
- * structural problems.
+ * and parse as JSON. A parse failure — and a file that cannot be decoded as UTF-8 at
+ * all — is collected as a violation rather than thrown, so it is reported through the
+ * shared {@link #report} path alongside any structural problems.
  * <p>
  * A subclass names its file parameter and the human-readable description used in
  * messages at construction, and contributes the file itself, the report header,
@@ -49,11 +52,35 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 			return;
 		}
 		List<String> violations = new ArrayList<>();
-		JsonNode root = JsonNodes.parseObject(requireContent(file, description), description, violations);
+		collectFileViolations(file, violations);
+		report(header(), violations);
+	}
+
+	/**
+	 * A file that cannot be decoded as UTF-8 is reported rather than read. A rule
+	 * whose file is optional meets whatever a repository put at that path, and an
+	 * {@link java.io.UncheckedIOException} escaping here aborted the build as an
+	 * internal error instead of reporting the malformed configuration the rule exists
+	 * to catch — the same outcome a parse failure is deliberately spared.
+	 */
+	private void collectFileViolations(File file, List<String> violations) throws EnforcerRuleException {
+		Optional<String> content = MarkdownText.readIfText(file);
+		if (content.isEmpty()) {
+			violations.add(description + " cannot be read as UTF-8 text: " + file);
+			return;
+		}
+		requireNotBlank(file, content.get());
+		JsonNode root = JsonNodes.parseObject(content.get(), description, violations);
 		if (root != null) {
 			collectViolations(root, violations);
 		}
-		report(header(), violations);
+	}
+
+	/** An empty file is a build-setup mistake, so it always fails regardless of severity. */
+	private void requireNotBlank(File file, String content) throws EnforcerRuleException {
+		if (content.isBlank()) {
+			throw new EnforcerRuleException(description + " is empty: " + file);
+		}
 	}
 
 	/** The JSON file to validate. Injected from the rule configuration. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -205,7 +205,7 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 			return;
 		}
 		for (String token : forbiddenTokens) {
-			if (document.containsOutsideFences(token)) {
+			if (document.containsOnStructuralLine(token)) {
 				violations.add(documentName() + " must not contain forbidden token: " + token);
 			}
 		}
@@ -235,12 +235,15 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	/**
-	 * Links are read outside code fences and inline code spans alike, so a sample
-	 * link written as {@code `[label](example.md)`} is documentation rather than a
-	 * reference this rule must resolve on disk.
+	 * Links are read outside code fences, HTML comments and inline code spans alike,
+	 * so a sample link written as {@code `[label](example.md)`} is documentation
+	 * rather than a reference this rule must resolve on disk, and a link an author
+	 * commented out alongside the section that used it is no longer a reference at
+	 * all — requiring its target to exist failed the build over a file the document
+	 * had deliberately stopped pointing at.
 	 */
 	private void collectLineReferences(MarkdownDocument document, int index, File baseDir, List<String> violations) {
-		if (document.isInsideFence(index)) {
+		if (!document.carriesStructure(index)) {
 			return;
 		}
 		Matcher matcher = MARKDOWN_LINK.matcher(MarkdownText.withoutCodeSpans(document.line(index)));

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -140,8 +140,12 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 			violations.add("settings.json does not exist at " + settingsFile);
 			return;
 		}
-		String content = MarkdownText.read(settingsFile, "settings.json");
-		JsonNode settings = JsonNodes.parseObject(content, "settings.json", violations);
+		Optional<String> content = MarkdownText.readIfText(settingsFile);
+		if (content.isEmpty()) {
+			violations.add("settings.json cannot be read as UTF-8 text: " + settingsFile);
+			return;
+		}
+		JsonNode settings = JsonNodes.parseObject(content.get(), "settings.json", violations);
 		if (settings == null) {
 			return;
 		}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -39,7 +39,10 @@ import java.util.stream.Collectors;
  * {@code #} that follows whitespace outside quotes, so {@code name: git-commit # the
  * commit helper} declares {@code git-commit}. Reading the note as part of the value
  * failed a name over the kebab-case convention it follows and made every such
- * description count characters Claude Code never sees.
+ * description count characters Claude Code never sees. What quotes a scalar is a
+ * quote that <em>opens</em> it; a quote anywhere else is an ordinary character, so
+ * the apostrophe of {@code description: Claude's helper # a note} does not shelter
+ * the note from being dropped.
  * <p>
  * A key declared twice yields its <em>last</em> declaration, which is the one a YAML
  * loader keeps and so the one Claude Code acts on. Reading the first instead
@@ -208,24 +211,64 @@ public final class FrontMatter {
 	 * so Claude Code — never reads.
 	 */
 	private static String withoutComment(String value) {
-		char quote = NONE;
-		for (int i = 0; i < value.length(); i++) {
-			char character = value.charAt(i);
-			if (quote != NONE) {
-				i += isEscape(quote, character) ? 1 : 0;
-				quote = character == quote ? NONE : quote;
-			} else if (character == DOUBLE_QUOTE || character == SINGLE_QUOTE) {
-				quote = character;
-			} else if (character == COMMENT_START && startsComment(value, i)) {
-				return value.substring(0, i).strip();
-			}
-		}
-		return value;
+		int comment = commentStart(value);
+		return comment < 0 ? value : value.substring(0, comment).strip();
 	}
 
-	/** A backslash escapes the next character inside a double-quoted scalar, but not a single-quoted one. */
-	private static boolean isEscape(char quote, char character) {
-		return quote == DOUBLE_QUOTE && character == ESCAPE;
+	/** Where a trailing comment opens, or -1 when the value carries none. */
+	private static int commentStart(String value) {
+		for (int index = endOfScalar(value); index < value.length(); index++) {
+			if (value.charAt(index) == COMMENT_START && startsComment(value, index)) {
+				return index;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * Where a comment could begin: past the closing quote of a scalar written as a
+	 * quoted one, or at the very start of a plain one. Only a quote that <em>opens</em>
+	 * the scalar quotes it — everywhere else a quote is an ordinary character, which
+	 * is what {@code description: Claude's helper} is made of. Treating that
+	 * apostrophe as the start of a quoted run left the scalar looking unterminated,
+	 * so the {@code # note} after it was read as part of the description Claude Code
+	 * never sees, and every such value counted characters it does not have.
+	 */
+	private static int endOfScalar(String value) {
+		char quote = openingQuote(value);
+		return quote == NONE ? 0 : endOfQuotedScalar(value, quote);
+	}
+
+	/** The quote a scalar opens with, or {@link #NONE} when it is a plain one. */
+	private static char openingQuote(String value) {
+		char first = value.isEmpty() ? NONE : value.charAt(0);
+		return first == DOUBLE_QUOTE || first == SINGLE_QUOTE ? first : NONE;
+	}
+
+	/**
+	 * The index just past the closing quote, or the value's length when the scalar
+	 * never closes. A {@code \"} inside a double-quoted scalar and a doubled
+	 * {@code ''} inside a single-quoted one are the escapes each style writes, not
+	 * the close.
+	 */
+	private static int endOfQuotedScalar(String value, char quote) {
+		int index = 1;
+		while (index < value.length() && !closesAt(value, index, quote)) {
+			index += isEscapeAt(value, index, quote) ? 2 : 1;
+		}
+		return index + 1;
+	}
+
+	private static boolean closesAt(String value, int index, char quote) {
+		return value.charAt(index) == quote && !isEscapeAt(value, index, quote);
+	}
+
+	/** True when the character at {@code index} escapes the one after it, in the style {@code quote} uses. */
+	private static boolean isEscapeAt(String value, int index, char quote) {
+		if (quote == DOUBLE_QUOTE) {
+			return value.charAt(index) == ESCAPE;
+		}
+		return value.charAt(index) == SINGLE_QUOTE && value.startsWith(ESCAPED_SINGLE_QUOTE, index);
 	}
 
 	/** A {@code #} opens a comment at the start of the value or after whitespace, never mid-token. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -80,14 +80,21 @@ public final class MarkdownDocument {
 		return insideFence[index];
 	}
 
+	/**
+	 * True when the line at {@code index} says something about the document rather
+	 * than illustrating or retracting it: outside a fenced code block and outside an
+	 * HTML comment alike. A rule that reads a line for what it declares — a token it
+	 * forbids, a link it must resolve, a memory import it must follow — reads only
+	 * these, for the same reason {@link #headings()} does: sample text inside a fence
+	 * and text an author commented out are both inert.
+	 */
+	public boolean carriesStructure(int index) {
+		return !insideFence[index] && !insideComment[index];
+	}
+
 	/** The first line that is not blank, stripped of surrounding whitespace, or empty if none. */
 	public String firstNonBlankLine() {
 		return MarkdownText.firstNonBlankLine(lines.stream());
-	}
-
-	/** The indices of the lines outside fenced code blocks, in document order. */
-	private IntStream outsideFences() {
-		return IntStream.range(0, lines.size()).filter(index -> !insideFence[index]);
 	}
 
 	/**
@@ -96,12 +103,18 @@ public final class MarkdownDocument {
 	 * these.
 	 */
 	private IntStream structuralLines() {
-		return outsideFences().filter(index -> !insideComment[index]);
+		return IntStream.range(0, lines.size()).filter(this::carriesStructure);
 	}
 
-	/** True when {@code token} appears on a line outside a fenced code block. */
-	public boolean containsOutsideFences(String token) {
-		return outsideFences().anyMatch(index -> lines.get(index).contains(token));
+	/**
+	 * True when {@code token} appears on a line that carries document structure. A
+	 * mention inside a fenced code block is an example and one inside an HTML comment
+	 * is text its author removed, so neither states anything the document still says:
+	 * counting them let a commented-out reference satisfy the check that demands it,
+	 * and reported a commented-out token as forbidden content.
+	 */
+	public boolean containsOnStructuralLine(String token) {
+		return structuralLines().anyMatch(index -> lines.get(index).contains(token));
 	}
 
 	/** The heading lines outside fenced code blocks and HTML comments, in document order. */

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.List;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.Test;
@@ -98,6 +99,18 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
+	void failsWhenTheOnlyAgentsReferenceIsCommentedOut() {
+		// The reference is what makes CLAUDE.md defer to AGENTS.md; one an author
+		// commented out says nothing, so it must not satisfy the check.
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace(
+				"See [AGENTS.md](AGENTS.md) for the full agent guide.",
+				"<!--\nSee [AGENTS.md](AGENTS.md) for the full agent guide.\n-->"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("must reference AGENTS.md"), exception.getMessage());
+	}
+
+	@Test
 	void failsWhenARequiredSectionIsMissing() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "## Quality"));
 
@@ -186,7 +199,7 @@ class ClaudeMdFormatRuleTest {
 	@Test
 	void failsWhenAForbiddenTokenAppears() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nTODO: finish this.\n");
-		rule.setForbiddenTokens(java.util.List.of("TODO"));
+		rule.setForbiddenTokens(List.of("TODO"));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
 		assertTrue(exception.getMessage().contains("forbidden token: TODO"), exception.getMessage());
@@ -195,7 +208,7 @@ class ClaudeMdFormatRuleTest {
 	@Test
 	void ignoresAForbiddenTokenInsideACodeFence() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n```\nTODO inside code\n```\n");
-		rule.setForbiddenTokens(java.util.List.of("TODO"));
+		rule.setForbiddenTokens(List.of("TODO"));
 
 		assertDoesNotThrow(rule::execute);
 	}
@@ -203,7 +216,7 @@ class ClaudeMdFormatRuleTest {
 	@Test
 	void ignoresAForbiddenTokenInsideATildeFence() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n~~~\nTODO inside code\n~~~\n");
-		rule.setForbiddenTokens(java.util.List.of("TODO"));
+		rule.setForbiddenTokens(List.of("TODO"));
 
 		assertDoesNotThrow(rule::execute);
 	}
@@ -245,7 +258,7 @@ class ClaudeMdFormatRuleTest {
 		// inner three-backtick delimiters and everything they wrap stay code.
 		ClaudeMdFormatRule rule = ruleFor(
 				VALID_CONTENT + "\n````markdown\n```java\nTODO in an example\n```\n````\n");
-		rule.setForbiddenTokens(java.util.List.of("TODO"));
+		rule.setForbiddenTokens(List.of("TODO"));
 
 		assertDoesNotThrow(rule::execute);
 	}
@@ -253,7 +266,7 @@ class ClaudeMdFormatRuleTest {
 	@Test
 	void scansTheContentThatFollowsANestedFence() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n```\n```java\n```\n\nTODO left behind\n");
-		rule.setForbiddenTokens(java.util.List.of("TODO"));
+		rule.setForbiddenTokens(List.of("TODO"));
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
 		assertTrue(exception.getMessage().contains("forbidden token: TODO"), exception.getMessage());
@@ -404,6 +417,26 @@ class ClaudeMdFormatRuleTest {
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
 		assertTrue(exception.getMessage().contains("missing file: docs/no%20such.md"), exception.getMessage());
+	}
+
+	@Test
+	void ignoresACommentedOutReferenceWhenValidatingReferences() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n<!--\nSee [old plan](docs/old-plan.md).\n-->\n");
+		rule.setValidateFileReferences(true);
+
+		// A link an author commented out alongside the section that used it is no
+		// longer a reference, so requiring its target to exist failed the build over
+		// a file the document had deliberately stopped pointing at.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void ignoresAForbiddenTokenThatIsCommentedOut() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n<!--\nTODO: rewrite this section.\n-->\n");
+		rule.setForbiddenTokens(List.of("TODO"));
+
+		assertDoesNotThrow(rule::execute);
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
@@ -67,6 +67,14 @@ class MemoryImportsRuleTest {
 	}
 
 	@Test
+	void ignoresImportsInsideAnHtmlComment() {
+		// Claude Code never loads a commented-out import, so demanding its target
+		// exist failed the build over a file the memory had stopped importing.
+		assertDoesNotThrow(
+				ruleFor("# CLAUDE.md\n\n<!--\nWe used to import @docs/absent.md here.\n-->\n")::execute);
+	}
+
+	@Test
 	void ignoresImportsInInlineCodeSpans() {
 		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nan `@claude`-mention workflow\n")::execute);
 	}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRuleTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.enforcer.mcp;
 
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -147,6 +148,19 @@ class McpServersValidRuleTest {
 
 		assertDoesNotThrow(rule::execute);
 		assertTrue(logger.warnings().stream().anyMatch(w -> w.contains("mystery")), logger.warnings().toString());
+	}
+
+	@Test
+	void reportsAFileThatCannotBeReadAsTextInsteadOfAbortingTheBuild() {
+		Path file = tempDir.resolve(".mcp.json");
+		writeBytes(file, new byte[] { '{', (byte) 0xC3, (byte) 0x28, '}' });
+		McpServersValidRule rule = new McpServersValidRule();
+		rule.setMcpFile(file.toFile());
+
+		// An UncheckedIOException escaping here aborted the build as an internal error
+		// instead of reporting the malformed configuration the rule exists to catch.
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("cannot be read as UTF-8 text"), exception.getMessage());
 	}
 
 	private McpServersValidRule ruleFor(String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -309,6 +309,20 @@ class HooksFormatRuleTest {
 	}
 
 	@Test
+	void reportsASettingsFileThatCannotBeReadAsTextInsteadOfAbortingTheBuild() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		Path settings = tempDir.resolve(".claude/settings.json");
+		TestFiles.writeBytes(settings, new byte[] { '{', (byte) 0xC3, (byte) 0x28, '}' });
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settings.toFile());
+
+		// The settings file is optional here, so an UncheckedIOException escaping the
+		// rule aborted the build as an internal error over a file it only cross-checks.
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("cannot be read as UTF-8 text"), exception.getMessage());
+	}
+
+	@Test
 	void namesTheHooksDirectoryInItsDescription() {
 		HooksFormatRule rule = ruleFor();
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -291,4 +291,40 @@ class FrontMatterTest {
 
 		assertEquals(Optional.of("one two"), frontMatter.orElseThrow().value("description"));
 	}
+
+	/**
+	 * Only a quote that opens a scalar quotes it. An apostrophe mid-value is an
+	 * ordinary character, and reading it as the start of a quoted run left the
+	 * scalar looking unterminated, so the note after it was kept as part of the
+	 * description Claude Code never sees.
+	 */
+	@Test
+	void dropsATrailingCommentFromAValueCarryingAnApostrophe() {
+		Optional<FrontMatter> frontMatter = FrontMatter
+				.parse("---\ndescription: Claude's helper # the commit helper\n---\n");
+
+		assertEquals(Optional.of("Claude's helper"), frontMatter.orElseThrow().value("description"));
+	}
+
+	@Test
+	void dropsATrailingCommentFromAValueCarryingADoubleQuoteMidWord() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\ndescription: say \"hi\" often # note\n---\n");
+
+		assertEquals(Optional.of("say \"hi\" often"), frontMatter.orElseThrow().value("description"));
+	}
+
+	@Test
+	void keepsAHashInsideASingleQuotedScalarThatEscapesItsQuote() {
+		Optional<FrontMatter> frontMatter = FrontMatter
+				.parse("---\ndescription: 'it''s # kept' # dropped\n---\n");
+
+		assertEquals(Optional.of("it's # kept"), frontMatter.orElseThrow().value("description"));
+	}
+
+	@Test
+	void keepsAValueWhoseOpeningQuoteNeverCloses() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\ndescription: \"unterminated # note\n---\n");
+
+		assertEquals(Optional.of("\"unterminated # note"), frontMatter.orElseThrow().value("description"));
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
@@ -151,7 +151,7 @@ class MarkdownDocumentTest {
 				""");
 
 		assertEquals(List.of(0, 1, 2), fencedLines(document));
-		assertTrue(document.containsOutsideFences("TODO"));
+		assertTrue(document.containsOnStructuralLine("TODO"));
 	}
 
 	@Test
@@ -164,7 +164,7 @@ class MarkdownDocumentTest {
 				````
 				""");
 
-		assertFalse(document.containsOutsideFences("TODO"));
+		assertFalse(document.containsOnStructuralLine("TODO"));
 	}
 
 	@Test
@@ -283,8 +283,43 @@ class MarkdownDocumentTest {
 		assertTrue(document.hasBody("## Testing"));
 	}
 
+	@Test
+	void doesNotFindATokenInsideAnHtmlComment() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				<!--
+				TODO dropped along with the section that used it.
+				-->
+
+				Body.
+				""");
+
+		assertFalse(document.containsOnStructuralLine("TODO"));
+	}
+
+	@Test
+	void doesNotCountACommentedLineAsCarryingStructure() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				<!--
+				@docs/removed.md
+				-->
+
+				@docs/kept.md
+				""");
+
+		assertEquals(List.of(0, 1, 5, 6), structuralLines(document));
+	}
+
 	/** The indices of the lines the document masks as fenced code, in document order. */
 	private static List<Integer> fencedLines(MarkdownDocument document) {
 		return IntStream.range(0, document.lineCount()).filter(document::isInsideFence).boxed().toList();
+	}
+
+	/** The indices of the lines that carry document structure, in document order. */
+	private static List<Integer> structuralLines(MarkdownDocument document) {
+		return IntStream.range(0, document.lineCount()).filter(document::carriesStructure).boxed().toList();
 	}
 }


### PR DESCRIPTION
Four defects found while auditing the rules, each verified with a failing
test first.

MarkdownDocument built an HTML-comment mask but only heading detection used
it, so every other consumer read text an author had commented out as if the
document still said it:

- claudeMdFormat's "must reference AGENTS.md" check was satisfied by a
  commented-out mention, the one thing that check exists to prevent, while
  forbiddenTokens fired on a token that had been commented out;
- validateFileReferences demanded a commented-out link resolve on disk,
  failing the build over a file the document had deliberately stopped
  pointing at;
- memoryImports followed a commented-out @path import and reported its
  target as missing, though Claude Code never loads it.

containsOutsideFences becomes containsOnStructuralLine and a new
carriesStructure(index) gives the line-by-line consumers the same answer
headings() already used.

FrontMatter treated any quote as opening a quoted scalar, so the apostrophe
in "description: Claude's helper # a note" left the scalar looking
unterminated and the note was kept as part of the value — lengthening every
such description past what Claude Code reads and breaking name conventions.
Only a quote that opens a scalar quotes it now, with each style's escape
(\" and '') still honoured.

JsonFileRule read its file with MarkdownText.read, so a JSON configuration
that is not valid UTF-8 escaped as an UncheckedIOException and aborted the
build as an internal error rather than being reported as the violation the
rule exists to catch — the outcome a parse failure is already spared, and
the one every directory-scanning rule already takes care to avoid.
HooksFormatRule read its optional settings.json the same way.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DiZRGZXXphyWoQ9vkVEuSX