### PR TITLE
refactor(adopt, claude-code-enforcer): say the failure assertion once

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ not yet in force, and names what must land first).
 tools (root pom, packaging=pom)
 ├── claude-code-enforcer        # custom maven-enforcer rules validating CLAUDE.md,
 │                               #   AGENTS.md, README.md and the .claude config
-├── test-common                 # shared ArchUnit rule libraries, published as a test-jar
+├── test-common                 # shared ArchUnit rule libraries and assertions, published as a test-jar
 ├── mcp-common                  # shared MCP server scaffolding (transport wiring, tool SPI)
 ├── data                        # data sources, uniqueness checks, structures, MCP server
 ├── code
@@ -549,6 +549,15 @@ longer and carry no timeout.
   that poms configure by name. Adding a repository-wide convention means editing
   one library, not six tests; an exemption means a module not importing a
   library, which stays visible in that module's test.
+- **Shared assertions.** `test-common` also carries `ExpectedFailures`, whose
+  `assertFailure(type, call, fragments...)` is the assertion nearly every rule and
+  adoption-step test makes: the call must fail with that exception, and its
+  message must carry each fragment. Written out that is an `assertThrows` naming
+  the type twice, a local to hold the failure, and one
+  `assertTrue(...contains(...), ...getMessage())` per fragment — three lines to
+  say what one now says, with the thrown message as the assertion description by
+  construction rather than by every call remembering to pass it. A test with more
+  to say about the failure keeps the local, since the helper returns it.
 - **Integration tests** are gated behind the `integration-tests` profile
   (defined in `data`, `code/context`, `adopt`, and `claude-code-enforcer`) and are
   the tests that need

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ separately):
 ```
 tools (root pom, packaging=pom)
 ├── claude-code-enforcer   # custom maven-enforcer rules validating CLAUDE.md/AGENTS.md & agent config
-├── test-common            # shared ArchUnit rule libraries (test-jar), reused by every module's architecture tests
+├── test-common            # shared ArchUnit rule libraries and test assertions (test-jar), reused by every module
 ├── mcp-common             # shared MCP server scaffolding
 ├── data                   # data sources, uniqueness checks, structures, MCP server
 ├── code

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionFilesTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionFilesTest.java
@@ -1,8 +1,7 @@
 package io.github.adamw7.tools.adopt;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -22,9 +21,7 @@ class AdoptionFilesTest {
 	@Test
 	void namesTheFileAndItsDescriptionWhenAReadFails(@TempDir Path directory) {
 		Path missing = directory.resolve("absent.txt");
-		AdoptionException thrown = assertThrows(AdoptionException.class, () -> AdoptionFiles.read(missing, "POM"));
-		assertTrue(thrown.getMessage().contains("POM"), thrown.getMessage());
-		assertTrue(thrown.getMessage().contains(missing.toString()), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> AdoptionFiles.read(missing, "POM"), "POM", missing.toString());
 	}
 
 	@Test
@@ -50,9 +47,7 @@ class AdoptionFilesTest {
 	void namesTheFileAndItsDescriptionWhenAWriteFails(@TempDir Path directory) throws IOException {
 		Path file = directory.resolve("occupied");
 		Files.createDirectory(file);
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> AdoptionFiles.write(file, "content", "workflow file"));
-		assertTrue(thrown.getMessage().contains("workflow file"), thrown.getMessage());
-		assertTrue(thrown.getMessage().contains(file.toString()), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> AdoptionFiles.write(file, "content", "workflow file"),
+				"workflow file", file.toString());
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CheckoutsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CheckoutsTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,10 +53,9 @@ class CheckoutsTest {
 	@Test
 	void rejectsTwoOwnersRepositoriesOfTheSameName() {
 		checkouts.claim("https://github.com/owner/tools.git");
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> checkouts.claim("https://github.com/other-owner/tools.git"));
-		assertTrue(exception.getMessage().contains("other-owner/tools"), exception.getMessage());
-		assertTrue(exception.getMessage().contains(WORKSPACE.resolve("tools").toString()), exception.getMessage());
+		assertFailure(IllegalArgumentException.class,
+				() -> checkouts.claim("https://github.com/other-owner/tools.git"), "other-owner/tools",
+				WORKSPACE.resolve("tools").toString());
 	}
 
 	/**
@@ -79,20 +79,17 @@ class CheckoutsTest {
 	@Test
 	void namesBothCollidingRepositories() {
 		checkouts.claim(REPO_URL);
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> checkouts.claim("https://github.com/other-owner/repo.git"));
-		assertTrue(exception.getMessage().contains(REPO_URL), exception.getMessage());
-		assertTrue(exception.getMessage().contains("other-owner/repo.git"), exception.getMessage());
+		assertFailure(IllegalArgumentException.class, () -> checkouts.claim("https://github.com/other-owner/repo.git"),
+				REPO_URL, "other-owner/repo.git");
 	}
 
 	/** A collision names the repository it refused, never the credentials its URL carried. */
 	@Test
 	void masksTheCredentialsOfACollidingUrl() {
 		checkouts.claim(REPO_URL);
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> checkouts.claim("https://x-access-token:secret@github.com/other-owner/repo.git"));
-		assertTrue(exception.getMessage().contains("https://***@github.com/other-owner/repo.git"),
-				exception.getMessage());
+		IllegalArgumentException exception = assertFailure(IllegalArgumentException.class,
+				() -> checkouts.claim("https://x-access-token:secret@github.com/other-owner/repo.git"),
+				"https://***@github.com/other-owner/repo.git");
 		assertTrue(!exception.getMessage().contains("secret"), exception.getMessage());
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -105,9 +106,8 @@ class CliArgumentsTest {
 
 	@Test
 	void rejectsABlankRepositoryListFileName() {
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> CliArguments.parse(new String[] { REPO_URL, "--repos", "  " }));
-		assertTrue(exception.getMessage().contains("--repos"), exception.getMessage());
+		assertFailure(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { REPO_URL, "--repos", "  " }), "--repos");
 	}
 
 	@Test
@@ -260,16 +260,14 @@ class CliArgumentsTest {
 
 	@Test
 	void rejectsUnknownOption() {
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> CliArguments.parse(new String[] { REPO_URL, "--frobnicate" }));
-		assertTrue(exception.getMessage().contains("--frobnicate"), exception.getMessage());
+		assertFailure(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { REPO_URL, "--frobnicate" }), "--frobnicate");
 	}
 
 	@Test
 	void rejectsFlagMissingItsValue() {
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> CliArguments.parse(new String[] { REPO_URL, "--title" }));
-		assertTrue(exception.getMessage().contains("--title"), exception.getMessage());
+		assertFailure(IllegalArgumentException.class, () -> CliArguments.parse(new String[] { REPO_URL, "--title" }),
+				"--title");
 	}
 
 	@Test
@@ -308,10 +306,9 @@ class CliArgumentsTest {
 	@Test
 	void rejectsAWorkspacePositionalAlongsideTheRepositoryFlags(@TempDir Path dir) throws IOException {
 		Path list = Files.writeString(dir.resolve("repos.txt"), REPO_URL + "\n");
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> CliArguments.parse(new String[] { "/tmp/ws", "--repos", list.toString() }));
-		assertTrue(exception.getMessage().contains("--workspace"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("/tmp/ws"), exception.getMessage());
+		assertFailure(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { "/tmp/ws", "--repos", list.toString() }), "--workspace",
+				"/tmp/ws");
 	}
 
 	@Test
@@ -478,8 +475,6 @@ class CliArgumentsTest {
 	}
 
 	private void assertUsageFailure(String[] args) {
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> CliArguments.parse(args));
-		assertTrue(exception.getMessage().contains("Usage"), exception.getMessage());
+		assertFailure(IllegalArgumentException.class, () -> CliArguments.parse(args), "Usage");
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MainTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -28,9 +29,7 @@ class MainTest {
 
 	@Test
 	void rejectsMissingArguments() {
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> Main.main(new String[0]));
-		assertTrue(exception.getMessage().contains("Usage"), exception.getMessage());
+		assertFailure(IllegalArgumentException.class, () -> Main.main(new String[0]), "Usage");
 	}
 
 	@Test
@@ -134,9 +133,9 @@ class MainTest {
 	@Test
 	void writesTheReportWhenTheAdoptionFails(@TempDir Path dir) throws IOException {
 		Path file = dir.resolve("report.json");
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> Main.runAndReport(cli(dir, file), checkouts(dir), failingAdopter()));
-		assertTrue(thrown.getMessage().contains(REPO_URL + ": explode: boom"), thrown.getMessage());
+		assertFailure(AdoptionException.class,
+				() -> Main.runAndReport(cli(dir, file), checkouts(dir), failingAdopter()),
+				REPO_URL + ": explode: boom");
 		JsonNode node = new ObjectMapper().readTree(Files.readString(file));
 		assertFalse(node.get("succeeded").asBoolean());
 		assertEquals("explode: boom", node.get("failure").asText());
@@ -186,9 +185,10 @@ class MainTest {
 	@Test
 	void anUnwritableReportDoesNotReplaceTheAdoptionFailure(@TempDir Path dir) throws IOException {
 		Path blockingFile = Files.createFile(dir.resolve("not-a-directory"));
-		AdoptionException thrown = assertThrows(AdoptionException.class, () -> Main
-				.runAndReport(cli(dir, blockingFile.resolve("report.json")), checkouts(dir), failingAdopter()));
-		assertTrue(thrown.getMessage().contains("explode: boom"), thrown.getMessage());
+		AdoptionException thrown = assertFailure(AdoptionException.class,
+				() -> Main.runAndReport(cli(dir, blockingFile.resolve("report.json")), checkouts(dir),
+						failingAdopter()),
+				"explode: boom");
 		assertEquals(1, thrown.getSuppressed().length);
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MultiRepoAdoptionIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MultiRepoAdoptionIT.java
@@ -1,8 +1,8 @@
 package io.github.adamw7.tools.adopt;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -113,11 +113,8 @@ class MultiRepoAdoptionIT {
 		Path report = reports.resolve("partial.json");
 		CliArguments cli = parse("--repos", listFile(HELLO_WORLD, MISSING, SPOON_KNIFE).toString(),
 				"--workspace", workspace.toString(), "--branch", BRANCH, "--report", report.toString());
-		AdoptionException failure = assertThrows(AdoptionException.class,
-				() -> Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter()));
-
-		assertTrue(failure.getMessage().contains("1 of 3 repositories"), failure.getMessage());
-		assertTrue(failure.getMessage().contains(MISSING), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter()),
+				"1 of 3 repositories", MISSING);
 		assertCheckedOut(HELLO_WORLD);
 		assertCheckedOut(SPOON_KNIFE);
 		assertFalse(Files.exists(workspace.resolve("no-such-repository-tools-adopt-it")),
@@ -138,12 +135,8 @@ class MultiRepoAdoptionIT {
 		CliArguments cli = parse("--repo", HELLO_WORLD, "--repo", HELLO_WORLD_OVER_SSH,
 				"--workspace", workspace.toString(), "--branch", BRANCH);
 
-		AdoptionException failure = assertThrows(AdoptionException.class,
-				() -> Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter()));
-
-		assertTrue(failure.getMessage().contains("1 of 2 repositories"), failure.getMessage());
-		assertTrue(failure.getMessage().contains(HELLO_WORLD_OVER_SSH), failure.getMessage());
-		assertTrue(failure.getMessage().contains(workspace.resolve("Hello-World").toString()), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter()),
+				"1 of 2 repositories", HELLO_WORLD_OVER_SSH, workspace.resolve("Hello-World").toString());
 		assertCheckedOut(HELLO_WORLD);
 	}
 
@@ -158,10 +151,8 @@ class MultiRepoAdoptionIT {
 		CliArguments cli = parse("--repos", listFile(HELLO_WORLD, "https://github.com/owner/.git", SPOON_KNIFE).toString(),
 				"--workspace", workspace.toString(), "--branch", BRANCH, "--report", report.toString());
 
-		AdoptionException failure = assertThrows(AdoptionException.class,
-				() -> Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter()));
-
-		assertTrue(failure.getMessage().contains("1 of 3 repositories"), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter()),
+				"1 of 3 repositories");
 		assertCheckedOut(HELLO_WORLD);
 		assertCheckedOut(SPOON_KNIFE);
 		assertBatchReport(report, false, List.of(HELLO_WORLD, "https://github.com/owner/.git", SPOON_KNIFE));
@@ -183,11 +174,8 @@ class MultiRepoAdoptionIT {
 		git(workspace, "clone", HELLO_WORLD, checkout.toString());
 		CliArguments cli = parse("--repo", SPOON_KNIFE, "--workspace", workspace.toString(), "--branch", BRANCH);
 
-		AdoptionException failure = assertThrows(AdoptionException.class,
-				() -> Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter()));
-
-		assertTrue(failure.getMessage().contains(checkout.toString()), failure.getMessage());
-		assertTrue(failure.getMessage().contains("Hello-World"), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> Main.runAndReport(cli, Main.checkouts(cli), cloneOnlyAdopter()),
+				checkout.toString(), "Hello-World");
 		assertTrue(git(checkout, "remote", "get-url", "origin").endsWith("Hello-World.git"),
 				"the checkout of another repository must be left as it was found");
 		assertFalse(BRANCH.equals(git(checkout, "rev-parse", "--abbrev-ref", "HEAD")),

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -230,9 +231,9 @@ class RepositoryUrlTest {
 	/** A URL refused on its input is quoted back, so it must be masked there too. */
 	@Test
 	void masksTheCredentialsOfARejectedUrl() {
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> RepositoryUrl.of("https://x-access-token:secret@github.com/owner/.git"));
-		assertTrue(exception.getMessage().contains("https://***@github.com/owner/.git"), exception.getMessage());
+		assertFailure(IllegalArgumentException.class,
+				() -> RepositoryUrl.of("https://x-access-token:secret@github.com/owner/.git"),
+				"https://***@github.com/owner/.git");
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlsTest.java
@@ -1,7 +1,7 @@
 package io.github.adamw7.tools.adopt;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -56,8 +56,7 @@ class RepositoryUrlsTest {
 	@Test
 	void failsWithAdoptionExceptionWhenTheFileCannotBeRead(@TempDir Path dir) {
 		Path missing = dir.resolve("absent.txt");
-		AdoptionException thrown = assertThrows(AdoptionException.class, () -> RepositoryUrls.fromFile(missing));
-		assertTrue(thrown.getMessage().contains("the repository URL list"), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> RepositoryUrls.fromFile(missing), "the repository URL list");
 	}
 
 	private Path listFile(Path dir, String content) throws IOException {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunnerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunnerTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt.command;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -68,9 +69,8 @@ class ProcessCommandRunnerTest {
 	@Test
 	void killsAndReportsACommandThatOutlivesTheTimeout() {
 		ProcessCommandRunner impatient = new ProcessCommandRunner(Duration.ofMillis(100));
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> impatient.run(Path.of("."), PlatformCommands.sleepingFor(30)));
-		assertTrue(thrown.getMessage().contains("Timed out"), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> impatient.run(Path.of("."), PlatformCommands.sleepingFor(30)),
+				"Timed out");
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -49,9 +50,7 @@ class BuildToolchainStepTest {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
 		RecordingCommandRunner runner = RecordingCommandRunner.failing(127, "gradle: not found");
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> new BuildToolchainStep().execute(context, runner));
-		assertTrue(thrown.getMessage().contains("gradle"), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> new BuildToolchainStep().execute(context, runner), "gradle");
 	}
 
 	@Test
@@ -90,11 +89,8 @@ class BuildToolchainStepTest {
 			throw new AdoptionException("Could not start command: " + String.join(" ", command));
 		});
 
-		AdoptionException failure = assertThrows(AdoptionException.class,
-				() -> new BuildToolchainStep().execute(context, runner));
-
-		assertTrue(failure.getMessage().contains("build-toolchain failed"), failure.getMessage());
-		assertTrue(failure.getMessage().contains("sh"), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> new BuildToolchainStep().execute(context, runner),
+				"build-toolchain failed", "sh");
 	}
 
 	/**
@@ -129,10 +125,8 @@ class BuildToolchainStepTest {
 		AdoptionContexts.write(context, "pom.xml", "<project/>");
 		RecordingCommandRunner runner = RecordingCommandRunner.failing(127, "mvn: not found");
 
-		AdoptionException failure = assertThrows(AdoptionException.class,
-				() -> new BuildToolchainStep().execute(context, runner));
-
-		assertTrue(failure.getMessage().contains("Install maven on the PATH"), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> new BuildToolchainStep().execute(context, runner),
+				"Install maven on the PATH");
 	}
 
 	@Test
@@ -211,12 +205,10 @@ class BuildToolchainStepTest {
 		AdoptionContexts.write(context, "gradlew", "#!/bin/sh\n");
 		RecordingCommandRunner runner = RecordingCommandRunner.failing(126, "Permission denied");
 
-		AdoptionException failure = assertThrows(AdoptionException.class,
+		assertFailure(AdoptionException.class,
 				() -> new BuildToolchainStep(
 						List.of(new GradleBuildSystem(new BuildWrapper("gradlew", "gradlew.bat", false))))
-								.execute(context, runner));
-
-		assertTrue(failure.getMessage().contains("gradlew"), failure.getMessage());
-		assertTrue(failure.getMessage().contains("could not be run"), failure.getMessage());
+								.execute(context, runner),
+				"gradlew", "could not be run");
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -62,9 +63,8 @@ class ClaudeInitStepTest {
 			blockRestore(context);
 			return new CommandResult(command, 3, "claude: the underlying failure");
 		});
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> new ClaudeInitStep(List.of("claude")).execute(context, runner));
-		assertTrue(thrown.getMessage().contains("the underlying failure"), thrown.getMessage());
+		AdoptionException thrown = assertFailure(AdoptionException.class,
+				() -> new ClaudeInitStep(List.of("claude")).execute(context, runner), "the underlying failure");
 		assertEquals(1, thrown.getSuppressed().length, "the failed restore must be attached, not thrown");
 	}
 
@@ -159,9 +159,8 @@ class ClaudeInitStepTest {
 	void missingClaudeMdIsReportedWithWhatTheCliSaid(@TempDir Path workspace) throws IOException {
 		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
 		RecordingCommandRunner runner = RecordingCommandRunner.answering("I did not create a CLAUDE.md");
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> new ClaudeInitStep().execute(context, runner));
-		assertTrue(thrown.getMessage().contains("I did not create a CLAUDE.md"), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> new ClaudeInitStep().execute(context, runner),
+				"I did not create a CLAUDE.md");
 	}
 
 	/** The transcript is redacted like every other one, since it is the run's reported failure. */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -72,9 +73,8 @@ class CloneStepTest {
 	void refusesCheckoutOfADifferentRepository(@TempDir Path existingWorkspace) throws IOException {
 		AdoptionContext existing = checkedOut(existingWorkspace);
 		RecordingCommandRunner runner = origin("https://github.com/someone-else/tools.git");
-		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
-		assertTrue(failure.getMessage().contains("someone-else/tools"), failure.getMessage());
-		assertTrue(failure.getMessage().contains("adamw7/tools"), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> step.execute(existing, runner), "someone-else/tools",
+				"adamw7/tools");
 		assertEquals(1, runner.count(), "nothing may be done to a checkout of another repository");
 	}
 
@@ -153,8 +153,7 @@ class CloneStepTest {
 	void refusesCheckoutWithNoOriginRemote(@TempDir Path existingWorkspace) throws IOException {
 		AdoptionContext existing = checkedOut(existingWorkspace);
 		RecordingCommandRunner runner = RecordingCommandRunner.failing(2, "error: No such remote 'origin'");
-		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
-		assertTrue(failure.getMessage().contains("no 'origin' remote"), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> step.execute(existing, runner), "no 'origin' remote");
 	}
 
 	@Test
@@ -188,10 +187,8 @@ class CloneStepTest {
 		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
 				" M src/main/java/Service.java" + System.lineSeparator() + "?? notes.txt");
 
-		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
-
-		assertTrue(failure.getMessage().contains("src/main/java/Service.java"), failure.getMessage());
-		assertTrue(failure.getMessage().contains("notes.txt"), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> step.execute(existing, runner), "src/main/java/Service.java",
+				"notes.txt");
 		assertEquals(2, runner.count(), "a checkout with unrelated work may not even be fetched into");
 	}
 
@@ -294,9 +291,7 @@ class CloneStepTest {
 		AdoptionContext existing = checkedOut(existingWorkspace);
 		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git", "?? .claude/");
 
-		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
-
-		assertTrue(failure.getMessage().contains(".claude/"), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> step.execute(existing, runner), ".claude/");
 	}
 
 	/**
@@ -311,9 +306,8 @@ class CloneStepTest {
 				"?? CLAUDE.md" + System.lineSeparator() + "?? .claude/settings.json" + System.lineSeparator()
 						+ "?? .claude/scratch.md");
 
-		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
-
-		assertTrue(failure.getMessage().contains(".claude/scratch.md"), failure.getMessage());
+		AdoptionException failure = assertFailure(AdoptionException.class, () -> step.execute(existing, runner),
+				".claude/scratch.md");
 		assertFalse(failure.getMessage().contains("settings.json"), failure.getMessage());
 	}
 
@@ -353,9 +347,8 @@ class CloneStepTest {
 		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
 				"R  old/name.txt -> \"my notes.txt\"");
 
-		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
-
-		assertTrue(failure.getMessage().contains("my notes.txt"), failure.getMessage());
+		AdoptionException failure = assertFailure(AdoptionException.class, () -> step.execute(existing, runner),
+				"my notes.txt");
 		assertFalse(failure.getMessage().contains("->"), failure.getMessage());
 	}
 
@@ -373,9 +366,7 @@ class CloneStepTest {
 		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
 				"R  docs/CLAUDE.md -> CLAUDE.md");
 
-		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
-
-		assertTrue(failure.getMessage().contains("docs/CLAUDE.md"), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> step.execute(existing, runner), "docs/CLAUDE.md");
 	}
 
 	/** A copy leaves its source in place but is reported the same way, so it is read the same way. */
@@ -386,9 +377,7 @@ class CloneStepTest {
 		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git",
 				"C  Feature.java -> pom.xml");
 
-		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
-
-		assertTrue(failure.getMessage().contains("Feature.java"), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> step.execute(existing, runner), "Feature.java");
 	}
 
 	/** Both sides being the adoption's own is a resume, not a contributor's work in progress. */
@@ -411,9 +400,7 @@ class CloneStepTest {
 				? new CommandResult(command, 128, "fatal: not a git repository")
 				: new CommandResult(command, 0, "https://github.com/adamw7/tools.git"));
 
-		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
-
-		assertTrue(failure.getMessage().contains("status could not be read"), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> step.execute(existing, runner), "status could not be read");
 	}
 
 	/**
@@ -445,9 +432,8 @@ class CloneStepTest {
 				"warning: could not open directory 'vendor/': Permission denied",
 				" M src/Main.java"));
 
-		AdoptionException failure = assertThrows(AdoptionException.class, () -> step.execute(existing, runner));
-
-		assertTrue(failure.getMessage().contains("src/Main.java"), failure.getMessage());
+		AdoptionException failure = assertFailure(AdoptionException.class, () -> step.execute(existing, runner),
+				"src/Main.java");
 		assertFalse(failure.getMessage().contains("warning"), failure.getMessage());
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -75,9 +76,8 @@ class CommitStepTest {
 	@Test
 	void refusesToCommitAFileTheCheckoutIgnores() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(ignoring("CLAUDE.md"));
-		AdoptionException failure = assertThrows(AdoptionException.class,
-				() -> new CommitStep("msg", "claude-md").execute(context, runner));
-		assertTrue(failure.getMessage().contains("CLAUDE.md"), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> new CommitStep("msg", "claude-md").execute(context, runner),
+				"CLAUDE.md");
 		assertEquals(1, runner.count(), "nothing may be staged once a path is known to be excluded");
 	}
 
@@ -86,10 +86,8 @@ class CommitStepTest {
 	void namesEveryIgnoredPath() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(
 				ignoring(AdoptionAssets.SETTINGS_FILE + "\n" + AdoptionAssets.SESSION_START_HOOK_FILE));
-		AdoptionException failure = assertThrows(AdoptionException.class,
-				() -> new CommitStep("msg", "assets").execute(context, runner));
-		assertTrue(failure.getMessage().contains(AdoptionAssets.SETTINGS_FILE), failure.getMessage());
-		assertTrue(failure.getMessage().contains(AdoptionAssets.SESSION_START_HOOK_FILE), failure.getMessage());
+		assertFailure(AdoptionException.class, () -> new CommitStep("msg", "assets").execute(context, runner),
+				AdoptionAssets.SETTINGS_FILE, AdoptionAssets.SESSION_START_HOOK_FILE);
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersionTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersionTest.java
@@ -1,10 +1,9 @@
 package io.github.adamw7.tools.adopt.step;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,9 +33,8 @@ class EnforcerRuleVersionTest {
 	 */
 	@Test
 	void aSnapshotRuleVersionIsRefused() {
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> EnforcerRuleVersion.requireRelease("2.6.0-SNAPSHOT"));
-		assertTrue(thrown.getMessage().contains("2.6.0-SNAPSHOT"), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> EnforcerRuleVersion.requireRelease("2.6.0-SNAPSHOT"),
+				"2.6.0-SNAPSHOT");
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ToolchainStepTest.java
@@ -1,10 +1,10 @@
 package io.github.adamw7.tools.adopt.step;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -84,9 +84,7 @@ class ToolchainStepTest {
 	@Test
 	void aTokenThatCannotSeeTheRepositoryAbortsTheAdoption() {
 		RecordingCommandRunner runner = RecordingCommandRunner.failingOn("repos/adamw7/demo", 1, "HTTP 404");
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> new ToolchainStep().execute(context, runner));
-		assertTrue(thrown.getMessage().contains("adamw7/demo"), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> new ToolchainStep().execute(context, runner), "adamw7/demo");
 	}
 
 	/**
@@ -140,9 +138,7 @@ class ToolchainStepTest {
 	@Test
 	void aDryRunStillAbortsWhenClaudeIsMissing() {
 		RecordingCommandRunner runner = RecordingCommandRunner.failingOn("claude", 127, "claude: not found");
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> ToolchainStep.forDryRun().execute(context, runner));
-		assertTrue(thrown.getMessage().contains("claude"), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> ToolchainStep.forDryRun().execute(context, runner), "claude");
 	}
 
 	/**
@@ -153,9 +149,7 @@ class ToolchainStepTest {
 	@Test
 	void anUnauthenticatedGitHubCliAbortsTheAdoption() {
 		RecordingCommandRunner runner = RecordingCommandRunner.failingOn("api", 1, "HTTP 401");
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> new ToolchainStep().execute(context, runner));
-		assertTrue(thrown.getMessage().contains("cannot reach"), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> new ToolchainStep().execute(context, runner), "cannot reach");
 	}
 
 	/**
@@ -169,9 +163,7 @@ class ToolchainStepTest {
 	@Test
 	void aGitHubCliWhoseTokenGitHubRejectsAbortsTheAdoption() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::rejectedByGitHub);
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> new ToolchainStep().execute(context, runner));
-		assertTrue(thrown.getMessage().contains("cannot reach"), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> new ToolchainStep().execute(context, runner), "cannot reach");
 	}
 
 	/**
@@ -229,9 +221,7 @@ class ToolchainStepTest {
 	@Test
 	void aToolThatExitsNonZeroAbortsTheAdoption() {
 		RecordingCommandRunner runner = RecordingCommandRunner.failingOn("gh", 127, "gh: not found");
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> new ToolchainStep().execute(context, runner));
-		assertTrue(thrown.getMessage().contains("gh"), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> new ToolchainStep().execute(context, runner), "gh");
 	}
 
 	@Test
@@ -247,18 +237,14 @@ class ToolchainStepTest {
 		RecordingCommandRunner runner = new RecordingCommandRunner(
 				command -> command.contains("git") ? new CommandResult(command, 0, "")
 						: new CommandResult(command, 1, "missing"));
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> new ToolchainStep().execute(context, runner));
-		assertTrue(thrown.getMessage().contains("claude"), thrown.getMessage());
-		assertTrue(thrown.getMessage().contains("gh"), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> new ToolchainStep().execute(context, runner), "claude", "gh");
 	}
 
 	@Test
 	void reportsMissingToolsInDeclarationOrder() {
 		RecordingCommandRunner runner = RecordingCommandRunner.failing(1, "missing");
-		AdoptionException thrown = assertThrows(AdoptionException.class,
-				() -> new ToolchainStep(List.of("git", "gh")).execute(context, runner));
-		assertTrue(thrown.getMessage().contains("git, gh"), thrown.getMessage());
+		assertFailure(AdoptionException.class, () -> new ToolchainStep(List.of("git", "gh")).execute(context, runner),
+				"git, gh");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -44,11 +44,6 @@ public class CommandFormatRule extends DefinitionFormatRule {
 	}
 
 	@Override
-	protected File[] entriesIn(File directory) {
-		return DefinitionFiles.markdownFiles(directory);
-	}
-
-	@Override
 	protected void collectEntryViolations(File command, List<String> violations) {
 		contentOf(command, violations).ifPresent(content -> collectNamedViolations(command, content, violations));
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFormatRule.java
@@ -70,8 +70,15 @@ abstract class DefinitionFormatRule extends ClaudeCodeEnforcerRule {
 	/** The directory to scan. Injected from the rule configuration. */
 	protected abstract File definitionDir();
 
-	/** The entries of {@code directory} that each carry one definition. */
-	protected abstract File[] entriesIn(File directory);
+	/**
+	 * The entries of {@code directory} that each carry one definition: its
+	 * {@code *.md} files, which is what a command and a sub-agent are. A kind whose
+	 * definition is a directory instead — a skill, carrying a {@code SKILL.md} —
+	 * says so by overriding.
+	 */
+	protected File[] entriesIn(File directory) {
+		return DefinitionFiles.markdownFiles(directory);
+	}
 
 	/** Collects everything wrong with the definition that {@code entry} carries. */
 	protected abstract void collectEntryViolations(File entry, List<String> violations);

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -45,11 +45,6 @@ public class SubAgentFormatRule extends DefinitionFormatRule {
 	}
 
 	@Override
-	protected File[] entriesIn(File directory) {
-		return DefinitionFiles.markdownFiles(directory);
-	}
-
-	@Override
 	protected void collectEntryViolations(File definition, List<String> violations) {
 		contentOf(definition, violations)
 				.flatMap(content -> requiredFrontMatterOf(content, definition, violations))

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
@@ -4,8 +4,8 @@ import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -74,38 +74,31 @@ class CommandFormatRuleTest {
 		writeString(tempDir.resolve("blank.md"), "   ");
 		writeString(tempDir.resolve("BadName.md"), "Review the pull request.");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("blank.md"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("BadName.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "blank.md", "BadName.md");
 	}
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new CommandFormatRule()::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new CommandFormatRule()::execute, "not configured");
 	}
 
 	@Test
 	void failsWhenDirectoryIsMissing() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor(tempDir.resolve("absent"))::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir.resolve("absent"))::execute, "does not exist");
 	}
 
 	@Test
 	void failsWhenCommandIsEmpty() {
 		writeString(tempDir.resolve("blank.md"), "   ");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("is empty"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "is empty");
 	}
 
 	@Test
 	void failsWhenFileNameIsNotKebabCase() {
 		writeString(tempDir.resolve("ReviewPR.md"), "Review the pull request.");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("must be lower-case kebab-case"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "must be lower-case kebab-case");
 	}
 
 	@Test
@@ -117,8 +110,7 @@ class CommandFormatRuleTest {
 				Review the diff.
 				""");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("description must not be empty"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "description must not be empty");
 	}
 
 	@Test
@@ -132,8 +124,7 @@ class CommandFormatRuleTest {
 		CommandFormatRule rule = ruleFor(tempDir);
 		rule.setAllowedModels(List.of("claude-opus-4-8", "claude-sonnet-4-6"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("unsupported model 'claud-opus'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "unsupported model 'claud-opus'");
 	}
 
 	@Test
@@ -147,8 +138,7 @@ class CommandFormatRuleTest {
 		CommandFormatRule rule = ruleFor(tempDir);
 		rule.setAllowedFrontMatterKeys(List.of("description", "argument-hint", "allowed-tools", "model"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("unknown key 'descripton:'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "unknown key 'descripton:'");
 	}
 
 	@Test
@@ -183,8 +173,7 @@ class CommandFormatRuleTest {
 	void reportsACommandThatCannotBeReadAsText() {
 		writeBytes(tempDir.resolve("binary.md"), new byte[] { (byte) 0xC3, (byte) 0x28 });
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("cannot be read as text"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "cannot be read as text");
 	}
 
 	private CommandFormatRule ruleFor(Path commandsDir) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/DefinitionFilesTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/DefinitionFilesTest.java
@@ -2,11 +2,10 @@ package io.github.adamw7.tools.enforcer.definition;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -31,19 +30,16 @@ class DefinitionFilesTest {
 	void verifyDirectoryFailsWithLabelWhenDirectoryIsMissing() {
 		File absent = tempDir.resolve("absent").toFile();
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				() -> DefinitionFiles.verifyDirectory(absent, "Agents"));
-		assertTrue(exception.getMessage().contains("Agents directory does not exist at"), exception.getMessage());
-		assertTrue(exception.getMessage().contains(absent.toString()), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, () -> DefinitionFiles.verifyDirectory(absent, "Agents"),
+				"Agents directory does not exist at", absent.toString());
 	}
 
 	@Test
 	void verifyDirectoryFailsWhenPathIsAFileRatherThanADirectory() {
 		File file = writeString(tempDir.resolve("review.md"), "body").toFile();
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				() -> DefinitionFiles.verifyDirectory(file, "Skills"));
-		assertTrue(exception.getMessage().contains("Skills directory does not exist at"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, () -> DefinitionFiles.verifyDirectory(file, "Skills"),
+				"Skills directory does not exist at");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRuleTest.java
@@ -1,9 +1,8 @@
 package io.github.adamw7.tools.enforcer.definition;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -40,35 +39,30 @@ class PluginFormatRuleTest {
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new PluginFormatRule()::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new PluginFormatRule()::execute, "not configured");
 	}
 
 	@Test
 	void failsWhenTheManifestIsMalformedJson() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("{ \"name\": ")::execute);
-		assertTrue(exception.getMessage().contains("not valid JSON"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"name\": ")::execute, "not valid JSON");
 	}
 
 	@Test
 	void failsWhenARequiredKeyIsMissing() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"version\": \"1.0.0\" }")::execute);
-		assertTrue(exception.getMessage().contains("missing required key 'name'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"version\": \"1.0.0\" }")::execute,
+				"missing required key 'name'");
 	}
 
 	@Test
 	void failsWhenTheNameBreaksConvention() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"name\": \"My Plugin\" }")::execute);
-		assertTrue(exception.getMessage().contains("lower-case kebab-case"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"name\": \"My Plugin\" }")::execute,
+				"lower-case kebab-case");
 	}
 
 	@Test
 	void failsForAMalformedVersion() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"name\": \"my-plugin\", \"version\": \"one\" }")::execute);
-		assertTrue(exception.getMessage().contains("not a dotted version number"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"name\": \"my-plugin\", \"version\": \"one\" }")::execute, "not a dotted version number");
 	}
 
 	@Test
@@ -83,9 +77,9 @@ class PluginFormatRuleTest {
 
 	@Test
 	void failsForABlankDescription() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"name\": \"my-plugin\", \"description\": \"  \" }")::execute);
-		assertTrue(exception.getMessage().contains("description must not be empty"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"name\": \"my-plugin\", \"description\": \"  \" }")::execute,
+				"description must not be empty");
 	}
 
 	@Test
@@ -93,8 +87,7 @@ class PluginFormatRuleTest {
 		PluginFormatRule rule = ruleFor("{ \"name\": \"my-plugin\", \"descripton\": \"typo\" }");
 		rule.setAllowedKeys(List.of("name", "version", "description", "author"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("unknown key 'descripton'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "unknown key 'descripton'");
 	}
 
 	@Test
@@ -102,8 +95,7 @@ class PluginFormatRuleTest {
 		PluginFormatRule rule = ruleFor("{ \"name\": \"my-plugin\" }");
 		rule.setRequiredKeys(List.of("name", "description"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing required key 'description'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing required key 'description'");
 	}
 
 	private PluginFormatRule ruleFor(String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
@@ -4,8 +4,8 @@ import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -33,16 +33,14 @@ class SkillFilesExistRuleTest {
 	void failsWhenFileIsNotConfigured() {
 		SkillFilesExistRule rule = new SkillFilesExistRule();
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "not configured");
 	}
 
 	@Test
 	void failsWhenDirectoryIsMissing() {
 		SkillFilesExistRule rule = ruleFor(tempDir.resolve("absent"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not exist");
 	}
 
 	@Test
@@ -55,9 +53,7 @@ class SkillFilesExistRuleTest {
 		createSkill("git-commit");
 		createDirectory(tempDir.resolve("broken-skill"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("Missing SKILL.md"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("broken-skill"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "Missing SKILL.md", "broken-skill");
 	}
 
 	@Test
@@ -65,9 +61,7 @@ class SkillFilesExistRuleTest {
 		Path skillDir = createDirectory(tempDir.resolve("empty-skill"));
 		writeString(skillDir.resolve("SKILL.md"), "   \n  ");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("is empty"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("empty-skill"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "is empty", "empty-skill");
 	}
 
 	@Test
@@ -75,9 +69,7 @@ class SkillFilesExistRuleTest {
 		Path skillDir = createDirectory(tempDir.resolve("untitled-skill"));
 		writeString(skillDir.resolve("SKILL.md"), "# Just a heading, no front matter.");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("front matter"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("untitled-skill"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "front matter", "untitled-skill");
 	}
 
 	@Test
@@ -90,9 +82,7 @@ class SkillFilesExistRuleTest {
 				# Body
 				""");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("name:"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("nameless-skill"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "name:", "nameless-skill");
 	}
 
 	@Test
@@ -101,9 +91,7 @@ class SkillFilesExistRuleTest {
 		Path empty = createDirectory(tempDir.resolve("empty-skill"));
 		writeString(empty.resolve("SKILL.md"), "");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("no-file"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("empty-skill"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "no-file", "empty-skill");
 	}
 
 	@Test
@@ -116,8 +104,7 @@ class SkillFilesExistRuleTest {
 				---
 				""");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("must match 'git-commit'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "must match 'git-commit'");
 	}
 
 	@Test
@@ -130,8 +117,7 @@ class SkillFilesExistRuleTest {
 				---
 				""");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("kebab-case"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "kebab-case");
 	}
 
 	@Test
@@ -144,8 +130,7 @@ class SkillFilesExistRuleTest {
 				---
 				""");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("description must not be empty"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "description must not be empty");
 	}
 
 	@Test
@@ -154,8 +139,7 @@ class SkillFilesExistRuleTest {
 		SkillFilesExistRule rule = ruleFor(tempDir);
 		rule.setMaxDescriptionLength(5);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("description exceeds 5"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "description exceeds 5");
 	}
 
 	@Test
@@ -171,8 +155,7 @@ class SkillFilesExistRuleTest {
 		SkillFilesExistRule rule = ruleFor(tempDir);
 		rule.setAllowedFrontMatterKeys(java.util.List.of("name", "description"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("unknown key 'descripton:'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "unknown key 'descripton:'");
 	}
 
 	@Test
@@ -187,8 +170,7 @@ class SkillFilesExistRuleTest {
 		SkillFilesExistRule rule = ruleFor(tempDir);
 		rule.setRequiredKeys(java.util.List.of("name", "description", "model"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing 'model:'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing 'model:'");
 	}
 
 	@Test
@@ -254,8 +236,7 @@ class SkillFilesExistRuleTest {
 		SkillFilesExistRule rule = ruleFor(tempDir);
 		rule.setMaxDescriptionLength(20);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("exceeds 20 characters"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "exceeds 20 characters");
 	}
 
 	/** Quoting a value is ordinary YAML, so the name inside the quotes is the one checked. */
@@ -278,8 +259,7 @@ class SkillFilesExistRuleTest {
 		Path skillDir = createDirectory(tempDir.resolve("binary"));
 		writeBytes(skillDir.resolve("SKILL.md"), new byte[] { (byte) 0xC3, (byte) 0x28 });
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("cannot be read as text"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "cannot be read as text");
 	}
 
 	/**
@@ -297,8 +277,8 @@ class SkillFilesExistRuleTest {
 				# git-commit
 				""");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("declares 'description:' more than once"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute,
+				"declares 'description:' more than once");
 	}
 
 	/** The cap applies to the declaration that wins, not to the one it replaced. */
@@ -315,8 +295,7 @@ class SkillFilesExistRuleTest {
 		SkillFilesExistRule rule = ruleFor(tempDir);
 		rule.setMaxDescriptionLength(20);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("description exceeds 20 characters"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "description exceeds 20 characters");
 	}
 
 	/** A YAML loader ends a plain scalar at the comment, so the name Claude Code reads follows the convention. */

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
@@ -4,8 +4,8 @@ import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -54,31 +54,24 @@ class SubAgentFormatRuleTest {
 		writeString(tempDir.resolve("reviewer.md"), "# Reviewer\nNo front matter.");
 		writeString(tempDir.resolve("planner.md"), "# Planner\nNo front matter either.");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("reviewer.md"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("planner.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "reviewer.md", "planner.md");
 	}
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new SubAgentFormatRule()::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new SubAgentFormatRule()::execute, "not configured");
 	}
 
 	@Test
 	void failsWhenDirectoryIsMissing() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor(tempDir.resolve("absent"))::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir.resolve("absent"))::execute, "does not exist");
 	}
 
 	@Test
 	void failsWhenDefinitionHasNoFrontMatter() {
 		writeString(tempDir.resolve("reviewer.md"), "# Reviewer\nNo front matter.");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("front matter"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("reviewer.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "front matter", "reviewer.md");
 	}
 
 	@Test
@@ -90,8 +83,7 @@ class SubAgentFormatRuleTest {
 				# Reviewer
 				""");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("missing 'description:'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "missing 'description:'");
 	}
 
 	@Test
@@ -104,8 +96,7 @@ class SubAgentFormatRuleTest {
 				# Reviewer
 				""");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("description must not be empty"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "description must not be empty");
 	}
 
 	@Test
@@ -117,8 +108,7 @@ class SubAgentFormatRuleTest {
 				---
 				""");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("must match 'reviewer'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "must match 'reviewer'");
 	}
 
 	@Test
@@ -127,8 +117,7 @@ class SubAgentFormatRuleTest {
 		SubAgentFormatRule rule = ruleFor(tempDir);
 		rule.setAllowedModels(List.of("claude-opus-4-8", "claude-sonnet-4-6"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("unsupported model 'claud-opus'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "unsupported model 'claud-opus'");
 	}
 
 	@Test
@@ -166,8 +155,7 @@ class SubAgentFormatRuleTest {
 				# Reviewer
 				""");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("front matter"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "front matter");
 	}
 
 	/** Quoting a value is ordinary YAML, so the name inside the quotes is the one checked. */
@@ -191,8 +179,7 @@ class SubAgentFormatRuleTest {
 	void reportsADefinitionThatCannotBeReadAsText() {
 		writeBytes(tempDir.resolve("binary.md"), new byte[] { (byte) 0xC3, (byte) 0x28 });
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
-		assertTrue(exception.getMessage().contains("cannot be read as text"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(tempDir)::execute, "cannot be read as text");
 	}
 
 	private void createAgent(String name, String model) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
@@ -3,8 +3,8 @@ package io.github.adamw7.tools.enforcer.definition;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -39,10 +39,8 @@ class UniqueDescriptionsRuleTest {
 		writeAgent("reviewer", "Reviews code.");
 		writeAgent("checker", "Reviews code.");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, agentsRule()::execute);
-		assertTrue(exception.getMessage().contains("Reviews code."), exception.getMessage());
-		assertTrue(exception.getMessage().contains("reviewer.md"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("checker.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, agentsRule()::execute, "Reviews code.", "reviewer.md",
+				"checker.md");
 	}
 
 	@Test
@@ -50,8 +48,7 @@ class UniqueDescriptionsRuleTest {
 		writeAgent("reviewer", "Reviews   code.");
 		writeAgent("checker", "reviews code.");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, agentsRule()::execute);
-		assertTrue(exception.getMessage().contains("is used by 2"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, agentsRule()::execute, "is used by 2");
 	}
 
 	/**
@@ -82,8 +79,7 @@ class UniqueDescriptionsRuleTest {
 		rule.setAgentsDir(agentsDir().toFile());
 		rule.setSkillsDir(skillsDir().toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("is used by 2"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "is used by 2");
 	}
 
 	@Test
@@ -96,9 +92,7 @@ class UniqueDescriptionsRuleTest {
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				new UniqueDescriptionsRule()::execute);
-		assertTrue(exception.getMessage().contains("must be configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new UniqueDescriptionsRule()::execute, "must be configured");
 	}
 
 	@Test
@@ -106,8 +100,7 @@ class UniqueDescriptionsRuleTest {
 		UniqueDescriptionsRule rule = new UniqueDescriptionsRule();
 		rule.setAgentsDir(tempDir.resolve("absent").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not exist");
 	}
 
 	@Test
@@ -138,8 +131,7 @@ class UniqueDescriptionsRuleTest {
 		writeAgentWithBlockScalarDescription("reviewer", "Reviews Java code for defects.");
 		writeAgentWithBlockScalarDescription("auditor", "Reviews Java code for defects.");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, agentsRule()::execute);
-		assertTrue(exception.getMessage().contains("Reviews Java code for defects."), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, agentsRule()::execute, "Reviews Java code for defects.");
 	}
 
 	private void writeAgentWithBlockScalarDescription(String name, String description) {
@@ -168,8 +160,7 @@ class UniqueDescriptionsRuleTest {
 		writeAgent("reviewer", "Reviews code.");
 		writeAgent("checker", "\"Reviews code.\"");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, agentsRule()::execute);
-		assertTrue(exception.getMessage().contains("checker.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, agentsRule()::execute, "checker.md");
 	}
 
 	private UniqueDescriptionsRule agentsRule() {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRuleTest.java
@@ -2,8 +2,8 @@ package io.github.adamw7.tools.enforcer.definition;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -77,8 +77,7 @@ class UniqueNamesRuleTest {
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new UniqueNamesRule()::execute);
-		assertTrue(exception.getMessage().contains("must be configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new UniqueNamesRule()::execute, "must be configured");
 	}
 
 	@Test
@@ -86,8 +85,7 @@ class UniqueNamesRuleTest {
 		UniqueNamesRule rule = new UniqueNamesRule();
 		rule.setCommandsDir(tempDir.resolve("absent").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not exist");
 	}
 
 	@Test
@@ -101,11 +99,8 @@ class UniqueNamesRuleTest {
 		rule.setCommandsDir(commands.toFile());
 		rule.setAgentsDir(agents.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("name 'review'"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("2 definitions"), exception.getMessage());
-		assertTrue(exception.getMessage().contains(commands.resolve("review.md").toString()), exception.getMessage());
-		assertTrue(exception.getMessage().contains(agents.resolve("review.md").toString()), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "name 'review'", "2 definitions",
+				commands.resolve("review.md").toString(), agents.resolve("review.md").toString());
 	}
 
 	@Test
@@ -119,8 +114,7 @@ class UniqueNamesRuleTest {
 		rule.setAgentsDir(agents.toFile());
 		rule.setSkillsDir(skills.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("name 'commit'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "name 'commit'");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRuleTest.java
@@ -1,9 +1,8 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 
@@ -61,8 +60,7 @@ class AgentsMdFormatRuleTest {
 	void failsWhenFileIsNotConfigured() {
 		AgentsMdFormatRule rule = new AgentsMdFormatRule();
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "not configured");
 	}
 
 	@Test
@@ -70,41 +68,35 @@ class AgentsMdFormatRuleTest {
 		AgentsMdFormatRule rule = new AgentsMdFormatRule();
 		rule.setAgentsMdFile(tempDir.resolve("absent.md").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not exist");
 	}
 
 	@Test
 	void failsWhenFileIsEmpty() {
 		AgentsMdFormatRule rule = ruleFor("   \n  ");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("empty"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "empty");
 	}
 
 	@Test
 	void failsWhenTitleHeadingIsWrong() {
 		AgentsMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# AGENTS.md", "# Something Else"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("title heading"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "title heading");
 	}
 
 	@Test
 	void failsWhenARequiredSectionIsMissing() {
 		AgentsMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Releasing", "## Shipping"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("## Releasing"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "## Releasing");
 	}
 
 	@Test
 	void failsWhenSectionHeadingAppearsOnlyInsideCodeFence() {
 		AgentsMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Releasing", "```\n## Releasing\n```"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing required section heading: ## Releasing"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing required section heading: ## Releasing");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -1,8 +1,8 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -60,8 +60,7 @@ class ClaudeMdFormatRuleTest {
 	void failsWhenFileIsNotConfigured() {
 		ClaudeMdFormatRule rule = new ClaudeMdFormatRule();
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "not configured");
 	}
 
 	@Test
@@ -69,65 +68,56 @@ class ClaudeMdFormatRuleTest {
 		ClaudeMdFormatRule rule = new ClaudeMdFormatRule();
 		rule.setClaudeMdFile(tempDir.resolve("absent.md").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not exist");
 	}
 
 	@Test
 	void failsWhenFileIsEmpty() {
 		ClaudeMdFormatRule rule = ruleFor("   \n  ");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("empty"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "empty");
 	}
 
 	@Test
 	void failsWhenTitleHeadingIsWrong() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# CLAUDE.md", "# Something Else"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("title heading"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "title heading");
 	}
 
 	@Test
 	void failsWhenAgentsReferenceIsMissing() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("AGENTS.md", "OTHER.md"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("AGENTS.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "AGENTS.md");
 	}
 
 	@Test
 	void failsWhenARequiredSectionIsMissing() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "## Quality"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("## Testing"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "## Testing");
 	}
 
 	@Test
 	void failsWhenSectionHeadingAppearsOnlyInsideCodeFence() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "```\n## Testing\n```"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing required section heading: ## Testing"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing required section heading: ## Testing");
 	}
 
 	@Test
 	void failsWhenTitleIsOnlyAPartialMatch() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# CLAUDE.md", "# CLAUDE.md-extended"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("title heading"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "title heading");
 	}
 
 	@Test
 	void failsWhenARequiredSectionIsEmpty() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("Ask before adding a new one.", ""));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("empty section: ## Dependencies"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "empty section: ## Dependencies");
 	}
 
 	@Test
@@ -170,17 +160,14 @@ class ClaudeMdFormatRuleTest {
 				""";
 		ClaudeMdFormatRule rule = ruleFor(content);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("empty section: ## Dependencies"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "empty section: ## Dependencies");
 	}
 
 	@Test
 	void reportsEveryProblemTogether() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("# CLAUDE.md", "# Wrong").replace("## Maven", "## Build"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("title heading"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("## Maven"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "title heading", "## Maven");
 	}
 
 	@Test
@@ -188,8 +175,7 @@ class ClaudeMdFormatRuleTest {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nTODO: finish this.\n");
 		rule.setForbiddenTokens(java.util.List.of("TODO"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("forbidden token: TODO"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "forbidden token: TODO");
 	}
 
 	@Test
@@ -216,8 +202,7 @@ class ClaudeMdFormatRuleTest {
 				"See [AGENTS.md](AGENTS.md) for the full agent guide.",
 				"<!--\nSee [AGENTS.md](AGENTS.md) for the full agent guide.\n-->"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("must reference AGENTS.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "must reference AGENTS.md");
 	}
 
 	/** A link an author commented out is one the document no longer makes. */
@@ -242,9 +227,7 @@ class ClaudeMdFormatRuleTest {
 	void failsWhenSectionHeadingAppearsOnlyInsideTildeFence() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "~~~\n## Testing\n~~~"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing required section heading: ## Testing"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing required section heading: ## Testing");
 	}
 
 	@Test
@@ -255,9 +238,7 @@ class ClaudeMdFormatRuleTest {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing\nWrite unit tests for all new logic.\n",
 				"For example:\n\n    ## Testing\n\n    Write unit tests for all new logic.\n"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing required section heading: ## Testing"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing required section heading: ## Testing");
 	}
 
 	@Test
@@ -285,9 +266,7 @@ class ClaudeMdFormatRuleTest {
 		// two backtick lines stays code and the required section is reported missing.
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "~~~\n```\n## Testing\n```\n~~~"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing required section heading: ## Testing"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing required section heading: ## Testing");
 	}
 
 	@Test
@@ -317,8 +296,7 @@ class ClaudeMdFormatRuleTest {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n```\n```java\n```\n\nTODO left behind\n");
 		rule.setForbiddenTokens(java.util.List.of("TODO"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("forbidden token: TODO"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "forbidden token: TODO");
 	}
 
 	@Test
@@ -357,8 +335,7 @@ class ClaudeMdFormatRuleTest {
 		ClaudeMdFormatRule rule = ruleFor(reordered);
 		rule.setEnforceSectionOrder(true);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("out of order"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "out of order");
 	}
 
 	@Test
@@ -380,8 +357,7 @@ class ClaudeMdFormatRuleTest {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n" + "x".repeat(200) + "\n");
 		rule.setMaxLineLength(120);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("exceeds 120 characters"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "exceeds 120 characters");
 	}
 
 	@Test
@@ -389,8 +365,7 @@ class ClaudeMdFormatRuleTest {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
 		rule.setValidateFileReferences(true);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing file: AGENTS.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing file: AGENTS.md");
 	}
 
 	@Test
@@ -429,8 +404,7 @@ class ClaudeMdFormatRuleTest {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\n[a](AGENTS.md) and [b](absent.md).\n");
 		rule.setValidateFileReferences(true);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing file: absent.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing file: absent.md");
 	}
 
 	@Test
@@ -464,8 +438,7 @@ class ClaudeMdFormatRuleTest {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nSee [guide](docs/no%20such.md).\n");
 		rule.setValidateFileReferences(true);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing file: docs/no%20such.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing file: docs/no%20such.md");
 	}
 
 	@Test
@@ -526,8 +499,6 @@ class ClaudeMdFormatRuleTest {
 				"## Testing\nWrite unit tests for all new logic.\n",
 				"<!--\n## Testing\nWrite unit tests for all new logic.\n-->\n"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing required section heading: ## Testing"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing required section heading: ## Testing");
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.doc;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -35,9 +36,8 @@ class ContextBudgetRuleTest {
 
 	@Test
 	void failsWhenNoLimitIsConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleForFile("content")::execute);
-		assertTrue(exception.getMessage().contains("maxBytes, maxLines, or maxTokens"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleForFile("content")::execute,
+				"maxBytes, maxLines, or maxTokens");
 	}
 
 	@Test
@@ -45,8 +45,7 @@ class ContextBudgetRuleTest {
 		ContextBudgetRule rule = new ContextBudgetRule();
 		rule.setMaxBytes(1000);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("files or directories"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "files or directories");
 	}
 
 	@Test
@@ -55,8 +54,7 @@ class ContextBudgetRuleTest {
 		rule.setMaxBytes(1000);
 		rule.setFiles(List.of(tempDir.resolve("absent.md").toFile()));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not exist");
 	}
 
 	@Test
@@ -64,8 +62,7 @@ class ContextBudgetRuleTest {
 		ContextBudgetRule rule = ruleForFile("x".repeat(100));
 		rule.setMaxBytes(50);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("over the 50-byte budget"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "over the 50-byte budget");
 	}
 
 	@Test
@@ -85,8 +82,7 @@ class ContextBudgetRuleTest {
 		ContextBudgetRule rule = ruleForFile("x".repeat(51));
 		rule.setMaxBytes(50);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("is 51 bytes, over the 50-byte budget"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "is 51 bytes, over the 50-byte budget");
 	}
 
 	@Test
@@ -102,8 +98,7 @@ class ContextBudgetRuleTest {
 		ContextBudgetRule rule = ruleForFile("one\ntwo\nthree\n");
 		rule.setMaxLines(2);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("has 3 lines, over the 2-line budget"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "has 3 lines, over the 2-line budget");
 	}
 
 	@Test
@@ -121,9 +116,7 @@ class ContextBudgetRuleTest {
 		ContextBudgetRule rule = ruleForFile("x".repeat(41));
 		rule.setMaxTokens(10);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("estimated 11 tokens, over the 10-token budget"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "estimated 11 tokens, over the 10-token budget");
 	}
 
 	@Test
@@ -131,8 +124,7 @@ class ContextBudgetRuleTest {
 		ContextBudgetRule rule = ruleForFile("one\ntwo\nthree\n");
 		rule.setMaxLines(2);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("over the 2-line budget"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "over the 2-line budget");
 	}
 
 	@Test
@@ -140,9 +132,7 @@ class ContextBudgetRuleTest {
 		ContextBudgetRule rule = ruleForFile("x".repeat(100));
 		rule.setMaxTokens(10);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("estimated 25 tokens, over the 10-token budget"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "estimated 25 tokens, over the 10-token budget");
 	}
 
 	@Test
@@ -152,8 +142,7 @@ class ContextBudgetRuleTest {
 		rule.setDirectories(List.of(tempDir.resolve("skills").toFile()));
 		rule.setMaxBytes(50);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("SKILL.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "SKILL.md");
 	}
 
 	@Test
@@ -190,8 +179,7 @@ class ContextBudgetRuleTest {
 		rule.setBaselineFile(baseline);
 		rule.setLog(new CapturingLogger());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("over the 50-byte budget"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "over the 50-byte budget");
 	}
 
 	@Test
@@ -236,9 +224,8 @@ class ContextBudgetRuleTest {
 		rule.setDirectories(List.of(directory.toFile()));
 		rule.setMaxLines(1);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("cannot be read as text"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("broken.md"), exception.getMessage());
+		EnforcerRuleException exception = assertFailure(EnforcerRuleException.class, rule::execute,
+				"cannot be read as text", "broken.md");
 		// The undecodable file no longer aborts the run before the next one is measured.
 		assertTrue(exception.getMessage().contains("fine.md"), exception.getMessage());
 		assertTrue(exception.getMessage().contains("2 lines, over the 1-line budget"), exception.getMessage());
@@ -267,8 +254,7 @@ class ContextBudgetRuleTest {
 
 		// The *.md filter narrows the directory scan; a file named outright was
 		// chosen by the configuration and is measured whatever it is called.
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("notes.txt"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "notes.txt");
 	}
 
 	private static int occurrences(String message, String token) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
@@ -1,9 +1,8 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -30,9 +29,7 @@ class CrossDocConsistencyRuleTest {
 		CrossDocConsistencyRule rule = ruleFor("Java 25 is required.", "We target Java 24.");
 		rule.setConsistentPatterns(List.of("Java (\\d+)"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("'25'"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("'24'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "'25'", "'24'");
 	}
 
 	@Test
@@ -40,8 +37,7 @@ class CrossDocConsistencyRuleTest {
 		CrossDocConsistencyRule rule = ruleFor("Java 25 is required.", "No version here.");
 		rule.setConsistentPatterns(List.of("Java (\\d+)"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("<absent>"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "<absent>");
 	}
 
 	@Test
@@ -62,8 +58,7 @@ class CrossDocConsistencyRuleTest {
 		CrossDocConsistencyRule rule = ruleFor("Java 25.", "Java 25.");
 		rule.setConsistentPatterns(List.of("Java \\d+"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("must declare a capturing group"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "must declare a capturing group");
 	}
 
 	@Test
@@ -73,8 +68,7 @@ class CrossDocConsistencyRuleTest {
 
 		// The group is optional, so a bare "proto" match captures null. That must be
 		// treated as a mismatch against the concrete "3", not throw a NullPointerException.
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("'3'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "'3'");
 	}
 
 	@Test
@@ -83,8 +77,7 @@ class CrossDocConsistencyRuleTest {
 		rule.setClaudeMdFile(tempDir.resolve("absent-claude.md").toFile());
 		rule.setAgentsMdFile(tempDir.resolve("absent-agents.md").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not exist");
 	}
 
 	@Test
@@ -95,8 +88,7 @@ class CrossDocConsistencyRuleTest {
 		CrossDocConsistencyRule rule = ruleFor(craftedContent, craftedContent);
 		rule.setConsistentPatterns(List.of("(x+x+)+y"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("catastrophic backtracking"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "catastrophic backtracking");
 	}
 
 	@Test
@@ -107,9 +99,7 @@ class CrossDocConsistencyRuleTest {
 		// A misconfigured pattern is a build-setup mistake and must name itself,
 		// rather than escaping as a PatternSyntaxException the build reports as an
 		// internal error.
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("not a valid regular expression"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("Java (\\d+"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "not a valid regular expression", "Java (\\d+");
 	}
 
 	private CrossDocConsistencyRule ruleFor(String claudeContent, String agentsContent) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
@@ -1,8 +1,8 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -34,8 +34,7 @@ class MemoryImportsRuleTest {
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new MemoryImportsRule()::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new MemoryImportsRule()::execute, "not configured");
 	}
 
 	@Test
@@ -43,16 +42,13 @@ class MemoryImportsRuleTest {
 		MemoryImportsRule rule = new MemoryImportsRule();
 		rule.setClaudeMdFile(tempDir.resolve("absent.md").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not exist");
 	}
 
 	@Test
 	void failsForAMissingImportTarget() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("# CLAUDE.md\n\nSee @docs/absent.md\n")::execute);
-		assertTrue(exception.getMessage().contains("imports a missing file: @docs/absent.md"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("# CLAUDE.md\n\nSee @docs/absent.md\n")::execute,
+				"imports a missing file: @docs/absent.md");
 	}
 
 	@Test
@@ -110,17 +106,15 @@ class MemoryImportsRuleTest {
 	@Test
 	void followsImportsRecursively() {
 		writeString(tempDir.resolve("first.md"), "See @second.md\n");
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("# CLAUDE.md\n\nSee @first.md\n")::execute);
-		assertTrue(exception.getMessage().contains("imports a missing file: @second.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("# CLAUDE.md\n\nSee @first.md\n")::execute,
+				"imports a missing file: @second.md");
 	}
 
 	@Test
 	void failsForACircularImport() {
 		writeString(tempDir.resolve("loop.md"), "Back to @CLAUDE.md\n");
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("# CLAUDE.md\n\nSee @loop.md\n")::execute);
-		assertTrue(exception.getMessage().contains("circular import: @CLAUDE.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("# CLAUDE.md\n\nSee @loop.md\n")::execute,
+				"circular import: @CLAUDE.md");
 	}
 
 	@Test
@@ -130,8 +124,7 @@ class MemoryImportsRuleTest {
 		MemoryImportsRule rule = ruleFor("# CLAUDE.md\n\nSee @first.md\n");
 		rule.setMaxDepth(1);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("nested deeper than 1 hops"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "nested deeper than 1 hops");
 	}
 
 	@Test
@@ -172,8 +165,7 @@ class MemoryImportsRuleTest {
 
 		// Same files, but nothing imports shallow.md directly any more, so its
 		// only chain is six hops long and leaf.md really is out of reach.
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("nested deeper than 5 hops"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "nested deeper than 5 hops");
 	}
 
 	@Test
@@ -197,8 +189,7 @@ class MemoryImportsRuleTest {
 		MemoryImportsRule rule = ruleFor("# CLAUDE.md\n\nSee @docs/absent.md\n");
 		rule.setIgnoredImports(List.of("something/else.md"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("imports a missing file"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "imports a missing file");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRuleTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,9 +38,7 @@ class ModuleMapConsistencyRuleTest {
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				new ModuleMapConsistencyRule()::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new ModuleMapConsistencyRule()::execute, "not configured");
 	}
 
 	@Test
@@ -48,22 +47,19 @@ class ModuleMapConsistencyRuleTest {
 		rule.setPomFile(write("pom.xml", POM).toFile());
 		rule.setDocFiles(List.of());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("at least one file"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "at least one file");
 	}
 
 	@Test
 	void failsWhenThePomDeclaresNoModules() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("<project></project>", "docs")::execute);
-		assertTrue(exception.getMessage().contains("declares no <module> entries"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("<project></project>", "docs")::execute,
+				"declares no <module> entries");
 	}
 
 	@Test
 	void failsWhenAModuleIsNotMentioned() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor(POM, "Only the data module.\n")::execute);
-		assertTrue(exception.getMessage().contains("does not mention module 'context'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(POM, "Only the data module.\n")::execute,
+				"does not mention module 'context'");
 	}
 
 	@Test
@@ -90,9 +86,7 @@ class ModuleMapConsistencyRuleTest {
 		Path second = write("README.md", "Only data here.\n");
 		rule.setDocFiles(List.of(tempDir.resolve("CLAUDE.md").toFile(), second.toFile()));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("README.md"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("'context'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "README.md", "'context'");
 	}
 
 	@Test
@@ -106,10 +100,10 @@ class ModuleMapConsistencyRuleTest {
 
 	@Test
 	void failsWhenAModuleNameOnlyAppearsInsideAHyphenatedName() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
+		assertFailure(EnforcerRuleException.class,
 				ruleFor("<project><modules><module>code</module></modules></project>",
-						"The claude-code-enforcer module.\n")::execute);
-		assertTrue(exception.getMessage().contains("does not mention module 'code'"), exception.getMessage());
+						"The claude-code-enforcer module.\n")::execute,
+				"does not mention module 'code'");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRuleTest.java
@@ -1,8 +1,8 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -32,9 +32,7 @@ class ReadmeConsistencyRuleTest {
 		ReadmeConsistencyRule rule = ruleFor("Now supports proto3.", "Supports only proto2.");
 		rule.setConsistentPatterns(List.of("proto(\\d)"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("'3'"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("'2'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "'3'", "'2'");
 	}
 
 	@Test
@@ -71,9 +69,7 @@ class ReadmeConsistencyRuleTest {
 		ReadmeConsistencyRule rule = ruleFor("proto3 and Java 24.", "proto2 and Java 25.");
 		rule.setConsistentPatterns(List.of("proto(\\d)", "Java (\\d+)"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("proto(\\d)"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("Java (\\d+)"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "proto(\\d)", "Java (\\d+)");
 	}
 
 	@Test
@@ -81,8 +77,7 @@ class ReadmeConsistencyRuleTest {
 		ReadmeConsistencyRule rule = ruleFor("proto2.", "proto2.");
 		rule.setConsistentPatterns(List.of("proto\\d"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("must declare a capturing group"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "must declare a capturing group");
 	}
 
 	@Test
@@ -103,8 +98,7 @@ class ReadmeConsistencyRuleTest {
 		rule.setReadmeFile(tempDir.resolve("absent-readme.md").toFile());
 		rule.setAgentDocFile(tempDir.resolve("absent-agents.md").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not exist");
 	}
 
 	@Test
@@ -112,8 +106,7 @@ class ReadmeConsistencyRuleTest {
 		ReadmeConsistencyRule rule = new ReadmeConsistencyRule();
 		rule.setAgentDocFile(tempDir.resolve("AGENTS.md").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("readmeFile"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "readmeFile");
 	}
 
 	private ReadmeConsistencyRule ruleFor(String readmeContent, String agentDocContent) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.enforcer.mcp;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -50,58 +51,57 @@ class McpConfigFormatRuleTest {
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new McpConfigFormatRule()::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new McpConfigFormatRule()::execute, "not configured");
 	}
 
 	@Test
 	void failsWhenArgsIsNotAnArray() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"args\": \"-y\" } } }")::execute);
-		assertTrue(exception.getMessage().contains("'args' that is not an array"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"args\": \"-y\" } } }")::execute,
+				"'args' that is not an array");
 	}
 
 	@Test
 	void failsWhenArgsHasANonStringEntry() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"args\": [ 7 ] } } }")::execute);
-		assertTrue(exception.getMessage().contains("non-string entry in 'args'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"args\": [ 7 ] } } }")::execute,
+				"non-string entry in 'args'");
 	}
 
 	@Test
 	void failsWhenEnvIsNotAnObject() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"env\": [ ] } } }")::execute);
-		assertTrue(exception.getMessage().contains("'env' that is not an object"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"env\": [ ] } } }")::execute,
+				"'env' that is not an object");
 	}
 
 	@Test
 	void failsWhenAnEnvValueIsNotAString() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"env\": { \"PORT\": 8080 } } } }")::execute);
-		assertTrue(exception.getMessage().contains("non-string value for 'env.PORT'"), exception.getMessage());
+		String config = "{ \"mcpServers\": { \"fs\": { \"command\": \"npx\", \"env\": { \"PORT\": 8080 } } } }";
+
+		assertFailure(EnforcerRuleException.class, ruleFor(config)::execute, "non-string value for 'env.PORT'");
 	}
 
 	@Test
 	void failsWhenAHeaderValueIsNotAString() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(
-				"{ \"mcpServers\": { \"r\": { \"type\": \"http\", \"url\": \"https://x.io\", \"headers\": { \"X\": 1 } } } }")
-						::execute);
-		assertTrue(exception.getMessage().contains("non-string value for 'headers.X'"), exception.getMessage());
+		String config = "{ \"mcpServers\": { \"r\": { \"type\": \"http\", \"url\": \"https://x.io\","
+				+ " \"headers\": { \"X\": 1 } } } }";
+
+		assertFailure(EnforcerRuleException.class, ruleFor(config)::execute, "non-string value for 'headers.X'");
 	}
 
 	@Test
 	void failsWhenUrlIsMalformed() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"r\": { \"type\": \"sse\", \"url\": \"not a url\" } } }")::execute);
-		assertTrue(exception.getMessage().contains("malformed 'url'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"r\": { \"type\": \"sse\", \"url\": \"not a url\" } } }")::execute,
+				"malformed 'url'");
 	}
 
 	@Test
 	void failsWhenAServerDeclaresBothCommandAndUrl() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(
-				"{ \"mcpServers\": { \"x\": { \"command\": \"npx\", \"url\": \"https://x.io\" } } }")::execute);
-		assertTrue(exception.getMessage().contains("declares both a 'command' and a 'url'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"x\": { \"command\": \"npx\", \"url\": \"https://x.io\" } } }")::execute,
+				"declares both a 'command' and a 'url'");
 	}
 
 	@Test
@@ -110,8 +110,7 @@ class McpConfigFormatRuleTest {
 				"{ \"mcpServers\": { \"r\": { \"type\": \"http\", \"url\": \"http://x.io\" } } }");
 		rule.setRequireHttps(true);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("must use an https 'url'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "must use an https 'url'");
 	}
 
 	@Test
@@ -165,23 +164,23 @@ class McpConfigFormatRuleTest {
 
 	@Test
 	void failsWhenAUrlHasNoScheme() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"remote\": { \"url\": \"example.com/sse\" } } }")::execute);
-		assertTrue(exception.getMessage().contains("malformed 'url'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"remote\": { \"url\": \"example.com/sse\" } } }")::execute,
+				"malformed 'url'");
 	}
 
 	@Test
 	void failsWhenAUrlHasNoHost() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"remote\": { \"url\": \"http:///sse\" } } }")::execute);
-		assertTrue(exception.getMessage().contains("malformed 'url'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"remote\": { \"url\": \"http:///sse\" } } }")::execute,
+				"malformed 'url'");
 	}
 
 	@Test
 	void failsWhenAUrlUsesASchemeThatIsNotHttp() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"remote\": { \"url\": \"ftp://example.com/sse\" } } }")::execute);
-		assertTrue(exception.getMessage().contains("malformed 'url'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"remote\": { \"url\": \"ftp://example.com/sse\" } } }")::execute,
+				"malformed 'url'");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRuleTest.java
@@ -1,8 +1,8 @@
 package io.github.adamw7.tools.enforcer.mcp;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -41,8 +41,7 @@ class McpServersValidRuleTest {
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new McpServersValidRule()::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new McpServersValidRule()::execute, "not configured");
 	}
 
 	@Test
@@ -55,60 +54,50 @@ class McpServersValidRuleTest {
 
 	@Test
 	void failsWhenFileIsEmpty() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("   ")::execute);
-		assertTrue(exception.getMessage().contains("empty"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("   ")::execute, "empty");
 	}
 
 	@Test
 	void failsWhenJsonIsMalformed() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": ")::execute);
-		assertTrue(exception.getMessage().contains("not valid JSON"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"mcpServers\": ")::execute, "not valid JSON");
 	}
 
 	@Test
 	void failsWhenMcpServersObjectIsMissing() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("{ }")::execute);
-		assertTrue(exception.getMessage().contains("missing the 'mcpServers' object"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ }")::execute, "missing the 'mcpServers' object");
 	}
 
 	@Test
 	void failsWhenServerIsNotAnObject() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"broken\": \"npx\" } }")::execute);
-		assertTrue(exception.getMessage().contains("server 'broken' must be a JSON object"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"mcpServers\": { \"broken\": \"npx\" } }")::execute,
+				"server 'broken' must be a JSON object");
 	}
 
 	@Test
 	void failsWhenStdioServerHasNoCommand() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"local\": { \"type\": \"stdio\" } } }")::execute);
-		assertTrue(exception.getMessage().contains("server 'local' (stdio) is missing a 'command'"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"local\": { \"type\": \"stdio\" } } }")::execute,
+				"server 'local' (stdio) is missing a 'command'");
 	}
 
 	@Test
 	void failsWhenRemoteServerHasNoUrl() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"remote\": { \"type\": \"http\" } } }")::execute);
-		assertTrue(exception.getMessage().contains("server 'remote' (http) is missing a 'url'"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"remote\": { \"type\": \"http\" } } }")::execute,
+				"server 'remote' (http) is missing a 'url'");
 	}
 
 	@Test
 	void failsWhenTransportCannotBeInferred() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"mystery\": { } } }")::execute);
-		assertTrue(exception.getMessage().contains("must declare a 'command' (stdio) or a 'type' with a 'url'"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"mcpServers\": { \"mystery\": { } } }")::execute,
+				"must declare a 'command' (stdio) or a 'type' with a 'url'");
 	}
 
 	@Test
 	void failsWhenTypeIsUnsupported() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"mcpServers\": { \"odd\": { \"type\": \"htttp\", \"url\": \"https://x\" } } }")::execute);
-		assertTrue(exception.getMessage().contains("server 'odd' has an unsupported type: htttp"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"mcpServers\": { \"odd\": { \"type\": \"htttp\", \"url\": \"https://x\" } } }")::execute,
+				"server 'odd' has an unsupported type: htttp");
 	}
 
 	@Test
@@ -116,8 +105,7 @@ class McpServersValidRuleTest {
 		McpServersValidRule rule = ruleFor(VALID_MCP);
 		rule.setRequiredServers(List.of("github"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing required server: github"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing required server: github");
 	}
 
 	@Test
@@ -125,8 +113,7 @@ class McpServersValidRuleTest {
 		McpServersValidRule rule = ruleFor(VALID_MCP);
 		rule.setForbiddenServers(List.of("remote"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("forbidden server: remote"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "forbidden server: remote");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRuleTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.okf;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -104,9 +105,8 @@ class OkfBundleFormatRuleTest {
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				new OkfBundleFormatRule()::execute);
-		assertTrue(exception.getMessage().contains("bundleDir parameter is not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new OkfBundleFormatRule()::execute,
+				"bundleDir parameter is not configured");
 	}
 
 	@Test
@@ -272,9 +272,8 @@ class OkfBundleFormatRuleTest {
 		OkfBundleFormatRule rule = rule();
 		rule.setOkfVersion("0.2");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("declares 'okf_version: 0.1' but the build expects 0.2"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute,
+				"declares 'okf_version: 0.1' but the build expects 0.2");
 	}
 
 	@Test
@@ -283,8 +282,7 @@ class OkfBundleFormatRuleTest {
 		OkfBundleFormatRule rule = rule();
 		rule.setOkfVersion("0.2");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("declares no index.md at its root"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "declares no index.md at its root");
 	}
 
 	@Test
@@ -300,9 +298,8 @@ class OkfBundleFormatRuleTest {
 		OkfBundleFormatRule rule = rule();
 		rule.setRequiredKeys(List.of("title", "description"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("declares no non-empty 'title'"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("declares no non-empty 'description'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "declares no non-empty 'title'",
+				"declares no non-empty 'description'");
 	}
 
 	@Test
@@ -312,8 +309,7 @@ class OkfBundleFormatRuleTest {
 		OkfBundleFormatRule rule = rule();
 		rule.setRequireIndex(true);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("pkg holds concepts but no index.md"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "pkg holds concepts but no index.md");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/HtmlReportTest.java
@@ -1,7 +1,7 @@
 package io.github.adamw7.tools.enforcer.rule;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -123,9 +123,9 @@ class HtmlReportTest {
 		Files.writeString(tempDir.resolve("blocker"), "a file, not a directory");
 		File unwritable = tempDir.resolve("blocker").resolve("report.html").toFile();
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				() -> new HtmlReport("header", List.of("boom"), List.of("fix it")).writeTo(unwritable));
-		assertTrue(exception.getMessage().contains("Could not write HTML report"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				() -> new HtmlReport("header", List.of("boom"), List.of("fix it")).writeTo(unwritable),
+				"Could not write HTML report");
 	}
 
 	/** Parses with the HTML5 parser in error-tracking mode and fails on any reported problem. */

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.enforcer.rule;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -29,8 +30,8 @@ class JsonFileRuleTest {
 
 	@Test
 	void failsWhenFileIsNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new TestJsonRule()::execute);
-		assertTrue(exception.getMessage().contains("The testFile parameter is not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new TestJsonRule()::execute,
+				"The testFile parameter is not configured");
 	}
 
 	@Test
@@ -38,8 +39,7 @@ class JsonFileRuleTest {
 		TestJsonRule rule = new TestJsonRule();
 		rule.setFile(tempDir.resolve("absent.json").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("test.json does not exist at"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "test.json does not exist at");
 	}
 
 	@Test
@@ -54,16 +54,14 @@ class JsonFileRuleTest {
 
 	@Test
 	void failsWhenFileIsEmpty() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("   ")::execute);
-		assertTrue(exception.getMessage().contains("test.json is empty"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("   ")::execute, "test.json is empty");
 	}
 
 	@Test
 	void reportsMalformedJsonAsAViolationWithoutDispatchingToCollect() {
 		TestJsonRule rule = ruleFor("{ \"broken\": ");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("test.json is not valid JSON"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "test.json is not valid JSON");
 		assertNull(rule.parsedRoot, "collectViolations must not run when parsing fails");
 	}
 
@@ -81,9 +79,8 @@ class JsonFileRuleTest {
 		TestJsonRule rule = ruleFor("{ }");
 		rule.addViolation("something is wrong");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("test.json is not well formed:"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("something is wrong"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "test.json is not well formed:",
+				"something is wrong");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRuleTest.java
@@ -1,11 +1,11 @@
 package io.github.adamw7.tools.enforcer.secret;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -36,8 +36,7 @@ class NoSecretsRuleTest {
 
 	@Test
 	void failsWhenNoTargetsAreConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new NoSecretsRule()::execute);
-		assertTrue(exception.getMessage().contains("files or directories"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new NoSecretsRule()::execute, "files or directories");
 	}
 
 	@Test
@@ -45,38 +44,32 @@ class NoSecretsRuleTest {
 		NoSecretsRule rule = ruleForFile("clean");
 		rule.setUseDefaultPatterns(false);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("secretPatterns"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "secretPatterns");
 	}
 
 	@Test
 	void failsForAnAnthropicKey() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleForFile("{ \"env\": { \"KEY\": \"" + ANTHROPIC_KEY + "\" } }")::execute);
-		assertTrue(exception.getMessage().contains("Anthropic API key"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleForFile("{ \"env\": { \"KEY\": \"" + ANTHROPIC_KEY + "\" } }")::execute, "Anthropic API key");
 	}
 
 	@Test
 	void reportsTheLineWithoutEchoingTheSecret() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleForFile("first line\nkey = " + ANTHROPIC_KEY + "\n")::execute);
-		assertTrue(exception.getMessage().contains("line 2"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("sk-ant-a..."), exception.getMessage());
+		EnforcerRuleException exception = assertFailure(EnforcerRuleException.class,
+				ruleForFile("first line\nkey = " + ANTHROPIC_KEY + "\n")::execute, "line 2", "sk-ant-a...");
 		assertFalse(exception.getMessage().contains(ANTHROPIC_KEY), exception.getMessage());
 	}
 
 	@Test
 	void failsForAGithubToken() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleForFile("token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij")::execute);
-		assertTrue(exception.getMessage().contains("GitHub token"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleForFile("token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij")::execute, "GitHub token");
 	}
 
 	@Test
 	void failsForAPrivateKeyBlock() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleForFile("-----BEGIN RSA PRIVATE KEY-----")::execute);
-		assertTrue(exception.getMessage().contains("private key block"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleForFile("-----BEGIN RSA PRIVATE KEY-----")::execute,
+				"private key block");
 	}
 
 	@Test
@@ -85,8 +78,7 @@ class NoSecretsRuleTest {
 		NoSecretsRule rule = new NoSecretsRule();
 		rule.setDirectories(List.of(tempDir.resolve("hooks").toFile()));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("script.sh"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "script.sh");
 	}
 
 	@Test
@@ -102,8 +94,7 @@ class NoSecretsRuleTest {
 		NoSecretsRule rule = ruleForFile("password = hunter2");
 		rule.setSecretPatterns(List.of("password\\s*=\\s*\\S+"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("password"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "password");
 	}
 
 	@Test
@@ -111,9 +102,7 @@ class NoSecretsRuleTest {
 		NoSecretsRule rule = ruleForFile("nothing to see here");
 		rule.setSecretPatterns(List.of("(unclosed"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("not a valid regular expression"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("(unclosed"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "not a valid regular expression", "(unclosed");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.enforcer.settings;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -78,14 +79,12 @@ class HookCommandsValidRuleTest {
 		HookCommandsValidRule rule = ruleFor(hooksReferencing("\\\"$CLAUDE_PROJECT_DIR/gone.sh\\\""));
 		rule.setProjectDir(tempDir.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("references a missing script"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "references a missing script");
 	}
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new HookCommandsValidRule()::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new HookCommandsValidRule()::execute, "not configured");
 	}
 
 	@Test
@@ -93,14 +92,12 @@ class HookCommandsValidRuleTest {
 		HookCommandsValidRule rule = new HookCommandsValidRule();
 		rule.setSettingsFile(tempDir.resolve("absent.json").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not exist");
 	}
 
 	@Test
 	void failsWhenJsonIsMalformed() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("{ \"hooks\": ")::execute);
-		assertTrue(exception.getMessage().contains("not valid JSON"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"hooks\": ")::execute, "not valid JSON");
 	}
 
 	@Test
@@ -108,16 +105,12 @@ class HookCommandsValidRuleTest {
 		HookCommandsValidRule rule = ruleFor(hooksReferencing("$CLAUDE_PROJECT_DIR/gone.sh"));
 		rule.setProjectDir(tempDir.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("references a missing script"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "references a missing script", "gone.sh");
 	}
 
 	@Test
 	void failsWhenCommandIsEmpty() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor(hooksReferencing(""))::execute);
-		assertTrue(exception.getMessage().contains("empty 'command'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(hooksReferencing(""))::execute, "empty 'command'");
 	}
 
 	@Test
@@ -126,8 +119,7 @@ class HookCommandsValidRuleTest {
 				{ "hooks": { "SessionStart": [ { "hooks": [ { "command": "echo hi" } ] } ] } }
 				""";
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(content)::execute);
-		assertTrue(exception.getMessage().contains("missing 'type'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(content)::execute, "missing 'type'");
 	}
 
 	@Test
@@ -136,8 +128,7 @@ class HookCommandsValidRuleTest {
 				{ "hooks": { "SessionStart": [ { "matcher": "*" } ] } }
 				""";
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor(content)::execute);
-		assertTrue(exception.getMessage().contains("missing a 'hooks' array"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor(content)::execute, "missing a 'hooks' array");
 	}
 
 	@Test
@@ -147,8 +138,7 @@ class HookCommandsValidRuleTest {
 		rule.setProjectDir(tempDir.toFile());
 		rule.setAllowedEvents(List.of("PreToolUse", "PostToolUse"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("is not an allowed event"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "is not an allowed event");
 	}
 
 	@Test
@@ -184,9 +174,8 @@ class HookCommandsValidRuleTest {
 
 	@Test
 	void failsWhenHooksIsAString() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"hooks\": \"SessionStart\" }")::execute);
-		assertTrue(exception.getMessage().contains("'hooks' must be a JSON object"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"hooks\": \"SessionStart\" }")::execute,
+				"'hooks' must be a JSON object");
 	}
 
 	@Test
@@ -197,8 +186,7 @@ class HookCommandsValidRuleTest {
 		rule.setProjectDir(tempDir.toFile());
 
 		// Every reference in the command is checked, not just the first one.
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("second.sh"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "second.sh");
 	}
 
 	@Test
@@ -214,23 +202,23 @@ class HookCommandsValidRuleTest {
 
 	@Test
 	void failsWhenAnEventDoesNotMapToAnArray() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"hooks\": { \"SessionStart\": { \"type\": \"command\" } } }")::execute);
-		assertTrue(exception.getMessage().contains("must be a JSON array"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"hooks\": { \"SessionStart\": { \"type\": \"command\" } } }")::execute,
+				"must be a JSON array");
 	}
 
 	@Test
 	void failsWhenAGroupIsNotAnObject() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"hooks\": { \"SessionStart\": [ \"not-a-group\" ] } }")::execute);
-		assertTrue(exception.getMessage().contains("entry that is not a JSON object"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"hooks\": { \"SessionStart\": [ \"not-a-group\" ] } }")::execute,
+				"entry that is not a JSON object");
 	}
 
 	@Test
 	void failsWhenAHookEntryIsNotAnObject() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"hooks\": { \"SessionStart\": [ { \"hooks\": [ \"echo hi\" ] } ] } }")::execute);
-		assertTrue(exception.getMessage().contains("hook that is not a JSON object"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"hooks\": { \"SessionStart\": [ { \"hooks\": [ \"echo hi\" ] } ] } }")::execute,
+				"hook that is not a JSON object");
 	}
 
 	@Test
@@ -280,8 +268,8 @@ class HookCommandsValidRuleTest {
 		HookCommandsValidRule rule = ruleFor(hooksReferencing("bash ${CLAUDE_PROJECT_DIR}/absent.sh"));
 		rule.setProjectDir(tempDir.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("references a missing script"), exception.getMessage());
+		EnforcerRuleException exception = assertFailure(EnforcerRuleException.class, rule::execute,
+				"references a missing script");
 		assertTrue(exception.getMessage().endsWith("absent.sh"), exception.getMessage());
 	}
 
@@ -296,8 +284,7 @@ class HookCommandsValidRuleTest {
 		HookCommandsValidRule rule = ruleFor(hooksReferencing(".claude/hooks/gone.sh"));
 		rule.setProjectDir(tempDir.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("references a missing script"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "references a missing script");
 	}
 
 	@Test
@@ -381,8 +368,7 @@ class HookCommandsValidRuleTest {
 		HookCommandsValidRule rule = ruleFor(hooksReferencing("hooks/present.sh\\nhooks/gone.sh"));
 		rule.setProjectDir(tempDir.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+		EnforcerRuleException exception = assertFailure(EnforcerRuleException.class, rule::execute, "gone.sh");
 		assertFalse(exception.getMessage().contains("present.sh"), exception.getMessage());
 	}
 
@@ -391,8 +377,7 @@ class HookCommandsValidRuleTest {
 		HookCommandsValidRule rule = ruleFor(hooksReferencing("LOG_LEVEL=debug hooks/gone.sh"));
 		rule.setProjectDir(tempDir.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "gone.sh");
 	}
 
 	/** The parentheses belong to the shell, not to the path, so no file is named by them. */
@@ -437,8 +422,7 @@ class HookCommandsValidRuleTest {
 		HookCommandsValidRule rule = ruleFor(hooksReferencing("bash $CLAUDE_PROJECT_DIR/gone.sh"));
 		rule.setProjectDir(tempDir.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "gone.sh");
 	}
 
 	@Test
@@ -446,8 +430,7 @@ class HookCommandsValidRuleTest {
 		HookCommandsValidRule rule = ruleFor(hooksReferencing("bash hooks/gone.sh"));
 		rule.setProjectDir(tempDir.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "gone.sh");
 	}
 
 	private HookCommandsValidRule ruleFor(String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.settings;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.assumeSymlink;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -44,16 +45,14 @@ class HooksFormatRuleTest {
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new HooksFormatRule()::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new HooksFormatRule()::execute, "not configured");
 	}
 
 	@Test
 	void failsWhenScriptHasNoShebang() {
 		writeScript("session-start.sh", "echo hi\n", true);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
-		assertTrue(exception.getMessage().contains("shebang"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor()::execute, "shebang");
 	}
 
 	@Test
@@ -61,16 +60,14 @@ class HooksFormatRuleTest {
 		assumeTrue(supportsExecutableBit(), "filesystem has no executable bit to clear");
 		writeScript("session-start.sh", "#!/bin/sh\n", false);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
-		assertTrue(exception.getMessage().contains("not executable"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor()::execute, "not executable");
 	}
 
 	@Test
 	void failsWhenScriptIsEmpty() {
 		writeScript("session-start.sh", "   \n", true);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
-		assertTrue(exception.getMessage().contains("empty"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor()::execute, "empty");
 	}
 
 	@Test
@@ -79,8 +76,7 @@ class HooksFormatRuleTest {
 		HooksFormatRule rule = ruleFor();
 		rule.setAllowedExtensions(List.of("sh"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("disallowed extension"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "disallowed extension");
 	}
 
 	@Test
@@ -99,9 +95,7 @@ class HooksFormatRuleTest {
 		rule.setSettingsFile(settingsReferencing("$CLAUDE_PROJECT_DIR/.claude/hooks/gone.sh"));
 		rule.setProjectDir(tempDir.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("references a missing hook script"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "references a missing hook script", "gone.sh");
 	}
 
 	@Test
@@ -123,9 +117,7 @@ class HooksFormatRuleTest {
 		rule.setProjectDir(tempDir.toFile());
 		rule.setReportUnreferencedScripts(true);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("not referenced"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("orphan.sh"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "not referenced", "orphan.sh");
 	}
 
 	/**
@@ -151,9 +143,7 @@ class HooksFormatRuleTest {
 		rule.setSettingsFile(settingsReferencing(".claude/hooks/gone.sh"));
 		rule.setProjectDir(tempDir.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("references a missing hook script"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "references a missing hook script", "gone.sh");
 	}
 
 	/** A hook chaining two scripts references both, whichever spelling each is written with. */
@@ -246,9 +236,7 @@ class HooksFormatRuleTest {
 				+ " && $CLAUDE_PROJECT_DIR/.claude/hooks/gone.sh"));
 		rule.setProjectDir(tempDir.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing hook script"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing hook script", "gone.sh");
 	}
 
 	@Test
@@ -263,8 +251,7 @@ class HooksFormatRuleTest {
 		rule.setProjectDir(tempDir.toFile());
 		rule.setReportUnreferencedScripts(true);
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("not referenced"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "not referenced");
 	}
 
 	@Test
@@ -282,8 +269,7 @@ class HooksFormatRuleTest {
 		HooksFormatRule rule = ruleFor();
 		rule.setAllowedExtensions(List.of("sh"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("disallowed extension"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "disallowed extension");
 	}
 
 	@Test
@@ -292,8 +278,7 @@ class HooksFormatRuleTest {
 		HooksFormatRule rule = ruleFor();
 		rule.setSettingsFile(tempDir.resolve("absent.json").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("settings.json does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "settings.json does not exist");
 	}
 
 	@Test
@@ -304,8 +289,7 @@ class HooksFormatRuleTest {
 		HooksFormatRule rule = ruleFor();
 		rule.setSettingsFile(settings.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("not valid JSON"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "not valid JSON");
 	}
 
 	@Test
@@ -331,9 +315,8 @@ class HooksFormatRuleTest {
 	void reportsAFileThatCannotBeDecodedAsTextInsteadOfFailingTheBuildOutright() {
 		writeBytes("logo.png", new byte[] { (byte) 0x89, 0x50, 0x4E, 0x47, (byte) 0xFF, (byte) 0xFE });
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor()::execute);
-		assertTrue(exception.getMessage().contains("cannot be read as a text script"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("logo.png"), exception.getMessage());
+		EnforcerRuleException exception = assertFailure(EnforcerRuleException.class, ruleFor()::execute,
+				"cannot be read as a text script", "logo.png");
 		assertFalse(exception.getMessage().contains("is empty"), exception.getMessage());
 	}
 
@@ -422,9 +405,7 @@ class HooksFormatRuleTest {
 		rule.setSettingsFile(settingsReferencing("if true; then .claude/hooks/gone.sh; fi"));
 		rule.setProjectDir(tempDir.toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("references a missing hook script"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("gone.sh"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "references a missing hook script", "gone.sh");
 	}
 
 	private HooksFormatRule ruleFor() {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRuleTest.java
@@ -1,9 +1,8 @@
 package io.github.adamw7.tools.enforcer.settings;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -34,9 +33,7 @@ class LocalSettingsIgnoredRuleTest {
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				new LocalSettingsIgnoredRule()::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new LocalSettingsIgnoredRule()::execute, "not configured");
 	}
 
 	@Test
@@ -44,23 +41,19 @@ class LocalSettingsIgnoredRuleTest {
 		LocalSettingsIgnoredRule rule = new LocalSettingsIgnoredRule();
 		rule.setGitignoreFile(tempDir.resolve("absent").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not exist");
 	}
 
 	@Test
 	void failsWhenThePathIsNotCovered() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("target/\n*.log\n")::execute);
-		assertTrue(exception.getMessage().contains("does not cover: .claude/settings.local.json"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("target/\n*.log\n")::execute,
+				"does not cover: .claude/settings.local.json");
 	}
 
 	@Test
 	void failsWhenANegationReincludesThePath() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("*.local.json\n!settings.local.json\n")::execute);
-		assertTrue(exception.getMessage().contains("does not cover"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("*.local.json\n!settings.local.json\n")::execute,
+				"does not cover");
 	}
 
 	@Test
@@ -68,8 +61,7 @@ class LocalSettingsIgnoredRuleTest {
 		LocalSettingsIgnoredRule rule = ruleFor(".claude/settings.local.json\n");
 		rule.setIgnoredPaths(List.of("./.claude/settings.local.json", ".env"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not cover: .env"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not cover: .env");
 	}
 
 	private LocalSettingsIgnoredRule ruleFor(String gitignoreContent) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRuleTest.java
@@ -1,9 +1,8 @@
 package io.github.adamw7.tools.enforcer.settings;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -39,66 +38,58 @@ class PermissionsFormatRuleTest {
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				new PermissionsFormatRule()::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new PermissionsFormatRule()::execute, "not configured");
 	}
 
 	@Test
 	void failsWhenPermissionsIsNotAnObject() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"permissions\": [] }")::execute);
-		assertTrue(exception.getMessage().contains("must be a JSON object"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"permissions\": [] }")::execute,
+				"must be a JSON object");
 	}
 
 	@Test
 	void failsWhenAListIsNotAnArray() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"permissions\": { \"allow\": \"Edit\" } }")::execute);
-		assertTrue(exception.getMessage().contains("'permissions.allow' must be an array"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"permissions\": { \"allow\": \"Edit\" } }")::execute,
+				"'permissions.allow' must be an array");
 	}
 
 	@Test
 	void failsForANonStringEntry() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"permissions\": { \"allow\": [ 42 ] } }")::execute);
-		assertTrue(exception.getMessage().contains("entry 1 must be a string"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"permissions\": { \"allow\": [ 42 ] } }")::execute,
+				"entry 1 must be a string");
 	}
 
 	@Test
 	void failsForABlankEntry() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"permissions\": { \"ask\": [ \"  \" ] } }")::execute);
-		assertTrue(exception.getMessage().contains("blank entry"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"permissions\": { \"ask\": [ \"  \" ] } }")::execute,
+				"blank entry");
 	}
 
 	@Test
 	void failsForMalformedEntrySyntax() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"permissions\": { \"allow\": [ \"Bash(mvn *\" ] } }")::execute);
-		assertTrue(exception.getMessage().contains("not of the form Tool or Tool(specifier)"),
-				exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": { \"allow\": [ \"Bash(mvn *\" ] } }")::execute,
+				"not of the form Tool or Tool(specifier)");
 	}
 
 	@Test
 	void failsForABlankSpecifier() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"permissions\": { \"allow\": [ \"Bash( )\" ] } }")::execute);
-		assertTrue(exception.getMessage().contains("blank specifier"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": { \"allow\": [ \"Bash( )\" ] } }")::execute, "blank specifier");
 	}
 
 	@Test
 	void failsForADuplicateEntry() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"permissions\": { \"allow\": [ \"Edit\", \"Edit\" ] } }")::execute);
-		assertTrue(exception.getMessage().contains("lists 'Edit' more than once"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": { \"allow\": [ \"Edit\", \"Edit\" ] } }")::execute,
+				"lists 'Edit' more than once");
 	}
 
 	@Test
 	void failsWhenAnEntryIsBothAllowedAndDenied() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"permissions\": { \"allow\": [ \"Edit\" ], \"deny\": [ \"Edit\" ] } }")::execute);
-		assertTrue(exception.getMessage().contains("appears in both 'allow' and 'deny'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class,
+				ruleFor("{ \"permissions\": { \"allow\": [ \"Edit\" ], \"deny\": [ \"Edit\" ] } }")::execute,
+				"appears in both 'allow' and 'deny'");
 	}
 
 	@Test
@@ -106,8 +97,7 @@ class PermissionsFormatRuleTest {
 		PermissionsFormatRule rule = ruleFor("{ \"permissions\": { \"allow\": [ \"Bsah(mvn *)\" ] } }");
 		rule.setAllowedTools(List.of("Bash", "Edit"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("unknown tool 'Bsah'"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "unknown tool 'Bsah'");
 	}
 
 	@Test
@@ -134,8 +124,7 @@ class PermissionsFormatRuleTest {
 		PermissionsFormatRule rule = ruleFor("{ \"permissions\": { \"allow\": [ \"Bash(*)\" ] } }");
 		rule.setForbiddenEntryPatterns(List.of("Bash\\(\\*\\)"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("matches forbidden pattern"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "matches forbidden pattern");
 	}
 
 	@Test
@@ -143,9 +132,7 @@ class PermissionsFormatRuleTest {
 		PermissionsFormatRule rule = ruleFor(
 				"{ \"permissions\": { \"allow\": [ \"Edit\", \"Edit\", \"Bash(mvn *\" ] } }");
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("more than once"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("not of the form"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "more than once", "not of the form");
 	}
 
 	@Test
@@ -153,9 +140,7 @@ class PermissionsFormatRuleTest {
 		PermissionsFormatRule rule = ruleFor("{ \"permissions\": { \"allow\": [ \"Bash(mvn *)\" ] } }");
 		rule.setForbiddenEntryPatterns(List.of("Bash(\\*"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("not a valid regular expression"), exception.getMessage());
-		assertTrue(exception.getMessage().contains("Bash(\\*"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "not a valid regular expression", "Bash(\\*");
 	}
 
 	private PermissionsFormatRule ruleFor(String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRuleTest.java
@@ -1,9 +1,8 @@
 package io.github.adamw7.tools.enforcer.settings;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -32,8 +31,7 @@ class SettingsJsonValidRuleTest {
 
 	@Test
 	void failsWhenNotConfigured() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, new SettingsJsonValidRule()::execute);
-		assertTrue(exception.getMessage().contains("not configured"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, new SettingsJsonValidRule()::execute, "not configured");
 	}
 
 	@Test
@@ -41,21 +39,17 @@ class SettingsJsonValidRuleTest {
 		SettingsJsonValidRule rule = new SettingsJsonValidRule();
 		rule.setSettingsFile(tempDir.resolve("absent.json").toFile());
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("does not exist"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "does not exist");
 	}
 
 	@Test
 	void failsWhenFileIsEmpty() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, ruleFor("   ")::execute);
-		assertTrue(exception.getMessage().contains("empty"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("   ")::execute, "empty");
 	}
 
 	@Test
 	void failsWhenJsonIsMalformed() {
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class,
-				ruleFor("{ \"permissions\": ")::execute);
-		assertTrue(exception.getMessage().contains("not valid JSON"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, ruleFor("{ \"permissions\": ")::execute, "not valid JSON");
 	}
 
 	@Test
@@ -63,8 +57,7 @@ class SettingsJsonValidRuleTest {
 		SettingsJsonValidRule rule = ruleFor(VALID_SETTINGS);
 		rule.setRequiredPermissions(List.of("Bash(git *)"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("missing required permission: Bash(git *)"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing required permission: Bash(git *)");
 	}
 
 	@Test
@@ -72,8 +65,7 @@ class SettingsJsonValidRuleTest {
 		SettingsJsonValidRule rule = ruleFor(VALID_SETTINGS);
 		rule.setForbiddenPermissions(List.of("Edit"));
 
-		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
-		assertTrue(exception.getMessage().contains("forbidden permission: Edit"), exception.getMessage());
+		assertFailure(EnforcerRuleException.class, rule::execute, "forbidden permission: Edit");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownTextTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownTextTest.java
@@ -3,10 +3,9 @@ package io.github.adamw7.tools.enforcer.text;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.assumeSymlink;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
@@ -96,9 +95,8 @@ class MarkdownTextTest {
 		Path link = tempDir.resolve("link.md");
 		assumeSymlink(link, target);
 
-		UncheckedIOException exception = assertThrows(UncheckedIOException.class,
-				() -> MarkdownText.write(link.toFile(), "overwritten", "link.md"));
-		assertTrue(exception.getMessage().contains("link.md"), exception.getMessage());
+		assertFailure(UncheckedIOException.class, () -> MarkdownText.write(link.toFile(), "overwritten", "link.md"),
+				"link.md");
 		assertEquals("original", readString(target));
 	}
 
@@ -106,8 +104,7 @@ class MarkdownTextTest {
 	void readWrapsAReadFailureWithTheDescription() {
 		Path missing = tempDir.resolve("absent.md");
 
-		UncheckedIOException exception = assertThrows(UncheckedIOException.class,
-				() -> MarkdownText.read(missing.toFile(), "absent.md"));
-		assertTrue(exception.getMessage().contains("absent.md"), exception.getMessage());
+		assertFailure(UncheckedIOException.class, () -> MarkdownText.read(missing.toFile(), "absent.md"),
+				"absent.md");
 	}
 }

--- a/test-common/pom.xml
+++ b/test-common/pom.xml
@@ -10,10 +10,10 @@
 	<artifactId>tools.test-common</artifactId>
 	<packaging>jar</packaging>
 	<name>Shared test scaffolding</name>
-	<description>Shared ArchUnit rule libraries reused by every module's architecture tests.</description>
+	<description>Shared ArchUnit rule libraries and test assertions reused by every module's tests.</description>
 	<properties>
-		<!-- This module carries no production code, only the rule libraries the
-		     other modules' architecture tests import, so keep it out of both
+		<!-- This module carries no production code, only the rule libraries and
+		     assertions the other modules' tests import, so keep it out of both
 		     publications: the GitHub Packages deployment maven-deploy-plugin
 		     performs on `mvn deploy`, and the Maven Central bundle the root pom's
 		     release profile publishes. -->

--- a/test-common/src/test/java/io/github/adamw7/tools/test/ExpectedFailures.java
+++ b/test-common/src/test/java/io/github/adamw7/tools/test/ExpectedFailures.java
@@ -1,0 +1,41 @@
+package io.github.adamw7.tools.test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.function.Executable;
+
+/**
+ * Asserts that a call fails, and that its message says why. Nearly every test of
+ * a rule or of an adoption step asserts exactly that pair, which written out is
+ * the {@code assertThrows} that names the exception type twice, a local to hold
+ * it, and one {@code assertTrue(...contains(...), ...getMessage())} per fragment
+ * the message must carry — with the message repeated as the failure description
+ * so a test that breaks says what was actually thrown.
+ * <p>
+ * Collecting it here leaves each test naming only what it expects, and makes the
+ * message the assertion description by construction rather than something every
+ * call has to remember to pass.
+ */
+public final class ExpectedFailures {
+
+	private ExpectedFailures() {
+	}
+
+	/**
+	 * @param type              the exception the call must fail with
+	 * @param failing           the call under test
+	 * @param expectedInMessage fragments the failure's message must contain, in no
+	 *                          particular order; none asserts only the type
+	 * @return the failure, for a test that has more to say about it than its message
+	 */
+	public static <T extends Throwable> T assertFailure(Class<T> type, Executable failing,
+			String... expectedInMessage) {
+		T failure = assertThrows(type, failing);
+		String message = String.valueOf(failure.getMessage());
+		for (String expected : expectedInMessage) {
+			assertTrue(message.contains(expected), message);
+		}
+		return failure;
+	}
+}


### PR DESCRIPTION
Nearly every rule and adoption-step test asserts the same pair: the call
fails with a given exception, and its message carries given fragments.
Written out that is an assertThrows naming the type twice, a local to hold
the failure, and one assertTrue(...contains(...), ...getMessage()) per
fragment — three lines to say what one can, with the thrown message
repeated as the assertion description so a broken test still says what was
actually thrown.

Collect it in test-common as ExpectedFailures.assertFailure(type, call,
fragments...), which makes that description part of the helper rather than
something each call has to remember, and apply it to the 275 sites across
the two modules that made exactly that assertion. A test with more to say
about the failure keeps its local, since the helper returns it; a fixture
built from a text block is left alone.

Also drop the two identical entriesIn overrides in the definition format
rules: scanning a directory's *.md files is what a command and a sub-agent
both are, so it becomes the base's default and only the skill rule — whose
definition is a directory — still says otherwise.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GH8cYcU4AupWKJfmhMqQNs