### PR TITLE
fix(mcp-common): advertise the build version in the MCP handshake

### DIFF
--- a/mcp-common/pom.xml
+++ b/mcp-common/pom.xml
@@ -12,6 +12,22 @@
 	<name>Shared MCP server scaffolding</name>
 	<description>Shared MCP server scaffolding providing transport wiring and the tool SPI reused by the repository's MCP servers.</description>
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+			</resource>
+			<!-- A dedicated directory that IS filtered, so the project version is
+			     baked into mcp-common-build.properties and advertised in every MCP
+			     handshake (see ServerVersion). The spring-boot-starter parent filters
+			     with the @...@ delimiter, which that file uses. Kept separate from
+			     src/main/resources because overlapping filtered and unfiltered
+			     entries on one directory are unreliable, and because a future
+			     log4j2.properties here must stay unfiltered. -->
+			<resource>
+				<directory>src/main/filtered-resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<plugins>
 			<!-- This module has no module-info.java, so the JPMS name that
 			     `requires tools.mcp.common` in tools.data resolves against was being

--- a/mcp-common/src/main/filtered-resources/mcp-common-build.properties
+++ b/mcp-common/src/main/filtered-resources/mcp-common-build.properties
@@ -1,0 +1,10 @@
+# Build metadata, filtered by Maven at build time (see the <resources> block in
+# mcp-common/pom.xml, which filters this directory). Supplies the version every
+# MCP server here advertises in its handshake (see ServerVersion), so clients are
+# told the tools release they are actually talking to instead of a hardcoded
+# literal unrelated to ${revision}.
+#
+# The @...@ delimiter (rather than ${...}) is deliberate: the spring-boot-starter
+# parent configures resource filtering with useDefaultDelimiters=false and the
+# @ delimiter, so ${...} tokens are left untouched and only @...@ is substituted.
+mcp.server.version=@project.version@

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
@@ -45,7 +45,7 @@ public abstract class AbstractMcpConfiguration {
 
 	protected static final String MCP_ENDPOINT = "/mcp";
 
-	private static final String SERVER_VERSION = "0.0.1";
+	private static final String SERVER_VERSION = ServerVersion.current();
 
 	private static final Logger log = LogManager.getLogger(AbstractMcpConfiguration.class);
 

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/ServerVersion.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/ServerVersion.java
@@ -1,0 +1,78 @@
+package io.github.adamw7.tools.mcp;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * The version every MCP server here reports in its handshake: the version of the
+ * {@code tools} build the server was packaged from, read from metadata Maven
+ * filters at build time rather than from a literal in the source that has to be
+ * remembered at release time.
+ *
+ * <p>A version that cannot be read is answered with {@value #UNKNOWN} and a
+ * warning, because the version is descriptive: a client that cannot be told which
+ * release it is talking to is better served by a server that still starts than by
+ * one that refuses to.
+ */
+final class ServerVersion {
+
+	static final String BUILD_PROPERTIES = "/mcp-common-build.properties";
+	static final String VERSION_KEY = "mcp.server.version";
+	static final String UNKNOWN = "unknown";
+
+	private static final Logger log = LogManager.getLogger(ServerVersion.class);
+	private static final String CURRENT = fromBuildMetadata();
+
+	private ServerVersion() {
+	}
+
+	/**
+	 * The version to advertise. Resolved once at class initialization, since the
+	 * metadata is fixed for the life of the process and every transport asks for the
+	 * same answer.
+	 */
+	static String current() {
+		return CURRENT;
+	}
+
+	/**
+	 * Reads the version from the metadata Maven filters into
+	 * {@value #BUILD_PROPERTIES} at build time, so it tracks the project's
+	 * {@code revision} property.
+	 */
+	static String fromBuildMetadata() {
+		try (InputStream stream = ServerVersion.class.getResourceAsStream(BUILD_PROPERTIES)) {
+			return read(stream);
+		} catch (IOException e) {
+			log.warn("Could not read build metadata {}; advertising {} to MCP clients", BUILD_PROPERTIES, UNKNOWN, e);
+			return UNKNOWN;
+		}
+	}
+
+	/**
+	 * Falls back to {@value #UNKNOWN} when the metadata is missing from the classpath
+	 * or reached the classpath unfiltered — an unsubstituted token would otherwise be
+	 * advertised verbatim, which is a worse answer than admitting the version is not
+	 * known.
+	 */
+	static String read(InputStream stream) throws IOException {
+		if (stream == null) {
+			log.warn("Build metadata {} is not on the classpath; advertising {} to MCP clients", BUILD_PROPERTIES,
+					UNKNOWN);
+			return UNKNOWN;
+		}
+		Properties properties = new Properties();
+		properties.load(stream);
+		String version = properties.getProperty(VERSION_KEY, "").strip();
+		if (version.isEmpty() || version.startsWith("@") || version.startsWith("${")) {
+			log.warn("{} was not filtered into {} (found: '{}'); advertising {} to MCP clients", VERSION_KEY,
+					BUILD_PROPERTIES, version, UNKNOWN);
+			return UNKNOWN;
+		}
+		return version;
+	}
+}

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/AbstractMcpConfigurationTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/AbstractMcpConfigurationTest.java
@@ -110,6 +110,27 @@ public class AbstractMcpConfigurationTest {
 		inputWriter.close();
 	}
 
+	/**
+	 * The handshake must name the build the server was packaged from, so a client can
+	 * tell which release it is talking to.
+	 */
+	@Test
+	public void mcpSyncServerStreamableAdvertisesTheBuildVersion() {
+		TestMcpConfiguration config = new TestMcpConfiguration();
+		McpSyncServer server = config.mcpSyncServerStreamable(config.streamableServerTransport());
+		assertEquals(ServerVersion.current(), server.getServerInfo().version());
+		assertEquals(SERVER_NAME, server.getServerInfo().name());
+		server.close();
+	}
+
+	@Test
+	public void mcpStatelessSyncServerAdvertisesTheBuildVersion() {
+		TestMcpConfiguration config = new TestMcpConfiguration();
+		McpStatelessSyncServer server = config.mcpStatelessSyncServer(config.statelessServerTransport());
+		assertEquals(ServerVersion.current(), server.getServerInfo().version());
+		server.close();
+	}
+
 	@Test
 	public void mcpSyncServerStreamableHasTools() {
 		TestMcpConfiguration config = new TestMcpConfiguration();

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/ServerVersionTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/ServerVersionTest.java
@@ -1,0 +1,90 @@
+package io.github.adamw7.tools.mcp;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+public class ServerVersionTest {
+
+	/**
+	 * The handshake must advertise the version Maven filtered into
+	 * {@code mcp-common-build.properties} — the build the server was packaged from —
+	 * rather than a literal in the source unrelated to the project's revision.
+	 */
+	@Test
+	void readsTheFilteredBuildVersion() throws IOException {
+		assertEquals(filteredVersion(), ServerVersion.fromBuildMetadata());
+	}
+
+	@Test
+	void theFilteredBuildVersionIsAConcreteVersion() throws IOException {
+		assertNotEquals(ServerVersion.UNKNOWN, filteredVersion());
+	}
+
+	/**
+	 * Resolved once, so every transport advertises the same answer as a direct read.
+	 */
+	@Test
+	void currentIsTheVersionFromTheBuildMetadata() {
+		assertEquals(ServerVersion.fromBuildMetadata(), ServerVersion.current());
+	}
+
+	@Test
+	void metadataMissingFromTheClasspathFallsBackToUnknown() throws IOException {
+		assertEquals(ServerVersion.UNKNOWN, ServerVersion.read(null));
+	}
+
+	/**
+	 * An unsubstituted token would otherwise be advertised verbatim, telling a client
+	 * it is talking to a server named after the filtering expression.
+	 */
+	@Test
+	void anUnfilteredTokenFallsBackToUnknown() throws IOException {
+		assertEquals(ServerVersion.UNKNOWN, versionIn("mcp.server.version=@project.version@"));
+	}
+
+	@Test
+	void anUnresolvedPropertyReferenceFallsBackToUnknown() throws IOException {
+		assertEquals(ServerVersion.UNKNOWN, versionIn("mcp.server.version=${project.version}"));
+	}
+
+	@Test
+	void aMissingKeyFallsBackToUnknown() throws IOException {
+		assertEquals(ServerVersion.UNKNOWN, versionIn("some.other.key=2.6.0"));
+	}
+
+	@Test
+	void aBlankVersionFallsBackToUnknown() throws IOException {
+		assertEquals(ServerVersion.UNKNOWN, versionIn("mcp.server.version=   "));
+	}
+
+	@Test
+	void aFilteredVersionIsReadAsIs() throws IOException {
+		assertEquals("2.6.0", versionIn("mcp.server.version=2.6.0"));
+	}
+
+	private String versionIn(String metadata) throws IOException {
+		return ServerVersion.read(new ByteArrayInputStream(metadata.getBytes(UTF_8)));
+	}
+
+	private String filteredVersion() throws IOException {
+		try (InputStream stream = getClass().getResourceAsStream(ServerVersion.BUILD_PROPERTIES)) {
+			assertNotNull(stream, ServerVersion.BUILD_PROPERTIES + " must be filtered onto the test classpath");
+			Properties properties = new Properties();
+			properties.load(stream);
+			String version = properties.getProperty(ServerVersion.VERSION_KEY, "").strip();
+			assertFalse(version.isEmpty() || version.startsWith("@") || version.startsWith("${"),
+					ServerVersion.VERSION_KEY + " must be filtered to a concrete version, was: " + version);
+			return version;
+		}
+	}
+}


### PR DESCRIPTION
AbstractMcpConfiguration reported a hardcoded "0.0.1" as the server
version, so every handshake told clients a version unrelated to the
project's ${revision} and unchanged by any release.

Read it instead from build metadata Maven filters at build time, the
pattern adopt already uses for the enforcer rule version: a filtered
mcp-common-build.properties supplies @project.version@, and ServerVersion
resolves it once. Metadata that is missing or reached the classpath
unfiltered falls back to "unknown" with a warning rather than failing the
server or advertising an unsubstituted token, since the version is
descriptive and a server that still starts is the better answer.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014Dm4dTkEegFRbmdYQBz23N