### PR TITLE
fix(adopt): read CLAUDE.md the way the rule it wires in reads it

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -367,7 +367,21 @@ public final class CliArguments {
 		}
 	}
 
+	/**
+	 * An argument {@link RepositoryUrl} cannot parse at all names no owner either —
+	 * and no repository, so no adoption was ever going to be made of it whichever
+	 * argument the operator meant it to be. Answering the question rather than
+	 * letting the parse failure out is what puts the refusal above in front of them:
+	 * a {@code /tmp/workspace//} whose trailing slashes leave no last segment, or a
+	 * {@code C:\workspaces\ws} on Windows, was refused with the parser's own
+	 * "repositoryUrl must end in a repository name" — which names neither the
+	 * argument that was misread nor the flag that was meant.
+	 */
 	private boolean namesNoOwner(String url) {
-		return RepositoryUrl.of(url).slug().isEmpty();
+		try {
+			return RepositoryUrl.of(url).slug().isEmpty();
+		} catch (IllegalArgumentException e) {
+			return true;
+		}
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -21,9 +21,9 @@ import java.util.stream.IntStream;
  * <p>The reshape is deterministic and conservative: a near-miss heading is
  * <em>renamed</em> in place so its body survives, only a genuinely absent section
  * is appended, and a required section left empty gets a stub body because the rule
- * fails an empty section just as it fails a missing one. Fenced code and
- * commented-out text are left alone, mirroring how the rule matches, and reshaping
- * an already-conforming document is a no-op.
+ * fails an empty section just as it fails a missing one. Code — fenced or indented
+ * — and commented-out text are left alone, mirroring how the rule matches, and
+ * reshaping an already-conforming document is a no-op.
  *
  * <p>Which sections it demands is the caller's to choose, because the guard being
  * wired in differs by build system — see
@@ -74,6 +74,12 @@ public class ClaudeMdConformer {
 	private static final String COMMENT_START = "<!--";
 	private static final String COMMENT_END = "-->";
 	private static final String STUB_BODY = "See [AGENTS.md](AGENTS.md).";
+
+	private static final char TAB = '\t';
+	private static final char SPACE = ' ';
+
+	/** The indent Markdown reads as a code block, and the width a tab advances to. */
+	private static final int CODE_INDENT = 4;
 
 	/**
 	 * One to six {@code #} characters, then whitespace and any text, or nothing at
@@ -256,10 +262,19 @@ public class ClaudeMdConformer {
 	 * {@code claude init} wrote, blank line and all, and closing the insertion with
 	 * one of its own left a double blank in the first commit of every repository
 	 * whose guard demands no section.
+	 *
+	 * <p>An existing mention only counts where the rule counts one: its
+	 * {@code containsInProse} reads the lines that carry document structure, so a
+	 * mention inside a code sample or an HTML comment satisfies it no more than a
+	 * commented-out heading satisfies a required section. Asking the looser question
+	 * — outside fences alone — let a generated document whose only {@code AGENTS.md}
+	 * sat in a comment or an indented sample keep the reference it never had, and the
+	 * adoption then failed its own {@link VerifyStep} on the one line it exists to
+	 * add.
 	 */
 	private void ensureAgentsReference(List<String> lines) {
 		Outline outline = Outline.of(lines);
-		if (outline.matching(line -> line.contains(AGENTS_REFERENCE)).findAny().isPresent()) {
+		if (outline.structural(line -> line.contains(AGENTS_REFERENCE)).findAny().isPresent()) {
 			return;
 		}
 		int index = outline.titleIndex() + 1;
@@ -279,67 +294,64 @@ public class ClaudeMdConformer {
 	}
 
 	/**
-	 * The document as the reshape reads it: the lines themselves, which of them sit
-	 * inside a code fence, and which sit inside an HTML comment. The three travel
-	 * together because every search the reshape makes is against one of those masks,
-	 * and a mask taken from lines other than the ones it is applied to would quietly
-	 * mis-answer — so a reshape that inserts or removes lines takes a fresh outline
-	 * rather than carrying this one on.
+	 * The document as the reshape reads it: the lines themselves, which of them are
+	 * code, and which sit inside an HTML comment. The three travel together because
+	 * every search the reshape makes is against one of those masks, and a mask taken
+	 * from lines other than the ones it is applied to would quietly mis-answer — so a
+	 * reshape that inserts or removes lines takes a fresh outline rather than carrying
+	 * this one on.
 	 *
 	 * <p>Renaming a line in place keeps the outline valid, since the masks are
 	 * indexed by line number and the count has not moved.
 	 *
+	 * @param code        which lines Markdown quotes as code, fenced or indented
 	 * @param openFence   the delimiter of a fence the document never closed, or
 	 *                    {@code null} when its fences balance
 	 * @param openComment whether the document left an HTML comment unterminated
 	 */
-	private record Outline(List<String> lines, boolean[] fence, boolean[] comment, Delimiter openFence,
+	private record Outline(List<String> lines, boolean[] code, boolean[] comment, Delimiter openFence,
 			boolean openComment) {
 
 		/**
-		 * Both masks are read in one pass, because a comment inside a fenced code block
-		 * is sample text rather than a comment and so the comment scan needs the fence
-		 * verdict for the very line it is on — which the fence scan has just settled.
+		 * The code mask is settled before the comment scan runs, because a comment
+		 * inside code is sample text rather than a comment and so that scan needs the
+		 * code verdict for the very line it is on.
 		 */
 		static Outline of(List<String> lines) {
-			boolean[] fence = new boolean[lines.size()];
+			boolean[] code = new boolean[lines.size()];
+			Delimiter openFence = markCode(lines, code);
 			boolean[] comment = new boolean[lines.size()];
-			Delimiter openFence = null;
-			boolean openComment = false;
-			for (int index = 0; index < lines.size(); index++) {
-				String line = lines.get(index).strip();
-				openFence = applyFence(line, openFence, fence, index);
-				openComment = applyComment(line, openComment, fence[index], comment, index);
-			}
-			return new Outline(lines, fence, comment, openFence, openComment);
+			boolean openComment = markComments(lines, code, comment);
+			return new Outline(lines, code, comment, openFence, openComment);
 		}
 
-		/** The indices of the lines outside code fences whose text matches, in document order. */
+		/** The indices of the lines outside code whose text matches, in document order. */
 		IntStream matching(Predicate<String> match) {
-			return IntStream.range(0, lines.size()).filter(index -> !fence[index] && match.test(lines.get(index)));
+			return IntStream.range(0, lines.size()).filter(index -> !code[index] && match.test(lines.get(index)));
 		}
 
 		/**
-		 * The indices of the lines that can carry document structure — outside code
-		 * fences and outside HTML comments alike — whose text matches. A heading is
-		 * only ever looked for, and only ever renamed, on one of these, because that
-		 * is where the rule recognises one: a section commented out with
-		 * {@code <!-- ... -->} is inert text, and counting it left the real section
-		 * unwritten while the rule went on demanding it.
+		 * The indices of the lines that can carry document structure — outside code and
+		 * outside HTML comments alike — whose text matches. A heading is only ever
+		 * looked for, and only ever renamed, on one of these, because that is where the
+		 * rule recognises one: a section commented out with {@code <!-- ... -->} is
+		 * inert text, and counting it left the real section unwritten while the rule
+		 * went on demanding it.
 		 */
 		IntStream structural(Predicate<String> match) {
 			return matching(match).filter(index -> !comment[index]);
 		}
 
-		/** @return the index of the heading outside code fences and comments, or {@code -1} when absent */
+		/** @return the index of the heading outside code and comments, or {@code -1} when absent */
 		int indexOfHeading(String heading) {
 			return structural(line -> line.strip().equals(heading)).findFirst().orElse(-1);
 		}
 
 		/**
-		 * The title is the first non-blank line by the time this is asked, and a fence
-		 * marker would itself be a non-blank line before it, so the title can never be
-		 * one the mask covers. A document with no title line at all falls back to the top.
+		 * The title is the first non-blank line by the time this is asked, and both a
+		 * fence marker and the blank line an indented block opens below would themselves
+		 * be lines before it, so the title can never be one the mask covers. A document
+		 * with no title line at all falls back to the top.
 		 */
 		int titleIndex() {
 			return Math.max(indexOfHeading(TITLE), 0);
@@ -356,7 +368,7 @@ public class ClaudeMdConformer {
 			return IntStream.range(headingIndex + 1, lines.size())
 					.filter(this::decidesBody)
 					.limit(1)
-					.anyMatch(index -> fence[index] || isBodyLine(lines.get(index).strip(), level));
+					.anyMatch(index -> code[index] || isBodyLine(lines.get(index).strip(), level));
 		}
 
 		/**
@@ -367,7 +379,7 @@ public class ClaudeMdConformer {
 		 * already has a body and leave the adoption to fail its own {@link VerifyStep}.
 		 */
 		private boolean decidesBody(int index) {
-			return fence[index] || (!comment[index] && !lines.get(index).isBlank());
+			return code[index] || (!comment[index] && !lines.get(index).isBlank());
 		}
 	}
 
@@ -405,26 +417,124 @@ public class ClaudeMdConformer {
 	}
 
 	/**
+	 * Marks every line Markdown quotes as code, both ways it allows: the fenced
+	 * blocks first, then the indented ones over the same mask, so a fence's own lines
+	 * are already spoken for and an indent inside one is content rather than a block
+	 * of its own. This mirrors {@code MarkdownDocument} in the
+	 * {@code claude-code-enforcer} module, as {@link Delimiter} does; keep the two in
+	 * sync.
+	 *
+	 * @return the fence delimiter still open at the end of the document, or
+	 *         {@code null} when its fences balance
+	 */
+	private static Delimiter markCode(List<String> lines, boolean[] mask) {
+		Delimiter openFence = markFences(lines, mask);
+		markIndentedCode(lines, mask);
+		return openFence;
+	}
+
+	private static Delimiter markFences(List<String> lines, boolean[] mask) {
+		Delimiter open = null;
+		for (int index = 0; index < lines.size(); index++) {
+			open = applyFence(lines.get(index).strip(), open, mask, index);
+		}
+		return open;
+	}
+
+	/**
+	 * Marks the code Markdown quotes the other way it allows — by indenting it four
+	 * columns, a tab counting on to the next four-column stop. The rule has always
+	 * read those lines as code, and reading them as prose here made the reshape act
+	 * on a sample: a {@code ## Testing} shown as an indented example was taken for the
+	 * section the document already had, so the real one was never appended and the
+	 * adoption failed its own {@link VerifyStep} — and a near-miss heading inside one
+	 * was renamed in place, rewriting the sample and losing its indentation.
+	 */
+	private static void markIndentedCode(List<String> lines, boolean[] mask) {
+		boolean mayOpen = true;
+		for (int index = 0; index < lines.size(); index++) {
+			mayOpen = applyIndent(lines.get(index), mayOpen, mask, index);
+		}
+	}
+
+	/**
+	 * Marks whether the line is indented code and returns whether an indented line
+	 * below it would open a block. Only a blank line, a line already masked as code,
+	 * and the start of the document leave that open: an indented line below a
+	 * paragraph is a lazy continuation of that paragraph rather than code. A blank
+	 * line is left unmarked, since it carries nothing to read either way.
+	 */
+	private static boolean applyIndent(String line, boolean mayOpen, boolean[] mask, int index) {
+		if (mask[index] || line.isBlank()) {
+			return true;
+		}
+		mask[index] = mayOpen && indentWidth(line) >= CODE_INDENT;
+		return mask[index];
+	}
+
+	/** The line's indent in columns, a tab counting on to the next four-column stop. */
+	private static int indentWidth(String line) {
+		int width = 0;
+		int index = 0;
+		while (index < line.length() && isIndent(line.charAt(index))) {
+			width += line.charAt(index) == TAB ? CODE_INDENT - width % CODE_INDENT : 1;
+			index++;
+		}
+		return width;
+	}
+
+	private static boolean isIndent(char character) {
+		return character == SPACE || character == TAB;
+	}
+
+	private static boolean markComments(List<String> lines, boolean[] code, boolean[] mask) {
+		boolean open = false;
+		for (int index = 0; index < lines.size(); index++) {
+			open = applyComment(lines.get(index).strip(), open, code[index], mask, index);
+		}
+		return open;
+	}
+
+	/**
 	 * Marks whether the line is commented out and returns whether a comment is still
 	 * open after it. A comment that opens and closes on one line masks nothing —
 	 * {@code <!-- ## Testing -->} is not a heading to begin with — while a block
-	 * comment hides the lines it spans from every heading search. This mirrors
-	 * {@code MarkdownDocument} in the {@code claude-code-enforcer} module, as
-	 * {@link Delimiter} does; keep the two in sync.
+	 * comment hides the lines it spans from every heading search.
 	 *
-	 * @param insideFence whether the line is code, because a comment inside a fenced
-	 *                    code block is sample text rather than a comment: the fence wins
+	 * <p>Whether a comment remains open is read from every delimiter on the line
+	 * rather than from its first characters, the reading the rule takes: a comment
+	 * opened after text — {@code Superseded: <!--} — hides the lines below it, and a
+	 * line that closes one comment and opens another leaves one open. Asking only
+	 * whether the line began with {@value #COMMENT_START} left those lines visible to
+	 * the reshape and invisible to the rule, so a required section the document had
+	 * commented out was counted as present, never appended, and the adoption failed
+	 * its own {@link VerifyStep}.
+	 *
+	 * @param insideCode whether the line is code, because a comment inside a code
+	 *                   block is sample text rather than a comment: the code wins
 	 */
-	private static boolean applyComment(String line, boolean open, boolean insideFence, boolean[] mask, int index) {
-		if (insideFence) {
+	private static boolean applyComment(String line, boolean open, boolean insideCode, boolean[] mask, int index) {
+		if (insideCode) {
 			return open;
 		}
-		if (open) {
-			mask[index] = true;
-			return !line.contains(COMMENT_END);
-		}
-		mask[index] = line.startsWith(COMMENT_START) && !line.contains(COMMENT_END);
-		return mask[index];
+		mask[index] = open || opensBlock(line);
+		return remainsOpen(line, 0, open);
+	}
+
+	/** Whether the line's own content starts a comment that the same line does not close. */
+	private static boolean opensBlock(String line) {
+		return line.startsWith(COMMENT_START) && remainsOpen(line, 0, false);
+	}
+
+	/**
+	 * Whether a comment is open once {@code line} has been read from {@code from},
+	 * following each delimiter in turn: an open comment looks for its
+	 * {@value #COMMENT_END}, a closed one for the next {@value #COMMENT_START}.
+	 */
+	private static boolean remainsOpen(String line, int from, boolean open) {
+		String delimiter = open ? COMMENT_END : COMMENT_START;
+		int next = line.indexOf(delimiter, from);
+		return next < 0 ? open : remainsOpen(line, next + delimiter.length(), !open);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PluginVersion.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PluginVersion.java
@@ -1,0 +1,80 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Compares the leading numbers of a Maven version literal against a minimum,
+ * which is all the adoption asks of one: whether the plugin a project pinned is
+ * too old to run the rule being wired into it.
+ *
+ * <p>Only the numeric prefix is read, so {@code 3.0.0-M3} compares as
+ * {@code 3.0.0}. That is the safe direction for the one question asked: a
+ * qualifier only ever precedes the release it qualifies, so a milestone of the
+ * minimum reads as the release and is not refused, while every version genuinely
+ * below it still is.
+ *
+ * <p>A literal carrying no leading number at all — an unsubstituted
+ * {@code ${enforcer.version}}, or the empty text of a version the POM leaves to a
+ * {@code pluginManagement} entry or a parent — is <em>not</em> below anything.
+ * Refusing what cannot be read here would turn an ordinary POM into an unadoptable
+ * one, and {@link VerifyStep} still runs the guard before any of it is pushed.
+ */
+final class PluginVersion {
+
+	/** The separators Maven writes between a version's components. */
+	private static final String SEPARATORS = "[.-]";
+
+	/**
+	 * The longest run of digits still read as a number. A component past it is not a
+	 * version number anybody wrote, and reading one would overflow rather than answer.
+	 */
+	private static final int MAX_DIGITS = 9;
+
+	private PluginVersion() {
+	}
+
+	/**
+	 * @param version the version literal the POM declares, blank when it declares none
+	 * @param minimum the oldest version that will do
+	 * @return whether {@code version} names a release older than {@code minimum}, and
+	 *         {@code false} for a literal that names no number at all
+	 */
+	static boolean isBelow(String version, String minimum) {
+		List<Integer> numbers = numbersOf(version);
+		return !numbers.isEmpty() && compare(numbers, numbersOf(minimum)) < 0;
+	}
+
+	/**
+	 * The components are read until one is not a number, so a qualifier and whatever
+	 * follows it are left out rather than compared as text.
+	 */
+	private static List<Integer> numbersOf(String version) {
+		return Stream.of(version.strip().split(SEPARATORS))
+				.takeWhile(PluginVersion::isNumber)
+				.map(Integer::valueOf)
+				.toList();
+	}
+
+	private static boolean isNumber(String component) {
+		return !component.isEmpty() && component.length() <= MAX_DIGITS
+				&& component.chars().allMatch(Character::isDigit);
+	}
+
+	/**
+	 * A component the shorter version does not carry counts as zero, so {@code 3.1}
+	 * and {@code 3.1.0} are one version rather than the shorter being the older.
+	 */
+	private static int compare(List<Integer> version, List<Integer> minimum) {
+		return IntStream.range(0, Math.max(version.size(), minimum.size()))
+				.map(index -> Integer.compare(at(version, index), at(minimum, index)))
+				.filter(comparison -> comparison != 0)
+				.findFirst()
+				.orElse(0);
+	}
+
+	private static int at(List<Integer> numbers, int index) {
+		return index < numbers.size() ? numbers.get(index) : 0;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -138,13 +138,14 @@ final class PomDocument {
 		return element.tag().localName();
 	}
 
+	/** @return the text of the element's {@code name} child, stripped, or empty when it has none */
+	static Optional<String> childText(Element element, String name) {
+		return child(element, name).map(Element::wholeText).map(String::strip);
+	}
+
 	/** @return whether the element declares exactly this {@code artifactId} */
 	static boolean hasArtifactId(Element element, String artifactId) {
-		return child(element, "artifactId")
-				.map(Element::wholeText)
-				.map(String::strip)
-				.filter(artifactId::equals)
-				.isPresent();
+		return childText(element, "artifactId").filter(artifactId::equals).isPresent();
 	}
 
 	/** @return {@code body} wrapped in a {@code name} element, its lines indented one level deeper */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -7,6 +7,8 @@ import java.util.function.Supplier;
 
 import org.jsoup.nodes.Element;
 
+import io.github.adamw7.tools.adopt.AdoptionException;
+
 /**
  * Adds the {@code claude-code-enforcer} to a Maven project's {@code pom.xml} by
  * wiring the {@code maven-enforcer-plugin} with the {@code claudeMdFormat} rule,
@@ -16,14 +18,26 @@ import org.jsoup.nodes.Element;
  * <p>The install is idempotent: a POM that already wires the rule is left
  * untouched, and one whose {@code build} already uses the plugin for other rules
  * has that declaration augmented in place, so the project keeps a single enforcer
- * entry. {@link PomDocument} does the reading, splicing, and verbatim writing, and
- * the rule version comes from {@link EnforcerRuleVersion} and must be a release.
+ * entry — unless that declaration is pinned too far back to run the rule at all,
+ * which is refused rather than wired in (see {@link #requireRunnableEnforcer}).
+ * {@link PomDocument} does the reading, splicing, and verbatim writing, and the
+ * rule version comes from {@link EnforcerRuleVersion} and must be a release.
  */
 public class PomEnforcerInstaller {
 
 	private static final String ENFORCER_GROUP_ID = "org.apache.maven.plugins";
 	static final String ENFORCER_ARTIFACT_ID = "maven-enforcer-plugin";
 	static final String ENFORCER_VERSION = "3.6.3";
+
+	/**
+	 * The oldest {@value #ENFORCER_ARTIFACT_ID} that can run the rule wired in here.
+	 * {@value #CLAUDE_MD_RULE} is looked up by the component name it is published
+	 * under, which the plugin only does from this version; an older one fails the
+	 * build complaining it cannot find a rule the POM plainly declares. A declaration
+	 * this installer writes itself pins {@value #ENFORCER_VERSION}, so only a plugin
+	 * the project pinned can be too old — see {@link #requireRunnableEnforcer}.
+	 */
+	static final String MINIMUM_ENFORCER_VERSION = "3.1.0";
 	private static final String RULE_ARTIFACT_ID = "tools.claude-code-enforcer";
 	private static final String RULE_GROUP_ID = "io.github.adamw7";
 	private static final String CLAUDE_MD_FILE = "${project.basedir}/CLAUDE.md";
@@ -93,6 +107,8 @@ public class PomEnforcerInstaller {
 	/**
 	 * @return {@code true} when the rule was wired in, {@code false} when the POM
 	 *         already runs the {@code claudeMdFormat} rule and was left unchanged.
+	 * @throws io.github.adamw7.tools.adopt.AdoptionException when the project's own
+	 *         {@value #ENFORCER_ARTIFACT_ID} is pinned too far back to run the rule
 	 */
 	public boolean install(Path pomFile) {
 		PomDocument pom = PomDocument.read(pomFile);
@@ -189,10 +205,39 @@ public class PomEnforcerInstaller {
 	 * leave the plugin's classpath deciding between two versions of it.
 	 */
 	private void augment(PomDocument pom, Element plugin) {
+		requireRunnableEnforcer(plugin);
 		if (!declaresRuleDependency(plugin)) {
 			pom.insertUnder(plugin, List.of("dependencies"), ruleDependency());
 		}
 		pom.insertUnder(plugin, List.of("executions"), EXECUTION);
+	}
+
+	/**
+	 * Refuses to splice the execution into a {@value #ENFORCER_ARTIFACT_ID} the
+	 * project pinned below {@value #MINIMUM_ENFORCER_VERSION}, which cannot resolve
+	 * the rule by name. Adding it anyway left the adoption advertising a guard that
+	 * fails every build it runs in — for a reason no reader of the pull request would
+	 * connect to the plugin version a line above it.
+	 *
+	 * <p>Raising the project's pinned version instead is not the adoption's call to
+	 * make: it is the version the project chose for the rules it already runs, and
+	 * bumping it under them would change how those behave — the same reason
+	 * {@link CommitStep} refuses an ignored path rather than forcing the file in.
+	 *
+	 * <p>Only a version literal is judged. One the POM leaves to a
+	 * {@code pluginManagement} entry, a parent, or a property cannot be read from
+	 * here, and refusing on that would turn the ordinary POM into an unadoptable one;
+	 * see {@link PluginVersion}.
+	 */
+	private void requireRunnableEnforcer(Element plugin) {
+		String version = PomDocument.childText(plugin, "version").orElse("");
+		if (PluginVersion.isBelow(version, MINIMUM_ENFORCER_VERSION)) {
+			throw new AdoptionException("Cannot wire the " + CLAUDE_MD_RULE + " rule into the "
+					+ ENFORCER_ARTIFACT_ID + " this project pins to " + version + ": the rule is looked up by name,"
+					+ " which the plugin only does from " + MINIMUM_ENFORCER_VERSION + ", so the guard would fail"
+					+ " every build that runs it. Raise " + ENFORCER_ARTIFACT_ID + " to "
+					+ MINIMUM_ENFORCER_VERSION + " or later, then adopt the repository again.");
+		}
 	}
 
 	/** A freshly declared enforcer plugin: pinned to a version, carrying the rule and its execution. */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -311,6 +311,20 @@ class CliArgumentsTest {
 				"/tmp/ws");
 	}
 
+	/**
+	 * A positional the URL parser cannot read at all is refused the same way, naming
+	 * the flag the operator meant. It used to escape as the parser's own
+	 * "must end in a repository name", which says nothing about the argument that was
+	 * misread — and the URL names no repository either way, so nothing adoptable is
+	 * turned away by answering the question here instead.
+	 */
+	@Test
+	void rejectsAnUnparseablePositionalWithTheAdviceRatherThanTheParsersComplaint() {
+		assertFailure(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { "/tmp/ws//", "--repo", REPO_URL }), "--workspace",
+				"names no repository owner");
+	}
+
 	@Test
 	void rejectsAWorkspacePositionalWhateverOrderTheRepositoryFlagCameIn() {
 		assertThrows(IllegalArgumentException.class,

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
@@ -226,6 +226,177 @@ class ClaudeMdConformerContractTest {
 		assertRuleAccepts(conformer.conform(generated));
 	}
 
+	/**
+	 * Markdown quotes code by indenting it four columns as readily as by fencing it,
+	 * and the rule reads both as code. A conformer that only knew fences counted this
+	 * sample's heading as the section the document already had, appended nothing, and
+	 * left the rule demanding a section the document never carried.
+	 */
+	@Test
+	void appendsASectionThatAppearsOnlyInsideAnIndentedCodeBlock() {
+		String generated = """
+				# CLAUDE.md
+
+				See [AGENTS.md](AGENTS.md) for the full guide.
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Run `mvn install`.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Dependencies
+
+				Existing only.
+
+				A section skeleton looks like this:
+
+				    ## Testing
+
+				    Write unit tests for all new logic.
+				""";
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformer.conform(generated));
+	}
+
+	/**
+	 * The reference is held to the same reading as a heading: the rule's
+	 * {@code containsInProse} looks only at the lines that carry structure, so a
+	 * mention shown as an indented sample satisfies it no more than one inside a
+	 * fence.
+	 */
+	@Test
+	void addsTheReferenceWhenTheOnlyMentionIsInsideAnIndentedCodeBlock() {
+		String generated = """
+				# CLAUDE.md
+
+				An example of the line to add:
+
+				    See [AGENTS.md](AGENTS.md) for the guide.
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Run `mvn install`.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Testing
+
+				JUnit 5.
+
+				## Dependencies
+
+				Existing only.
+				""";
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformer.conform(generated));
+	}
+
+	/** A commented-out mention is inert for the rule, so the reference still has to be added. */
+	@Test
+	void addsTheReferenceWhenTheOnlyMentionIsInsideAnHtmlComment() {
+		String generated = """
+				# CLAUDE.md
+
+				<!--
+				See [AGENTS.md](AGENTS.md) for the full guide.
+				-->
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Run `mvn install`.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Testing
+
+				JUnit 5.
+
+				## Dependencies
+
+				Existing only.
+				""";
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformer.conform(generated));
+	}
+
+	/**
+	 * The rule ends a comment's reach by following every delimiter on the line, so a
+	 * comment opened after text hides what comes below it. A conformer that only
+	 * recognised a comment beginning at the start of a line read the hidden section as
+	 * present and appended nothing.
+	 */
+	@Test
+	void appendsASectionHiddenByACommentOpenedAfterText() {
+		String generated = """
+				# CLAUDE.md
+
+				See [AGENTS.md](AGENTS.md) for the full guide.
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Run `mvn install`.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				Superseded: <!--
+				## Testing
+
+				JUnit 5.
+				-->
+
+				## Dependencies
+
+				Existing only.
+				""";
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformer.conform(generated));
+	}
+
 	@Test
 	void leavesADocumentThatAlreadySatisfiesTheRuleAcceptable() {
 		String conforming = """

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -292,6 +292,56 @@ class ClaudeMdConformerTest {
 		assertTrue(headings(conformed).contains("## Project"));
 	}
 
+	/**
+	 * Markdown quotes code by indenting it four columns as well as by fencing it, and
+	 * the rule reads both the same way. Reading only fences here let the reshape act
+	 * on a sample: the heading below was renamed in place, so the document's example
+	 * came back as {@code ## Testing} with its indentation gone — a rewrite of the
+	 * project's own prose, committed and pushed as part of adopting Claude Code.
+	 */
+	@Test
+	void leavesANearMissHeadingInsideAnIndentedCodeBlockAlone() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				A section skeleton looks like this:
+
+				    ## Testing conventions
+
+				    Write unit tests for all new logic.
+				""";
+		String conformed = conformer.conform(generated);
+		assertTrue(conformed.contains("    ## Testing conventions"),
+				"the indented sample must be left untouched:\n" + conformed);
+		assertTrue(headings(conformed).contains("## Testing"),
+				"the section the sample only illustrates must still be appended:\n" + conformed);
+	}
+
+	/**
+	 * A body shown as an indented sample is code, and the rule counts a code block as
+	 * a section's body — so the section is not empty and must not be given a stub in
+	 * front of the body it already carries.
+	 */
+	@Test
+	void countsAnIndentedCodeBlockAsASectionBody() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				## Testing
+
+				    mvn -pl adopt -am test
+				""";
+		String conformed = conformer.conform(generated);
+		List<String> body = conformed.lines().dropWhile(line -> !line.equals("## Testing")).skip(1)
+				.dropWhile(String::isBlank).toList();
+		assertEquals("    mvn -pl adopt -am test", body.getFirst(),
+				"the indented body must stay the section's first content:\n" + conformed);
+	}
+
 	@Test
 	void addsTheAgentsReferenceWhenTheOnlyMentionIsInsideAFence() {
 		String generated = """

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PluginVersionTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PluginVersionTest.java
@@ -1,0 +1,64 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class PluginVersionTest {
+
+	private static final String MINIMUM = "3.1.0";
+
+	@Test
+	void readsAReleaseBelowTheMinimumAsBelowIt() {
+		assertBelow(List.of("3.0.0", "3.0.5", "2.9.9", "1", "3.0"));
+	}
+
+	@Test
+	void readsTheMinimumAndEveryLaterReleaseAsNotBelowIt() {
+		assertNotBelow(List.of("3.1.0", "3.1.1", "3.2", "3.6.3", "4.0.0", "10.0.0"));
+	}
+
+	/**
+	 * A component the shorter version does not carry counts as zero, so the two name
+	 * one release rather than the shorter being the older.
+	 */
+	@Test
+	void readsAMissingTrailingComponentAsZero() {
+		assertNotBelow(List.of("3.1"));
+		assertBelow(List.of("3.0"));
+	}
+
+	/**
+	 * Only the numeric prefix is compared, which is the safe direction: a milestone of
+	 * the minimum reads as that release and is not refused, while a milestone of an
+	 * older one still is.
+	 */
+	@Test
+	void comparesOnlyTheNumbersBeforeAQualifier() {
+		assertBelow(List.of("3.0.0-M3"));
+		assertNotBelow(List.of("3.1.0-M1", "3.2.1-SNAPSHOT"));
+	}
+
+	/**
+	 * A literal naming no number at all cannot be judged from the POM in hand — the
+	 * version is a property, or comes from a parent — and answering "below" would
+	 * refuse an ordinary project over a version nobody can read here. The last of
+	 * these is longer than any version anybody writes, which is read as no number
+	 * rather than overflowed into one.
+	 */
+	@Test
+	void readsAVersionThatNamesNoNumberAsNotBelowAnything() {
+		assertNotBelow(List.of("", "   ", "${enforcer.version}", "RELEASE", "9999999999"));
+	}
+
+	private void assertBelow(List<String> versions) {
+		versions.forEach(version -> assertTrue(PluginVersion.isBelow(version, MINIMUM), version));
+	}
+
+	private void assertNotBelow(List<String> versions) {
+		versions.forEach(version -> assertFalse(PluginVersion.isBelow(version, MINIMUM), version));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -512,6 +512,53 @@ class PomEnforcerInstallerTest {
 		assertTrue(result.contains("claudeMdFormat"), "the rule must be wired in");
 	}
 
+	/**
+	 * The rule is looked up by the component name it is published under, which the
+	 * enforcer only does from 3.1.0. Splicing the execution into an older plugin left
+	 * a pull request advertising a guard that fails every build it runs in, so the
+	 * project is told to raise its plugin instead — the adoption does not raise it for
+	 * them, since that is the version they chose for the rules they already run.
+	 */
+	@Test
+	void refusesToWireTheRuleIntoAnEnforcerPinnedTooFarBack(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, pomPinningEnforcerTo("3.0.0"));
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> installer.install(pom));
+		assertTrue(failure.getMessage().contains(PomEnforcerInstaller.MINIMUM_ENFORCER_VERSION),
+				"the failure must name the version to raise the plugin to: " + failure.getMessage());
+		assertFalse(Files.readString(pom).contains("claudeMdFormat"), "nothing may be written to a refused POM");
+	}
+
+	@Test
+	void augmentsAnEnforcerPinnedToTheMinimumVersion(@TempDir Path dir) throws IOException {
+		String result = install(dir, pomPinningEnforcerTo(PomEnforcerInstaller.MINIMUM_ENFORCER_VERSION));
+		assertTrue(result.contains("claudeMdFormat"), "the minimum version runs the rule and must be augmented");
+	}
+
+	/**
+	 * A version left to a property, a {@code pluginManagement} entry, or a parent
+	 * cannot be read from the POM in hand. Refusing on what cannot be read would turn
+	 * an ordinary project into an unadoptable one, and {@link VerifyStep} still runs
+	 * the guard before the branch is pushed.
+	 */
+	@Test
+	void augmentsAnEnforcerWhoseVersionCannotBeReadFromThePom(@TempDir Path dir) throws IOException {
+		assertTrue(install(dir, pomPinningEnforcerTo("${enforcer.version}")).contains("claudeMdFormat"),
+				"a version given as a property must not be read as an old one");
+		assertTrue(install(dir, POM_WITH_ENFORCER).contains("claudeMdFormat"),
+				"a plugin declaring no version at all must not be read as an old one");
+	}
+
+	/**
+	 * The version is written as a child of the plugin itself. {@link #POM_WITH_ENFORCER}
+	 * already carries a {@code <version>3.9.0</version>} inside a
+	 * {@code requireMavenVersion} rule, so a fixture built here also shows the plugin's
+	 * own version is the one read rather than whichever comes first below it.
+	 */
+	private String pomPinningEnforcerTo(String version) {
+		return POM_WITH_ENFORCER.replace("<artifactId>maven-enforcer-plugin</artifactId>",
+				"<artifactId>maven-enforcer-plugin</artifactId>\n        <version>" + version + "</version>");
+	}
+
 	@Test
 	void secondInstallIsIdempotent(@TempDir Path dir) throws IOException {
 		Path pom = write(dir, POM_WITH_BUILD);


### PR DESCRIPTION
ClaudeMdConformer reshapes the generated CLAUDE.md so the claudeMdFormat
rule EnforcerStep wires into the build accepts it. Its reader had drifted
from MarkdownDocument, the reader that rule actually uses, in three ways —
each one leaving the adoption to fail its own VerifyStep on a document it
had just conformed, after the clone, the claude init and both commits:

- Indented code was not read as code at all. A required heading shown as a
  four-column sample counted as the section the document had, so the real
  one was never appended; an AGENTS.md mention in one counted as the
  reference; and a near-miss heading inside one was renamed in place,
  rewriting the project's own sample and losing its indentation.
- ensureAgentsReference asked whether any line outside a fence mentioned
  AGENTS.md, while the rule's containsInProse reads only structural lines,
  so a mention inside an HTML comment kept the reference from being added.
- A comment only counted as opening where the line began with <!--, while
  the rule follows every delimiter on the line, so "Superseded: <!--" hid a
  section from the rule and from nothing else.

The reader now mirrors MarkdownDocument in all three, and the contract test
covers each case against the real rule rather than a copy of its wants.

Two more adoptions that stopped for the wrong reason:

- A first positional the URL parser cannot read at all — /tmp/ws//, or a
  Windows path — escaped as "repositoryUrl must end in a repository name",
  naming neither the argument that was misread nor the flag that was meant.
  It is answered as naming no owner, so the refusal that points at
  --workspace is the one the operator gets.
- PomEnforcerInstaller spliced the execution into whatever
  maven-enforcer-plugin the project pinned. The rule is looked up by name,
  which the plugin only does from 3.1.0, so an older pin left a pull request
  advertising a guard that fails every build it runs in. A version literal
  below the minimum is now refused with what to raise; one left to a
  property, a parent or pluginManagement cannot be read and is not judged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B42PtvBaCFmAfxpePbop9j