### PR TITLE
docs(skills): teach the review skills the defects this repository ships

### DIFF
--- a/.claude/skills/java-code-review/README.md
+++ b/.claude/skills/java-code-review/README.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-Systematic code review checklist for Java projects. Covers null safety, exception handling, collections, concurrency, idioms, resource management, API design, and performance.
+Systematic code review for this repo. Leads with the rules the build fails on, then the five defect shapes this repository actually ships fixes for, then the general Java checks: null safety, exception handling, collections, concurrency, idioms, resource management, API design, and performance.
 
 ---
 
@@ -31,6 +31,7 @@ Systematic code review checklist for Java projects. Covers null safety, exceptio
 
 ## Checklist Categories
 
+0. **Enforced repo rules** - what ArchUnit and Surefire fail the build on
 1. **Null Safety** - NPE risks, Optional usage
 2. **Exception Handling** - Swallowed exceptions, stack traces
 3. **Collections & Streams** - Iteration, mutability
@@ -39,11 +40,14 @@ Systematic code review checklist for Java projects. Covers null safety, exceptio
 6. **Resource Management** - try-with-resources
 7. **API Design** - Boolean params, validation
 8. **Performance** - String concat, N+1 queries
+9. **Defect shapes** - hand-rolled readers, drifting duplicate implementations,
+   command transcripts, success reported for work never done, credential paths
 
 ---
 
 ## Notes / Tips
 
+- Section 9 is the high-yield pass here; sections 1–8 are the generic checks
 - Works best on focused changes (single class or PR)
 - Includes positive feedback section for good practices
 - Suggests tests for edge cases found during review

--- a/.claude/skills/java-code-review/SKILL.md
+++ b/.claude/skills/java-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: java-code-review
-description: Systematic Java code review for the tools repo — leads with the ArchUnit-enforced rules the build fails on, then null safety, exceptions, concurrency, and performance. Use when the user says "review code", "check this PR", "code review", or before merging changes.
+description: Systematic Java code review for the tools repo — leads with the ArchUnit-enforced rules the build fails on, then the five defect shapes this repository actually ships fixes for, then null safety, exceptions, concurrency, and performance. Use when the user says "review code", "check this PR", "code review", or before merging changes.
 ---
 
 # Java Code Review Skill
@@ -15,11 +15,13 @@ fails the build, not just review — then work through the general Java checks.
 - After implementing a feature
 
 ## Review Strategy
-1. **Enforced-rules pass first** — anything below fails the build, so flag it as
-   Critical regardless of how the code otherwise reads.
-2. **Checklist pass** — null safety, exceptions, collections, concurrency,
+1. **Enforced-rules pass first** (section 0) — anything there fails the build, so
+   flag it as Critical regardless of how the code otherwise reads.
+2. **Defect-shapes pass** (section 9) — the five shapes this repo actually ships
+   fixes for. Highest yield after section 0; a generic checklist misses all five.
+3. **Checklist pass** — null safety, exceptions, collections, concurrency,
    idioms, resources, API, performance.
-3. **Summary** — findings by severity (Critical → Minor), with line references.
+4. **Summary** — findings by severity (Critical → Minor), with line references.
 
 ## Output Format
 
@@ -202,6 +204,110 @@ access patterns, object churn in tight loops, not using primitive streams
 
 ---
 
+## 9. The defect shapes this repo actually ships
+
+Sections 1–8 are the general Java checks. They are worth running, but on the
+evidence of this repository's own history they are not where its bugs are: of the
+last 26 `fix(...)` commits, **almost none** would have been caught by them. These
+five shapes would have been. Review for them explicitly.
+
+### 9.1 A hand-rolled reader meeting real input
+
+The largest class by a distance — `FrontMatter`, `CommandTokens`,
+`MarkdownDocument`, `ImportGraph` and `MarkdownFormatRule` account for most of
+the fix commits here. Every one was input the reader was not written for: a
+comment opened after text on its line, an apostrophe read as an opening quote, a
+newline inside a hook command, `[logo](assets/logo(1).png)`, a bare `@claude`
+mention read as a memory import.
+
+**Ask:**
+- Does this track state across the whole line, or does it `startsWith` /
+  `contains` and hope? A delimiter can appear anywhere, and twice.
+- Does the regex stop at the *first* closing delimiter when the content can nest?
+- Is markup matched *after* `withoutCodeSpans` and the fence/comment masks, or
+  before?
+- Does an unterminated construct at end of file leave the mask in a sane state?
+
+**Load the `text-parsers` skill** before changing any of these — it carries each
+reader's invariants and the full adversarial-input checklist.
+
+### 9.2 Two implementations of one format, drifting
+
+`ClaudeMdConformer` duplicates `claudeMdFormat`'s reading of a Markdown document
+because `adopt` must not ship the maven-enforcer API. #536 was four defects from
+exactly that copy drifting: the conformer produced a document the rule it exists
+to satisfy rejects, so the adoption failed its own `VerifyStep` on a file it had
+just reshaped to pass. #557 is the same shape one level up — detection asked
+whether a pom *depended on* the enforcer artifact rather than whether it
+*configures the rule*, so a project running `noSecrets` and no CLAUDE.md guard at
+all was reported as already guarded.
+
+**Ask:**
+- Is there a second implementation of this format, constant, or predicate
+  anywhere in the reactor? Search before assuming not.
+- Is there a test that runs the **real** other side over this side's output —
+  not a copy of what the other side is believed to want? See
+  `ClaudeMdConformerContractTest`.
+- Does the check test for the *thing it cares about*, or for a proxy that
+  correlates with it?
+
+### 9.3 Reading a command transcript
+
+The runner merges stderr into the transcript. A `git` that warns about an
+unreadable system config puts that line in with the `--porcelain` entries, and
+#539 read its fourth character onwards as a changed path — refusing a resume the
+step promises. That was the *second* time: the fix commit notes the identical
+defect had already been fixed for the origin query beside it.
+
+**Ask:**
+- Is this parsing output that can carry stderr noise? Skip lines that are not
+  well-formed entries rather than reading them as one — while still letting a
+  real entry beside the warning take effect.
+- Is captured output bounded?
+- Is the exit code checked, or only the text?
+
+### 9.4 Success reported for work that never happened
+
+The most expensive shape, because nothing downstream catches it. `git add -A`
+skips an ignored path in silence, so a file the adoption wrote stayed in the
+working tree — where `VerifyStep` went on finding it and passing — while the
+pushed branch carried nothing of it. `okfBundleFormat` returned early for an
+absent bundle and never reached `report()`, leaving a previous failing run's HTML
+on disk claiming a failure for a check that had just passed.
+
+**Ask:**
+- Does the verification read the same state the operation actually wrote — the
+  commit, not the working tree; the remote, not the local branch?
+- Does **every** exit path, including the early and empty ones, go through the
+  reporting call?
+- Can this succeed by doing nothing? Does a test assert the input was rejected
+  *before* the operation, so a no-op cannot pass it?
+
+### 9.5 A new path for a credential
+
+Three separate commits: a token in a rejected-positional message, in a `gh`
+transcript logged raw, in an MCP argument log. A `gh` without `--repo` reads the
+remote through git, which echoes a credentialled clone URL back.
+
+**Ask:**
+- Does any new message, log line, exception, or report field carry a URL or a
+  command transcript? It goes through `Redaction`.
+- Is the masking **structural** — on the type that holds the value, like
+  `CommandResult.redactedOutput()` — or does it depend on every call site
+  remembering? Prefer the former; the latter is what leaked.
+
+### Quick pass
+
+| If the diff touches… | Check |
+|---|---|
+| a parser / regex / mask | 9.1 — and load `text-parsers` |
+| a constant or predicate that exists twice | 9.2 — is there a contract test? |
+| `CommandResult`, `--porcelain`, `gh`, `git` output | 9.3, 9.5 |
+| a step that verifies, reports, or commits | 9.4 |
+| any log, message, exception, or report field | 9.5 |
+
+---
+
 ## Severity Guidelines
 
 | Severity | Criteria |
@@ -220,4 +326,7 @@ access patterns, object churn in tight loops, not using primitive streams
 - `CLAUDE.md` / `AGENTS.md` — source of truth for the enforced rules
 - Module `.architecture` tests (e.g. `ProtogenArchitectureTest`,
   `ContextArchitectureTest`, `TestConventionsArchitectureTest`)
-- Related skills: `solid-principles`, `testing-conventions`, `maven-conventions`
+- `git log --grep='^fix'` — the source of section 9; each commit body names the
+  input that broke the code and why
+- Related skills: `text-parsers` (section 9.1), `solid-principles`,
+  `testing-conventions`, `maven-conventions`

--- a/.claude/skills/text-parsers/README.md
+++ b/.claude/skills/text-parsers/README.md
@@ -1,0 +1,41 @@
+# Text Parsers
+
+**Load**: `view .claude/skills/text-parsers/SKILL.md`
+
+---
+
+## Description
+
+Carries the invariants of this repo's hand-rolled text readers —
+`MarkdownDocument`, `FrontMatter`, `MarkdownText`, `ImportGraph`, `CommandTokens`
+and the `ClaudeMdConformer` copy of them — together with the adversarial input
+that has broken each one, so a change starts from that list instead of
+rediscovering it.
+
+---
+
+## Use Cases
+
+- "The enforcer fails a document that looks fine"
+- "Add a rule that reads headings / front matter / imports"
+- "Change how a hook command is split"
+- "Keep the conformer in step with the rule it must satisfy"
+
+---
+
+## Examples
+
+```
+> view .claude/skills/text-parsers/SKILL.md
+> "Why does memoryImports follow an import inside an HTML comment?"
+→ Comment mask, isInsideComment, and the three rules that share it
+```
+
+---
+
+## Notes / Tips
+
+- Change the shared reader, not the caller — a local re-derivation is how these
+  drifted before.
+- A second copy of a format is only safe with a contract test running the real
+  rule over its output.

--- a/.claude/skills/text-parsers/SKILL.md
+++ b/.claude/skills/text-parsers/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: text-parsers
+description: Work on this repo's hand-rolled text readers — MarkdownDocument, FrontMatter, MarkdownText, ImportGraph, CommandTokens and the ClaudeMdConformer copy of them — and the adversarial input that has broken each. Use when changing how a document, YAML front matter, a memory import or a hook command is read, when a rule fires on valid input or passes invalid input, or when the user says "fence", "front matter", "heading detection", "memory import", or "hook command".
+---
+
+# Text Parsers Skill
+
+The `claude-code-enforcer` rules and the `adopt` conformer read Markdown, YAML
+front matter, `@path` imports and shell hook commands with small hand-rolled
+readers rather than a library. Those readers carry the largest share of this
+repository's shipped defects: `FrontMatter` and `CommandTokens` have each been
+fixed in six or seven separate commits, `MarkdownDocument` and
+`ClaudeMdConformer` in four or five.
+
+Every one of those fixes was the same thing — real input the reader had not been
+written for. This skill is the accumulated list, so the next change starts from
+it instead of rediscovering it.
+
+## When to Use
+- Changing any reader in `claude-code-enforcer/.../text`, `.../doc/ImportGraph`,
+  `.../settings/CommandTokens`, or `adopt`'s `ClaudeMdConformer`
+- A rule fails a valid document, or passes an invalid one
+- Adding a rule that reads document structure rather than a whole file
+- The user says "fence", "front matter", "heading", "memory import",
+  "hook command", or "the enforcer rejects a file it shouldn't"
+
+## The one rule that matters most
+
+**Change the shared reader, never the caller.** `MarkdownDocument`,
+`FrontMatter`, `MarkdownText` and `CommandTokens` exist so every rule agrees on
+what a fence, a key, a code span and a token are. A rule that re-derives one of
+those locally is how the readers drifted in the first place — a fix landed in one
+place and the other two callers kept the bug.
+
+Concretely: commit #560 fixed *three* rules at once (`memoryImports`,
+`validateFileReferences`, `forbiddenTokens`) because the comment mask they all
+share was only being consulted by heading detection. The fix was one method
+exposed on `MarkdownDocument`, not three patches.
+
+## The readers and their invariants
+
+### `MarkdownDocument`
+
+Parses lines plus two masks — fenced code, and HTML comment — once at
+construction, so structural checks share them.
+
+| Invariant | Why |
+|---|---|
+| A fence closes only on a run of the **same character**, **at least as long**, carrying **no info string** | Docs about Markdown nest fences: `~~~` inside ```` ``` ````, ```` ```java ```` inside ```` ```` ````. Closing on the first character ends the block early, then reads the real closer as a *fresh opening* one and masks the rest of the file as code. |
+| A heading is ATX — `#{1,6}` then whitespace or end of line | `#1 rule: run mvn install` is prose. Read as an H1 it ends the section above and that section gets reported empty. |
+| Headings are recognised **outside fences and outside comments** | A commented-out section must not satisfy the check that demands it. |
+| Comment state is tracked from **every delimiter on the line**, not the first characters | `Superseded: <!--` opens a block. `<!-- a --> <!-- b` ends open. Both were missed by a `startsWith`/`contains` pair. |
+| A comment inside a fence is sample text — **the fence wins** | Ordering matters: `commentMask` takes `insideFence` as input. |
+| `containsInProse` skips comments *and* fences, both directions | A commented-out mention must neither satisfy a required-token check nor trip a forbidden-token one. |
+| A blank line and a commented-out line do **not** settle whether a section has a body | A section whose only content is commented out reads as empty, which is what commenting it out meant. |
+
+### `FrontMatter`
+
+A deliberately small YAML reader, not a parser. It answers each `key: value` as
+one line of text — length, blankness, uniqueness, shape. **A rule that needs the
+structure wants a real YAML parser, not this.**
+
+| Invariant | Why |
+|---|---|
+| A key is recognised only at column 0, with `key:` or `key: value` (space or tab) | An indented line continues the value above. `Use this when:` inside a wrapped description is not a key. |
+| A value the key's line does not carry is **folded from the indented lines below** | Covers all three YAML continuations — block scalar, wrapped plain scalar, nested mapping. Reading them as `""` let every block scalar claim a one-character description and escape the length cap. |
+| Folding a mapping is **lossy on purpose** | `by: agent/1` comes back as text. |
+| A quoted value yields the text **inside** the quotes | `name: "git-commit"` failed kebab-case; every quoted description counted two characters it does not have. A description containing `: ` *must* be quoted to parse at all. |
+| Only a quote that **opens** the value quotes it | `Don't stop # a note` — the apostrophe is not an opening quote. Treating it as one left a scalar that never closed and kept the trailing comment as part of the value. |
+| A `#` opens a comment only **after whitespace, outside quotes** | `version: 1.0#2` has no comment. |
+| A key declared twice yields its **last** declaration | That is the one a YAML loader keeps, so the one Claude Code acts on. `duplicateKeys()` reports the duplication separately. |
+| Front matter opens on the **very first line** | Content reaching `---` after blank lines has no front matter, because Claude Code sees none either. |
+
+### `MarkdownText`
+
+- `read` throws `UncheckedIOException`; `readIfText` yields empty. **A rule
+  scanning a directory it does not control uses `readIfText`** — an undecodable
+  file must be reported as a malformed definition, not abort the build and take
+  the remaining definitions' violations with it.
+- `withoutCodeSpans` before matching any markup. Documentation about Markdown
+  writes its sample link or import in backticks precisely because it is a sample.
+- `write` refuses a symbolic link, so an auto-fix cannot be redirected through a
+  planted link.
+- Strip the byte-order mark on read, once, centrally.
+
+### `ImportGraph`
+
+- Built **breadth-first** so a file is first reached by its *shortest* chain —
+  Claude Code's hop limit is about the shortest chain, so a depth-first count
+  would make the rule decide differently run to run.
+- An import must **look like a path**: a separator, an extension, or both. A bare
+  `@claude` mention or an `@adamw7` handle is prose. No amount of backticking
+  every occurrence could be relied on instead.
+- Trailing sentence dots are dropped: `see @docs/setup.md.` imports
+  `docs/setup.md`.
+- A rooted `@/docs.md` resolves against **the importing file's** root, not the
+  process's — otherwise Windows picks whichever drive the build started on.
+- An unreadable target is a **leaf, not a failure**: an imported file may be any
+  format.
+
+### `CommandTokens`
+
+Splits a hook command the way a shell would.
+
+- Separators are whitespace **and** `;`, `&`, `|`, **newline**, and subshell
+  `(`/`)` — all outside quotes. A newline separates commands: a hook written
+  across several lines had every line after the first taken for arguments. Glued
+  parens invent a program named `(script.sh)`.
+- Quotes are honoured and **kept on the token** — a hook path with a space is
+  legitimate and quoted for that reason; `ClaudeProjectDir` strips them while
+  expanding.
+- Skip `VAR=value` prefixes and shell **reserved words** (`if`, `then`, `fi`, …)
+  to find the program, as a shell does. Reading the first token blindly took
+  `then` for the program.
+- An interpreter (`bash`, `python3`, `node`, …) names a script in its first
+  non-option argument — **unless** `-c` is present, alone or in a cluster like
+  `-ec`, where the argument is script text and not a path.
+- Only the program of each segment, plus an interpreted script, is a script
+  candidate. An ordinary argument that looks like a path is not: requiring
+  `--out target/log.txt` to exist fails a build over a file the hook is about to
+  write.
+
+## The two-readers problem
+
+`ClaudeMdConformer` in `adopt` spells out a second copy of `MarkdownDocument`'s
+fence and comment reading, plus `claudeMdFormat`'s required sections. It has to —
+`adopt` is a plain library and must not put the maven-enforcer API on every
+consumer's classpath.
+
+**A copy is only safe when a test proves it agrees.** The pattern here is
+`ClaudeMdConformerContractTest`: it runs the *real* rule, on a test-scoped
+dependency, over the conformer's output, and asserts the raw fixture is rejected
+first so a conformer that stopped reshaping cannot pass by doing nothing.
+
+When you touch either side:
+
+1. Change the enforcer reader.
+2. Mirror it in the conformer.
+3. Add the case to the contract test — **fixture rejected before, accepted after**.
+
+Skipping step 3 is what shipped #536: four defects where the conformer produced a
+document the rule it exists to satisfy rejects, so the adoption failed its own
+`VerifyStep` on a file it had just reshaped to pass it. On someone else's
+repository, after the branch was pushed.
+
+## Adversarial input checklist
+
+Every row has broken a reader here. Run a new or changed reader against the ones
+in its column before calling it done.
+
+| Input | Reader |
+|---|---|
+| ```` ```` ````-wrapped ```` ``` ````; `~~~` inside backticks; ```` ```java ```` as a closer | fences |
+| `#1 rule: …`; `#hashtag`; `####### seven` | headings |
+| `Superseded: <!--`; `<!-- a --> <!-- b`; comment inside a fence; unterminated comment at EOF | comments |
+| `name: "git-commit"`; `Don't stop # a note`; `version: 1.0#2`; `description: >` then indented lines; `key:` bare; a key declared twice; `key:value` with no space | front matter |
+| `[logo](assets/logo(1).png)`; a link inside backticks; a link inside a comment | links |
+| `@claude` in prose; `@adamw7`; `` `@docs/x.md` ``; `see @docs/setup.md.`; `@~/global.md`; `@/rooted.md` | imports |
+| `a.sh; b.sh`; a command across two lines; `( a.sh )`; `FOO=bar a.sh`; `if [ -n "$CI" ]; then a.sh; fi`; `bash -ec 'echo hi'`; `"my hook.sh"` | hook commands |
+| A UTF-8 BOM; a file that is not UTF-8 at all; CRLF line endings; an empty file | every file reader |
+
+## Testing
+
+- **Table-driven, one row per adversarial input.** The existing `*Test` classes
+  beside each reader are the model; add rows rather than new classes.
+- **Pin the bug, not the fix.** Each fix commit here adds a case named for the
+  input that broke it. A test that only exercises the happy path lets the next
+  refactor undo the fix silently.
+- **Assert both directions** on any check with a mirror: a commented-out token
+  must not satisfy a required-token rule *and* must not trip a forbidden-token
+  one. Half of #560 was the mirror case.
+- **Every exit path reports.** A rule that returns early for an absent or empty
+  input still calls `report()` — otherwise a configured `reportFile` keeps a
+  previous failing run's HTML on disk and `writeBaseline` records nothing.
+- Mutation testing is the sharpest tool for these readers, and
+  `claude-code-enforcer` holds an 88% threshold:
+  `mvn -Ppitest install -pl claude-code-enforcer -am`. A surviving mutant on a
+  boundary condition in a mask is very often a real gap.
+- Standard rules still apply — 5 s per unit test, JUnit 5, no `Thread.sleep`.
+  See `testing-conventions`.
+
+## Common mistakes
+
+- Reading a line with `startsWith` / `contains` where state must be tracked
+  across the whole line.
+- Matching markup before `withoutCodeSpans`, or before checking
+  `isInsideFence` / `isInsideComment`.
+- Regex that stops at the first closing delimiter — `[^)]` truncated
+  `assets/logo(1).png` and reported the half as missing.
+- Fixing one caller of a shared reader and leaving the others.
+- Adding a check to the conformer without adding its case to the contract test.
+- Reaching for a fuller YAML/Markdown model inside these readers. If a rule needs
+  real structure, that is a signal to bring in a parser deliberately — and a new
+  dependency needs asking first (see `CLAUDE.md`, *Dependencies*).
+
+## References
+- `claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/`
+  — `MarkdownDocument`, `FrontMatter`, `MarkdownText`, `FrontMatterFixer`
+- `.../enforcer/doc/ImportGraph.java`, `.../enforcer/settings/CommandTokens.java`
+- `adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java`
+  and `ClaudeMdConformerContractTest`
+- The javadoc on each reader records *why* each invariant exists — read it before
+  changing the code under it
+- Related skills: `enforcer-rules`, `adopt-pipeline`, `java-code-review`,
+  `testing-conventions`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -688,7 +688,7 @@ change the build checks.
 
 ### Skills
 
-`.claude/skills/` holds **twelve** project skills, each a directory with a
+`.claude/skills/` holds **thirteen** project skills, each a directory with a
 `SKILL.md` whose YAML front matter declares a `name` (lower-case kebab-case,
 matching the directory name) and a `description` saying both what the skill
 covers and when to load it. Skills are loaded on demand rather than into every
@@ -706,16 +706,25 @@ Six cover one module each:
 | `mcp-server` | adding a tool or server on the `mcp-common` scaffolding — the `McpTool` SPI, the three transports, path confinement, `MCP_USAGE.md`, the `*IT`s |
 | `enforcer-rules` | writing, testing and wiring a `claude-code-enforcer` rule, including `severity`/`reportFile`/`baselineFile` |
 
-Six hold across the repository:
+Seven hold across the repository:
 
 | Skill | Covers |
 | --- | --- |
 | `doc-contract` | keeping `CLAUDE.md`, `AGENTS.md` and `README.md` inside the enforced documentation contract |
 | `maven-conventions` | versions only in the root pom, version-free module poms, the profiles, clean-after-codegen |
 | `testing-conventions` | the Surefire timeouts, network-off unit tests, the ArchUnit conventions, JUnit 5 only |
-| `java-code-review` | review led by the rules the build fails on, then null safety, exceptions, concurrency, performance |
+| `java-code-review` | review led by the rules the build fails on, then the five defect shapes this repository ships fixes for, then null safety, exceptions, concurrency, performance |
+| `text-parsers` | the invariants of the hand-rolled readers — `MarkdownDocument`, `FrontMatter`, `MarkdownText`, `ImportGraph`, `CommandTokens`, the `ClaudeMdConformer` copy — and the adversarial input that has broken each |
 | `solid-principles` | the per-principle detection heuristics and the refactorings that fix them |
 | `git-commit` | conventional commit messages using this repository's real module scopes |
+
+The last two of those are the bug-finding pair, and they are written from this
+repository's own `fix(...)` history rather than from a generic checklist: the
+readers `text-parsers` covers carry the largest share of the defects fixed here,
+and section 9 of `java-code-review` generalises the rest into five shapes — a
+hand-rolled reader meeting real input, two implementations of one format
+drifting, a command transcript read as structured output, success reported for
+work that never happened, and a new path for a credential.
 
 A new skill needs no wiring: `skillFilesExist`, `uniqueNames` and
 `uniqueDescriptions` already point at `.claude/skills`, so it is validated the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,12 +273,12 @@ asked.**
 
 ## Agent configuration
 
-- `.claude/skills/` holds twelve project skills that carry the detail this file
+- `.claude/skills/` holds thirteen project skills that carry the detail this file
   only summarises — per module: `data-sources`, `context-finder`, `protogen`,
   `adopt-pipeline`, `mcp-server`, `enforcer-rules`; across the repo:
   `doc-contract`, `git-commit`, `java-code-review`, `maven-conventions`,
-  `solid-principles`, and `testing-conventions`. Prefer loading the relevant
-  skill over re-deriving a convention.
+  `solid-principles`, `testing-conventions`, and `text-parsers`. Prefer loading
+  the relevant skill over re-deriving a convention.
 - `.claude/settings.json` allows the `mvn` and archive-inspection Bash commands
   and wires the `SessionStart` hook; `.claude/hooks/session-start.sh` provisions
   the JDK and warms the Maven cache in web/remote sessions.


### PR DESCRIPTION
The twelve project skills carried no account of where this repository's bugs
actually are. `java-code-review` led with the enforced rules and then ran a
generic Java checklist -- null safety, exceptions, concurrency, performance --
and almost none of the last 26 `fix(...)` commits would have been caught by any
section of it.

Read from that history instead. The readers account for most of it: FrontMatter
and CommandTokens have each been fixed in six or seven commits, MarkdownDocument
and ClaudeMdConformer in four or five, every time on real input they were not
written for. A new `text-parsers` skill collects what each reader now knows -- a
fence closes only on the same character, at least as long, carrying no info
string; a heading is ATX so `#1 rule` is prose; comment state comes from every
delimiter on the line, so `Superseded: <!--` opens a block; only a quote that
opens a value quotes it; an import must look like a path; a newline separates
hook commands -- with the adversarial input that broke each and the contract-test
pattern that holds a duplicated reader to the rule it must satisfy. That
knowledge lived only in commit messages and javadoc, so each change rediscovered
it.

`java-code-review` gains a section 9 generalising the rest into the five shapes
the fix commits keep taking: a hand-rolled reader meeting real input, two
implementations of one format drifting apart, a command transcript read as
structured output when it also carries stderr, success reported for work that
never happened, and a new path for a credential. Each names the commit it comes
from and the questions to ask, and the review strategy now runs it as its second
pass, before the generic checklist rather than after it.

CLAUDE.md and AGENTS.md count thirteen skills.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WmKwApoy3bkdG1A9m4RSkc