### PR TITLE
fix(adopt): ask a dry run only for the tools it runs, and conform to the wired guard

### DIFF
--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -20,7 +20,9 @@ module's rules are unusually strict because it shells out to `git`, `gh` and
 `GitHubRepoAdopter.defaultSteps(options)` assembles:
 
 1. `ToolchainStep` — the pipeline's own tools: `git`, `claude`, `gh` (and `gh`
-   is logged in). Fails before any expensive work.
+   is logged in). Fails before any expensive work. A dry run is checked with
+   `ToolchainStep.forDryRun()` — `git` and `claude` only, since `gh` is used by
+   the pull request the run leaves out.
 2. `CloneStep` — clones into the workspace. **The only step allowed to read the
    credentialled URL.**
 3. `BuildToolchainStep` — the *cloned project's* build tool, checked as soon as
@@ -29,8 +31,9 @@ module's rules are unusually strict because it shells out to `git`, `gh` and
    default branch is never written to.
 5. `TrustStep` — marks the checkout trusted for Claude Code.
 6. `ClaudeInitStep` → `ClaudeMdConformanceStep` → `CommitStep` — generate
-   `CLAUDE.md`, conform it (plus a companion `AGENTS.md`) so it satisfies the
-   guard about to be wired in, commit.
+   `CLAUDE.md`, conform it (plus a companion `AGENTS.md`) as far as the guard
+   about to be wired in demands — `BuildSystem.requiredClaudeMdSections()`, so
+   only the Maven path adds the format rule's Java/Maven headings — commit.
 7. `EnforcerStep` → `CommitStep` — wire the build-tool-aware guard in and commit.
 8. *(optional)* `AssetsStep` → `CommitStep` — starter config assets, on `--assets`.
 9. `VerifyStep` — proves the guard passes on the generated file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,9 @@ Maven project. The notable capabilities are:
   uniqueness checker as a tool for AI assistants.
 - **Claude Code adoption** (`adopt`) — an ordered pipeline that adopts Claude
   Code into a GitHub repository: it first checks the required tools (`git`,
-  `claude`, `gh`) are on the `PATH` so a missing one fails fast, then clones the
+  `claude`, `gh`) are on the `PATH` so a missing one fails fast — and that `gh`
+  can reach the repository, since `gh --version` succeeds for a CLI nobody is
+  logged in to — then clones the
   repo, creates a feature branch,
   marks the checkout trusted in `~/.claude.json` so the headless CLI is not
   blocked by the folder-trust prompt, runs the Claude Code CLI (`claude init`) to
@@ -62,7 +64,17 @@ Maven project. The notable capabilities are:
   verified by running that task; a repository with no recognised build file falls
   back to a GitHub Actions workflow and the portable `.github/claude-md-guard.sh`
   check it runs, verified by running that script — so a build-less repository
-  still keeps the guard. A checkout that ships a build wrapper (`mvnw`, `gradlew`,
+  still keeps the guard. How far `ClaudeMdConformanceStep` reshapes the generated
+  `CLAUDE.md` follows from that same choice, through
+  `BuildSystem.requiredClaudeMdSections`: only the Maven path wires in the format
+  rule, so only it demands the rule's Java and Maven headings, which a Maven
+  checkout can answer. The other two guards ask merely that the file exist and
+  carry something, and conforming to the rule's list regardless stamped
+  `## Java version`, `## Maven` and `## Principles for Java Development` — each
+  stubbed with a pointer to `AGENTS.md` — onto repositories that are neither Java
+  nor Maven, where nothing then checked them. The title and the `AGENTS.md`
+  reference are settled either way, since the step writes that companion file for
+  every adopted repository. A checkout that ships a build wrapper (`mvnw`, `gradlew`,
   or their Windows `.cmd`/`.bat` forms) is verified with that wrapper rather than
   with a build tool off the `PATH`, so the guard runs under the version the
   project pinned; most Gradle projects ship only the wrapper, so probing the
@@ -93,7 +105,12 @@ Maven project. The notable capabilities are:
   neither grows a parameter per switch and the two cannot drift apart on what an
   omitted option means. `--dry-run` (`dry_run` on the MCP tool) rehearses an
   adoption: the pipeline is assembled *without* `PushStep` and `PullRequestStep`
-  rather than with steps that decide to do nothing, so nothing is left that could
+  rather than with steps that decide to do nothing, and `ToolchainStep.forDryRun`
+  then asks only for the `git` and `claude` that a rehearsal really runs — `gh` is
+  used by the pull request alone, since the push runs `git`, so requiring it (and
+  the GitHub credentials the login probe wants behind it) aborted `--dry-run` on
+  its very first step over the one capability the flag exists to leave out —
+  so nothing is left that could
   push and the report's `completedSteps` ends at `verify` — everything before it
   still runs, leaving the adoption's commits in the workspace to be read before
   any of it reaches GitHub. `--timeout <minutes>` (`timeout_minutes`, bounded to a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,9 @@ run `mvn install` from the repository root. The main capabilities are:
   and that `gh` is logged in, clone, check the cloned project's own build tool is
   installed too, create a feature branch, mark the checkout trusted, `claude
   init` to generate `CLAUDE.md`, conform that file (and add a companion
-  `AGENTS.md`) so it satisfies the guard about to be wired in, commit it, wire a
+  `AGENTS.md`) as far as the guard about to be wired in demands — only the Maven
+  path wires in the format rule, so only it gets that rule's Java and Maven
+  headings — commit it, wire a
   build-tool-aware `CLAUDE.md` guard into the repo (the `claude-code-enforcer`
   rule for Maven `pom.xml`, an `enforceClaudeMd` guard task for Gradle, and a
   GitHub Actions workflow plus `.github/claude-md-guard.sh` check as the
@@ -48,8 +50,10 @@ run `mvn install` from the repository root. The main capabilities are:
   hand to the pipeline factory; exposed as CLI flags such as `--title`,
   `--reviewer`, `--draft`, and `--timeout <minutes>`); the default branch is never
   written to directly. `--dry-run` (`dry_run` on the MCP tool) assembles the
-  pipeline without the push and pull-request steps, so a run can be rehearsed into
-  the workspace without writing to GitHub, and `--help` answers with the usage
+  pipeline without the push and pull-request steps — and so asks the toolchain
+  check only for the `git` and `claude` it will really run, not the `gh` the pull
+  request alone uses — so a run can be rehearsed into the workspace with no GitHub
+  credentials at all, and `--help` answers with the usage
   line. One run adopts a list of repositories — repeatable `--repo <url>` or
   `--repos <file>` on the command line, `repository_urls` on the MCP tool — each
   with its own report, and a repository that fails does not stop the rest — a

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -68,7 +68,7 @@ public class GitHubRepoAdopter {
 	public static List<AdoptionStep> defaultSteps(AdoptionOptions options) {
 		List<BuildSystem> buildSystems = BuildSystems.defaults(options.pinnedRuleVersion());
 		return Stream.of(
-				adoptionSteps(buildSystems),
+				adoptionSteps(buildSystems, options),
 				assetSteps(options),
 				List.<AdoptionStep>of(new VerifyStep(buildSystems)),
 				publicationSteps(options))
@@ -76,18 +76,27 @@ public class GitHubRepoAdopter {
 				.toList();
 	}
 
-	private static List<AdoptionStep> adoptionSteps(List<BuildSystem> buildSystems) {
+	private static List<AdoptionStep> adoptionSteps(List<BuildSystem> buildSystems, AdoptionOptions options) {
 		return List.of(
-				new ToolchainStep(),
+				toolchainStep(options),
 				new CloneStep(),
 				new BuildToolchainStep(buildSystems),
 				new BranchStep(),
 				new TrustStep(),
 				new ClaudeInitStep(),
-				new ClaudeMdConformanceStep(),
+				new ClaudeMdConformanceStep(buildSystems),
 				new CommitStep("Adopt Claude Code: add CLAUDE.md", "claude-md"),
 				new EnforcerStep(buildSystems),
 				new CommitStep("Add claude-code-enforcer to the build", "guard"));
+	}
+
+	/**
+	 * The toolchain check is asked for exactly what the assembled pipeline will run,
+	 * so the two stay in step: a dry run that leaves out the pull request is not held
+	 * to the {@code gh} that only the pull request uses.
+	 */
+	private static AdoptionStep toolchainStep(AdoptionOptions options) {
+		return options.dryRun() ? ToolchainStep.forDryRun() : new ToolchainStep();
 	}
 
 	private static List<AdoptionStep> assetSteps(AdoptionOptions options) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -30,6 +30,23 @@ public interface BuildSystem {
 	boolean install(Path repositoryDirectory);
 
 	/**
+	 * The {@code CLAUDE.md} sections the guard this build system wires in will hold
+	 * the generated file to, so {@link ClaudeMdConformanceStep} reshapes the file
+	 * only as far as {@link #install(Path)} and {@link #verifyCommand(Path)} between
+	 * them actually demand.
+	 *
+	 * <p>Empty by default, which is what a presence-and-non-empty guard wants: it
+	 * asks for no section in particular, so appending any is noise in the adoption's
+	 * first pull request rather than something the build would have rejected. A build
+	 * system wiring in a guard that does demand sections names them by overriding.
+	 *
+	 * @return the required headings, empty when the guard demands none
+	 */
+	default List<String> requiredClaudeMdSections() {
+		return List.of();
+	}
+
+	/**
 	 * Command that runs the wired guard so a missing or malformed {@code CLAUDE.md}
 	 * fails the build. The checkout is a parameter because the command depends on
 	 * what the checkout itself ships: a project carrying a build wrapper is built

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.adopt.step;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,10 +15,17 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
 /**
  * Makes the adoption self-consistent: after {@link ClaudeInitStep} generates a
  * {@code CLAUDE.md}, this reshapes it with a {@link ClaudeMdConformer} so it
- * satisfies the {@code claudeMdFormat} rule {@link EnforcerStep} wires into the
- * build, and writes a companion {@code AGENTS.md} so the reference the rule
- * expects resolves to a real file. Without it the adoption fails its own
+ * satisfies the guard {@link EnforcerStep} wires into the build, and writes a
+ * companion {@code AGENTS.md} so the reference resolves to a real file. Without it
+ * an adoption whose guard is the {@code claudeMdFormat} rule fails its own
  * {@link VerifyStep}.
+ *
+ * <p>How much reshaping that takes is the detected {@link BuildSystem}'s to say,
+ * through {@link BuildSystem#requiredClaudeMdSections()}: the Maven path wires in
+ * the full format rule and gets the full set of sections, while a guard that asks
+ * only for a non-empty file leaves the generated document as {@code claude init}
+ * wrote it. Reshaping past what the guard checks would put a Java project's
+ * headings into repositories that are not one.
  *
  * <p>The step runs before the first commit so both files are committed together.
  * It never overwrites an {@code AGENTS.md} the project already carries, and
@@ -30,15 +38,20 @@ public class ClaudeMdConformanceStep implements AdoptionStep {
 
 	private static final String CLAUDE_MD = AdoptionAssets.CLAUDE_MD_FILE;
 
-	private final ClaudeMdConformer conformer;
+	private final List<BuildSystem> buildSystems;
 	private final AssetInstaller agentsMdInstaller;
 
+	/** Detects the checkout's build system among {@link BuildSystems#DEFAULTS}. */
 	public ClaudeMdConformanceStep() {
-		this(new ClaudeMdConformer(), AdoptionAssets.agentsMd());
+		this(BuildSystems.DEFAULTS);
 	}
 
-	ClaudeMdConformanceStep(ClaudeMdConformer conformer, AssetInstaller agentsMdInstaller) {
-		this.conformer = conformer;
+	public ClaudeMdConformanceStep(List<BuildSystem> buildSystems) {
+		this(buildSystems, AdoptionAssets.agentsMd());
+	}
+
+	ClaudeMdConformanceStep(List<BuildSystem> buildSystems, AssetInstaller agentsMdInstaller) {
+		this.buildSystems = List.copyOf(buildSystems);
 		this.agentsMdInstaller = agentsMdInstaller;
 	}
 
@@ -64,13 +77,29 @@ public class ClaudeMdConformanceStep implements AdoptionStep {
 	private void conformClaudeMd(Path checkout) {
 		Path claudeMd = checkout.resolve(CLAUDE_MD);
 		String original = read(claudeMd);
-		String conformed = LineTerminators.matching(conformer.conform(original), original);
+		String conformed = LineTerminators.matching(conformer(checkout).conform(original), original);
 		if (conformed.equals(original)) {
 			log.info("{} already satisfies the claudeMdFormat rule; left unchanged", CLAUDE_MD);
 		} else {
 			AdoptionFiles.write(claudeMd, conformed, CLAUDE_MD);
 			log.info("Normalised {} to satisfy the claudeMdFormat rule", CLAUDE_MD);
 		}
+	}
+
+	/**
+	 * Reshapes to the contract of the guard {@link EnforcerStep} is about to wire
+	 * into this very checkout, detected from the same build-system list that step is
+	 * given, so the two never disagree about what the file has to carry.
+	 *
+	 * <p>A list detection comes up empty on — one configured without a catch-all,
+	 * since {@link BuildSystems#DEFAULTS} always matches — leaves no guard to satisfy
+	 * and so demands no section, the same answer as a guard that only wants the file
+	 * to be there.
+	 */
+	private ClaudeMdConformer conformer(Path checkout) {
+		return new ClaudeMdConformer(BuildSystems.detect(buildSystems, checkout)
+				.map(BuildSystem::requiredClaudeMdSections)
+				.orElseGet(List::of));
 	}
 
 	private String read(Path claudeMd) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -24,6 +24,13 @@ import java.util.stream.IntStream;
  * fails an empty section just as it fails a missing one. Fenced code and
  * commented-out text are left alone, mirroring how the rule matches, and reshaping
  * an already-conforming document is a no-op.
+ *
+ * <p>Which sections it demands is the caller's to choose, because the guard being
+ * wired in differs by build system — see
+ * {@link BuildSystem#requiredClaudeMdSections()}. The title and the
+ * {@code AGENTS.md} reference are settled either way: the step writes a companion
+ * {@code AGENTS.md} for every adopted repository, and a document that never points
+ * at it leaves the pair pointing only one way.
  */
 public class ClaudeMdConformer {
 
@@ -42,6 +49,15 @@ public class ClaudeMdConformer {
 	 */
 	static final String TITLE = "# CLAUDE.md";
 	static final String AGENTS_REFERENCE = "AGENTS.md";
+
+	/**
+	 * The sections the {@code claudeMdFormat} rule demands, and so the sections to
+	 * conform to <em>where that rule is the guard being wired in</em> — the Maven
+	 * path, {@link MavenBuildSystem#requiredClaudeMdSections()}. They are Java and
+	 * Maven sections because the rule is a Java project's rule; a build system whose
+	 * guard asks only that the file exist and carry something does not want them, and
+	 * says so by requiring none.
+	 */
 	static final List<String> REQUIRED_SECTIONS = List.of(
 			"## Project",
 			"## Java version",
@@ -71,6 +87,31 @@ public class ClaudeMdConformer {
 
 	/** The blank lines the reshape may leave at the end, dropped so the document keeps a single one. */
 	private static final Pattern TRAILING_BLANK_LINES = Pattern.compile("\\n\\s*+\\z");
+
+	private final List<String> requiredSections;
+
+	/** Conforms to the full {@code claudeMdFormat} contract. */
+	public ClaudeMdConformer() {
+		this(REQUIRED_SECTIONS);
+	}
+
+	/**
+	 * Conforms only as far as the guard being wired in actually demands. Stamping the
+	 * {@code claudeMdFormat} sections onto every adopted repository put
+	 * {@code ## Java version}, {@code ## Maven} and
+	 * {@code ## Principles for Java Development} — each stubbed with a pointer to
+	 * {@code AGENTS.md} — into the {@code CLAUDE.md} of projects that are neither
+	 * Java nor Maven, where nothing then checked them: the Gradle and GitHub Actions
+	 * guards ask only that the file exist and carry something. The reshape is worth
+	 * making only where a guard would otherwise reject the file, so what to require
+	 * is the build system's to say.
+	 *
+	 * @param requiredSections the headings to canonicalize, append and give a body to,
+	 *                         empty for a guard that demands no particular section
+	 */
+	public ClaudeMdConformer(List<String> requiredSections) {
+		this.requiredSections = List.copyOf(requiredSections);
+	}
 
 	/**
 	 * @return {@code content} reshaped so the {@code claudeMdFormat} rule passes,
@@ -140,7 +181,7 @@ public class ClaudeMdConformer {
 	private void canonicalizeHeadings(List<String> lines) {
 		Outline outline = Outline.of(lines);
 		Set<Integer> claimed = reservedHeadings(outline);
-		REQUIRED_SECTIONS.forEach(required -> canonicalize(outline, required, claimed));
+		requiredSections.forEach(required -> canonicalize(outline, required, claimed));
 	}
 
 	/**
@@ -149,7 +190,7 @@ public class ClaudeMdConformer {
 	 * required section.
 	 */
 	private Set<Integer> reservedHeadings(Outline outline) {
-		return outline.structural(line -> REQUIRED_SECTIONS.contains(line.strip()))
+		return outline.structural(line -> requiredSections.contains(line.strip()))
 				.boxed()
 				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
@@ -191,7 +232,7 @@ public class ClaudeMdConformer {
 	 * an empty section just as it fails a missing one, so both are settled here.
 	 */
 	private void ensureRequiredSections(List<String> lines) {
-		REQUIRED_SECTIONS.forEach(required -> ensureSection(lines, required));
+		requiredSections.forEach(required -> ensureSection(lines, required));
 	}
 
 	/**
@@ -218,11 +259,28 @@ public class ClaudeMdConformer {
 		return (int) heading.chars().takeWhile(character -> character == '#').count();
 	}
 
+	/**
+	 * The reference is separated from what follows it only when that line is not
+	 * already blank. A document conformed to no required sections keeps the body
+	 * {@code claude init} wrote, blank line and all, and closing the insertion with
+	 * one of its own left a double blank in the first commit of every repository
+	 * whose guard demands no section.
+	 */
 	private void ensureAgentsReference(List<String> lines) {
 		Outline outline = Outline.of(lines);
-		if (outline.matching(line -> line.contains(AGENTS_REFERENCE)).findAny().isEmpty()) {
-			lines.addAll(outline.titleIndex() + 1, List.of("", AGENTS_REFERENCE_LINE, ""));
+		if (outline.matching(line -> line.contains(AGENTS_REFERENCE)).findAny().isPresent()) {
+			return;
 		}
+		int index = outline.titleIndex() + 1;
+		List<String> reference = new ArrayList<>(List.of("", AGENTS_REFERENCE_LINE));
+		if (!isBlankAt(lines, index)) {
+			reference.add("");
+		}
+		lines.addAll(index, reference);
+	}
+
+	private static boolean isBlankAt(List<String> lines, int index) {
+		return index < lines.size() && lines.get(index).isBlank();
 	}
 
 	private static boolean isHeading(String stripped) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -65,6 +65,18 @@ public class MavenBuildSystem implements BuildSystem {
 		return installer.install(repositoryDirectory.resolve(POM));
 	}
 
+	/**
+	 * The only build system that demands sections, because it is the only one wiring
+	 * in the {@code claudeMdFormat} rule — the guard {@link #verifyCommand(Path)}
+	 * then runs, and the one that fails a {@code CLAUDE.md} for a missing section
+	 * rather than merely for being absent or blank. A Maven checkout is a JVM project,
+	 * so the rule's Java and Maven sections are ones it can answer.
+	 */
+	@Override
+	public List<String> requiredClaudeMdSections() {
+		return ClaudeMdConformer.REQUIRED_SECTIONS;
+	}
+
 	@Override
 	public List<String> verifyCommand(Path repositoryDirectory) {
 		return wrapper.commandIn(repositoryDirectory, MAVEN, VERIFY_ARGUMENTS);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
@@ -25,6 +25,10 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * {@link #authenticationProbe}. The adopted project's own build tool only becomes
  * known once the repository is cloned, so {@link BuildToolchainStep} probes it
  * there.
+ *
+ * <p>Which tools are required follows what the run will actually do: a dry run
+ * needs neither {@code gh} nor the credentials behind it, and is checked with
+ * {@link #forDryRun()}.
  */
 public class ToolchainStep implements AdoptionStep {
 
@@ -32,6 +36,14 @@ public class ToolchainStep implements AdoptionStep {
 
 	static final String GITHUB_CLI = "gh";
 	static final List<String> DEFAULT_TOOLS = List.of("git", "claude", GITHUB_CLI);
+
+	/**
+	 * What a dry run actually shells out to. A dry run's pipeline is assembled
+	 * without {@link PushStep} and {@link PullRequestStep}, and {@code gh} is used
+	 * by the pull request alone — {@link PushStep} pushes with {@code git} — so a
+	 * rehearsal never calls it.
+	 */
+	static final List<String> DRY_RUN_TOOLS = List.of("git", "claude");
 
 	/**
 	 * The probe for a run whose URL names no owner, and so no repository to ask
@@ -49,6 +61,19 @@ public class ToolchainStep implements AdoptionStep {
 
 	public ToolchainStep(List<String> tools) {
 		this.tools = List.copyOf(tools);
+	}
+
+	/**
+	 * The check for a run that will not publish. Holding a rehearsal to the
+	 * credentials of the one capability it has been told not to exercise failed
+	 * {@code --dry-run} on its very first step, for want of a {@code gh} the run was
+	 * never going to call — on a host with no GitHub CLI installed, and on a token
+	 * that cannot read the repository, both of which leave the rest of the pipeline
+	 * perfectly runnable. Dropping {@code gh} from the list also settles the login
+	 * probe, which asks about GitHub only while the pull request is still ahead.
+	 */
+	public static ToolchainStep forDryRun() {
+		return new ToolchainStep(DRY_RUN_TOOLS);
 	}
 
 	@Override

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -174,6 +175,27 @@ class GitHubRepoAdopterTest {
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
 				"commit:claude-md", "enforcer", "commit:guard", "assets", "commit:assets", "verify"),
 				stepNames(options));
+	}
+
+	/**
+	 * The toolchain check and the pipeline it opens have to agree about {@code gh}.
+	 * They did not: a dry run assembled without the pull request was still held to
+	 * the GitHub CLI and the credentials behind it, so {@code --dry-run} aborted on
+	 * its very first step over the one capability the flag exists to leave out.
+	 */
+	@Test
+	void aDryRunsToolchainStepDoesNotRequireTheGitHubCli() {
+		AdoptionStep toolchain = GitHubRepoAdopter.defaultSteps(dryRun()).get(0);
+		RecordingCommandRunner runner = RecordingCommandRunner.failingOn("gh", 127, "gh: not found");
+		assertDoesNotThrow(() -> toolchain.execute(context, runner));
+	}
+
+	/** A run that will open the pull request is still held to the tool that opens it. */
+	@Test
+	void aPublishingPipelinesToolchainStepStillRequiresTheGitHubCli() {
+		AdoptionStep toolchain = GitHubRepoAdopter.defaultSteps(withAssets()).get(0);
+		RecordingCommandRunner runner = RecordingCommandRunner.failingOn("gh", 127, "gh: not found");
+		assertThrows(AdoptionException.class, () -> toolchain.execute(context, runner));
 	}
 
 	private List<String> stepNames(AdoptionOptions options) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStepTest.java
@@ -31,6 +31,18 @@ class ClaudeMdConformanceStepTest {
 		return context.repositoryDirectory().resolve(AdoptionAssets.AGENTS_MD_FILE);
 	}
 
+	/**
+	 * A checkout the Maven guard is wired into, and so the one checkout held to the
+	 * {@code claudeMdFormat} rule's sections. A checkout with no build file gets the
+	 * workflow guard instead, which asks only that {@code CLAUDE.md} be there and
+	 * carry something.
+	 */
+	private AdoptionContext mavenCheckout(Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "pom.xml", "<project/>");
+		return context;
+	}
+
 	@Test
 	void isNamedConform() {
 		assertEquals("conform", new ClaudeMdConformanceStep().name());
@@ -38,13 +50,60 @@ class ClaudeMdConformanceStepTest {
 
 	@Test
 	void writesAgentsMdAndNormalisesClaudeMd(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContext context = mavenCheckout(workspace);
 		writeClaudeMd(context, "# CLAUDE.md\n\n## Project purpose\n\nA repo.\n");
 		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
 		assertTrue(Files.isRegularFile(agentsMd(context)), "a companion AGENTS.md must be written");
 		String claudeMd = claudeMd(context);
 		assertTrue(claudeMd.contains(ClaudeMdConformer.AGENTS_REFERENCE), "CLAUDE.md must reference AGENTS.md");
-		assertTrue(claudeMd.contains("## Project"), "CLAUDE.md must carry the required heading");
+		assertTrue(claudeMd.contains("## Project\n"), "CLAUDE.md must carry the required heading");
+	}
+
+	/**
+	 * The sections come from the guard being wired in, so a Maven checkout — the one
+	 * the {@code claudeMdFormat} rule is wired into — is held to all of them.
+	 */
+	@Test
+	void conformsAMavenCheckoutToEveryRequiredSection(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = mavenCheckout(workspace);
+		writeClaudeMd(context, "# CLAUDE.md\n\nA repo.\n");
+		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
+		String claudeMd = claudeMd(context);
+		ClaudeMdConformer.REQUIRED_SECTIONS.forEach(section -> assertTrue(claudeMd.contains(section + "\n"),
+				() -> section + " must be present: " + claudeMd));
+	}
+
+	/**
+	 * A repository with no Maven build gets the workflow guard, which asks only that
+	 * {@code CLAUDE.md} exist and carry something. Conforming it to the rule's
+	 * sections anyway stamped {@code ## Java version}, {@code ## Maven} and
+	 * {@code ## Principles for Java Development} onto projects that are neither Java
+	 * nor Maven — a static site among them — where nothing then checked them.
+	 */
+	@Test
+	void leavesANonMavenCheckoutFreeOfTheRulesJavaSections(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		writeClaudeMd(context, "# CLAUDE.md\n\n## Structure\n\nOne HTML page.\n");
+		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
+		String claudeMd = claudeMd(context);
+		ClaudeMdConformer.REQUIRED_SECTIONS.forEach(section -> assertFalse(claudeMd.contains(section + "\n"),
+				() -> section + " must not be added to a project with no Maven guard: " + claudeMd));
+		assertTrue(claudeMd.contains("## Structure"), "the generated document's own sections must survive");
+		assertTrue(claudeMd.contains(ClaudeMdConformer.AGENTS_REFERENCE),
+				"the companion AGENTS.md must still be referenced");
+	}
+
+	/**
+	 * Conforming to no required section leaves the body {@code claude init} wrote,
+	 * blank line and all, so closing the inserted reference with a blank of its own
+	 * put a double blank into the first commit of every such adoption.
+	 */
+	@Test
+	void insertsTheAgentsReferenceWithoutDoublingABlankLine(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		writeClaudeMd(context, "# CLAUDE.md\n\nOne HTML page.\n");
+		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
+		assertFalse(claudeMd(context).contains("\n\n\n"), claudeMd(context));
 	}
 
 	@Test
@@ -78,7 +137,7 @@ class ClaudeMdConformanceStepTest {
 	 */
 	@Test
 	void keepsACrlfClaudeMdOnCrlf(@TempDir Path workspace) throws IOException {
-		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContext context = mavenCheckout(workspace);
 		writeClaudeMd(context, "# CLAUDE.md\r\n\r\n## Project purpose\r\n\r\nA repo.\r\n");
 		new ClaudeMdConformanceStep().execute(context, new RecordingCommandRunner());
 		String claudeMd = claudeMd(context);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
@@ -109,6 +109,43 @@ class ToolchainStepTest {
 	}
 
 	/**
+	 * A dry run's pipeline is assembled without the push and the pull request, and
+	 * {@code gh} is used by the pull request alone — the push runs {@code git} — so
+	 * the rehearsal is checked for what it will really run.
+	 */
+	@Test
+	void aDryRunProbesOnlyTheToolsItWillActuallyRun() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		ToolchainStep.forDryRun().execute(context, runner);
+		assertEquals(List.of("git", "--version"), runner.commandAt(0));
+		assertEquals(List.of("claude", "--version"), runner.commandAt(1));
+		assertEquals(2, runner.count(), runner.invocations().toString());
+	}
+
+	/**
+	 * Asking GitHub whether the pull request could be opened failed {@code --dry-run}
+	 * on its first step, over the one capability the flag exists to leave out: a host
+	 * with no GitHub CLI, and a token that cannot read the repository, both leave the
+	 * rest of the rehearsal perfectly runnable.
+	 */
+	@Test
+	void aDryRunCompletesWithNoGitHubCliAtAll() {
+		RecordingCommandRunner runner = RecordingCommandRunner.failingOn("gh", 127, "gh: not found");
+		assertDoesNotThrow(() -> ToolchainStep.forDryRun().execute(context, runner));
+		assertFalse(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("gh")),
+				runner.invocations().toString());
+	}
+
+	/** The rehearsal still needs the two tools it does run. */
+	@Test
+	void aDryRunStillAbortsWhenClaudeIsMissing() {
+		RecordingCommandRunner runner = RecordingCommandRunner.failingOn("claude", 127, "claude: not found");
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> ToolchainStep.forDryRun().execute(context, runner));
+		assertTrue(thrown.getMessage().contains("claude"), thrown.getMessage());
+	}
+
+	/**
 	 * {@code gh --version} succeeds for a GitHub CLI nobody is logged in to, so
 	 * without this the adoption would only find out at its very last step, after a
 	 * clone, a claude init, and a build have already run.


### PR DESCRIPTION
A --dry-run is assembled without PushStep and PullRequestStep, but its
ToolchainStep still required `gh` and probed GitHub for the repository, so a
rehearsal aborted on its very first step over the one capability the flag exists
to leave out — on a host with no GitHub CLI, and on a token that cannot read the
repository, both of which leave the rest of the pipeline perfectly runnable.
`gh` is used by the pull request alone, since PushStep pushes with `git`, so a
dry run is now checked with ToolchainStep.forDryRun(): `git` and `claude` only,
which also settles the login probe.

ClaudeMdConformanceStep conformed every adopted CLAUDE.md to the claudeMdFormat
rule's section list, stamping `## Java version`, `## Maven` and `## Principles
for Java Development` — each stubbed with a pointer to AGENTS.md — onto
repositories that are neither Java nor Maven. Only the Maven path wires that
rule in; the Gradle and GitHub Actions guards ask merely that CLAUDE.md exist
and carry something, so nothing then checked those headings. The sections now
come from BuildSystem.requiredClaudeMdSections(), detected from the same
build-system list EnforcerStep is given, so the reshape and the guard cannot
disagree. The title and the AGENTS.md reference stay unconditional, and the
reference no longer doubles a blank line when it leads an unreshaped document.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LiN5Hsfhf9cBMvDkdE9fuf