### PR TITLE
fix(claude-code-enforcer): read an indented sample as the code it is

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
@@ -31,9 +31,10 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * <p>
  * Imports are recognised the way Claude Code evaluates them: an {@code @} preceded
  * by start-of-line or whitespace and followed by a path — one carrying a directory
- * separator, an extension, or both — outside fenced code blocks, HTML comments and
- * inline code spans, so neither {@code `@claude`} nor a bare {@code @claude} in
- * prose is an import, and an import an author commented out is one the document no
+ * separator, an extension, or both — outside code, HTML comments and inline code
+ * spans alike, so neither {@code `@claude`} nor a bare {@code @claude} in prose is
+ * an import, an import shown as a sample (fenced or indented) is one the document
+ * illustrates rather than makes, and one an author commented out is one it no
  * longer makes. A
  * home-relative import ({@code @~/...}) does not match the path syntax at all and
  * so is skipped, as is any import the {@code ignored} predicate accepts. A file
@@ -123,7 +124,7 @@ final class ImportGraph {
 	private List<Reference> referencesIn(File file) {
 		MarkdownDocument document = MarkdownDocument.parse(readSafely(file));
 		return IntStream.range(0, document.lineCount())
-				.filter(index -> !document.isInsideFence(index) && !document.isInsideComment(index))
+				.filter(index -> !document.isInsideCode(index) && !document.isInsideComment(index))
 				.mapToObj(document::line)
 				.flatMap(line -> lineReferences(file, line))
 				.toList();

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -33,9 +33,10 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
  * <p>
  * Imports are recognised the way Claude Code evaluates them: an {@code @} preceded
  * by start-of-line or whitespace and followed by a path — one carrying a directory
- * separator, an extension, or both — outside fenced code blocks, HTML comments and
- * inline code spans, so neither {@code `@claude`} nor a bare {@code @claude} in
- * prose is an import, and an import an author commented out is one the document no
+ * separator, an extension, or both — outside code, HTML comments and inline code
+ * spans alike, so neither {@code `@claude`} nor a bare {@code @claude} in prose is
+ * an import, an import shown as a sample (fenced or indented) is one the document
+ * illustrates rather than makes, and one an author commented out is one it no
  * longer makes. A
  * home-relative import ({@code @~/...}) points at machine-specific state a build
  * cannot see and is skipped, as is any import listed in {@code ignoredImports}.

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -21,15 +21,15 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * leading UTF-8 BOM is tolerated), and contain every required section heading as a
  * real, non-empty heading.
  * <p>
- * Headings are matched on whole lines outside fenced code blocks, so a heading
- * mentioned inside a fence or in prose does not satisfy a requirement, and a
+ * Headings are matched on whole lines outside code, so a heading mentioned in a
+ * sample — fenced or indented — or in prose does not satisfy a requirement, and a
  * partial match such as {@code # CLAUDE.md-extended} does not satisfy
  * {@code # CLAUDE.md}. All structural problems are collected and reported
  * together.
  * <p>
  * Several optional checks, each disabled by default, can be switched on from the
- * rule configuration: {@code forbiddenTokens} that must not appear outside code
- * fences, {@code enforceSectionOrder}, a {@code maxLineLength} cap, and
+ * rule configuration: {@code forbiddenTokens} that must not appear outside code,
+ * {@code enforceSectionOrder}, a {@code maxLineLength} cap, and
  * {@code validateFileReferences} to confirm that links to local files resolve on
  * disk. The title and required sections default to the subclass-provided values
  * but can be overridden, so the rule is reusable across projects without a
@@ -55,13 +55,13 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	/** Optional override for the required sections. Falls back to the subclass default. */
 	private List<String> requiredSections;
 
-	/** Optional tokens that must not appear outside fenced code blocks. */
+	/** Optional tokens that must not appear outside code. */
 	private List<String> forbiddenTokens;
 
 	/** When true, the required sections must appear in the configured order. */
 	private boolean enforceSectionOrder;
 
-	/** Maximum allowed line length outside code fences. Zero (default) disables the check. */
+	/** Maximum allowed line length outside code. Zero (default) disables the check. */
 	private int maxLineLength;
 
 	/** When true, Markdown links to local files must resolve to an existing file. */
@@ -217,7 +217,7 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 		}
 		for (int i = 0; i < document.lineCount(); i++) {
 			String line = document.line(i);
-			if (!document.isInsideFence(i) && line.length() > maxLineLength) {
+			if (!document.isInsideCode(i) && line.length() > maxLineLength) {
 				violations.add(documentName() + " line " + (i + 1) + " exceeds " + maxLineLength
 						+ " characters (" + line.length() + ")");
 			}
@@ -235,13 +235,13 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	}
 
 	/**
-	 * Links are read outside code fences, HTML comments and inline code spans alike,
-	 * so a sample link written as {@code `[label](example.md)`} is documentation
-	 * rather than a reference this rule must resolve on disk, and a link an author
+	 * Links are read outside code, HTML comments and inline code spans alike, so a
+	 * sample link written as {@code `[label](example.md)`} is documentation rather
+	 * than a reference this rule must resolve on disk, and a link an author
 	 * commented out is one the document no longer makes.
 	 */
 	private void collectLineReferences(MarkdownDocument document, int index, File baseDir, List<String> violations) {
-		if (document.isInsideFence(index) || document.isInsideComment(index)) {
+		if (document.isInsideCode(index) || document.isInsideComment(index)) {
 			return;
 		}
 		Matcher matcher = MARKDOWN_LINK.matcher(MarkdownText.withoutCodeSpans(document.line(index)));

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -9,15 +9,15 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * A parsed Markdown document: its lines plus the masks marking which of them belong
- * to a fenced code block and which sit inside an HTML comment. Parsing the masks
- * once, at construction, lets the structural checks share them instead of each
- * rebuilding them.
+ * A parsed Markdown document: its lines plus the masks marking which of them are
+ * code and which sit inside an HTML comment. Parsing the masks once, at
+ * construction, lets the structural checks share them instead of each rebuilding
+ * them.
  * <p>
- * Headings are recognised on whole lines outside fenced code blocks, so a heading
- * mentioned inside a fence or in prose is not treated as document structure. The
- * mask includes the opening and closing delimiters themselves, so heading and body
- * detection agree on what is code. A heading is an ATX one — one to six {@code #}
+ * Headings are recognised on whole lines outside code, so a heading mentioned in a
+ * sample or in prose is not treated as document structure. The mask includes a
+ * fence's opening and closing delimiters themselves, so heading and body detection
+ * agree on what is code. A heading is an ATX one — one to six {@code #}
  * characters followed by whitespace or nothing else — so a line that merely starts
  * with a hash, such as {@code #1 rule: run mvn install}, stays prose. Counting it
  * as a heading would end the section it sits in and report that section as empty.
@@ -35,12 +35,29 @@ import java.util.stream.IntStream;
  * {@code ````} wrapper all stay content. Closing on the first character alone would
  * end the block early and then treat the real closing delimiter as a fresh opening
  * one, silently masking the rest of the document as code.
+ * <p>
+ * Code is also quoted the other way Markdown allows — by indenting it four columns,
+ * a tab counting on to the next four-column stop — and those lines are masked
+ * alike. Such a block opens only where one may, after a blank line, because an
+ * indented line below a paragraph is a lazy continuation of that paragraph rather
+ * than code; it then runs on through indented and blank lines until the next line
+ * that is neither. Reading an indented sample as prose let a {@code ## Testing}
+ * shown as an example satisfy the very check that demands that section, and
+ * reported the sample's own {@code TODO} and its {@code [link](sample.md)} as the
+ * document's own — while the identical text inside a fence was correctly ignored.
  */
 public final class MarkdownDocument {
 
 	private static final char BACKTICK = '`';
 	private static final char TILDE = '~';
 	private static final int MIN_FENCE_LENGTH = 3;
+
+	private static final char TAB = '\t';
+	private static final char SPACE = ' ';
+
+	/** The indent Markdown reads as a code block, and the width a tab advances to. */
+	private static final int CODE_INDENT = 4;
+
 	private static final char HEADING_CHAR = '#';
 	private static final String COMMENT_START = "<!--";
 	private static final String COMMENT_END = "-->";
@@ -49,20 +66,20 @@ public final class MarkdownDocument {
 	private static final Pattern ATX_HEADING = Pattern.compile("#{1,6}(\\s.*)?");
 
 	private final List<String> lines;
-	private final boolean[] insideFence;
+	private final boolean[] insideCode;
 	private final boolean[] insideComment;
 
-	private MarkdownDocument(List<String> lines, boolean[] insideFence, boolean[] insideComment) {
+	private MarkdownDocument(List<String> lines, boolean[] insideCode, boolean[] insideComment) {
 		this.lines = lines;
-		this.insideFence = insideFence;
+		this.insideCode = insideCode;
 		this.insideComment = insideComment;
 	}
 
-	/** Parses {@code content} into lines, a fenced-code-block mask, and an HTML-comment mask. */
+	/** Parses {@code content} into lines, a code mask, and an HTML-comment mask. */
 	public static MarkdownDocument parse(String content) {
 		List<String> lines = content.lines().toList();
-		boolean[] insideFence = fenceMask(lines);
-		return new MarkdownDocument(lines, insideFence, commentMask(lines, insideFence));
+		boolean[] insideCode = codeMask(lines);
+		return new MarkdownDocument(lines, insideCode, commentMask(lines, insideCode));
 	}
 
 	public int lineCount() {
@@ -74,15 +91,15 @@ public final class MarkdownDocument {
 		return lines.get(index);
 	}
 
-	/** True when the line at {@code index} is part of a fenced code block. */
-	public boolean isInsideFence(int index) {
-		return insideFence[index];
+	/** True when the line at {@code index} is code, quoted by a fence or by its indent. */
+	public boolean isInsideCode(int index) {
+		return insideCode[index];
 	}
 
 	/**
 	 * True when the line at {@code index} sits inside an HTML comment. A caller that
 	 * reads a line for what it says — a link to resolve, an import to follow — asks
-	 * this as well as {@link #isInsideFence}, because commented-out text is inert:
+	 * this as well as {@link #isInsideCode}, because commented-out text is inert:
 	 * following it reports a violation about content the author had already removed.
 	 */
 	public boolean isInsideComment(int index) {
@@ -94,25 +111,24 @@ public final class MarkdownDocument {
 		return MarkdownText.firstNonBlankLine(lines.stream());
 	}
 
-	/** The indices of the lines outside fenced code blocks, in document order. */
-	private IntStream outsideFences() {
-		return IntStream.range(0, lines.size()).filter(index -> !insideFence[index]);
+	/** The indices of the lines outside code, in document order. */
+	private IntStream outsideCode() {
+		return IntStream.range(0, lines.size()).filter(index -> !insideCode[index]);
 	}
 
 	/**
-	 * The indices of the lines that can carry document structure: outside fenced code
-	 * blocks and outside HTML comments alike. A heading is only recognised on one of
-	 * these.
+	 * The indices of the lines that can carry document structure: outside code and
+	 * outside HTML comments alike. A heading is only recognised on one of these.
 	 */
 	private IntStream structuralLines() {
-		return outsideFences().filter(index -> !insideComment[index]);
+		return outsideCode().filter(index -> !insideComment[index]);
 	}
 
 	/**
 	 * True when {@code token} appears on a line that carries document structure:
-	 * outside fenced code blocks and outside HTML comments alike. A commented-out
-	 * mention is inert both ways round — it must not satisfy a check that demands the
-	 * token, and must not trip one that forbids it.
+	 * outside code and outside HTML comments alike. A commented-out mention is inert
+	 * both ways round — it must not satisfy a check that demands the token, and must
+	 * not trip one that forbids it.
 	 */
 	public boolean containsInProse(String token) {
 		return structuralLines().anyMatch(index -> lines.get(index).contains(token));
@@ -168,7 +184,7 @@ public final class MarkdownDocument {
 		return IntStream.range(headingIndex + 1, lines.size())
 				.filter(this::decidesBody)
 				.limit(1)
-				.anyMatch(index -> insideFence[index] || isBody(lines.get(index).strip(), sectionLevel));
+				.anyMatch(index -> insideCode[index] || isBody(lines.get(index).strip(), sectionLevel));
 	}
 
 	/**
@@ -178,7 +194,7 @@ public final class MarkdownDocument {
 	 * it out meant.
 	 */
 	private boolean decidesBody(int index) {
-		return insideFence[index] || (!insideComment[index] && !lines.get(index).isBlank());
+		return insideCode[index] || (!insideComment[index] && !lines.get(index).isBlank());
 	}
 
 	/** A deeper sub-heading continues the section; one at its level or shallower ends it. */
@@ -194,6 +210,21 @@ public final class MarkdownDocument {
 		return runLength(heading, HEADING_CHAR);
 	}
 
+	/**
+	 * Marks every line Markdown reads as code, both ways it is quoted: the fenced
+	 * blocks first, then the indented ones over the same mask, so a fence's own
+	 * lines are already spoken for and an indent inside one is content rather than a
+	 * block of its own.
+	 */
+	private static boolean[] codeMask(List<String> lines) {
+		boolean[] mask = fenceMask(lines);
+		boolean mayOpen = true;
+		for (int i = 0; i < lines.size(); i++) {
+			mayOpen = applyIndent(lines.get(i), mayOpen, mask, i);
+		}
+		return mask;
+	}
+
 	private static boolean[] fenceMask(List<String> lines) {
 		boolean[] mask = new boolean[lines.size()];
 		Delimiter open = null;
@@ -204,18 +235,49 @@ public final class MarkdownDocument {
 	}
 
 	/**
+	 * Marks line {@code index} as indented code or not and returns whether an
+	 * indented line below it would open a block. Only a blank line, a line already
+	 * masked as code, and the start of the document leave that open: an indented
+	 * line below a paragraph is a lazy continuation of it, which is what stops an
+	 * indented code block interrupting one. A blank line is left unmarked, since it
+	 * carries nothing to read either way.
+	 */
+	private static boolean applyIndent(String line, boolean mayOpen, boolean[] mask, int index) {
+		if (mask[index] || line.isBlank()) {
+			return true;
+		}
+		mask[index] = mayOpen && indentWidth(line) >= CODE_INDENT;
+		return mask[index];
+	}
+
+	/** The line's indent in columns, a tab counting on to the next four-column stop. */
+	private static int indentWidth(String line) {
+		int width = 0;
+		int index = 0;
+		while (index < line.length() && isIndent(line.charAt(index))) {
+			width += line.charAt(index) == TAB ? CODE_INDENT - width % CODE_INDENT : 1;
+			index++;
+		}
+		return width;
+	}
+
+	private static boolean isIndent(char character) {
+		return character == SPACE || character == TAB;
+	}
+
+	/**
 	 * Marks the lines an HTML comment spans, so a commented-out section is not read
 	 * as document structure. A comment that opens and closes on one line masks
 	 * nothing — {@code <!-- ## Testing -->} is not a heading to begin with — while a
 	 * block comment hid a required section from the check that exists to demand it
-	 * and satisfied it at the same time. A comment inside a fenced code block is
-	 * sample text, so the fence wins.
+	 * and satisfied it at the same time. A comment inside code is sample text, so
+	 * the code wins.
 	 */
-	private static boolean[] commentMask(List<String> lines, boolean[] insideFence) {
+	private static boolean[] commentMask(List<String> lines, boolean[] insideCode) {
 		boolean[] mask = new boolean[lines.size()];
 		boolean open = false;
 		for (int i = 0; i < lines.size(); i++) {
-			open = applyComment(lines.get(i).strip(), open, insideFence[i], mask, i);
+			open = applyComment(lines.get(i).strip(), open, insideCode[i], mask, i);
 		}
 		return mask;
 	}
@@ -228,8 +290,8 @@ public final class MarkdownDocument {
 	 * first characters, so a comment opened after text — {@code Superseded: <!--} —
 	 * still hides the lines below it.
 	 */
-	private static boolean applyComment(String line, boolean open, boolean insideFence, boolean[] mask, int index) {
-		if (insideFence) {
+	private static boolean applyComment(String line, boolean open, boolean insideCode, boolean[] mask, int index) {
+		if (insideCode) {
 			return open;
 		}
 		mask[index] = open || opensBlock(line);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -248,6 +248,38 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	@Test
+	void failsWhenSectionHeadingAppearsOnlyInsideAnIndentedBlock() {
+		// Indenting four columns is the other way Markdown quotes a sample, so a
+		// heading shown as an example must no more satisfy the requirement than one
+		// inside a fence does.
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing\nWrite unit tests for all new logic.\n",
+				"For example:\n\n    ## Testing\n\n    Write unit tests for all new logic.\n"));
+
+		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(exception.getMessage().contains("missing required section heading: ## Testing"),
+				exception.getMessage());
+	}
+
+	@Test
+	void treatsAForbiddenTokenInsideAnIndentedBlockAsSampleCode() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nFor example:\n\n    TODO in a sample\n");
+		rule.setForbiddenTokens(java.util.List.of("TODO"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void treatsALinkInsideAnIndentedBlockAsSampleCode() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nFor example:\n\n    See [guide](example.md).\n");
+		rule.setValidateFileReferences(true);
+
+		// The sample's target names no file this document links to, so requiring it to
+		// exist failed the build over a file the author never meant to ship.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
 	void treatsABacktickLineInsideATildeFenceAsCode() {
 		// The ``` does not close the ~~~ block, so the ## Testing heading between the
 		// two backtick lines stays code and the required section is reported missing.

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
@@ -66,6 +66,12 @@ class MemoryImportsRuleTest {
 		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\n```\n@docs/absent.md\n```\n")::execute);
 	}
 
+	/** An import shown as an indented sample is one the document illustrates, not one it makes. */
+	@Test
+	void ignoresImportsInIndentedCodeBlocks() {
+		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nFor example:\n\n    @docs/absent.md\n")::execute);
+	}
+
 	@Test
 	void ignoresImportsInInlineCodeSpans() {
 		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nan `@claude`-mention workflow\n")::execute);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
@@ -11,12 +11,13 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 /**
- * Asserts the fenced-code-block mask line by line rather than through a rule's
- * pass or fail, because every structural check the rules make — headings,
- * section bodies, forbidden tokens, line lengths, file references, and the
- * memory imports {@code ImportGraph} reads — is a question asked of this mask.
- * A delimiter mistaken for the end of a block silently reclassifies everything
- * after it, so the exact set of code lines is what needs pinning.
+ * Asserts the code mask line by line rather than through a rule's pass or fail,
+ * because every structural check the rules make — headings, section bodies,
+ * forbidden tokens, line lengths, file references, and the memory imports
+ * {@code ImportGraph} reads — is a question asked of this mask. A delimiter
+ * mistaken for the end of a block, or an indent read as prose, silently
+ * reclassifies whole passages, so the exact set of code lines is what needs
+ * pinning.
  */
 class MarkdownDocumentTest {
 
@@ -32,7 +33,7 @@ class MarkdownDocumentTest {
 				## Section
 				""");
 
-		assertEquals(List.of(2, 3, 4), fencedLines(document));
+		assertEquals(List.of(2, 3, 4), codeLines(document));
 	}
 
 	@Test
@@ -52,7 +53,7 @@ class MarkdownDocumentTest {
 
 		// Lines 2 to 6 are the whole block: ```java is an opening delimiter, so it
 		// cannot end it and leave line 6's ``` to open a second fence.
-		assertEquals(List.of(2, 3, 4, 5, 6), fencedLines(document));
+		assertEquals(List.of(2, 3, 4, 5, 6), codeLines(document));
 		assertEquals(Set.of("# Title", "## Section"), document.headings());
 	}
 
@@ -71,7 +72,7 @@ class MarkdownDocumentTest {
 				body
 				""");
 
-		assertEquals(List.of(2, 3, 4, 5, 6), fencedLines(document));
+		assertEquals(List.of(2, 3, 4, 5, 6), codeLines(document));
 		assertEquals(Set.of("# Title", "## Section"), document.headings());
 	}
 
@@ -85,7 +86,7 @@ class MarkdownDocumentTest {
 				## Section
 				""");
 
-		assertEquals(List.of(0, 1, 2), fencedLines(document));
+		assertEquals(List.of(0, 1, 2), codeLines(document));
 		assertTrue(document.hasHeading("## Section"));
 	}
 
@@ -99,7 +100,7 @@ class MarkdownDocumentTest {
 				# After
 				""");
 
-		assertEquals(List.of(0, 1, 2), fencedLines(document));
+		assertEquals(List.of(0, 1, 2), codeLines(document));
 		assertTrue(document.hasHeading("# After"));
 	}
 
@@ -108,7 +109,7 @@ class MarkdownDocumentTest {
 		// Written without a text block, which would strip the trailing spaces away.
 		MarkdownDocument document = MarkdownDocument.parse("```\nint x;\n```   \n\n## Section\n");
 
-		assertEquals(List.of(0, 1, 2), fencedLines(document));
+		assertEquals(List.of(0, 1, 2), codeLines(document));
 		assertTrue(document.hasHeading("## Section"));
 	}
 
@@ -122,7 +123,7 @@ class MarkdownDocumentTest {
 				## Section
 				""");
 
-		assertEquals(List.of(2, 3, 4), fencedLines(document));
+		assertEquals(List.of(2, 3, 4), codeLines(document));
 		assertFalse(document.hasHeading("## Section"));
 	}
 
@@ -136,7 +137,7 @@ class MarkdownDocumentTest {
 				## Section
 				""");
 
-		assertEquals(List.of(), fencedLines(document));
+		assertEquals(List.of(), codeLines(document));
 		assertEquals(Set.of("# Title", "## Section"), document.headings());
 	}
 
@@ -150,7 +151,7 @@ class MarkdownDocumentTest {
 				TODO left behind
 				""");
 
-		assertEquals(List.of(0, 1, 2), fencedLines(document));
+		assertEquals(List.of(0, 1, 2), codeLines(document));
 		assertTrue(document.containsInProse("TODO"));
 	}
 
@@ -165,6 +166,109 @@ class MarkdownDocumentTest {
 				""");
 
 		assertFalse(document.containsInProse("TODO"));
+	}
+
+	/**
+	 * The other way Markdown quotes a sample. The blank line between the two chunks
+	 * separates them rather than ending the block, and carries nothing either way, so
+	 * it is left unmasked.
+	 */
+	@Test
+	void masksAnIndentedCodeBlock() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				An example of the section a template adds:
+
+				    ## Testing
+
+				    Write tests.
+
+				## Maven
+				Body.
+				""");
+
+		assertEquals(List.of(4, 6), codeLines(document));
+		assertEquals(Set.of("# Title", "## Maven"), document.headings());
+	}
+
+	@Test
+	void masksATabIndentedBlock() {
+		// Written without a text block, so the single leading tab is unambiguous.
+		MarkdownDocument document = MarkdownDocument.parse("# Title\n\n\tTODO in a sample\n\n## Maven\nBody.\n");
+
+		assertEquals(List.of(2), codeLines(document));
+		assertFalse(document.containsInProse("TODO"));
+	}
+
+	/** A forbidden token inside an indented sample is the sample's, not the document's. */
+	@Test
+	void doesNotFindATokenInsideAnIndentedBlock() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				For example:
+
+				    TODO left in a sample
+
+				## Maven
+				Body.
+				""");
+
+		assertFalse(document.containsInProse("TODO"));
+	}
+
+	/**
+	 * An indented code block cannot interrupt a paragraph: the indented line below one
+	 * is a lazy continuation of it. Masking it would hide prose the document really
+	 * does say.
+	 */
+	@Test
+	void treatsAnIndentedLineBelowAParagraphAsPartOfThatParagraph() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				A wrapped sentence
+				    continued with a deep indent.
+
+				## Maven
+				Body.
+				""");
+
+		assertEquals(List.of(), codeLines(document));
+		assertTrue(document.containsInProse("continued"));
+	}
+
+	/** Three spaces is the deepest a heading may be indented and stay one. */
+	@Test
+	void doesNotTreatAThreeSpaceIndentAsCode() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				   ## Testing
+
+				Body.
+				""");
+
+		assertEquals(List.of(), codeLines(document));
+		assertTrue(document.hasHeading("## Testing"));
+	}
+
+	/** An indented block is content, so a section whose only body is one is not empty. */
+	@Test
+	void readsAnIndentedBlockAsASectionBody() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				## Maven
+
+				    mvn install
+
+				## Testing
+				Body.
+				""");
+
+		assertTrue(document.hasBody("## Maven"));
 	}
 
 	@Test
@@ -350,9 +454,9 @@ class MarkdownDocumentTest {
 		assertEquals(List.of(2, 3, 4), commentedLines(document));
 	}
 
-	/** The indices of the lines the document masks as fenced code, in document order. */
-	private static List<Integer> fencedLines(MarkdownDocument document) {
-		return IntStream.range(0, document.lineCount()).filter(document::isInsideFence).boxed().toList();
+	/** The indices of the lines the document masks as code, in document order. */
+	private static List<Integer> codeLines(MarkdownDocument document) {
+		return IntStream.range(0, document.lineCount()).filter(document::isInsideCode).boxed().toList();
 	}
 
 	/** The indices of the lines the document masks as an HTML comment, in document order. */


### PR DESCRIPTION
## The bug

`MarkdownDocument` masks fenced code blocks and HTML comments, but not the other
way Markdown quotes a sample: a four-column indent. Every rule built on it —
`claudeMdFormat`, `agentsMdFormat`, `memoryImports` — therefore read an indented
sample as document structure, and got the answer wrong in both directions.

A required heading shown as an example satisfied the check that demands it:

```
For example:

    ## Testing

    Write unit tests for all new logic.
```

`claudeMdFormat` passed on a CLAUDE.md with no real `## Testing` section.

And the same sample's own content was reported as the document's own:

| Sample content | Indented (before) | Fenced (control) |
|---|---|---|
| `TODO in a sample` | `must not contain forbidden token: TODO` | passes |
| `See [guide](example.md).` | `references a missing file: example.md` | passes |
| `@docs/absent.md` | `imports a missing file: @docs/absent.md` | passes |

Same class of bug as the fenced-block and HTML-comment fixes already landed
(#560, and the comment mask before it); this is the third form of "this is code,
not structure".

## The fix

The fence mask becomes a **code** mask: `codeMask` runs `fenceMask` first, then a
second pass marks indented lines over the same array. A tab counts on to the next
four-column stop.

A block opens only after a blank line — CommonMark's rule that an indented code
block cannot interrupt a paragraph — so a wrapped sentence with a deep indent
stays prose. It then runs through indented and blank lines until the next line
that is neither. Blank lines are left unmarked, since they carry nothing either
way.

`commentMask` now takes the combined mask, so a `<!--` inside an indented sample
no longer opens a comment that swallows the rest of the document — the same
reason a fence already won there.

`isInsideFence` is renamed `isInsideCode` for what it now answers. Nothing
outside this module compiles against it: `adopt`'s conformer keeps its own
private copy and only mentions `MarkdownDocument` in javadoc.

## Verification

- 727 unit tests and the 12 `*IT`s that fork real Maven builds pass.
- `mvn -N validate -DenforceClaudeMd` passes all 19 wired rules against this
  repository's real docs. CLAUDE.md and AGENTS.md carry no indented blocks, so
  the change is a no-op for the current build — it is the guard that changes.
- Each reproduction above now matches its fenced control.

New tests: six in `MarkdownDocumentTest` pinning the mask indices (two-chunk
block, tab indent, the three-space indent that stays a heading, the
lazy-continuation guard, an indented block counting as a section body), three
rule-level regressions in `ClaudeMdFormatRuleTest`, one in `MemoryImportsRuleTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
