### PR TITLE
fix(claude-code-enforcer): two ways a reader misread the text it was given

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
@@ -2,10 +2,12 @@ package io.github.adamw7.tools.enforcer.settings;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.IntPredicate;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
@@ -37,16 +39,21 @@ final class CommandTokens {
 	private static final char PATH_SEPARATOR = '/';
 	private static final String OPTION_PREFIX = "-";
 	private static final String LONG_OPTION_PREFIX = "--";
-	private static final char INLINE_SCRIPT_FLAG = 'c';
+	private static final char SET_OPTION_PREFIX = '+';
 
 	/**
-	 * The programs that run a script named by their first non-option argument rather
-	 * than being that script themselves. A hook wired as {@code bash <script>} names a
-	 * file that must exist just as plainly as one wired as {@code <script>}, and
-	 * reading only the program would leave it unchecked.
+	 * The programs that run a script named by one of their arguments rather than
+	 * being that script themselves, each described by how its own options are
+	 * written. A hook wired as {@code bash <script>} names a file that must exist
+	 * just as plainly as one wired as {@code <script>}, and reading only the program
+	 * would leave it unchecked.
+	 * <p>
+	 * The descriptions differ per program because the same letter means different
+	 * things to different ones: a shell's {@code -e} stops on error while node's,
+	 * perl's and ruby's carries the script's own text, and python's {@code -m} takes
+	 * a module name where a shell's takes nothing at all.
 	 */
-	private static final List<String> INTERPRETERS = List.of(
-			"bash", "sh", "zsh", "dash", "ksh", "python", "python3", "node", "ruby", "perl");
+	private static final Map<String, Interpreter> INTERPRETERS = interpreters();
 
 	/**
 	 * The shell operators that end a token just as whitespace does, and that end one
@@ -126,31 +133,119 @@ final class CommandTokens {
 		return ASSIGNMENT.matcher(token).matches() || RESERVED_WORDS.contains(token);
 	}
 
-	/**
-	 * The script an interpreter is handed: its first non-option argument. A segment
-	 * carrying the {@code -c} flag names no file at all — the argument is the script's
-	 * text — so it yields nothing rather than a path that was never meant to be one.
-	 */
+	/** The script an interpreter is handed, or nothing when the program is not one. */
 	private static Optional<String> interpretedScript(String program, List<String> arguments) {
-		if (!INTERPRETERS.contains(commandName(program)) || arguments.stream().anyMatch(CommandTokens::isInlineScript)) {
-			return Optional.empty();
-		}
-		return arguments.stream().filter(argument -> !argument.startsWith(OPTION_PREFIX)).findFirst();
-	}
-
-	/**
-	 * True for the {@code -c} flag, alone or inside a cluster of short ones. A shell
-	 * reads {@code -ec} as {@code -e -c} just as it reads {@code -c}, and missing the
-	 * cluster would take the inline script's text for a path on disk.
-	 */
-	private static boolean isInlineScript(String argument) {
-		return argument.startsWith(OPTION_PREFIX) && !argument.startsWith(LONG_OPTION_PREFIX)
-				&& argument.indexOf(INLINE_SCRIPT_FLAG) > 0;
+		Interpreter interpreter = INTERPRETERS.get(commandName(program));
+		return interpreter == null ? Optional.empty() : interpreter.scriptIn(arguments);
 	}
 
 	/** The program's own name, so an interpreter is recognised however it was spelled on disk. */
 	private static String commandName(String program) {
 		return program.substring(program.lastIndexOf(PATH_SEPARATOR) + 1);
+	}
+
+	/**
+	 * How one interpreter writes its options, which is all a reader needs to find the
+	 * script among its arguments: the short flags whose argument is the script's own
+	 * text rather than a path, the long options that say the same, and the flags and
+	 * options that consume the word after them.
+	 * <p>
+	 * The last of these is what a naive "first non-option argument" misses. A hook
+	 * wired as {@code bash -euo pipefail .claude/hooks/session-start.sh} hands the
+	 * word {@code pipefail} to the {@code -o} ending the cluster, so reading it as the
+	 * script both invented a file no hook ever named and hid the real one behind it —
+	 * and with {@code reportUnreferencedScripts}, reported a script the hook really
+	 * does run as referenced by nothing.
+	 *
+	 * @param inlineFlags   the short flags carrying the script's text, e.g. a
+	 *                      shell's {@code c} or node's {@code e} and {@code p}
+	 * @param valueFlags    the short flags consuming the word after them, e.g. a
+	 *                      shell's {@code o}
+	 * @param inlineOptions the long options carrying the script's text
+	 * @param valueOptions  the long options consuming the word after them
+	 */
+	private record Interpreter(String inlineFlags, String valueFlags, Set<String> inlineOptions,
+			Set<String> valueOptions) {
+
+		/**
+		 * The script this interpreter is handed. A segment carrying an inline-script
+		 * option names no file at all, so it yields nothing rather than a path that was
+		 * never meant to be one.
+		 */
+		Optional<String> scriptIn(List<String> arguments) {
+			if (arguments.stream().anyMatch(this::isInlineScript)) {
+				return Optional.empty();
+			}
+			return IntStream.range(0, arguments.size())
+					.filter(index -> isOperand(arguments, index))
+					.mapToObj(arguments::get)
+					.findFirst();
+		}
+
+		/** True for the first word that is neither an option nor the value of the option before it. */
+		private boolean isOperand(List<String> arguments, int index) {
+			return !isOption(arguments.get(index))
+					&& (index == 0 || !consumesValue(arguments.get(index - 1)));
+		}
+
+		/**
+		 * An option is written with a leading dash, or is one of the {@code +o}
+		 * spellings a shell also takes — which a leading dash alone would leave looking
+		 * like the script.
+		 */
+		private boolean isOption(String argument) {
+			return argument.startsWith(OPTION_PREFIX) || consumesValue(argument);
+		}
+
+		private boolean isInlineScript(String argument) {
+			return inlineOptions.contains(argument) || carriesFlag(argument, inlineFlags);
+		}
+
+		private boolean consumesValue(String argument) {
+			return valueOptions.contains(argument) || endsWithFlag(argument, valueFlags);
+		}
+
+		/**
+		 * True when a cluster of short options carries one of {@code flags} anywhere in
+		 * it. A shell reads {@code -ec} as {@code -e -c} just as it reads {@code -c},
+		 * and missing the cluster would take the inline script's text for a path on
+		 * disk.
+		 */
+		private boolean carriesFlag(String argument, String flags) {
+			return isShortCluster(argument) && argument.chars().skip(1).anyMatch(flag -> flags.indexOf(flag) >= 0);
+		}
+
+		/**
+		 * True when a cluster of short options <em>ends</em> in one of {@code flags}.
+		 * Only the last flag of a cluster can take the word after it, which is why
+		 * {@code -euo} swallows a value and {@code -oe} does not.
+		 */
+		private boolean endsWithFlag(String argument, String flags) {
+			return isShortCluster(argument) && flags.indexOf(argument.charAt(argument.length() - 1)) >= 0;
+		}
+
+		/** A run of short options, written with the leading {@code -} or the {@code +} that unsets them. */
+		private static boolean isShortCluster(String argument) {
+			return argument.length() > 1 && !argument.startsWith(LONG_OPTION_PREFIX)
+					&& (argument.startsWith(OPTION_PREFIX) || argument.charAt(0) == SET_OPTION_PREFIX);
+		}
+	}
+
+	/**
+	 * The interpreters this reader knows, each named by every spelling a hook invokes
+	 * it with. Only the options that decide where the script is are listed: one that
+	 * neither carries the script nor takes a value needs no entry, because a leading
+	 * dash is already enough to skip it.
+	 */
+	private static Map<String, Interpreter> interpreters() {
+		Interpreter shell = new Interpreter("c", "o", Set.of(), Set.of("--rcfile", "--init-file"));
+		Interpreter python = new Interpreter("c", "mWXQ", Set.of(), Set.of("--check-hash-based-pycs"));
+		Interpreter node = new Interpreter("ep", "r", Set.of("--eval", "--print"),
+				Set.of("--require", "--import", "--loader", "--experimental-loader", "--conditions"));
+		Interpreter ruby = new Interpreter("e", "rICEK", Set.of(), Set.of());
+		Interpreter perl = new Interpreter("e", "IMm", Set.of(), Set.of());
+		return Map.of("bash", shell, "sh", shell, "zsh", shell, "dash", shell, "ksh", shell,
+				"python", python, "python3", python, "node", node, "ruby", ruby, "perl", perl);
 	}
 
 	/** Splits on every {@code separator} character outside quotes, dropping the empty pieces. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -45,6 +45,14 @@ import java.util.stream.IntStream;
  * shown as an example satisfy the very check that demands that section, and
  * reported the sample's own {@code TODO} and its {@code [link](sample.md)} as the
  * document's own — while the identical text inside a fence was correctly ignored.
+ * <p>
+ * The two ways are read in a single pass, because each decides what the other may
+ * read. A fence inside an indented block is the delimiter that block illustrates,
+ * not one this document opens: a lone {@code ```} shown four columns in is exactly
+ * how a document explains what a fence looks like. Marking the fences first and the
+ * indents afterwards left that lone delimiter opening a block nothing closed, and
+ * so masked every line below it — the document's remaining headings included — as
+ * code.
  */
 public final class MarkdownDocument {
 
@@ -211,43 +219,17 @@ public final class MarkdownDocument {
 	}
 
 	/**
-	 * Marks every line Markdown reads as code, both ways it is quoted: the fenced
-	 * blocks first, then the indented ones over the same mask, so a fence's own
-	 * lines are already spoken for and an indent inside one is content rather than a
-	 * block of its own.
+	 * Marks every line Markdown reads as code, both ways it is quoted, in one left
+	 * to right pass, so a fence's own lines are spoken for before an indent is read
+	 * into them and an indented block's lines before a fence is.
 	 */
 	private static boolean[] codeMask(List<String> lines) {
-		boolean[] mask = fenceMask(lines);
-		boolean mayOpen = true;
-		for (int i = 0; i < lines.size(); i++) {
-			mayOpen = applyIndent(lines.get(i), mayOpen, mask, i);
-		}
-		return mask;
-	}
-
-	private static boolean[] fenceMask(List<String> lines) {
 		boolean[] mask = new boolean[lines.size()];
-		Delimiter open = null;
+		Scan scan = Scan.start();
 		for (int i = 0; i < lines.size(); i++) {
-			open = applyFence(lines.get(i).strip(), open, mask, i);
+			scan = scan.read(lines.get(i), mask, i);
 		}
 		return mask;
-	}
-
-	/**
-	 * Marks line {@code index} as indented code or not and returns whether an
-	 * indented line below it would open a block. Only a blank line, a line already
-	 * masked as code, and the start of the document leave that open: an indented
-	 * line below a paragraph is a lazy continuation of it, which is what stops an
-	 * indented code block interrupting one. A blank line is left unmarked, since it
-	 * carries nothing to read either way.
-	 */
-	private static boolean applyIndent(String line, boolean mayOpen, boolean[] mask, int index) {
-		if (mask[index] || line.isBlank()) {
-			return true;
-		}
-		mask[index] = mayOpen && indentWidth(line) >= CODE_INDENT;
-		return mask[index];
 	}
 
 	/** The line's indent in columns, a tab counting on to the next four-column stop. */
@@ -315,17 +297,49 @@ public final class MarkdownDocument {
 	}
 
 	/**
-	 * Marks line {@code index} as code or structure and returns the fence delimiter
-	 * still open afterwards.
+	 * The state one pass over the document carries: the fence delimiter still open,
+	 * and whether an indented line would open a code block. Only a blank line, a line
+	 * already read as code, and the start of the document leave the latter open — an
+	 * indented line below a paragraph is a lazy continuation of it, which is what
+	 * stops an indented code block interrupting one.
 	 */
-	private static Delimiter applyFence(String line, Delimiter open, boolean[] mask, int index) {
-		Delimiter delimiter = delimiterOf(line);
-		if (open == null) {
-			mask[index] = delimiter != null;
-			return delimiter;
+	private record Scan(Delimiter fence, boolean mayIndent) {
+
+		static Scan start() {
+			return new Scan(null, true);
 		}
-		mask[index] = true;
-		return delimiter != null && delimiter.closes(open) ? null : open;
+
+		/**
+		 * Marks line {@code index} and answers the state the next line is read in. An
+		 * open fence claims the line first, then a blank line, which carries nothing to
+		 * read either way and so is left unmarked; only then may an indent open a block,
+		 * and only a line no indent claimed is read as a fence delimiter.
+		 */
+		Scan read(String line, boolean[] mask, int index) {
+			if (fence != null) {
+				return insideFence(line, mask, index);
+			}
+			if (line.isBlank()) {
+				return start();
+			}
+			if (mayIndent && indentWidth(line) >= CODE_INDENT) {
+				mask[index] = true;
+				return start();
+			}
+			return atDelimiter(line, mask, index);
+		}
+
+		private Scan insideFence(String line, boolean[] mask, int index) {
+			mask[index] = true;
+			Delimiter delimiter = delimiterOf(line.strip());
+			return new Scan(delimiter != null && delimiter.closes(fence) ? null : fence, true);
+		}
+
+		private Scan atDelimiter(String line, boolean[] mask, int index) {
+			Delimiter delimiter = delimiterOf(line.strip());
+			mask[index] = delimiter != null;
+			return new Scan(delimiter, delimiter != null);
+		}
 	}
 
 	/** The fence delimiter a line declares, or null when the line is not one. */

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
@@ -104,6 +104,61 @@ class CommandTokensTest {
 		assertEquals(List.of("bash"), CommandTokens.scriptCandidatesOf("bash -ec \"run.sh --flag\""));
 	}
 
+	/**
+	 * The {@code pipefail} of {@code -euo pipefail} is the value the {@code o}
+	 * ending the cluster takes, not the script. Reading the first non-option
+	 * argument blindly took it for one and left the real script — the word behind
+	 * it — unread.
+	 */
+	@Test
+	void readsPastTheValueAShortOptionClusterTakes() {
+		assertEquals(List.of("bash", ".claude/hooks/run.sh"),
+				CommandTokens.scriptCandidatesOf("bash -euo pipefail .claude/hooks/run.sh"));
+	}
+
+	/** Only the last flag of a cluster can take a value, so {@code -oe} takes none. */
+	@Test
+	void readsAValueOnlyForTheFlagThatEndsACluster() {
+		assertEquals(List.of("bash", "run.sh"), CommandTokens.scriptCandidatesOf("bash -oe run.sh"));
+	}
+
+	@Test
+	void readsPastTheValueALongOptionTakes() {
+		assertEquals(List.of("bash", ".claude/hooks/run.sh"),
+				CommandTokens.scriptCandidatesOf("bash --rcfile config/bashrc .claude/hooks/run.sh"));
+	}
+
+	/** A python {@code -m} names a module, not a file, so the segment names no script. */
+	@Test
+	void readsNoScriptFromAModuleName() {
+		assertEquals(List.of("python3"), CommandTokens.scriptCandidatesOf("python3 -m tools.runner"));
+	}
+
+	/**
+	 * The {@code -e} of node, perl and ruby carries the script's text the way a
+	 * shell's {@code -c} does. Reading only {@code -c} took that text for a path,
+	 * and {@code require('./boot')} was reported as a script missing from disk.
+	 */
+	@Test
+	void readsNoScriptFromAnInlineRuntimeScript() {
+		assertEquals(List.of("node"), CommandTokens.scriptCandidatesOf("node -e \"require('./boot')\""));
+		assertEquals(List.of("perl"), CommandTokens.scriptCandidatesOf("perl -e 'print \"a/b\"'"));
+		assertEquals(List.of("ruby"), CommandTokens.scriptCandidatesOf("ruby -e 'puts 1/2'"));
+	}
+
+	/** A shell's {@code -e} stops on error; only a runtime's carries a script. */
+	@Test
+	void readsTheScriptOfAShellRunWithErrexit() {
+		assertEquals(List.of("sh", ".claude/hooks/run.sh"),
+				CommandTokens.scriptCandidatesOf("sh -e .claude/hooks/run.sh"));
+	}
+
+	/** Node's {@code -c} checks the syntax of a file it is handed, unlike a shell's. */
+	@Test
+	void readsTheScriptNodeIsAskedToCheck() {
+		assertEquals(List.of("node", "boot.js"), CommandTokens.scriptCandidatesOf("node -c boot.js"));
+	}
+
 	@Test
 	void recognisesAnInterpreterNamedByAnAbsolutePath() {
 		assertEquals(List.of("/usr/bin/bash", "run.sh"), CommandTokens.scriptCandidatesOf("/usr/bin/bash run.sh"));

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -310,6 +310,33 @@ class HookCommandsValidRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
+	/**
+	 * The {@code -e} of node, perl and ruby carries the script's own text the way a
+	 * shell's {@code -c} does. Reading only {@code -c} took that text for a path, so
+	 * the {@code ./boot} inside an inline script was reported as a file missing from
+	 * the repository.
+	 */
+	@Test
+	void doesNotReadAnInlineRuntimeScriptAsAPath() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("node -e \\\"require('./boot')\\\""));
+		rule.setProjectDir(tempDir.toFile());
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/**
+	 * A word an option takes as its value is not the script, and the script is the
+	 * word behind it. Reading the first non-option argument blindly checked
+	 * {@code pipefail} and left the real script unchecked.
+	 */
+	@Test
+	void checksTheScriptBehindAnOptionValue() {
+		HookCommandsValidRule rule = ruleFor(hooksReferencing("bash -euo pipefail .claude/hooks/gone.sh"));
+		rule.setProjectDir(tempDir.toFile());
+
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing script", "gone.sh");
+	}
+
 	/** A bare program name is looked up on the PATH, so it is no repository file to require. */
 	@Test
 	void doesNotReadABareProgramNameAsAProjectScript() {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -188,6 +188,23 @@ class HooksFormatRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
+	/**
+	 * A hook run under {@code set -euo pipefail} hands {@code pipefail} to the
+	 * {@code -o} ending the cluster. Reading that word as the script left the script
+	 * behind it unread, and so reported a script the hook really does run as
+	 * referenced by nothing.
+	 */
+	@Test
+	void treatsTheScriptBehindAnOptionValueAsReferenced() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("bash -euo pipefail .claude/hooks/session-start.sh"));
+		rule.setProjectDir(tempDir.toFile());
+		rule.setReportUnreferencedScripts(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
 	/** An argument is not a script, so it cannot mark one referenced or be required to exist. */
 	@Test
 	void doesNotTreatAnArgumentThatLooksLikeAPathAsAScript() {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
@@ -254,6 +254,51 @@ class MarkdownDocumentTest {
 		assertTrue(document.hasHeading("## Testing"));
 	}
 
+	/**
+	 * A lone {@code ```} shown four columns in is how a document explains what a
+	 * fence looks like, not a fence this document opens. Reading the fences first and
+	 * the indents afterwards let that delimiter open a block nothing closed, which
+	 * masked every line below it — the document's remaining headings included — as
+	 * code.
+	 */
+	@Test
+	void doesNotOpenAFenceOnADelimiterShownInsideAnIndentedBlock() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				A block is delimited by three backticks:
+
+				    ```
+
+				## Testing
+				Body.
+				""");
+
+		assertEquals(List.of(4), codeLines(document));
+		assertEquals(Set.of("# Title", "## Testing"), document.headings());
+		assertTrue(document.hasBody("## Testing"));
+	}
+
+	/** A balanced pair shown that way is the sample's too, so nothing below it changes. */
+	@Test
+	void readsABalancedFencePairInsideAnIndentedBlockAsThatBlock() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				Write it like this:
+
+				    ```java
+				    int x;
+				    ```
+
+				## Testing
+				Body.
+				""");
+
+		assertEquals(List.of(4, 5, 6), codeLines(document));
+		assertEquals(Set.of("# Title", "## Testing"), document.headings());
+	}
+
 	/** An indented block is content, so a section whose only body is one is not empty. */
 	@Test
 	void readsAnIndentedBlockAsASectionBody() {


### PR DESCRIPTION
Two readers underneath the rules answered questions about text with
something the text does not say. Each turned a well-formed repository into
a failing build, or let a malformed one through.

- MarkdownDocument built its code mask in two passes, fences first and
  indents over the top, so an indented block's own lines were never
  protected from being read as fence delimiters. A lone ``` shown four
  columns in — which is exactly how a document explains what a fence looks
  like — opened a block nothing closed, and every line below it was masked
  as code: the remaining headings vanished, so claudeMdFormat reported a
  section the document plainly has as missing, and forbidden tokens, line
  lengths, file references and memory imports all stopped being read from
  the rest of the file. The two ways code is quoted are now read in one
  left-to-right pass, where each decides what the other may claim.

- CommandTokens read the script an interpreter runs as its first non-option
  argument, which is the option's value whenever the flag before it takes
  one. A hook wired as `bash -euo pipefail .claude/hooks/session-start.sh`
  named `pipefail` as its script and hid the real one behind it, so
  hookCommandsValid left a renamed script unchecked while hooksFormat, with
  reportUnreferencedScripts, reported a script the hook really does run as
  referenced by nothing. The inline-script flag was read as `-c` for every
  interpreter, so node's, perl's and ruby's `-e` was missed and the script's
  own text was resolved as a path: `node -e "require('./boot')"` was
  reported as referencing a missing file. Each interpreter now describes the
  options that carry a script and the ones that consume the word after them,
  which is why a shell's `-e` still stops on error and node's `-c` still
  names the file it checks.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U3s5jurLgbxfSB6h2NHAbG