### PR TITLE
fix(claude-code-enforcer): read a ~ inside an import path as a path character

### DIFF
--- a/.claude/skills/text-parsers/SKILL.md
+++ b/.claude/skills/text-parsers/SKILL.md
@@ -150,7 +150,7 @@ in its column before calling it done.
 | `Superseded: <!--`; `<!-- a --> <!-- b`; comment inside a fence; unterminated comment at EOF | comments |
 | `name: "git-commit"`; `Don't stop # a note`; `version: 1.0#2`; `description: >` then indented lines; `key:` bare; a key declared twice; `key:value` with no space | front matter |
 | `[logo](assets/logo(1).png)`; a link inside backticks; a link inside a comment | links |
-| `@claude` in prose; `@adamw7`; `` `@docs/x.md` ``; `see @docs/setup.md.`; `@~/global.md`; `@/rooted.md` | imports |
+| `@claude` in prose; `@adamw7`; `` `@docs/x.md` ``; `see @docs/setup.md.`; `@~/global.md`; `@/rooted.md`; `@RUNNER~1/notes.md` | imports |
 | `a.sh; b.sh`; a command across two lines; `( a.sh )`; `FOO=bar a.sh`; `if [ -n "$CI" ]; then a.sh; fi`; `bash -ec 'echo hi'`; `"my hook.sh"` | hook commands |
 | A UTF-8 BOM; a file that is not UTF-8 at all; CRLF line endings; an empty file | every file reader |
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
@@ -36,8 +36,11 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * an import, an import shown as a sample (fenced or indented) is one the document
  * illustrates rather than makes, and one an author commented out is one it no
  * longer makes. A
- * home-relative import ({@code @~/...}) does not match the path syntax at all and
- * so is skipped, as is any import the {@code ignored} predicate accepts. A file
+ * home-relative import ({@code @~/...}) names machine-specific state a build
+ * cannot see and is skipped, as is any import the {@code ignored} predicate
+ * accepts. Only a <em>leading</em> {@code ~} makes an import home-relative: one
+ * inside a path is an ordinary character, which is how Windows spells a short
+ * (8.3) name such as {@code RUNNER~1}. A file
  * that cannot be read as text is treated as a leaf rather than a failure, because
  * an imported file may be any format.
  */
@@ -47,10 +50,11 @@ final class ImportGraph {
 	record Reference(String text, File target) {
 	}
 
-	private static final Pattern IMPORT = Pattern.compile("(?<=^|\\s)@([A-Za-z0-9_./-]+)");
+	private static final Pattern IMPORT = Pattern.compile("(?<=^|\\s)@([A-Za-z0-9_./~-]+)");
 	private static final Pattern TRAILING_DOTS = Pattern.compile("\\.+$");
 	private static final char PATH_SEPARATOR = '/';
 	private static final char EXTENSION_SEPARATOR = '.';
+	private static final String HOME_PREFIX = "~";
 
 	private final Map<Path, List<Reference>> references = new LinkedHashMap<>();
 	private final Map<Path, Integer> hops = new LinkedHashMap<>();
@@ -135,6 +139,7 @@ final class ImportGraph {
 				.results()
 				.map(match -> withoutTrailingDots(match.group(1)))
 				.filter(ImportGraph::isPath)
+				.filter(imported -> !isHomeRelative(imported))
 				.filter(imported -> !ignored.test(imported))
 				.map(imported -> new Reference(imported, resolve(file, imported)));
 	}
@@ -155,6 +160,17 @@ final class ImportGraph {
 	 */
 	private static boolean isPath(String imported) {
 		return imported.indexOf(PATH_SEPARATOR) >= 0 || imported.indexOf(EXTENSION_SEPARATOR) >= 0;
+	}
+
+	/**
+	 * True when the import starts at the importing user's home directory, which is
+	 * machine-specific state a build cannot see. Only the leading position counts:
+	 * a {@code ~} further along is an ordinary path character — {@code RUNNER~1} is
+	 * how Windows shortens a profile name, and an import spelling an absolute path
+	 * on such a machine has to carry it.
+	 */
+	private static boolean isHomeRelative(String imported) {
+		return imported.startsWith(HOME_PREFIX);
 	}
 
 	private File resolve(File file, String imported) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -39,7 +39,9 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
  * illustrates rather than makes, and one an author commented out is one it no
  * longer makes. A
  * home-relative import ({@code @~/...}) points at machine-specific state a build
- * cannot see and is skipped, as is any import listed in {@code ignoredImports}.
+ * cannot see and is skipped, as is any import listed in {@code ignoredImports};
+ * only a leading {@code ~} makes an import home-relative, so a path carrying a
+ * Windows short name such as {@code RUNNER~1} is still followed.
  * Each file is scanned once; all problems found are reported together.
  */
 @Named("memoryImports")

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
@@ -154,6 +154,21 @@ class ImportGraphTest {
 		assertEquals(List.of(), graphFrom(root).importsOf(root));
 	}
 
+	/**
+	 * Only a leading {@code ~} is home-relative. Windows shortens a long directory
+	 * name to an 8.3 one — {@code RUNNER~1} — so a path a document spells on such a
+	 * machine carries a {@code ~} the import syntax has to be able to write.
+	 */
+	@Test
+	void followsAnImportThroughAPathSegmentCarryingATilde() {
+		File target = write("RUNNER~1/notes.md", "# Notes\n");
+		File root = write("CLAUDE.md", "See @RUNNER~1/notes.md\n");
+		ImportGraph graph = graphFrom(root);
+
+		assertEquals(List.of("RUNNER~1/notes.md"), textOf(graph.importsOf(root)));
+		assertEquals(1, graph.hopsTo(target));
+	}
+
 	@Test
 	void dropsSentencePunctuationFromTheImportPath() {
 		File root = write("CLAUDE.md", "See @docs.md.\n");

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
@@ -95,6 +95,13 @@ class MemoryImportsRuleTest {
 		assertDoesNotThrow(ruleFor("# CLAUDE.md\n\nAlso @~/personal/prefs.md is loaded.\n")::execute);
 	}
 
+	/** A {@code ~} inside a path — a Windows short name — is read, not skipped as home-relative. */
+	@Test
+	void readsAnImportThroughAPathSegmentCarryingATilde() {
+		assertFailure(EnforcerRuleException.class, ruleFor("# CLAUDE.md\n\nSee @RUNNER~1/absent.md\n")::execute,
+				"imports a missing file: @RUNNER~1/absent.md");
+	}
+
 	@Test
 	void skipsExplicitlyIgnoredImports() {
 		MemoryImportsRule rule = ruleFor("# CLAUDE.md\n\nSee @docs/absent.md\n");


### PR DESCRIPTION
The memory-import token was spelled `[A-Za-z0-9_./-]`, so a `~` ended the
path being read. A leading `~` was meant to: a home-relative import names
machine-specific state a build cannot see, and not matching the syntax was
how it got skipped. But the same charset also cut a path off at a `~`
anywhere further along, which is exactly how Windows spells a shortened
(8.3) directory name — `C:\Users\RUNNER~1\...` is every GitHub Windows
runner's temp directory. An import of `/Users/RUNNER~1/AppData/.../x.md`
was read as `/Users/RUNNER`, resolved to a file that does not exist, and so
reached nothing: memoryImports would report a missing file for an import
whose target is right there, and the enforcer's own
ImportGraphTest.resolvesAnAbsoluteImportAsAnAbsolutePath failed on Windows
only, which is why the scheduled maven-windows build went red while the
pull-request build stayed green.

The `~` is now part of an import path, and home-relative imports are
skipped by an explicit leading-`~` check instead of by a charset that could
not tell the two positions apart.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U9rWruR5uWMEMiMKT4UMyj