### PR TITLE
refactor(protogen-maven-plugin): collapse duplicated generator code

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommands.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommands.java
@@ -18,10 +18,15 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
  */
 final class HookCommands {
 
-	private static final String HOOKS_KEY = "hooks";
-	private static final String TYPE_KEY = "type";
-	private static final String COMMAND_KEY = "command";
-	private static final String COMMAND_TYPE = "command";
+	/*
+	 * The keys of the hooks section, shared with HookCommandsValidRule: this
+	 * collector reads the structure that rule validates, so the two must name it
+	 * identically or one would check a section the other never sees.
+	 */
+	static final String HOOKS_KEY = "hooks";
+	static final String TYPE_KEY = "type";
+	static final String COMMAND_KEY = "command";
+	static final String COMMAND_TYPE = "command";
 
 	private HookCommands() {
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -33,10 +33,11 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 @Named("hookCommandsValid")
 public class HookCommandsValidRule extends JsonFileRule {
 
-	private static final String HOOKS_KEY = "hooks";
-	private static final String TYPE_KEY = "type";
-	private static final String COMMAND_KEY = "command";
-	private static final String COMMAND_TYPE = "command";
+	/** The keys of the hooks section, named once in {@link HookCommands} and read the same way here. */
+	private static final String HOOKS_KEY = HookCommands.HOOKS_KEY;
+	private static final String TYPE_KEY = HookCommands.TYPE_KEY;
+	private static final String COMMAND_KEY = HookCommands.COMMAND_KEY;
+	private static final String COMMAND_TYPE = HookCommands.COMMAND_TYPE;
 
 	/** The {@code .claude/settings.json} file to validate. Injected from the rule configuration. */
 	private File settingsFile;

--- a/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundler.java
+++ b/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundler.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import io.github.adamw7.context.Language;
 import io.github.adamw7.context.tree.ProjectTreeNode;
@@ -159,16 +161,23 @@ public class OkfBundler {
 	}
 
 	private List<String> directoryEntries(ProjectTreeNode node) {
-		return entries(node).stream()
-				.filter(ProjectTreeNode::isDirectory)
-				.map(child -> "[" + child.name() + "](" + child.name() + SEPARATOR + ") - " + describe(child))
-				.toList();
+		return indexEntries(node, ProjectTreeNode::isDirectory, child -> child.name() + SEPARATOR);
 	}
 
 	private List<String> fileEntries(ProjectTreeNode node) {
+		return indexEntries(node, child -> !child.isDirectory(), this::conceptName);
+	}
+
+	/**
+	 * One index line per accepted child: a markdown link to it, then what it holds.
+	 * A directory and a file differ only in which of them is accepted and where the
+	 * link points, so the line itself is written once.
+	 */
+	private List<String> indexEntries(ProjectTreeNode node, Predicate<ProjectTreeNode> accepted,
+			Function<ProjectTreeNode, String> target) {
 		return entries(node).stream()
-				.filter(child -> !child.isDirectory())
-				.map(child -> "[" + child.name() + "](" + conceptName(child) + ") - " + describe(child))
+				.filter(accepted)
+				.map(child -> "[" + child.name() + "](" + target.apply(child) + ") - " + describe(child))
 				.toList();
 	}
 

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/Documents.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/Documents.java
@@ -1,0 +1,39 @@
+package io.github.adamw7.tools.code.format;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.text.edits.TextEdit;
+
+/**
+ * Applies an Eclipse {@link TextEdit} to source text. Both the formatter and the
+ * unused-import remover end the same way — wrap the code in a {@link Document},
+ * apply the edits the tool computed, and hand back the result — so the wrapping,
+ * and the {@link BadLocationException} that becomes a {@link FormatException},
+ * live here once rather than in each of them.
+ */
+final class Documents {
+
+	/**
+	 * Computes the edits to apply. The document is passed in because a rewrite
+	 * derives its edits from the very document they are applied to.
+	 */
+	@FunctionalInterface
+	interface Edits {
+		TextEdit of(IDocument document) throws BadLocationException;
+	}
+
+	private Documents() {
+	}
+
+	/** @return {@code code} with {@code edits} applied to it */
+	static String edited(String code, Edits edits) {
+		IDocument document = new Document(code);
+		try {
+			edits.of(document).apply(document);
+		} catch (BadLocationException e) {
+			throw new FormatException(e);
+		}
+		return document.get();
+	}
+}

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/Formatter.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/Formatter.java
@@ -2,23 +2,13 @@ package io.github.adamw7.tools.code.format;
 
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
-import org.eclipse.jface.text.BadLocationException;
-import org.eclipse.jface.text.Document;
-import org.eclipse.jface.text.IDocument;
-import org.eclipse.text.edits.TextEdit;
 
 public class Formatter implements FormatterIfc {
 
 	@Override
 	public String format(String code) {
 		CodeFormatter codeFormatter = ToolFactory.createCodeFormatter(null);
-		TextEdit textEdit = codeFormatter.format(CodeFormatter.K_COMPILATION_UNIT, code, 0, code.length(), 0, null);
-		IDocument doc = new Document(code);
-		try {
-			textEdit.apply(doc);
-		} catch (BadLocationException e) {
-			throw new FormatException(e);
-		}
-		return doc.get();
+		return Documents.edited(code,
+				document -> codeFormatter.format(CodeFormatter.K_COMPILATION_UNIT, code, 0, code.length(), 0, null));
 	}
 }

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/UnusedImportsRemover.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/UnusedImportsRemover.java
@@ -12,10 +12,6 @@ import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
-import org.eclipse.jface.text.BadLocationException;
-import org.eclipse.jface.text.Document;
-import org.eclipse.jface.text.IDocument;
-import org.eclipse.text.edits.TextEdit;
 
 public class UnusedImportsRemover implements ImportRemoverIfc {
 
@@ -71,13 +67,6 @@ public class UnusedImportsRemover implements ImportRemoverIfc {
 	}
 
 	private String applyRewrite(String code, ASTRewrite rewrite) {
-		IDocument document = new Document(code);
-		try {
-			TextEdit edits = rewrite.rewriteAST(document, null);
-			edits.apply(document);
-		} catch (BadLocationException e) {
-			throw new FormatException(e);
-		}
-		return document.get();
+		return Documents.edited(code, document -> rewrite.rewriteAST(document, null));
 	}
 }

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/ClassInfo.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/ClassInfo.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.code.gen;
 
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
@@ -24,48 +25,33 @@ public class ClassInfo {
 	private final String outputPkg;
 
 	public ClassInfo(Descriptor descriptor, String inputPkg, String outputPkg) {
-		mapFields = getMapFields(descriptor);
-		optionalFields = getOptionalFields(descriptor);
-		repeatedFields = getRepeatedFields(descriptor);
-		requiredFields = getRequiredFields(descriptor);
-		groupFields = getGroupFields(descriptor);
-		pureComplexFields = getPureComplexFields(descriptor);
+		mapFields = fieldsMatching(descriptor, FieldDescriptor::isMapField);
+		optionalFields = fieldsMatching(descriptor, ClassInfo::hasOptionalLabel);
+		repeatedFields = fieldsMatching(descriptor, ClassInfo::isPureRepeated);
+		requiredFields = fieldsMatching(descriptor, FieldDescriptor::isRequired);
+		groupFields = fieldsMatching(descriptor, ClassInfo::isGroup);
+		pureComplexFields = fieldsMatching(descriptor, field -> isComplexType(field) && isPure(field));
 		this.descriptor = descriptor;
 		this.nonOptionalFields = Stream.of(required(), map(), repeated()).flatMap(List::stream).toList();
 		this.inputPkg = inputPkg;
 		this.outputPkg = outputPkg;
 	}
 
-	private List<FieldDescriptor> getRepeatedFields(Descriptor descriptor) {
-		return descriptor.getFields().stream().filter(f -> f.isRepeated() && !f.isMapField()).toList();
+	/** The descriptor's fields the predicate accepts, in declaration order — how every field group here is derived. */
+	private static List<FieldDescriptor> fieldsMatching(Descriptor descriptor, Predicate<FieldDescriptor> accepted) {
+		return descriptor.getFields().stream().filter(accepted).toList();
 	}
 
-	private List<FieldDescriptor> getMapFields(Descriptor descriptor) {
-		return descriptor.getFields().stream().filter(FieldDescriptor::isMapField).toList();
-	}
-
-	private List<FieldDescriptor> getRequiredFields(Descriptor descriptor) {
-		return descriptor.getFields().stream().filter(FieldDescriptor::isRequired).toList();
-	}
-
-	private List<FieldDescriptor> getOptionalFields(Descriptor descriptor) {
-		return descriptor.getFields().stream().filter(ClassInfo::hasOptionalLabel).toList();
+	private static boolean isPureRepeated(FieldDescriptor field) {
+		return field.isRepeated() && !field.isMapField();
 	}
 
 	private static boolean hasOptionalLabel(FieldDescriptor field) {
 		return field.toProto().getLabel() == FieldDescriptorProto.Label.LABEL_OPTIONAL;
 	}
-	
-	private static List<FieldDescriptor> getPureComplexFields(Descriptor descriptor) {
-		return descriptor.getFields().stream().filter(ClassInfo::isComplexType).filter(ClassInfo::isPure).toList();
-	}
 
 	private static boolean isPure(FieldDescriptor field) {
 		return !isGroup(field) && !field.isMapField() && !field.isRepeated();
-	}
-
-	private static List<FieldDescriptor> getGroupFields(Descriptor descriptor) {
-		return descriptor.getFields().stream().filter(ClassInfo::isGroup).toList();
 	}
 
 	private static boolean isGroup(Descriptors.FieldDescriptor fieldDescriptor) {

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Clazz.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Clazz.java
@@ -60,27 +60,22 @@ public class Clazz implements Generator {
 	}
 
 	private CharSequence handleOptionalMethods() {
-	    StringBuilder builder = new StringBuilder();
-	    builder.append(implementations.generateOptionalBuilderField());
-	    builder.append(implementations.generateOptionalBuilderDefaultConstructor(builderClassName));
-	    builder.append(implementations.generateOptionalBuilderConstructor(builderClassName));
-	    builder.append(implementations.generateMethods());
-	    builder.append(methods.build());
-	    return builder;
+		return new StringBuilder()
+				.append(implementations.generateOptionalBuilderField())
+				.append(implementations.generateOptionalBuilderDefaultConstructor(builderClassName))
+				.append(implementations.generateOptionalBuilderConstructor(builderClassName))
+				.append(implementations.generateMethods())
+				.append(methods.build());
 	}
 
 	private CharSequence handleRequiredMethods() {
-	    StringBuilder builder = new StringBuilder();
-	    builder.append(generateFields());
-
-	    FieldDescriptor firstNonOptionalField = info.nonOptional().getFirst();
-	    String builderName = Utils.firstToLower(builderClassName);
-
-	    builder.append(methods.has(builderName, firstNonOptionalField));
-	    builder.append(methods.requiredSetter(builderName, firstNonOptionalField, info.nonOptional()));
-	    builder.append(methods.clear(builderName, firstNonOptionalField, Utils.getNextIfc(info.name(), info.nonOptional(), firstNonOptionalField)));
-
-	    return builder;
+		FieldDescriptor first = info.nonOptional().getFirst();
+		String builderName = Utils.firstToLower(builderClassName);
+		return new StringBuilder()
+				.append(generateFields())
+				.append(methods.has(builderName, first))
+				.append(methods.requiredSetter(builderName, first, info.nonOptional()))
+				.append(methods.clear(builderName, first, Utils.getNextIfc(info.name(), info.nonOptional(), first)));
 	}
 
 	private String generatePackage() {
@@ -88,12 +83,9 @@ public class Clazz implements Generator {
 	}
 
 	private StringBuilder generateFields() {
-		StringBuilder builder = new StringBuilder("private final ");
-		builder.append(info.name()).append(".Builder ");
-
-		builder.append(Utils.firstToLower(builderClassName)).append(" = ");
-		builder.append(info.name()).append(".newBuilder();");
-		return builder;
+		return new StringBuilder("private final ").append(info.name()).append(".Builder ")
+				.append(Utils.firstToLower(builderClassName)).append(" = ")
+				.append(info.name()).append(".newBuilder();");
 	}
 
 	private StringBuilder generateFooter() {
@@ -101,29 +93,28 @@ public class Clazz implements Generator {
 	}
 
 	private StringBuilder generateHeader() {
-		StringBuilder builder = new StringBuilder("public class ").append(builderClassName).append(" implements ");
-		builder.append(firstInterface());
-		builder.append(" {");
-		return builder;
+		return new StringBuilder("public class ").append(builderClassName).append(" implements ")
+				.append(firstInterface()).append(" {");
 	}
 
 	private String firstInterface() {
-		return info.name() + (info.nonOptional().isEmpty() ? "OptionalIfc" : Utils.to(info.nonOptional().getFirst(), "Ifc"));
+		return info.name() + (info.nonOptional().isEmpty()
+				? "Optional" + Utils.IFC_SUFFIX
+				: Utils.to(info.nonOptional().getFirst(), Utils.IFC_SUFFIX));
 	}
 
 	private StringBuilder generateImports() {
-		StringBuilder builder = new StringBuilder();
-		StringBuilder prefix = new StringBuilder("import ").append(info.getInputPkg()).append(".");
-		builder.append(prefix).append("*;");
-		builder.append(prefix).append(info.fullName()).append(";");
-		builder.append(prefix).append(info.fullName()).append(".Builder").append(";");				
+		String prefix = "import " + info.getInputPkg() + ".";
+		StringBuilder builder = new StringBuilder()
+				.append(prefix).append("*;")
+				.append(prefix).append(info.fullName()).append(";")
+				.append(prefix).append(info.fullName()).append(".Builder;");
 		for (FieldDescriptor field : info.getGroupFields()) {
-			String fieldName = Utils.toUpperCamelCase(field.getName());
-			builder.append(prefix).append(info.name()).append(".").append(fieldName).append(";");
+			builder.append(prefix).append(info.name()).append(".")
+					.append(Utils.toUpperCamelCase(field.getName())).append(";");
 		}
 		for (FieldDescriptor field : info.getPureComplexFields()) {
-			String type = Utils.getClassName(field.toProto().getTypeName());
-			builder.append(prefix).append(type).append(";");
+			builder.append(prefix).append(Utils.getClassName(field.toProto().getTypeName())).append(";");
 		}
 		return builder;
 	}

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Implementations.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Implementations.java
@@ -20,50 +20,38 @@ public class Implementations extends AbstractStatements {
 		String classOrBuilder = Utils.firstToLower(info.name()) + "OrBuilder";
 		FieldDescriptor field = info.nonOptional().get(requiredFieldNumber);
 		String prefix = info.name() + Utils.firstToUpper(field.getName());
-		String ifcName = prefix + "Ifc";
-		String implName = prefix + "Impl";
-		StringBuilder builder = new StringBuilder(header);
-		builder.append("public class ").append(implName).append(" implements ").append(ifcName).append(" {");
-		builder.append("private final Builder ").append(classOrBuilder).append(";");
-		builder.append(methods.constructor(implName, classOrBuilder));
-		builder.append(methods.requiredSetter(classOrBuilder, field, info.nonOptional()));
-		builder.append(methods.has(classOrBuilder, field));	
-		String clearReturnType = Utils.getNextIfc(info.name(), info.nonOptional(), field);
-		builder.append(methods.clear(classOrBuilder, field, clearReturnType));					
-		builder.append("}");
-		
+		String ifcName = prefix + Utils.IFC_SUFFIX;
+		String implName = prefix + Utils.IMPL_SUFFIX;
+		StringBuilder builder = new StringBuilder(header)
+				.append("public class ").append(implName).append(" implements ").append(ifcName).append(" {")
+				.append("private final Builder ").append(classOrBuilder).append(";")
+				.append(methods.constructor(implName, classOrBuilder))
+				.append(methods.requiredSetter(classOrBuilder, field, info.nonOptional()))
+				.append(methods.has(classOrBuilder, field))
+				.append(methods.clear(classOrBuilder, field, Utils.getNextIfc(info.name(), info.nonOptional(), field)))
+				.append("}");
 		return new ClassContainer(implName, builder);
 	}
 
 	public ClassContainer generateOptional() {
-		StringBuilder builder = new StringBuilder(header);
-		builder.append("public class ");
-		builder.append(optionalImplName);
-		builder.append(" implements ");
-		builder.append(optionalIfcName);
-		builder.append(" {");
-		builder.append(generateOptionalBuilderField());
-		builder.append(generateOptionalBuilderConstructor(optionalImplName));
-		builder.append(generateMethods());
-		builder.append(methods.build());
-		builder.append("}");
+		StringBuilder builder = new StringBuilder(header)
+				.append("public class ").append(optionalImplName)
+				.append(" implements ").append(optionalIfcName).append(" {")
+				.append(generateOptionalBuilderField())
+				.append(generateOptionalBuilderConstructor(optionalImplName))
+				.append(generateMethods())
+				.append(methods.build())
+				.append("}");
 		return new ClassContainer(optionalImplName, builder);
 	}
-	
+
 	public StringBuilder generateOptionalBuilderDefaultConstructor(String name) {
-		StringBuilder builder = new StringBuilder();
-		builder.append("public ").append(name);
-		builder.append("() {this.builder = ");
-		builder.append(info.name()).append(".newBuilder();");
-		builder.append("}");
-		return builder;
+		return new StringBuilder("public ").append(name)
+				.append("() {this.builder = ").append(info.name()).append(".newBuilder();}");
 	}
 
 	public StringBuilder generateOptionalBuilderConstructor(String name) {
-		StringBuilder builder = new StringBuilder();
-		builder.append("public ").append(name);
-		builder.append("(Builder builder) {this.builder = builder;}");
-		return builder;
+		return new StringBuilder("public ").append(name).append("(Builder builder) {this.builder = builder;}");
 	}
 
 	public StringBuilder generateMethods() {

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Interfaces.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Interfaces.java
@@ -16,39 +16,35 @@ public class Interfaces extends AbstractStatements {
 	}
 	
 	public ClassContainer generateOptional() {
-		StringBuilder builder = new StringBuilder(header);
-		builder.append("public interface ").append(optionalIfcName).append(" {");
-		
+		StringBuilder builder = new StringBuilder(header)
+				.append("public interface ").append(optionalIfcName).append(" {");
+
 		for (FieldDescriptor optionalField : info.optional()) {
-			builder.append(methods.declareSetter(optionalField, optionalIfcName));
-			builder.append(methods.declareHas(optionalField));
-			String clearReturnType = Utils.getNextIfc(info.name(), info.nonOptional(), optionalField);
-			builder.append(methods.declareClear(optionalField, clearReturnType));
+			builder.append(methods.declareSetter(optionalField, optionalIfcName))
+					.append(methods.declareHas(optionalField))
+					.append(methods.declareClear(optionalField,
+							Utils.getNextIfc(info.name(), info.nonOptional(), optionalField)));
 		}
 
 		for (OneofDescriptor oneof : info.realOneofs()) {
-			builder.append(methods.declareOneofCaseGetter(oneof));
-			builder.append(methods.declareOneofClear(oneof, optionalIfcName));
+			builder.append(methods.declareOneofCaseGetter(oneof))
+					.append(methods.declareOneofClear(oneof, optionalIfcName));
 		}
 
 		builder.append(info.name()).append(" build();}");
-		
+
 		return new ClassContainer(optionalIfcName, builder);
 	}
-	
+
 	private ClassContainer generateInterface(FieldDescriptor requiredField) {
-		StringBuilder ifc = new StringBuilder(header);
-		ifc.append("public interface ");
-		String ifcName = info.name() + Utils.to(requiredField, "Ifc");
-		ifc.append(ifcName);
-		ifc.append(" {");
+		String ifcName = info.name() + Utils.to(requiredField, Utils.IFC_SUFFIX);
 		String returnType = Utils.getNextIfc(info.name(), info.nonOptional(), requiredField);
-		ifc.append(methods.declareSetter(requiredField, returnType));
-		ifc.append(methods.declareHas(requiredField));
-		ifc.append(methods.declareClear(requiredField, returnType));		
-		
-		ifc.append("}");
-				
+		StringBuilder ifc = new StringBuilder(header)
+				.append("public interface ").append(ifcName).append(" {")
+				.append(methods.declareSetter(requiredField, returnType))
+				.append(methods.declareHas(requiredField))
+				.append(methods.declareClear(requiredField, returnType))
+				.append("}");
 		return new ClassContainer(ifcName, ifc);
 	}
 }

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Methods.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Methods.java
@@ -40,16 +40,14 @@ public class Methods {
 	}
 
 	private String builderMethodName(FieldDescriptor field) {
-		String suffix = Utils.toUpperCamelCase(field.getName());
-		String method;
+		return accessorPrefix(field) + Utils.toUpperCamelCase(field.getName());
+	}
+
+	private String accessorPrefix(FieldDescriptor field) {
 		if (field.isMapField()) {
-			method = ".putAll";
-		} else if (field.isRepeated()) {
-			method = ".addAll";
-		} else {
-			method = ".set";
+			return ".putAll";
 		}
-		return method + suffix;
+		return field.isRepeated() ? ".addAll" : ".set";
 	}
 
 	public StringBuilder has(String classOrBuilder, FieldDescriptor field) {

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Utils.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/Utils.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.code.gen;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 
 import com.google.protobuf.Descriptors.FieldDescriptor;
@@ -17,18 +18,26 @@ public class Utils {
 		return Utils.firstToUpper(fieldDescriptor.getName()) + suffix;
 	}
 
-	public static String firstToLower(String string) {
+	/**
+	 * Recases the first character and the rest independently, which is the whole of
+	 * what the three case helpers below differ in. An empty string has neither part
+	 * and is returned as it is: a leading, trailing or doubled underscore in a proto
+	 * name yields an empty split part, and it contributes nothing to the camel-case
+	 * name.
+	 */
+	private static String recased(String string, UnaryOperator<String> first, UnaryOperator<String> rest) {
 		if (string.isEmpty()) {
 			return string;
 		}
-		return string.substring(0, 1).toLowerCase() + string.substring(1);
+		return first.apply(string.substring(0, 1)) + rest.apply(string.substring(1));
+	}
+
+	public static String firstToLower(String string) {
+		return recased(string, String::toLowerCase, UnaryOperator.identity());
 	}
 
 	public static String firstToUpper(String string) {
-		if (string.isEmpty()) {
-			return string;
-		}
-		return string.substring(0, 1).toUpperCase() + string.substring(1);
+		return recased(string, String::toUpperCase, UnaryOperator.identity());
 	}
 
 	public static String toUpperCamelCase(String s) {
@@ -41,12 +50,7 @@ public class Utils {
 	}
 
 	static String toProperCase(String s) {
-		if (s.isEmpty()) {
-			// A leading, trailing or doubled underscore in a proto name yields an
-			// empty split part; it contributes nothing to the camel-case name.
-			return s;
-		}
-		return s.substring(0, 1).toUpperCase() + s.substring(1).toLowerCase();
+		return recased(s, String::toUpperCase, String::toLowerCase);
 	}
 	
 	public static String getNextIfc(String className, List<FieldDescriptor> fields, FieldDescriptor requiredField) {
@@ -68,17 +72,26 @@ public class Utils {
 	
 	public static String getSuffixOf(String type, int howMany, String delimiter) {
 		String[] tokens = type.split(Pattern.quote(delimiter));
-		return String.join(delimiter, Arrays.copyOfRange(tokens, tokens.length - howMany, tokens.length));
+		return joinFrom(tokens, tokens.length - howMany, delimiter);
 	}
 
 	public static String getClassName(String fullName) {
 		String[] tokens = fullName.split(Pattern.quote("."));
 		for (int i = 0; i < tokens.length; ++i) {
-			if (!tokens[i].isEmpty() && Character.isUpperCase(tokens[i].charAt(0))) {
-				 return String.join(".", Arrays.copyOfRange(tokens, i, tokens.length));
+			if (startsUpperCase(tokens[i])) {
+				return joinFrom(tokens, i, ".");
 			}
 		}
 		return "";
+	}
+
+	/** The tokens from {@code first} onwards, rejoined with the delimiter they were split on. */
+	private static String joinFrom(String[] tokens, int first, String delimiter) {
+		return String.join(delimiter, Arrays.copyOfRange(tokens, first, tokens.length));
+	}
+
+	private static boolean startsUpperCase(String token) {
+		return !token.isEmpty() && Character.isUpperCase(token.charAt(0));
 	}
 
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/DuckDbParquet.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/DuckDbParquet.java
@@ -1,7 +1,5 @@
 package io.github.adamw7.tools.data.source.db;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -20,11 +18,7 @@ final class DuckDbParquet {
 	}
 
 	static Connection connect() {
-		try {
-			return DriverManager.getConnection(IN_MEMORY_URL);
-		} catch (SQLException e) {
-			throw new UncheckedIOException(new IOException(e));
-		}
+		return Sql.answering(() -> DriverManager.getConnection(IN_MEMORY_URL));
 	}
 
 	static String readQuery(String filePath) {
@@ -39,12 +33,12 @@ final class DuckDbParquet {
 	}
 
 	static void close(Connection connection) {
-		try {
-			if (connection != null && !connection.isClosed()) {
-				connection.close();
-			}
-		} catch (SQLException e) {
-			throw new UncheckedIOException(new IOException(e));
+		Sql.running(() -> closeIfOpen(connection));
+	}
+
+	private static void closeIfOpen(Connection connection) throws SQLException {
+		if (connection != null && !connection.isClosed()) {
+			connection.close();
 		}
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -1,7 +1,5 @@
 package io.github.adamw7.tools.data.source.db;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -36,28 +34,26 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 
 	private void closeQueryResources() {
 		try {
-			if (resultSet != null) {
-				resultSet.close();
-			}
-			if (statement != null) {
-				statement.close();
-			}
-		} catch (SQLException e) {
-			throw new UncheckedIOException(new IOException(e));
+			Sql.running(this::closeOpenResources);
 		} finally {
 			resultSet = null;
 			statement = null;
 		}
 	}
 
+	private void closeOpenResources() throws SQLException {
+		if (resultSet != null) {
+			resultSet.close();
+		}
+		if (statement != null) {
+			statement.close();
+		}
+	}
+
 	@Override
 	public String[] getColumnNames() {
 		checkIfOpen();
-		try {
-			return getColumnsFrom(resultSet);
-		} catch (SQLException e) {
-			throw new UncheckedIOException(new IOException(e));
-		}
+		return Sql.answering(() -> getColumnsFrom(resultSet));
 	}
 
 	private void checkIfOpen() {
@@ -69,24 +65,24 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 	@Override
 	public void open() {
 		closeQueryResources();
-		try {
-			statement = connection.createStatement();
-			log.info("Executing query: {}", query);
-			resultSet = statement.executeQuery(query);
-		} catch (SQLException e) {
-			throw new UncheckedIOException(new IOException(e));
-		}
+		Sql.running(this::executeQuery);
+	}
+
+	private void executeQuery() throws SQLException {
+		statement = connection.createStatement();
+		log.info("Executing query: {}", query);
+		resultSet = statement.executeQuery(query);
 	}
 
 	@Override
 	public String[] nextRow() {
 		checkIfOpen();
-		try {
-			hasMoreData = resultSet.next();
-			return hasMoreData ? getNextFrom(resultSet) : null;
-		} catch (SQLException e) {
-			throw new UncheckedIOException(new IOException(e));
-		}
+		return Sql.answering(this::readRow);
+	}
+
+	private String[] readRow() throws SQLException {
+		hasMoreData = resultSet.next();
+		return hasMoreData ? getNextFrom(resultSet) : null;
 	}
 
 	@Override
@@ -105,11 +101,7 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 			return;
 		}
 		checkIfOpen();
-		try {
-			resultSet.setFetchSize(batchSize);
-		} catch (SQLException e) {
-			throw new UncheckedIOException(new IOException(e));
-		}
+		Sql.running(() -> resultSet.setFetchSize(batchSize));
 	}
 
 	/**
@@ -126,21 +118,31 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 	}
 
 	protected static String[] getNextFrom(ResultSet resultSet) throws SQLException {
-		int columnCount = resultSet.getMetaData().getColumnCount();
-		String[] row = new String[columnCount];
-		for (int i = 0; i < columnCount; ++i) {
-			row[i] = resultSet.getString(i + 1);
-		}
-		return row;
+		return byColumn(resultSet.getMetaData().getColumnCount(), resultSet::getString);
 	}
 
 	protected static String[] getColumnsFrom(ResultSet resultSet) throws SQLException {
 		ResultSetMetaData meta = resultSet.getMetaData();
-		String[] columns = new String[meta.getColumnCount()];
-		for (int i = 0; i < columns.length; ++i) {
-			columns[i] = meta.getColumnName(i + 1);
+		return byColumn(meta.getColumnCount(), meta::getColumnName);
+	}
+
+	/**
+	 * Reads one value per column into an array, translating this class's zero-based
+	 * indexing to JDBC's one-based. A row and a header differ only in which accessor
+	 * supplies the value, so the walk lives here rather than in each of them.
+	 */
+	private static String[] byColumn(int columnCount, ColumnValue value) throws SQLException {
+		String[] values = new String[columnCount];
+		for (int i = 0; i < columnCount; ++i) {
+			values[i] = value.at(i + 1);
 		}
-		return columns;
+		return values;
+	}
+
+	/** A value read from a one-based JDBC column: a row's cell, or a column's name. */
+	@FunctionalInterface
+	private interface ColumnValue {
+		String at(int column) throws SQLException;
 	}
 
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/Sql.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/Sql.java
@@ -1,0 +1,48 @@
+package io.github.adamw7.tools.data.source.db;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.sql.SQLException;
+
+/**
+ * Runs JDBC work that reports failure as a checked {@link SQLException} and
+ * re-raises it the way the data sources report every other read failure: an
+ * {@link UncheckedIOException}, so a caller iterating a source handles one kind of
+ * failure whether it is backed by a file or by a database.
+ *
+ * <p>Every JDBC call in this package needs that same wrapping, so it lives here
+ * rather than in a {@code try}/{@code catch} around each of them — which is what
+ * the sources carried before, once per call.
+ */
+final class Sql {
+
+	/** JDBC work that answers with a value. */
+	@FunctionalInterface
+	interface Query<T> {
+		T run() throws SQLException;
+	}
+
+	/** JDBC work that answers with nothing. */
+	@FunctionalInterface
+	interface Call {
+		void run() throws SQLException;
+	}
+
+	private Sql() {
+	}
+
+	static <T> T answering(Query<T> query) {
+		try {
+			return query.run();
+		} catch (SQLException e) {
+			throw new UncheckedIOException(new IOException(e));
+		}
+	}
+
+	static void running(Call call) {
+		answering(() -> {
+			call.run();
+			return null;
+		});
+	}
+}

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/IntKeyOpenAddressingMap.java
@@ -2,7 +2,8 @@ package io.github.adamw7.tools.data.structure;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import io.github.adamw7.tools.data.structure.internal.DoubleHashing;
 import io.github.adamw7.tools.data.structure.internal.Primes;
@@ -188,23 +189,19 @@ public class IntKeyOpenAddressingMap<V> {
 	}
 
 	public int[] keys() {
-		int[] result = new int[size];
-		int next = 0;
-		for (int i = 0; i < state.length; ++i) {
-			if (state[i] == LIVE) {
-				result[next++] = keys[i];
-			}
-		}
-		return result;
+		return liveSlots().map(slot -> keys[slot]).toArray();
 	}
 
 	public Collection<V> values() {
-		List<V> result = new ArrayList<>(size);
-		for (int i = 0; i < state.length; ++i) {
-			if (state[i] == LIVE) {
-				result.add(values[i]);
-			}
-		}
-		return result;
+		return liveSlots().mapToObj(slot -> values[slot])
+				.collect(Collectors.toCollection(() -> new ArrayList<>(size)));
+	}
+
+	/**
+	 * The slots holding a live entry, in table order — how both views of the map's
+	 * contents are walked, so the {@link #LIVE} test is written once.
+	 */
+	private IntStream liveSlots() {
+		return IntStream.range(0, state.length).filter(slot -> state[slot] == LIVE);
 	}
 }


### PR DESCRIPTION
ClassInfo derived its six field groups through six near-identical
stream-filter methods; they now share one fieldsMatching helper. Utils
spelled the same empty-check-then-recase in firstToLower, firstToUpper and
toProperCase, and the same split-and-rejoin in getSuffixOf and
getClassName. Formatter and UnusedImportsRemover both wrapped code in a
Document, applied a TextEdit and turned BadLocationException into a
FormatException, now done once in Documents. Clazz, Interfaces and
Implementations assembled their output through repeated single-append
statements, now chained.

No change to the generated builders: the plugin's integration test module
regenerates them and its tests pass unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PZmQFzNDDBYK7TB2NpxXoQ