### PR TITLE
refactor(context,data,mcp-common,adopt): collapse duplicated walks and skeletons

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
@@ -35,15 +35,7 @@ final class ToolProbe {
 	 *         absent tools at once.
 	 */
 	List<String> missingFrom(List<String> tools, Path directory, CommandRunner runner) {
-		return tools.stream().filter(tool -> !found(tool, directory, runner)).toList();
-	}
-
-	private boolean found(String tool, Path directory, CommandRunner runner) {
-		boolean installed = isInstalled(tool, directory, runner);
-		if (installed) {
-			log.info("Found required tool: {}", tool);
-		}
-		return installed;
+		return tools.stream().filter(tool -> !isInstalled(tool, directory, runner)).toList();
 	}
 
 	/**
@@ -52,7 +44,11 @@ final class ToolProbe {
 	 *         {@link BuildToolchainStep} cannot drift apart on it.
 	 */
 	boolean isInstalled(String tool, Path directory, CommandRunner runner) {
-		return succeeds(List.of(tool, VERSION_FLAG), directory, runner);
+		boolean installed = succeeds(List.of(tool, VERSION_FLAG), directory, runner);
+		if (installed) {
+			log.info("Found required tool: {}", tool);
+		}
+		return installed;
 	}
 
 	/**

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractClassContextTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractClassContextTool.java
@@ -1,11 +1,7 @@
 package io.github.adamw7.context.mcp;
 
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.context.ClassContainer;
 import io.github.adamw7.context.Language;
@@ -15,48 +11,37 @@ import io.github.adamw7.tools.mcp.ToolResult;
 
 /**
  * Shared skeleton for the MCP tools that operate on a single class within a
- * project. They all confine and resolve the project path, load every source of
- * the requested {@link Language}, and locate the target class by its simple name;
- * they differ only in what they compute from that class, which subclasses supply
- * through {@link #result}. Keeping the common steps here removes the duplication
- * between {@link ContextFinderTool} and {@link EstimateTokensTool} and keeps their
- * argument handling, class lookup and result envelopes identical.
+ * project. On top of the arguments {@link AbstractContextTool} resolves for every
+ * tool, they load every source of the requested {@link Language} and locate the
+ * target class by its simple name; they differ only in what they compute from that
+ * class, which subclasses supply through {@link #result}. Keeping those steps here
+ * removes the duplication between {@link ContextFinderTool} and
+ * {@link EstimateTokensTool} and keeps their class lookup and result envelopes
+ * identical.
  */
-abstract class AbstractClassContextTool implements ContextTool {
-
-	protected static final int DEFAULT_DEPTH = 1;
-	protected static final int MAX_DEPTH = 10;
-
-	private static final Logger log = LogManager.getLogger(AbstractClassContextTool.class);
-
-	protected final PathPolicy pathPolicy;
+abstract class AbstractClassContextTool extends AbstractContextTool {
 
 	protected AbstractClassContextTool(PathPolicy pathPolicy) {
-		this.pathPolicy = pathPolicy;
+		super(pathPolicy);
 	}
 
 	@Override
-	public ToolResult apply(Map<String, Object> arguments) {
-		log.info("Calling MCP {} tool for {}", getToolDefinition().name(), arguments);
-		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
-		Language language = LanguageArguments.optionalLanguage(arguments, "language", Language.JAVA);
-		int depth = ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH);
-		Set<ClassContainer> containers = Set.copyOf(new ProjectSources(language).load(root).values());
-
-		ClassContainer target = findTarget(containers, arguments, language);
+	protected final ToolResult answer(Scan scan, Map<String, Object> arguments) {
+		Set<ClassContainer> containers = Set.copyOf(new ProjectSources(scan.language()).load(scan.root()).values());
+		String className = ToolArguments.requiredString(arguments, "class_name");
+		ClassContainer target = findTarget(containers, className, scan.language());
 		if (target == null) {
-			return ToolResult.error("Class not found: " + ToolArguments.requiredString(arguments, "class_name"));
+			return ToolResult.error("Class not found: " + className);
 		}
-		return ToolResult.success(result(containers, target, language, depth));
+		return ToolResult.success(result(containers, target, scan.language(), scan.depth()));
 	}
 
 	/** Computes the tool's textual result from the located class within its project. */
 	protected abstract String result(Set<ClassContainer> containers, ClassContainer target,
 			Language language, int depth);
 
-	private ClassContainer findTarget(Set<ClassContainer> containers, Map<String, Object> arguments,
-			Language language) {
-		String fileName = fileNameOf(ToolArguments.requiredString(arguments, "class_name"), language);
+	private ClassContainer findTarget(Set<ClassContainer> containers, String className, Language language) {
+		String fileName = fileNameOf(className, language);
 		return containers.stream()
 				.filter(container -> container.className().equals(fileName))
 				.findFirst()

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractContextTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractContextTool.java
@@ -1,0 +1,52 @@
+package io.github.adamw7.context.mcp;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.context.Language;
+import io.github.adamw7.tools.mcp.ToolArguments;
+import io.github.adamw7.tools.mcp.ToolResult;
+
+/**
+ * Shared skeleton for every MCP tool this server exposes. They all take the same
+ * three arguments — the project to look at, the language its sources are written in,
+ * and how far to follow dependencies — so confining the path, defaulting the language
+ * and bounding the depth happens once here, next to the {@link ContextToolSchema}
+ * that advertises them. What a tool does with the {@link Scan} is its own, supplied
+ * through {@link #answer}.
+ */
+abstract class AbstractContextTool implements ContextTool {
+
+	private static final Logger log = LogManager.getLogger(AbstractContextTool.class);
+
+	private static final int DEFAULT_DEPTH = 1;
+	private static final int MAX_DEPTH = 10;
+
+	protected final PathPolicy pathPolicy;
+
+	protected AbstractContextTool(PathPolicy pathPolicy) {
+		this.pathPolicy = pathPolicy;
+	}
+
+	/** What every context tool is asked to look at: a confined project root, a language and a depth. */
+	protected record Scan(Path root, Language language, int depth) {
+	}
+
+	@Override
+	public final ToolResult apply(Map<String, Object> arguments) {
+		log.info("Calling MCP {} tool for {}", getToolDefinition().name(), arguments);
+		Scan scan = new Scan(pathPolicy.resolve(ToolArguments.requiredString(arguments, "path")),
+				LanguageArguments.optionalLanguage(arguments, "language", Language.JAVA),
+				ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH));
+		return answer(scan, arguments);
+	}
+
+	/**
+	 * Answers the call with the arguments every tool takes already resolved.
+	 * {@code arguments} is passed on for a tool that reads one of its own beyond them.
+	 */
+	protected abstract ToolResult answer(Scan scan, Map<String, Object> arguments);
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractProjectScanTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractProjectScanTool.java
@@ -1,46 +1,30 @@
 package io.github.adamw7.context.mcp;
 
-import java.nio.file.Path;
 import java.util.Map;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.context.Language;
 import io.github.adamw7.context.tree.ProjectTreeBuilder;
 import io.github.adamw7.context.tree.ProjectTreeNode;
-import io.github.adamw7.tools.mcp.ToolArguments;
 import io.github.adamw7.tools.mcp.ToolResult;
 
 /**
  * Shared skeleton for the MCP tools that scan a whole project rather than a single
- * class within it. They all confine and resolve the project path, read the optional
- * language and depth, and build the same tree; they differ only in how they render
- * it, which subclasses supply through {@link #render}. Keeping the common steps here
- * removes the duplication between {@link ProjectTreeTool} and {@link OkfBundleTool}
- * and keeps their argument handling identical — the whole-project counterpart of
- * {@link AbstractClassContextTool}.
+ * class within it. On top of the arguments {@link AbstractContextTool} resolves for
+ * every tool, they build the same tree; they differ only in how they render it,
+ * which subclasses supply through {@link #render}. Keeping that step here removes
+ * the duplication between {@link ProjectTreeTool} and {@link OkfBundleTool} — the
+ * whole-project counterpart of {@link AbstractClassContextTool}.
  */
-abstract class AbstractProjectScanTool implements ContextTool {
-
-	private static final Logger log = LogManager.getLogger(AbstractProjectScanTool.class);
-
-	private static final int DEFAULT_DEPTH = 1;
-	private static final int MAX_DEPTH = 10;
-
-	private final PathPolicy pathPolicy;
+abstract class AbstractProjectScanTool extends AbstractContextTool {
 
 	protected AbstractProjectScanTool(PathPolicy pathPolicy) {
-		this.pathPolicy = pathPolicy;
+		super(pathPolicy);
 	}
 
 	@Override
-	public final ToolResult apply(Map<String, Object> arguments) {
-		log.info("Calling MCP {} tool for {}", getToolDefinition().name(), arguments);
-		Path root = pathPolicy.resolve(ToolArguments.requiredString(arguments, "path"));
-		Language language = LanguageArguments.optionalLanguage(arguments, "language", Language.JAVA);
-		int depth = ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH);
-		return ToolResult.success(render(new ProjectTreeBuilder(language, depth).build(root), language, arguments));
+	protected final ToolResult answer(Scan scan, Map<String, Object> arguments) {
+		ProjectTreeNode tree = new ProjectTreeBuilder(scan.language(), scan.depth()).build(scan.root());
+		return ToolResult.success(render(tree, scan.language(), arguments));
 	}
 
 	/**

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
@@ -31,18 +31,7 @@ public class ContextFinderTool extends AbstractClassContextTool {
 
 	private final ToolDefinition toolDefinition = new ToolDefinition("find_context",
 			"Find the classes a given class depends on, within a Java, Kotlin or Scala project",
-			Map.of(
-					"type", "object",
-					"properties", Map.of(
-							"path", Map.of("type", "string",
-									"description", "absolute path to the project root directory"),
-							"class_name", Map.of("type", "string",
-									"description", "simple name of the class to inspect, e.g. Foo or Foo.java"),
-							"language", Map.of("type", "string",
-									"description", "source language: java (default), kotlin or scala"),
-							"depth", Map.of("type", "integer",
-									"description", "how many levels of transitive dependencies to resolve (default 1)")),
-					"required", List.of("path", "class_name")));
+			ContextToolSchema.singleClass());
 
 	@Override
 	public ToolDefinition getToolDefinition() {

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ContextToolSchema.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ContextToolSchema.java
@@ -1,0 +1,50 @@
+package io.github.adamw7.context.mcp;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The JSON schemas the context tools advertise. Every one of them takes the same
+ * project path, language and depth that {@link AbstractContextTool} reads, and
+ * two of them additionally name a class, so the property definitions and their
+ * wording live here rather than being spelled out again in each tool — where a
+ * description could drift from the argument handling that is already shared.
+ */
+final class ContextToolSchema {
+
+	private static final Map<String, Object> PATH = property("string",
+			"absolute path to the project root directory");
+	private static final Map<String, Object> LANGUAGE = property("string",
+			"source language: java (default), kotlin or scala");
+	private static final Map<String, Object> DEPTH = property("integer",
+			"how many levels of transitive dependencies to resolve (default 1)");
+	private static final Map<String, Object> CLASS_NAME = property("string",
+			"simple name of the class to inspect, e.g. Foo or Foo.java");
+
+	private ContextToolSchema() {
+	}
+
+	/** The schema of a tool that scans a whole project, plus whatever else it takes. */
+	static Map<String, Object> project(Map<String, Object> ownProperties) {
+		return schema(ownProperties, List.of("path"));
+	}
+
+	/** The schema of a tool that operates on one class within a project. */
+	static Map<String, Object> singleClass() {
+		return schema(Map.of("class_name", CLASS_NAME), List.of("path", "class_name"));
+	}
+
+	static Map<String, Object> property(String type, String description) {
+		return Map.of("type", type, "description", description);
+	}
+
+	private static Map<String, Object> schema(Map<String, Object> ownProperties, List<String> required) {
+		Map<String, Object> properties = new LinkedHashMap<>();
+		properties.put("path", PATH);
+		properties.putAll(ownProperties);
+		properties.put("language", LANGUAGE);
+		properties.put("depth", DEPTH);
+		return Map.of("type", "object", "properties", Map.copyOf(properties), "required", required);
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/EstimateTokensTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/EstimateTokensTool.java
@@ -41,18 +41,7 @@ public class EstimateTokensTool extends AbstractClassContextTool {
 
 	private final ToolDefinition toolDefinition = new ToolDefinition("estimate_tokens",
 			"Estimate the LLM token cost of the context assembled for a class and its dependencies",
-			Map.of(
-					"type", "object",
-					"properties", Map.of(
-							"path", Map.of("type", "string",
-									"description", "absolute path to the project root directory"),
-							"class_name", Map.of("type", "string",
-									"description", "simple name of the class to inspect, e.g. Foo or Foo.java"),
-							"language", Map.of("type", "string",
-									"description", "source language: java (default), kotlin or scala"),
-							"depth", Map.of("type", "integer",
-									"description", "how many levels of transitive dependencies to include (default 1)")),
-					"required", List.of("path", "class_name")));
+			ContextToolSchema.singleClass());
 
 	@Override
 	public ToolDefinition getToolDefinition() {

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -113,7 +113,7 @@ dependencies, to a bounded depth.
 - `path` (string, required): absolute path to the project root directory
 - `class_name` (string, required): simple name of the class to inspect, e.g. `Foo` or `Foo.java`
 - `language` (string, optional): `java` (default), `kotlin` or `scala`
-- `depth` (integer, optional): levels of transitive dependencies to include (default `1`)
+- `depth` (integer, optional): levels of transitive dependencies to resolve (default `1`)
 
 **Returns:** a JSON object with the `total` token estimate and a `classes` array of
 `{ "class": ..., "tokens": ... }` entries, the target class first. An unknown

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/OkfBundleTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/OkfBundleTool.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.context.mcp;
 
-import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,16 +32,7 @@ public class OkfBundleTool extends AbstractProjectScanTool {
 
 	private final ToolDefinition toolDefinition = new ToolDefinition("okf_bundle",
 			"Scan a Java, Kotlin or Scala project into an Open Knowledge Format (OKF) bundle of markdown documents",
-			Map.of(
-					"type", "object",
-					"properties", Map.of(
-							"path", Map.of("type", "string",
-									"description", "absolute path to the project root directory"),
-							"language", Map.of("type", "string",
-									"description", "source language: java (default), kotlin or scala"),
-							"depth", Map.of("type", "integer",
-									"description", "how many levels of transitive dependencies to resolve (default 1)")),
-					"required", List.of("path")));
+			ContextToolSchema.project(Map.of()));
 
 	@Override
 	public ToolDefinition getToolDefinition() {

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ProjectTreeTool.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.context.mcp;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -33,18 +32,8 @@ public class ProjectTreeTool extends AbstractProjectScanTool {
 
 	private final ToolDefinition toolDefinition = new ToolDefinition("project_tree",
 			"Scan a Java, Kotlin or Scala project into a tree of folders, files and class dependencies",
-			Map.of(
-					"type", "object",
-					"properties", Map.of(
-							"path", Map.of("type", "string",
-									"description", "absolute path to the project root directory"),
-							"language", Map.of("type", "string",
-									"description", "source language: java (default), kotlin or scala"),
-							"depth", Map.of("type", "integer",
-									"description", "how many levels of transitive dependencies to resolve (default 1)"),
-							"format", Map.of("type", "string",
-									"description", "output format: json (default), markdown, text, dot or mermaid")),
-					"required", List.of("path")));
+			ContextToolSchema.project(Map.of("format", ContextToolSchema.property("string",
+					"output format: json (default), markdown, text, dot or mermaid"))));
 
 	@Override
 	public ToolDefinition getToolDefinition() {

--- a/code/context/src/main/java/io/github/adamw7/context/tree/AbstractProjectTreeGraphSerializer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/AbstractProjectTreeGraphSerializer.java
@@ -1,0 +1,41 @@
+package io.github.adamw7.context.tree;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared skeleton for the serializers that render the tree's dependency graph
+ * rather than its shape: every file becomes a node and every dependency a directed
+ * edge to the depended-on class, with directories contributing structure but not
+ * drawn. Which edges there are is the same question whatever the target syntax, so
+ * the walk lives here and a subclass only says how to write them out — the
+ * difference between {@link ProjectTreeDotSerializer} and
+ * {@link ProjectTreeMermaidSerializer}. Collecting them first also lets a format
+ * that numbers its nodes hold that state for one call, so a serializer stays
+ * reusable.
+ */
+public abstract class AbstractProjectTreeGraphSerializer implements ProjectTreeSerializer {
+
+	protected static final String INDENT = "  ";
+
+	/** One directed edge, from the file that declares the dependency to the class it depends on. */
+	protected record Edge(String from, String to) {
+	}
+
+	@Override
+	public final String serialize(ProjectTreeNode root) {
+		List<Edge> edges = new ArrayList<>();
+		collect(root, edges);
+		return render(edges);
+	}
+
+	/** Writes the whole graph, header and all, in the target syntax. */
+	protected abstract String render(List<Edge> edges);
+
+	private void collect(ProjectTreeNode node, List<Edge> edges) {
+		if (!node.isDirectory()) {
+			node.dependencies().forEach(dependency -> edges.add(new Edge(node.name(), dependency)));
+		}
+		node.children().forEach(child -> collect(child, edges));
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/tree/AbstractProjectTreeIndentedSerializer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/AbstractProjectTreeIndentedSerializer.java
@@ -1,0 +1,35 @@
+package io.github.adamw7.context.tree;
+
+/**
+ * Shared skeleton for the serializers that render the tree's shape rather than its
+ * dependency graph: every node on a line of its own, indented one level per folder,
+ * with the classes a file depends on listed beneath it. How deep a node sits is the
+ * same question whatever the target syntax, so the walk lives here and a subclass
+ * only says how a node and a dependency are written — the difference between
+ * {@link ProjectTreePrinter} and {@link ProjectTreeMarkdownSerializer}.
+ */
+public abstract class AbstractProjectTreeIndentedSerializer implements ProjectTreeSerializer {
+
+	protected static final String INDENT = "  ";
+
+	@Override
+	public final String serialize(ProjectTreeNode root) {
+		StringBuilder builder = new StringBuilder();
+		append(builder, root, "");
+		return builder.toString();
+	}
+
+	/** How the node itself is written, without its indentation or line terminator. */
+	protected abstract String line(ProjectTreeNode node);
+
+	/** How one class the node depends on is written, without its indentation or line terminator. */
+	protected abstract String dependencyLine(String dependency);
+
+	private void append(StringBuilder builder, ProjectTreeNode node, String indent) {
+		builder.append(indent).append(line(node)).append(System.lineSeparator());
+		String deeper = indent + INDENT;
+		node.dependencies().forEach(dependency ->
+				builder.append(deeper).append(dependencyLine(dependency)).append(System.lineSeparator()));
+		node.children().forEach(child -> append(builder, child, deeper));
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeDotSerializer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeDotSerializer.java
@@ -1,5 +1,7 @@
 package io.github.adamw7.context.tree;
 
+import java.util.List;
+
 /**
  * Renders the dependency graph of a {@link ProjectTreeNode} tree as a Graphviz
  * <a href="https://graphviz.org/doc/info/lang.html">DOT</a> digraph: every file
@@ -9,34 +11,14 @@ package io.github.adamw7.context.tree;
  * classes depend on one another — complementary to the tree-shaped text, Markdown
  * and JSON serializers.
  */
-public class ProjectTreeDotSerializer implements ProjectTreeSerializer {
-
-	private static final String INDENT = "  ";
+public class ProjectTreeDotSerializer extends AbstractProjectTreeGraphSerializer {
 
 	@Override
-	public String serialize(ProjectTreeNode root) {
-		StringBuilder builder = new StringBuilder();
-		builder.append("digraph project {").append(System.lineSeparator());
-		appendEdges(builder, root);
-		builder.append("}").append(System.lineSeparator());
-		return builder.toString();
-	}
-
-	private void appendEdges(StringBuilder builder, ProjectTreeNode node) {
-		appendNodeEdges(builder, node);
-		node.children().forEach(child -> appendEdges(builder, child));
-	}
-
-	private void appendNodeEdges(StringBuilder builder, ProjectTreeNode node) {
-		if (node.isDirectory()) {
-			return;
-		}
-		node.dependencies().forEach(dependency -> appendEdge(builder, node.name(), dependency));
-	}
-
-	private void appendEdge(StringBuilder builder, String from, String to) {
-		builder.append(INDENT).append(quote(from)).append(" -> ").append(quote(to)).append(";")
-				.append(System.lineSeparator());
+	protected String render(List<Edge> edges) {
+		StringBuilder builder = new StringBuilder("digraph project {").append(System.lineSeparator());
+		edges.forEach(edge -> builder.append(INDENT).append(quote(edge.from())).append(" -> ")
+				.append(quote(edge.to())).append(";").append(System.lineSeparator()));
+		return builder.append("}").append(System.lineSeparator()).toString();
 	}
 
 	private String quote(String label) {

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeMarkdownSerializer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeMarkdownSerializer.java
@@ -6,36 +6,26 @@ package io.github.adamw7.context.tree;
  * as indented child bullets. The result is a compact, Markdown-aware view well
  * suited to documents and chat-based gen-AI agents.
  */
-public class ProjectTreeMarkdownSerializer implements ProjectTreeSerializer {
+public class ProjectTreeMarkdownSerializer extends AbstractProjectTreeIndentedSerializer {
 
-	private static final String INDENT = "  ";
 	private static final String BULLET = "- ";
 	private static final String DIRECTORY_MARKER = "**";
 	private static final String DEPENDENCY_MARKER = "depends on: ";
 
 	@Override
-	public String serialize(ProjectTreeNode root) {
-		StringBuilder builder = new StringBuilder();
-		append(builder, root, "");
-		return builder.toString();
-	}
-
-	private void append(StringBuilder builder, ProjectTreeNode node, String indent) {
-		builder.append(indent).append(BULLET).append(label(node)).append(System.lineSeparator());
-		appendDependencies(builder, node, indent + INDENT);
-		node.children().forEach(child -> append(builder, child, indent + INDENT));
-	}
-
-	private void appendDependencies(StringBuilder builder, ProjectTreeNode node, String indent) {
-		node.dependencies().forEach(dependency ->
-				builder.append(indent).append(BULLET).append(DEPENDENCY_MARKER).append('`')
-						.append(dependency).append('`').append(System.lineSeparator()));
-	}
-
-	private String label(ProjectTreeNode node) {
+	protected String line(ProjectTreeNode node) {
 		if (node.isDirectory()) {
-			return DIRECTORY_MARKER + node.name() + DIRECTORY_MARKER;
+			return BULLET + DIRECTORY_MARKER + node.name() + DIRECTORY_MARKER;
 		}
-		return "`" + node.name() + "`";
+		return BULLET + code(node.name());
+	}
+
+	@Override
+	protected String dependencyLine(String dependency) {
+		return BULLET + DEPENDENCY_MARKER + code(dependency);
+	}
+
+	private String code(String text) {
+		return "`" + text + "`";
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeMermaidSerializer.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeMermaidSerializer.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.context.tree;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -13,36 +14,20 @@ import java.util.Map;
  * renders inline on GitHub, in Markdown viewers and in many gen-AI agent surfaces
  * without any external tooling.
  */
-public class ProjectTreeMermaidSerializer implements ProjectTreeSerializer {
+public class ProjectTreeMermaidSerializer extends AbstractProjectTreeGraphSerializer {
 
-	private static final String INDENT = "  ";
 	private static final String HEADER = "flowchart LR";
 	private static final String ARROW = " --> ";
 	private static final String NODE_PREFIX = "n";
 
+	/** The ids are numbered per call, so one serializer renders any number of trees. */
 	@Override
-	public String serialize(ProjectTreeNode root) {
-		StringBuilder builder = new StringBuilder();
-		builder.append(HEADER).append(System.lineSeparator());
-		appendEdges(builder, root, new LinkedHashMap<>());
+	protected String render(List<Edge> edges) {
+		Map<String, String> ids = new LinkedHashMap<>();
+		StringBuilder builder = new StringBuilder(HEADER).append(System.lineSeparator());
+		edges.forEach(edge -> builder.append(INDENT).append(nodeFor(edge.from(), ids)).append(ARROW)
+				.append(nodeFor(edge.to(), ids)).append(System.lineSeparator()));
 		return builder.toString();
-	}
-
-	private void appendEdges(StringBuilder builder, ProjectTreeNode node, Map<String, String> ids) {
-		appendNodeEdges(builder, node, ids);
-		node.children().forEach(child -> appendEdges(builder, child, ids));
-	}
-
-	private void appendNodeEdges(StringBuilder builder, ProjectTreeNode node, Map<String, String> ids) {
-		if (node.isDirectory()) {
-			return;
-		}
-		node.dependencies().forEach(dependency -> appendEdge(builder, node.name(), dependency, ids));
-	}
-
-	private void appendEdge(StringBuilder builder, String from, String to, Map<String, String> ids) {
-		builder.append(INDENT).append(nodeFor(from, ids)).append(ARROW).append(nodeFor(to, ids))
-				.append(System.lineSeparator());
 	}
 
 	private String nodeFor(String label, Map<String, String> ids) {

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreePrinter.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreePrinter.java
@@ -5,37 +5,24 @@ package io.github.adamw7.context.tree;
  * files are listed hierarchically and each file's dependencies are printed
  * beneath it, giving a compact, human- and LLM-readable view of the project.
  */
-public class ProjectTreePrinter implements ProjectTreeSerializer {
+public class ProjectTreePrinter extends AbstractProjectTreeIndentedSerializer {
 
-	private static final String INDENT = "  ";
 	private static final String DIRECTORY_MARKER = "[dir] ";
 	private static final String FILE_MARKER = "[file] ";
 	private static final String DEPENDENCY_MARKER = "-> ";
 
-	@Override
-	public String serialize(ProjectTreeNode root) {
-		return print(root);
-	}
-
+	/** The printer's own name for {@link #serialize}, kept for callers that hold one directly. */
 	public String print(ProjectTreeNode root) {
-		StringBuilder builder = new StringBuilder();
-		append(builder, root, "");
-		return builder.toString();
+		return serialize(root);
 	}
 
-	private void append(StringBuilder builder, ProjectTreeNode node, String indent) {
-		builder.append(indent).append(marker(node)).append(node.name()).append(System.lineSeparator());
-		appendDependencies(builder, node, indent + INDENT);
-		node.children().forEach(child -> append(builder, child, indent + INDENT));
+	@Override
+	protected String line(ProjectTreeNode node) {
+		return (node.isDirectory() ? DIRECTORY_MARKER : FILE_MARKER) + node.name();
 	}
 
-	private void appendDependencies(StringBuilder builder, ProjectTreeNode node, String indent) {
-		node.dependencies().forEach(dependency ->
-				builder.append(indent).append(DEPENDENCY_MARKER).append(dependency)
-						.append(System.lineSeparator()));
-	}
-
-	private String marker(ProjectTreeNode node) {
-		return node.isDirectory() ? DIRECTORY_MARKER : FILE_MARKER;
+	@Override
+	protected String dependencyLine(String dependency) {
+		return DEPENDENCY_MARKER + dependency;
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/ToonSyntax.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/ToonSyntax.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.data.source.file;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
@@ -36,12 +37,7 @@ final class ToonSyntax {
 
 	/** Splits a comma-separated tabular field list, trimming each field name. */
 	static String[] splitFields(String fieldsText) {
-		String[] raw = fieldsText.split(",");
-		String[] trimmed = new String[raw.length];
-		for (int i = 0; i < raw.length; i++) {
-			trimmed[i] = raw[i].trim();
-		}
-		return trimmed;
+		return Arrays.stream(fieldsText.split(",")).map(String::trim).toArray(String[]::new);
 	}
 
 	/** Emits the header pairs of a tabular array: its declared count, then each field as its own key. */
@@ -71,22 +67,13 @@ final class ToonSyntax {
 		}
 	}
 
+	/** A tab counts as two columns, so a document indented with either character nests the same way. */
 	static int indentationOf(String line) {
-		int count = 0;
-		int i = 0;
-		while (i < line.length() && isWhitespace(line.charAt(i))) {
-			count += whitespaceValue(line.charAt(i));
-			i++;
-		}
-		return count;
+		return line.chars().takeWhile(ToonSyntax::isWhitespace).map(character -> character == '\t' ? 2 : 1).sum();
 	}
 
-	private static boolean isWhitespace(char c) {
-		return c == ' ' || c == '\t';
-	}
-
-	private static int whitespaceValue(char c) {
-		return c == '\t' ? 2 : 1;
+	private static boolean isWhitespace(int character) {
+		return character == ' ' || character == '\t';
 	}
 
 	static String[] splitRow(String row) {

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.logging.log4j.LogManager;
@@ -25,8 +27,25 @@ public abstract class AbstractUniqueness<T extends ColumnarDataSource> implement
 		this.dataSource = dataSource;
 	}
 
-	protected void checkIfCandidatesExistIn(String[] keyCandidates, String[] allColumns) {
-		Set<String> all = new HashSet<>(Arrays.asList(toLower(allColumns)));
+	/**
+	 * The positions the named columns sit at in the open source, once it is confirmed
+	 * to declare every one of them. The two questions are asked of the same reading of
+	 * the column names, so a source that answers slowly is only asked once.
+	 */
+	protected int[] indicesOf(String[] keyCandidates) {
+		String[] allColumns = dataSource.getColumnNames();
+		checkIfCandidatesExistIn(keyCandidates, allColumns);
+		return IntStream.range(0, allColumns.length)
+				.flatMap(index -> Arrays.stream(keyCandidates)
+						.filter(candidate -> allColumns[index].equalsIgnoreCase(candidate))
+						.mapToInt(candidate -> index))
+				.toArray();
+	}
+
+	private void checkIfCandidatesExistIn(String[] keyCandidates, String[] allColumns) {
+		Set<String> all = Arrays.stream(allColumns)
+				.map(column -> column == null ? null : column.toLowerCase())
+				.collect(Collectors.toCollection(HashSet::new));
 
 		for (String candidate : keyCandidates) {
 			if (!all.contains(candidate.toLowerCase())) {
@@ -34,21 +53,8 @@ public abstract class AbstractUniqueness<T extends ColumnarDataSource> implement
 			}
 		}
 	}
-	
-	protected String[] toLower(String[] items) {
-		return Arrays.stream(items)
-				.map(item -> item == null ? null : item.toLowerCase())
-				.toArray(String[]::new);
-	}
 
-	protected int[] getIndiciesOf(String[] keyCandidates, String[] allColumns) {
-		return IntStream.range(0, allColumns.length)
-				.flatMap(index -> Arrays.stream(keyCandidates)
-						.filter(candidate -> allColumns[index].equalsIgnoreCase(candidate))
-						.mapToInt(candidate -> index))
-				.toArray();
-	}
-	
+
 	protected void check(String[] keyCandidates) {
 		handleNullsAndEmpty(keyCandidates);
 		handleDuplicates(keyCandidates);
@@ -129,15 +135,34 @@ public abstract class AbstractUniqueness<T extends ColumnarDataSource> implement
 	 */
 	protected abstract Result execOnOpenSource(String[] keyCandidates);
 
+	/**
+	 * The columns are validated before the source is opened, since a caller's input is
+	 * wrong whatever the source holds, and a rejected call should leave the source as it
+	 * found it.
+	 */
 	@Override
-	public Result execForAllColumns() {
+	public final Result exec(String... keyCandidates) {
+		check(keyCandidates);
+		return onOpenSource(source -> keyCandidates);
+	}
+
+	/** The columns can only be named once the source is open, so they are checked there. */
+	@Override
+	public final Result execForAllColumns() {
+		return onOpenSource(source -> checked(source.getColumnNames()));
+	}
+
+	private Result onOpenSource(Function<T, String[]> keyCandidates) {
 		dataSource.open();
 		try {
-			String[] keyCandidates = dataSource.getColumnNames();
-			check(keyCandidates);
-			return execOnOpenSource(keyCandidates);
+			return execOnOpenSource(keyCandidates.apply(dataSource));
 		} finally {
 			close(dataSource);
 		}
+	}
+
+	private String[] checked(String[] keyCandidates) {
+		check(keyCandidates);
+		return keyCandidates;
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/InMemoryUniquenessCheck.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/InMemoryUniquenessCheck.java
@@ -1,7 +1,5 @@
 package io.github.adamw7.tools.data.uniqueness;
 
-import java.util.List;
-
 import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
 
 public class InMemoryUniquenessCheck extends AbstractUniqueness<InMemoryDataSource> {
@@ -11,40 +9,24 @@ public class InMemoryUniquenessCheck extends AbstractUniqueness<InMemoryDataSour
 	}
 
 	@Override
-	public Result exec(String... keyCandidates) {
-		check(keyCandidates);
-		dataSource.open();
-		try {
-			return execOnOpenSource(keyCandidates);
-		} finally {
-			close(dataSource);
-		}
+	protected Result execOnOpenSource(String[] keyCandidates) {
+		return findUnique(keyCandidates);
 	}
 
 	@Override
-	protected Result execOnOpenSource(String[] keyCandidates) {
-		checkIfCandidatesExistIn(keyCandidates, dataSource.getColumnNames());
-
-		int[] indices = getIndiciesOf(keyCandidates, dataSource.getColumnNames());
-		return findUnique(indices, keyCandidates);
+	protected Result checkSubset(String[] newCandidates) {
+		return findUnique(newCandidates);
 	}
 
-	private Result findUnique(int[] indices, String... keyCandidates) {
+	private Result findUnique(String... keyCandidates) {
+		KeyFinder finder = new KeyFinder(indicesOf(keyCandidates));
 		dataSource.reset();
-		List<String[]> data = dataSource.readAll();
-		KeyFinder finder = new KeyFinder(indices);
-		for (String[] row : data) {
+		for (String[] row : dataSource.readAll()) {
 			if (finder.found(row)) {
 				return new Result(false, keyCandidates, row);
 			}
 		}
 
 		return handleSuccessfulCheck(keyCandidates);
-	}
-
-	@Override
-	protected Result checkSubset(String[] newCandidates) {
-		int[] indices = getIndiciesOf(newCandidates, dataSource.getColumnNames());
-		return findUnique(indices, newCandidates);
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/KeyFinder.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/KeyFinder.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.data.uniqueness;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -13,18 +14,10 @@ public class KeyFinder {
 	}
 
 	public boolean found(String[] row) {
-		if (row == null) {
-			return false;
-		}
-		return !set.add(key(row, indices));
+		return row != null && !set.add(key(row));
 	}
 
-	protected Key key(String[] row, int[] indices) {
-		String[] values = new String[indices.length];
-		for (int i = 0; i < indices.length; ++i) {
-			values[i] = row[indices[i]];
-		}
-		return new Key(values);
+	protected Key key(String[] row) {
+		return new Key(Arrays.stream(indices).mapToObj(index -> row[index]).toArray(String[]::new));
 	}
-
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/NoMemoryUniquenessCheck.java
@@ -9,21 +9,8 @@ public class NoMemoryUniquenessCheck extends AbstractUniqueness<ColumnarDataSour
 	}
 
 	@Override
-	public Result exec(String... keyCandidates) {
-		check(keyCandidates);
-		dataSource.open();
-		try {
-			return execOnOpenSource(keyCandidates);
-		} finally {
-			close(dataSource);
-		}
-	}
-
-	@Override
 	protected Result execOnOpenSource(String[] keyCandidates) {
-		checkIfCandidatesExistIn(keyCandidates, dataSource.getColumnNames());
-		int[] indices = getIndiciesOf(keyCandidates, dataSource.getColumnNames());
-		KeyFinder finder = new KeyFinder(indices);
+		KeyFinder finder = new KeyFinder(indicesOf(keyCandidates));
 		while (dataSource.hasMoreData()) {
 			String[] row = dataSource.nextRow();
 			if (finder.found(row)) {

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/KeyFinderTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/KeyFinderTest.java
@@ -79,7 +79,7 @@ public class KeyFinderTest {
 	public void keyProjectsConfiguredColumnsInOrder() {
 		KeyFinder finder = new KeyFinder(new int[] { 2, 0 });
 
-		Key key = finder.key(new String[] { "x", "y", "z" }, new int[] { 2, 0 });
+		Key key = finder.key(new String[] { "x", "y", "z" });
 
 		assertTrue(key.equals(new Key(new String[] { "z", "x" })));
 	}

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
@@ -127,7 +127,7 @@ public abstract class AbstractMcpConfiguration {
 				.serverInfo(serverName(), SERVER_VERSION)
 				.capabilities(serverCapabilities())
 				.build();
-		registerStatelessTools(statelessServer);
+		tools().forEach(tool -> statelessServer.addTool(statelessSpecificationFor(tool)));
 		return statelessServer;
 	}
 
@@ -136,7 +136,7 @@ public abstract class AbstractMcpConfiguration {
 				.serverInfo(serverName(), SERVER_VERSION)
 				.capabilities(serverCapabilities())
 				.build();
-		registerTools(syncServer);
+		tools().forEach(tool -> syncServer.addTool(specificationFor(tool)));
 		return syncServer;
 	}
 
@@ -145,19 +145,11 @@ public abstract class AbstractMcpConfiguration {
 				.tools(true).resources(false, false).prompts(false).build();
 	}
 
-	private void registerTools(McpSyncServer server) {
-		tools().forEach(tool -> server.addTool(specificationFor(tool)));
-	}
-
 	private SyncToolSpecification specificationFor(McpTool tool) {
 		return SyncToolSpecification.builder()
 				.tool(sdkTool(tool.getToolDefinition()))
 				.callHandler((exchange, request) -> sdkResult(safeApply(tool, request.arguments())))
 				.build();
-	}
-
-	private void registerStatelessTools(McpStatelessSyncServer server) {
-		tools().forEach(tool -> server.addTool(statelessSpecificationFor(tool)));
 	}
 
 	private McpStatelessServerFeatures.SyncToolSpecification statelessSpecificationFor(McpTool tool) {

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/ToolArguments.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/ToolArguments.java
@@ -16,19 +16,11 @@ public final class ToolArguments {
 	}
 
 	public static String requiredString(Map<String, Object> arguments, String key) {
-		Object value = arguments.get(key);
-		if (value == null) {
-			throw new IllegalArgumentException("Missing required argument: " + key);
-		}
-		return String.valueOf(value);
+		return String.valueOf(required(arguments, key));
 	}
 
 	public static int requiredInt(Map<String, Object> arguments, String key) {
-		Object value = arguments.get(key);
-		if (value == null) {
-			throw new IllegalArgumentException("Missing required argument: " + key);
-		}
-		return parseInt(key, value);
+		return parseInt(key, required(arguments, key));
 	}
 
 	public static String optionalString(Map<String, Object> arguments, String key, String defaultValue) {
@@ -51,6 +43,14 @@ public final class ToolArguments {
 		if (value < min || value > max) {
 			throw new IllegalArgumentException(
 					"Argument " + key + " must be between " + min + " and " + max + " but was " + value);
+		}
+		return value;
+	}
+
+	private static Object required(Map<String, Object> arguments, String key) {
+		Object value = arguments.get(key);
+		if (value == null) {
+			throw new IllegalArgumentException("Missing required argument: " + key);
 		}
 		return value;
 	}


### PR DESCRIPTION
Six structures were written out more than once. Each is now stated once and
reused, leaving the same behaviour in fewer lines of code:

- context: the DOT and Mermaid serializers walked the tree identically to find
  the same edges, and the text and Markdown serializers walked it identically to
  indent the same nodes. Both walks move into AbstractProjectTreeGraphSerializer
  and AbstractProjectTreeIndentedSerializer, so a serializer states only how it
  writes an edge or a line.
- context: every MCP tool resolved the same path, language and depth by hand.
  AbstractContextTool does it once and hands on a Scan; ContextToolSchema holds
  the property definitions the four tool schemas each spelled out, so a
  description can no longer drift from the argument handling it describes.
- data: both uniqueness checks carried the same open/check/close exec, and each
  read the source's column names twice to answer two questions. exec and
  execForAllColumns are now the abstract class's, and indicesOf answers both
  from one reading.
- data: ToonSyntax's field split and indentation scan, and KeyFinder's key
  projection, were index loops over what a stream states directly.
- mcp-common: the two required-argument readers repeated the same null check and
  message; the two tool registrations were single-use wrappers.
- adopt: ToolProbe's found() was a log line wrapped around isInstalled().

The estimate_tokens depth description now matches the other three tools' wording
("resolve" rather than "include"), and MCP_USAGE.md follows it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HZ7j7SiWuKjXCZgDHSxvFi