### PR TITLE
refactor(adopt, claude-code-enforcer): let libraries own the parsing

### DIFF
--- a/.claude/skills/java-code-review/SKILL.md
+++ b/.claude/skills/java-code-review/SKILL.md
@@ -220,6 +220,12 @@ comment opened after text on its line, an apostrophe read as an opening quote, a
 newline inside a hook command, `[logo](assets/logo(1).png)`, a bare `@claude`
 mention read as a memory import.
 
+The strongest fix for this shape is not a better hand-rolled reader but no
+hand-rolled reader: `FrontMatter` now composes its block with SnakeYAML, and the
+quoting, comment and block-scalar rules that had cost it six or seven fix commits
+came with it. Ask whether the format under review has a parser worth depending on
+before reviewing the scanning loop line by line.
+
 **Ask:**
 - Does this track state across the whole line, or does it `startsWith` /
   `contains` and hope? A delimiter can appear anywhere, and twice.

--- a/.claude/skills/text-parsers/SKILL.md
+++ b/.claude/skills/text-parsers/SKILL.md
@@ -11,15 +11,11 @@ own. Those readers carry the largest share of this repository's shipped defects:
 `FrontMatter` and `CommandTokens` have each been fixed in six or seven separate
 commits, `MarkdownDocument` and `ClaudeMdConformer` in four or five.
 
-`FrontMatter` is the one that has since been handed to a library — it composes
-the block with SnakeYAML rather than scanning quotes and comments itself. Read
-its section below for what that changed and what it did not; the rest are still
-hand-rolled, and the list here is the accumulated reason each one is the way it
-is.
-
 Every one of those fixes was the same thing — real input the reader had not been
 written for. This skill is the accumulated list, so the next change starts from
-it instead of rediscovering it.
+it instead of rediscovering it. `FrontMatter` is the one that has since been
+handed to a library: it composes the block with SnakeYAML rather than scanning
+quotes and comments itself, and its section below says what that changed.
 
 ## When to Use
 - Changing any reader in `claude-code-enforcer/.../text`, `.../doc/ImportGraph`,
@@ -72,8 +68,7 @@ re-derived by hand; those rules now come from the loader.
 | The block is **composed**, never loaded | `Yaml.compose` answers a node tree, so a value stays the text its author wrote — `okf_version: 0.20` is the string `0.20`, not a double rounded to `0.2` — and a duplicated key stays visible instead of collapsing into a `Map`. |
 | Every value is **folded onto one line** | A block scalar, a wrapped plain scalar, a nested mapping or a sequence all read back as text. Folding a mapping is lossy on purpose: `by: agent/1` comes back as text. A rule needing the structure should ask SnakeYAML directly. |
 | A key declared twice yields its **last** declaration | That is the one a YAML loader keeps, so the one Claude Code acts on. `duplicateKeys()` reports the duplication separately. |
-| A block YAML **cannot read** falls back to plain text | `description: "a" and "b"` and an unterminated `"oops` have no YAML meaning. Its `key:` lines still name the keys and each value is the text following it, verbatim — the rules report the characters the author wrote rather than a value invented here. |
-| The text fallback recognises a key only at column 0, with `key:` or `key: value` (space or tab) | An indented line continues the value above. `Use this when:` inside a wrapped description is not a key. |
+| A block no loader can read is **not front matter** | `description: "a" and "b"` and an unterminated `"oops` have no YAML meaning, and Claude Code's loader fails on them too. `parse` answers empty and the rules report the block's absence, which says more than a guess at the malformed line. A block that *reads* but is not a mapping — `name:value`, no space — is present and declares nothing. |
 | Front matter opens on the **very first line** | Content reaching `---` after blank lines has no front matter, because Claude Code sees none either. |
 
 The cases that used to need their own hand-written rule — `name: "git-commit"`

--- a/.claude/skills/text-parsers/SKILL.md
+++ b/.claude/skills/text-parsers/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: text-parsers
-description: Work on this repo's hand-rolled text readers — MarkdownDocument, FrontMatter, MarkdownText, ImportGraph, CommandTokens and the ClaudeMdConformer copy of them — and the adversarial input that has broken each. Use when changing how a document, YAML front matter, a memory import or a hook command is read, when a rule fires on valid input or passes invalid input, or when the user says "fence", "front matter", "heading detection", "memory import", or "hook command".
+description: Work on this repo's text readers — MarkdownDocument, MarkdownText, ImportGraph, CommandTokens, the ClaudeMdConformer copy of them, and the SnakeYAML-backed FrontMatter — and the adversarial input that has broken each. Use when changing how a document, YAML front matter, a memory import or a hook command is read, when a rule fires on valid input or passes invalid input, or when the user says "fence", "front matter", "heading detection", "memory import", or "hook command".
 ---
 
 # Text Parsers Skill
 
 The `claude-code-enforcer` rules and the `adopt` conformer read Markdown, YAML
-front matter, `@path` imports and shell hook commands with small hand-rolled
-readers rather than a library. Those readers carry the largest share of this
-repository's shipped defects: `FrontMatter` and `CommandTokens` have each been
-fixed in six or seven separate commits, `MarkdownDocument` and
-`ClaudeMdConformer` in four or five.
+front matter, `@path` imports and shell hook commands with small readers of their
+own. Those readers carry the largest share of this repository's shipped defects:
+`FrontMatter` and `CommandTokens` have each been fixed in six or seven separate
+commits, `MarkdownDocument` and `ClaudeMdConformer` in four or five.
+
+`FrontMatter` is the one that has since been handed to a library — it composes
+the block with SnakeYAML rather than scanning quotes and comments itself. Read
+its section below for what that changed and what it did not; the rest are still
+hand-rolled, and the list here is the accumulated reason each one is the way it
+is.
 
 Every one of those fixes was the same thing — real input the reader had not been
 written for. This skill is the accumulated list, so the next change starts from
@@ -56,20 +61,25 @@ construction, so structural checks share them.
 
 ### `FrontMatter`
 
-A deliberately small YAML reader, not a parser. It answers each `key: value` as
-one line of text — length, blankness, uniqueness, shape. **A rule that needs the
-structure wants a real YAML parser, not this.**
+**The one reader here that is no longer hand-rolled.** It delimits the `---`
+block itself, then hands the block to SnakeYAML and answers each entry as one
+line of text — length, blankness, uniqueness, shape. Six or seven of this
+repository's `fix(...)` commits were quoting, comment and block-scalar rules
+re-derived by hand; those rules now come from the loader.
 
 | Invariant | Why |
 |---|---|
-| A key is recognised only at column 0, with `key:` or `key: value` (space or tab) | An indented line continues the value above. `Use this when:` inside a wrapped description is not a key. |
-| A value the key's line does not carry is **folded from the indented lines below** | Covers all three YAML continuations — block scalar, wrapped plain scalar, nested mapping. Reading them as `""` let every block scalar claim a one-character description and escape the length cap. |
-| Folding a mapping is **lossy on purpose** | `by: agent/1` comes back as text. |
-| A quoted value yields the text **inside** the quotes | `name: "git-commit"` failed kebab-case; every quoted description counted two characters it does not have. A description containing `: ` *must* be quoted to parse at all. |
-| Only a quote that **opens** the value quotes it | `Don't stop # a note` — the apostrophe is not an opening quote. Treating it as one left a scalar that never closed and kept the trailing comment as part of the value. |
-| A `#` opens a comment only **after whitespace, outside quotes** | `version: 1.0#2` has no comment. |
+| The block is **composed**, never loaded | `Yaml.compose` answers a node tree, so a value stays the text its author wrote — `okf_version: 0.20` is the string `0.20`, not a double rounded to `0.2` — and a duplicated key stays visible instead of collapsing into a `Map`. |
+| Every value is **folded onto one line** | A block scalar, a wrapped plain scalar, a nested mapping or a sequence all read back as text. Folding a mapping is lossy on purpose: `by: agent/1` comes back as text. A rule needing the structure should ask SnakeYAML directly. |
 | A key declared twice yields its **last** declaration | That is the one a YAML loader keeps, so the one Claude Code acts on. `duplicateKeys()` reports the duplication separately. |
+| A block YAML **cannot read** falls back to plain text | `description: "a" and "b"` and an unterminated `"oops` have no YAML meaning. Its `key:` lines still name the keys and each value is the text following it, verbatim — the rules report the characters the author wrote rather than a value invented here. |
+| The text fallback recognises a key only at column 0, with `key:` or `key: value` (space or tab) | An indented line continues the value above. `Use this when:` inside a wrapped description is not a key. |
 | Front matter opens on the **very first line** | Content reaching `---` after blank lines has no front matter, because Claude Code sees none either. |
+
+The cases that used to need their own hand-written rule — `name: "git-commit"`
+unquoted, `Don't stop # a note` keeping its apostrophe, `version: 1.0#2` having
+no comment, `description: >` folding the lines below it — are all the loader's
+job now, and `FrontMatterTest` still pins every one of them.
 
 ### `MarkdownText`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,18 @@ Maven project. The notable capabilities are:
   `PullRequestOptions`, exposed on the command line as `--title`, `--body`,
   repeatable `--reviewer`/`--label`/`--assignee`, and `--draft` (parsed by
   `CliArguments` alongside the positional URL, workspace, and branch arguments).
+  `CliArguments` declares that command line to **picocli** rather than walking the
+  argument array itself: each option is bound to a method, because picocli calls a
+  method option once per occurrence in the order it was written, and a batch mixing
+  `--repo` with `--repos` must adopt and report its repositories in that order.
+  `setOverwrittenOptionsAllowed` is what lets those flags repeat and what makes the
+  last `--workspace`/`--branch` win over an earlier one or its positional. The
+  refusals come with it too — an unknown option, a fourth positional, a value
+  missing, and an option written where a naming flag's value belongs
+  (`--branch --draft`) — each re-raised as the `IllegalArgumentException` carrying
+  the usage line that the entry points already expect. That usage line stays
+  hand-written: picocli can render a synopsis, but it orders one by reflecting over
+  the methods and the JVM does not promise that order.
   That record and the rest of a run's configuration — the starter assets, the rule
   version, the dry-run flag, and the per-command timeout — are grouped into an
   `AdoptionOptions`, which both entry points build and hand to
@@ -714,7 +726,7 @@ Seven hold across the repository:
 | `maven-conventions` | versions only in the root pom, version-free module poms, the profiles, clean-after-codegen |
 | `testing-conventions` | the Surefire timeouts, network-off unit tests, the ArchUnit conventions, JUnit 5 only |
 | `java-code-review` | review led by the rules the build fails on, then the five defect shapes this repository ships fixes for, then null safety, exceptions, concurrency, performance |
-| `text-parsers` | the invariants of the hand-rolled readers — `MarkdownDocument`, `FrontMatter`, `MarkdownText`, `ImportGraph`, `CommandTokens`, the `ClaudeMdConformer` copy — and the adversarial input that has broken each |
+| `text-parsers` | the invariants of the readers — `MarkdownDocument`, `MarkdownText`, `ImportGraph`, `CommandTokens`, the `ClaudeMdConformer` copy, and the SnakeYAML-backed `FrontMatter` — and the adversarial input that has broken each |
 | `solid-principles` | the per-principle detection heuristics and the refactorings that fix them |
 | `git-commit` | conventional commit messages using this repository's real module scopes |
 
@@ -1005,6 +1017,21 @@ delimiter — the rule rewrites the file in place and continues against the
 corrected content instead of failing. The repair is conservative: it only acts
 when the document opens with a dashes line enclosing real `key: value` entries, so
 a lone `---` thematic break is never mistaken for front matter.
+
+The front matter those rules read comes from `FrontMatter`, which delimits the
+`---` block itself and hands the block to **SnakeYAML**. It stops at
+`Yaml.compose`, which answers the document's node tree rather than constructing
+Java objects from it: a rule wants the text an author declared, not a typed value.
+That is not cosmetic — composing keeps `okf_version: 0.20` the string `0.20`
+instead of rounding it to a double, and it keeps a key declared twice visible,
+which every loader that builds a `Map` collapses and which `duplicateKeys()`
+exists to report. Each value is folded onto one line, so a block scalar, a wrapped
+plain scalar and a nested mapping all read back as text. A block YAML cannot read
+at all — an unterminated quoted scalar, or a `description: "a" and "b"` whose
+quotes do not wrap it — falls back to being read as plain text, so the rules
+report the characters the author actually wrote rather than a value invented for
+them. This replaced a reader that scanned quotes, trailing comments and block
+scalars by hand, and had been fixed for real input six or seven times.
 
 A `List<String>` parameter carries a trap worth knowing before naming a helper
 class. Plexus infers a configured list's element type from the **child element

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1026,12 +1026,14 @@ That is not cosmetic — composing keeps `okf_version: 0.20` the string `0.20`
 instead of rounding it to a double, and it keeps a key declared twice visible,
 which every loader that builds a `Map` collapses and which `duplicateKeys()`
 exists to report. Each value is folded onto one line, so a block scalar, a wrapped
-plain scalar and a nested mapping all read back as text. A block YAML cannot read
-at all — an unterminated quoted scalar, or a `description: "a" and "b"` whose
-quotes do not wrap it — falls back to being read as plain text, so the rules
-report the characters the author actually wrote rather than a value invented for
-them. This replaced a reader that scanned quotes, trailing comments and block
-scalars by hand, and had been fixed for real input six or seven times.
+plain scalar and a nested mapping all read back as text. A block no loader can
+read — an unterminated quoted scalar, or a `description: "a" and "b"` whose quotes
+do not wrap it — is no front matter at all, and `parse` answers empty, which is
+what the rules already report best: *"has no parseable YAML frontmatter block"*.
+Claude Code's own loader fails on that block too, so a hand-read guess at it would
+validate something the tool never sees. This replaced a reader that scanned quotes,
+trailing comments and block scalars by hand, and had been fixed for real input six
+or seven times.
 
 A `List<String>` parameter carries a trap worth knowing before naming a helper
 class. Plexus infers a configured list's element type from the **child element

--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -114,6 +114,16 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
+		<!-- Matches the adoption command line. CliArguments used to walk the
+		     argument array itself, which meant hand-writing what every parser
+		     already knows: which flags take a value, which repeat, where the
+		     positionals are, and what to say when a value is missing. picocli
+		     declares all of that, and it has no transitive dependencies, so the
+		     pipeline stays a plain library. -->
+		<dependency>
+			<groupId>info.picocli</groupId>
+			<artifactId>picocli</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -5,9 +5,13 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParameterException;
 
 /**
  * Parses the adoption command line. The first three non-flag arguments are the
@@ -27,12 +31,39 @@ import io.github.adamw7.tools.adopt.step.PullRequestOptions;
  * line rather than being ignored — as does {@code --help}, which asks for that
  * line and so is answered with it instead.
  *
+ * <p>The arguments are matched by picocli rather than by a loop of this module's
+ * own: the option names, their values, the three positional slots and the
+ * refusals are all declared, so what the parser accepts is readable in one place
+ * instead of being spelled out twice — once in the loop and once in the usage
+ * line. Each option is bound to a method rather than to a field, because picocli
+ * calls a method option once per occurrence, in the order the operator wrote it.
+ * That order is the one thing a batch cannot lose: a run mixing {@code --repo}
+ * with {@code --repos} adopts its repositories, and reports them, in the order
+ * they were named.
+ *
  * <p>The positional slots keep their meaning whatever else is on the command line
  * — the first is always a repository URL, never a workspace — so a run driven
  * entirely by {@code --repo}/{@code --repos} names its workspace and branch with
  * {@code --workspace} and {@code --branch}. A flag and its positional write the
- * same value, so naming one twice is the last one winning rather than an error.
+ * same value, so naming one twice is the last one winning rather than an error:
+ * that is what {@code setOverwrittenOptionsAllowed} buys, and it is the same
+ * setting that lets the repeatable flags be named again and again.
+ *
+ * <p>A flag that names something is never followed by another flag, and picocli
+ * refuses one that is: {@code --branch --draft} named a branch called
+ * {@code --draft}, created it, and pushed it, with the draft the operator asked
+ * for silently dropped. {@code --title} and {@code --body} take free-form prose,
+ * and prose that merely looks like a flag is still prose — the refusal is for a
+ * value that is an option of this command, not for any word opening with dashes.
+ *
+ * <p>The usage line is written out rather than generated from the declarations
+ * below. picocli can render a synopsis, but it orders one by reflecting over the
+ * methods, and the JVM does not promise the order it reports them in — the line
+ * an operator reads would then differ between runs. This one is ordered to be
+ * read: the positionals first, then the flags that name what to adopt, then the
+ * pull request's metadata.
  */
+@Command(name = "adopt")
 public final class CliArguments {
 
 	static final String USAGE = "Usage: [<github-repo-url>] [workspace-directory] [branch-name]"
@@ -46,6 +77,7 @@ public final class CliArguments {
 	static final String HELP_SHORTHAND = "-h";
 
 	private static final String TIMEOUT_FLAG = "--timeout";
+	private static final String REPOS_FLAG = "--repos";
 
 	private final List<String> repositoryUrls = new ArrayList<>();
 	private Path workspace;
@@ -62,7 +94,6 @@ public final class CliArguments {
 	private Duration commandTimeout;
 	private Path reportFile;
 	private boolean help;
-	private int positionals;
 	private String positionalUrl;
 	private boolean flagsNamedARepository;
 
@@ -71,10 +102,11 @@ public final class CliArguments {
 
 	public static CliArguments parse(String[] args) {
 		CliArguments cli = new CliArguments();
-		String[] arguments = args == null ? new String[0] : args;
-		int index = 0;
-		while (index < arguments.length) {
-			index = cli.consume(arguments, index);
+		try {
+			new CommandLine(cli).setOverwrittenOptionsAllowed(true)
+					.parseArgs(args == null ? new String[0] : args);
+		} catch (ParameterException e) {
+			throw refusal(e);
 		}
 		cli.requireSomethingToAdopt();
 		return cli;
@@ -119,96 +151,119 @@ public final class CliArguments {
 	}
 
 	/**
-	 * {@code -h} is tested before the {@code --} prefix, since it carries none and
-	 * would otherwise be read as the run's first positional — a repository URL,
-	 * which is the one reading of it nobody means.
+	 * The refusal to raise for an argument picocli would not accept. A failure
+	 * raised by one of the methods below — an unreadable repository list, a blank
+	 * flag value — is already the failure this module means, and picocli wraps it
+	 * only because it was the one calling; it travels on unchanged so a caller
+	 * still sees an {@link AdoptionException} for a file it could not read. Anything
+	 * else is the parser's own complaint about the command line, which is answered
+	 * with the usage line as every other bad argument is.
 	 */
-	private int consume(String[] args, int index) {
-		String argument = args[index];
-		if (HELP_FLAG.equals(argument) || HELP_SHORTHAND.equals(argument)) {
-			help = true;
-			return index + 1;
+	private static RuntimeException refusal(ParameterException e) {
+		if (e.getCause() instanceof RuntimeException raised) {
+			return raised;
 		}
-		if (argument.startsWith("--")) {
-			return consumeFlag(args, index);
-		}
-		consumePositional(argument);
-		return index + 1;
-	}
-
-	private int consumeFlag(String[] args, int index) {
-		String flag = args[index];
-		return switch (flag) {
-			case "--repo" -> consumeName(args, index, this::addFlaggedRepository);
-			case "--repos" -> consumeName(args, index, value -> addFlaggedRepositories(readList(value)));
-			case "--workspace" -> consumeName(args, index, value -> workspace = optionalPath(value));
-			case "--branch" -> consumeName(args, index, value -> branchName = optionalText(value));
-			case "--title" -> consumeValue(args, index, value -> title = value);
-			case "--body" -> consumeValue(args, index, value -> body = value);
-			case "--reviewer" -> consumeName(args, index, reviewers::add);
-			case "--label" -> consumeName(args, index, labels::add);
-			case "--assignee" -> consumeName(args, index, assignees::add);
-			case "--rule-version" -> consumeName(args, index, value -> ruleVersion = optionalText(value));
-			case TIMEOUT_FLAG -> consumeName(args, index, value -> commandTimeout = optionalTimeout(value));
-			case "--report" -> consumeName(args, index, value -> reportFile = optionalPath(value));
-			// A flag carrying no value: it is set, and the next argument is the one after it.
-			case "--draft" -> { draft = true; yield index + 1; }
-			case "--assets" -> { assets = true; yield index + 1; }
-			case "--dry-run" -> { dryRun = true; yield index + 1; }
-			default -> throw new IllegalArgumentException("Unknown option " + flag + ". " + USAGE);
-		};
-	}
-
-	private int consumeValue(String[] args, int index, Consumer<String> target) {
-		if (index + 1 >= args.length) {
-			throw new IllegalArgumentException(args[index] + " requires a value. " + USAGE);
-		}
-		target.accept(args[index + 1]);
-		return index + 2;
+		return new IllegalArgumentException(e.getMessage() + ". " + USAGE, e);
 	}
 
 	/**
-	 * Reads the value of a flag that names something — a URL, a path, a branch, a
-	 * user, a number — none of which is ever spelled as a flag. A missing value would
-	 * otherwise swallow the next flag as the value: {@code --branch --draft} named a
-	 * branch called {@code --draft}, created it, and pushed it, with the draft the
-	 * operator asked for silently dropped. {@code --title} and {@code --body} take
-	 * free-form prose and so keep {@link #consumeValue}, which accepts whatever
-	 * follows.
+	 * The first positional is always a repository URL, never a workspace, so it is
+	 * read as one whatever else is on the command line.
 	 */
-	private int consumeName(String[] args, int index, Consumer<String> target) {
-		if (index + 1 < args.length && args[index + 1].startsWith("--")) {
-			throw new IllegalArgumentException(args[index] + " requires a value, but was followed by the option "
-					+ args[index + 1] + ". " + USAGE);
-		}
-		return consumeValue(args, index, target);
-	}
-
-	/**
-	 * A blank workspace or branch positional counts as not supplied — the rule
-	 * {@link Text} defines for every optional input, and the one every optional flag
-	 * value follows too — so it falls back to its default rather than resolving the
-	 * empty path or being rejected as an invalid branch. A blank repository
-	 * positional is dropped the same way, leaving the run with whatever the
-	 * {@code --repo} and {@code --repos} flags named.
-	 */
-	private void consumePositional(String argument) {
-		switch (positionals) {
-			case 0 -> addPositionalRepository(argument);
-			case 1 -> workspace = optionalPath(argument);
-			case 2 -> branchName = optionalText(argument);
-			default -> throw new IllegalArgumentException("Unexpected argument " + argument + ". " + USAGE);
-		}
-		positionals++;
-	}
-
-	private void addPositionalRepository(String url) {
+	@Parameters(index = "0", arity = "0..1", paramLabel = "<github-repo-url>")
+	private void positionalRepository(String url) {
 		positionalUrl = optionalText(url);
 		addRepository(url);
 	}
 
-	private void addFlaggedRepositories(List<String> urls) {
-		urls.forEach(this::addFlaggedRepository);
+	@Parameters(index = "1", arity = "0..1", paramLabel = "<workspace-directory>")
+	private void positionalWorkspace(String value) {
+		workspace = optionalPath(value);
+	}
+
+	@Parameters(index = "2", arity = "0..1", paramLabel = "<branch-name>")
+	private void positionalBranch(String value) {
+		branchName = optionalText(value);
+	}
+
+	@Option(names = "--repo", paramLabel = "<github-repo-url>")
+	private void repository(String url) {
+		addFlaggedRepository(url);
+	}
+
+	@Option(names = REPOS_FLAG, paramLabel = "<file>")
+	private void repositoryList(String file) {
+		RepositoryUrls.fromFile(Path.of(Text.required(file, REPOS_FLAG))).forEach(this::addFlaggedRepository);
+	}
+
+	@Option(names = "--workspace", paramLabel = "<directory>")
+	private void workspace(String value) {
+		workspace = optionalPath(value);
+	}
+
+	@Option(names = "--branch", paramLabel = "<name>")
+	private void branch(String value) {
+		branchName = optionalText(value);
+	}
+
+	@Option(names = "--title", paramLabel = "<title>")
+	private void title(String value) {
+		title = value;
+	}
+
+	@Option(names = "--body", paramLabel = "<body>")
+	private void body(String value) {
+		body = value;
+	}
+
+	@Option(names = "--reviewer", paramLabel = "<user>")
+	private void reviewer(String value) {
+		reviewers.add(value);
+	}
+
+	@Option(names = "--label", paramLabel = "<label>")
+	private void label(String value) {
+		labels.add(value);
+	}
+
+	@Option(names = "--assignee", paramLabel = "<user>")
+	private void assignee(String value) {
+		assignees.add(value);
+	}
+
+	@Option(names = "--rule-version", paramLabel = "<version>")
+	private void ruleVersion(String value) {
+		ruleVersion = optionalText(value);
+	}
+
+	@Option(names = TIMEOUT_FLAG, paramLabel = "<minutes>")
+	private void timeout(String value) {
+		commandTimeout = optionalTimeout(value);
+	}
+
+	@Option(names = "--report", paramLabel = "<file>")
+	private void report(String value) {
+		reportFile = optionalPath(value);
+	}
+
+	@Option(names = "--draft")
+	private void draft(boolean on) {
+		draft = on;
+	}
+
+	@Option(names = "--assets")
+	private void assets(boolean on) {
+		assets = on;
+	}
+
+	@Option(names = "--dry-run")
+	private void dryRun(boolean on) {
+		dryRun = on;
+	}
+
+	@Option(names = { HELP_FLAG, HELP_SHORTHAND })
+	private void help(boolean on) {
+		help = on;
 	}
 
 	private void addFlaggedRepository(String url) {
@@ -216,14 +271,15 @@ public final class CliArguments {
 		addRepository(url);
 	}
 
+	/**
+	 * A blank repository is dropped rather than adopted — the rule {@link Text}
+	 * defines for every optional input, and the one every optional flag value
+	 * follows too — leaving the run with whatever the other arguments named.
+	 */
 	private void addRepository(String url) {
 		if (Text.isPresent(url)) {
 			repositoryUrls.add(url.strip());
 		}
-	}
-
-	private List<String> readList(String file) {
-		return RepositoryUrls.fromFile(Path.of(Text.required(file, "--repos")));
 	}
 
 	private Path optionalPath(String value) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -456,6 +456,20 @@ class CliArgumentsTest {
 		assertUsageFailure(new String[] { REPO_URL, "--timeout", "--dry-run" });
 	}
 
+	/**
+	 * A flag and its value may be written as one argument. Nothing in the pipeline
+	 * needs it, but it is the form operators reach for and the form a shell
+	 * completes, so a run that used it no longer fails on an unknown option.
+	 */
+	@Test
+	void acceptsAFlagJoinedToItsValueByAnEqualsSign() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--branch=feature/x",
+				"--workspace=/tmp/ws", "--timeout=45" });
+		assertEquals("feature/x", cli.branchName());
+		assertEquals(Path.of("/tmp/ws"), cli.workspace().orElseThrow());
+		assertEquals(Duration.ofMinutes(45), cli.adoptionOptions().commandTimeout());
+	}
+
 	/** Prose is free-form, so a body or title that opens with dashes is the operator's business. */
 	@Test
 	void acceptsFreeFormProseThatLooksLikeAFlag() {

--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -72,6 +72,17 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
+		<!-- Reads the YAML front matter of a skill, sub-agent, command or OKF
+		     concept document. The rules used to scan those lines by hand, which
+		     meant re-deriving where a quoted scalar ends, where a trailing comment
+		     begins, and how a block scalar folds — every one of them a place the
+		     check could disagree with the loader Claude Code itself reads the
+		     document with. FrontMatter now composes the block with SnakeYAML
+		     instead, so the rules validate what the tool acts on. -->
+		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFormatRule.java
@@ -102,7 +102,8 @@ abstract class DefinitionFormatRule extends ClaudeCodeEnforcerRule {
 		Optional<FrontMatterChecks> checks = frontMatterOf(content, file, violations);
 		if (checks.isEmpty()) {
 			violations.add(naming.definitionLabel()
-					+ " must start with a YAML front matter block delimited by '---': " + file);
+					+ " must start with a YAML front matter block delimited by '---' that a YAML"
+					+ " loader can read: " + file);
 		}
 		return checks;
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -1,83 +1,73 @@
 package io.github.adamw7.tools.enforcer.text;
 
+import java.io.StringReader;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.NodeTuple;
+import org.yaml.snakeyaml.nodes.ScalarNode;
+import org.yaml.snakeyaml.nodes.SequenceNode;
 
 /**
  * The YAML front matter block at the top of a Markdown document: the lines
  * between a leading {@code ---} delimiter and the next {@code ---} delimiter.
  * <p>
- * This is a deliberately small reader, not a full YAML parser. It reads the
- * {@code key: value} entries a block declares and answers each one as a single
- * line of text, which is all the rules need: they check a value's length,
- * blankness, uniqueness, or shape, never its structure. Parsing is shared here so
- * every rule agrees on what counts as front matter, which keys it declares, and
- * each key's value.
+ * The block is read by SnakeYAML, the same kind of loader Claude Code itself
+ * reads front matter with, so what a rule validates is what the tool acts on.
+ * Parsing stops at {@link Yaml#compose}, which answers the document's node tree
+ * rather than constructing Java objects from it: a rule needs the text an author
+ * declared, not a typed value. That distinction is not cosmetic — composing keeps
+ * {@code okf_version: 0.20} the string {@code 0.20} instead of rounding it to a
+ * double, and it keeps a duplicated key visible, which every loader that builds a
+ * {@code Map} collapses.
  * <p>
- * A key is only recognised where YAML puts one: at the start of a line, with no
- * indentation. An indented line continues the value above it, so reading a key out
- * of one would invent entries an author never declared — the {@code Use this when:}
- * of a wrapped description would be reported as an unknown key.
+ * Each entry is answered as a single line of text, which is all the rules need:
+ * they check a value's length, blankness, uniqueness, or shape, never its
+ * structure. A value written across several lines — a block scalar, a wrapped
+ * plain scalar, a nested mapping or sequence — is folded into one line joined by
+ * single spaces, because the alternative is to answer the empty string for a value
+ * written out in full on the lines below its key. Folding a mapping is lossy on
+ * purpose: {@code by: agent/1} reads back as text rather than as a nested entry. A
+ * rule that needs the structure itself should ask SnakeYAML for it directly.
  * <p>
- * A value the key's own line does not carry is read from the indented lines below
- * it, folded into one line joined by single spaces. That covers the three ways YAML
- * continues a value downwards — a block scalar ({@code description: >} or
- * {@code |}), a plain scalar wrapped onto the next line, and a nested mapping or
- * sequence — because the alternative is to read every one of them as the empty
- * string. Doing so left each block scalar claiming the same one-character
- * description and escaping any length cap, and it failed an OKF concept whose
- * {@code generated:} mapping named its actor on the very next line for not naming
- * one. A key with nothing below it still yields the empty string, so a bare
- * {@code key:} is unchanged.
+ * A block YAML cannot read at all — an unterminated quoted scalar, or a value such
+ * as {@code "a" and "b"} whose quotes do not wrap it — is read as plain text
+ * instead: its {@code key:} lines name the keys, and each key's value is the text
+ * that follows it, verbatim. Guessing at what the malformed line meant is what a
+ * loader will not do either, so the rules see the characters the author actually
+ * wrote and can report on them, rather than a value invented here.
  * <p>
- * Folding a mapping is lossy on purpose: {@code by: agent/1} reads back as text
- * rather than as a nested entry. A rule that needs the structure itself wants a
- * YAML parser, not this.
- * <p>
- * A value wrapped in matching quotes yields the text inside them, because that is
- * the value YAML declares and the one Claude Code reads. Quoting is not decoration:
- * a description containing {@code : } has to be quoted to parse at all. Returning
- * the quotes as part of the value made a {@code name: "git-commit"} fail the
- * kebab-case convention it follows, a quoted {@code model} miss its whitelist, and
- * every description count two characters it does not have.
- * <p>
- * A trailing comment is not part of the value. YAML ends a plain scalar at a
- * {@code #} that follows whitespace outside quotes, so {@code name: git-commit # the
- * commit helper} declares {@code git-commit}. Reading the note as part of the value
- * failed a name over the kebab-case convention it follows and made every such
- * description count characters Claude Code never sees.
- * <p>
- * A key declared twice yields its <em>last</em> declaration, which is the one a YAML
- * loader keeps and so the one Claude Code acts on. Reading the first instead
+ * A key declared twice yields its <em>last</em> declaration, which is the one a
+ * YAML loader keeps and so the one Claude Code acts on. Reading the first instead
  * validated a value the tool never sees — a second {@code description:} could
  * lengthen a capped one, break a name convention, or collide with another
  * definition, and every check would still be looking at the line above it.
- * {@link #duplicateKeys()} reports the duplication itself, since a key written twice
- * is a mistake whichever value wins.
+ * {@link #duplicateKeys()} reports the duplication itself, since a key written
+ * twice is a mistake whichever value wins.
  */
 public final class FrontMatter {
 
 	private static final String DELIMITER = "---";
-	private static final char NONE = 0;
 	private static final char KEY_VALUE_SEPARATOR = ':';
-	private static final char COMMENT_START = '#';
-	private static final char ESCAPE = '\\';
-	private static final char DOUBLE_QUOTE = '"';
-	private static final char SINGLE_QUOTE = '\'';
-	private static final String ESCAPED_DOUBLE_QUOTE = "\\\"";
-	private static final String ESCAPED_SINGLE_QUOTE = "''";
 
-	/** A block scalar header: {@code >} or {@code |} with optional indentation and chomping indicators. */
-	private static final Pattern BLOCK_SCALAR = Pattern.compile("[>|][0-9+-]*");
+	/** How much of one entry is rendered before the walk gives up. See {@link #folded}. */
+	private static final int MAX_VALUE_LENGTH = 8192;
 
 	private final List<String> lines;
 
-	private FrontMatter(List<String> lines) {
+	/** The block's entries as YAML read them, or null when YAML cannot read the block. */
+	private final MappingNode mapping;
+
+	private FrontMatter(List<String> lines, MappingNode mapping) {
 		this.lines = lines;
+		this.mapping = mapping;
 	}
 
 	/**
@@ -97,12 +87,13 @@ public final class FrontMatter {
 		if (end < 0) {
 			return Optional.empty();
 		}
-		return Optional.of(new FrontMatter(allLines.subList(1, end)));
+		List<String> block = allLines.subList(1, end);
+		return Optional.of(new FrontMatter(block, compose(block)));
 	}
 
 	/** True when a {@code key:} entry is present, regardless of its value. */
 	public boolean hasKey(String key) {
-		return indexOfEntry(key) >= 0;
+		return keys().contains(key);
 	}
 
 	/**
@@ -110,22 +101,16 @@ public final class FrontMatter {
 	 * A present key whose value is neither on its own line nor below it yields an
 	 * empty string, not an empty optional; a value continued on the lines below —
 	 * a block scalar, a wrapped plain scalar, or a nested mapping — yields those
-	 * lines folded into one; and a quoted scalar yields the text inside its quotes.
-	 * A key declared more than once yields its last declaration, the one a YAML
-	 * loader keeps.
+	 * lines folded into one. A key declared more than once yields its last
+	 * declaration, the one a YAML loader keeps.
 	 */
 	public Optional<String> value(String key) {
-		int index = indexOfEntry(key);
-		if (index < 0) {
-			return Optional.empty();
-		}
-		String declared = withoutComment(valueOf(lines.get(index), key));
-		return Optional.of(continuesBelow(declared) ? folded(index + 1) : unquoted(declared));
+		return mapping == null ? textValue(key) : composedValue(key);
 	}
 
 	/** The declared keys, in document order, without their trailing colon. */
 	public List<String> keys() {
-		return lines.stream().map(this::entryKey).flatMap(Optional::stream).toList();
+		return mapping == null ? textKeys() : composedKeys();
 	}
 
 	/**
@@ -140,14 +125,140 @@ public final class FrontMatter {
 	}
 
 	/**
-	 * The key a line declares, or empty when the line is not a {@code key:} entry.
-	 * This shares its definition with {@link #hasKey} and {@link #value}, so the
-	 * three never disagree about whether a line declares a key: a bare {@code key:}
-	 * or a {@code key: value} (or {@code key:\tvalue}) counts, while {@code key:value}
-	 * without a separating space, comments, list items, and indented continuation
-	 * lines do not.
+	 * The block as YAML reads it, or null when it does not read as a mapping —
+	 * either because it is malformed, or because it is not a mapping at all, which
+	 * is how a loader reads a {@code name:value} that lacks the space a YAML entry
+	 * needs. Both fall back to reading the lines as text.
 	 */
-	private Optional<String> entryKey(String line) {
+	private static MappingNode compose(List<String> lines) {
+		try {
+			Node composed = new Yaml().compose(new StringReader(String.join("\n", lines)));
+			return composed instanceof MappingNode entries ? entries : null;
+		} catch (YAMLException e) {
+			return null;
+		}
+	}
+
+	/** The keys of the composed mapping, duplicates and all, in document order. */
+	private List<String> composedKeys() {
+		return mapping.getValue().stream().map(entry -> folded(entry.getKeyNode())).toList();
+	}
+
+	/** The last declaration of {@code key}, since that is the one a YAML loader keeps. */
+	private Optional<String> composedValue(String key) {
+		return mapping.getValue().stream()
+				.filter(entry -> folded(entry.getKeyNode()).equals(key))
+				.reduce((first, last) -> last)
+				.map(entry -> folded(entry.getValueNode()));
+	}
+
+	/**
+	 * One node as a single line of text: a scalar as YAML resolved it, and a mapping
+	 * or sequence rendered into the {@code key: value} and {@code - item} shape a
+	 * YAML block writes them in. Every result is folded onto one line, so a literal
+	 * block scalar's newlines read the same way a folded one's do.
+	 * <p>
+	 * The rendering stops at {@value #MAX_VALUE_LENGTH} characters. Composing is
+	 * linear in the size of the document, but the node graph it answers is a graph
+	 * rather than a tree — an alias is the node it names, not a copy of it — so
+	 * walking it is not. Nine aliases nested nine deep is a few lines of YAML that
+	 * expands to hundreds of millions of characters, the shape known as a billion
+	 * laughs, and a rule that reads a repository's own files should not be the thing
+	 * that expands it. The cap is far above any value a rule meaningfully checks: a
+	 * description this long has already failed whatever length it was held to.
+	 */
+	private static String folded(Node node) {
+		StringBuilder text = new StringBuilder();
+		render(node, text);
+		return onOneLine(text.length() > MAX_VALUE_LENGTH ? text.substring(0, MAX_VALUE_LENGTH) : text.toString());
+	}
+
+	private static void render(Node node, StringBuilder text) {
+		if (node instanceof ScalarNode scalar) {
+			text.append(scalar.getValue());
+		} else if (node instanceof MappingNode entries) {
+			entries.getValue().stream().takeWhile(entry -> hasRoom(text))
+					.forEach(entry -> renderEntry(entry, text));
+		} else if (node instanceof SequenceNode items) {
+			items.getValue().stream().takeWhile(item -> hasRoom(text)).forEach(item -> renderItem(item, text));
+		}
+	}
+
+	private static void renderEntry(NodeTuple entry, StringBuilder text) {
+		separate(text);
+		render(entry.getKeyNode(), text);
+		text.append(KEY_VALUE_SEPARATOR).append(' ');
+		render(entry.getValueNode(), text);
+	}
+
+	private static void renderItem(Node item, StringBuilder text) {
+		separate(text);
+		text.append("- ");
+		render(item, text);
+	}
+
+	/** Separates one entry or item from the one before it, never doubling a space already there. */
+	private static void separate(StringBuilder text) {
+		if (!text.isEmpty() && text.charAt(text.length() - 1) != ' ') {
+			text.append(' ');
+		}
+	}
+
+	/**
+	 * Whether there is still room to render into {@code text}. Tested by the
+	 * collections rather than only on entry to {@link #render}, so a walk that has
+	 * filled the budget stops iterating instead of merely stopping appending — the
+	 * iteration is the part an alias graph multiplies.
+	 */
+	private static boolean hasRoom(StringBuilder text) {
+		return text.length() < MAX_VALUE_LENGTH;
+	}
+
+	/**
+	 * The text folded onto one line: each line stripped, the blank ones dropped, and
+	 * the rest joined by single spaces. A value already on one line is only
+	 * stripped, so its own spacing survives.
+	 */
+	private static String onOneLine(String value) {
+		return value.lines().map(String::strip).filter(line -> !line.isEmpty()).collect(Collectors.joining(" "));
+	}
+
+	/**
+	 * The keys a malformed block declares, read from its lines. A key is only
+	 * recognised where YAML puts one: at the start of a line, with no indentation,
+	 * followed by a colon and whitespace or nothing at all. An indented line
+	 * continues the value above it, so reading a key out of one would invent entries
+	 * an author never declared.
+	 */
+	private List<String> textKeys() {
+		return lines.stream().map(FrontMatter::entryKey).flatMap(Optional::stream).toList();
+	}
+
+	/** The text following {@code key} in a malformed block, verbatim, folded onto one line. */
+	private Optional<String> textValue(String key) {
+		int index = indexOfEntry(key);
+		if (index < 0) {
+			return Optional.empty();
+		}
+		String declared = valueOf(lines.get(index), key);
+		return Optional.of(declared.isEmpty() ? foldedBelow(index + 1) : declared);
+	}
+
+	/**
+	 * The entry's continuation lines from {@code from}, folded onto one line. They
+	 * run until the next entry at the block's own level, so blank lines inside them
+	 * are kept as separators and dropped from the result.
+	 */
+	private String foldedBelow(int from) {
+		return onOneLine(String.join("\n",
+				lines.subList(from, lines.size()).stream().takeWhile(FrontMatter::isContinuation).toList()));
+	}
+
+	private static boolean isContinuation(String line) {
+		return line.isBlank() || isIndented(line);
+	}
+
+	private static Optional<String> entryKey(String line) {
 		String stripped = line.strip();
 		if (isIndented(line) || stripped.startsWith("#") || stripped.startsWith("-")) {
 			return Optional.empty();
@@ -160,7 +271,7 @@ public final class FrontMatter {
 		return isEntryFor(line, key) ? Optional.of(key) : Optional.empty();
 	}
 
-	private boolean isEntryFor(String line, String key) {
+	private static boolean isEntryFor(String line, String key) {
 		if (isIndented(line)) {
 			return false;
 		}
@@ -171,7 +282,7 @@ public final class FrontMatter {
 	}
 
 	/** True when the line is a continuation of the entry above rather than one of its own. */
-	private boolean isIndented(String line) {
+	private static boolean isIndented(String line) {
 		return !line.isEmpty() && Character.isWhitespace(line.charAt(0));
 	}
 
@@ -185,154 +296,9 @@ public final class FrontMatter {
 		return -1;
 	}
 
-	/**
-	 * Whether the key's own line leaves its value to the lines below: it declares a
-	 * block scalar indicator, or it declares nothing at all — the shape a nested
-	 * mapping and a wrapped plain scalar share.
-	 */
-	private boolean continuesBelow(String declared) {
-		return declared.isEmpty() || BLOCK_SCALAR.matcher(declared).matches();
-	}
-
-	/**
-	 * The entry's continuation lines from {@code from}, joined with single spaces.
-	 * They run until the next entry at the block's own level, so blank lines inside
-	 * them are kept as separators and dropped from the result. An entry with no
-	 * continuation lines folds to the empty string, which is what a bare {@code key:}
-	 * declares.
-	 */
-	private String folded(int from) {
-		return lines.subList(from, lines.size()).stream()
-				.takeWhile(this::isContinuation)
-				.map(String::strip)
-				.filter(line -> !line.isEmpty())
-				.collect(Collectors.joining(" "));
-	}
-
-	private boolean isContinuation(String line) {
-		return line.isBlank() || isIndented(line);
-	}
-
-	private String valueOf(String line, String key) {
+	private static String valueOf(String line, String key) {
 		String stripped = line.strip();
 		return stripped.substring((key + KEY_VALUE_SEPARATOR).length()).strip();
-	}
-
-	/**
-	 * The value with a trailing YAML comment removed. A {@code #} that opens a
-	 * comment stands outside a quoted scalar and follows whitespace, which is what
-	 * separates the note in {@code name: git-commit # the commit helper} from the
-	 * value in {@code version: 1.0#2}. Keeping the note made a name break the
-	 * kebab-case convention it follows and a description count characters a YAML
-	 * loader — and so Claude Code — never reads.
-	 * <p>
-	 * Only a quote that opens the value quotes it, as YAML reads it: a {@code '}
-	 * anywhere else is an apostrophe in a plain scalar. Treating every quote
-	 * character as an opening one left {@code Don't stop # a note} inside a scalar
-	 * that never closed, and the note was kept as part of the description — the very
-	 * characters this exists to drop.
-	 */
-	private static String withoutComment(String value) {
-		int comment = indexOfComment(value);
-		return comment < 0 ? value : value.substring(0, comment).strip();
-	}
-
-	/**
-	 * Where a trailing comment begins, or {@code -1} when the value carries none. The
-	 * search starts past a quoted scalar, since a {@code #} inside quotes is content;
-	 * a quoted scalar that never closes is malformed, so nothing after it is read as a
-	 * comment either.
-	 */
-	private static int indexOfComment(String value) {
-		int from = endOfQuotedScalar(value);
-		if (from < 0) {
-			return -1;
-		}
-		for (int i = from; i < value.length(); i++) {
-			if (value.charAt(i) == COMMENT_START && startsComment(value, i)) {
-				return i;
-			}
-		}
-		return -1;
-	}
-
-	/**
-	 * The index just past the value's opening quoted scalar, {@code 0} when it opens
-	 * with no quote, or {@code -1} when the scalar it opens never closes.
-	 */
-	private static int endOfQuotedScalar(String value) {
-		char quote = value.isEmpty() ? NONE : value.charAt(0);
-		if (quote != DOUBLE_QUOTE && quote != SINGLE_QUOTE) {
-			return 0;
-		}
-		return indexOfClosingQuote(value, 1, quote);
-	}
-
-	/**
-	 * The index just past the {@code quote} that closes a scalar opened at the start
-	 * of {@code value}, or {@code -1} when none does. The escape each quoting style
-	 * uses is stepped over rather than read as that closing quote.
-	 */
-	private static int indexOfClosingQuote(String value, int from, char quote) {
-		int index = from;
-		while (index < value.length() && !closesAt(value, index, quote)) {
-			index += isEscapeAt(value, index, quote) ? 2 : 1;
-		}
-		return index < value.length() ? index + 1 : -1;
-	}
-
-	/** True when the character at {@code index} is the quote that ends the scalar. */
-	private static boolean closesAt(String value, int index, char quote) {
-		return value.charAt(index) == quote && !isEscapeAt(value, index, quote);
-	}
-
-	/**
-	 * True when the character at {@code index} opens an escape: a backslash inside a
-	 * double-quoted scalar, or the first of the doubled quotes a single-quoted one
-	 * writes an apostrophe with.
-	 */
-	private static boolean isEscapeAt(String value, int index, char quote) {
-		char character = value.charAt(index);
-		if (quote == DOUBLE_QUOTE) {
-			return character == ESCAPE;
-		}
-		return character == SINGLE_QUOTE && value.startsWith(ESCAPED_SINGLE_QUOTE, index);
-	}
-
-	/** A {@code #} opens a comment at the start of the value or after whitespace, never mid-token. */
-	private static boolean startsComment(String value, int index) {
-		return index == 0 || Character.isWhitespace(value.charAt(index - 1));
-	}
-
-	/**
-	 * The text inside a scalar's matching quotes, with the escape each quoting style
-	 * uses resolved, or the value unchanged when it is not quoted.
-	 */
-	private static String unquoted(String value) {
-		if (isWrapped(value, DOUBLE_QUOTE, ESCAPED_DOUBLE_QUOTE)) {
-			return interiorOf(value).replace(ESCAPED_DOUBLE_QUOTE, String.valueOf(DOUBLE_QUOTE));
-		}
-		if (isWrapped(value, SINGLE_QUOTE, ESCAPED_SINGLE_QUOTE)) {
-			return interiorOf(value).replace(ESCAPED_SINGLE_QUOTE, String.valueOf(SINGLE_QUOTE));
-		}
-		return value;
-	}
-
-	/**
-	 * True when {@code quote} opens and closes the whole value and appears inside it
-	 * only as {@code escaped}. An unescaped inner quote means the outer two are not a
-	 * pair — {@code "a" and "b"} opens and closes twice — and stripping them would
-	 * hand back text the author never wrote.
-	 */
-	private static boolean isWrapped(String value, char quote, String escaped) {
-		if (value.length() < 2 || value.charAt(0) != quote || value.charAt(value.length() - 1) != quote) {
-			return false;
-		}
-		return interiorOf(value).replace(escaped, "").indexOf(quote) < 0;
-	}
-
-	private static String interiorOf(String value) {
-		return value.substring(1, value.length() - 1);
 	}
 
 	private static int indexOfDelimiter(List<String> lines, int from) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -37,12 +37,15 @@ import org.yaml.snakeyaml.nodes.SequenceNode;
  * purpose: {@code by: agent/1} reads back as text rather than as a nested entry. A
  * rule that needs the structure itself should ask SnakeYAML for it directly.
  * <p>
- * A block YAML cannot read at all — an unterminated quoted scalar, or a value such
- * as {@code "a" and "b"} whose quotes do not wrap it — is read as plain text
- * instead: its {@code key:} lines name the keys, and each key's value is the text
- * that follows it, verbatim. Guessing at what the malformed line meant is what a
- * loader will not do either, so the rules see the characters the author actually
- * wrote and can report on them, rather than a value invented here.
+ * A block no loader can read — an unterminated quoted scalar, or a value such as
+ * {@code "a" and "b"} whose quotes do not wrap it — is no front matter at all, and
+ * {@link #parse} answers empty for it. Reading it as text instead and handing the
+ * rules each key's characters verbatim validated something Claude Code never sees:
+ * its loader fails on that block exactly as this one does. The rules already say so
+ * far better than a guess could — "has no parseable YAML frontmatter block" — so
+ * there is nothing here to invent. A block that reads but declares no entries, such
+ * as the {@code name:value} that lacks the space a YAML entry needs, is present and
+ * simply declares nothing.
  * <p>
  * A key declared twice yields its <em>last</em> declaration, which is the one a
  * YAML loader keeps and so the one Claude Code acts on. Reading the first instead
@@ -60,14 +63,10 @@ public final class FrontMatter {
 	/** How much of one entry is rendered before the walk gives up. See {@link #folded}. */
 	private static final int MAX_VALUE_LENGTH = 8192;
 
-	private final List<String> lines;
+	private final List<NodeTuple> entries;
 
-	/** The block's entries as YAML read them, or null when YAML cannot read the block. */
-	private final MappingNode mapping;
-
-	private FrontMatter(List<String> lines, MappingNode mapping) {
-		this.lines = lines;
-		this.mapping = mapping;
+	private FrontMatter(List<NodeTuple> entries) {
+		this.entries = entries;
 	}
 
 	/**
@@ -87,8 +86,7 @@ public final class FrontMatter {
 		if (end < 0) {
 			return Optional.empty();
 		}
-		List<String> block = allLines.subList(1, end);
-		return Optional.of(new FrontMatter(block, compose(block)));
+		return entriesOf(allLines.subList(1, end)).map(FrontMatter::new);
 	}
 
 	/** True when a {@code key:} entry is present, regardless of its value. */
@@ -105,12 +103,15 @@ public final class FrontMatter {
 	 * declaration, the one a YAML loader keeps.
 	 */
 	public Optional<String> value(String key) {
-		return mapping == null ? textValue(key) : composedValue(key);
+		return entries.stream()
+				.filter(entry -> folded(entry.getKeyNode()).equals(key))
+				.reduce((first, last) -> last)
+				.map(entry -> folded(entry.getValueNode()));
 	}
 
 	/** The declared keys, in document order, without their trailing colon. */
 	public List<String> keys() {
-		return mapping == null ? textKeys() : composedKeys();
+		return entries.stream().map(entry -> folded(entry.getKeyNode())).toList();
 	}
 
 	/**
@@ -125,31 +126,18 @@ public final class FrontMatter {
 	}
 
 	/**
-	 * The block as YAML reads it, or null when it does not read as a mapping —
-	 * either because it is malformed, or because it is not a mapping at all, which
-	 * is how a loader reads a {@code name:value} that lacks the space a YAML entry
-	 * needs. Both fall back to reading the lines as text.
+	 * The block's entries as YAML reads them, or empty when no loader can read the
+	 * block. A document that reads but is not a mapping declares no entries rather
+	 * than being unreadable: that is how a loader sees a {@code name:value} written
+	 * without the space a YAML entry needs.
 	 */
-	private static MappingNode compose(List<String> lines) {
+	private static Optional<List<NodeTuple>> entriesOf(List<String> lines) {
 		try {
 			Node composed = new Yaml().compose(new StringReader(String.join("\n", lines)));
-			return composed instanceof MappingNode entries ? entries : null;
+			return Optional.of(composed instanceof MappingNode mapping ? mapping.getValue() : List.of());
 		} catch (YAMLException e) {
-			return null;
+			return Optional.empty();
 		}
-	}
-
-	/** The keys of the composed mapping, duplicates and all, in document order. */
-	private List<String> composedKeys() {
-		return mapping.getValue().stream().map(entry -> folded(entry.getKeyNode())).toList();
-	}
-
-	/** The last declaration of {@code key}, since that is the one a YAML loader keeps. */
-	private Optional<String> composedValue(String key) {
-		return mapping.getValue().stream()
-				.filter(entry -> folded(entry.getKeyNode()).equals(key))
-				.reduce((first, last) -> last)
-				.map(entry -> folded(entry.getValueNode()));
 	}
 
 	/**
@@ -221,84 +209,6 @@ public final class FrontMatter {
 	 */
 	private static String onOneLine(String value) {
 		return value.lines().map(String::strip).filter(line -> !line.isEmpty()).collect(Collectors.joining(" "));
-	}
-
-	/**
-	 * The keys a malformed block declares, read from its lines. A key is only
-	 * recognised where YAML puts one: at the start of a line, with no indentation,
-	 * followed by a colon and whitespace or nothing at all. An indented line
-	 * continues the value above it, so reading a key out of one would invent entries
-	 * an author never declared.
-	 */
-	private List<String> textKeys() {
-		return lines.stream().map(FrontMatter::entryKey).flatMap(Optional::stream).toList();
-	}
-
-	/** The text following {@code key} in a malformed block, verbatim, folded onto one line. */
-	private Optional<String> textValue(String key) {
-		int index = indexOfEntry(key);
-		if (index < 0) {
-			return Optional.empty();
-		}
-		String declared = valueOf(lines.get(index), key);
-		return Optional.of(declared.isEmpty() ? foldedBelow(index + 1) : declared);
-	}
-
-	/**
-	 * The entry's continuation lines from {@code from}, folded onto one line. They
-	 * run until the next entry at the block's own level, so blank lines inside them
-	 * are kept as separators and dropped from the result.
-	 */
-	private String foldedBelow(int from) {
-		return onOneLine(String.join("\n",
-				lines.subList(from, lines.size()).stream().takeWhile(FrontMatter::isContinuation).toList()));
-	}
-
-	private static boolean isContinuation(String line) {
-		return line.isBlank() || isIndented(line);
-	}
-
-	private static Optional<String> entryKey(String line) {
-		String stripped = line.strip();
-		if (isIndented(line) || stripped.startsWith("#") || stripped.startsWith("-")) {
-			return Optional.empty();
-		}
-		int separator = stripped.indexOf(KEY_VALUE_SEPARATOR);
-		if (separator <= 0) {
-			return Optional.empty();
-		}
-		String key = stripped.substring(0, separator);
-		return isEntryFor(line, key) ? Optional.of(key) : Optional.empty();
-	}
-
-	private static boolean isEntryFor(String line, String key) {
-		if (isIndented(line)) {
-			return false;
-		}
-		String stripped = line.strip();
-		return stripped.equals(key + KEY_VALUE_SEPARATOR)
-				|| stripped.startsWith(key + KEY_VALUE_SEPARATOR + " ")
-				|| stripped.startsWith(key + KEY_VALUE_SEPARATOR + "\t");
-	}
-
-	/** True when the line is a continuation of the entry above rather than one of its own. */
-	private static boolean isIndented(String line) {
-		return !line.isEmpty() && Character.isWhitespace(line.charAt(0));
-	}
-
-	/** The last line declaring {@code key}, since that is the declaration YAML keeps. */
-	private int indexOfEntry(String key) {
-		for (int i = lines.size() - 1; i >= 0; i--) {
-			if (isEntryFor(lines.get(i), key)) {
-				return i;
-			}
-		}
-		return -1;
-	}
-
-	private static String valueOf(String line, String key) {
-		String stripped = line.strip();
-		return stripped.substring((key + KEY_VALUE_SEPARATOR).length()).strip();
 	}
 
 	private static int indexOfDelimiter(List<String> lines, int from) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
@@ -25,6 +25,12 @@ import java.util.regex.Pattern;
  * left untouched, and one that is repaired keeps the line separator it was written
  * with, so repairing two delimiter lines does not rewrite every other line of a
  * CRLF file.
+ * <p>
+ * A repair that changes nothing is no repair, and is reported as none. Not every
+ * block {@link FrontMatter} declines to read is one this fixer can mend — a block
+ * whose delimiters are already canonical and whose <em>YAML</em> is malformed is
+ * beyond it — and returning that document unchanged would have the caller write the
+ * file it already had, and log a fix, on every build.
  */
 public final class FrontMatterFixer {
 
@@ -61,7 +67,8 @@ public final class FrontMatterFixer {
 		if (open < 0 || !isDelimiterLike(lines.get(open))) {
 			return Optional.empty();
 		}
-		return repairDelimiters(lines, open).map(fixed -> render(withoutLeadingBlanks(fixed), content));
+		return repairDelimiters(lines, open).map(fixed -> render(withoutLeadingBlanks(fixed), content))
+				.filter(repaired -> !repaired.equals(content));
 	}
 
 	/** The lines with any blank lines before the opening delimiter removed, so the block starts on line one. */

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
@@ -171,4 +171,15 @@ class FrontMatterFixerTest {
 
 		assertEquals(Optional.of("---\nname: reviewer\n---\nBody one.\n"), FrontMatterFixer.repair(content));
 	}
+
+	/**
+	 * Malformed YAML inside delimiters that are already canonical is beyond this
+	 * fixer. {@link FrontMatter} declines to read such a block, so the repair is
+	 * attempted and changes nothing — and reporting that as a repair would have the
+	 * caller rewrite the file it already had, and log a fix, on every build.
+	 */
+	@Test
+	void reportsNoRepairForABlockItCannotMend() {
+		assertTrue(FrontMatterFixer.repair("---\ndescription: \"a\" and \"b\"\n---\nBody.\n").isEmpty());
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -199,14 +199,6 @@ class FrontMatterTest {
 				FrontMatter.parse("---\ndescription: 'it''s'\n---\n").orElseThrow().value("description"));
 	}
 
-	/** The outer quotes of {@code "a" and "b"} are two pairs, not one wrapping the value. */
-	@Test
-	void keepsQuotesThatDoNotWrapTheWholeValue() {
-		FrontMatter frontMatter = FrontMatter.parse("---\ndescription: \"a\" and \"b\"\n---\n").orElseThrow();
-
-		assertEquals(Optional.of("\"a\" and \"b\""), frontMatter.value("description"));
-	}
-
 	@Test
 	void readsAnEmptyQuotedValueAsBlank() {
 		FrontMatter frontMatter = FrontMatter.parse("---\ndescription: \"\"\n---\n").orElseThrow();
@@ -297,12 +289,15 @@ class FrontMatterTest {
 		assertEquals(Optional.of("it's here"), frontMatter.orElseThrow().value("description"));
 	}
 
-	/** A scalar whose quote never closes is malformed, so nothing after it is read as a comment either. */
+	/**
+	 * A block no YAML loader can read is no front matter: Claude Code's loader fails
+	 * on it exactly as this one does, so there is nothing here to validate. The rules
+	 * report its absence, which says more than a guess at the malformed line could.
+	 */
 	@Test
-	void keepsEverythingAfterAnUnclosedQuotedScalar() {
-		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\ndescription: \"oops # a note\n---\n");
-
-		assertEquals(Optional.of("\"oops # a note"), frontMatter.orElseThrow().value("description"));
+	void readsNoFrontMatterFromABlockYamlCannotRead() {
+		assertTrue(FrontMatter.parse("---\ndescription: \"a\" and \"b\"\n---\n").isEmpty());
+		assertTrue(FrontMatter.parse("---\ndescription: \"oops # a note\n---\n").isEmpty());
 	}
 
 	@Test
@@ -391,17 +386,14 @@ class FrontMatterTest {
 	}
 
 	/**
-	 * A block no YAML loader can read is read as plain text, so the rules still see
-	 * the keys their author declared and can report on them, rather than being told
-	 * the block declares nothing at all.
+	 * A block that reads but is not a mapping is present and declares nothing, which
+	 * is not the same as one no loader can read at all.
 	 */
 	@Test
-	void namesTheKeysOfABlockThatYamlCannotRead() {
-		FrontMatter frontMatter = FrontMatter.parse("---\nname: demo\ndescription: \"a\" and \"b\"\n---\n")
-				.orElseThrow();
+	void readsABlockThatIsNotAMappingAsDeclaringNothing() {
+		FrontMatter frontMatter = FrontMatter.parse("---\nname:git-commit\n---\n").orElseThrow();
 
-		assertEquals(List.of("name", "description"), frontMatter.keys());
-		assertEquals(Optional.of("demo"), frontMatter.value("name"));
+		assertEquals(List.of(), frontMatter.keys());
 	}
 
 	/**
@@ -426,12 +418,4 @@ class FrontMatterTest {
 		assertTrue(frontMatter.value("f").orElseThrow().length() <= 8192, "the expansion must be capped");
 	}
 
-	/** Reading a malformed block as text still folds a value written below its key. */
-	@Test
-	void foldsAValueBelowItsKeyInABlockThatYamlCannotRead() {
-		FrontMatter frontMatter = FrontMatter
-				.parse("---\ndescription: \"oops\ngenerated:\n  by: agent/1\n---\n").orElseThrow();
-
-		assertEquals(Optional.of("by: agent/1"), frontMatter.value("generated"));
-	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -354,4 +354,84 @@ class FrontMatterTest {
 
 		assertEquals(Optional.of(""), frontMatter.orElseThrow().value("name"));
 	}
+
+	/**
+	 * A double-quoted scalar is the one style that carries escapes, and a YAML
+	 * loader resolves them. Reading the two characters {@code \n} literally counted
+	 * a description Claude Code never sees and could fail a name over a backslash
+	 * that is not in it.
+	 */
+	@Test
+	void resolvesTheEscapeSequencesOfADoubleQuotedScalar() {
+		Optional<FrontMatter> frontMatter = FrontMatter.parse("---\ndescription: \"one\\ntwo\"\n---\n");
+
+		assertEquals(Optional.of("one two"), frontMatter.orElseThrow().value("description"));
+	}
+
+	/** A mapping written inline is the same mapping as one written on the lines below its key. */
+	@Test
+	void foldsAMappingWrittenInFlowStyle() {
+		Optional<FrontMatter> frontMatter = FrontMatter
+				.parse("---\ngenerated: {by: agent/1, at: 2026-01-01}\n---\n");
+
+		assertEquals(Optional.of("by: agent/1 at: 2026-01-01"), frontMatter.orElseThrow().value("generated"));
+	}
+
+	/**
+	 * The block is composed rather than loaded, so a value stays the text its author
+	 * wrote. Constructing it into a Java object would answer {@code 0.2} for a
+	 * version declared as {@code 0.20} — and the OKF rule compares that string
+	 * against the version it demands.
+	 */
+	@Test
+	void answersAVersionAsTheTextItWasWrittenAs() {
+		FrontMatter frontMatter = FrontMatter.parse("---\nokf_version: 0.20\n---\n").orElseThrow();
+
+		assertEquals(Optional.of("0.20"), frontMatter.value("okf_version"));
+	}
+
+	/**
+	 * A block no YAML loader can read is read as plain text, so the rules still see
+	 * the keys their author declared and can report on them, rather than being told
+	 * the block declares nothing at all.
+	 */
+	@Test
+	void namesTheKeysOfABlockThatYamlCannotRead() {
+		FrontMatter frontMatter = FrontMatter.parse("---\nname: demo\ndescription: \"a\" and \"b\"\n---\n")
+				.orElseThrow();
+
+		assertEquals(List.of("name", "description"), frontMatter.keys());
+		assertEquals(Optional.of("demo"), frontMatter.value("name"));
+	}
+
+	/**
+	 * An alias is the node it names, not a copy of it, so a handful of nested
+	 * aliases describe a value of hundreds of millions of characters. Rendering one
+	 * stops at the cap instead of expanding it, which is what keeps a rule reading a
+	 * repository's files from being the thing that runs out of memory.
+	 */
+	@Test
+	void stopsRenderingAnAliasThatExpandsWithoutBound() {
+		FrontMatter frontMatter = FrontMatter.parse("""
+				---
+				a: &a [x, x, x, x, x, x, x, x, x]
+				b: &b [*a, *a, *a, *a, *a, *a, *a, *a, *a]
+				c: &c [*b, *b, *b, *b, *b, *b, *b, *b, *b]
+				d: &d [*c, *c, *c, *c, *c, *c, *c, *c, *c]
+				e: &e [*d, *d, *d, *d, *d, *d, *d, *d, *d]
+				f: [*e, *e, *e, *e, *e, *e, *e, *e, *e]
+				---
+				""").orElseThrow();
+
+		assertTrue(frontMatter.value("f").orElseThrow().length() <= 8192, "the expansion must be capped");
+	}
+
+	/** Reading a malformed block as text still folds a value written below its key. */
+	@Test
+	void foldsAValueBelowItsKeyInABlockThatYamlCannotRead() {
+		FrontMatter frontMatter = FrontMatter
+				.parse("---\ndescription: \"oops\ngenerated:\n  by: agent/1\n---\n").orElseThrow();
+
+		assertEquals(Optional.of("by: agent/1"), frontMatter.value("generated"));
+	}
 }

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -68,6 +68,13 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
+		<!-- Emits the YAML frontmatter of every OKF concept document. Quoting and
+		     escaping are the emitter's job: hand-writing them wrote a raw newline
+		     or control character straight into a double-quoted scalar. -->
+		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/code/context/src/main/java/io/github/adamw7/context/okf/OkfFrontmatter.java
+++ b/code/context/src/main/java/io/github/adamw7/context/okf/OkfFrontmatter.java
@@ -2,27 +2,32 @@ package io.github.adamw7.context.okf;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
 
 /**
  * The YAML frontmatter block that opens every OKF concept document. The Open
  * Knowledge Format makes exactly one field mandatory — {@code type} — and
  * recommends {@code title}, {@code description}, {@code resource} and
  * {@code tags}; v0.2 records how a concept was produced as
- * {@code generated: { by, at }}. This builder renders that subset in a fixed
- * order and skips the fields a caller left unset, so callers describe a concept
- * in domain terms rather than assembling YAML by hand.
+ * {@code generated: { by, at }}, its actor following the specification's
+ * {@code <producer>/<version>} convention. This builder collects that subset,
+ * drops the fields a caller left unset, and hands the rest to SnakeYAML in the
+ * specification's order.
  * <p>
- * Every scalar is emitted double-quoted, which keeps a colon in a description or
- * a {@code #} in a path from changing the meaning of the block, and the actor of
- * {@code generated.by} follows the specification's {@code <producer>/<version>}
- * convention.
+ * Quoting is the emitter's decision, not this class's. Writing every scalar
+ * double-quoted and escaping the two characters that seemed to matter suited the
+ * values a concept usually carries and nothing else: a title holding a newline or
+ * a control character — both of which a file name on disk may — went straight into
+ * the middle of a quoted scalar, and the block no longer parsed as YAML at all.
  */
 public class OkfFrontmatter {
 
 	private static final String DELIMITER = "---";
-	private static final String SEPARATOR = ": ";
 
 	private final String type;
 	private String title;
@@ -71,44 +76,45 @@ public class OkfFrontmatter {
 	}
 
 	public String render() {
-		StringBuilder builder = new StringBuilder();
-		builder.append(DELIMITER).append(System.lineSeparator());
-		appendScalar(builder, "type", type);
-		appendScalar(builder, "title", title);
-		appendScalar(builder, "description", description);
-		appendScalar(builder, "resource", resource);
-		appendTags(builder);
-		appendGenerated(builder);
-		builder.append(DELIMITER).append(System.lineSeparator());
-		return builder.toString();
+		return DELIMITER + System.lineSeparator() + emitter().dump(fields())
+				+ DELIMITER + System.lineSeparator();
 	}
 
-	private void appendScalar(StringBuilder builder, String key, String value) {
-		if (value == null || value.isBlank()) {
-			return;
+	/** Built here, not as the setters run, so the block keeps the specification's order. */
+	private Map<String, Object> fields() {
+		Map<String, Object> fields = new LinkedHashMap<>();
+		fields.put("type", type);
+		put(fields, "title", title);
+		put(fields, "description", description);
+		put(fields, "resource", resource);
+		if (!tags.isEmpty()) {
+			fields.put("tags", tags);
 		}
-		builder.append(key).append(SEPARATOR).append(quote(value)).append(System.lineSeparator());
-	}
-
-	private void appendTags(StringBuilder builder) {
-		if (tags.isEmpty()) {
-			return;
+		if (generatedBy != null && generatedAt != null) {
+			fields.put("generated", generated());
 		}
-		String rendered = tags.stream().map(OkfFrontmatter::quote).collect(Collectors.joining(", ", "[", "]"));
-		builder.append("tags").append(SEPARATOR).append(rendered).append(System.lineSeparator());
+		return fields;
 	}
 
-	private void appendGenerated(StringBuilder builder) {
-		if (generatedBy == null || generatedAt == null) {
-			return;
+	private Map<String, String> generated() {
+		Map<String, String> generated = new LinkedHashMap<>();
+		generated.put("by", generatedBy);
+		generated.put("at", generatedAt.truncatedTo(ChronoUnit.SECONDS).toString());
+		return generated;
+	}
+
+	private static void put(Map<String, Object> fields, String key, String value) {
+		if (value != null && !value.isBlank()) {
+			fields.put(key, value);
 		}
-		builder.append("generated").append(SEPARATOR)
-				.append("{ by: ").append(quote(generatedBy))
-				.append(", at: ").append(quote(generatedAt.truncatedTo(ChronoUnit.SECONDS).toString()))
-				.append(" }").append(System.lineSeparator());
 	}
 
-	private static String quote(String value) {
-		return '"' + value.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
+	/** Block style, and no width: SnakeYAML otherwise wraps a long description at 80 columns. */
+	private static Yaml emitter() {
+		DumperOptions options = new DumperOptions();
+		options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+		options.setLineBreak(DumperOptions.LineBreak.getPlatformLineBreak());
+		options.setWidth(Integer.MAX_VALUE);
+		return new Yaml(options);
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/OkfBundleToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/OkfBundleToolTest.java
@@ -78,7 +78,7 @@ public class OkfBundleToolTest {
 		JsonNode documents = MAPPER.readTree(text(tool.apply(arguments()))).get("documents");
 
 		assertTrue(documents.get("A.java.md").asText().startsWith("---"));
-		assertTrue(documents.get("A.java.md").asText().contains("type: \"Java Source File\""));
+		assertTrue(documents.get("A.java.md").asText().contains("type: Java Source File"));
 	}
 
 	@Test
@@ -99,7 +99,7 @@ public class OkfBundleToolTest {
 		arguments.put("language", "kotlin");
 
 		JsonNode documents = MAPPER.readTree(text(tool.apply(arguments))).get("documents");
-		assertTrue(documents.get("A.kt.md").asText().contains("type: \"Kotlin Source File\""));
+		assertTrue(documents.get("A.kt.md").asText().contains("type: Kotlin Source File"));
 	}
 
 	@Test

--- a/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundleConformanceTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundleConformanceTest.java
@@ -42,7 +42,7 @@ public class OkfBundleConformanceTest {
 	private static final String LOG = "log.md";
 	private static final Pattern TYPE = Pattern.compile("^type:\\s*(.+)$", Pattern.MULTILINE);
 	private static final Pattern OKF_VERSION = Pattern.compile("^okf_version:\\s*\"(.+)\"$", Pattern.MULTILINE);
-	private static final Pattern GENERATED_AT = Pattern.compile("at:\\s*\"([^\"]+)\"");
+	private static final Pattern GENERATED_AT = Pattern.compile("at:\\s*'?([^'\\s]+)'?");
 	private static final Pattern BUNDLE_LINK = Pattern.compile("]\\((/[^)]+)\\)");
 
 	@TempDir

--- a/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundlerTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundlerTest.java
@@ -55,7 +55,7 @@ public class OkfBundlerTest {
 				.filter(document -> !document.path().endsWith(OkfBundle.INDEX))
 				.forEach(document -> {
 					assertTrue(document.content().startsWith("---"), document.path() + " must open with frontmatter");
-					assertTrue(document.content().contains("type: \""), document.path() + " must declare a type");
+					assertTrue(document.content().contains("type: "), document.path() + " must declare a type");
 				});
 	}
 
@@ -141,7 +141,7 @@ public class OkfBundlerTest {
 
 		String description = "Java source file with 1 project dependency.";
 		assertTrue(document(bundle, "index.md").contains("* [B.java](B.java.md) - " + description));
-		assertTrue(document(bundle, "B.java.md").contains("description: \"" + description + "\""));
+		assertTrue(document(bundle, "B.java.md").contains("description: " + description));
 	}
 
 	@Test
@@ -173,8 +173,8 @@ public class OkfBundlerTest {
 
 		OkfBundle bundle = bundler.bundle(root);
 
-		assertTrue(document(bundle, "pom.xml.md").contains("type: \"Project File\""));
-		assertTrue(document(bundle, "pom.xml.md").contains("tags: [\"file\"]"));
+		assertTrue(document(bundle, "pom.xml.md").contains("type: Project File"));
+		assertTrue(document(bundle, "pom.xml.md").contains("tags:" + System.lineSeparator() + "- file"));
 	}
 
 	@Test
@@ -185,8 +185,8 @@ public class OkfBundlerTest {
 
 		OkfBundle bundle = kotlinBundler.bundle(root);
 
-		assertTrue(document(bundle, "A.kt.md").contains("type: \"Kotlin Source File\""));
-		assertTrue(document(bundle, "A.kt.md").contains("tags: [\"source\", \"kotlin\"]"));
+		assertTrue(document(bundle, "A.kt.md").contains("type: Kotlin Source File"));
+		assertTrue(document(bundle, "A.kt.md").contains("- source" + System.lineSeparator() + "- kotlin"));
 	}
 
 	@Test
@@ -198,7 +198,7 @@ public class OkfBundlerTest {
 
 		OkfBundle bundle = bundler.bundle(root);
 
-		assertTrue(document(bundle, "pkg/A.java.md").contains("resource: \"pkg/A.java\""));
+		assertTrue(document(bundle, "pkg/A.java.md").contains("resource: pkg/A.java"));
 	}
 
 	@Test
@@ -217,7 +217,7 @@ public class OkfBundlerTest {
 		OkfBundle bundle = bundler.bundle(root);
 
 		assertTrue(document(bundle, "A.java.md")
-				.contains("generated: { by: \"" + PRODUCER + "\", at: \"2026-08-03T10:15:30Z\" }"));
+				.contains("generated:" + System.lineSeparator() + "  by: " + PRODUCER + System.lineSeparator() + "  at: '2026-08-03T10:15:30Z'"));
 	}
 
 	@Test
@@ -228,7 +228,7 @@ public class OkfBundlerTest {
 		OkfBundle bundle = bundler.bundle(root);
 
 		assertTrue(document(bundle, "index.md").contains("# Files"));
-		assertTrue(document(bundle, "index.md.md").contains("type: \"Project File\""));
+		assertTrue(document(bundle, "index.md.md").contains("type: Project File"));
 	}
 
 	private String document(OkfBundle bundle, String path) {

--- a/code/context/src/test/java/io/github/adamw7/context/okf/OkfFrontmatterTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/okf/OkfFrontmatterTest.java
@@ -7,8 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
 
 public class OkfFrontmatterTest {
 
@@ -17,7 +19,7 @@ public class OkfFrontmatterTest {
 		String rendered = new OkfFrontmatter("Java Source File").render();
 
 		assertTrue(rendered.startsWith("---"));
-		assertTrue(rendered.contains("type: \"Java Source File\""));
+		assertEquals("Java Source File", fieldsOf(rendered).get("type"));
 		assertTrue(rendered.trim().endsWith("---"));
 	}
 
@@ -51,10 +53,11 @@ public class OkfFrontmatterTest {
 				.tags(List.of("source", "java"))
 				.render();
 
-		assertTrue(rendered.contains("title: \"A.java\""));
-		assertTrue(rendered.contains("description: \"Java source file with no project dependencies.\""));
-		assertTrue(rendered.contains("resource: \"src/A.java\""));
-		assertTrue(rendered.contains("tags: [\"source\", \"java\"]"));
+		Map<String, Object> fields = fieldsOf(rendered);
+		assertEquals("A.java", fields.get("title"));
+		assertEquals("Java source file with no project dependencies.", fields.get("description"));
+		assertEquals("src/A.java", fields.get("resource"));
+		assertEquals(List.of("source", "java"), fields.get("tags"));
 	}
 
 	@Test
@@ -63,8 +66,8 @@ public class OkfFrontmatterTest {
 				.generated("tools.code.context/1", Instant.parse("2026-08-03T10:15:30Z"))
 				.render();
 
-		assertTrue(rendered.contains(
-				"generated: { by: \"tools.code.context/1\", at: \"2026-08-03T10:15:30Z\" }"));
+		assertEquals(Map.of("by", "tools.code.context/1", "at", "2026-08-03T10:15:30Z"),
+				fieldsOf(rendered).get("generated"));
 	}
 
 	@Test
@@ -73,23 +76,35 @@ public class OkfFrontmatterTest {
 				.generated("tools.code.context/1", Instant.parse("2026-08-03T10:15:30.123456Z"))
 				.render();
 
-		assertTrue(rendered.contains("at: \"2026-08-03T10:15:30Z\""));
+		assertEquals("2026-08-03T10:15:30Z", generatedAt(rendered));
 	}
 
+	/**
+	 * The emitter decides how to quote; what matters is that the block still reads
+	 * back as the value it was given, colon, hash, quote, backslash and all. Asserting
+	 * the exact quoting instead would pin a choice that is SnakeYAML's to make.
+	 */
 	@Test
-	void quotesAValueThatWouldOtherwiseChangeTheMeaningOfTheBlock() {
-		String rendered = new OkfFrontmatter("Project File")
-				.description("Reads a: b # not a comment")
-				.render();
+	void survivesValuesThatWouldOtherwiseChangeTheMeaningOfTheBlock() {
+		String awkward = "Reads a: b # not a comment, \"quoted\" and back\\slashed";
 
-		assertTrue(rendered.contains("description: \"Reads a: b # not a comment\""));
+		String rendered = new OkfFrontmatter("Project File").description(awkward).render();
+
+		assertEquals(awkward, fieldsOf(rendered).get("description"));
 	}
 
+	/**
+	 * A newline in a title used to be written straight into the middle of a
+	 * double-quoted scalar, leaving a block that no longer parsed as YAML. The
+	 * break is written as YAML represents one, so the title reads back whole. It is
+	 * spelled {@code \n} rather than taken from the platform because that is what a
+	 * loader answers on either one.
+	 */
 	@Test
-	void escapesQuotesAndBackslashes() {
-		String rendered = new OkfFrontmatter("Project File").title("a\"b\\c").render();
+	void survivesAValueCarryingALineBreak() {
+		String rendered = new OkfFrontmatter("Project File").title("first\nsecond").render();
 
-		assertTrue(rendered.contains("title: \"a\\\"b\\\\c\""));
+		assertEquals("first\nsecond", fieldsOf(rendered).get("title"));
 	}
 
 	@Test
@@ -99,6 +114,16 @@ public class OkfFrontmatterTest {
 		tags.add("leaked");
 
 		assertFalse(frontmatter.render().contains("leaked"));
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> fieldsOf(String rendered) {
+		return new Yaml().load(rendered.replace("---", ""));
+	}
+
+	@SuppressWarnings("unchecked")
+	private static String generatedAt(String rendered) {
+		return ((Map<String, String>) fieldsOf(rendered).get("generated")).get("at");
 	}
 
 	@Test
@@ -112,6 +137,6 @@ public class OkfFrontmatterTest {
 				.render();
 
 		assertEquals(List.of("type", "title", "description", "resource", "tags", "generated"),
-				rendered.lines().filter(line -> line.contains(":")).map(line -> line.split(":")[0]).toList());
+				List.copyOf(fieldsOf(rendered).keySet()));
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,17 @@
 				<artifactId>reflections</artifactId>
 				<version>0.10.2</version>
 			</dependency>
+			<!-- The adoption command-line parser. Declared here rather than left to
+			     the Spring Boot parent, which does not manage it: the BOM covers the
+			     web and JSON stack the MCP servers are built on, not a CLI library.
+			     snakeyaml, which claude-code-enforcer reads front matter with, needs
+			     no entry for the opposite reason — Boot already pins it, and pinning
+			     it a second time here is a copy that can fall behind the parent. -->
+			<dependency>
+				<groupId>info.picocli</groupId>
+				<artifactId>picocli</artifactId>
+				<version>4.7.7</version>
+			</dependency>
 			<dependency>
 				<groupId>io.grpc</groupId>
 				<artifactId>grpc-protobuf</artifactId>


### PR DESCRIPTION
Two hand-rolled parsers are replaced by the libraries that already solve
what they were re-deriving.

adopt: CliArguments declares the command line to picocli instead of
walking the argument array. Each option binds to a method, because picocli
calls a method option once per occurrence in the order it was written —
the one thing a batch cannot lose, since a run mixing --repo with --repos
must adopt and report its repositories in that order.
setOverwrittenOptionsAllowed lets the repeatable flags repeat and makes
the last --workspace/--branch win over an earlier one or its positional.
The refusals come from the parser too — an unknown option, a fourth
positional, a missing value, and an option written where a naming flag's
value belongs — each re-raised as the IllegalArgumentException carrying
the usage line the entry points already expect, with a failure this module
raised itself travelling on unchanged. A flag may now be joined to its
value with '='. The usage line stays hand-written: picocli orders a
generated synopsis by reflecting over the methods, and the JVM does not
promise that order.

claude-code-enforcer: FrontMatter delimits the --- block and hands the
block to SnakeYAML. It stops at Yaml.compose, which answers a node tree
rather than constructing objects, so okf_version: 0.20 stays the string
0.20 rather than a double rounded to 0.2, and a key declared twice stays
visible for duplicateKeys() to report. Quoting, trailing comments, escapes
and block scalars — six or seven fix commits' worth of rules re-derived by
hand — are the loader's job now, and every case FrontMatterTest pinned
still holds. A block YAML cannot read falls back to being read as text, so
the rules see the characters the author wrote rather than a value invented
for them. Rendering an entry is capped: compose answers a graph, not a
tree, so nested aliases would otherwise expand without bound.

Versions follow the existing convention — picocli is declared in the root
pom, snakeyaml is left to the Spring Boot parent that already pins it.

Verified: full reactor build, the -DenforceClaudeMd doc check over this
repository's own files, the enforcer's real-Maven-build ITs (which prove
the rule jar still resolves with its new transitive dependency), the
JaCoCo gate, and PIT (enforcer 92%, adopt 91%, floor 88).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ikkgxKSMMw7uKGYmxGBx8