### PR TITLE
fix(context): expect the frontmatter YAML the emitter now writes

### DIFF
--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpIT.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpIT.java
@@ -98,7 +98,7 @@ public class McpStreamableHttpIT extends AbstractContextMcpIT {
 		assertEquals("0.2", bundle.get("okf_version").asText());
 		JsonNode documents = bundle.get("documents");
 		assertTrue(documents.get("index.md").asText().contains("okf_version: \"0.2\""));
-		assertTrue(documents.get("A.java.md").asText().contains("type: \"Java Source File\""));
+		assertTrue(documents.get("A.java.md").asText().contains("type: Java Source File"));
 		assertTrue(documents.get("B.java.md").asText().contains("[`A.java`](/A.java.md)"));
 	}
 


### PR DESCRIPTION
The OKF frontmatter block moved to SnakeYAML, which writes a plain scalar
unquoted. The unit tests followed, but this integration test kept asserting
the old double-quoted form and only the daily integration-tests workflow
runs it, so the drift stayed invisible on the pull request that caused it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01McQr624fuaAu2hWk2ggmW9