### PR TITLE
fix(claude-code-enforcer): three ways a check read text its author had retired

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
@@ -58,7 +58,7 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 
 	@Override
 	protected void collectAdditionalViolations(MarkdownDocument document, List<String> violations) {
-		if (!document.containsOutsideFences(AGENTS_REFERENCE)) {
+		if (!document.containsInProse(AGENTS_REFERENCE)) {
 			violations.add("CLAUDE.md must reference " + AGENTS_REFERENCE + " as the source of truth");
 		}
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
@@ -31,9 +31,10 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * <p>
  * Imports are recognised the way Claude Code evaluates them: an {@code @} preceded
  * by start-of-line or whitespace and followed by a path — one carrying a directory
- * separator, an extension, or both — outside fenced code blocks and inline code
- * spans, so neither {@code `@claude`} nor a bare {@code @claude} in prose is an
- * import. A
+ * separator, an extension, or both — outside fenced code blocks, HTML comments and
+ * inline code spans, so neither {@code `@claude`} nor a bare {@code @claude} in
+ * prose is an import, and an import an author commented out is one the document no
+ * longer makes. A
  * home-relative import ({@code @~/...}) does not match the path syntax at all and
  * so is skipped, as is any import the {@code ignored} predicate accepts. A file
  * that cannot be read as text is treated as a leaf rather than a failure, because
@@ -122,7 +123,7 @@ final class ImportGraph {
 	private List<Reference> referencesIn(File file) {
 		MarkdownDocument document = MarkdownDocument.parse(readSafely(file));
 		return IntStream.range(0, document.lineCount())
-				.filter(index -> !document.isInsideFence(index))
+				.filter(index -> !document.isInsideFence(index) && !document.isInsideComment(index))
 				.mapToObj(document::line)
 				.flatMap(line -> lineReferences(file, line))
 				.toList();

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -33,9 +33,10 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
  * <p>
  * Imports are recognised the way Claude Code evaluates them: an {@code @} preceded
  * by start-of-line or whitespace and followed by a path — one carrying a directory
- * separator, an extension, or both — outside fenced code blocks and inline code
- * spans, so neither {@code `@claude`} nor a bare {@code @claude} in prose is an
- * import. A
+ * separator, an extension, or both — outside fenced code blocks, HTML comments and
+ * inline code spans, so neither {@code `@claude`} nor a bare {@code @claude} in
+ * prose is an import, and an import an author commented out is one the document no
+ * longer makes. A
  * home-relative import ({@code @~/...}) points at machine-specific state a build
  * cannot see and is skipped, as is any import listed in {@code ignoredImports}.
  * Each file is scanned once; all problems found are reported together.

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -205,7 +205,7 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 			return;
 		}
 		for (String token : forbiddenTokens) {
-			if (document.containsOutsideFences(token)) {
+			if (document.containsInProse(token)) {
 				violations.add(documentName() + " must not contain forbidden token: " + token);
 			}
 		}
@@ -235,12 +235,13 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	/**
-	 * Links are read outside code fences and inline code spans alike, so a sample
-	 * link written as {@code `[label](example.md)`} is documentation rather than a
-	 * reference this rule must resolve on disk.
+	 * Links are read outside code fences, HTML comments and inline code spans alike,
+	 * so a sample link written as {@code `[label](example.md)`} is documentation
+	 * rather than a reference this rule must resolve on disk, and a link an author
+	 * commented out is one the document no longer makes.
 	 */
 	private void collectLineReferences(MarkdownDocument document, int index, File baseDir, List<String> violations) {
-		if (document.isInsideFence(index)) {
+		if (document.isInsideFence(index) || document.isInsideComment(index)) {
 			return;
 		}
 		Matcher matcher = MARKDOWN_LINK.matcher(MarkdownText.withoutCodeSpans(document.line(index)));

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -220,31 +220,83 @@ public final class FrontMatter {
 
 	/**
 	 * The value with a trailing YAML comment removed. A {@code #} that opens a
-	 * comment stands outside quotes and follows whitespace, which is what separates
-	 * the note in {@code name: git-commit # the commit helper} from the value in
-	 * {@code version: 1.0#2}. Keeping the note made a name break the kebab-case
-	 * convention it follows and a description count characters a YAML loader — and
-	 * so Claude Code — never reads.
+	 * comment stands outside a quoted scalar and follows whitespace, which is what
+	 * separates the note in {@code name: git-commit # the commit helper} from the
+	 * value in {@code version: 1.0#2}. Keeping the note made a name break the
+	 * kebab-case convention it follows and a description count characters a YAML
+	 * loader — and so Claude Code — never reads.
+	 * <p>
+	 * Only a quote that opens the value quotes it, as YAML reads it: a {@code '}
+	 * anywhere else is an apostrophe in a plain scalar. Treating every quote
+	 * character as an opening one left {@code Don't stop # a note} inside a scalar
+	 * that never closed, and the note was kept as part of the description — the very
+	 * characters this exists to drop.
 	 */
 	private static String withoutComment(String value) {
-		char quote = NONE;
-		for (int i = 0; i < value.length(); i++) {
-			char character = value.charAt(i);
-			if (quote != NONE) {
-				i += isEscape(quote, character) ? 1 : 0;
-				quote = character == quote ? NONE : quote;
-			} else if (character == DOUBLE_QUOTE || character == SINGLE_QUOTE) {
-				quote = character;
-			} else if (character == COMMENT_START && startsComment(value, i)) {
-				return value.substring(0, i).strip();
-			}
-		}
-		return value;
+		int comment = indexOfComment(value);
+		return comment < 0 ? value : value.substring(0, comment).strip();
 	}
 
-	/** A backslash escapes the next character inside a double-quoted scalar, but not a single-quoted one. */
-	private static boolean isEscape(char quote, char character) {
-		return quote == DOUBLE_QUOTE && character == ESCAPE;
+	/**
+	 * Where a trailing comment begins, or {@code -1} when the value carries none. The
+	 * search starts past a quoted scalar, since a {@code #} inside quotes is content;
+	 * a quoted scalar that never closes is malformed, so nothing after it is read as a
+	 * comment either.
+	 */
+	private static int indexOfComment(String value) {
+		int from = endOfQuotedScalar(value);
+		if (from < 0) {
+			return -1;
+		}
+		for (int i = from; i < value.length(); i++) {
+			if (value.charAt(i) == COMMENT_START && startsComment(value, i)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * The index just past the value's opening quoted scalar, {@code 0} when it opens
+	 * with no quote, or {@code -1} when the scalar it opens never closes.
+	 */
+	private static int endOfQuotedScalar(String value) {
+		char quote = value.isEmpty() ? NONE : value.charAt(0);
+		if (quote != DOUBLE_QUOTE && quote != SINGLE_QUOTE) {
+			return 0;
+		}
+		return indexOfClosingQuote(value, 1, quote);
+	}
+
+	/**
+	 * The index just past the {@code quote} that closes a scalar opened at the start
+	 * of {@code value}, or {@code -1} when none does. The escape each quoting style
+	 * uses is stepped over rather than read as that closing quote.
+	 */
+	private static int indexOfClosingQuote(String value, int from, char quote) {
+		int index = from;
+		while (index < value.length() && !closesAt(value, index, quote)) {
+			index += isEscapeAt(value, index, quote) ? 2 : 1;
+		}
+		return index < value.length() ? index + 1 : -1;
+	}
+
+	/** True when the character at {@code index} is the quote that ends the scalar. */
+	private static boolean closesAt(String value, int index, char quote) {
+		return value.charAt(index) == quote && !isEscapeAt(value, index, quote);
+	}
+
+	/**
+	 * True when the character at {@code index} opens an escape: a backslash inside a
+	 * double-quoted scalar, or the first of the doubled quotes a single-quoted one
+	 * writes an apostrophe with.
+	 */
+	private static boolean isEscapeAt(String value, int index, char quote) {
+		char character = value.charAt(index);
+		if (quote == DOUBLE_QUOTE) {
+			return character == ESCAPE;
+		}
+		return character == SINGLE_QUOTE && value.startsWith(ESCAPED_SINGLE_QUOTE, index);
 	}
 
 	/** A {@code #} opens a comment at the start of the value or after whitespace, never mid-token. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -79,6 +79,16 @@ public final class MarkdownDocument {
 		return insideFence[index];
 	}
 
+	/**
+	 * True when the line at {@code index} sits inside an HTML comment. A caller that
+	 * reads a line for what it says — a link to resolve, an import to follow — asks
+	 * this as well as {@link #isInsideFence}, because commented-out text is inert:
+	 * following it reports a violation about content the author had already removed.
+	 */
+	public boolean isInsideComment(int index) {
+		return insideComment[index];
+	}
+
 	/** The first line that is not blank, stripped of surrounding whitespace, or empty if none. */
 	public String firstNonBlankLine() {
 		return MarkdownText.firstNonBlankLine(lines.stream());
@@ -98,9 +108,14 @@ public final class MarkdownDocument {
 		return outsideFences().filter(index -> !insideComment[index]);
 	}
 
-	/** True when {@code token} appears on a line outside a fenced code block. */
-	public boolean containsOutsideFences(String token) {
-		return outsideFences().anyMatch(index -> lines.get(index).contains(token));
+	/**
+	 * True when {@code token} appears on a line that carries document structure:
+	 * outside fenced code blocks and outside HTML comments alike. A commented-out
+	 * mention is inert both ways round — it must not satisfy a check that demands the
+	 * token, and must not trip one that forbids it.
+	 */
+	public boolean containsInProse(String token) {
+		return structuralLines().anyMatch(index -> lines.get(index).contains(token));
 	}
 
 	/** The heading lines outside fenced code blocks and HTML comments, in document order. */
@@ -207,18 +222,34 @@ public final class MarkdownDocument {
 
 	/**
 	 * Marks line {@code index} as commented or not and returns whether a comment is
-	 * still open afterwards.
+	 * still open afterwards. A line is inert when a comment was already open at its
+	 * start, or when its own content opens one it does not close; whether a comment
+	 * remains open is read from every delimiter on the line rather than from its
+	 * first characters, so a comment opened after text — {@code Superseded: <!--} —
+	 * still hides the lines below it.
 	 */
 	private static boolean applyComment(String line, boolean open, boolean insideFence, boolean[] mask, int index) {
 		if (insideFence) {
 			return open;
 		}
-		if (open) {
-			mask[index] = true;
-			return !line.contains(COMMENT_END);
-		}
-		mask[index] = line.startsWith(COMMENT_START) && !line.contains(COMMENT_END);
-		return mask[index];
+		mask[index] = open || opensBlock(line);
+		return remainsOpen(line, 0, open);
+	}
+
+	/** True when the line's own content starts a comment that the same line does not close. */
+	private static boolean opensBlock(String line) {
+		return line.startsWith(COMMENT_START) && remainsOpen(line, 0, false);
+	}
+
+	/**
+	 * Whether a comment is open once {@code line} has been read from {@code from},
+	 * following each delimiter in turn: an open comment looks for its {@code -->},
+	 * a closed one for the next {@code <!--}.
+	 */
+	private static boolean remainsOpen(String line, int from, boolean open) {
+		String delimiter = open ? COMMENT_END : COMMENT_START;
+		int next = line.indexOf(delimiter, from);
+		return next < 0 ? open : remainsOpen(line, next + delimiter.length(), !open);
 	}
 
 	/**

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -200,6 +200,36 @@ class ClaudeMdFormatRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
+	/** Commented-out text is inert, so a token an author retired no longer trips the ban. */
+	@Test
+	void ignoresAForbiddenTokenInsideAnHtmlComment() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n<!--\nTODO: finish this.\n-->\n");
+		rule.setForbiddenTokens(java.util.List.of("TODO"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/** The same reading the other way round: a commented-out mention satisfies nothing. */
+	@Test
+	void failsWhenTheAgentsReferenceAppearsOnlyInsideAnHtmlComment() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace(
+				"See [AGENTS.md](AGENTS.md) for the full agent guide.",
+				"<!--\nSee [AGENTS.md](AGENTS.md) for the full agent guide.\n-->"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("must reference AGENTS.md"), exception.getMessage());
+	}
+
+	/** A link an author commented out is one the document no longer makes. */
+	@Test
+	void ignoresAFileReferenceInsideAnHtmlComment() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md\n");
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n<!--\nWas: [gone](docs/absent.md)\n-->\n");
+		rule.setValidateFileReferences(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
 	@Test
 	void ignoresAForbiddenTokenInsideATildeFence() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n~~~\nTODO inside code\n~~~\n");

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
@@ -71,6 +71,12 @@ class MemoryImportsRuleTest {
 		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nan `@claude`-mention workflow\n")::execute);
 	}
 
+	/** An import an author commented out is one the document no longer makes. */
+	@Test
+	void ignoresImportsInsideAnHtmlComment() {
+		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\n<!--\nWas: @docs/absent.md\n-->\n")::execute);
+	}
+
 	/** A mention is a word, not a path, so it names no file the build could be failed over. */
 	@Test
 	void ignoresABareMentionThatNamesNoPath() {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -271,6 +271,40 @@ class FrontMatterTest {
 		assertEquals(Optional.of("issue#7"), frontMatter.orElseThrow().value("name"));
 	}
 
+	/**
+	 * Only a quote that opens the value quotes it. Reading the apostrophe as an
+	 * opening quote left a scalar that never closed, and the trailing note was kept
+	 * as part of the description Claude Code never sees it in.
+	 */
+	@Test
+	void dropsATrailingCommentAfterAnApostropheInAPlainScalar() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\ndescription: Don't stop # a note\n---\n");
+
+		assertEquals(Optional.of("Don't stop"), frontMatter.orElseThrow().value("description"));
+	}
+
+	@Test
+	void dropsATrailingCommentAfterADoubleQuoteInAPlainScalar() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\nname: say \"hi\" now # a note\n---\n");
+
+		assertEquals(Optional.of("say \"hi\" now"), frontMatter.orElseThrow().value("name"));
+	}
+
+	@Test
+	void dropsATrailingCommentAfterASingleQuotedScalarWithAnEscapedQuote() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\ndescription: 'it''s here' # a note\n---\n");
+
+		assertEquals(Optional.of("it's here"), frontMatter.orElseThrow().value("description"));
+	}
+
+	/** A scalar whose quote never closes is malformed, so nothing after it is read as a comment either. */
+	@Test
+	void keepsEverythingAfterAnUnclosedQuotedScalar() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\ndescription: \"oops # a note\n---\n");
+
+		assertEquals(Optional.of("\"oops # a note"), frontMatter.orElseThrow().value("description"));
+	}
+
 	@Test
 	void keepsAHashInsideQuotes() {
 		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\ndescription: \"tag # here\"\n---\n");

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
@@ -151,7 +151,7 @@ class MarkdownDocumentTest {
 				""");
 
 		assertEquals(List.of(0, 1, 2), fencedLines(document));
-		assertTrue(document.containsOutsideFences("TODO"));
+		assertTrue(document.containsInProse("TODO"));
 	}
 
 	@Test
@@ -164,7 +164,7 @@ class MarkdownDocumentTest {
 				````
 				""");
 
-		assertFalse(document.containsOutsideFences("TODO"));
+		assertFalse(document.containsInProse("TODO"));
 	}
 
 	@Test
@@ -283,8 +283,80 @@ class MarkdownDocumentTest {
 		assertTrue(document.hasBody("## Testing"));
 	}
 
+	/**
+	 * A comment opened after text on its line still hides what follows. Reading only
+	 * the first characters of the line left the block unopened, and the heading it
+	 * was written to retire went on satisfying the check that demands it.
+	 */
+	@Test
+	void doesNotTreatAHeadingHiddenByACommentOpenedAfterTextAsAHeading() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				Superseded, kept for reference: <!--
+				## Testing
+				Body.
+				-->
+
+				## Maven
+				Body.
+				""");
+
+		assertEquals(Set.of("# Title", "## Maven"), document.headings());
+	}
+
+	/** A line that closes one comment and opens another leaves the next line commented. */
+	@Test
+	void keepsACommentOpenedAfterAClosedOneOpen() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				<!-- a --> <!--
+				## Testing
+				-->
+
+				## Maven
+				Body.
+				""");
+
+		assertEquals(Set.of("# Title", "## Maven"), document.headings());
+	}
+
+	/** A commented-out mention is inert: it neither satisfies a required token nor trips a forbidden one. */
+	@Test
+	void doesNotFindATokenInsideAnHtmlComment() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				<!--
+				TODO left behind
+				-->
+				""");
+
+		assertFalse(document.containsInProse("TODO"));
+	}
+
+	@Test
+	void marksTheLinesAnHtmlCommentSpansAsCommented() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				<!--
+				A note.
+				-->
+				Body.
+				""");
+
+		assertEquals(List.of(2, 3, 4), commentedLines(document));
+	}
+
 	/** The indices of the lines the document masks as fenced code, in document order. */
 	private static List<Integer> fencedLines(MarkdownDocument document) {
 		return IntStream.range(0, document.lineCount()).filter(document::isInsideFence).boxed().toList();
+	}
+
+	/** The indices of the lines the document masks as an HTML comment, in document order. */
+	private static List<Integer> commentedLines(MarkdownDocument document) {
+		return IntStream.range(0, document.lineCount()).filter(document::isInsideComment).boxed().toList();
 	}
 }


### PR DESCRIPTION
The HTML-comment mask MarkdownDocument builds was only consulted by heading
detection, and it missed a comment opened after text on its line. Three checks
therefore read commented-out content as if it were live:

- memoryImports followed an @path import inside a comment and failed the build
  over a file the document no longer names;
- validateFileReferences resolved a Markdown link inside a comment the same way;
- forbiddenTokens tripped on a token an author had already retired, while the
  mirror case let a commented-out AGENTS.md mention satisfy the reference
  claudeMdFormat demands.

A comment opened mid-line - "Superseded: <!--" - left the block unopened
altogether, so the section it was written to retire went on satisfying the
required-heading check.

Expose isInsideComment, rename containsOutsideFences to containsInProse now
that it skips comments too, and track the open state from every delimiter on a
line rather than its first characters.

Separately, FrontMatter read a quote anywhere in a value as opening a quoted
scalar, so the apostrophe in "Don't stop # a note" opened one that never closed
and the trailing comment was kept as part of the description. Only a quote that
opens the value quotes it, as YAML reads it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BiGZgxVkNhXsL9nEpA9mxm