### PR TITLE
fix(claude-code-enforcer): read a front matter value written below its key

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -171,11 +171,29 @@ public final class RepositoryUrl {
 	 * rather than several steps later on a checkout directory nobody intended.
 	 */
 	private static String requireName(String name, String repositoryUrl) {
-		if (name.isEmpty() || ".".equals(name) || "..".equals(name) || isPath(name)) {
+		if (name.isEmpty() || ".".equals(name) || "..".equals(name) || isPath(name) || isUserInfo(name)) {
 			throw new IllegalArgumentException(
 					"repositoryUrl must end in a repository name but was: " + Redaction.of(repositoryUrl));
 		}
 		return name;
+	}
+
+	/**
+	 * A last segment that ends at an {@code @} is the URL's user information and
+	 * nothing else — {@code https://token@} names credentials and no repository at
+	 * all. Only a URL with no path past its authority reaches this, since every other
+	 * form has a separator after the {@code @} for {@link #lastSegment} to cut at, so
+	 * a checkout directory legitimately containing an {@code @} is unaffected.
+	 *
+	 * <p>What it protects is {@link #identity}, which strips exactly that user
+	 * information: such a URL reduced to the empty identity that
+	 * {@link #isSameRepositoryAs} answers for text naming no repository, so the two
+	 * compared equal and a checkout of <em>any</em> other repository — or one whose
+	 * {@code origin} could not be read at all — was accepted as this one, then
+	 * branched, committed, and pushed.
+	 */
+	private static boolean isUserInfo(String name) {
+		return name.endsWith("@");
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
@@ -273,4 +273,24 @@ class RepositoryUrlTest {
 		assertFalse(url.isSameRepositoryAs(""));
 		assertFalse(url.isSameRepositoryAs("  "));
 	}
+
+	/**
+	 * A URL that is credentials and no path names no repository, and reduced to the
+	 * same empty identity as text that names none — so it answered every blank line
+	 * of a checkout's {@code origin} transcript as a match on itself, and the
+	 * adoption branched, committed, and pushed into whatever checkout it found.
+	 */
+	@Test
+	void aUrlThatIsOnlyUserInformationIsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> RepositoryUrl.of("https://token@"));
+		assertThrows(IllegalArgumentException.class, () -> RepositoryUrl.of("https://x-access-token:secret@"));
+		assertThrows(IllegalArgumentException.class, () -> RepositoryUrl.of("git@"));
+	}
+
+	/** An {@code @} inside a checkout name is not user information; only a trailing one is. */
+	@Test
+	void aRepositoryNameCarryingAnAtSignIsAccepted() {
+		assertEquals("foo@bar", RepositoryUrl.of("/tmp/workspace/foo@bar").name());
+		assertEquals("tools", RepositoryUrl.of("https://x-access-token:secret@github.com/alice/tools.git").name());
+	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRule.java
@@ -97,15 +97,27 @@ public class OkfBundleFormatRule extends ClaudeCodeEnforcerRule {
 	@Override
 	public void execute() throws EnforcerRuleException {
 		requireConfigured(bundleDir, "bundleDir");
+		report("The OKF bundle at " + bundleDir + " is not conformant:", violations());
+	}
+
+	/**
+	 * An absent bundle is answered as no violations rather than by returning early,
+	 * so the pass still goes through {@link #report}. That is what writes a
+	 * configured {@code reportFile}: skipping it left the HTML report of a previous,
+	 * failing run on disk claiming the check had failed, for a rule that had just
+	 * passed — and this is the ordinary state of the rule, wired before a repository
+	 * emits a bundle so it starts enforcing the day one is committed.
+	 */
+	private List<String> violations() {
 		if (!bundleDir.isDirectory()) {
-			return;
+			return List.of();
 		}
 		List<File> documents = markdownFiles();
 		List<String> violations = new ArrayList<>();
 		documents.forEach(document -> collectDocumentViolations(document, violations));
 		collectVersionViolations(documents, violations);
 		collectMissingIndexViolations(documents, violations);
-		report("The OKF bundle at " + bundleDir + " is not conformant:", violations);
+		return violations;
 	}
 
 	@Override

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -11,22 +11,32 @@ import java.util.stream.Collectors;
  * The YAML front matter block at the top of a Markdown document: the lines
  * between a leading {@code ---} delimiter and the next {@code ---} delimiter.
  * <p>
- * This is a deliberately small reader, not a full YAML parser. It understands
- * the flat {@code key: value} shape that Claude Code skill and sub-agent files
- * use, which is all the rules need. Parsing is shared here so every rule agrees
- * on what counts as front matter, which keys it declares, and each key's value.
+ * This is a deliberately small reader, not a full YAML parser. It reads the
+ * {@code key: value} entries a block declares and answers each one as a single
+ * line of text, which is all the rules need: they check a value's length,
+ * blankness, uniqueness, or shape, never its structure. Parsing is shared here so
+ * every rule agrees on what counts as front matter, which keys it declares, and
+ * each key's value.
  * <p>
  * A key is only recognised where YAML puts one: at the start of a line, with no
  * indentation. An indented line continues the value above it, so reading a key out
  * of one would invent entries an author never declared — the {@code Use this when:}
  * of a wrapped description would be reported as an unknown key.
  * <p>
- * A value written as a block scalar ({@code description: >} or {@code |}, with the
- * text on the indented lines below) is folded back into a single line, since the
- * indicator alone is not the value: reading it literally would leave every such
- * definition claiming the same one-character description and escape any length cap.
- * The fold joins the continuation lines with single spaces, which is all the
- * length, blankness, and uniqueness checks need.
+ * A value the key's own line does not carry is read from the indented lines below
+ * it, folded into one line joined by single spaces. That covers the three ways YAML
+ * continues a value downwards — a block scalar ({@code description: >} or
+ * {@code |}), a plain scalar wrapped onto the next line, and a nested mapping or
+ * sequence — because the alternative is to read every one of them as the empty
+ * string. Doing so left each block scalar claiming the same one-character
+ * description and escaping any length cap, and it failed an OKF concept whose
+ * {@code generated:} mapping named its actor on the very next line for not naming
+ * one. A key with nothing below it still yields the empty string, so a bare
+ * {@code key:} is unchanged.
+ * <p>
+ * Folding a mapping is lossy on purpose: {@code by: agent/1} reads back as text
+ * rather than as a nested entry. A rule that needs the structure itself wants a
+ * YAML parser, not this.
  * <p>
  * A value wrapped in matching quotes yields the text inside them, because that is
  * the value YAML declares and the one Claude Code reads. Quoting is not decoration:
@@ -97,10 +107,12 @@ public final class FrontMatter {
 
 	/**
 	 * The trimmed value declared for {@code key}, or empty when the key is absent.
-	 * A present key with no value yields an empty string, not an empty optional, a
-	 * block scalar yields its folded continuation lines rather than the indicator,
-	 * and a quoted scalar yields the text inside its quotes. A key declared more than
-	 * once yields its last declaration, the one a YAML loader keeps.
+	 * A present key whose value is neither on its own line nor below it yields an
+	 * empty string, not an empty optional; a value continued on the lines below —
+	 * a block scalar, a wrapped plain scalar, or a nested mapping — yields those
+	 * lines folded into one; and a quoted scalar yields the text inside its quotes.
+	 * A key declared more than once yields its last declaration, the one a YAML
+	 * loader keeps.
 	 */
 	public Optional<String> value(String key) {
 		int index = indexOfEntry(key);
@@ -108,7 +120,7 @@ public final class FrontMatter {
 			return Optional.empty();
 		}
 		String declared = withoutComment(valueOf(lines.get(index), key));
-		return Optional.of(isBlockScalar(declared) ? folded(index + 1) : unquoted(declared));
+		return Optional.of(continuesBelow(declared) ? folded(index + 1) : unquoted(declared));
 	}
 
 	/** The declared keys, in document order, without their trailing colon. */
@@ -173,14 +185,21 @@ public final class FrontMatter {
 		return -1;
 	}
 
-	private boolean isBlockScalar(String declared) {
-		return BLOCK_SCALAR.matcher(declared).matches();
+	/**
+	 * Whether the key's own line leaves its value to the lines below: it declares a
+	 * block scalar indicator, or it declares nothing at all — the shape a nested
+	 * mapping and a wrapped plain scalar share.
+	 */
+	private boolean continuesBelow(String declared) {
+		return declared.isEmpty() || BLOCK_SCALAR.matcher(declared).matches();
 	}
 
 	/**
-	 * The block scalar's continuation lines from {@code from}, joined with single
-	 * spaces. The block runs until the next entry at the block's own level, so blank
-	 * lines inside it are kept as separators and dropped from the result.
+	 * The entry's continuation lines from {@code from}, joined with single spaces.
+	 * They run until the next entry at the block's own level, so blank lines inside
+	 * them are kept as separators and dropped from the result. An entry with no
+	 * continuation lines folds to the empty string, which is what a bare {@code key:}
+	 * declares.
 	 */
 	private String folded(int from) {
 		return lines.subList(from, lines.size()).stream()

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRuleTest.java
@@ -4,9 +4,13 @@ import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -66,6 +70,31 @@ class OkfBundleFormatRuleTest {
 		rule.setBundleDir(tempDir.resolve("no-bundle-here").toFile());
 
 		assertDoesNotThrow(rule::execute);
+	}
+
+	/**
+	 * An absent bundle is the ordinary state of a rule wired before a repository
+	 * emits one, and returning early on it skipped the reporting the pass goes
+	 * through — leaving a previous run's failing HTML report on disk, claiming a
+	 * failure for a check that had just passed.
+	 */
+	@Test
+	void anAbsentBundleRefreshesTheReportRatherThanLeavingTheLastFailure() throws IOException {
+		File report = tempDir.resolve("report.html").toFile();
+		OkfBundleFormatRule failing = rule();
+		failing.setReportFile(report);
+		writeString(bundle.resolve("A.java.md"), "# Dependencies\n");
+		assertThrows(EnforcerRuleException.class, failing::execute);
+
+		Files.delete(bundle.resolve("A.java.md"));
+		Files.delete(bundle);
+		OkfBundleFormatRule absent = rule();
+		absent.setReportFile(report);
+
+		assertDoesNotThrow(absent::execute);
+		String html = Files.readString(report.toPath());
+		assertTrue(html.contains("Check passed"), html);
+		assertFalse(html.contains("Check failed"), html);
 	}
 
 	@Test
@@ -160,6 +189,42 @@ class OkfBundleFormatRuleTest {
 	void failsWhenGeneratedNamesNoActor() {
 		writeString(bundle.resolve("A.java.md"),
 				"---\ntype: \"Java Source File\"\ngenerated: { at: 2026-08-03T10:15:30Z }\n---\n\n# Dependencies\n");
+
+		assertTrue(failure().contains("declares a 'generated' without the actor that produced it"));
+	}
+
+	/**
+	 * YAML writes a mapping in flow or block style, and OKF prefers neither. Reading
+	 * only the flow spelling failed a conformant concept for not naming the actor
+	 * standing on the very next line.
+	 */
+	@Test
+	void acceptsAGeneratedMappingWrittenInBlockStyle() {
+		writeString(bundle.resolve("A.java.md"), """
+				---
+				type: "Java Source File"
+				generated:
+				  by: "tools.code.context/1"
+				  at: "2026-08-03T10:15:30Z"
+				---
+
+				# Dependencies
+				""");
+
+		assertDoesNotThrow(rule()::execute);
+	}
+
+	@Test
+	void failsWhenAGeneratedMappingInBlockStyleNamesNoActor() {
+		writeString(bundle.resolve("A.java.md"), """
+				---
+				type: "Java Source File"
+				generated:
+				  at: "2026-08-03T10:15:30Z"
+				---
+
+				# Dependencies
+				""");
 
 		assertTrue(failure().contains("declares a 'generated' without the actor that produced it"));
 	}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -291,4 +291,33 @@ class FrontMatterTest {
 
 		assertEquals(Optional.of("one two"), frontMatter.orElseThrow().value("description"));
 	}
+
+	/**
+	 * A nested mapping leaves the key's own line empty, and reading it literally
+	 * answered the empty string for a value written out in full on the lines below —
+	 * so a rule looking for something in it reported it missing while it was there.
+	 */
+	@Test
+	void foldsAMappingWrittenOnTheLinesBelowItsKey() {
+		Optional<FrontMatter> frontMatter = FrontMatter
+				.parse("---\ngenerated:\n  by: agent/1\n  at: 2026-01-01\n---\n");
+
+		assertEquals(Optional.of("by: agent/1 at: 2026-01-01"), frontMatter.orElseThrow().value("generated"));
+	}
+
+	/** YAML continues a plain scalar on the indented lines below it, and so does this. */
+	@Test
+	void foldsAPlainScalarWrappedOntoTheNextLine() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\ndescription:\n  one\n  two\n---\n");
+
+		assertEquals(Optional.of("one two"), frontMatter.orElseThrow().value("description"));
+	}
+
+	/** A key with nothing below it still declares nothing, which is what the format rules report. */
+	@Test
+	void readsABareKeyWithNothingBelowItAsEmpty() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\nname:\ndescription: d\n---\n");
+
+		assertEquals(Optional.of(""), frontMatter.orElseThrow().value("name"));
+	}
 }


### PR DESCRIPTION
FrontMatter.value answered the empty string for every key whose value is
not on the key's own line, folding the continuation lines only for a block
scalar. YAML continues a value downwards in three ways, though — a block
scalar, a plain scalar wrapped onto the next line, and a nested mapping or
sequence — and the other two read as blank however fully they were written
out. A rule looking for something in such a value reported it missing while
it stood on the very next line.

Fold whenever the key's own line carries nothing, which is the shape all
three share. A key with nothing below it still yields the empty string, so
a bare `key:` is unchanged and the format rules go on reporting it.

Folding a mapping is lossy on purpose: `by: agent/1` reads back as text
rather than as a nested entry, which is all the length, blankness,
uniqueness and shape checks need. A rule that wants the structure itself
wants a YAML parser, not this reader.

Claude-Session: https://claude.ai/code/session_018h1mxDquvaSZt4CUcHPzwT

Co-authored-by: Claude <noreply@anthropic.com>