### PR TITLE
docs: correct facts that had drifted away from the code

### DIFF
--- a/.claude/skills/context-finder/README.md
+++ b/.claude/skills/context-finder/README.md
@@ -9,7 +9,7 @@
 Helps Claude use the `code/context` module: the `Context` contract, the
 name-based `Finder` vs the `PackageAwareFinder`, `ProjectSources` loading,
 `BudgetedContext` with a `TokenEstimator`, the project-tree builder and its
-serializers, and the three MCP tools over them.
+serializers, OKF bundles, and the four MCP tools over them.
 
 ---
 

--- a/.claude/skills/text-parsers/README.md
+++ b/.claude/skills/text-parsers/README.md
@@ -6,11 +6,11 @@
 
 ## Description
 
-Carries the invariants of this repo's hand-rolled text readers —
-`MarkdownDocument`, `FrontMatter`, `MarkdownText`, `ImportGraph`, `CommandTokens`
-and the `ClaudeMdConformer` copy of them — together with the adversarial input
-that has broken each one, so a change starts from that list instead of
-rediscovering it.
+Carries the invariants of this repo's text readers — the hand-rolled
+`MarkdownDocument`, `MarkdownText`, `ImportGraph` and `CommandTokens`, the
+`ClaudeMdConformer` copy of them, and the SnakeYAML-backed `FrontMatter` —
+together with the adversarial input that has broken each one, so a change starts
+from that list instead of rediscovering it.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -514,10 +514,12 @@ Every workflow builds on JDK 25 (Temurin) and passes `-ntp`.
 
 ### Dependency updates
 
-Version bumps arrive from two bots with a deliberate division of labour
-([ADR 0005](docs/adr/0005-renovate-dependency-updates.md),
+Two bots are meant to split the work ([ADR 0005](docs/adr/0005-renovate-dependency-updates.md),
 [ADR 0006](docs/adr/0006-dependabot-security-updates.md)): **Renovate** owns
-routine version currency, **Dependabot** owns security remediation. Renovate's
+routine version currency, **Dependabot** owns security remediation. Only Renovate
+is in force today — ADR 0006 is still `Proposed`, because Dependabot security
+updates are a repository *setting* rather than a committed file and have not been
+switched on; the record flips to `Accepted` when they are. Renovate's
 configuration is `.github/renovate.json`:
 
 - It runs on a **schedule** (Monday before 06:00 UTC, ≤ 5 open PRs, 2 per hour),

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Solution:
 	<groupId>io.github.adamw7</groupId>
 	<artifactId>protogen-maven-plugin</artifactId>
 	<!-- Use the latest release: https://github.com/adamw7/tools/releases/latest -->
-	<version>2.4.0</version>
+	<version>2.5.0</version>
 	<configuration>
 		<generatedSourcesDir>${project.basedir}/target/generated-sources/</generatedSourcesDir>
 		<pkgs>
@@ -368,9 +368,24 @@ Given [`greeter.proto`](grpc-example/src/main/proto/greeter.proto):
 ```proto
 syntax = "proto2";
 
-message HelloRequest {
+package greeter;
+
+option java_multiple_files = true;
+option java_package = "io.github.adamw7.tools.grpc.proto";
+
+message Address {
+  required string city = 1;
+  optional string country = 2;
+}
+
+message Person {
   required string name = 1;
   optional string title = 2;
+  optional Address address = 3;
+}
+
+message HelloRequest {
+  required Person person = 1;
 }
 
 message HelloReply {
@@ -384,7 +399,16 @@ service Greeter {
 
 Two generators run during the build:
 1. **`protobuf-maven-plugin`** compiles the proto definitions into protobuf message classes and gRPC service stubs (`GreeterGrpc`).
-2. **`protogen-maven-plugin`** (this repo) generates compile-time-safe builders (`HelloRequestBuilder`, `HelloReplyBuilder`) that refuse to call `build()` until every `required` field is set.
+2. **`protogen-maven-plugin`** (this repo) generates compile-time-safe builders (`AddressBuilder`, `PersonBuilder`, `HelloRequestBuilder`, `HelloReplyBuilder`) that refuse to call `build()` until every `required` field is set.
+
+The messages are composed — a `HelloRequest` points to a `Person`, which points to
+an `Address` — so the generated builders compose the same way, assembling a request
+bottom-up through a three-level chain:
+```java
+Address address = new AddressBuilder().setCity("London").setCountry("UK").build();
+Person person = new PersonBuilder().setName("Smith").setTitle("Dr.").setAddress(address).build();
+HelloRequest request = new HelloRequestBuilder().setPerson(person).build();
+```
 
 The service implementation uses the generated builder:
 ```java
@@ -1039,9 +1063,8 @@ The default pipeline runs these steps in order:
    (`Adopt Claude Code: add CLAUDE.md`), reported as `commit:claude-md`.
 9. **`EnforcerStep`** — detects the checkout's build system and wires the
    `CLAUDE.md` guard into it. A Maven project has the `claude-code-enforcer` added
-   to its root `pom.xml` via `PomEnforcerInstaller` (the edit is done on the JDK's
-   DOM — no third-party XML library — is namespace-aware, and is idempotent); a
-   Gradle project has a `enforceClaudeMd` guard task appended to its
+   to its root `pom.xml` via `PomEnforcerInstaller` (namespace-aware and
+   idempotent); a Gradle project has a `enforceClaudeMd` guard task appended to its
    `build.gradle`/`build.gradle.kts` via `GradleGuardInstaller`, wired into
    `check`. A repository with no recognised build file falls back to a
    `FallbackBuildSystem` that installs a GitHub Actions workflow and the portable
@@ -1054,8 +1077,9 @@ The default pipeline runs these steps in order:
    only its `build/plugins`: a project running the rule behind an opt-in profile,
    or declaring it in `pluginManagement`, is left alone instead of being given a
    second, always-on copy. The POM edit is spliced into the bytes the file already
-   holds, so the adoption commit shows the added block and nothing else — writing
-   the edited DOM out whole would normalise details a DOM does not record,
+   holds, at the source offsets `PomDocument` reads back from **jsoup**'s XML
+   parser, so the adoption commit shows the added block and nothing else — writing
+   a parsed document out whole would normalise details a DOM does not record,
    collapsing a start tag spread over several lines and rewriting `<rule />` as
    `<rule/>`, turning a fourteen-line addition into a diff across the file.
 10. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
@@ -1194,7 +1218,7 @@ mvn -pl data -am test
 `ReactorModuleConvergence` enforcer rule.)
 or across the whole repository as part of `mvn install`.
 
-# Building
+## Building
 ```
 mvn clean install
 ```
@@ -1202,13 +1226,13 @@ The clean part is needed since the build contain code generation so if you remov
 ```
 mvn install
 ```
-# Releasing
+## Releasing
 In order to release a new version - X you need to:
 1. Change the revision property to X in root pom.xml
 2. Commit and push
 3. Check if all builds pass
 4. Release and mark as latest in GitHub
 
-# License
+## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
@@ -195,7 +195,10 @@ If the uniqueness_check tool doesn't appear in your MCP client:
 The server communicates using the Model Context Protocol over stdio:
 - **Input**: JSON-RPC messages via standard input
 - **Output**: JSON-RPC responses via standard output
-- **Logging**: Log messages are written to stderr (configured via Log4j2)
+- **Logging**: Log messages go to a rolling file, `logs/app.log`
+  (`src/main/resources/log4j2.properties`). The configuration is deliberately
+  file-only: this server owns standard output for the JSON-RPC stream, and a
+  console appender there would corrupt the protocol
 
 ### Server Capabilities
 
@@ -233,51 +236,67 @@ mvn test
 
 ### Debugging
 
-To enable debug logging, modify the Log4j2 configuration or set system properties:
+To enable debug logging, modify the Log4j2 configuration or point Log4j2 at
+another one. Keep the replacement file-based for the stdio transport — a console
+appender would write into the JSON-RPC stream:
 
 ```bash
-java -Dlog4j.configurationFile=log4j2-debug.xml -jar tools.data-{version}-boot.jar
+java -Dlog4j2.configurationFile=log4j2-debug.xml -jar tools.data-{version}-boot.jar
 ```
 
 ## Extending the Server
 
-To add new tools to the MCP server:
+Tools are written against the `mcp-common` module's own SPI, never against the
+MCP SDK: a tool implements `McpTool` and speaks in the transport-neutral
+`ToolDefinition`, `ToolArguments` and `ToolResult` types, and
+`AbstractMcpConfiguration` translates them for the SDK when it wires the server.
+An ArchUnit rule pins this — every concrete `*Tool` must implement `McpTool`.
 
-1. Create a new tool class implementing `Function<Map<String, Object>, CallToolResult>`
-2. Define the tool specification using `Tool.builder()`
-3. Register the tool in `McpConfiguration.java` using `syncServer.addTool()`
+1. Create a new tool class implementing `McpTool`, exposing its
+   `ToolDefinition` (name, description, JSON input schema) and mapping the
+   call's arguments to a `ToolResult`
+2. Read arguments through `ToolArguments`, which reports a missing or
+   ill-typed one for you
+3. Add it to the list `McpConfiguration.tools()` returns
 
 Example:
 ```java
-@Component
-public class MyNewTool implements Function<Map<String, Object>, CallToolResult> {
+public class MyNewTool implements McpTool {
 
-    private final Tool toolDefinition = Tool.builder()
-        .name("my_tool")
-        .description("Description of what this tool does")
-        .inputSchema("{ /* JSON schema */ }")
-        .build();
+    private final ToolDefinition toolDefinition = new ToolDefinition("my_tool",
+            "Description of what this tool does",
+            Map.of(
+                "type", "object",
+                "properties", Map.of(
+                    "file", Map.of("type", "string", "description", "filename")
+                ),
+                "required", List.of("file")
+            ));
 
     @Override
-    public CallToolResult apply(Map<String, Object> arguments) {
-        // Tool implementation
-        return new CallToolResult(List.of(new TextContent(result)), false);
+    public ToolDefinition getToolDefinition() {
+        return toolDefinition;
     }
 
-    public Tool getToolDefinition() {
-        return toolDefinition;
+    @Override
+    public ToolResult apply(Map<String, Object> arguments) {
+        String file = ToolArguments.requiredString(arguments, "file");
+        return ToolResult.success(resultFor(file));
     }
 }
 ```
 
 Then register it in `McpConfiguration`:
 ```java
-MyNewTool myTool = new MyNewTool();
-SyncToolSpecification.Builder toolSpec = SyncToolSpecification.builder()
-    .tool(myTool.getToolDefinition())
-    .callHandler((exchange, request) -> myTool.apply(request.arguments()));
-syncServer.addTool(toolSpec.build());
+@Override
+protected List<McpTool> tools() {
+    confineFileAccess();
+    return List.of(new UniquenessTool(), new MyNewTool());
+}
 ```
+
+A `RuntimeException` thrown out of `apply` already becomes an error result, so
+there is no need to catch one just to report it over the protocol.
 
 ## Related Documentation
 

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -528,7 +528,7 @@ flowchart TB
         direction TB
 
         subgraph base ["rule — shared bases"]
-            entry["<b>ClaudeCodeEnforcerRule</b><br/><i>the aggregate entry rule</i>"]
+            entry["<b>ClaudeCodeEnforcerRule</b><br/><i>the base every rule extends:<br/>severity · reportFile · baselineFile</i>"]
             bases["<b>MarkdownFormatRule ·<br/>JsonFileRule · ScanTargets ·<br/>JsonNodes · Baseline · HtmlReport</b>"]
         end
 
@@ -548,6 +548,10 @@ flowchart TB
             secrets["<b>NoSecretsRule / CredentialPattern</b>"]
         end
 
+        subgraph okfRules ["okf — Open Knowledge Format bundles"]
+            okf["<b>OkfBundleFormatRule</b>"]
+        end
+
         subgraph textSupport ["text — parsing support"]
             text["<b>MarkdownDocument · FrontMatter ·<br/>FrontMatterFixer · NameConvention</b>"]
         end
@@ -556,32 +560,41 @@ flowchart TB
     docsFiles["📄 CLAUDE.md · AGENTS.md · README.md"]
     config["🗂️ .claude/ · .mcp.json ·<br/>.claude-plugin/plugin.json"]
     pom["📦 Root pom.xml<br/><i>&lt;module&gt; list</i>"]
+    bundle["🗂️ OKF bundle<br/><i>bundleDir</i>"]
 
-    build --> entry
+    build -->|"runs the configured rules"| docs
+    build --> defs
+    build --> sets
+    build --> secrets
+    build --> okf
+    docs -.->|"extends"| entry
+    defs -.->|"extends"| entry
+    sets -.->|"extends"| entry
+    secrets -.->|"extends"| entry
+    okf -.->|"extends"| entry
     entry --> bases
-    entry --> docs
-    entry --> defs
-    entry --> sets
-    entry --> secrets
     docs --> text
     defs --> text
+    okf --> text
     docs --> docsFiles
     docs --> pom
     defs --> config
     sets --> config
     secrets --> config
     secrets --> docsFiles
+    okf --> bundle
 
     classDef comp fill:#85bbf0,stroke:#5d82a8,color:#08427b
     classDef ext fill:#999999,stroke:#6b6b6b,color:#fff
-    class entry,bases,docs,defs,sets,secrets,text comp
-    class build,docsFiles,config,pom ext
+    class entry,bases,docs,defs,sets,secrets,okf,text comp
+    class build,docsFiles,config,pom,bundle ext
     style enforcer fill:#f2f7fc,stroke:#438dd5,color:#08427b
     style base fill:#eef4ec,stroke:#6b3fa0,color:#46296b
     style docRules fill:#fff7ec,stroke:#d59a43,color:#7a5418
     style defRules fill:#fdf0f0,stroke:#d56b6b,color:#7a3030
     style setRules fill:#eef4ec,stroke:#6b8e6b,color:#2f5230
     style secRules fill:#f0f0fb,stroke:#6b3fa0,color:#46296b
+    style okfRules fill:#fdf0f0,stroke:#d56b6b,color:#7a3030
     style textSupport fill:#f5f5f5,stroke:#999999,color:#333333
 ```
 
@@ -654,7 +667,7 @@ flowchart TB
     dev["👤 Java Developer<br/><i>./k8s/run-on-minikube.sh</i>"]
 
     subgraph build ["Build host (docker + Maven)"]
-        maven["<b>mvn package</b><br/><i>assembly fat jar</i>"]
+        maven["<b>mvn package</b><br/><i>assembly distribution:<br/>launcher jar + lib/</i>"]
         image["<b>tools-k8s image</b><br/><i>assembly/Dockerfile</i><br/>launcher jar + lib/ + console log4j2"]
     end
 

--- a/docs/compile-time-safe-builders.md
+++ b/docs/compile-time-safe-builders.md
@@ -86,7 +86,7 @@ exist on the earlier interfaces.
 
 ```mermaid
 flowchart LR
-    start(["Person.newBuilder()<br/>returns <b>IdIfc</b>"])
+    start(["new PersonBuilder()<br/>is an <b>IdIfc</b>"])
 
     subgraph req ["REQUIRED — one interface per field, no build() here"]
         direction LR

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -12,7 +12,6 @@ for a run-to-completion workload is a **Job**, not a Deployment.
 
 | File                         | Purpose                                                             |
 | ---------------------------- | ------------------------------------------------------------------- |
-| `Dockerfile`                 | Runnable deployment image (fixed numeric UID for `runAsNonRoot`).   |
 | `configmap-sample-data.yaml` | Sample CSV (`people.csv`) mounted at `/data`.                       |
 | `job-uniqueness-check.yaml`  | Job that runs `SampleApp` against the CSV and prints the result.    |
 | `kustomization.yaml`         | Bundles the ConfigMap + Job for `kubectl apply -k k8s/`.            |


### PR DESCRIPTION
Fifteen documentation bugs found by checking every markdown file against the
sources, poms, workflows and configs it describes.

Wrong facts:

- README: EnforcerStep was described as editing a pom "on the JDK's DOM — no
  third-party XML library". PomDocument and PomEnforcerInstaller read through
  jsoup; AGENTS.md already records the switch.
- README: the inlined greeter.proto was two messages behind the real file,
  which now composes HelloRequest -> Person -> Address. The builder list and a
  three-level chain example follow it.
- k8s/README: the Contents table listed a k8s/Dockerfile that does not exist,
  in a document whose next section explains why it was removed.
- data MCP_USAGE: logging was said to go to stderr. The module's log4j2
  config is file-only on purpose, because the stdio transport owns stdout.
- data MCP_USAGE: "Extending the Server" taught the MCP SDK's
  Function<Map, CallToolResult> / Tool.builder() / syncServer.addTool(), not
  the mcp-common McpTool SPI the module actually uses and ArchUnit pins.
- context-finder skill README: "three MCP tools"; there are four.
- compile-time-safe-builders: the chain diagram started at
  Person.newBuilder(), protobuf's stock builder, rather than the generated
  new PersonBuilder() the rest of the document uses.
- c4-architecture: the k8s view called the distribution a fat jar, the one
  packaging both AGENTS.md and k8s/README record as deliberately avoided.
- c4-architecture: ClaudeCodeEnforcerRule was labelled the aggregate entry
  rule with arrows pointing from it to the rules; it is the base they extend.
- c4-architecture: the enforcer view showed 21 of the 22 shipped rules,
  missing okfBundleFormat and its okf package.

Smaller drift:

- README: Building/Releasing/License were H1s in a document of H2 sections.
- AGENTS.md: Dependabot was described as in force, while ADR 0006 is still
  Proposed and no repository setting has been switched on.
- data MCP_USAGE: -Dlog4j.configurationFile, not log4j2's own property name.
- README: the protogen plugin example pinned 2.4.0, one release behind.
- text-parsers skill README: FrontMatter listed as hand-rolled; it is
  SnakeYAML-backed.

Verified with mvn -N validate -DenforceClaudeMd: all 20 wired rules pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LC7xRdV7Tn6HQK5BffGXkM