### PR TITLE
refactor(adopt): centralise the optional-value rule and let each build system name its files

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -85,7 +85,7 @@ public final class AdoptionContext {
 	 *         back to the default instead of being rejected as an invalid branch.
 	 */
 	public static String branchOrDefault(String branchName) {
-		return Text.isPresent(branchName) ? branchName.strip() : DEFAULT_BRANCH;
+		return Text.orDefault(branchName, DEFAULT_BRANCH);
 	}
 
 	private static Path requireWorkspace(Path workspace) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
@@ -41,7 +41,7 @@ public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAss
 
 	public AdoptionOptions {
 		pullRequest = pullRequest == null ? PullRequestOptions.defaults() : pullRequest;
-		ruleVersion = Text.isPresent(ruleVersion) ? ruleVersion.strip() : null;
+		ruleVersion = Text.orDefault(ruleVersion, null);
 		commandTimeout = commandTimeout == null ? ProcessCommandRunner.DEFAULT_TIMEOUT : requirePositive(commandTimeout);
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -151,17 +151,12 @@ public final class CliArguments {
 			case "--rule-version" -> consumeName(args, index, value -> ruleVersion = optionalText(value));
 			case TIMEOUT_FLAG -> consumeName(args, index, value -> commandTimeout = optionalTimeout(value));
 			case "--report" -> consumeName(args, index, value -> reportFile = optionalPath(value));
-			case "--draft" -> switchOn(index, () -> draft = true);
-			case "--assets" -> switchOn(index, () -> assets = true);
-			case "--dry-run" -> switchOn(index, () -> dryRun = true);
+			// A flag carrying no value: it is set, and the next argument is the one after it.
+			case "--draft" -> { draft = true; yield index + 1; }
+			case "--assets" -> { assets = true; yield index + 1; }
+			case "--dry-run" -> { dryRun = true; yield index + 1; }
 			default -> throw new IllegalArgumentException("Unknown option " + flag + ". " + USAGE);
 		};
-	}
-
-	/** A flag that carries no value: it is set, and the next argument is the one after it. */
-	private int switchOn(int index, Runnable target) {
-		target.run();
-		return index + 1;
 	}
 
 	private int consumeValue(String[] args, int index, Consumer<String> target) {
@@ -232,11 +227,12 @@ public final class CliArguments {
 	}
 
 	private Path optionalPath(String value) {
-		return Text.isPresent(value) ? Path.of(value.strip()) : null;
+		String path = optionalText(value);
+		return path == null ? null : Path.of(path);
 	}
 
 	private String optionalText(String value) {
-		return Text.isPresent(value) ? value.strip() : null;
+		return Text.orDefault(value, null);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Text.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Text.java
@@ -27,4 +27,19 @@ public final class Text {
 	public static boolean isPresent(String value) {
 		return value != null && !value.isBlank();
 	}
+
+	/**
+	 * Reads an optional value: the value stripped when it carries text, the fallback
+	 * when it is blank. Every optional input the adoption takes — a flag, a
+	 * positional, an MCP argument — falls back the same way, so the rule lives here
+	 * rather than being re-typed at each of them.
+	 *
+	 * @param value    the supplied value, possibly {@code null} or blank
+	 * @param fallback what an absent value means, {@code null} when absence is the
+	 *                 answer the caller wants back
+	 * @return the stripped value, or {@code fallback}
+	 */
+	public static String orDefault(String value, String fallback) {
+		return isPresent(value) ? value.strip() : fallback;
+	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
@@ -7,7 +7,9 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -37,6 +39,15 @@ final class ExecutableResolver {
 	private final boolean windows;
 	private final List<Path> pathDirectories;
 	private final List<String> pathExtensions;
+
+	/**
+	 * What the {@code PATH} search already found, keyed by program name. One resolver
+	 * serves a whole run, which launches the same handful of programs — {@code git}
+	 * alone half a dozen times per repository — and each search stats every
+	 * {@code PATH} directory against every {@code PATHEXT} extension until it hits.
+	 * Remembering the answer keeps that to one search per distinct program.
+	 */
+	private final Map<String, Optional<Path>> located = new ConcurrentHashMap<>();
 
 	ExecutableResolver() {
 		this(Platform.isWindows(), pathDirectories(System.getenv("PATH")),
@@ -73,6 +84,10 @@ final class ExecutableResolver {
 	}
 
 	private Optional<Path> locate(String program) {
+		return located.computeIfAbsent(program, this::search);
+	}
+
+	private Optional<Path> search(String program) {
 		return pathDirectories.stream()
 				.flatMap(directory -> candidates(directory, program))
 				.filter(Files::isRegularFile)

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
@@ -117,26 +117,24 @@ public final class AdoptionAssets {
 
 	/**
 	 * Every checkout-relative path an adoption may write or edit: the starter assets,
-	 * the generated {@code CLAUDE.md}, the fallback guard's two files, and the build
-	 * files the guard is wired into.
+	 * the generated {@code CLAUDE.md}, and whatever build file each supported build
+	 * system wires its guard into.
 	 *
 	 * <p>{@link CloneStep} reads this to tell the adoption's own work apart from a
-	 * contributor's, so a path missing from it is a file the adoption writes and
-	 * cannot account for. Extend it when the adoption learns to write a new one — the
-	 * asset installers and the two guard installers are read from their own constants
-	 * here, so only a genuinely new file has to be added by hand.
+	 * contributor's, and {@link CommitStep} refuses to commit while the checkout
+	 * ignores one of them, so a path missing from it is a file the adoption writes and
+	 * cannot account for. Nothing has to be added by hand for a new build system: the
+	 * asset installers name their own paths and each {@link BuildSystem} is asked for
+	 * {@link BuildSystem#writtenPaths()}, which it has to answer.
 	 */
 	public static final List<String> WRITTEN_PATHS = writtenPaths();
 
 	private static List<String> writtenPaths() {
-		return Stream.concat(
+		return Stream.of(
 				DEFAULTS.stream().map(AssetInstaller::relativePath),
-				Stream.of(CLAUDE_MD_FILE,
-						WorkflowGuardInstaller.WORKFLOW_FILE,
-						WorkflowGuardInstaller.SCRIPT_FILE,
-						MavenBuildSystem.POM,
-						GradleBuildSystem.GROOVY_BUILD_FILE,
-						GradleBuildSystem.KOTLIN_BUILD_FILE))
+				Stream.of(CLAUDE_MD_FILE),
+				BuildSystems.DEFAULTS.stream().map(BuildSystem::writtenPaths).flatMap(List::stream))
+				.flatMap(paths -> paths)
 				.distinct()
 				.toList();
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -21,6 +21,22 @@ public interface BuildSystem {
 	boolean matches(Path repositoryDirectory);
 
 	/**
+	 * Every checkout-relative path {@link #install(Path)} may write or edit, named by
+	 * the build system that writes it so {@link AdoptionAssets} can account for the
+	 * adoption's own files without keeping a second copy of each name.
+	 *
+	 * <p>Deliberately not defaulted. {@link AdoptionAssets#WRITTEN_PATHS} is what
+	 * {@link CloneStep} tells the adoption's work apart with and what
+	 * {@link CommitStep} refuses an ignored path over, so a build system that wrote a
+	 * file this list did not name would have it silently dropped from the branch. A
+	 * default of "none" would let a new build system be added without anyone noticing
+	 * that gap; requiring an answer makes the compiler ask.
+	 *
+	 * @return the paths, listed whether or not the checkout happens to carry them
+	 */
+	List<String> writtenPaths();
+
+	/**
 	 * Wires the {@code CLAUDE.md} guard into the checkout's build file so the
 	 * generated file keeps being validated on every build.
 	 *

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
@@ -29,6 +29,11 @@ final class EnforcerRuleVersion {
 	 * actually being edited — keeps merely constructing the default
 	 * {@link BuildSystems#DEFAULTS} list, or adopting a repository that builds with
 	 * something other than Maven, from depending on the running build's version.
+	 *
+	 * <p>Re-read for each repository of a batch rather than remembered, so this class
+	 * keeps the immutability every step here is held to: caching a classpath read
+	 * that costs nothing beside the clone and the {@code claude init} it sits between
+	 * would buy back no time worth holding mutable state for.
 	 */
 	static String release() {
 		return requireRelease(fromBuildMetadata());
@@ -70,6 +75,13 @@ final class EnforcerRuleVersion {
 		}
 	}
 
+	/**
+	 * Refuses metadata that reached the classpath unfiltered as firmly as metadata
+	 * that is missing: an unsubstituted token would otherwise be wired into the
+	 * adopted POM as if it were a version. Both delimiters are rejected — the
+	 * resource is written with {@code @...@}, which is what this build filters, and
+	 * {@code ${...}} is what it would carry had that configuration changed.
+	 */
 	private static String read(InputStream stream) throws IOException {
 		if (stream == null) {
 			throw new AdoptionException("Build metadata not on the classpath: " + BUILD_PROPERTIES
@@ -78,7 +90,7 @@ final class EnforcerRuleVersion {
 		Properties properties = new Properties();
 		properties.load(stream);
 		String version = properties.getProperty(RULE_VERSION_KEY, "").strip();
-		if (version.isEmpty() || version.startsWith("${")) {
+		if (version.isEmpty() || version.startsWith("@") || version.startsWith("${")) {
 			throw new AdoptionException(
 					RULE_VERSION_KEY + " was not filtered into " + BUILD_PROPERTIES + " (found: '" + version + "')");
 		}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
@@ -44,6 +44,11 @@ public class FallbackBuildSystem implements BuildSystem {
 	}
 
 	@Override
+	public List<String> writtenPaths() {
+		return List.of(WorkflowGuardInstaller.WORKFLOW_FILE, WorkflowGuardInstaller.SCRIPT_FILE);
+	}
+
+	@Override
 	public boolean install(Path repositoryDirectory) {
 		return installer.install(repositoryDirectory);
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
@@ -48,6 +48,16 @@ public class GradleBuildSystem implements BuildSystem {
 		return locate(repositoryDirectory).isPresent();
 	}
 
+	/**
+	 * Both build scripts, not merely the one {@link #locate} would pick: the checkout
+	 * carrying either is a file the adoption may edit, and which of them it is is not
+	 * known until a repository is in hand.
+	 */
+	@Override
+	public List<String> writtenPaths() {
+		return List.of(GROOVY_BUILD_FILE, KOTLIN_BUILD_FILE);
+	}
+
 	@Override
 	public boolean install(Path repositoryDirectory) {
 		Path buildFile = locate(repositoryDirectory)

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -22,7 +22,6 @@ public class MavenBuildSystem implements BuildSystem {
 	private static final String MAVEN = "mvn";
 	private static final List<String> VERIFY_ARGUMENTS = List.of("-q", "-N", "validate");
 
-	/** Package-visible so {@link AdoptionAssets} can name it among the files the adoption edits. */
 	static final String POM = "pom.xml";
 
 	private final PomEnforcerInstaller installer;
@@ -58,6 +57,11 @@ public class MavenBuildSystem implements BuildSystem {
 	@Override
 	public boolean matches(Path repositoryDirectory) {
 		return Files.isRegularFile(repositoryDirectory.resolve(POM));
+	}
+
+	@Override
+	public List<String> writtenPaths() {
+		return List.of(POM);
 	}
 
 	@Override

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
@@ -39,8 +39,8 @@ public record PullRequestOptions(String title, String body, List<String> reviewe
 			+ "into the build so the file keeps being validated.";
 
 	public PullRequestOptions {
-		title = orDefault(title, DEFAULT_TITLE);
-		body = orDefault(body, DEFAULT_BODY);
+		title = Text.orDefault(title, DEFAULT_TITLE);
+		body = Text.orDefault(body, DEFAULT_BODY);
 		reviewers = supplied(reviewers);
 		labels = supplied(labels);
 		assignees = supplied(assignees);
@@ -54,9 +54,5 @@ public record PullRequestOptions(String title, String body, List<String> reviewe
 	/** The adoption's own title and body, requesting nobody and not a draft. */
 	public static PullRequestOptions defaults() {
 		return new PullRequestOptions(null, null, List.of(), List.of(), List.of(), false);
-	}
-
-	private static String orDefault(String value, String fallback) {
-		return Text.isPresent(value) ? value.strip() : fallback;
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -244,6 +244,11 @@ class BuildSystemsTest {
 		}
 
 		@Override
+		public List<String> writtenPaths() {
+			return List.of();
+		}
+
+		@Override
 		public boolean install(Path repositoryDirectory) {
 			return false;
 		}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
@@ -99,6 +99,11 @@ class VerifyStepTest {
 		}
 
 		@Override
+		public List<String> writtenPaths() {
+			return List.of();
+		}
+
+		@Override
 		public boolean install(Path repositoryDirectory) {
 			return true;
 		}


### PR DESCRIPTION
Four cleanup passes over the adopt module turned up duplication that the
module's own abstractions were already positioned to absorb.

Text gains orDefault, the "stripped when it carries text, fallback when
blank" rule that CliArguments, AdoptionOptions, AdoptionContext and
PullRequestOptions had each re-typed. Text already documents itself as the
home for what counts as absent, so a change to that rule now lands in one
place instead of five.

BuildSystem gains writtenPaths, so each build system names the files its
guard install may write instead of AdoptionAssets reaching into
MavenBuildSystem, GradleBuildSystem and WorkflowGuardInstaller for their
constants. The method is deliberately not defaulted: WRITTEN_PATHS is what
CloneStep tells the adoption's work apart with and what CommitStep refuses
an ignored path over, so a build system whose files went unnamed would have
them silently dropped from the branch -- the compiler now asks. The
resolved list is unchanged.

CliArguments drops switchOn, whose whole body the switch expression's own
yield says directly. ExecutableResolver remembers what the PATH search
found per program name, which on Windows had been re-stat'ing every PATH
directory against every PATHEXT extension for each of the half-dozen git
invocations a repository takes.

EnforcerRuleVersion now rejects an unfiltered @...@ token as well as
${...}. The resource is written with the @ delimiter -- the one this build
actually filters -- so that was the form that could have reached an adopted
pom.xml as if it were a version, and ServerVersion already checked both.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R6oS74BagdL9kzvJ7uZs6N