### PR TITLE
refactor(data,context): collapse duplicated sources, tools and fixtures

### DIFF
--- a/code/context/src/main/java/io/github/adamw7/context/AbstractTokenEstimator.java
+++ b/code/context/src/main/java/io/github/adamw7/context/AbstractTokenEstimator.java
@@ -1,0 +1,36 @@
+package io.github.adamw7.context;
+
+/**
+ * What the dependency-free {@link TokenEstimator}s share: the characters-per-token
+ * ratio they are configured with, the rejection of a non-positive one, the rule
+ * that absent or empty text costs nothing, and the rounding-up that gives any
+ * shorter run one token rather than none. Subclasses supply only how they count
+ * the text itself, which is the one concern in which they differ.
+ */
+public abstract class AbstractTokenEstimator implements TokenEstimator {
+
+	public static final int DEFAULT_CHARACTERS_PER_TOKEN = 4;
+
+	protected final int charactersPerToken;
+
+	protected AbstractTokenEstimator(int charactersPerToken) {
+		if (charactersPerToken <= 0) {
+			throw new IllegalArgumentException(
+					"charactersPerToken must be positive and received: " + charactersPerToken);
+		}
+		this.charactersPerToken = charactersPerToken;
+	}
+
+	@Override
+	public final int estimate(String text) {
+		return text == null || text.isEmpty() ? 0 : count(text);
+	}
+
+	/** Counts the tokens of text already known to be non-empty. */
+	protected abstract int count(String text);
+
+	/** Rounds up, so a run shorter than one token's worth of characters still costs one. */
+	protected final int tokensFor(int characters) {
+		return (characters + charactersPerToken - 1) / charactersPerToken;
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/HeuristicTokenEstimator.java
+++ b/code/context/src/main/java/io/github/adamw7/context/HeuristicTokenEstimator.java
@@ -8,37 +8,18 @@ package io.github.adamw7.context;
  * without a tokenizer dependency. The estimate is rounded up so that any
  * non-empty text costs at least one token.
  */
-public class HeuristicTokenEstimator implements TokenEstimator {
-
-	public static final int DEFAULT_CHARACTERS_PER_TOKEN = 4;
-
-	private final int charactersPerToken;
+public class HeuristicTokenEstimator extends AbstractTokenEstimator {
 
 	public HeuristicTokenEstimator() {
 		this(DEFAULT_CHARACTERS_PER_TOKEN);
 	}
 
 	public HeuristicTokenEstimator(int charactersPerToken) {
-		requirePositive(charactersPerToken);
-		this.charactersPerToken = charactersPerToken;
-	}
-
-	private void requirePositive(int charactersPerToken) {
-		if (charactersPerToken <= 0) {
-			throw new IllegalArgumentException(
-					"charactersPerToken must be positive and received: " + charactersPerToken);
-		}
+		super(charactersPerToken);
 	}
 
 	@Override
-	public int estimate(String text) {
-		if (text == null || text.isEmpty()) {
-			return 0;
-		}
-		return ceilDivision(text.length(), charactersPerToken);
-	}
-
-	private int ceilDivision(int dividend, int divisor) {
-		return (dividend + divisor - 1) / divisor;
+	protected int count(String text) {
+		return tokensFor(text.length());
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/PackageAwareFinder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/PackageAwareFinder.java
@@ -2,10 +2,13 @@ package io.github.adamw7.context;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A {@link Context} that resolves dependencies using each source's {@code package}
@@ -75,20 +78,17 @@ public class PackageAwareFinder extends AbstractFinder {
 		return dot < 0 ? reference : reference.substring(0, dot);
 	}
 
+	/** The candidates in order of preference; the first that resolves wins, and none resolving leaves the reference unresolved. */
 	private ClassContainer resolve(String simpleName, ResolutionScope scope) {
-		ClassContainer imported = resolveImported(simpleName, scope);
-		if (imported != null) {
-			return imported;
-		}
-		ClassContainer samePackage = containersByFqn.get(qualify(scope.packageName(), simpleName));
-		if (samePackage != null) {
-			return samePackage;
-		}
-		ClassContainer wildcard = resolveWildcard(simpleName, scope);
-		if (wildcard != null) {
-			return wildcard;
-		}
-		return resolveUniqueSimpleName(simpleName);
+		return Stream.<Supplier<ClassContainer>>of(
+						() -> resolveImported(simpleName, scope),
+						() -> containersByFqn.get(qualify(scope.packageName(), simpleName)),
+						() -> resolveWildcard(simpleName, scope),
+						() -> resolveUniqueSimpleName(simpleName))
+				.map(Supplier::get)
+				.filter(Objects::nonNull)
+				.findFirst()
+				.orElse(null);
 	}
 
 	private ClassContainer resolveImported(String simpleName, ResolutionScope scope) {
@@ -99,7 +99,7 @@ public class PackageAwareFinder extends AbstractFinder {
 	private ClassContainer resolveWildcard(String simpleName, ResolutionScope scope) {
 		return scope.wildcardPackages().stream()
 				.map(packageName -> containersByFqn.get(qualify(packageName, simpleName)))
-				.filter(container -> container != null)
+				.filter(Objects::nonNull)
 				.findFirst()
 				.orElse(null);
 	}

--- a/code/context/src/main/java/io/github/adamw7/context/SubwordTokenEstimator.java
+++ b/code/context/src/main/java/io/github/adamw7/context/SubwordTokenEstimator.java
@@ -11,37 +11,18 @@ package io.github.adamw7.context;
  * tokenizer more closely than {@link HeuristicTokenEstimator} on
  * punctuation-dense source code, while staying fast and tokenizer-free.
  */
-public class SubwordTokenEstimator implements TokenEstimator {
-
-	public static final int DEFAULT_CHARACTERS_PER_TOKEN = 4;
-
-	private final int charactersPerToken;
+public class SubwordTokenEstimator extends AbstractTokenEstimator {
 
 	public SubwordTokenEstimator() {
 		this(DEFAULT_CHARACTERS_PER_TOKEN);
 	}
 
 	public SubwordTokenEstimator(int charactersPerToken) {
-		requirePositive(charactersPerToken);
-		this.charactersPerToken = charactersPerToken;
-	}
-
-	private void requirePositive(int charactersPerToken) {
-		if (charactersPerToken <= 0) {
-			throw new IllegalArgumentException(
-					"charactersPerToken must be positive and received: " + charactersPerToken);
-		}
+		super(charactersPerToken);
 	}
 
 	@Override
-	public int estimate(String text) {
-		if (text == null || text.isEmpty()) {
-			return 0;
-		}
-		return countTokens(text);
-	}
-
-	private int countTokens(String text) {
+	protected int count(String text) {
 		int total = 0;
 		int wordLength = 0;
 		for (int index = 0; index < text.length(); index++) {
@@ -61,10 +42,7 @@ public class SubwordTokenEstimator implements TokenEstimator {
 	}
 
 	private int wordTokens(int wordLength) {
-		if (wordLength == 0) {
-			return 0;
-		}
-		return (wordLength + charactersPerToken - 1) / charactersPerToken;
+		return wordLength == 0 ? 0 : tokensFor(wordLength);
 	}
 
 	private int symbolTokens(char character) {

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractProjectScanTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractProjectScanTool.java
@@ -1,0 +1,52 @@
+package io.github.adamw7.context.mcp;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.context.Language;
+import io.github.adamw7.context.tree.ProjectTreeBuilder;
+import io.github.adamw7.context.tree.ProjectTreeNode;
+import io.github.adamw7.tools.mcp.ToolArguments;
+import io.github.adamw7.tools.mcp.ToolResult;
+
+/**
+ * Shared skeleton for the MCP tools that scan a whole project rather than a single
+ * class within it. They all confine and resolve the project path, read the optional
+ * language and depth, and build the same tree; they differ only in how they render
+ * it, which subclasses supply through {@link #render}. Keeping the common steps here
+ * removes the duplication between {@link ProjectTreeTool} and {@link OkfBundleTool}
+ * and keeps their argument handling identical — the whole-project counterpart of
+ * {@link AbstractClassContextTool}.
+ */
+abstract class AbstractProjectScanTool implements ContextTool {
+
+	private static final Logger log = LogManager.getLogger(AbstractProjectScanTool.class);
+
+	private static final int DEFAULT_DEPTH = 1;
+	private static final int MAX_DEPTH = 10;
+
+	private final PathPolicy pathPolicy;
+
+	protected AbstractProjectScanTool(PathPolicy pathPolicy) {
+		this.pathPolicy = pathPolicy;
+	}
+
+	@Override
+	public final ToolResult apply(Map<String, Object> arguments) {
+		log.info("Calling MCP {} tool for {}", getToolDefinition().name(), arguments);
+		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
+		Language language = LanguageArguments.optionalLanguage(arguments, "language", Language.JAVA);
+		int depth = ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH);
+		return ToolResult.success(render(new ProjectTreeBuilder(language, depth).build(root), language, arguments));
+	}
+
+	/**
+	 * Renders the scanned tree in whatever shape the tool returns it. {@code arguments}
+	 * is passed on for a tool that reads one of its own beyond the path, language and
+	 * depth every scan takes.
+	 */
+	protected abstract String render(ProjectTreeNode tree, Language language, Map<String, Object> arguments);
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/OkfBundleTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/OkfBundleTool.java
@@ -1,11 +1,7 @@
 package io.github.adamw7.context.mcp;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -13,11 +9,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.adamw7.context.Language;
 import io.github.adamw7.context.okf.OkfBundle;
 import io.github.adamw7.context.okf.OkfBundler;
-import io.github.adamw7.context.tree.ProjectTreeBuilder;
 import io.github.adamw7.context.tree.ProjectTreeNode;
-import io.github.adamw7.tools.mcp.ToolArguments;
 import io.github.adamw7.tools.mcp.ToolDefinition;
-import io.github.adamw7.tools.mcp.ToolResult;
 
 /**
  * MCP tool that scans a Java, Kotlin or Scala project and returns it as a bundle
@@ -30,18 +23,12 @@ import io.github.adamw7.tools.mcp.ToolResult;
  * document, rather than written to disk: the server stays read-only, so a client
  * cannot use it to create files anywhere on the host.
  */
-public class OkfBundleTool implements ContextTool {
+public class OkfBundleTool extends AbstractProjectScanTool {
 
-	private static final Logger log = LogManager.getLogger(OkfBundleTool.class.getName());
-
-	private static final int DEFAULT_DEPTH = 1;
-	private static final int MAX_DEPTH = 10;
 	private static final ObjectMapper MAPPER = new ObjectMapper();
 
-	private final PathPolicy pathPolicy;
-
 	public OkfBundleTool(PathPolicy pathPolicy) {
-		this.pathPolicy = pathPolicy;
+		super(pathPolicy);
 	}
 
 	private final ToolDefinition toolDefinition = new ToolDefinition("okf_bundle",
@@ -63,16 +50,7 @@ public class OkfBundleTool implements ContextTool {
 	}
 
 	@Override
-	public ToolResult apply(Map<String, Object> arguments) {
-		log.info("Calling MCP okf_bundle tool for {}", arguments);
-		return ToolResult.success(buildBundle(arguments));
-	}
-
-	private String buildBundle(Map<String, Object> arguments) {
-		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
-		Language language = LanguageArguments.optionalLanguage(arguments, "language", Language.JAVA);
-		int depth = ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH);
-		ProjectTreeNode tree = new ProjectTreeBuilder(language, depth).build(root);
+	protected String render(ProjectTreeNode tree, Language language, Map<String, Object> arguments) {
 		return toJson(new OkfBundler(language).bundle(tree));
 	}
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
@@ -1,14 +1,10 @@
 package io.github.adamw7.context.mcp;
 
-import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import io.github.adamw7.context.Language;
-import io.github.adamw7.context.tree.ProjectTreeBuilder;
 import io.github.adamw7.context.tree.ProjectTreeDotSerializer;
 import io.github.adamw7.context.tree.ProjectTreeJsonSerializer;
 import io.github.adamw7.context.tree.ProjectTreeMarkdownSerializer;
@@ -18,7 +14,6 @@ import io.github.adamw7.context.tree.ProjectTreePrinter;
 import io.github.adamw7.context.tree.ProjectTreeSerializer;
 import io.github.adamw7.tools.mcp.ToolArguments;
 import io.github.adamw7.tools.mcp.ToolDefinition;
-import io.github.adamw7.tools.mcp.ToolResult;
 
 /**
  * MCP tool that scans a Java, Kotlin or Scala project into a tree of folders,
@@ -28,18 +23,12 @@ import io.github.adamw7.tools.mcp.ToolResult;
  * {@code mermaid}) is chosen by the caller; JSON is the default as it is the most
  * convenient for programmatic consumers.
  */
-public class ProjectTreeTool implements ContextTool {
+public class ProjectTreeTool extends AbstractProjectScanTool {
 
-	private static final Logger log = LogManager.getLogger(ProjectTreeTool.class.getName());
-
-	private static final int DEFAULT_DEPTH = 1;
-	private static final int MAX_DEPTH = 10;
 	private static final String DEFAULT_FORMAT = "json";
 
-	private final PathPolicy pathPolicy;
-
 	public ProjectTreeTool(PathPolicy pathPolicy) {
-		this.pathPolicy = pathPolicy;
+		super(pathPolicy);
 	}
 
 	private final ToolDefinition toolDefinition = new ToolDefinition("project_tree",
@@ -63,22 +52,12 @@ public class ProjectTreeTool implements ContextTool {
 	}
 
 	@Override
-	public ToolResult apply(Map<String, Object> arguments) {
-		log.info("Calling MCP project_tree tool for {}", arguments);
-		String rendered = buildTree(arguments);
-		return ToolResult.success(rendered);
-	}
-
-	private String buildTree(Map<String, Object> arguments) {
-		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
-		Language language = LanguageArguments.optionalLanguage(arguments, "language", Language.JAVA);
-		int depth = ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH);
-		ProjectTreeNode tree = new ProjectTreeBuilder(language, depth).build(root);
+	protected String render(ProjectTreeNode tree, Language language, Map<String, Object> arguments) {
 		return serializerFor(ToolArguments.optionalString(arguments, "format", DEFAULT_FORMAT)).serialize(tree);
 	}
 
 	private ProjectTreeSerializer serializerFor(String format) {
-		return switch (format.trim().toLowerCase(java.util.Locale.ROOT)) {
+		return switch (format.trim().toLowerCase(Locale.ROOT)) {
 			case "markdown" -> new ProjectTreeMarkdownSerializer();
 			case "text" -> new ProjectTreePrinter();
 			case "dot" -> new ProjectTreeDotSerializer();

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/AbstractContextMcpIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/AbstractContextMcpIT.java
@@ -1,0 +1,93 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * The fixture every context-engineering MCP integration test shares: a two-class
+ * project in a temporary directory, a synchronous client connected to the server
+ * the subclass's {@code @SpringBootTest} started, and the helpers that unwrap a
+ * tool result. Only the transport differs between the stateless, streamable-HTTP
+ * and HTTPS servers, so that is all a subclass supplies — along with the tool
+ * calls it is there to assert.
+ */
+abstract class AbstractContextMcpIT {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	@LocalServerPort
+	protected int port;
+
+	@TempDir
+	protected Path projectRoot;
+
+	protected McpSyncClient client;
+
+	@BeforeEach
+	void startClient() throws IOException {
+		Files.writeString(projectRoot.resolve("A.java"), "public class A {}");
+		Files.writeString(projectRoot.resolve("B.java"), "public class B { A a; }");
+		client = McpClient.sync(transport())
+				.clientInfo(McpSchema.Implementation.builder(clientName(), "1.0").build())
+				.build();
+		client.initialize();
+	}
+
+	@AfterEach
+	void closeClient() {
+		client.close();
+	}
+
+	/** The transport reaching the server this test started, built once {@link #port} is known. */
+	protected abstract HttpClientStreamableHttpTransport transport();
+
+	/** The name this test's client identifies itself to the server with. */
+	protected abstract String clientName();
+
+	protected McpSchema.CallToolResult call(String tool, Map<String, Object> arguments) {
+		return client.callTool(McpSchema.CallToolRequest.builder(tool).arguments(arguments).build());
+	}
+
+	protected List<String> textValues(JsonNode array) {
+		List<String> values = new ArrayList<>();
+		array.forEach(node -> values.add(node.asText()));
+		return values;
+	}
+
+	protected String singleTextResult(McpSchema.CallToolResult result) {
+		assertFalse(result.isError(), () -> "unexpected error result: " + result.content());
+		assertEquals(1, result.content().size(), "expected exactly one content element");
+		McpSchema.Content content = result.content().getFirst();
+		assertInstanceOf(McpSchema.TextContent.class, content);
+		return ((McpSchema.TextContent) content).text();
+	}
+
+	protected JsonNode parse(String json) {
+		try {
+			return MAPPER.readTree(json);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Invalid JSON: " + json, e);
+		}
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpStatelessHttpIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpStatelessHttpIT.java
@@ -1,30 +1,16 @@
 package io.github.adamw7.context.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 
-import io.modelcontextprotocol.client.McpClient;
-import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 
@@ -42,34 +28,16 @@ import io.modelcontextprotocol.spec.McpSchema;
 				"transport.mode=stateless-http",
 				"spring.main.banner-mode=off",
 				"context.allowed-roots=${java.io.tmpdir}" })
-public class McpStatelessHttpIT {
+public class McpStatelessHttpIT extends AbstractContextMcpIT {
 
-	private static final ObjectMapper MAPPER = new ObjectMapper();
-
-	@LocalServerPort
-	private int port;
-
-	@TempDir
-	Path projectRoot;
-
-	private McpSyncClient client;
-
-	@BeforeEach
-	void setUp() throws IOException {
-		Files.writeString(projectRoot.resolve("A.java"), "public class A {}");
-		Files.writeString(projectRoot.resolve("B.java"), "public class B { A a; }");
-		HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
-				.builder("http://localhost:" + port)
-				.build();
-		client = McpClient.sync(transport)
-				.clientInfo(McpSchema.Implementation.builder("integration-test-stateless-client", "1.0").build())
-				.build();
-		client.initialize();
+	@Override
+	protected HttpClientStreamableHttpTransport transport() {
+		return HttpClientStreamableHttpTransport.builder("http://localhost:" + port).build();
 	}
 
-	@AfterEach
-	void tearDown() {
-		client.close();
+	@Override
+	protected String clientName() {
+		return "integration-test-stateless-client";
 	}
 
 	@Test
@@ -82,35 +50,10 @@ public class McpStatelessHttpIT {
 
 	@Test
 	void findContextToolReturnsDependencies() {
-		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("find_context")
-				.arguments(Map.of("path", projectRoot.toString(), "class_name", "B"))
-				.build();
-
-		McpSchema.CallToolResult result = client.callTool(request);
+		McpSchema.CallToolResult result = call("find_context",
+				Map.of("path", projectRoot.toString(), "class_name", "B"));
 
 		JsonNode dependencies = parse(singleTextResult(result));
 		assertEquals(List.of("A.java"), textValues(dependencies));
-	}
-
-	private List<String> textValues(JsonNode array) {
-		List<String> values = new ArrayList<>();
-		array.forEach(node -> values.add(node.asText()));
-		return values;
-	}
-
-	private String singleTextResult(McpSchema.CallToolResult result) {
-		assertFalse(result.isError(), () -> "unexpected error result: " + result.content());
-		assertEquals(1, result.content().size(), "expected exactly one content element");
-		McpSchema.Content content = result.content().getFirst();
-		assertInstanceOf(McpSchema.TextContent.class, content);
-		return ((McpSchema.TextContent) content).text();
-	}
-
-	private JsonNode parse(String json) {
-		try {
-			return MAPPER.readTree(json);
-		} catch (JsonProcessingException e) {
-			throw new IllegalStateException("Invalid JSON: " + json, e);
-		}
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpIT.java
@@ -1,30 +1,17 @@
 package io.github.adamw7.context.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 
-import io.modelcontextprotocol.client.McpClient;
-import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 
@@ -35,34 +22,16 @@ import io.modelcontextprotocol.spec.McpSchema;
 				"transport.mode=streamable-http",
 				"spring.main.banner-mode=off",
 				"context.allowed-roots=${java.io.tmpdir}" })
-public class McpStreamableHttpIT {
+public class McpStreamableHttpIT extends AbstractContextMcpIT {
 
-	private static final ObjectMapper MAPPER = new ObjectMapper();
-
-	@LocalServerPort
-	private int port;
-
-	@TempDir
-	Path projectRoot;
-
-	private McpSyncClient client;
-
-	@BeforeEach
-	void setUp() throws IOException {
-		Files.writeString(projectRoot.resolve("A.java"), "public class A {}");
-		Files.writeString(projectRoot.resolve("B.java"), "public class B { A a; }");
-		HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
-				.builder("http://localhost:" + port)
-				.build();
-		client = McpClient.sync(transport)
-				.clientInfo(McpSchema.Implementation.builder("integration-test-client", "1.0").build())
-				.build();
-		client.initialize();
+	@Override
+	protected HttpClientStreamableHttpTransport transport() {
+		return HttpClientStreamableHttpTransport.builder("http://localhost:" + port).build();
 	}
 
-	@AfterEach
-	void tearDown() {
-		client.close();
+	@Override
+	protected String clientName() {
+		return "integration-test-client";
 	}
 
 	@Test
@@ -75,11 +44,7 @@ public class McpStreamableHttpIT {
 
 	@Test
 	void projectTreeToolReturnsTheScannedTree() {
-		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("project_tree")
-				.arguments(Map.of("path", projectRoot.toString()))
-				.build();
-
-		McpSchema.CallToolResult result = client.callTool(request);
+		McpSchema.CallToolResult result = call("project_tree", Map.of("path", projectRoot.toString()));
 
 		JsonNode tree = parse(singleTextResult(result));
 		assertEquals("directory", tree.get("type").asText());
@@ -92,11 +57,8 @@ public class McpStreamableHttpIT {
 
 	@Test
 	void findContextToolReturnsDependencies() {
-		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("find_context")
-				.arguments(Map.of("path", projectRoot.toString(), "class_name", "B"))
-				.build();
-
-		McpSchema.CallToolResult result = client.callTool(request);
+		McpSchema.CallToolResult result = call("find_context",
+				Map.of("path", projectRoot.toString(), "class_name", "B"));
 
 		JsonNode dependencies = parse(singleTextResult(result));
 		assertEquals(List.of("A.java"), textValues(dependencies));
@@ -104,11 +66,8 @@ public class McpStreamableHttpIT {
 
 	@Test
 	void estimateTokensToolReportsATokenBreakdown() {
-		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("estimate_tokens")
-				.arguments(Map.of("path", projectRoot.toString(), "class_name", "B"))
-				.build();
-
-		McpSchema.CallToolResult result = client.callTool(request);
+		McpSchema.CallToolResult result = call("estimate_tokens",
+				Map.of("path", projectRoot.toString(), "class_name", "B"));
 
 		JsonNode report = parse(singleTextResult(result));
 		JsonNode classes = report.get("classes");
@@ -122,11 +81,8 @@ public class McpStreamableHttpIT {
 
 	@Test
 	void projectTreeToolHonoursTheRequestedFormat() {
-		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("project_tree")
-				.arguments(Map.of("path", projectRoot.toString(), "format", "markdown"))
-				.build();
-
-		McpSchema.CallToolResult result = client.callTool(request);
+		McpSchema.CallToolResult result = call("project_tree",
+				Map.of("path", projectRoot.toString(), "format", "markdown"));
 
 		String tree = singleTextResult(result);
 		assertTrue(tree.contains("- `A.java`"));
@@ -136,11 +92,7 @@ public class McpStreamableHttpIT {
 
 	@Test
 	void okfBundleToolReturnsAConformantBundle() {
-		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("okf_bundle")
-				.arguments(Map.of("path", projectRoot.toString()))
-				.build();
-
-		McpSchema.CallToolResult result = client.callTool(request);
+		McpSchema.CallToolResult result = call("okf_bundle", Map.of("path", projectRoot.toString()));
 
 		JsonNode bundle = parse(singleTextResult(result));
 		assertEquals("0.2", bundle.get("okf_version").asText());
@@ -152,11 +104,8 @@ public class McpStreamableHttpIT {
 
 	@Test
 	void findContextToolReportsAnErrorForAnUnknownClass() {
-		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("find_context")
-				.arguments(Map.of("path", projectRoot.toString(), "class_name", "Missing"))
-				.build();
-
-		McpSchema.CallToolResult result = client.callTool(request);
+		McpSchema.CallToolResult result = call("find_context",
+				Map.of("path", projectRoot.toString(), "class_name", "Missing"));
 
 		assertTrue(result.isError());
 		assertEquals(1, result.content().size());
@@ -182,27 +131,5 @@ public class McpStreamableHttpIT {
 			}
 		}
 		throw new AssertionError("No entry for class " + className + " in " + classes);
-	}
-
-	private List<String> textValues(JsonNode array) {
-		List<String> values = new java.util.ArrayList<>();
-		array.forEach(node -> values.add(node.asText()));
-		return values;
-	}
-
-	private String singleTextResult(McpSchema.CallToolResult result) {
-		assertFalse(result.isError(), () -> "unexpected error result: " + result.content());
-		assertEquals(1, result.content().size(), "expected exactly one content element");
-		McpSchema.Content content = result.content().getFirst();
-		assertInstanceOf(McpSchema.TextContent.class, content);
-		return ((McpSchema.TextContent) content).text();
-	}
-
-	private JsonNode parse(String json) {
-		try {
-			return MAPPER.readTree(json);
-		} catch (JsonProcessingException e) {
-			throw new IllegalStateException("Invalid JSON: " + json, e);
-		}
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpsIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpsIT.java
@@ -1,8 +1,6 @@
 package io.github.adamw7.context.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -11,7 +9,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -22,18 +19,10 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 
-import io.modelcontextprotocol.client.McpClient;
-import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 
@@ -60,46 +49,10 @@ import io.modelcontextprotocol.spec.McpSchema;
 				"server.ssl.key-store-type=PKCS12",
 				"server.ssl.key-alias=mcp",
 				"context.allowed-roots=${java.io.tmpdir}" })
-public class McpStreamableHttpsIT {
+public class McpStreamableHttpsIT extends AbstractContextMcpIT {
 
 	static {
 		generateKeystore();
-	}
-
-	@LocalServerPort
-	private int port;
-
-	@TempDir
-	Path projectRoot;
-
-	private McpSyncClient client;
-
-	@BeforeEach
-	void setUp() throws IOException {
-		Files.writeString(projectRoot.resolve("A.java"), "public class A {}");
-		Files.writeString(projectRoot.resolve("B.java"), "public class B { A a; }");
-		HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
-				.builder("https://localhost:" + port)
-				.customizeClient(builder -> builder.sslContext(testTrustContext()))
-				.build();
-		client = McpClient.sync(transport)
-				.clientInfo(McpSchema.Implementation.builder("integration-test-https-client", "1.0").build())
-				.build();
-		client.initialize();
-	}
-
-	@AfterEach
-	void tearDown() {
-		client.close();
-	}
-
-	@Test
-	void negotiatesTls13OnTheMcpEndpoint() throws IOException {
-		SSLSocketFactory factory = testTrustContext().getSocketFactory();
-		try (SSLSocket socket = (SSLSocket) factory.createSocket("localhost", port)) {
-			socket.startHandshake();
-			assertEquals(TlsConfiguration.TLS_1_3, socket.getSession().getProtocol());
-		}
 	}
 
 	/**
@@ -118,6 +71,27 @@ public class McpStreamableHttpsIT {
 	 * merely being written to a system property.
 	 */
 	private static final String GROUP_OUTSIDE_PINNED_LIST = "secp521r1";
+
+	@Override
+	protected HttpClientStreamableHttpTransport transport() {
+		return HttpClientStreamableHttpTransport.builder("https://localhost:" + port)
+				.customizeClient(builder -> builder.sslContext(testTrustContext()))
+				.build();
+	}
+
+	@Override
+	protected String clientName() {
+		return "integration-test-https-client";
+	}
+
+	@Test
+	void negotiatesTls13OnTheMcpEndpoint() throws IOException {
+		SSLSocketFactory factory = testTrustContext().getSocketFactory();
+		try (SSLSocket socket = (SSLSocket) factory.createSocket("localhost", port)) {
+			socket.startHandshake();
+			assertEquals(TlsConfiguration.TLS_1_3, socket.getSession().getProtocol());
+		}
+	}
 
 	@Test
 	void acceptsAKeyExchangeGroupFromThePinnedList() throws IOException {
@@ -154,36 +128,11 @@ public class McpStreamableHttpsIT {
 
 	@Test
 	void findContextToolWorksOverTls13() {
-		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("find_context")
-				.arguments(Map.of("path", projectRoot.toString(), "class_name", "B"))
-				.build();
-
-		McpSchema.CallToolResult result = client.callTool(request);
+		McpSchema.CallToolResult result = call("find_context",
+				Map.of("path", projectRoot.toString(), "class_name", "B"));
 
 		JsonNode dependencies = parse(singleTextResult(result));
 		assertEquals(List.of("A.java"), textValues(dependencies));
-	}
-
-	private List<String> textValues(JsonNode array) {
-		List<String> values = new ArrayList<>();
-		array.forEach(node -> values.add(node.asText()));
-		return values;
-	}
-
-	private String singleTextResult(McpSchema.CallToolResult result) {
-		assertFalse(result.isError(), () -> "unexpected error result: " + result.content());
-		assertEquals(1, result.content().size(), "expected exactly one content element");
-		McpSchema.Content content = result.content().getFirst();
-		assertInstanceOf(McpSchema.TextContent.class, content);
-		return ((McpSchema.TextContent) content).text();
-	}
-
-	private JsonNode parse(String json) {
-		try {
-			return new ObjectMapper().readTree(json);
-		} catch (JsonProcessingException e) {
-			throw new IllegalStateException("Invalid JSON: " + json, e);
-		}
 	}
 
 	private static void generateKeystore() {

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/InMemoryParquetDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/InMemoryParquetDataSource.java
@@ -14,19 +14,8 @@ public class InMemoryParquetDataSource extends InMemorySQLDataSource {
 	}
 
 	@Override
-	public void reset() {
-		releaseQueryResources();
-		hasMoreData = true;
-		open();
-	}
-
-	@Override
 	public void close() {
-		releaseQueryResources();
-		DuckDbParquet.close(connection);
-	}
-
-	private void releaseQueryResources() {
 		super.close();
+		DuckDbParquet.close(connection);
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableParquetDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableParquetDataSource.java
@@ -18,19 +18,8 @@ public class IterableParquetDataSource extends IterableSQLDataSource {
 	}
 
 	@Override
-	public void reset() {
-		releaseQueryResources();
-		hasMoreData = true;
-		open();
-	}
-
-	@Override
 	public void close() {
-		releaseQueryResources();
-		DuckDbParquet.close(connection);
-	}
-
-	private void releaseQueryResources() {
 		super.close();
+		DuckDbParquet.close(connection);
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -112,9 +112,15 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 		}
 	}
 
+	/**
+	 * Releases the query resources directly rather than through {@link #close()}, so a
+	 * source that owns its connection — the Parquet ones, which close DuckDB in
+	 * {@code close()} — is re-read on the connection it already has instead of having
+	 * to override this method to say so.
+	 */
 	@Override
 	public void reset() {
-		close();
+		closeQueryResources();
 		hasMoreData = true;
 		open();
 	}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryJacksonDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryJacksonDataSource.java
@@ -1,0 +1,70 @@
+package io.github.adamw7.tools.data.source.file;
+
+import java.io.InputStream;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Base for the in-memory sources that read a whole Jackson document and flatten it
+ * into {@link #fieldsMap} as {@code key -> value} pairs keyed by dotted path, using
+ * {@code .} for nested object fields and {@code [index]} for array elements (for
+ * example {@code people[0].address.city}).
+ *
+ * <p>JSON and YAML differ only in the {@link ObjectMapper} that reads them, so the
+ * flattening lives here once instead of being written out per syntax. It walks the
+ * same tree the streaming {@link AbstractIterableJacksonDataSource} pulls token by
+ * token, so the same document read as JSON or YAML, in memory or iteratively,
+ * yields the same rows.</p>
+ */
+public abstract class AbstractInMemoryJacksonDataSource extends AbstractInMemoryMapDataSource {
+
+	protected AbstractInMemoryJacksonDataSource(InputStream inputStream) {
+		super(inputStream);
+	}
+
+	protected AbstractInMemoryJacksonDataSource(String filePath) {
+		super(filePath);
+	}
+
+	/**
+	 * The mapper for this source's syntax. It is asked for while the base constructor
+	 * parses, so it must answer from a constant rather than from instance state the
+	 * subclass has not assigned yet.
+	 */
+	protected abstract ObjectMapper mapper();
+
+	@Override
+	protected void parse() {
+		StringBuilder content = new StringBuilder();
+		while (scanner.hasNextLine()) {
+			content.append(scanner.nextLine()).append('\n');
+		}
+		flatten("", read(content.toString()));
+	}
+
+	private JsonNode read(String content) {
+		try {
+			return mapper().readTree(content);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Invalid " + mapper().getFactory().getFormatName() + " input", e);
+		}
+	}
+
+	private void flatten(String key, JsonNode value) {
+		if (value.isObject()) {
+			value.properties().forEach(field -> flatten(qualify(key, field.getKey()), field.getValue()));
+		} else if (value.isArray()) {
+			for (int index = 0; index < value.size(); index++) {
+				flatten(key + "[" + index + "]", value.get(index));
+			}
+		} else {
+			fieldsMap.put(key, value.asText());
+		}
+	}
+
+	private String qualify(String prefix, String field) {
+		return prefix.isEmpty() ? field : prefix + "." + field;
+	}
+}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
@@ -1,21 +1,17 @@
 package io.github.adamw7.tools.data.source.file;
 
 import java.io.InputStream;
-import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * In-memory JSON data source that flattens a document into {@link #fieldsMap} as
- * {@code key -> value} pairs keyed by dotted path, using {@code .} for nested
- * object fields and {@code [index]} for array elements (for example
- * {@code people[0].address.city}). This mirrors {@link InMemoryYAMLDataSource}
- * and the streaming {@link IterableJSONDataSource}, so the same document read as
- * JSON, YAML or through either access mode yields the same rows.
+ * In-memory JSON data source. The flattening into {@link #fieldsMap} is
+ * {@link AbstractInMemoryJacksonDataSource}'s, shared with
+ * {@link InMemoryYAMLDataSource} and matching the streaming
+ * {@link IterableJSONDataSource}, so the same document read as JSON, YAML or
+ * through either access mode yields the same rows.
  */
-public class InMemoryJSONDataSource extends AbstractInMemoryMapDataSource {
+public class InMemoryJSONDataSource extends AbstractInMemoryJacksonDataSource {
 
 	private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -28,42 +24,7 @@ public class InMemoryJSONDataSource extends AbstractInMemoryMapDataSource {
 	}
 
 	@Override
-	protected void parse() {
-		StringBuilder jsonContent = new StringBuilder();
-		while (scanner.hasNextLine()) {
-			jsonContent.append(scanner.nextLine());
-		}
-		flattenValue("", read(jsonContent.toString()));
-	}
-
-	private JsonNode read(String jsonString) {
-		try {
-			return MAPPER.readTree(jsonString);
-		} catch (JsonProcessingException e) {
-			throw new IllegalStateException("Invalid JSON input", e);
-		}
-	}
-
-	private void flattenValue(String key, JsonNode value) {
-		if (value.isObject()) {
-			flattenObject(key, value);
-		} else if (value.isArray()) {
-			flattenArray(key, value);
-		} else {
-			fieldsMap.put(key, value.asText());
-		}
-	}
-
-	private void flattenObject(String prefix, JsonNode object) {
-		for (Map.Entry<String, JsonNode> field : object.properties()) {
-			String key = prefix.isEmpty() ? field.getKey() : prefix + "." + field.getKey();
-			flattenValue(key, field.getValue());
-		}
-	}
-
-	private void flattenArray(String prefix, JsonNode array) {
-		for (int index = 0; index < array.size(); index++) {
-			flattenValue(prefix + "[" + index + "]", array.get(index));
-		}
+	protected ObjectMapper mapper() {
+		return MAPPER;
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryYAMLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryYAMLDataSource.java
@@ -1,13 +1,20 @@
 package io.github.adamw7.tools.data.source.file;
 
 import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
-public class InMemoryYAMLDataSource extends AbstractInMemoryMapDataSource {
+/**
+ * In-memory YAML data source. It flattens through
+ * {@link AbstractInMemoryJacksonDataSource}, the flattening
+ * {@link InMemoryJSONDataSource} uses, so a document written as either syntax
+ * yields the same rows — and the ones the streaming
+ * {@link IterableYAMLDataSource} emits.
+ */
+public class InMemoryYAMLDataSource extends AbstractInMemoryJacksonDataSource {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
 
 	public InMemoryYAMLDataSource(InputStream inputStream) {
 		super(inputStream);
@@ -18,49 +25,7 @@ public class InMemoryYAMLDataSource extends AbstractInMemoryMapDataSource {
 	}
 
 	@Override
-	protected void parse() {
-		StringBuilder yamlContent = new StringBuilder();
-		while (scanner.hasNextLine()) {
-			yamlContent.append(scanner.nextLine()).append("\n");
-		}
-		parseYAML(yamlContent.toString());
-	}
-
-	private void parseYAML(String yamlString) {
-		try {
-			ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
-			Object parsed = yamlMapper.readValue(yamlString, Object.class);
-			if (parsed instanceof Map<?, ?> map) {
-				flattenMap("", map);
-			} else if (parsed instanceof List<?> list) {
-				flattenList("", list);
-			}
-		} catch (Exception e) {
-			throw new IllegalArgumentException("Failed to parse YAML", e);
-		}
-	}
-
-	private void flattenMap(String prefix, Map<?, ?> map) {
-		for (Map.Entry<?, ?> entry : map.entrySet()) {
-			String key = prefix.isEmpty() ? String.valueOf(entry.getKey())
-					: prefix + "." + entry.getKey();
-			flattenValue(key, entry.getValue());
-		}
-	}
-
-	private void flattenList(String prefix, List<?> list) {
-		for (int i = 0; i < list.size(); i++) {
-			flattenValue(prefix + "[" + i + "]", list.get(i));
-		}
-	}
-
-	private void flattenValue(String key, Object value) {
-		if (value instanceof Map<?, ?> map) {
-			flattenMap(key, map);
-		} else if (value instanceof List<?> list) {
-			flattenList(key, list);
-		} else {
-			fieldsMap.put(key, String.valueOf(value));
-		}
+	protected ObjectMapper mapper() {
+		return MAPPER;
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/Key.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/Key.java
@@ -9,25 +9,18 @@ public record Key(String[] values) {
 		return Arrays.toString(values);
 	}
 
+	/**
+	 * A record compares and hashes its array component by identity, which would make
+	 * two keys holding equal values distinct; both are answered by content instead, so
+	 * a key works as a map key and a set element.
+	 */
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + Arrays.hashCode(values);
-		return result;
+		return Arrays.hashCode(values);
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Key other = (Key) obj;
-		return Arrays.equals(values, other.values);
+		return obj instanceof Key other && Arrays.equals(values, other.values);
 	}
-	
-	
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/ConflictingKey.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/ConflictingKey.java
@@ -1,31 +1,14 @@
 package io.github.adamw7.tools.data.structure;
 
-import java.util.Objects;
+/**
+ * A key whose hash collides with every other one, so a map test can drive the
+ * probe chain — insertion past a taken slot, and a live entry found past a
+ * tombstone — rather than hope a real hash produces the collision.
+ */
+public record ConflictingKey(int number, String string) {
 
-public class ConflictingKey {
-
-	private final int number;
-	private final String string;
-	
-	public ConflictingKey(int number, String string) {
-		this.number = number;
-		this.string = string;
-	}
-	
 	@Override
 	public int hashCode() {
 		return 1; // conflicting hash
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		ConflictingKey other = (ConflictingKey) obj;
-		return number == other.number && Objects.equals(string, other.string);
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/AbstractUniquenessMcpIT.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/AbstractUniquenessMcpIT.java
@@ -1,0 +1,76 @@
+package io.github.adamw7.tools.data.uniqueness.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import io.github.adamw7.tools.data.Utils;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * What every uniqueness MCP integration test asserts, whichever HTTP transport the
+ * subclass's {@code @SpringBootTest} started the server with: a synchronous client
+ * reaches the {@code /mcp} endpoint and {@code uniqueness_check} answers correctly
+ * for a column that is a key and one that is not. The transport differs only in
+ * the client name it announces, so that is all a subclass supplies.
+ */
+abstract class AbstractUniquenessMcpIT {
+
+	@LocalServerPort
+	private int port;
+
+	private McpSyncClient client;
+
+	@BeforeEach
+	void startClient() {
+		HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
+				.builder("http://localhost:" + port)
+				.build();
+		client = McpClient.sync(transport)
+				.clientInfo(McpSchema.Implementation.builder(clientName(), "1.0").build())
+				.build();
+		client.initialize();
+	}
+
+	@AfterEach
+	void closeClient() {
+		client.close();
+	}
+
+	/** The name this test's client identifies itself to the server with. */
+	protected abstract String clientName();
+
+	@Test
+	void nonUniqueColumnReturnsFalse() {
+		assertEquals("false", singleTextResult(uniquenessOf("year1")));
+	}
+
+	@Test
+	void uniqueColumnReturnsTrue() {
+		assertEquals("true", singleTextResult(uniquenessOf("income")));
+	}
+
+	private McpSchema.CallToolResult uniquenessOf(String column) {
+		return client.callTool(McpSchema.CallToolRequest.builder("uniqueness_check")
+				.arguments(Map.of("file", Utils.getHouseholdFile(), "columns_row", 1, "columns_name", column))
+				.build());
+	}
+
+	private String singleTextResult(McpSchema.CallToolResult result) {
+		assertFalse(result.isError(), () -> "unexpected error result: " + result.content());
+		assertEquals(1, result.content().size(), "expected exactly one content element");
+		McpSchema.Content content = result.content().getFirst();
+		assertInstanceOf(McpSchema.TextContent.class, content);
+		return ((McpSchema.TextContent) content).text();
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpStatelessHttpIT.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpStatelessHttpIT.java
@@ -1,22 +1,6 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-
-import java.util.Map;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
-
-import io.github.adamw7.tools.data.Utils;
-import io.modelcontextprotocol.client.McpClient;
-import io.modelcontextprotocol.client.McpSyncClient;
-import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
-import io.modelcontextprotocol.spec.McpSchema;
 
 /**
  * Integration test that serves the uniqueness MCP server over the stateless HTTP
@@ -28,56 +12,10 @@ import io.modelcontextprotocol.spec.McpSchema;
 		classes = Main.class,
 		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		properties = { "transport.mode=stateless-http", "spring.main.banner-mode=off" })
-public class McpStatelessHttpIT {
+public class McpStatelessHttpIT extends AbstractUniquenessMcpIT {
 
-	@LocalServerPort
-	private int port;
-
-	private McpSyncClient client;
-
-	@BeforeEach
-	void setUp() {
-		HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
-				.builder("http://localhost:" + port)
-				.build();
-		client = McpClient.sync(transport)
-				.clientInfo(McpSchema.Implementation.builder("integration-test-stateless-client", "1.0").build())
-				.build();
-		client.initialize();
-	}
-
-	@AfterEach
-	void tearDown() {
-		client.close();
-	}
-
-	@Test
-	void nonUniqueColumnReturnsFalse() {
-		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("uniqueness_check")
-				.arguments(Map.of("file", Utils.getHouseholdFile(), "columns_row", 1, "columns_name", "year1"))
-				.build();
-
-		McpSchema.CallToolResult result = client.callTool(request);
-
-		assertEquals("false", singleTextResult(result));
-	}
-
-	@Test
-	void uniqueColumnReturnsTrue() {
-		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("uniqueness_check")
-				.arguments(Map.of("file", Utils.getHouseholdFile(), "columns_row", 1, "columns_name", "income"))
-				.build();
-
-		McpSchema.CallToolResult result = client.callTool(request);
-
-		assertEquals("true", singleTextResult(result));
-	}
-
-	private String singleTextResult(McpSchema.CallToolResult result) {
-		assertFalse(result.isError(), () -> "unexpected error result: " + result.content());
-		assertEquals(1, result.content().size(), "expected exactly one content element");
-		McpSchema.Content content = result.content().getFirst();
-		assertInstanceOf(McpSchema.TextContent.class, content);
-		return ((McpSchema.TextContent) content).text();
+	@Override
+	protected String clientName() {
+		return "integration-test-stateless-client";
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpStreamableHttpIT.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpStreamableHttpIT.java
@@ -1,77 +1,15 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-
-import java.util.Map;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
-
-import io.github.adamw7.tools.data.Utils;
-import io.modelcontextprotocol.client.McpClient;
-import io.modelcontextprotocol.client.McpSyncClient;
-import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
-import io.modelcontextprotocol.spec.McpSchema;
 
 @SpringBootTest(
 		classes = Main.class,
 		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		properties = { "transport.mode=streamable-http", "spring.main.banner-mode=off" })
-public class McpStreamableHttpIT {
+public class McpStreamableHttpIT extends AbstractUniquenessMcpIT {
 
-	@LocalServerPort
-	private int port;
-
-	private McpSyncClient client;
-
-	@BeforeEach
-	void setUp() {
-		HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport
-				.builder("http://localhost:" + port)
-				.build();
-		client = McpClient.sync(transport)
-				.clientInfo(McpSchema.Implementation.builder("integration-test-client", "1.0").build())
-				.build();
-		client.initialize();
-	}
-
-	@AfterEach
-	void tearDown() {
-		client.close();
-	}
-
-	@Test
-	void nonUniqueColumnReturnsFalse() {
-		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("uniqueness_check")
-				.arguments(Map.of("file", Utils.getHouseholdFile(), "columns_row", 1, "columns_name", "year1"))
-				.build();
-
-		McpSchema.CallToolResult result = client.callTool(request);
-
-		assertEquals("false", singleTextResult(result));
-	}
-
-	@Test
-	void uniqueColumnReturnsTrue() {
-		McpSchema.CallToolRequest request = McpSchema.CallToolRequest.builder("uniqueness_check")
-				.arguments(Map.of("file", Utils.getHouseholdFile(), "columns_row", 1, "columns_name", "income"))
-				.build();
-
-		McpSchema.CallToolResult result = client.callTool(request);
-
-		assertEquals("true", singleTextResult(result));
-	}
-
-	private String singleTextResult(McpSchema.CallToolResult result) {
-		assertFalse(result.isError(), () -> "unexpected error result: " + result.content());
-		assertEquals(1, result.content().size(), "expected exactly one content element");
-		McpSchema.Content content = result.content().getFirst();
-		assertInstanceOf(McpSchema.TextContent.class, content);
-		return ((McpSchema.TextContent) content).text();
+	@Override
+	protected String clientName() {
+		return "integration-test-client";
 	}
 }


### PR DESCRIPTION
Removes copy-pasted code without changing what any of it does, dropping
~180 lines net.

data:
- IterableSQLDataSource.reset() now releases the query resources directly
  instead of going through the overridable close(). Both Parquet sources
  only overrode reset() to say exactly that, so their identical reset(),
  close() and releaseQueryResources() collapse to a close() that adds
  disposing of the DuckDB connection they own.
- InMemoryJSONDataSource and InMemoryYAMLDataSource flattened the same
  document shape twice, once over JsonNode and once over Map/List. The
  flattening moves to a shared AbstractInMemoryJacksonDataSource and each
  source now supplies only its ObjectMapper.
- Key's hand-written equals/hashCode shrink to the array-aware pair a
  record needs; ConflictingKey becomes a record.

context:
- ProjectTreeTool and OkfBundleTool repeated the same logging, path
  confinement, language/depth reading and tree build; that moves to
  AbstractProjectScanTool, leaving each tool its schema and its rendering.
- HeuristicTokenEstimator and SubwordTokenEstimator shared their ratio,
  its validation, the empty-text rule and the round-up, now in
  AbstractTokenEstimator.
- PackageAwareFinder.resolve states its four candidates in order of
  preference rather than as a null-check chain.

tests:
- The context MCP integration tests shared their whole fixture and result
  helpers across three transports, and the uniqueness ones shared both
  their tests; those move to AbstractContextMcpIT and
  AbstractUniquenessMcpIT. The same tests run, in the same numbers.

Two YAML edge cases change as a consequence of reading it as a tree, in
both cases towards what the JSON source and the streaming YAML source
already did: a top-level scalar document now yields a row rather than
none, and malformed YAML raises IllegalStateException rather than
IllegalArgumentException.

Verified with mvn package, -Pcoverage verify, -P integration-tests verify
(context 5/2/7 and data 2/2, unchanged), and -Ppitest for data (88%) and
code/context (95%).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019vt8QEQ5DwGJMFKLXxH4DG