### PR TITLE
refactor(enforcer,adopt): collapse duplicated rule and conformer logic

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -151,20 +151,17 @@ public final class CliArguments {
 			case "--rule-version" -> consumeName(args, index, value -> ruleVersion = optionalText(value));
 			case TIMEOUT_FLAG -> consumeName(args, index, value -> commandTimeout = optionalTimeout(value));
 			case "--report" -> consumeName(args, index, value -> reportFile = optionalPath(value));
-			case "--draft" -> {
-				draft = true;
-				yield index + 1;
-			}
-			case "--assets" -> {
-				assets = true;
-				yield index + 1;
-			}
-			case "--dry-run" -> {
-				dryRun = true;
-				yield index + 1;
-			}
+			case "--draft" -> switchOn(index, () -> draft = true);
+			case "--assets" -> switchOn(index, () -> assets = true);
+			case "--dry-run" -> switchOn(index, () -> dryRun = true);
 			default -> throw new IllegalArgumentException("Unknown option " + flag + ". " + USAGE);
 		};
+	}
+
+	/** A flag that carries no value: it is set, and the next argument is the one after it. */
+	private int switchOn(int index, Runnable target) {
+		target.run();
+		return index + 1;
 	}
 
 	private int consumeValue(String[] args, int index, Consumer<String> target) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -119,8 +119,7 @@ public class ClaudeMdConformer {
 	 */
 	public String conform(String content) {
 		List<String> lines = splitLines(content);
-		closeUnterminatedFence(lines);
-		closeUnterminatedComment(lines);
+		closeUnterminatedBlocks(lines);
 		ensureTitle(lines);
 		canonicalizeHeadings(lines);
 		ensureRequiredSections(lines);
@@ -133,32 +132,24 @@ public class ClaudeMdConformer {
 	}
 
 	/**
-	 * Closes a fence the document opened and never closed — with a delimiter that
-	 * actually closes it, so a {@code ````} wrapper is not left open by a {@code ```}
-	 * line — so everything appended below lands outside the block. A document whose
-	 * fences balance is returned untouched, keeping the reshape idempotent.
-	 */
-	private void closeUnterminatedFence(List<String> lines) {
-		Delimiter open = scanFences(lines).openAtEnd();
-		if (open != null) {
-			lines.add(open.closing());
-		}
-	}
-
-	/**
-	 * Closes an HTML comment the document opened and never closed, for the same
-	 * reason {@link #closeUnterminatedFence} closes a fence: everything appended
-	 * below has to land outside the block. A section appended inside an open comment
-	 * is inert text the rule does not see, so the adoption would fail its own
-	 * {@link VerifyStep} on a section it had just added. A document whose comments
-	 * balance is returned untouched, keeping the reshape idempotent.
+	 * Closes a fence and an HTML comment the document opened and never closed, so
+	 * everything appended below lands outside the block. The fence is closed with a
+	 * delimiter that actually closes it, so a {@code ````} wrapper is not left open by
+	 * a {@code ```} line. A section appended inside an open comment is inert text the
+	 * rule does not see, so the adoption would fail its own {@link VerifyStep} on a
+	 * section it had just added. A document whose fences and comments balance is left
+	 * untouched, keeping the reshape idempotent.
 	 *
-	 * <p>Fences are closed first, because a comment inside a fenced code block is
+	 * <p>The fence is closed first, because a comment inside a fenced code block is
 	 * sample text rather than a comment — the same precedence the rule reads them
-	 * with.
+	 * with — and the outline is taken afresh afterwards so the added line counts.
 	 */
-	private void closeUnterminatedComment(List<String> lines) {
-		if (scanComments(lines, scanFences(lines).mask()).openAtEnd()) {
+	private void closeUnterminatedBlocks(List<String> lines) {
+		Delimiter openFence = Outline.of(lines).openFence();
+		if (openFence != null) {
+			lines.add(openFence.closing());
+		}
+		if (Outline.of(lines).openComment()) {
 			lines.add(COMMENT_END);
 		}
 	}
@@ -297,12 +288,30 @@ public class ClaudeMdConformer {
 	 *
 	 * <p>Renaming a line in place keeps the outline valid, since the masks are
 	 * indexed by line number and the count has not moved.
+	 *
+	 * @param openFence   the delimiter of a fence the document never closed, or
+	 *                    {@code null} when its fences balance
+	 * @param openComment whether the document left an HTML comment unterminated
 	 */
-	private record Outline(List<String> lines, boolean[] fence, boolean[] comment) {
+	private record Outline(List<String> lines, boolean[] fence, boolean[] comment, Delimiter openFence,
+			boolean openComment) {
 
+		/**
+		 * Both masks are read in one pass, because a comment inside a fenced code block
+		 * is sample text rather than a comment and so the comment scan needs the fence
+		 * verdict for the very line it is on — which the fence scan has just settled.
+		 */
 		static Outline of(List<String> lines) {
-			boolean[] fence = scanFences(lines).mask();
-			return new Outline(lines, fence, scanComments(lines, fence).mask());
+			boolean[] fence = new boolean[lines.size()];
+			boolean[] comment = new boolean[lines.size()];
+			Delimiter openFence = null;
+			boolean openComment = false;
+			for (int index = 0; index < lines.size(); index++) {
+				String line = lines.get(index).strip();
+				openFence = applyFence(line, openFence, fence, index);
+				openComment = applyComment(line, openComment, fence[index], comment, index);
+			}
+			return new Outline(lines, fence, comment, openFence, openComment);
 		}
 
 		/** The indices of the lines outside code fences whose text matches, in document order. */
@@ -396,46 +405,15 @@ public class ClaudeMdConformer {
 	}
 
 	/**
-	 * The outcome of reading the document's fences: which lines are code, and the
-	 * delimiter still open once the last line has been read.
-	 *
-	 * @param openAtEnd the unterminated fence's delimiter, or {@code null} when the
-	 *                  document's fences balance
-	 */
-	private record Fences(boolean[] mask, Delimiter openAtEnd) {
-	}
-
-	/**
-	 * The outcome of reading the document's HTML comments: which lines are commented
-	 * out, and whether one is still open once the last line has been read.
-	 *
-	 * @param openAtEnd whether the document left a comment unterminated
-	 */
-	private record Comments(boolean[] mask, boolean openAtEnd) {
-	}
-
-	/**
-	 * Reads which lines an HTML comment spans. A comment that opens and closes on one
-	 * line masks nothing — {@code <!-- ## Testing -->} is not a heading to begin with
-	 * — while a block comment hides the lines it spans from every heading search.
-	 * This mirrors {@code MarkdownDocument} in the {@code claude-code-enforcer}
-	 * module, as {@link Delimiter} does; keep the two in sync.
-	 *
-	 * @param fence the fence mask, because a comment inside a fenced code block is
-	 *              sample text rather than a comment: the fence wins
-	 */
-	private static Comments scanComments(List<String> lines, boolean[] fence) {
-		boolean[] mask = new boolean[lines.size()];
-		boolean open = false;
-		for (int index = 0; index < lines.size(); index++) {
-			open = applyComment(lines.get(index).strip(), open, fence[index], mask, index);
-		}
-		return new Comments(mask, open);
-	}
-
-	/**
 	 * Marks whether the line is commented out and returns whether a comment is still
-	 * open after it.
+	 * open after it. A comment that opens and closes on one line masks nothing —
+	 * {@code <!-- ## Testing -->} is not a heading to begin with — while a block
+	 * comment hides the lines it spans from every heading search. This mirrors
+	 * {@code MarkdownDocument} in the {@code claude-code-enforcer} module, as
+	 * {@link Delimiter} does; keep the two in sync.
+	 *
+	 * @param insideFence whether the line is code, because a comment inside a fenced
+	 *                    code block is sample text rather than a comment: the fence wins
 	 */
 	private static boolean applyComment(String line, boolean open, boolean insideFence, boolean[] mask, int index) {
 		if (insideFence) {
@@ -447,15 +425,6 @@ public class ClaudeMdConformer {
 		}
 		mask[index] = line.startsWith(COMMENT_START) && !line.contains(COMMENT_END);
 		return mask[index];
-	}
-
-	private static Fences scanFences(List<String> lines) {
-		boolean[] mask = new boolean[lines.size()];
-		Delimiter open = null;
-		for (int index = 0; index < lines.size(); index++) {
-			open = applyFence(lines.get(index).strip(), open, mask, index);
-		}
-		return new Fences(mask, open);
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -3,7 +3,6 @@ package io.github.adamw7.tools.enforcer.definition;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import javax.inject.Named;
 
@@ -11,7 +10,6 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.enforcer.text.FrontMatter;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
 import io.github.adamw7.tools.enforcer.text.NameConvention;
 
 /**
@@ -32,7 +30,7 @@ import io.github.adamw7.tools.enforcer.text.NameConvention;
 public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 
 	private static final String LABEL = "Command";
-	private static final String DEFINITION = "command definition";
+	private static final String DEFINITION = "Command definition";
 
 	/** The {@code .claude/commands} directory to scan. Injected from the rule configuration. */
 	private File commandsDir;
@@ -57,27 +55,15 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 		report("Command files are not well formed:", violations);
 	}
 
-	/**
-	 * A command that cannot be decoded as text is reported rather than read. The rule
-	 * scans a directory whose contents it does not control, and an
-	 * {@link java.io.UncheckedIOException} escaping here would abort the build as an
-	 * internal error instead of reporting the malformed command it exists to catch.
-	 */
 	private void collectCommandViolations(File command, List<String> violations) {
-		Optional<String> text = MarkdownText.readIfText(command);
-		if (text.isEmpty()) {
-			violations.add("Command definition cannot be read as text: " + command);
-			return;
-		}
-		String content = text.get();
-		if (content.isBlank()) {
-			violations.add("Command definition is empty: " + command);
-			return;
-		}
+		DefinitionContent.of(command, DEFINITION, autoFix, getLog(), violations)
+				.ifPresent(content -> collectNamedViolations(command, content, violations));
+	}
+
+	private void collectNamedViolations(File command, String content, List<String> violations) {
 		String baseName = DefinitionFiles.baseName(command);
 		NameConvention.collect(baseName, baseName, command.toString(), violations);
-		String fixed = FrontMatterAutoFix.apply(command, DEFINITION, content, autoFix, getLog());
-		FrontMatter.parse(fixed)
+		FrontMatter.parse(content)
 				.ifPresent(frontMatter -> collectFrontMatterViolations(command, frontMatter, violations));
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionContent.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionContent.java
@@ -1,0 +1,47 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * The text of one Claude Code definition, ready to be validated: read, checked for
+ * emptiness, and auto-fixed. Every definition rule starts the same way, so the
+ * three preliminaries live here and each rule keeps only the checks that are its
+ * own.
+ * <p>
+ * A file that cannot be decoded as text is reported rather than read. These rules
+ * scan a directory whose contents they do not control, and an
+ * {@link java.io.UncheckedIOException} escaping one would abort the build as an
+ * internal error instead of reporting the malformed definition it exists to catch
+ * — taking the remaining definitions' violations down with it.
+ */
+final class DefinitionContent {
+
+	private DefinitionContent() {
+	}
+
+	/**
+	 * @param label the definition kind as messages name it, e.g. {@code SKILL.md} or
+	 *              {@code Sub-agent definition}
+	 * @return the content to validate, or empty when a violation was collected
+	 *         instead
+	 */
+	static Optional<String> of(File file, String label, boolean autoFix, EnforcerLogger log,
+			List<String> violations) {
+		Optional<String> text = MarkdownText.readIfText(file);
+		if (text.isEmpty()) {
+			violations.add(label + " cannot be read as text: " + file);
+			return Optional.empty();
+		}
+		if (text.get().isBlank()) {
+			violations.add(label + " is empty: " + file);
+			return Optional.empty();
+		}
+		return Optional.of(FrontMatterAutoFix.apply(file, label, text.get(), autoFix, log));
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/FrontMatterChecks.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/FrontMatterChecks.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.definition;
 import java.io.File;
 import java.util.List;
 
+import io.github.adamw7.tools.enforcer.rule.Violations;
 import io.github.adamw7.tools.enforcer.text.FrontMatter;
 import io.github.adamw7.tools.enforcer.text.NameConvention;
 
@@ -39,11 +40,8 @@ final class FrontMatterChecks {
 
 	/** Reports every required key the front matter does not declare. */
 	void requireKeys(List<String> requiredKeys) {
-		for (String key : requiredKeys) {
-			if (!frontMatter.hasKey(key)) {
-				violations.add(label + " front matter is missing '" + key + ":' in: " + file);
-			}
-		}
+		Violations.each(requiredKeys, key -> !frontMatter.hasKey(key),
+				key -> frontMatterProblem("is missing '" + key + ":'"), violations);
 	}
 
 	/**
@@ -52,21 +50,18 @@ final class FrontMatterChecks {
 	 * reads — a second {@code description:} silently replaces the one above it.
 	 */
 	void rejectDuplicateKeys() {
-		for (String key : frontMatter.duplicateKeys()) {
-			violations.add(label + " front matter declares '" + key + ":' more than once in: " + file);
-		}
+		frontMatter.duplicateKeys()
+				.forEach(key -> violations.add(frontMatterProblem("declares '" + key + ":' more than once")));
 	}
 
 	/** Reports every declared key outside the whitelist, which catches a typo such as {@code descripton}. */
 	void allowOnlyKeys(List<String> allowedKeys) {
-		if (allowedKeys == null) {
-			return;
-		}
-		for (String key : frontMatter.keys()) {
-			if (!allowedKeys.contains(key)) {
-				violations.add(label + " front matter has unknown key '" + key + ":' in: " + file);
-			}
-		}
+		Violations.eachDisallowed(frontMatter.keys(), allowedKeys,
+				key -> frontMatterProblem("has unknown key '" + key + ":'"), violations);
+	}
+
+	private String frontMatterProblem(String problem) {
+		return label + " front matter " + problem + " in: " + file;
 	}
 
 	/** Reports a declared {@code name} that breaks convention or does not match {@code expected}. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRule.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
 import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+import io.github.adamw7.tools.enforcer.rule.Violations;
 import io.github.adamw7.tools.enforcer.text.NameConvention;
 
 /**
@@ -65,30 +66,17 @@ public class PluginFormatRule extends JsonFileRule {
 
 	@Override
 	protected void collectViolations(JsonNode manifest, List<String> violations) {
-		collectMissingKeys(manifest, violations);
-		collectUnknownKeys(manifest, violations);
+		Violations.each(Objects.requireNonNullElse(requiredKeys, DEFAULT_REQUIRED_KEYS), key -> !manifest.has(key),
+				key -> keyProblem("is missing required key '" + key + "'"), violations);
+		Violations.eachDisallowed(JsonNodes.fieldNames(manifest), allowedKeys,
+				key -> keyProblem("has unknown key '" + key + "'"), violations);
 		collectNameViolations(manifest, violations);
 		collectVersionViolation(manifest, violations);
 		collectDescriptionViolation(manifest, violations);
 	}
 
-	private void collectMissingKeys(JsonNode manifest, List<String> violations) {
-		for (String key : Objects.requireNonNullElse(requiredKeys, DEFAULT_REQUIRED_KEYS)) {
-			if (!manifest.has(key)) {
-				violations.add("plugin.json is missing required key '" + key + "' in: " + pluginFile);
-			}
-		}
-	}
-
-	private void collectUnknownKeys(JsonNode manifest, List<String> violations) {
-		if (allowedKeys == null) {
-			return;
-		}
-		for (String key : JsonNodes.fieldNames(manifest)) {
-			if (!allowedKeys.contains(key)) {
-				violations.add("plugin.json has unknown key '" + key + "' in: " + pluginFile);
-			}
-		}
+	private String keyProblem(String problem) {
+		return "plugin.json " + problem + " in: " + pluginFile;
 	}
 
 	/** A plugin name answers to no directory, so the convention check compares it only to itself. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -12,7 +12,6 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.enforcer.text.FrontMatter;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
 import io.github.adamw7.tools.enforcer.text.NameConvention;
 
 /**
@@ -73,26 +72,14 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 		}
 	}
 
-	/**
-	 * A {@code SKILL.md} that cannot be decoded as text is reported rather than read.
-	 * The rule scans a directory whose contents it does not control, and an
-	 * {@link java.io.UncheckedIOException} escaping here would abort the build as an
-	 * internal error instead of reporting the malformed skill it exists to catch —
-	 * and would take the remaining skills' violations down with it.
-	 */
 	private void collectContentViolations(File skillDirectory, File skillFile, List<String> violations) {
-		Optional<String> text = MarkdownText.readIfText(skillFile);
-		if (text.isEmpty()) {
-			violations.add(SKILL_FILE_NAME + " cannot be read as text: " + skillFile);
-			return;
-		}
-		String content = text.get();
-		if (content.isBlank()) {
-			violations.add(SKILL_FILE_NAME + " is empty: " + skillFile);
-			return;
-		}
-		String fixed = FrontMatterAutoFix.apply(skillFile, SKILL_FILE_NAME, content, autoFix, getLog());
-		Optional<FrontMatter> frontMatter = FrontMatter.parse(fixed);
+		DefinitionContent.of(skillFile, SKILL_FILE_NAME, autoFix, getLog(), violations)
+				.ifPresent(content -> collectParsedViolations(skillDirectory, skillFile, content, violations));
+	}
+
+	private void collectParsedViolations(File skillDirectory, File skillFile, String content,
+			List<String> violations) {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse(content);
 		if (frontMatter.isEmpty()) {
 			violations.add(SKILL_FILE_NAME + " must start with a YAML front matter block delimited by '---': "
 					+ skillFile);

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -12,7 +12,6 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.enforcer.text.FrontMatter;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
 /**
  * Enforcer rule that fails the build when any sub-agent definition under the
@@ -32,7 +31,7 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
 public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 
 	private static final String LABEL = "Sub-agent";
-	private static final String DEFINITION = "sub-agent definition";
+	private static final String DEFINITION = "Sub-agent definition";
 	private static final List<String> DEFAULT_REQUIRED_KEYS = List.of("name", "description");
 
 	/** The {@code .claude/agents} directory to scan. Injected from the rule configuration. */
@@ -58,28 +57,15 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 		report("Sub-agent files are not well formed:", violations);
 	}
 
-	/**
-	 * A definition that cannot be decoded as text is reported rather than read. The
-	 * rule scans a directory whose contents it does not control, and an
-	 * {@link java.io.UncheckedIOException} escaping here would abort the build as an
-	 * internal error instead of reporting the malformed definition it exists to
-	 * catch.
-	 */
 	private void collectDefinitionViolations(File definition, List<String> violations) {
-		Optional<String> text = MarkdownText.readIfText(definition);
-		if (text.isEmpty()) {
-			violations.add("Sub-agent definition cannot be read as text: " + definition);
-			return;
-		}
-		String content = text.get();
-		if (content.isBlank()) {
-			violations.add("Sub-agent definition is empty: " + definition);
-			return;
-		}
-		String fixed = FrontMatterAutoFix.apply(definition, DEFINITION, content, autoFix, getLog());
-		Optional<FrontMatter> frontMatter = FrontMatter.parse(fixed);
+		DefinitionContent.of(definition, DEFINITION, autoFix, getLog(), violations)
+				.ifPresent(content -> collectParsedViolations(definition, content, violations));
+	}
+
+	private void collectParsedViolations(File definition, String content, List<String> violations) {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse(content);
 		if (frontMatter.isEmpty()) {
-			violations.add("Sub-agent definition must start with a YAML front matter block delimited by '---': "
+			violations.add(DEFINITION + " must start with a YAML front matter block delimited by '---': "
 					+ definition);
 		} else {
 			collectFrontMatterViolations(definition, frontMatter.get(), violations);

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
@@ -6,11 +6,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.doc.BoundedCharSequence.BacktrackLimitExceededException;
+import io.github.adamw7.tools.enforcer.rule.Patterns;
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
 /**
@@ -34,6 +34,8 @@ final class DocumentConsistency {
 	 */
 	private static final long STEPS_PER_CHARACTER = 10_000L;
 	private static final long MINIMUM_STEPS = 1_000_000L;
+
+	private static final String PARAMETER = "consistentPattern";
 
 	/** A document to compare: its content, and the name shown in violation messages. */
 	private record Document(String name, String content) {
@@ -63,36 +65,25 @@ final class DocumentConsistency {
 		return violations;
 	}
 
-	private List<Pattern> compilePatterns() throws EnforcerRuleException {
-		List<Pattern> compiled = new ArrayList<>();
-		for (String pattern : patterns) {
-			compiled.add(verified(pattern));
-		}
-		return compiled;
-	}
-
 	/**
-	 * Each pattern must be a valid regular expression declaring a capturing group,
-	 * since comparison reads {@code group(1)}. Either mistake is a build-setup one,
-	 * so it fails with a message naming the pattern instead of letting an opaque
-	 * {@link java.util.regex.PatternSyntaxException} or
-	 * {@link IndexOutOfBoundsException} escape as an internal build error.
+	 * Each pattern must declare a capturing group, since comparison reads
+	 * {@code group(1)}. That is a build-setup mistake, so it fails with a message
+	 * naming the pattern instead of letting an opaque
+	 * {@link IndexOutOfBoundsException} escape as an internal build error — as
+	 * {@link Patterns} does for a pattern that does not compile at all.
 	 */
-	private Pattern verified(String pattern) throws EnforcerRuleException {
-		Pattern compiled = compile(pattern);
-		if (compiled.matcher("").groupCount() < 1) {
-			throw new EnforcerRuleException(
-					"consistentPattern '" + pattern + "' must declare a capturing group");
+	private List<Pattern> compilePatterns() throws EnforcerRuleException {
+		List<Pattern> compiled = Patterns.compileAll(patterns, PARAMETER);
+		for (Pattern pattern : compiled) {
+			requireCapturingGroup(pattern);
 		}
 		return compiled;
 	}
 
-	private Pattern compile(String pattern) throws EnforcerRuleException {
-		try {
-			return Pattern.compile(pattern);
-		} catch (PatternSyntaxException e) {
+	private void requireCapturingGroup(Pattern pattern) throws EnforcerRuleException {
+		if (pattern.matcher("").groupCount() < 1) {
 			throw new EnforcerRuleException(
-					"consistentPattern '" + pattern + "' is not a valid regular expression: " + e.getDescription());
+					PARAMETER + " '" + pattern.pattern() + "' must declare a capturing group");
 		}
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
 import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+import io.github.adamw7.tools.enforcer.rule.Violations;
 
 /**
  * Enforcer rule that fails the build when the project's {@code .mcp.json} is
@@ -75,8 +76,10 @@ public class McpServersValidRule extends JsonFileRule {
 		for (String name : JsonNodes.fieldNames(servers)) {
 			collectServerViolations(name, JsonNodes.objectAt(servers, name), violations);
 		}
-		collectRequiredServers(servers, violations);
-		collectForbiddenServers(servers, violations);
+		Violations.each(requiredServers, name -> !servers.has(name),
+				name -> "mcp.json is missing required server: " + name, violations);
+		Violations.each(forbiddenServers, servers::has,
+				name -> "mcp.json contains forbidden server: " + name, violations);
 	}
 
 	/**
@@ -124,28 +127,6 @@ public class McpServersValidRule extends JsonFileRule {
 	/** Every violation names the server whose entry is malformed. */
 	private void add(String name, String problem, List<String> violations) {
 		violations.add("mcp.json server '" + name + "' " + problem);
-	}
-
-	private void collectRequiredServers(JsonNode servers, List<String> violations) {
-		if (requiredServers == null) {
-			return;
-		}
-		for (String name : requiredServers) {
-			if (!servers.has(name)) {
-				violations.add("mcp.json is missing required server: " + name);
-			}
-		}
-	}
-
-	private void collectForbiddenServers(JsonNode servers, List<String> violations) {
-		if (forbiddenServers == null) {
-			return;
-		}
-		for (String name : forbiddenServers) {
-			if (servers.has(name)) {
-				violations.add("mcp.json contains forbidden server: " + name);
-			}
-		}
 	}
 
 	void setMcpFile(File mcpFile) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRule.java
@@ -20,6 +20,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.enforcer.rule.ScanTargets;
+import io.github.adamw7.tools.enforcer.rule.Violations;
 import io.github.adamw7.tools.enforcer.text.FrontMatter;
 import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
@@ -158,9 +159,8 @@ public class OkfBundleFormatRule extends ClaudeCodeEnforcerRule {
 		}
 		frontMatter.duplicateKeys()
 				.forEach(key -> violations.add(name + " declares '" + key + "' more than once"));
-		requiredKeys().stream()
-				.filter(key -> isBlank(frontMatter, key))
-				.forEach(key -> violations.add(name + " declares no non-empty '" + key + "'"));
+		Violations.each(requiredKeys, key -> isBlank(frontMatter, key),
+				key -> name + " declares no non-empty '" + key + "'", violations);
 	}
 
 	private void collectStatusViolations(String name, FrontMatter frontMatter, List<String> violations) {
@@ -270,10 +270,6 @@ public class OkfBundleFormatRule extends ClaudeCodeEnforcerRule {
 				.filter(directory -> !indexed.contains(directory))
 				.forEach(directory -> violations.add(
 						relativeDirectory(directory) + " holds concepts but no " + INDEX));
-	}
-
-	private List<String> requiredKeys() {
-		return requiredKeys != null ? requiredKeys : List.of();
 	}
 
 	private boolean isBlank(FrontMatter frontMatter, String key) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Patterns.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Patterns.java
@@ -1,0 +1,45 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * Compiles the regular expressions a rule takes from its configuration. A pattern
+ * that is not a valid regular expression is a build-setup mistake, so it fails
+ * with a message naming the parameter it was written under rather than letting a
+ * {@link PatternSyntaxException} escape as an internal build error. Every rule
+ * that takes a pattern says so the same way, which is why the wording lives here
+ * rather than in each of them.
+ */
+public final class Patterns {
+
+	private Patterns() {
+	}
+
+	/**
+	 * @param regex     the configured pattern
+	 * @param parameter the configuration parameter it was written under, e.g.
+	 *                  {@code secretPattern}, named in the failure message
+	 */
+	public static Pattern compile(String regex, String parameter) throws EnforcerRuleException {
+		try {
+			return Pattern.compile(regex);
+		} catch (PatternSyntaxException e) {
+			throw new EnforcerRuleException(
+					parameter + " '" + regex + "' is not a valid regular expression: " + e.getDescription());
+		}
+	}
+
+	/** Every configured pattern, compiled in order; a {@code null} list is read as none configured. */
+	public static List<Pattern> compileAll(List<String> regexes, String parameter) throws EnforcerRuleException {
+		List<Pattern> compiled = new ArrayList<>();
+		for (String regex : regexes != null ? regexes : List.<String>of()) {
+			compiled.add(compile(regex, parameter));
+		}
+		return compiled;
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Violations.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Violations.java
@@ -1,0 +1,41 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+/**
+ * The membership checks every configuration rule repeats: each value a policy list
+ * names that the document offends against — a required entry it does not declare,
+ * a forbidden entry it does — and each entry it declares that a whitelist does not
+ * allow.
+ * <p>
+ * Both take the message as a function of the offending value, so a rule keeps its
+ * own wording while the traversal lives here, along with the reading the rule
+ * configuration gives an unset parameter: a {@code null} policy list checks
+ * nothing, and a {@code null} whitelist allows anything.
+ */
+public final class Violations {
+
+	private Violations() {
+	}
+
+	/** Adds {@code message} for each of {@code configured} that {@code offends} accepts. */
+	public static void each(List<String> configured, Predicate<String> offends, UnaryOperator<String> message,
+			List<String> violations) {
+		if (configured == null) {
+			return;
+		}
+		configured.stream().filter(offends).map(message).forEach(violations::add);
+	}
+
+	/** Adds {@code message} for each of {@code declared} outside {@code allowed}. */
+	public static void eachDisallowed(Collection<String> declared, Collection<String> allowed,
+			UnaryOperator<String> message, List<String> violations) {
+		if (allowed == null) {
+			return;
+		}
+		declared.stream().filter(value -> !allowed.contains(value)).map(message).forEach(violations::add);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.PatternSyntaxException;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -13,6 +12,7 @@ import javax.inject.Named;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.rule.Patterns;
 import io.github.adamw7.tools.enforcer.rule.ScanTargets;
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
@@ -38,6 +38,7 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
 public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 
 	private static final int VISIBLE_PREFIX_LENGTH = 8;
+	private static final String SECRET_PATTERN_PARAMETER = "secretPattern";
 
 	/** Files to scan. An entry that does not exist is skipped, since most targets are optional. */
 	private List<File> files;
@@ -112,30 +113,16 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 		return content.map(text -> text.lines().toList()).orElseGet(List::of);
 	}
 
+	/** A configured pattern is reported under its own text, since only its author can name it. */
 	private List<CredentialPattern> patterns() throws EnforcerRuleException {
 		List<CredentialPattern> patterns = new ArrayList<>();
 		if (useDefaultPatterns) {
 			patterns.addAll(CredentialPattern.defaults());
 		}
-		List<String> configured = secretPatterns != null ? secretPatterns : List.of();
-		for (String regex : configured) {
-			patterns.add(compiled(regex));
+		for (String regex : secretPatterns != null ? secretPatterns : List.<String>of()) {
+			patterns.add(new CredentialPattern(regex, Patterns.compile(regex, SECRET_PATTERN_PARAMETER)));
 		}
 		return patterns;
-	}
-
-	/**
-	 * A configured pattern that is not a valid regular expression is a build-setup
-	 * mistake, so it fails with a message naming it rather than letting a
-	 * {@link PatternSyntaxException} escape as an internal build error.
-	 */
-	private CredentialPattern compiled(String regex) throws EnforcerRuleException {
-		try {
-			return CredentialPattern.of(regex, regex);
-		} catch (PatternSyntaxException e) {
-			throw new EnforcerRuleException(
-					"secretPattern '" + regex + "' is not a valid regular expression: " + e.getDescription());
-		}
 	}
 
 	void setFiles(List<File> files) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
@@ -1,12 +1,10 @@
 package io.github.adamw7.tools.enforcer.settings;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import javax.inject.Named;
@@ -17,6 +15,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
 import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+import io.github.adamw7.tools.enforcer.rule.Patterns;
 
 /**
  * Enforcer rule that validates the entries of the {@code permissions} lists in
@@ -53,6 +52,7 @@ public class PermissionsFormatRule extends JsonFileRule {
 	private static final Pattern ENTRY_SYNTAX = Pattern
 			.compile("(mcp__[A-Za-z0-9_-]+|[A-Za-z][A-Za-z0-9_]*)(\\(.+\\))?");
 	private static final String MCP_TOOL_PREFIX = "mcp__";
+	private static final String FORBIDDEN_PATTERN_PARAMETER = "forbiddenEntryPattern";
 
 	/** The {@code .claude/settings.json} file to validate. Injected from the rule configuration. */
 	private File settingsFile;
@@ -156,31 +156,9 @@ public class PermissionsFormatRule extends JsonFileRule {
 		if (forbiddenEntryPatterns == null) {
 			return;
 		}
-		List<Pattern> patterns = compiledForbiddenPatterns();
+		List<Pattern> patterns = Patterns.compileAll(forbiddenEntryPatterns, FORBIDDEN_PATTERN_PARAMETER);
 		for (String entry : textEntries(permissions, ALLOW_KEY)) {
 			addForbiddenEntryViolations(entry, patterns, violations);
-		}
-	}
-
-	/**
-	 * A configured pattern that is not a valid regular expression is a build-setup
-	 * mistake, so it fails with a message naming it rather than letting a
-	 * {@link PatternSyntaxException} escape as an internal build error.
-	 */
-	private List<Pattern> compiledForbiddenPatterns() throws EnforcerRuleException {
-		List<Pattern> patterns = new ArrayList<>();
-		for (String pattern : forbiddenEntryPatterns) {
-			patterns.add(compiled(pattern));
-		}
-		return patterns;
-	}
-
-	private Pattern compiled(String pattern) throws EnforcerRuleException {
-		try {
-			return Pattern.compile(pattern);
-		} catch (PatternSyntaxException e) {
-			throw new EnforcerRuleException("forbiddenEntryPattern '" + pattern
-					+ "' is not a valid regular expression: " + e.getDescription());
 		}
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
 import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+import io.github.adamw7.tools.enforcer.rule.Violations;
 
 /**
  * Enforcer rule that fails the build when {@code .claude/settings.json} is
@@ -52,36 +53,16 @@ public class SettingsJsonValidRule extends JsonFileRule {
 			return;
 		}
 		List<String> allow = allowList(settings);
-		collectRequiredPermissions(allow, violations);
-		collectForbiddenPermissions(allow, violations);
+		Violations.each(requiredPermissions, permission -> !allow.contains(permission),
+				permission -> "settings.json is missing required permission: " + permission, violations);
+		Violations.each(forbiddenPermissions, allow::contains,
+				permission -> "settings.json contains forbidden permission: " + permission, violations);
 	}
 
 	private List<String> allowList(JsonNode settings) {
 		JsonNode permissions = JsonNodes.objectAt(settings, PERMISSIONS_KEY);
 		JsonNode allow = permissions != null ? JsonNodes.arrayAt(permissions, ALLOW_KEY) : null;
 		return allow != null ? allow.valueStream().map(JsonNode::asText).toList() : List.of();
-	}
-
-	private void collectRequiredPermissions(List<String> allow, List<String> violations) {
-		if (requiredPermissions == null) {
-			return;
-		}
-		for (String permission : requiredPermissions) {
-			if (!allow.contains(permission)) {
-				violations.add("settings.json is missing required permission: " + permission);
-			}
-		}
-	}
-
-	private void collectForbiddenPermissions(List<String> allow, List<String> violations) {
-		if (forbiddenPermissions == null) {
-			return;
-		}
-		for (String permission : forbiddenPermissions) {
-			if (allow.contains(permission)) {
-				violations.add("settings.json contains forbidden permission: " + permission);
-			}
-		}
 	}
 
 	void setSettingsFile(File settingsFile) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -3,7 +3,6 @@ package io.github.adamw7.tools.enforcer.text;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -148,35 +147,28 @@ public final class MarkdownDocument {
 		return structuralLines().filter(index -> lines.get(index).strip().equals(section)).findFirst().orElse(-1);
 	}
 
+	/** The first line that settles the question decides it; a section nothing settles has no body. */
 	private boolean hasBodyAt(int headingIndex) {
 		int sectionLevel = headingLevel(lines.get(headingIndex).strip());
-		for (int i = headingIndex + 1; i < lines.size(); i++) {
-			Optional<Boolean> verdict = bodyVerdict(i, sectionLevel);
-			if (verdict.isPresent()) {
-				return verdict.get();
-			}
-		}
-		return false;
+		return IntStream.range(headingIndex + 1, lines.size())
+				.filter(this::decidesBody)
+				.limit(1)
+				.anyMatch(index -> insideFence[index] || isBody(lines.get(index).strip(), sectionLevel));
 	}
 
 	/**
-	 * Whether the line at {@code index} settles the question of the section's body,
-	 * or empty when it says nothing either way. A blank line does not, and neither
-	 * does a commented-out one: a section whose only content is inside an HTML
-	 * comment reads as empty, which is what commenting it out meant.
+	 * Whether the line at {@code index} settles the question of the section's body.
+	 * A blank line does not, and neither does a commented-out one: a section whose
+	 * only content is inside an HTML comment reads as empty, which is what commenting
+	 * it out meant.
 	 */
-	private Optional<Boolean> bodyVerdict(int index, int sectionLevel) {
-		if (insideComment[index]) {
-			return Optional.empty();
-		}
-		if (insideFence[index]) {
-			return Optional.of(Boolean.TRUE);
-		}
-		String line = lines.get(index).strip();
-		if (isHeading(line)) {
-			return Optional.of(headingLevel(line) > sectionLevel);
-		}
-		return line.isEmpty() ? Optional.empty() : Optional.of(Boolean.TRUE);
+	private boolean decidesBody(int index) {
+		return insideFence[index] || (!insideComment[index] && !lines.get(index).isBlank());
+	}
+
+	/** A deeper sub-heading continues the section; one at its level or shallower ends it. */
+	private static boolean isBody(String line, int sectionLevel) {
+		return !isHeading(line) || headingLevel(line) > sectionLevel;
 	}
 
 	private static boolean isHeading(String line) {
@@ -184,11 +176,7 @@ public final class MarkdownDocument {
 	}
 
 	private static int headingLevel(String heading) {
-		int level = 0;
-		while (level < heading.length() && heading.charAt(level) == HEADING_CHAR) {
-			level++;
-		}
-		return level;
+		return runLength(heading, HEADING_CHAR);
 	}
 
 	private static boolean[] fenceMask(List<String> lines) {
@@ -264,12 +252,9 @@ public final class MarkdownDocument {
 		return character == BACKTICK || character == TILDE;
 	}
 
+	/** How many times {@code character} repeats at the start of {@code line}. */
 	private static int runLength(String line, char character) {
-		int length = 0;
-		while (length < line.length() && line.charAt(length) == character) {
-			length++;
-		}
-		return length;
+		return (int) line.chars().takeWhile(candidate -> candidate == character).count();
 	}
 
 	/**


### PR DESCRIPTION
Extract the checks the enforcer rules were each writing out for
themselves, and fold the conformer's two Markdown scans into one.

claude-code-enforcer:
- add rule/Violations for the required-entry, forbidden-entry and
  whitelist loops repeated in settingsJsonValid, mcpServersValid,
  pluginFormat, okfBundleFormat and the front matter checks
- add rule/Patterns for the "compile a configured regex or fail naming
  the parameter" block repeated in permissionsFormat, noSecrets and the
  document-consistency comparison
- add definition/DefinitionContent for the read-as-text, non-blank and
  auto-fix preliminaries the skill, sub-agent and command rules share
- read a section's body from a single stream in MarkdownDocument rather
  than a loop over an Optional<Boolean> verdict, and derive the heading
  level from the shared run-length helper

adopt:
- build ClaudeMdConformer's fence and comment masks in one pass, so the
  Fences and Comments records and their two scan entry points go away
- give CliArguments one helper for the flags that carry no value

No behaviour change: every violation message, and every rule's
configuration, is what it was.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lr2joAjc1j4rEAyEY4VbrM