### PR TITLE
fix(adopt): two ways an adoption advertised a CLAUDE.md guard it never delivered

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.Text;
 import io.github.adamw7.tools.adopt.command.CommandLine;
 import io.github.adamw7.tools.adopt.command.CommandResult;
@@ -23,6 +24,11 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * aborts with "Author identity unknown". Each missing identity is supplied for the
  * commit alone with a {@code -c} override, so an identity the checkout already
  * configures stays in force.
+ *
+ * <p>Staging is also where the adoption finds out that the checkout excludes a file
+ * it wrote, since {@code git add -A} skips an ignored path without saying so. That
+ * is refused rather than committed around — see
+ * {@link #requireNothingTheAdoptionWroteIsIgnored}.
  *
  * <p>The pipeline runs this step two or three times, so each one is qualified with
  * what it commits. A report whose {@code completedSteps} read {@code commit} three
@@ -65,12 +71,63 @@ public class CommitStep extends AbstractCommandStep {
 
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
+		requireNothingTheAdoptionWroteIsIgnored(context, runner);
 		runOrFail(runner, context.repositoryDirectory(), List.of("git", "add", "-A"));
 		if (hasStagedChanges(context, runner)) {
 			commit(context, runner);
 		} else {
 			log.info("No changes to commit for: {}", message);
 		}
+	}
+
+	/**
+	 * Refuses to commit while a file the adoption wrote is excluded by the checkout's
+	 * ignore rules. {@code git add -A} skips an ignored path in silence, so the file
+	 * stays in the working tree — where {@link VerifyStep} goes on finding it and
+	 * passing — while the branch that is pushed carries nothing of it.
+	 *
+	 * <p>Nothing downstream could catch that. A repository ignoring {@code CLAUDE.md}
+	 * was adopted, reported as complete with every step passed, and left with the
+	 * guard the adoption had just wired in failing on a clean checkout of its own pull
+	 * request — the one outcome {@link VerifyStep} exists to prevent. One ignoring
+	 * {@code .claude/} had its starter assets logged as installed and committed none
+	 * of them. Neither shows up in {@code git status}, which is exactly what ignoring
+	 * a path means.
+	 *
+	 * <p>Failing is the answer rather than forcing the files in: the pattern is the
+	 * project's own decision about its repository, and the adoption is in no position
+	 * to overrule it.
+	 */
+	private void requireNothingTheAdoptionWroteIsIgnored(AdoptionContext context, CommandRunner runner) {
+		List<String> ignored = ignoredPaths(context, runner);
+		if (!ignored.isEmpty()) {
+			throw new AdoptionException(name() + " cannot commit " + String.join(", ", ignored) + " in "
+					+ context.repositoryDirectory() + ": the checkout's ignore rules exclude those paths, so they"
+					+ " would stay out of " + context.branchName() + " while the verification kept reading them from"
+					+ " the working tree. Stop ignoring those paths, or adopt a repository that does not.");
+		}
+	}
+
+	/**
+	 * The paths git would leave behind: the ones the adoption writes that exist in the
+	 * checkout, are not tracked, and are excluded. A path the checkout already tracks
+	 * is committed whatever the ignore rules say, so {@code --others} is what asks the
+	 * question.
+	 *
+	 * <p>Only {@link AdoptionAssets#WRITTEN_PATHS} is asked about, and only those are
+	 * read back out: the transcript merges the command's standard error, so a git that
+	 * warns puts a line in it that is no path of ours.
+	 */
+	private List<String> ignoredPaths(AdoptionContext context, CommandRunner runner) {
+		CommandResult result = runOrFail(runner, context.repositoryDirectory(),
+				CommandLine.of("git", "ls-files", "--others", "--ignored", "--exclude-standard", "--")
+						.addAll(AdoptionAssets.WRITTEN_PATHS)
+						.toList());
+		return result.output().lines()
+				.map(String::strip)
+				.filter(AdoptionAssets.WRITTEN_PATHS::contains)
+				.distinct()
+				.toList();
 	}
 
 	private boolean hasStagedChanges(AdoptionContext context, CommandRunner runner) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -113,7 +113,7 @@ final class PomDocument {
 	 * declared only there is a rule no build ever runs.
 	 */
 	List<Element> boundPlugins() {
-		return preOrder(root()).stream()
+		return selfAndDescendants(root()).stream()
 				.filter(element -> "plugin".equals(element.getLocalName()))
 				.filter(element -> !isManaged(element))
 				.toList();
@@ -283,7 +283,7 @@ final class PomDocument {
 	}
 
 	private static Map<Element, Span> spansOf(Document document, String original) {
-		List<Element> elements = preOrder(document.getDocumentElement());
+		List<Element> elements = selfAndDescendants(document.getDocumentElement());
 		List<Span> spans = XmlElementSpans.of(original);
 		if (elements.size() != spans.size()) {
 			throw new AdoptionException("Could not map the POM's " + elements.size() + " parsed elements onto the "
@@ -294,7 +294,13 @@ final class PomDocument {
 		return byElement;
 	}
 
-	private static List<Element> preOrder(Element root) {
+	/**
+	 * The element and every element below it, in document order — what a caller asks
+	 * for when the thing it is looking for may sit at any depth, such as the rule
+	 * inside a plugin's {@code configuration/rules} that
+	 * {@link PomEnforcerInstaller} looks for.
+	 */
+	static List<Element> selfAndDescendants(Element root) {
 		List<Element> elements = new ArrayList<>();
 		collect(root, elements);
 		return List.copyOf(elements);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 /**
  * Adds the {@code claude-code-enforcer} to a Maven project's {@code pom.xml} by
@@ -28,6 +29,15 @@ public class PomEnforcerInstaller {
 	private static final String RULE_GROUP_ID = "io.github.adamw7";
 	private static final String CLAUDE_MD_FILE = "${project.basedir}/CLAUDE.md";
 
+	/**
+	 * The rule the adoption wires in, named once so the declaration it writes and the
+	 * declaration it looks for cannot spell it differently.
+	 */
+	static final String CLAUDE_MD_RULE = "claudeMdFormat";
+
+	/** The element a maven-enforcer rule is configured under; see {@link #runsClaudeMdRule}. */
+	private static final String RULES = "rules";
+
 	/** The one place a plugin both runs from and is added to; see {@link #enforcerPluginOfTheBuild}. */
 	private static final List<String> BUILD_PLUGINS = List.of("build", "plugins");
 
@@ -45,12 +55,12 @@ public class PomEnforcerInstaller {
 			  </goals>
 			  <configuration>
 			    <rules>
-			      <claudeMdFormat>
-			        <claudeMdFile>%s</claudeMdFile>
-			      </claudeMdFormat>
+			      <%1$s>
+			        <claudeMdFile>%2$s</claudeMdFile>
+			      </%1$s>
 			    </rules>
 			  </configuration>
-			</execution>""".formatted(CLAUDE_MD_FILE);
+			</execution>""".formatted(CLAUDE_MD_RULE, CLAUDE_MD_FILE);
 
 	private final Supplier<String> ruleVersion;
 
@@ -83,12 +93,11 @@ public class PomEnforcerInstaller {
 
 	/**
 	 * @return {@code true} when the rule was wired in, {@code false} when the POM
-	 *         already declared the {@code claude-code-enforcer} rule and was left
-	 *         unchanged.
+	 *         already runs the {@code claudeMdFormat} rule and was left unchanged.
 	 */
 	public boolean install(Path pomFile) {
 		PomDocument pom = PomDocument.read(pomFile);
-		if (declaresClaudeRule(pom)) {
+		if (alreadyRunsTheRule(pom)) {
 			return false;
 		}
 		enforcerPluginOfTheBuild(pom).ifPresentOrElse(
@@ -110,9 +119,38 @@ public class PomEnforcerInstaller {
 	 * with none and the pull request still claiming one — the same silent outcome
 	 * {@link #enforcerPluginOfTheBuild} refuses to produce from the other direction,
 	 * since {@link VerifyStep}'s {@code mvn -N validate} passes either way.
+	 *
+	 * <p>What counts as already running it is the rule being configured, not the
+	 * artifact that supplies it being on the plugin — see {@link #runsClaudeMdRule}.
 	 */
-	private boolean declaresClaudeRule(PomDocument pom) {
-		return pom.boundPlugins().stream().anyMatch(this::declaresRuleDependency);
+	private boolean alreadyRunsTheRule(PomDocument pom) {
+		return pom.boundPlugins().stream().anyMatch(this::runsClaudeMdRule);
+	}
+
+	/**
+	 * Whether the plugin actually configures the {@code claudeMdFormat} rule, rather
+	 * than merely carrying the artifact that supplies it. The two are not the same
+	 * question: {@value #RULE_ARTIFACT_ID} ships a rule per document and per piece of
+	 * agent configuration, so a project that wired in {@code noSecrets} or
+	 * {@code settingsJsonValid} has the dependency and no {@code CLAUDE.md} guard at
+	 * all. Reading the dependency as the guard left that project's POM untouched, and
+	 * {@link VerifyStep} confirmed nothing — its {@code mvn -N validate} passes on the
+	 * rule the project already had — so the adoption ran to the end and opened a pull
+	 * request claiming a guard the build does not run.
+	 *
+	 * <p>The rule is looked for at any depth below the plugin, because it is
+	 * configured either on an execution or on the plugin itself, and only directly
+	 * under a {@code rules} element, so a project whose own configuration happens to
+	 * name an element the same way elsewhere is not mistaken for one running it.
+	 */
+	private boolean runsClaudeMdRule(Element plugin) {
+		return PomDocument.selfAndDescendants(plugin).stream().anyMatch(this::isClaudeMdRule);
+	}
+
+	private boolean isClaudeMdRule(Element element) {
+		Node parent = element.getParentNode();
+		return CLAUDE_MD_RULE.equals(element.getLocalName()) && parent != null
+				&& RULES.equals(parent.getLocalName());
 	}
 
 	private boolean declaresRuleDependency(Element plugin) {
@@ -124,7 +162,7 @@ public class PomEnforcerInstaller {
 	/**
 	 * The {@code maven-enforcer-plugin} of the POM's own {@code build}, and only that
 	 * one. Where the rule is <em>looked for</em> is every plugin the POM binds — see
-	 * {@link #declaresClaudeRule} — but where it is <em>added</em> cannot be: an
+	 * {@link #alreadyRunsTheRule} — but where it is <em>added</em> cannot be: an
 	 * execution spliced into {@code pluginManagement} only configures a plugin the
 	 * build never runs, and one spliced into a profile runs only when that profile is
 	 * activated. Neither enforces anything, and neither shows up as a failure —
@@ -145,9 +183,16 @@ public class PomEnforcerInstaller {
 	 * the build already declares — reusing its {@code dependencies} and
 	 * {@code executions} when it has them — so the project keeps a single enforcer
 	 * plugin entry and the rules it already ran keep running.
+	 *
+	 * <p>A plugin that already depends on {@value #RULE_ARTIFACT_ID} for a rule of its
+	 * own keeps the dependency it declared, at the version it pinned: only the
+	 * execution is missing, and adding a second dependency on the same artifact would
+	 * leave the plugin's classpath deciding between two versions of it.
 	 */
 	private void augment(PomDocument pom, Element plugin) {
-		pom.insertUnder(plugin, List.of("dependencies"), ruleDependency());
+		if (!declaresRuleDependency(plugin)) {
+			pom.insertUnder(plugin, List.of("dependencies"), ruleDependency());
+		}
 		pom.insertUnder(plugin, List.of("executions"), EXECUTION);
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,11 +23,11 @@ class CommitStepTest {
 	void stagesChecksThenCommitsWithMessage() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::stagedChanges);
 		new CommitStep("my message").execute(context, runner);
-		assertEquals(List.of("git", "add", "-A"), runner.commandAt(0));
-		assertEquals(List.of("git", "diff", "--cached", "--quiet"), runner.commandAt(1));
-		assertEquals(List.of("git", "config", "--get", "user.name"), runner.commandAt(2));
-		assertEquals(List.of("git", "config", "--get", "user.email"), runner.commandAt(3));
-		assertEquals(List.of("git", "commit", "-m", "my message"), runner.commandAt(4));
+		assertEquals(List.of("git", "add", "-A"), runner.commandAt(1));
+		assertEquals(List.of("git", "diff", "--cached", "--quiet"), runner.commandAt(2));
+		assertEquals(List.of("git", "config", "--get", "user.name"), runner.commandAt(3));
+		assertEquals(List.of("git", "config", "--get", "user.email"), runner.commandAt(4));
+		assertEquals(List.of("git", "commit", "-m", "my message"), runner.commandAt(5));
 	}
 
 	@Test
@@ -34,22 +35,73 @@ class CommitStepTest {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::stagedChangesWithoutIdentity);
 		new CommitStep("my message").execute(context, runner);
 		assertEquals(List.of("git", "-c", "user.name=" + CommitStep.FALLBACK_NAME, "-c",
-				"user.email=" + CommitStep.FALLBACK_EMAIL, "commit", "-m", "my message"), runner.commandAt(4));
+				"user.email=" + CommitStep.FALLBACK_EMAIL, "commit", "-m", "my message"), runner.commandAt(5));
 	}
 
 	@Test
 	void leavesAConfiguredIdentityInForce() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::stagedChanges);
 		new CommitStep("my message").execute(context, runner);
-		assertEquals(List.of("git", "commit", "-m", "my message"), runner.commandAt(4));
+		assertEquals(List.of("git", "commit", "-m", "my message"), runner.commandAt(5));
 	}
 
 	@Test
 	void skipsCommitWhenNothingIsStaged() {
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		new CommitStep("msg").execute(context, runner);
-		assertEquals(2, runner.count());
-		assertEquals(List.of("git", "diff", "--cached", "--quiet"), runner.commandAt(1));
+		assertEquals(3, runner.count());
+		assertEquals(List.of("git", "diff", "--cached", "--quiet"), runner.commandAt(2));
+	}
+
+	/**
+	 * The paths the adoption writes are asked about before anything is staged, since
+	 * {@code git add -A} answers nothing about the ones it skipped.
+	 */
+	@Test
+	void asksWhichOfTheAdoptionsOwnPathsTheCheckoutIgnores() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::stagedChanges);
+		new CommitStep("msg").execute(context, runner);
+		List<String> command = runner.commandAt(0);
+		assertEquals(List.of("git", "ls-files", "--others", "--ignored", "--exclude-standard", "--"),
+				command.subList(0, 6));
+		assertEquals(AdoptionAssets.WRITTEN_PATHS, command.subList(6, command.size()));
+	}
+
+	/**
+	 * A checkout that excludes {@code CLAUDE.md} would keep it in the working tree,
+	 * where the verification passes, and out of the branch — leaving the guard the
+	 * adoption wires in failing on a clean checkout of its own pull request.
+	 */
+	@Test
+	void refusesToCommitAFileTheCheckoutIgnores() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(ignoring("CLAUDE.md"));
+		AdoptionException failure = assertThrows(AdoptionException.class,
+				() -> new CommitStep("msg", "claude-md").execute(context, runner));
+		assertTrue(failure.getMessage().contains("CLAUDE.md"), failure.getMessage());
+		assertEquals(1, runner.count(), "nothing may be staged once a path is known to be excluded");
+	}
+
+	/** Every excluded path is named, so one run says which patterns have to go. */
+	@Test
+	void namesEveryIgnoredPath() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				ignoring(AdoptionAssets.SETTINGS_FILE + "\n" + AdoptionAssets.SESSION_START_HOOK_FILE));
+		AdoptionException failure = assertThrows(AdoptionException.class,
+				() -> new CommitStep("msg", "assets").execute(context, runner));
+		assertTrue(failure.getMessage().contains(AdoptionAssets.SETTINGS_FILE), failure.getMessage());
+		assertTrue(failure.getMessage().contains(AdoptionAssets.SESSION_START_HOOK_FILE), failure.getMessage());
+	}
+
+	/**
+	 * The transcript merges standard error, so a git that warns puts a line in it
+	 * that is no path of the adoption's and must not abort a perfectly good commit.
+	 */
+	@Test
+	void ignoresTranscriptNoiseThatNamesNoPathOfTheAdoptions() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(
+				ignoring("warning: unable to access '/etc/gitconfig'" + System.lineSeparator() + "build/output.txt"));
+		new CommitStep("msg").execute(context, runner);
+		assertEquals(List.of("git", "commit", "-m", "msg"), runner.commandAt(5));
 	}
 
 	@Test
@@ -83,6 +135,12 @@ class CommitStepTest {
 		AdoptionException failure = assertThrows(AdoptionException.class,
 				() -> new CommitStep("msg", "guard").execute(context, runner));
 		assertTrue(failure.getMessage().startsWith("commit:guard failed"), failure.getMessage());
+	}
+
+	private Function<List<String>, CommandResult> ignoring(String paths) {
+		return command -> command.contains("ls-files")
+				? new CommandResult(command, 0, paths + System.lineSeparator())
+				: stagedChanges(command);
 	}
 
 	private CommandResult stagedChanges(List<String> command) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -172,6 +172,27 @@ class PomEnforcerInstallerTest {
 			</project>
 			""".formatted(PROFILED_ENFORCER, MANAGED_ENFORCER);
 
+	/** The rule as a project configures it: the artifact that supplies it, and the rule itself. */
+	private static final String CLAUDE_RULE_DECLARATION = """
+			          <dependencies>
+			            <dependency>
+			              <groupId>io.github.adamw7</groupId>
+			              <artifactId>tools.claude-code-enforcer</artifactId>
+			              <version>1.0.0</version>
+			            </dependency>
+			          </dependencies>
+			          <executions>
+			            <execution>
+			              <id>enforce-claude-md</id>
+			              <goals><goal>enforce</goal></goals>
+			              <configuration>
+			                <rules>
+			                  <claudeMdFormat/>
+			                </rules>
+			              </configuration>
+			            </execution>
+			          </executions>""";
+
 	/** The rule pinned where nothing runs it: {@code pluginManagement} binds no plugin to any phase. */
 	private static final String POM_WITH_RULE_ONLY_MANAGED = """
 			<project xmlns="http://maven.apache.org/POM/4.0.0">
@@ -181,19 +202,13 @@ class PomEnforcerInstallerTest {
 			      <plugins>
 			        <plugin>
 			          <artifactId>maven-enforcer-plugin</artifactId>
-			          <dependencies>
-			            <dependency>
-			              <groupId>io.github.adamw7</groupId>
-			              <artifactId>tools.claude-code-enforcer</artifactId>
-			              <version>1.0.0</version>
-			            </dependency>
-			          </dependencies>
+			%s
 			        </plugin>
 			      </plugins>
 			    </pluginManagement>
 			  </build>
 			</project>
-			""";
+			""".formatted(CLAUDE_RULE_DECLARATION);
 
 	/** Wires the rule the way this repository does: behind an opt-in profile, not in the build. */
 	private static final String POM_WITH_RULE_IN_A_PROFILE = """
@@ -206,18 +221,47 @@ class PomEnforcerInstallerTest {
 			        <plugins>
 			          <plugin>
 			            <artifactId>maven-enforcer-plugin</artifactId>
-			            <dependencies>
-			              <dependency>
-			                <groupId>io.github.adamw7</groupId>
-			                <artifactId>tools.claude-code-enforcer</artifactId>
-			                <version>1.0.0</version>
-			              </dependency>
-			            </dependencies>
+			%s
 			          </plugin>
 			        </plugins>
 			      </build>
 			    </profile>
 			  </profiles>
+			</project>
+			""".formatted(CLAUDE_RULE_DECLARATION);
+
+	/**
+	 * Runs a rule of the {@code claude-code-enforcer}'s <em>other</em> kind, so the
+	 * artifact is on the plugin's classpath and no {@code CLAUDE.md} guard exists.
+	 */
+	private static final String POM_WITH_THE_ARTIFACT_FOR_ANOTHER_RULE = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+			  <artifactId>demo</artifactId>
+			  <build>
+			    <plugins>
+			      <plugin>
+			        <artifactId>maven-enforcer-plugin</artifactId>
+			        <dependencies>
+			          <dependency>
+			            <groupId>io.github.adamw7</groupId>
+			            <artifactId>tools.claude-code-enforcer</artifactId>
+			            <version>1.0.0</version>
+			          </dependency>
+			        </dependencies>
+			        <executions>
+			          <execution>
+			            <id>enforce-no-secrets</id>
+			            <goals><goal>enforce</goal></goals>
+			            <configuration>
+			              <rules>
+			                <noSecrets/>
+			              </rules>
+			            </configuration>
+			          </execution>
+			        </executions>
+			      </plugin>
+			    </plugins>
+			  </build>
 			</project>
 			""";
 
@@ -378,6 +422,38 @@ class PomEnforcerInstallerTest {
 		Path pom = write(dir, POM_WITH_RULE_IN_A_PROFILE);
 		assertFalse(installer.install(pom), "the rule is already wired in, in the profile");
 		assertEquals(POM_WITH_RULE_IN_A_PROFILE, Files.readString(pom), "the POM must not have been touched");
+	}
+
+	/**
+	 * The artifact is not the guard. {@value PomEnforcerInstaller#CLAUDE_MD_RULE} is
+	 * one of the rules {@code tools.claude-code-enforcer} ships, so a project running
+	 * any of the others already depends on it and has no {@code CLAUDE.md} guard.
+	 * Reading the dependency as the guard left such a POM untouched and
+	 * {@link VerifyStep} confirmed nothing — its {@code mvn -N validate} passes on the
+	 * rule the project already had — so the pull request advertised a guard the build
+	 * does not run.
+	 */
+	@Test
+	void wiresTheRuleInWhenTheArtifactIsOnlyThereForAnotherRule(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_THE_ARTIFACT_FOR_ANOTHER_RULE);
+		assertTrue(installer.install(pom), "the artifact is present but no CLAUDE.md guard is");
+		String result = Files.readString(pom);
+		assertTrue(result.contains(PomEnforcerInstaller.CLAUDE_MD_RULE), "the rule must be wired in:\n" + result);
+		assertTrue(result.contains("noSecrets"), "the rule the project already ran must keep running");
+	}
+
+	/**
+	 * The plugin keeps the one dependency it declared, at the version it pinned: a
+	 * second dependency on the same artifact would leave the plugin's classpath
+	 * deciding between two versions of it.
+	 */
+	@Test
+	void reusesADependencyOnTheRuleArtifactThePluginAlreadyDeclares(@TempDir Path dir) throws IOException {
+		String result = install(dir, POM_WITH_THE_ARTIFACT_FOR_ANOTHER_RULE);
+		assertEquals(1, countOccurrences(result, "<artifactId>tools.claude-code-enforcer</artifactId>"),
+				"the artifact must be declared once:\n" + result);
+		assertTrue(result.contains("<version>1.0.0</version>"), "the project's pinned version must survive");
+		assertFalse(result.contains("9.9.9"), "a second, differently pinned dependency must not be added:\n" + result);
 	}
 
 	/**


### PR DESCRIPTION
Found while auditing every Java file in `adopt` and driving the pipeline end to end against purpose-built sample repositories. Both bugs are the same shape: the run reports `succeeded: true` with every step passed, and the pull request it opens claims a guard the adopted project does not have.

## 1. The enforcer artifact was read as the guard

`PomEnforcerInstaller` treated any bound plugin depending on `tools.claude-code-enforcer` as a POM that already guards its `CLAUDE.md`. That artifact ships a rule per document and per piece of agent configuration, so a project running `noSecrets` or `settingsJsonValid` has the dependency and no `CLAUDE.md` guard at all.

Such a POM was left untouched, and `VerifyStep` confirmed nothing — its `mvn -N validate` passes on the rule the project already had. Reproduced end to end before the fix:

```
enforcer: The maven build ... already declares the guard; left unchanged
report:   succeeded=True, steps=[... 'enforcer', 'commit:guard', 'verify']
pom.xml:  claudeMdFormat occurrences = 0
```

Detection now asks whether a bound plugin *configures* the `claudeMdFormat` rule — at any depth below the plugin, and only directly under a `rules` element, so an execution's configuration and a plugin-level one both count while an unrelated element of the same name does not. The rule name is a constant the written declaration and the search share, so they cannot spell it differently.

Augmenting such a plugin adds only the execution: the dependency it already declares is kept at the version it pinned, since a second dependency on the same artifact would leave the plugin's classpath deciding between two versions of it.

## 2. `.gitignore` silently dropped the adoption's own files

`CommitStep` stages with `git add -A`, which skips an ignored path in silence, and `VerifyStep` validates the **working tree**, not the committed tree. Nothing compared the two, and ignoring a path is exactly what keeps it out of `git status`.

- A repository ignoring `.claude/` adopted with `--assets` logged `settings.json` and `hooks/session-start.sh` as installed, committed neither, and reported success.
- Worse, a repository ignoring `CLAUDE.md` reported **complete success with `verify` passed** while pushing a branch that has no `CLAUDE.md` and carries the guard demanding one. Running that guard on a clean checkout of the branch the adoption had just produced:

```
Rule 0: ClaudeMdFormatRule(claudeMdFormat) failed with message:
CLAUDE.md does not exist at .../export/CLAUDE.md
```

The pull request would break the target repository's build for every contributor — the one outcome `VerifyStep` exists to prevent.

`CommitStep` now asks git, before staging, which of the paths the adoption writes exist in the checkout but are excluded and untracked, and refuses the commit naming them. A path the checkout already tracks is committed whatever the ignore rules say, so `--others` is what asks the question. Only `AdoptionAssets.WRITTEN_PATHS` is asked about and only those are read back, since the transcript merges standard error.

Failing beats forcing the files in: the pattern is the project's own decision about its repository, and the adoption is in no position to overrule it. After the fix, both scenarios stop at the earliest possible step with the report saying how far they got:

```
commit:claude-md cannot commit CLAUDE.md in ...: the checkout's ignore rules
exclude those paths, so they would stay out of claude/adopt-claude-code while
the verification kept reading them from the working tree. Stop ignoring those
paths, or adopt a repository that does not.
```

## Verification

`mvn -B package -DenforceClaudeMd` passes. The `adopt` suite goes from 709 to 715 tests, all green.

Both bugs were reproduced and then re-checked end to end with real `--dry-run` adoptions. Regression runs cover all five shapes with `--assets` — Maven, Maven with an existing enforcer, Gradle with a non-executable wrapper, a CRLF POM, and a repository with no build file (fallback guard) — plus a second run into the same workspace to confirm idempotency. Everything the adoption writes is now actually on the branch.

`PushStep` and `PullRequestStep` are the only steps not exercised end to end: `gh` is not installed in the container, so every run was `--dry-run`. Neither is touched by this change.

## Not included

Four lower-severity findings from the same audit are left alone, none of them a correctness break:

- `ClaudeMdConformer`'s dedicated `AGENTS.md` reference line is never emitted on the Maven path — the section stubs it writes first already contain the token it searches for. Cosmetic; the rule still passes.
- `RepositoryUrl.identity` keeps a port as a path segment while `name()` ignores it, so `https://host:443/o/r` and `https://host/o/r` claim the same checkout directory but compare as different repositories.
- `Workspaces.createTemporary` never cleans up, so every `adopt_repo` MCP call without `workspace` leaves a full clone behind.
- `--repos <file>` is read during parsing, so `--repos missing.txt --help` fails on the file instead of printing usage.

Differential fuzzing of `ClaudeMdConformer` against the real `claudeMdFormat` rule (20 000 random documents, checked for both rule conformance and idempotency) and of `BoundedTranscript` (credential-leak and bound properties) found nothing; those harnesses were scratch and are not part of this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLciaKREn7LhTEMX6KC7Qn)_