### PR TITLE
refactor(context, data, adopt, claude-code-enforcer): say each shared test contract once

### DIFF
--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
+import static io.github.adamw7.tools.test.TestStrings.occurrences;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -371,7 +372,7 @@ class PomEnforcerInstallerTest {
 		String result = Files.readString(pom);
 		assertTrue(result.contains("tools.claude-code-enforcer"));
 		assertTrue(result.contains("claudeMdFormat"));
-		assertEquals(1, countOccurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"));
+		assertEquals(1, occurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"));
 	}
 
 	@Test
@@ -384,16 +385,6 @@ class PomEnforcerInstallerTest {
 		Path pom = write(dir, POM_WITH_ENFORCER);
 		assertTrue(installer.install(pom));
 		assertFalse(installer.install(pom));
-	}
-
-	private int countOccurrences(String text, String token) {
-		int count = 0;
-		int index = text.indexOf(token);
-		while (index >= 0) {
-			count++;
-			index = text.indexOf(token, index + token.length());
-		}
-		return count;
 	}
 
 	@Test
@@ -450,7 +441,7 @@ class PomEnforcerInstallerTest {
 	@Test
 	void reusesADependencyOnTheRuleArtifactThePluginAlreadyDeclares(@TempDir Path dir) throws IOException {
 		String result = install(dir, POM_WITH_THE_ARTIFACT_FOR_ANOTHER_RULE);
-		assertEquals(1, countOccurrences(result, "<artifactId>tools.claude-code-enforcer</artifactId>"),
+		assertEquals(1, occurrences(result, "<artifactId>tools.claude-code-enforcer</artifactId>"),
 				"the artifact must be declared once:\n" + result);
 		assertTrue(result.contains("<version>1.0.0</version>"), "the project's pinned version must survive");
 		assertFalse(result.contains("9.9.9"), "a second, differently pinned dependency must not be added:\n" + result);
@@ -469,7 +460,7 @@ class PomEnforcerInstallerTest {
 		assertTrue(installer.install(pom), "a managed rule binds to no phase, so the build still needs one");
 		String result = Files.readString(pom);
 		assertTrue(result.contains("claudeMdFormat"), "the rule must be wired into the build that runs");
-		assertEquals(2, countOccurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
+		assertEquals(2, occurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
 				"the build needs its own enforcer declaration alongside the managed one");
 	}
 
@@ -489,7 +480,7 @@ class PomEnforcerInstallerTest {
 		assertTrue(result.contains(MANAGED_ENFORCER),
 				"the managed declaration must be left verbatim; an execution there would never run");
 		assertTrue(result.contains("tools.claude-code-enforcer"), "the rule must still be wired in");
-		assertEquals(2, countOccurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
+		assertEquals(2, occurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
 				"the build needs its own enforcer declaration alongside the managed one");
 	}
 
@@ -517,7 +508,7 @@ class PomEnforcerInstallerTest {
 		String result = Files.readString(pom);
 		assertTrue(result.contains(PROFILED_ENFORCER), "the profile must be left verbatim");
 		assertTrue(result.contains(MANAGED_ENFORCER), "the managed declaration must be left verbatim");
-		assertEquals(3, countOccurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
+		assertEquals(3, occurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
 				"the build's existing declaration must be augmented, not joined by a fourth");
 		assertTrue(result.contains("claudeMdFormat"), "the rule must be wired in");
 	}
@@ -558,7 +549,7 @@ class PomEnforcerInstallerTest {
 		String result = install(dir, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + POM_WITH_BUILD);
 		assertTrue(result.startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project "),
 				"the original declaration must be kept verbatim on its own line, not rewritten");
-		assertEquals(1, countOccurrences(result, "<?xml"), "the declaration must not be duplicated");
+		assertEquals(1, occurrences(result, "<?xml"), "the declaration must not be duplicated");
 	}
 
 	@Test
@@ -623,7 +614,7 @@ class PomEnforcerInstallerTest {
 	void preservesADeclarationThatSharesItsLineWithTheRootElement(@TempDir Path dir) throws IOException {
 		String result = install(dir, "<?xml version=\"1.0\"?>" + POM_WITH_BUILD);
 		assertTrue(result.startsWith("<?xml version=\"1.0\"?><project "), "unexpected start:\n" + result);
-		assertEquals(1, countOccurrences(result, "<?xml"), "the declaration must not be duplicated");
+		assertEquals(1, occurrences(result, "<?xml"), "the declaration must not be duplicated");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.doc;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
+import static io.github.adamw7.tools.test.TestStrings.occurrences;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -255,10 +256,6 @@ class ContextBudgetRuleTest {
 		// The *.md filter narrows the directory scan; a file named outright was
 		// chosen by the configuration and is measured whatever it is called.
 		assertFailure(EnforcerRuleException.class, rule::execute, "notes.txt");
-	}
-
-	private static int occurrences(String message, String token) {
-		return message.split(java.util.regex.Pattern.quote(token), -1).length - 1;
 	}
 
 	private ContextBudgetRule ruleForFile(String content) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRuleTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.secret;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
+import static io.github.adamw7.tools.test.TestStrings.occurrences;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -114,10 +115,6 @@ class NoSecretsRuleTest {
 
 		EnforcerRuleException exception = assertThrows(EnforcerRuleException.class, rule::execute);
 		assertEquals(1, occurrences(exception.getMessage(), "script.sh"), exception.getMessage());
-	}
-
-	private static int occurrences(String message, String token) {
-		return message.split(java.util.regex.Pattern.quote(token), -1).length - 1;
 	}
 
 	private NoSecretsRule ruleForFile(String content) {

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/AbstractContextToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/AbstractContextToolTest.java
@@ -1,0 +1,81 @@
+package io.github.adamw7.context.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * What every context tool answers the same way, asserted once. {@link
+ * AbstractContextTool#apply} is final: it confines the path, defaults the
+ * language and bounds the depth before handing a {@code Scan} to the tool, so
+ * rejecting a missing path, a path outside the allowed roots and an excessive
+ * depth is one behaviour shared by all four tools rather than four behaviours
+ * that happen to agree. Asserting it in each tool's test repeated the same three
+ * cases — and the fixture they need — once per tool, and let a tool be added
+ * with none of them.
+ * <p>
+ * A subclass names its tool through {@link #tool()} and is left with only what
+ * is its own: the tool's name, the arguments beyond the shared three, and what
+ * it answers with.
+ */
+abstract class AbstractContextToolTest {
+
+	protected static final ObjectMapper MAPPER = new ObjectMapper();
+
+	@TempDir
+	Path projectRoot;
+
+	@TempDir
+	Path outsideRoot;
+
+	/** The tool under test, confined to {@link #projectRoot}. */
+	protected abstract ContextTool tool();
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void toolDefinitionRequiresPath() {
+		List<String> required = (List<String>) tool().getToolDefinition().inputSchema().get("required");
+		assertTrue(required.contains("path"));
+	}
+
+	@Test
+	void missingPathIsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> tool().apply(new HashMap<>()));
+	}
+
+	@Test
+	void pathOutsideTheAllowedRootIsRejected() {
+		assertThrows(SecurityException.class, () -> tool().apply(pathArgument(outsideRoot)));
+	}
+
+	@Test
+	void excessiveDepthIsRejected() {
+		// The depth is bounded while the shared arguments are read, before the tool is
+		// asked anything, so this needs no source file to scan.
+		Map<String, Object> arguments = pathArgument(projectRoot);
+		arguments.put("depth", 99);
+
+		assertThrows(IllegalArgumentException.class, () -> tool().apply(arguments));
+	}
+
+	/** The arguments naming a root, as the map a test then adds its own entries to. */
+	protected Map<String, Object> pathArgument(Path root) {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("path", root.toString());
+		return arguments;
+	}
+
+	protected void writeJava(String className, String body) throws IOException {
+		Files.writeString(projectRoot.resolve(className + ".java"), body);
+	}
+}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ContextFinderToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ContextFinderToolTest.java
@@ -6,37 +6,29 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.mcp.ToolResult;
 
-public class ContextFinderToolTest {
-
-	@TempDir
-	Path projectRoot;
-
-	@TempDir
-	Path outsideRoot;
-
-	private static final ObjectMapper MAPPER = new ObjectMapper();
+public class ContextFinderToolTest extends AbstractContextToolTest {
 
 	private ContextFinderTool tool;
 
 	@BeforeEach
 	void setUp() {
 		tool = new ContextFinderTool(new PathPolicy(projectRoot.toString()));
+	}
+
+	@Override
+	protected ContextTool tool() {
+		return tool;
 	}
 
 	@Test
@@ -46,9 +38,8 @@ public class ContextFinderToolTest {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	void toolDefinitionRequiresPathAndClassName() {
+	void toolDefinitionRequiresClassName() {
 		List<String> required = (List<String>) tool.getToolDefinition().inputSchema().get("required");
-		assertTrue(required.contains("path"));
 		assertTrue(required.contains("class_name"));
 	}
 
@@ -93,7 +84,7 @@ public class ContextFinderToolTest {
 		ToolResult result = tool.apply(arguments("Missing"));
 
 		assertTrue(result.isError());
-		assertTrue(text(result).contains("Class not found: Missing"));
+		assertTrue(result.text().contains("Class not found: Missing"));
 	}
 
 	@Test
@@ -108,49 +99,23 @@ public class ContextFinderToolTest {
 
 	@Test
 	void missingClassNameIsRejected() {
-		Map<String, Object> arguments = new HashMap<>();
-		arguments.put("path", projectRoot.toString());
-		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
-	}
-
-	@Test
-	void pathOutsideTheAllowedRootIsRejected() {
-		Map<String, Object> arguments = arguments("B");
-		arguments.put("path", outsideRoot.toString());
-		assertThrows(SecurityException.class, () -> tool.apply(arguments));
-	}
-
-	@Test
-	void excessiveDepthIsRejected() throws IOException {
-		writeJava("A", "public class A {}");
-		Map<String, Object> arguments = arguments("A");
-		arguments.put("depth", 99);
-		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
+		assertThrows(IllegalArgumentException.class, () -> tool.apply(pathArgument(projectRoot)));
 	}
 
 	private Map<String, Object> arguments(String className) {
-		Map<String, Object> arguments = new HashMap<>();
-		arguments.put("path", projectRoot.toString());
+		Map<String, Object> arguments = pathArgument(projectRoot);
 		arguments.put("class_name", className);
 		return arguments;
 	}
 
-	private void writeJava(String className, String body) throws IOException {
-		Files.writeString(projectRoot.resolve(className + ".java"), body);
-	}
-
 	private List<String> dependencies(ToolResult result) {
 		try {
-			JsonNode array = MAPPER.readTree(text(result));
+			JsonNode array = MAPPER.readTree(result.text());
 			List<String> values = new ArrayList<>();
 			array.forEach(node -> values.add(node.asText()));
 			return values;
 		} catch (JsonProcessingException e) {
 			throw new IllegalStateException("Invalid JSON result", e);
 		}
-	}
-
-	private String text(ToolResult result) {
-		return result.text();
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/EstimateTokensToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/EstimateTokensToolTest.java
@@ -7,36 +7,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.context.TokenEstimator;
 import io.github.adamw7.tools.mcp.ToolResult;
 
-public class EstimateTokensToolTest {
-
-	@TempDir
-	Path projectRoot;
-
-	@TempDir
-	Path outsideRoot;
-
-	private static final ObjectMapper MAPPER = new ObjectMapper();
+public class EstimateTokensToolTest extends AbstractContextToolTest {
 
 	private EstimateTokensTool tool;
 
 	@BeforeEach
 	void setUp() {
 		tool = new EstimateTokensTool(new PathPolicy(projectRoot.toString()), oneTokenPerCharacter());
+	}
+
+	@Override
+	protected ContextTool tool() {
+		return tool;
 	}
 
 	@Test
@@ -46,9 +39,8 @@ public class EstimateTokensToolTest {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	void toolDefinitionRequiresPathAndClassName() {
+	void toolDefinitionRequiresClassName() {
 		List<String> required = (List<String>) tool.getToolDefinition().inputSchema().get("required");
-		assertTrue(required.contains("path"));
 		assertTrue(required.contains("class_name"));
 	}
 
@@ -84,29 +76,12 @@ public class EstimateTokensToolTest {
 		ToolResult result = tool.apply(arguments("Missing"));
 
 		assertTrue(result.isError());
-		assertTrue(text(result).contains("Class not found: Missing"));
+		assertTrue(result.text().contains("Class not found: Missing"));
 	}
 
 	@Test
 	void missingClassNameIsRejected() {
-		Map<String, Object> arguments = new HashMap<>();
-		arguments.put("path", projectRoot.toString());
-		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
-	}
-
-	@Test
-	void pathOutsideTheAllowedRootIsRejected() {
-		Map<String, Object> arguments = arguments("A");
-		arguments.put("path", outsideRoot.toString());
-		assertThrows(SecurityException.class, () -> tool.apply(arguments));
-	}
-
-	@Test
-	void excessiveDepthIsRejected() throws IOException {
-		writeJava("A", "A");
-		Map<String, Object> arguments = arguments("A");
-		arguments.put("depth", 99);
-		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
+		assertThrows(IllegalArgumentException.class, () -> tool.apply(pathArgument(projectRoot)));
 	}
 
 	@Test
@@ -170,25 +145,16 @@ public class EstimateTokensToolTest {
 	}
 
 	private Map<String, Object> arguments(String className) {
-		Map<String, Object> arguments = new HashMap<>();
-		arguments.put("path", projectRoot.toString());
+		Map<String, Object> arguments = pathArgument(projectRoot);
 		arguments.put("class_name", className);
 		return arguments;
 	}
 
-	private void writeJava(String className, String body) throws IOException {
-		Files.writeString(projectRoot.resolve(className + ".java"), body);
-	}
-
 	private JsonNode report(ToolResult result) {
 		try {
-			return MAPPER.readTree(text(result));
+			return MAPPER.readTree(result.text());
 		} catch (JsonProcessingException e) {
 			throw new IllegalStateException("Invalid JSON result", e);
 		}
-	}
-
-	private String text(ToolResult result) {
-		return result.text();
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/McpConfigurationTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/McpConfigurationTest.java
@@ -1,8 +1,6 @@
 package io.github.adamw7.context.mcp;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.OutputStream;
 import java.io.PipedInputStream;
@@ -18,9 +16,10 @@ import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 
 public class McpConfigurationTest {
 
+	private final McpConfiguration config = new McpConfiguration();
+
 	@Test
 	public void happyPath() throws Exception {
-		McpConfiguration config = new McpConfiguration();
 		assertNotNull(config.objectMapper());
 		// Drive the stdio server from a controllable pipe instead of System.in. The
 		// reader thread is non-daemon and cannot be interrupted while blocked on a
@@ -37,29 +36,25 @@ public class McpConfigurationTest {
 
 	@Test
 	public void stdioTransportIsNotNull() {
-		McpConfiguration config = new McpConfiguration();
 		assertNotNull(config.stdioServerTransport());
 	}
 
 	@Test
 	public void streamableTransportIsNotNull() {
-		McpConfiguration config = new McpConfiguration();
 		assertNotNull(config.streamableServerTransport());
 	}
 
 	@Test
 	public void streamableServletRegistrationIsNotNull() {
-		McpConfiguration config = new McpConfiguration();
 		HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
 		assertNotNull(config.streamableServletRegistration(transport));
 	}
 
 	@Test
 	public void mcpSyncServerStreamableHasTools() {
-		McpConfiguration config = new McpConfiguration();
 		HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
 		McpSyncServer server = config.mcpSyncServerStreamable(transport);
-		assertFalse(server.getServerCapabilities().tools() == null);
+		assertNotNull(server.getServerCapabilities().tools());
 		server.close();
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/OkfBundleToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/OkfBundleToolTest.java
@@ -2,33 +2,18 @@ package io.github.adamw7.context.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import io.github.adamw7.tools.mcp.ToolResult;
-
-public class OkfBundleToolTest {
-
-	@TempDir
-	Path projectRoot;
-
-	@TempDir
-	Path outsideRoot;
-
-	private static final ObjectMapper MAPPER = new ObjectMapper();
+public class OkfBundleToolTest extends AbstractContextToolTest {
 
 	private OkfBundleTool tool;
 
@@ -37,23 +22,21 @@ public class OkfBundleToolTest {
 		tool = new OkfBundleTool(new PathPolicy(projectRoot.toString()));
 	}
 
+	@Override
+	protected ContextTool tool() {
+		return tool;
+	}
+
 	@Test
 	void toolDefinitionExposesName() {
 		assertEquals("okf_bundle", tool.getToolDefinition().name());
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
-	void toolDefinitionRequiresPath() {
-		List<String> required = (List<String>) tool.getToolDefinition().inputSchema().get("required");
-		assertTrue(required.contains("path"));
-	}
-
-	@Test
 	void returnsTheTargetedSpecificationVersion() throws IOException {
 		writeJava("A", "public class A {}");
 
-		JsonNode bundle = MAPPER.readTree(text(tool.apply(arguments())));
+		JsonNode bundle = bundle(arguments());
 
 		assertEquals("0.2", bundle.get("okf_version").asText());
 	}
@@ -63,7 +46,7 @@ public class OkfBundleToolTest {
 		writeJava("A", "public class A {}");
 		writeJava("B", "public class B { A a; }");
 
-		JsonNode documents = MAPPER.readTree(text(tool.apply(arguments()))).get("documents");
+		JsonNode documents = documents(arguments());
 
 		assertEquals(3, documents.size());
 		assertTrue(documents.has("index.md"));
@@ -75,10 +58,10 @@ public class OkfBundleToolTest {
 	void conceptDocumentsCarryFrontmatterWithAType() throws IOException {
 		writeJava("A", "public class A {}");
 
-		JsonNode documents = MAPPER.readTree(text(tool.apply(arguments()))).get("documents");
+		String document = documents(arguments()).get("A.java.md").asText();
 
-		assertTrue(documents.get("A.java.md").asText().startsWith("---"));
-		assertTrue(documents.get("A.java.md").asText().contains("type: Java Source File"));
+		assertTrue(document.startsWith("---"));
+		assertTrue(document.contains("type: Java Source File"));
 	}
 
 	@Test
@@ -86,7 +69,7 @@ public class OkfBundleToolTest {
 		writeJava("A", "public class A {}");
 		writeJava("B", "public class B { A a; }");
 
-		JsonNode documents = MAPPER.readTree(text(tool.apply(arguments()))).get("documents");
+		JsonNode documents = documents(arguments());
 
 		assertTrue(documents.get("B.java.md").asText().contains("[`A.java`](/A.java.md)"));
 	}
@@ -98,34 +81,14 @@ public class OkfBundleToolTest {
 		Map<String, Object> arguments = arguments();
 		arguments.put("language", "kotlin");
 
-		JsonNode documents = MAPPER.readTree(text(tool.apply(arguments))).get("documents");
-		assertTrue(documents.get("A.kt.md").asText().contains("type: Kotlin Source File"));
+		assertTrue(documents(arguments).get("A.kt.md").asText().contains("type: Kotlin Source File"));
 	}
 
 	@Test
 	void resultIsNotAnError() throws IOException {
 		writeJava("A", "public class A {}");
+
 		assertFalse(tool.apply(arguments()).isError());
-	}
-
-	@Test
-	void missingPathIsRejected() {
-		assertThrows(IllegalArgumentException.class, () -> tool.apply(new HashMap<>()));
-	}
-
-	@Test
-	void pathOutsideTheAllowedRootIsRejected() {
-		Map<String, Object> arguments = new HashMap<>();
-		arguments.put("path", outsideRoot.toString());
-		assertThrows(SecurityException.class, () -> tool.apply(arguments));
-	}
-
-	@Test
-	void excessiveDepthIsRejected() throws IOException {
-		writeJava("A", "public class A {}");
-		Map<String, Object> arguments = arguments();
-		arguments.put("depth", 99);
-		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
 	}
 
 	@Test
@@ -140,16 +103,14 @@ public class OkfBundleToolTest {
 	}
 
 	private Map<String, Object> arguments() {
-		Map<String, Object> arguments = new HashMap<>();
-		arguments.put("path", projectRoot.toString());
-		return arguments;
+		return pathArgument(projectRoot);
 	}
 
-	private void writeJava(String className, String body) throws IOException {
-		Files.writeString(projectRoot.resolve(className + ".java"), body);
+	private JsonNode bundle(Map<String, Object> arguments) throws IOException {
+		return MAPPER.readTree(tool.apply(arguments).text());
 	}
 
-	private String text(ToolResult result) {
-		return result.text();
+	private JsonNode documents(Map<String, Object> arguments) throws IOException {
+		return bundle(arguments).get("documents");
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
@@ -2,33 +2,16 @@ package io.github.adamw7.context.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import io.github.adamw7.tools.mcp.ToolResult;
-
-public class ProjectTreeToolTest {
-
-	@TempDir
-	Path projectRoot;
-
-	@TempDir
-	Path outsideRoot;
-
-	private static final ObjectMapper MAPPER = new ObjectMapper();
+public class ProjectTreeToolTest extends AbstractContextToolTest {
 
 	private ProjectTreeTool tool;
 
@@ -37,16 +20,14 @@ public class ProjectTreeToolTest {
 		tool = new ProjectTreeTool(new PathPolicy(projectRoot.toString()));
 	}
 
-	@Test
-	void toolDefinitionExposesName() {
-		assertEquals("project_tree", tool.getToolDefinition().name());
+	@Override
+	protected ContextTool tool() {
+		return tool;
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
-	void toolDefinitionRequiresPath() {
-		List<String> required = (List<String>) tool.getToolDefinition().inputSchema().get("required");
-		assertTrue(required.contains("path"));
+	void toolDefinitionExposesName() {
+		assertEquals("project_tree", tool.getToolDefinition().name());
 	}
 
 	@Test
@@ -54,7 +35,7 @@ public class ProjectTreeToolTest {
 		writeJava("A", "public class A {}");
 		writeJava("B", "public class B { A a; }");
 
-		JsonNode tree = MAPPER.readTree(text(tool.apply(arguments())));
+		JsonNode tree = MAPPER.readTree(tool.apply(arguments()).text());
 
 		assertEquals(projectRoot.getFileName().toString(), tree.get("name").asText());
 		assertEquals("directory", tree.get("type").asText());
@@ -65,22 +46,14 @@ public class ProjectTreeToolTest {
 	void honoursTheMarkdownFormat() throws IOException {
 		writeJava("A", "public class A {}");
 
-		Map<String, Object> arguments = arguments();
-		arguments.put("format", "markdown");
-
-		String rendered = text(tool.apply(arguments));
-		assertTrue(rendered.contains("- `A.java`"));
+		assertTrue(rendered("markdown").contains("- `A.java`"));
 	}
 
 	@Test
 	void honoursTheTextFormat() throws IOException {
 		writeJava("A", "public class A {}");
 
-		Map<String, Object> arguments = arguments();
-		arguments.put("format", "text");
-
-		String rendered = text(tool.apply(arguments));
-		assertTrue(rendered.contains("[file] A.java"));
+		assertTrue(rendered("text").contains("[file] A.java"));
 	}
 
 	@Test
@@ -88,10 +61,8 @@ public class ProjectTreeToolTest {
 		writeJava("A", "public class A {}");
 		writeJava("B", "public class B { A a; }");
 
-		Map<String, Object> arguments = arguments();
-		arguments.put("format", "mermaid");
+		String rendered = rendered("mermaid");
 
-		String rendered = text(tool.apply(arguments));
 		assertTrue(rendered.startsWith("flowchart LR"));
 		assertTrue(rendered.contains("[\"B.java\"] --> "));
 		assertTrue(rendered.contains("[\"A.java\"]"));
@@ -106,7 +77,8 @@ public class ProjectTreeToolTest {
 		Map<String, Object> arguments = arguments();
 		arguments.put("depth", 2);
 
-		String rendered = text(tool.apply(arguments));
+		String rendered = tool.apply(arguments).text();
+
 		assertTrue(rendered.contains("A.java"));
 		assertTrue(rendered.contains("B.java"));
 	}
@@ -114,40 +86,17 @@ public class ProjectTreeToolTest {
 	@Test
 	void resultIsNotAnError() throws IOException {
 		writeJava("A", "public class A {}");
+
 		assertFalse(tool.apply(arguments()).isError());
 	}
 
-	@Test
-	void missingPathIsRejected() {
-		assertThrows(IllegalArgumentException.class, () -> tool.apply(new HashMap<>()));
-	}
-
-	@Test
-	void pathOutsideTheAllowedRootIsRejected() {
-		Map<String, Object> arguments = new HashMap<>();
-		arguments.put("path", outsideRoot.toString());
-		assertThrows(SecurityException.class, () -> tool.apply(arguments));
-	}
-
-	@Test
-	void excessiveDepthIsRejected() throws IOException {
-		writeJava("A", "public class A {}");
-		Map<String, Object> arguments = arguments();
-		arguments.put("depth", 99);
-		assertThrows(IllegalArgumentException.class, () -> tool.apply(arguments));
-	}
-
 	private Map<String, Object> arguments() {
-		Map<String, Object> arguments = new HashMap<>();
-		arguments.put("path", projectRoot.toString());
-		return arguments;
+		return pathArgument(projectRoot);
 	}
 
-	private void writeJava(String className, String body) throws IOException {
-		Files.writeString(projectRoot.resolve(className + ".java"), body);
-	}
-
-	private String text(ToolResult result) {
-		return result.text();
+	private String rendered(String format) {
+		Map<String, Object> arguments = arguments();
+		arguments.put("format", format);
+		return tool.apply(arguments).text();
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/AbstractIterableDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/AbstractIterableDataSourceTest.java
@@ -1,0 +1,99 @@
+package io.github.adamw7.tools.data.source.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
+
+/**
+ * The forward-only contract every {@link AbstractIterableFileSource} keeps,
+ * asserted once for all of its formats. Opening twice, reading before opening
+ * and restarting an iteration are guarded in that shared base, not in the JSON,
+ * YAML or TOON source, so each format's own test was re-proving the same code —
+ * along with the {@code drain} and {@code collect} loops every one of them needs
+ * to say anything about a source that only goes forwards.
+ * <p>
+ * A subclass names its format through {@link #newSource()} and is left with what
+ * only its parser can be asked: how it flattens that format's documents.
+ */
+abstract class AbstractIterableDataSourceTest {
+
+	/** A file-backed source over the fixture for the format under test. */
+	protected abstract IterableDataSource newSource();
+
+	@Test
+	void resetRestartsTheIteration() throws IOException {
+		try (IterableDataSource source = newSource()) {
+			source.open();
+			int first = drain(source);
+			source.reset();
+
+			assertEquals(first, drain(source));
+		}
+	}
+
+	@Test
+	void openTwiceThrows() throws IOException {
+		try (IterableDataSource source = newSource()) {
+			source.open();
+
+			assertThrows(IllegalStateException.class, source::open);
+		}
+	}
+
+	@Test
+	void nextRowBeforeOpenThrows() throws IOException {
+		try (IterableDataSource source = newSource()) {
+			assertThrows(IllegalStateException.class, source::nextRow);
+		}
+	}
+
+	@Test
+	void hasMoreDataBeforeOpenThrows() throws IOException {
+		try (IterableDataSource source = newSource()) {
+			assertThrows(IllegalStateException.class, source::hasMoreData);
+		}
+	}
+
+	@Test
+	void nextRowsRejectsNonPositiveBatchSize() throws IOException {
+		try (IterableDataSource source = newSource()) {
+			source.open();
+
+			assertThrows(IllegalArgumentException.class, () -> source.nextRows(0));
+			assertThrows(IllegalArgumentException.class, () -> source.nextRows(-1));
+		}
+	}
+
+	/** Counts the rows an open source has left, so an iteration can be compared to another. */
+	protected int drain(IterableDataSource source) {
+		int rows = 0;
+		while (source.hasMoreData()) {
+			if (source.nextRow() != null) {
+				rows++;
+			}
+		}
+		return rows;
+	}
+
+	/** Reads a source to exhaustion into the flattened {@code key -> value} pairs it emits. */
+	protected Map<String, String> collect(IterableDataSource source) throws IOException {
+		try (source) {
+			source.open();
+			Map<String, String> map = new HashMap<>();
+			while (source.hasMoreData()) {
+				String[] row = source.nextRow();
+				if (row != null) {
+					map.put(row[0], row[1]);
+				}
+			}
+			return map;
+		}
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/IterableJSONDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/IterableJSONDataSourceTest.java
@@ -1,25 +1,27 @@
 package io.github.adamw7.tools.data.source.file;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import io.github.adamw7.tools.data.Utils;
-import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 
-public class IterableJSONDataSourceTest {
+public class IterableJSONDataSourceTest extends AbstractIterableDataSourceTest {
+
+	@Override
+	protected IterableJSONDataSource newSource() {
+		return new IterableJSONDataSource(Utils.getFileName("test.json"));
+	}
 
 	@Test
 	public void flattensNestedValues() throws IOException {
-		Map<String, String> data = collect(new IterableJSONDataSource(Utils.getFileName("test.json")));
+		Map<String, String> data = collect(newSource());
 		assertEquals(17, data.size());
 		assertEquals("Alice", data.get("people[0].name"));
 		assertEquals("30", data.get("people[0].age"));
@@ -52,27 +54,8 @@ public class IterableJSONDataSourceTest {
 	}
 
 	@Test
-	public void resetRestartsTheIteration() throws IOException {
-		try (IterableJSONDataSource source = new IterableJSONDataSource(Utils.getFileName("test.json"))) {
-			source.open();
-			int first = drain(source);
-			source.reset();
-			int second = drain(source);
-			assertEquals(first, second);
-		}
-	}
-
-	@Test
-	public void openTwiceThrows() throws IOException {
-		try (IterableJSONDataSource source = new IterableJSONDataSource(Utils.getFileName("test.json"))) {
-			source.open();
-			assertThrows(IllegalStateException.class, source::open);
-		}
-	}
-
-	@Test
 	public void nextRowsLoadsRequestedBatchThenDrainsRemainder() throws IOException {
-		try (IterableJSONDataSource source = new IterableJSONDataSource(Utils.getFileName("test.json"))) {
+		try (IterableJSONDataSource source = newSource()) {
 			source.open();
 
 			List<String[]> firstBatch = source.nextRows(5);
@@ -82,46 +65,6 @@ public class IterableJSONDataSourceTest {
 			assertEquals(12, rest.size());
 
 			assertTrue(source.nextRows(10).isEmpty());
-		}
-	}
-
-	@Test
-	public void nextRowsRejectsNonPositiveBatchSize() throws IOException {
-		try (IterableJSONDataSource source = new IterableJSONDataSource(Utils.getFileName("test.json"))) {
-			source.open();
-			assertThrows(IllegalArgumentException.class, () -> source.nextRows(0));
-			assertThrows(IllegalArgumentException.class, () -> source.nextRows(-1));
-		}
-	}
-
-	@Test
-	public void nextRowBeforeOpenThrows() throws IOException {
-		try (IterableJSONDataSource source = new IterableJSONDataSource(Utils.getFileName("test.json"))) {
-			assertThrows(IllegalStateException.class, source::nextRow);
-		}
-	}
-
-	private int drain(IterableDataSource source) {
-		int rows = 0;
-		while (source.hasMoreData()) {
-			if (source.nextRow() != null) {
-				rows++;
-			}
-		}
-		return rows;
-	}
-
-	private Map<String, String> collect(IterableDataSource source) throws IOException {
-		try (source) {
-			source.open();
-			Map<String, String> map = new HashMap<>();
-			while (source.hasMoreData()) {
-				String[] row = source.nextRow();
-				if (row != null) {
-					map.put(row[0], row[1]);
-				}
-			}
-			return map;
 		}
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/IterableTOONDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/IterableTOONDataSourceTest.java
@@ -1,32 +1,34 @@
 package io.github.adamw7.tools.data.source.file;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import io.github.adamw7.tools.data.Utils;
-import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 
-public class IterableTOONDataSourceTest {
+public class IterableTOONDataSourceTest extends AbstractIterableDataSourceTest {
+
+	@Override
+	protected IterableTOONDataSource newSource() {
+		return new IterableTOONDataSource(Utils.getFileName("test.toon"));
+	}
 
 	@Test
 	public void streamsSameRowsAsInMemorySource() throws IOException {
 		Map<String, String> inMemory = collect(new InMemoryTOONDataSource(Utils.getFileName("test.toon")));
-		Map<String, String> iterated = collect(new IterableTOONDataSource(Utils.getFileName("test.toon")));
+		Map<String, String> iterated = collect(newSource());
 		assertEquals(inMemory, iterated);
 		assertEquals(70, iterated.size());
 	}
 
 	@Test
 	public void readsSimpleKeyValuePairs() throws IOException {
-		Map<String, String> data = collect(new IterableTOONDataSource(Utils.getFileName("test.toon")));
+		Map<String, String> data = collect(newSource());
 		assertEquals("MyTestApp", data.get("appName"));
 		assertEquals("1.2.3", data.get("version"));
 		assertEquals("true", data.get("isEnabled"));
@@ -37,7 +39,7 @@ public class IterableTOONDataSourceTest {
 
 	@Test
 	public void readsNestedObjects() throws IOException {
-		Map<String, String> data = collect(new IterableTOONDataSource(Utils.getFileName("test.toon")));
+		Map<String, String> data = collect(newSource());
 		assertEquals("localhost", data.get("database.host"));
 		assertEquals("5432", data.get("database.port"));
 		assertEquals("admin", data.get("database.credentials.username"));
@@ -46,7 +48,7 @@ public class IterableTOONDataSourceTest {
 
 	@Test
 	public void readsTabularArray() throws IOException {
-		Map<String, String> data = collect(new IterableTOONDataSource(Utils.getFileName("test.toon")));
+		Map<String, String> data = collect(newSource());
 		assertEquals("Alice", data.get("people[0].name"));
 		assertEquals("30", data.get("people[0].age"));
 		assertEquals("New York", data.get("people[0].city"));
@@ -57,7 +59,7 @@ public class IterableTOONDataSourceTest {
 
 	@Test
 	public void readsNestedArray() throws IOException {
-		Map<String, String> data = collect(new IterableTOONDataSource(Utils.getFileName("test.toon")));
+		Map<String, String> data = collect(newSource());
 		assertEquals("3", data.get("priorities"));
 		assertEquals("high", data.get("priorities[0]"));
 		assertEquals("medium", data.get("priorities[1]"));
@@ -75,7 +77,7 @@ public class IterableTOONDataSourceTest {
 
 	@Test
 	public void unescapesQuotedValues() throws IOException {
-		Map<String, String> data = collect(new IterableTOONDataSource(Utils.getFileName("test.toon")));
+		Map<String, String> data = collect(newSource());
 		assertEquals("Hello, World!", data.get("greeting"));
 		assertEquals("C:\\Program Files\\App", data.get("pathWithSpaces"));
 		assertEquals("Line1\nLine2\nLine3", data.get("multilineHint"));
@@ -83,57 +85,7 @@ public class IterableTOONDataSourceTest {
 		assertEquals("She said \"Hello\" to me", data.get("quotedValue"));
 	}
 
-	@Test
-	public void resetRestartsTheIteration() throws IOException {
-		try (IterableTOONDataSource source = new IterableTOONDataSource(Utils.getFileName("test.toon"))) {
-			source.open();
-			int first = drain(source);
-			source.reset();
-			int second = drain(source);
-			assertEquals(first, second);
-		}
-	}
-
-	@Test
-	public void openTwiceThrows() throws IOException {
-		try (IterableTOONDataSource source = new IterableTOONDataSource(Utils.getFileName("test.toon"))) {
-			source.open();
-			assertThrows(IllegalStateException.class, source::open);
-		}
-	}
-
-	@Test
-	public void nextRowBeforeOpenThrows() throws IOException {
-		try (IterableTOONDataSource source = new IterableTOONDataSource(Utils.getFileName("test.toon"))) {
-			assertThrows(IllegalStateException.class, source::nextRow);
-		}
-	}
-
 	private IterableTOONDataSource fromString(String toon) {
 		return new IterableTOONDataSource(new ByteArrayInputStream(toon.getBytes(StandardCharsets.UTF_8)));
-	}
-
-	private int drain(IterableDataSource source) {
-		int rows = 0;
-		while (source.hasMoreData()) {
-			if (source.nextRow() != null) {
-				rows++;
-			}
-		}
-		return rows;
-	}
-
-	private Map<String, String> collect(IterableDataSource source) throws IOException {
-		try (source) {
-			source.open();
-			Map<String, String> map = new HashMap<>();
-			while (source.hasMoreData()) {
-				String[] row = source.nextRow();
-				if (row != null) {
-					map.put(row[0], row[1]);
-				}
-			}
-			return map;
-		}
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/IterableYAMLDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/IterableYAMLDataSourceTest.java
@@ -1,30 +1,31 @@
 package io.github.adamw7.tools.data.source.file;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import io.github.adamw7.tools.data.Utils;
-import io.github.adamw7.tools.data.source.interfaces.IterableDataSource;
 
-public class IterableYAMLDataSourceTest {
+public class IterableYAMLDataSourceTest extends AbstractIterableDataSourceTest {
+
+	@Override
+	protected IterableYAMLDataSource newSource() {
+		return new IterableYAMLDataSource(Utils.getFileName("test.yaml"));
+	}
 
 	@Test
 	public void streamsSameRowsAsInMemorySource() throws IOException {
 		Map<String, String> inMemory = collect(new InMemoryYAMLDataSource(Utils.getFileName("test.yaml")));
-		Map<String, String> iterated = collect(new IterableYAMLDataSource(Utils.getFileName("test.yaml")));
-		assertEquals(inMemory, iterated);
+		assertEquals(inMemory, collect(newSource()));
 	}
 
 	@Test
 	public void flattensNestedValues() throws IOException {
-		Map<String, String> data = collect(new IterableYAMLDataSource(Utils.getFileName("test.yaml")));
+		Map<String, String> data = collect(newSource());
 		assertEquals(17, data.size());
 		assertEquals("Alice", data.get("people[0].name"));
 		assertEquals("30", data.get("people[0].age"));
@@ -43,56 +44,6 @@ public class IterableYAMLDataSourceTest {
 				IterableYAMLDataSource source = new IterableYAMLDataSource(is)) {
 			source.open();
 			assertEquals(17, drain(source));
-		}
-	}
-
-	@Test
-	public void resetRestartsTheIteration() throws IOException {
-		try (IterableYAMLDataSource source = new IterableYAMLDataSource(Utils.getFileName("test.yaml"))) {
-			source.open();
-			int first = drain(source);
-			source.reset();
-			int second = drain(source);
-			assertEquals(first, second);
-		}
-	}
-
-	@Test
-	public void openTwiceThrows() throws IOException {
-		try (IterableYAMLDataSource source = new IterableYAMLDataSource(Utils.getFileName("test.yaml"))) {
-			source.open();
-			assertThrows(IllegalStateException.class, source::open);
-		}
-	}
-
-	@Test
-	public void hasMoreDataBeforeOpenThrows() throws IOException {
-		try (IterableYAMLDataSource source = new IterableYAMLDataSource(Utils.getFileName("test.yaml"))) {
-			assertThrows(IllegalStateException.class, source::hasMoreData);
-		}
-	}
-
-	private int drain(IterableDataSource source) {
-		int rows = 0;
-		while (source.hasMoreData()) {
-			if (source.nextRow() != null) {
-				rows++;
-			}
-		}
-		return rows;
-	}
-
-	private Map<String, String> collect(IterableDataSource source) throws IOException {
-		try (source) {
-			source.open();
-			Map<String, String> map = new HashMap<>();
-			while (source.hasMoreData()) {
-				String[] row = source.nextRow();
-				if (row != null) {
-					map.put(row[0], row[1]);
-				}
-			}
-			return map;
 		}
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
@@ -1,10 +1,8 @@
 package io.github.adamw7.tools.data.uniqueness.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -26,86 +24,79 @@ import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 
 public class McpConfigurationTest {
 
-    @AfterEach
-    public void clearBaseDir() {
-        // tools() confines file access through global PathValidator state; reset it
-        // so the restriction does not leak into other tests.
-        PathValidator.clearAllowedBaseDir();
-    }
+	private final McpConfiguration config = new McpConfiguration();
 
-    @Test
-    public void confinesFileAccessToConfiguredBaseDir(@TempDir Path baseDir) throws IOException {
-        Path insideFile = Files.createFile(baseDir.resolve("data.csv"));
-        McpConfiguration config = new McpConfiguration();
-        config.allowedBaseDir = baseDir.toString();
+	@AfterEach
+	public void clearBaseDir() {
+		// tools() confines file access through global PathValidator state; reset it
+		// so the restriction does not leak into other tests.
+		PathValidator.clearAllowedBaseDir();
+	}
 
-        config.tools();
+	@Test
+	public void confinesFileAccessToConfiguredBaseDir(@TempDir Path baseDir) throws IOException {
+		Path insideFile = Files.createFile(baseDir.resolve("data.csv"));
+		config.allowedBaseDir = baseDir.toString();
 
-        assertThrows(SecurityException.class,
-                () -> PathValidator.validate(outsideBase(baseDir)));
-        assertDoesNotThrow(() -> PathValidator.validate(insideFile.toRealPath().toString()));
-    }
+		config.tools();
 
-    @Test
-    public void defaultsToWorkingDirectoryWhenBaseDirBlank(@TempDir Path outsideDir) throws IOException {
-        Path outsideFile = Files.createFile(outsideDir.resolve("data.csv"));
-        McpConfiguration config = new McpConfiguration();
-        config.allowedBaseDir = "   ";
+		assertThrows(SecurityException.class, () -> PathValidator.validate(outsideBase(baseDir)));
+		assertDoesNotThrow(() -> PathValidator.validate(insideFile.toRealPath().toString()));
+	}
 
-        config.tools();
+	@Test
+	public void defaultsToWorkingDirectoryWhenBaseDirBlank(@TempDir Path outsideDir) throws IOException {
+		Path outsideFile = Files.createFile(outsideDir.resolve("data.csv"));
+		config.allowedBaseDir = "   ";
 
-        // The JUnit temp dir lives outside the module's working directory, so a file
-        // there must be rejected once access is confined to the default base.
-        assertThrows(SecurityException.class,
-                () -> PathValidator.validate(outsideFile.toRealPath().toString()));
-    }
+		config.tools();
 
-    private String outsideBase(Path baseDir) {
-        return baseDir.getParent().resolve("outside-the-base-dir.csv").toString();
-    }
+		// The JUnit temp dir lives outside the module's working directory, so a file
+		// there must be rejected once access is confined to the default base.
+		assertThrows(SecurityException.class, () -> PathValidator.validate(outsideFile.toRealPath().toString()));
+	}
 
-    @Test
-    public void happyPath() throws Exception {
-        McpConfiguration config = new McpConfiguration();
-        assertFalse(config.objectMapper() == null);
-        // Drive the stdio server from a controllable pipe instead of System.in. The
-        // reader thread is non-daemon and cannot be interrupted while blocked on a
-        // read, so closing the pipe is the only way to let it terminate and avoid
-        // leaking it into the forked test JVM.
-        PipedInputStream input = new PipedInputStream();
-        PipedOutputStream inputWriter = new PipedOutputStream(input);
-        McpSyncServer server = config.mcpSyncServer(new StdioServerTransportProvider(
-                new JacksonMcpJsonMapper(new ObjectMapper()), input, OutputStream.nullOutputStream()));
-        assertFalse(server.getServerCapabilities().tools() == null);
-        server.close();
-        inputWriter.close();
-    }
+	@Test
+	public void happyPath() throws Exception {
+		assertNotNull(config.objectMapper());
+		// Drive the stdio server from a controllable pipe instead of System.in. The
+		// reader thread is non-daemon and cannot be interrupted while blocked on a
+		// read, so closing the pipe is the only way to let it terminate and avoid
+		// leaking it into the forked test JVM.
+		PipedInputStream input = new PipedInputStream();
+		PipedOutputStream inputWriter = new PipedOutputStream(input);
+		McpSyncServer server = config.mcpSyncServer(new StdioServerTransportProvider(
+				new JacksonMcpJsonMapper(new ObjectMapper()), input, OutputStream.nullOutputStream()));
+		assertNotNull(server.getServerCapabilities().tools());
+		server.close();
+		inputWriter.close();
+	}
 
-    @Test
-    public void stdioTransportIsNotNull() {
-        McpConfiguration config = new McpConfiguration();
-        assertFalse(config.stdioServerTransport() == null);
-    }
+	@Test
+	public void stdioTransportIsNotNull() {
+		assertNotNull(config.stdioServerTransport());
+	}
 
-    @Test
-    public void streamableTransportIsNotNull() {
-        McpConfiguration config = new McpConfiguration();
-        assertNotNull(config.streamableServerTransport());
-    }
+	@Test
+	public void streamableTransportIsNotNull() {
+		assertNotNull(config.streamableServerTransport());
+	}
 
-    @Test
-    public void streamableServletRegistrationIsNotNull() {
-        McpConfiguration config = new McpConfiguration();
-        HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
-        assertNotNull(config.streamableServletRegistration(transport));
-    }
+	@Test
+	public void streamableServletRegistrationIsNotNull() {
+		HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
+		assertNotNull(config.streamableServletRegistration(transport));
+	}
 
-    @Test
-    public void mcpSyncServerStreamableHasTools() {
-        McpConfiguration config = new McpConfiguration();
-        HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
-        McpSyncServer server = config.mcpSyncServerStreamable(transport);
-        assertNotNull(server.getServerCapabilities().tools());
-        server.close();
-    }
+	@Test
+	public void mcpSyncServerStreamableHasTools() {
+		HttpServletStreamableServerTransportProvider transport = config.streamableServerTransport();
+		McpSyncServer server = config.mcpSyncServerStreamable(transport);
+		assertNotNull(server.getServerCapabilities().tools());
+		server.close();
+	}
+
+	private String outsideBase(Path baseDir) {
+		return baseDir.getParent().resolve("outside-the-base-dir.csv").toString();
+	}
 }

--- a/test-common/src/test/java/io/github/adamw7/tools/test/TestStrings.java
+++ b/test-common/src/test/java/io/github/adamw7/tools/test/TestStrings.java
@@ -1,0 +1,42 @@
+package io.github.adamw7.tools.test;
+
+/**
+ * Assertions about text that a test makes but {@code java.lang.String} does not
+ * answer directly. A test proving that something is said <em>once</em> — a rule
+ * reporting a file it was handed twice, an installer not duplicating a plugin
+ * declaration — has to count occurrences, which every such test grew its own
+ * copy of: one written as a hand-rolled {@code indexOf} loop, another as a split
+ * on a quoted pattern.
+ * <p>
+ * Saying it here once keeps those tests to what they are actually asserting, and
+ * settles the question the two implementations answered only by accident: what
+ * happens when a token overlaps itself.
+ */
+public final class TestStrings {
+
+	private TestStrings() {
+	}
+
+	/**
+	 * Counts how many times {@code token} appears in {@code text}, without
+	 * overlapping: each match resumes the search past the one just found, so
+	 * {@code "aaa"} contains {@code "aa"} once rather than twice. {@code token} is
+	 * matched literally, never as a regular expression.
+	 *
+	 * @param text  the text to search, which a failure message often is
+	 * @param token the literal to count; an empty token counts as absent
+	 * @return the number of non-overlapping occurrences
+	 */
+	public static int occurrences(String text, String token) {
+		if (text == null || token == null || token.isEmpty()) {
+			return 0;
+		}
+		int count = 0;
+		int index = text.indexOf(token);
+		while (index >= 0) {
+			count++;
+			index = text.indexOf(token, index + token.length());
+		}
+		return count;
+	}
+}


### PR DESCRIPTION
Three groups of unit tests were re-proving one piece of shared production code
per implementation, carrying a copy of its fixture each time.

AbstractContextTool.apply is final: it confines the path, defaults the language
and bounds the depth before the tool is asked anything. All four context MCP
tool tests asserted that separately, alongside their own @TempDir pair, ObjectMapper,
writeJava and a text(result) helper that only forwarded to result.text().
AbstractContextToolTest states it once, so a fifth tool cannot arrive without it —
find_context and estimate_tokens gain the missing-path case they had never made.

AbstractIterableFileSource guards open, nextRow and hasMoreData for every format
it backs, yet the JSON, YAML and TOON tests each guarded a subset of those and
each carried its own drain and collect loop. AbstractIterableDataSourceTest holds
the contract and the loops; every format now makes all five cases rather than the
three or four it happened to.

Counting how many times a message says something was written three times over,
as a hand-rolled indexOf loop in adopt and as a split on a quoted pattern in two
enforcer tests. TestStrings.occurrences joins ExpectedFailures in test-common and
settles what the two implementations agreed on only by accident: overlapping
tokens count once.

Also collapses the repeated McpConfiguration construction in the data and context
server tests to a field, and replaces data's assertFalse(x == null) with
assertNotNull.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WUvFpdF93LsXuBzHs7mJPG