### PR TITLE
refactor(claude-code-enforcer): share a base for the definition format rules

### DIFF
--- a/.claude/skills/enforcer-rules/SKILL.md
+++ b/.claude/skills/enforcer-rules/SKILL.md
@@ -59,6 +59,14 @@ commands) extend `MultiDefinitionRule` instead and call `forEachDefinition(...)`
 — it already owns `commandsDir` / `agentsDir` / `skillsDir` traversal, where a
 skill is a directory holding a `SKILL.md`.
 
+Rules that validate *one* kind of definition file by file extend
+`DefinitionFormatRule`, which owns the directory scan, the `autoFix` parameter
+and the grouped report. A subclass supplies the `Naming` its messages use, the
+directory, `entriesIn(...)` (the `*.md` files, or the subdirectories for skills),
+and `collectEntryViolations(...)` — reaching for `contentOf(...)` and
+`frontMatterOf(...)` / `requiredFrontMatterOf(...)` rather than reading and
+parsing again.
+
 ### What the base class gives you (don't reimplement it)
 | Member | Use it for |
 |---|---|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -983,6 +983,12 @@ root would suppress nothing when the build is started from a module directory or
 an IDE.
 
 The front-matter rules (`skillFilesExist`, `subAgentFormat`, `commandFormat`)
+share a `DefinitionFormatRule` base class that owns what all three do the same
+way: require the configured directory, scan it, read each definition, and report
+everything wrong with the lot together. A subclass says which entries of the
+directory carry a definition — a `*.md` file for a sub-agent or a command, a
+directory holding a `SKILL.md` for a skill — and which front-matter checks it
+asks for. They
 also accept an `autoFix` option (off by default). When enabled and a definition's
 front matter is malformed in a way that is safe to repair — a delimiter written
 with too many dashes such as `----`, or an opening `---` with no closing

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -1,15 +1,10 @@
 package io.github.adamw7.tools.enforcer.definition;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Named;
 
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-
-import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
-import io.github.adamw7.tools.enforcer.text.FrontMatter;
 import io.github.adamw7.tools.enforcer.text.NameConvention;
 
 /**
@@ -27,10 +22,7 @@ import io.github.adamw7.tools.enforcer.text.NameConvention;
  * problems found are reported together.
  */
 @Named("commandFormat")
-public class CommandFormatRule extends ClaudeCodeEnforcerRule {
-
-	private static final String LABEL = "Command";
-	private static final String DEFINITION = "Command definition";
+public class CommandFormatRule extends DefinitionFormatRule {
 
 	/** The {@code .claude/commands} directory to scan. Injected from the rule configuration. */
 	private File commandsDir;
@@ -41,34 +33,34 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 	/** Optional whitelist of model identifiers a command may declare. */
 	private List<String> allowedModels;
 
-	/** When true, a malformed front matter block is rewritten in place instead of failing the build. */
-	private boolean autoFix;
+	public CommandFormatRule() {
+		super(new Naming("commandsDir", "Commands", "Command definition", "Command",
+				"Command files are not well formed:"));
+	}
 
 	@Override
-	public void execute() throws EnforcerRuleException {
-		requireConfigured(commandsDir, "commandsDir");
-		DefinitionFiles.verifyDirectory(commandsDir, "Commands");
-		List<String> violations = new ArrayList<>();
-		for (File command : DefinitionFiles.markdownFiles(commandsDir)) {
-			collectCommandViolations(command, violations);
-		}
-		report("Command files are not well formed:", violations);
+	protected File definitionDir() {
+		return commandsDir;
 	}
 
-	private void collectCommandViolations(File command, List<String> violations) {
-		DefinitionContent.of(command, DEFINITION, autoFix, getLog(), violations)
-				.ifPresent(content -> collectNamedViolations(command, content, violations));
+	@Override
+	protected File[] entriesIn(File directory) {
+		return DefinitionFiles.markdownFiles(directory);
 	}
 
+	@Override
+	protected void collectEntryViolations(File command, List<String> violations) {
+		contentOf(command, violations).ifPresent(content -> collectNamedViolations(command, content, violations));
+	}
+
+	/** A command answers to its file name, so the convention check compares that name only to itself. */
 	private void collectNamedViolations(File command, String content, List<String> violations) {
 		String baseName = DefinitionFiles.baseName(command);
 		NameConvention.collect(baseName, baseName, command.toString(), violations);
-		FrontMatter.parse(content)
-				.ifPresent(frontMatter -> collectFrontMatterViolations(command, frontMatter, violations));
+		frontMatterOf(content, command, violations).ifPresent(this::collectFrontMatterViolations);
 	}
 
-	private void collectFrontMatterViolations(File command, FrontMatter frontMatter, List<String> violations) {
-		FrontMatterChecks checks = new FrontMatterChecks(frontMatter, LABEL, command, violations);
+	private void collectFrontMatterViolations(FrontMatterChecks checks) {
 		checks.rejectDuplicateKeys();
 		checks.allowOnlyKeys(allowedFrontMatterKeys);
 		checks.checkDescription(0);
@@ -85,9 +77,5 @@ public class CommandFormatRule extends ClaudeCodeEnforcerRule {
 
 	void setAllowedModels(List<String> allowedModels) {
 		this.allowedModels = allowedModels;
-	}
-
-	void setAutoFix(boolean autoFix) {
-		this.autoFix = autoFix;
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFormatRule.java
@@ -1,0 +1,113 @@
+package io.github.adamw7.tools.enforcer.definition;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.text.FrontMatter;
+
+/**
+ * Base for the enforcer rules that validate one kind of Claude Code definition —
+ * a skill, a sub-agent, a slash command — one file at a time. All three scan a
+ * configured directory, read each definition, repair its front matter when asked
+ * to, and report everything wrong with the lot in one grouped message. They differ
+ * only in which entries of the directory carry a definition and in which front
+ * matter checks they ask for.
+ * <p>
+ * The configured directory must exist, because that is a build-setup mistake
+ * rather than a content problem; a directory holding no definitions is a pass.
+ * <p>
+ * Where {@link MultiDefinitionRule} checks a property <em>across</em> every
+ * definition of every kind at once, this base checks each definition of one kind
+ * on its own.
+ */
+abstract class DefinitionFormatRule extends ClaudeCodeEnforcerRule {
+
+	/**
+	 * How a rule's messages name the definitions it checks. The five strings are one
+	 * thing — the vocabulary of a definition kind — so they are supplied together
+	 * rather than as five positional arguments a reader has to count.
+	 *
+	 * @param directoryParameter the configuration parameter naming the directory,
+	 *                           e.g. {@code skillsDir}
+	 * @param directoryLabel     the directory as a "does not exist" message names
+	 *                           it, e.g. {@code Skills}
+	 * @param definitionLabel    one definition as a whole-file message names it,
+	 *                           e.g. {@code Sub-agent definition}
+	 * @param frontMatterLabel   the kind as a front matter message names it, e.g.
+	 *                           {@code Sub-agent}
+	 * @param header             the header prefixing the grouped report
+	 */
+	record Naming(String directoryParameter, String directoryLabel, String definitionLabel,
+			String frontMatterLabel, String header) {
+	}
+
+	private final Naming naming;
+
+	/** When true, a malformed front matter block is rewritten in place instead of failing the build. */
+	private boolean autoFix;
+
+	protected DefinitionFormatRule(Naming naming) {
+		this.naming = naming;
+	}
+
+	@Override
+	public final void execute() throws EnforcerRuleException {
+		File directory = definitionDir();
+		requireConfigured(directory, naming.directoryParameter());
+		DefinitionFiles.verifyDirectory(directory, naming.directoryLabel());
+		List<String> violations = new ArrayList<>();
+		for (File entry : entriesIn(directory)) {
+			collectEntryViolations(entry, violations);
+		}
+		report(naming.header(), violations);
+	}
+
+	/** The directory to scan. Injected from the rule configuration. */
+	protected abstract File definitionDir();
+
+	/** The entries of {@code directory} that each carry one definition. */
+	protected abstract File[] entriesIn(File directory);
+
+	/** Collects everything wrong with the definition that {@code entry} carries. */
+	protected abstract void collectEntryViolations(File entry, List<String> violations);
+
+	/**
+	 * The definition's content, auto-fixed when the rule was configured to, or empty
+	 * when a violation was collected instead of content worth checking further.
+	 */
+	protected final Optional<String> contentOf(File file, List<String> violations) {
+		return DefinitionContent.of(file, naming.definitionLabel(), autoFix, getLog(), violations);
+	}
+
+	/**
+	 * The front matter checks for a block this definition kind may leave out, or
+	 * empty when it left it out.
+	 */
+	protected final Optional<FrontMatterChecks> frontMatterOf(String content, File file, List<String> violations) {
+		return FrontMatter.parse(content)
+				.map(frontMatter -> new FrontMatterChecks(frontMatter, naming.frontMatterLabel(), file, violations));
+	}
+
+	/**
+	 * The front matter checks for a block this definition kind must declare,
+	 * reporting its absence when there is none.
+	 */
+	protected final Optional<FrontMatterChecks> requiredFrontMatterOf(String content, File file,
+			List<String> violations) {
+		Optional<FrontMatterChecks> checks = frontMatterOf(content, file, violations);
+		if (checks.isEmpty()) {
+			violations.add(naming.definitionLabel()
+					+ " must start with a YAML front matter block delimited by '---': " + file);
+		}
+		return checks;
+	}
+
+	void setAutoFix(boolean autoFix) {
+		this.autoFix = autoFix;
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -1,17 +1,11 @@
 package io.github.adamw7.tools.enforcer.definition;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import javax.inject.Named;
 
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-
-import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
-import io.github.adamw7.tools.enforcer.text.FrontMatter;
 import io.github.adamw7.tools.enforcer.text.NameConvention;
 
 /**
@@ -31,7 +25,7 @@ import io.github.adamw7.tools.enforcer.text.NameConvention;
  * found are reported together.
  */
 @Named("skillFilesExist")
-public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
+public class SkillFilesExistRule extends DefinitionFormatRule {
 
 	private static final String SKILL_FILE_NAME = "SKILL.md";
 	private static final List<String> DEFAULT_REQUIRED_KEYS = List.of("name", "description");
@@ -49,48 +43,35 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 	/** Maximum allowed description length. */
 	private int maxDescriptionLength = DEFAULT_MAX_DESCRIPTION_LENGTH;
 
-	/** When true, a malformed front matter block is rewritten in place instead of failing the build. */
-	private boolean autoFix;
-
-	@Override
-	public void execute() throws EnforcerRuleException {
-		requireConfigured(skillsDir, "skillsDir");
-		DefinitionFiles.verifyDirectory(skillsDir, "Skills");
-		List<String> violations = new ArrayList<>();
-		for (File skillDirectory : DefinitionFiles.subdirectories(skillsDir)) {
-			collectSkillViolations(skillDirectory, violations);
-		}
-		report("Skill files are not well formed:", violations);
+	public SkillFilesExistRule() {
+		super(new Naming("skillsDir", "Skills", SKILL_FILE_NAME, SKILL_FILE_NAME,
+				"Skill files are not well formed:"));
 	}
 
-	private void collectSkillViolations(File skillDirectory, List<String> violations) {
+	@Override
+	protected File definitionDir() {
+		return skillsDir;
+	}
+
+	/** A skill is a directory, and the definition it carries is the {@code SKILL.md} inside it. */
+	@Override
+	protected File[] entriesIn(File directory) {
+		return DefinitionFiles.subdirectories(directory);
+	}
+
+	@Override
+	protected void collectEntryViolations(File skillDirectory, List<String> violations) {
 		File skillFile = new File(skillDirectory, SKILL_FILE_NAME);
 		if (!skillFile.isFile()) {
 			violations.add("Missing " + SKILL_FILE_NAME + " in skill directory: " + skillDirectory);
-		} else {
-			collectContentViolations(skillDirectory, skillFile, violations);
+			return;
 		}
+		contentOf(skillFile, violations)
+				.flatMap(content -> requiredFrontMatterOf(content, skillFile, violations))
+				.ifPresent(checks -> collectFrontMatterViolations(skillDirectory, checks));
 	}
 
-	private void collectContentViolations(File skillDirectory, File skillFile, List<String> violations) {
-		DefinitionContent.of(skillFile, SKILL_FILE_NAME, autoFix, getLog(), violations)
-				.ifPresent(content -> collectParsedViolations(skillDirectory, skillFile, content, violations));
-	}
-
-	private void collectParsedViolations(File skillDirectory, File skillFile, String content,
-			List<String> violations) {
-		Optional<FrontMatter> frontMatter = FrontMatter.parse(content);
-		if (frontMatter.isEmpty()) {
-			violations.add(SKILL_FILE_NAME + " must start with a YAML front matter block delimited by '---': "
-					+ skillFile);
-		} else {
-			collectFrontMatterViolations(skillDirectory, skillFile, frontMatter.get(), violations);
-		}
-	}
-
-	private void collectFrontMatterViolations(File skillDirectory, File skillFile, FrontMatter frontMatter,
-			List<String> violations) {
-		FrontMatterChecks checks = new FrontMatterChecks(frontMatter, SKILL_FILE_NAME, skillFile, violations);
+	private void collectFrontMatterViolations(File skillDirectory, FrontMatterChecks checks) {
 		checks.requireKeys(Objects.requireNonNullElse(requiredKeys, DEFAULT_REQUIRED_KEYS));
 		checks.rejectDuplicateKeys();
 		checks.allowOnlyKeys(allowedFrontMatterKeys);
@@ -112,9 +93,5 @@ public class SkillFilesExistRule extends ClaudeCodeEnforcerRule {
 
 	void setMaxDescriptionLength(int maxDescriptionLength) {
 		this.maxDescriptionLength = maxDescriptionLength;
-	}
-
-	void setAutoFix(boolean autoFix) {
-		this.autoFix = autoFix;
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -1,17 +1,10 @@
 package io.github.adamw7.tools.enforcer.definition;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import javax.inject.Named;
-
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-
-import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
-import io.github.adamw7.tools.enforcer.text.FrontMatter;
 
 /**
  * Enforcer rule that fails the build when any sub-agent definition under the
@@ -28,10 +21,8 @@ import io.github.adamw7.tools.enforcer.text.FrontMatter;
  * is allowed; all problems found are reported together.
  */
 @Named("subAgentFormat")
-public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
+public class SubAgentFormatRule extends DefinitionFormatRule {
 
-	private static final String LABEL = "Sub-agent";
-	private static final String DEFINITION = "Sub-agent definition";
 	private static final List<String> DEFAULT_REQUIRED_KEYS = List.of("name", "description");
 
 	/** The {@code .claude/agents} directory to scan. Injected from the rule configuration. */
@@ -43,37 +34,29 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 	/** Optional whitelist of model identifiers a sub-agent may declare. */
 	private List<String> allowedModels;
 
-	/** When true, a malformed front matter block is rewritten in place instead of failing the build. */
-	private boolean autoFix;
+	public SubAgentFormatRule() {
+		super(new Naming("agentsDir", "Agents", "Sub-agent definition", "Sub-agent",
+				"Sub-agent files are not well formed:"));
+	}
 
 	@Override
-	public void execute() throws EnforcerRuleException {
-		requireConfigured(agentsDir, "agentsDir");
-		DefinitionFiles.verifyDirectory(agentsDir, "Agents");
-		List<String> violations = new ArrayList<>();
-		for (File definition : DefinitionFiles.markdownFiles(agentsDir)) {
-			collectDefinitionViolations(definition, violations);
-		}
-		report("Sub-agent files are not well formed:", violations);
+	protected File definitionDir() {
+		return agentsDir;
 	}
 
-	private void collectDefinitionViolations(File definition, List<String> violations) {
-		DefinitionContent.of(definition, DEFINITION, autoFix, getLog(), violations)
-				.ifPresent(content -> collectParsedViolations(definition, content, violations));
+	@Override
+	protected File[] entriesIn(File directory) {
+		return DefinitionFiles.markdownFiles(directory);
 	}
 
-	private void collectParsedViolations(File definition, String content, List<String> violations) {
-		Optional<FrontMatter> frontMatter = FrontMatter.parse(content);
-		if (frontMatter.isEmpty()) {
-			violations.add(DEFINITION + " must start with a YAML front matter block delimited by '---': "
-					+ definition);
-		} else {
-			collectFrontMatterViolations(definition, frontMatter.get(), violations);
-		}
+	@Override
+	protected void collectEntryViolations(File definition, List<String> violations) {
+		contentOf(definition, violations)
+				.flatMap(content -> requiredFrontMatterOf(content, definition, violations))
+				.ifPresent(checks -> collectFrontMatterViolations(definition, checks));
 	}
 
-	private void collectFrontMatterViolations(File definition, FrontMatter frontMatter, List<String> violations) {
-		FrontMatterChecks checks = new FrontMatterChecks(frontMatter, LABEL, definition, violations);
+	private void collectFrontMatterViolations(File definition, FrontMatterChecks checks) {
 		checks.requireKeys(Objects.requireNonNullElse(requiredKeys, DEFAULT_REQUIRED_KEYS));
 		checks.rejectDuplicateKeys();
 		checks.checkName(DefinitionFiles.baseName(definition));
@@ -91,9 +74,5 @@ public class SubAgentFormatRule extends ClaudeCodeEnforcerRule {
 
 	void setAllowedModels(List<String> allowedModels) {
 		this.allowedModels = allowedModels;
-	}
-
-	void setAutoFix(boolean autoFix) {
-		this.autoFix = autoFix;
 	}
 }


### PR DESCRIPTION
skillFilesExist, subAgentFormat and commandFormat each carried the same
skeleton: require the directory parameter, verify the directory exists, scan
it, collect per-entry violations, report them together — plus their own copy of
the autoFix parameter and, for two of them, the same read-content-then-require-
front-matter block down to the wording of the message.

Move all of that into a DefinitionFormatRule base. A subclass now supplies the
Naming its messages use, the directory, which entries carry a definition
(*.md files, or subdirectories for skills), and the checks it asks for, reaching
for contentOf/frontMatterOf/requiredFrontMatterOf instead of reading and parsing
again. Behaviour and every message are unchanged.

Document the base in AGENTS.md beside the MarkdownFormatRule one it mirrors, and
in the enforcer-rules skill next to MultiDefinitionRule, so a new per-kind rule
starts from it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M29Zh2udj4g1E5NtB6doDB