### PR TITLE
fix(claude-code-enforcer, adopt): read a document's code the same way in both readers

### DIFF
--- a/.claude/skills/enforcer-rules/SKILL.md
+++ b/.claude/skills/enforcer-rules/SKILL.md
@@ -87,6 +87,14 @@ Report *all* violations together, not the first one. A rule that throws mid-scan
 makes a contributor fix one problem per build. Build a `List<String>` and hand it
 to `report(...)`.
 
+**One violation is one line.** A baseline stores one accepted violation per line,
+so a message spanning several could never be matched again: it was suppressed by
+nothing and reported as stale for ever. Rules build their own messages on one
+line, but they quote back text they did not write — the entry `permissionsFormat`
+echoes is any string the settings file declared — so `Baseline` folds every line
+break out of a live violation and a recorded entry alike. Interpolating
+untrusted text is fine; emitting a deliberate `\n` in a message is not.
+
 ## Testing a rule
 - Tests live beside the rule (`…/enforcer/<package>/MyNewRuleTest.java`) and lay
   out fixtures in a `@TempDir` with the `TestFiles` helpers

--- a/.claude/skills/text-parsers/SKILL.md
+++ b/.claude/skills/text-parsers/SKILL.md
@@ -42,6 +42,8 @@ construction, so structural checks share them.
 | Headings are recognised **outside fences and outside comments** | A commented-out section must not satisfy the check that demands it. |
 | Comment state is tracked from **every delimiter on the line**, not the first characters | `Superseded: <!--` opens a block. `<!-- a --> <!-- b` ends open. Both were missed by a `startsWith`/`contains` pair. |
 | A comment inside a fence is sample text — **the fence wins** | Ordering matters: `commentMask` takes `insideFence` as input. |
+| Fences and indented code are marked in **one left-to-right pass**, not one after the other | Each decides what the other may read. A lone ```` ``` ```` shown four columns in is an *indented sample*, not an opening fence; marking fences first opens a block nothing closes and masks the rest of the file as code. |
+| The code indent is measured **from the enclosing list item's content**, not the margin | A list item indents its own continuation paragraphs. Measuring from the margin read every such paragraph as code, so a module named only there counted as unmentioned and a forbidden token written there was never seen. |
 | `containsInProse` skips comments *and* fences, both directions | A commented-out mention must neither satisfy a required-token check nor trip a forbidden-token one. |
 | A blank line and a commented-out line do **not** settle whether a section has a body | A section whose only content is commented out reads as empty, which is what commenting it out meant. |
 
@@ -60,6 +62,7 @@ re-derived by hand; those rules now come from the loader.
 | A key declared twice yields its **last** declaration | That is the one a YAML loader keeps, so the one Claude Code acts on. `duplicateKeys()` reports the duplication separately. |
 | A block no loader can read is **not front matter** | `description: "a" and "b"` and an unterminated `"oops` have no YAML meaning, and Claude Code's loader fails on them too. `parse` answers empty and the rules report the block's absence, which says more than a guess at the malformed line. A block that *reads* but is not a mapping — `name:value`, no space — is present and declares nothing. |
 | Front matter opens on the **very first line** | Content reaching `---` after blank lines has no front matter, because Claude Code sees none either. |
+| The walk is capped on **length and depth**, both | An alias is the node it names, so a few nested ones expand to hundreds of millions of characters — and one that names a node *containing* it composes to a cycle, which the length cap never sees because the walk never reaches a leaf to append at. It recursed until the stack ran out, and a `StackOverflowError` is not the `YAMLException` `parse` catches: it failed the build as an internal error. |
 
 The cases that used to need their own hand-written rule — `name: "git-commit"`
 unquoted, `Don't stop # a note` keeping its apostrophe, `version: 1.0#2` having
@@ -138,6 +141,14 @@ document the rule it exists to satisfy rejects, so the adoption failed its own
 `VerifyStep` on a file it had just reshaped to pass it — on someone else's
 repository, after the branch was pushed.
 
+**Mirroring the invariant is not enough; mirror the *algorithm*.** The conformer
+once read fences and indents in two passes where the rule read them in one. Every
+row of the table above still held on each pass alone, and the contract test had a
+case for a fenced sample and a case for an indented one — but none for a fence
+*inside* an indented sample, which is the only input the two orderings disagree
+on. Both readers now run the same single-pass `Scan`, which is what makes a case
+like that impossible to have on one side only.
+
 ## Adversarial input checklist
 
 Every row has broken a reader here. Run a new or changed reader against the ones
@@ -145,10 +156,11 @@ in its column before calling it done.
 
 | Input | Reader |
 |---|---|
-| ```` ```` ````-wrapped ```` ``` ````; `~~~` inside backticks; ```` ```java ```` as a closer | fences |
+| ```` ```` ````-wrapped ```` ``` ````; `~~~` inside backticks; ```` ```java ```` as a closer; a lone ```` ``` ```` indented four columns | fences |
 | `#1 rule: …`; `#hashtag`; `####### seven` | headings |
+| A paragraph indented four columns under a `-` or `1.` item; a six-column block under one; `---` as a thematic break, not a marker | indented code |
 | `Superseded: <!--`; `<!-- a --> <!-- b`; comment inside a fence; unterminated comment at EOF | comments |
-| `name: "git-commit"`; `Don't stop # a note`; `version: 1.0#2`; `description: >` then indented lines; `key:` bare; a key declared twice; `key:value` with no space | front matter |
+| `name: "git-commit"`; `Don't stop # a note`; `version: 1.0#2`; `description: >` then indented lines; `key:` bare; a key declared twice; `key:value` with no space; `&loop` over a `- *loop` that names it | front matter |
 | `[logo](assets/logo(1).png)`; a link inside backticks; a link inside a comment | links |
 | `@claude` in prose; `@adamw7`; `` `@docs/x.md` ``; `see @docs/setup.md.`; `@~/global.md`; `@/rooted.md`; `@RUNNER~1/notes.md` | imports |
 | `a.sh; b.sh`; a command across two lines; `( a.sh )`; `FOO=bar a.sh`; `if [ -n "$CI" ]; then a.sh; fi`; `bash -ec 'echo hi'`; `"my hook.sh"` | hook commands |

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -90,6 +91,14 @@ public class ClaudeMdConformer {
 	 * front of the prose it already carried.
 	 */
 	private static final Pattern ATX_HEADING = Pattern.compile("#{1,6}(\\s.*)?");
+
+	/**
+	 * The marker opening a list item, with the whitespace that separates it from the
+	 * item's content: a bullet, or an ordered marker, indented too little to be code
+	 * itself. What the match is wanted for is its width — the column the item's content,
+	 * and so its continuation paragraphs, are indented to.
+	 */
+	private static final Pattern LIST_MARKER = Pattern.compile("[ \\t]{0,3}(?:[-+*]|\\d{1,9}[.)])(?:[ \\t]+|$)");
 
 	/** The blank lines the reshape may leave at the end, dropped so the document keeps a single one. */
 	private static final Pattern TRAILING_BLANK_LINES = Pattern.compile("\\n\\s*+\\z");
@@ -417,74 +426,142 @@ public class ClaudeMdConformer {
 	}
 
 	/**
-	 * Marks every line Markdown quotes as code, both ways it allows: the fenced
-	 * blocks first, then the indented ones over the same mask, so a fence's own lines
-	 * are already spoken for and an indent inside one is content rather than a block
-	 * of its own. This mirrors {@code MarkdownDocument} in the
-	 * {@code claude-code-enforcer} module, as {@link Delimiter} does; keep the two in
-	 * sync.
+	 * Marks every line Markdown quotes as code, both ways it allows, in one left to
+	 * right pass — so a fence's own lines are spoken for before an indent is read into
+	 * them, and an indented block's lines before a fence is. This mirrors
+	 * {@code MarkdownDocument} in the {@code claude-code-enforcer} module, as
+	 * {@link Delimiter} does; keep the two in sync.
+	 *
+	 * <p>The single pass is the whole point, because each way decides what the other
+	 * may read. Marking the fences first and the indents afterwards made a lone
+	 * {@code ```} shown four columns in — which is exactly how a document explains what
+	 * a fence looks like — open a block nothing closed. The reshape then read every
+	 * heading below it as code: it appended a closing fence of its own at the end of
+	 * the document and every section it went on to add landed <em>after</em> that
+	 * fence, where the rule reads them as code too. An already-conforming
+	 * {@code CLAUDE.md} came back with a stray delimiter and three duplicated sections,
+	 * and one that was missing a section came back still missing it — the adoption
+	 * failing its own {@link VerifyStep} on the very sections it had just written.
 	 *
 	 * @return the fence delimiter still open at the end of the document, or
 	 *         {@code null} when its fences balance
 	 */
 	private static Delimiter markCode(List<String> lines, boolean[] mask) {
-		Delimiter openFence = markFences(lines, mask);
-		markIndentedCode(lines, mask);
-		return openFence;
-	}
-
-	private static Delimiter markFences(List<String> lines, boolean[] mask) {
-		Delimiter open = null;
+		Scan scan = Scan.start();
 		for (int index = 0; index < lines.size(); index++) {
-			open = applyFence(lines.get(index).strip(), open, mask, index);
+			scan = scan.read(lines.get(index), mask, index);
 		}
-		return open;
+		return scan.fence();
 	}
 
 	/**
-	 * Marks the code Markdown quotes the other way it allows — by indenting it four
-	 * columns, a tab counting on to the next four-column stop. The rule has always
-	 * read those lines as code, and reading them as prose here made the reshape act
-	 * on a sample: a {@code ## Testing} shown as an indented example was taken for the
-	 * section the document already had, so the real one was never appended and the
-	 * adoption failed its own {@link VerifyStep} — and a near-miss heading inside one
-	 * was renamed in place, rewriting the sample and losing its indentation.
+	 * The state one pass over the document carries: the fence delimiter still open,
+	 * whether an indented line would open a code block, and the list item an indent is
+	 * measured against. Only a blank line, a line already read as code, and the start
+	 * of the document leave the second open — an indented line below a paragraph is a
+	 * lazy continuation of it rather than code. This mirrors {@code MarkdownDocument}'s
+	 * scan in the {@code claude-code-enforcer} module; keep the two in sync.
 	 */
-	private static void markIndentedCode(List<String> lines, boolean[] mask) {
-		boolean mayOpen = true;
-		for (int index = 0; index < lines.size(); index++) {
-			mayOpen = applyIndent(lines.get(index), mayOpen, mask, index);
-		}
-	}
+	private record Scan(Delimiter fence, boolean mayIndent, int listIndent) {
 
-	/**
-	 * Marks whether the line is indented code and returns whether an indented line
-	 * below it would open a block. Only a blank line, a line already masked as code,
-	 * and the start of the document leave that open: an indented line below a
-	 * paragraph is a lazy continuation of that paragraph rather than code. A blank
-	 * line is left unmarked, since it carries nothing to read either way.
-	 */
-	private static boolean applyIndent(String line, boolean mayOpen, boolean[] mask, int index) {
-		if (mask[index] || line.isBlank()) {
-			return true;
+		/** No list is open, so an indented line quotes code from the margin. */
+		static final int NO_LIST = -1;
+
+		static Scan start() {
+			return new Scan(null, true, NO_LIST);
 		}
-		mask[index] = mayOpen && indentWidth(line) >= CODE_INDENT;
-		return mask[index];
+
+		/**
+		 * Marks line {@code index} and answers the state the next line is read in. An
+		 * open fence claims the line first, then a blank line, which carries nothing to
+		 * read either way and so is left unmarked; only then may an indent open a block,
+		 * and only a line no indent claimed is read as a fence delimiter.
+		 */
+		Scan read(String line, boolean[] mask, int index) {
+			if (fence != null) {
+				return insideFence(line, mask, index);
+			}
+			if (line.isBlank()) {
+				return new Scan(null, true, listIndent);
+			}
+			if (mayIndent && indentWidth(line) >= codeIndent()) {
+				mask[index] = true;
+				return new Scan(null, true, listIndent);
+			}
+			return atDelimiter(line, mask, index);
+		}
+
+		/**
+		 * The column an indented code block opens at: four, or four past the content of
+		 * the list item the line sits in, since a list item indents its own continuation
+		 * paragraphs to that column. A blank line does not close a list, so this still
+		 * stands over the gap between an item and its continuation.
+		 */
+		private int codeIndent() {
+			return listIndent == NO_LIST ? CODE_INDENT : listIndent + CODE_INDENT;
+		}
+
+		private Scan insideFence(String line, boolean[] mask, int index) {
+			mask[index] = true;
+			Delimiter delimiter = delimiterOf(line.strip());
+			return new Scan(delimiter != null && delimiter.closes(fence) ? null : fence, true, listIndent);
+		}
+
+		private Scan atDelimiter(String line, boolean[] mask, int index) {
+			Delimiter delimiter = delimiterOf(line.strip());
+			mask[index] = delimiter != null;
+			return new Scan(delimiter, delimiter != null, listAfter(line));
+		}
+
+		/**
+		 * The list this line leaves open: the one its own marker opens, the one it
+		 * continues by staying indented to that item's content, or none when it falls
+		 * back to the margin and so ends the list.
+		 */
+		private int listAfter(String line) {
+			int opened = listContentIndent(line);
+			if (opened != NO_LIST) {
+				return opened;
+			}
+			return indentWidth(line) >= listIndent ? listIndent : NO_LIST;
+		}
 	}
 
 	/** The line's indent in columns, a tab counting on to the next four-column stop. */
 	private static int indentWidth(String line) {
-		int width = 0;
 		int index = 0;
 		while (index < line.length() && isIndent(line.charAt(index))) {
-			width += line.charAt(index) == TAB ? CODE_INDENT - width % CODE_INDENT : 1;
 			index++;
+		}
+		return widthOf(line, index);
+	}
+
+	/**
+	 * The display width of the line's first {@code length} characters, a tab counting
+	 * on to the next four-column stop. Both the indent that quotes code and the marker
+	 * that indents a list item's content are measured in these columns.
+	 */
+	private static int widthOf(String line, int length) {
+		int width = 0;
+		for (int index = 0; index < length; index++) {
+			width += line.charAt(index) == TAB ? CODE_INDENT - width % CODE_INDENT : 1;
 		}
 		return width;
 	}
 
 	private static boolean isIndent(char character) {
 		return character == SPACE || character == TAB;
+	}
+
+	/**
+	 * The column a list item's content is indented to when {@code line} opens one, or
+	 * {@link Scan#NO_LIST} when it opens none. A thematic break is not a list: its
+	 * {@code ---} carries no whitespace after the first dash, which is what separates a
+	 * marker from the content it introduces.
+	 */
+	private static int listContentIndent(String line) {
+		Matcher marker = LIST_MARKER.matcher(line);
+		return marker.lookingAt() ? widthOf(line, marker.end()) : Scan.NO_LIST;
 	}
 
 	private static boolean markComments(List<String> lines, boolean[] code, boolean[] mask) {
@@ -535,23 +612,6 @@ public class ClaudeMdConformer {
 		String delimiter = open ? COMMENT_END : COMMENT_START;
 		int next = line.indexOf(delimiter, from);
 		return next < 0 ? open : remainsOpen(line, next + delimiter.length(), !open);
-	}
-
-	/**
-	 * Marks whether the line is code and returns the fence delimiter still open after
-	 * it. A fence is closed only by a delimiter that {@link Delimiter#closes} it, so a
-	 * {@code ~~~} line inside a {@code ```} block, a {@code ```java} line inside a
-	 * {@code ```} block, and a {@code ```} line inside a {@code ````} wrapper all stay
-	 * content.
-	 */
-	private static Delimiter applyFence(String line, Delimiter open, boolean[] mask, int index) {
-		Delimiter delimiter = delimiterOf(line);
-		if (open == null) {
-			mask[index] = delimiter != null;
-			return delimiter;
-		}
-		mask[index] = true;
-		return delimiter != null && delimiter.closes(open) ? null : open;
 	}
 
 	/** @return the fence delimiter the line declares, or {@code null} when it declares none */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -18,6 +18,32 @@ import io.github.adamw7.tools.adopt.AdoptionException;
 
 class BuildSystemsTest {
 
+	/**
+	 * {@link AdoptionAssets#WRITTEN_PATHS} is built once from {@link BuildSystems#DEFAULTS},
+	 * but the pipeline runs on {@link BuildSystems#defaults(Optional)} with whatever rule
+	 * version the run pinned. The two lists are read for different things and nothing
+	 * makes them agree, so a build system whose written paths depended on its
+	 * configuration would drop out of the guards that list feeds: {@link CloneStep} would
+	 * read the file it writes as a contributor's uncommitted work and refuse to resume,
+	 * and {@link CommitStep} would stop noticing that the checkout ignores it — the
+	 * adoption reported complete with the guard it wired in missing from the branch.
+	 * Pinning the invariant here fails this module's build the day one does, rather than
+	 * some adopted repository's.
+	 */
+	@Test
+	void everyPinnedRuleVersionYieldsTheWrittenPathsTheGuardsWereBuiltFrom() {
+		List<String> fromDefaults = writtenPathsOf(BuildSystems.DEFAULTS);
+
+		assertEquals(fromDefaults, writtenPathsOf(BuildSystems.defaults(Optional.empty())));
+		assertEquals(fromDefaults, writtenPathsOf(BuildSystems.defaults(Optional.of("2.5.0"))));
+		assertTrue(AdoptionAssets.WRITTEN_PATHS.containsAll(fromDefaults),
+				"every build file a guard is wired into must be a path the adoption accounts for");
+	}
+
+	private List<String> writtenPathsOf(List<BuildSystem> buildSystems) {
+		return buildSystems.stream().map(BuildSystem::writtenPaths).flatMap(List::stream).toList();
+	}
+
 	@Test
 	void detectsMavenFromPom(@TempDir Path directory) throws IOException {
 		Files.writeString(directory.resolve("pom.xml"), "<project/>");

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -395,6 +396,122 @@ class ClaudeMdConformerContractTest {
 
 		assertRuleRejects(generated);
 		assertRuleAccepts(conformer.conform(generated));
+	}
+
+	/**
+	 * A lone fence delimiter shown four columns in is how a document explains what a
+	 * fence looks like, and the rule reads it as the indented code it is. A conformer
+	 * that marked fences before indents opened a block on it that nothing closed, read
+	 * every heading below as code, and appended its own closing delimiter — so the
+	 * sections it then added landed after that delimiter, where the rule reads them as
+	 * code too. The document came back still missing the sections the reshape had just
+	 * written, which is the adoption failing its own {@link VerifyStep}.
+	 */
+	@Test
+	void appendsSectionsOutsideAFenceShownInsideAnIndentedCodeBlock() {
+		String generated = """
+				# CLAUDE.md
+
+				See [AGENTS.md](AGENTS.md) for the full guide.
+
+				## Project
+
+				A fenced block opens with a line like this:
+
+				    ```
+
+				and closes with the same run.
+				""";
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformer.conform(generated));
+	}
+
+	/**
+	 * The same reading, on a document that already conforms. The reshape must be a
+	 * no-op: the two-pass masking left a stray delimiter at the end of the file and
+	 * appended a duplicate of every section it had read as code, and committed both.
+	 */
+	@Test
+	void leavesADocumentCarryingAnIndentedFenceSampleUnchanged() {
+		String conforming = """
+				# CLAUDE.md
+
+				See [AGENTS.md](AGENTS.md) for the full agent guide.
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				A fenced block opens with a line like this:
+
+				    ```
+
+				and closes with the same run.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Testing
+
+				JUnit 5.
+
+				## Dependencies
+
+				Ask before adding a new one.
+				""";
+
+		assertRuleAccepts(conforming);
+		assertEquals(conforming, conformer.conform(conforming));
+	}
+
+	/**
+	 * A paragraph continuing a list item is prose to the rule, so a conformer that read
+	 * it as code would append a section the document already carries.
+	 */
+	@Test
+	void leavesADocumentWhoseSectionBodyContinuesAListItemUnchanged() {
+		String conforming = """
+				# CLAUDE.md
+
+				See [AGENTS.md](AGENTS.md) for the full agent guide.
+
+				## Project
+
+				- the modules are:
+
+				    `data`, `code`, and `adopt` are the reactor modules.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Run `mvn install`.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Testing
+
+				JUnit 5.
+
+				## Dependencies
+
+				Ask before adding a new one.
+				""";
+
+		assertRuleAccepts(conforming);
+		assertEquals(conforming, conformer.conform(conforming));
 	}
 
 	@Test

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Baseline.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Baseline.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -121,9 +122,23 @@ final class Baseline {
 
 	/**
 	 * Rewrites the project base directory in a violation message as the
-	 * {@code ${basedir}} token, which is what makes a recorded baseline portable.
+	 * {@code ${basedir}} token, which is what makes a recorded baseline portable, and
+	 * folds the message onto one line, which is what makes it storable at all.
 	 */
 	private record Signatures(String base) {
+
+		/**
+		 * Any line break. A baseline stores one accepted violation per line, so a
+		 * violation carrying a break of its own could not survive the round trip: it was
+		 * written as several lines, each of which was read back as a separate entry that
+		 * no violation ever matches. The violation was therefore never suppressed and the
+		 * fragments were reported as stale for ever after. A rule builds its messages on
+		 * one line, but it interpolates text it did not write — the entry
+		 * {@code permissionsFormat} quotes back is any string the settings file declared,
+		 * newlines included — so the fold belongs here, where it is applied to a live
+		 * violation and a recorded entry alike and the two still compare equal.
+		 */
+		private static final Pattern LINE_BREAK = Pattern.compile("\\R");
 
 		/** Rooted at {@code baseDir}, or at the working directory when none was configured. */
 		static Signatures rootedAt(File baseDir) {
@@ -132,7 +147,7 @@ final class Baseline {
 		}
 
 		String normalize(String signature) {
-			return signature.replace(base, BASE_DIR_TOKEN);
+			return LINE_BREAK.matcher(signature.replace(base, BASE_DIR_TOKEN)).replaceAll(" ");
 		}
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatter.java
@@ -63,6 +63,9 @@ public final class FrontMatter {
 	/** How much of one entry is rendered before the walk gives up. See {@link #folded}. */
 	private static final int MAX_VALUE_LENGTH = 8192;
 
+	/** How deep the walk follows a node before it gives up. See {@link #folded}. */
+	private static final int MAX_DEPTH = 64;
+
 	private final List<NodeTuple> entries;
 
 	private FrontMatter(List<NodeTuple> entries) {
@@ -146,43 +149,64 @@ public final class FrontMatter {
 	 * YAML block writes them in. Every result is folded onto one line, so a literal
 	 * block scalar's newlines read the same way a folded one's do.
 	 * <p>
-	 * The rendering stops at {@value #MAX_VALUE_LENGTH} characters. Composing is
-	 * linear in the size of the document, but the node graph it answers is a graph
-	 * rather than a tree — an alias is the node it names, not a copy of it — so
-	 * walking it is not. Nine aliases nested nine deep is a few lines of YAML that
-	 * expands to hundreds of millions of characters, the shape known as a billion
-	 * laughs, and a rule that reads a repository's own files should not be the thing
-	 * that expands it. The cap is far above any value a rule meaningfully checks: a
-	 * description this long has already failed whatever length it was held to.
+	 * The rendering stops at {@value #MAX_VALUE_LENGTH} characters and
+	 * {@value #MAX_DEPTH} levels. Composing is linear in the size of the document, but
+	 * the node graph it answers is a graph rather than a tree — an alias is the node it
+	 * names, not a copy of it — so walking it is not. Nine aliases nested nine deep is a
+	 * few lines of YAML that expands to hundreds of millions of characters, the shape
+	 * known as a billion laughs, and a rule that reads a repository's own files should
+	 * not be the thing that expands it.
+	 * <p>
+	 * The two caps answer two different shapes, and the length alone answered only one.
+	 * An alias may name a node that <em>contains</em> it — {@code description: &loop}
+	 * over a {@code - *loop} composes to a graph with a cycle in it — and the walk of
+	 * such a graph never reaches a leaf to append at, so it recurses until the stack
+	 * runs out. A {@link StackOverflowError} is not a {@link YAMLException}: it escaped
+	 * {@link #entriesOf} and failed the build as an internal error rather than as the
+	 * unreadable front matter it is. Both caps are far above any value a rule
+	 * meaningfully checks: a description this long, or this deep, has already failed
+	 * whatever it was held to.
 	 */
 	private static String folded(Node node) {
 		StringBuilder text = new StringBuilder();
-		render(node, text);
+		render(node, text, 0);
 		return onOneLine(text.length() > MAX_VALUE_LENGTH ? text.substring(0, MAX_VALUE_LENGTH) : text.toString());
 	}
 
-	private static void render(Node node, StringBuilder text) {
+	/**
+	 * A scalar is rendered at any depth, since it ends the walk by itself. Only a
+	 * collection is held to {@value #MAX_DEPTH}, because only a collection can name a
+	 * node that leads back to it.
+	 */
+	private static void render(Node node, StringBuilder text, int depth) {
 		if (node instanceof ScalarNode scalar) {
 			text.append(scalar.getValue());
-		} else if (node instanceof MappingNode entries) {
-			entries.getValue().stream().takeWhile(entry -> hasRoom(text))
-					.forEach(entry -> renderEntry(entry, text));
-		} else if (node instanceof SequenceNode items) {
-			items.getValue().stream().takeWhile(item -> hasRoom(text)).forEach(item -> renderItem(item, text));
+		} else if (depth < MAX_DEPTH) {
+			renderCollection(node, text, depth);
 		}
 	}
 
-	private static void renderEntry(NodeTuple entry, StringBuilder text) {
-		separate(text);
-		render(entry.getKeyNode(), text);
-		text.append(KEY_VALUE_SEPARATOR).append(' ');
-		render(entry.getValueNode(), text);
+	private static void renderCollection(Node node, StringBuilder text, int depth) {
+		if (node instanceof MappingNode entries) {
+			entries.getValue().stream().takeWhile(entry -> hasRoom(text))
+					.forEach(entry -> renderEntry(entry, text, depth + 1));
+		} else if (node instanceof SequenceNode items) {
+			items.getValue().stream().takeWhile(item -> hasRoom(text))
+					.forEach(item -> renderItem(item, text, depth + 1));
+		}
 	}
 
-	private static void renderItem(Node item, StringBuilder text) {
+	private static void renderEntry(NodeTuple entry, StringBuilder text, int depth) {
+		separate(text);
+		render(entry.getKeyNode(), text, depth);
+		text.append(KEY_VALUE_SEPARATOR).append(' ');
+		render(entry.getValueNode(), text, depth);
+	}
+
+	private static void renderItem(Node item, StringBuilder text, int depth) {
 		separate(text);
 		text.append("- ");
-		render(item, text);
+		render(item, text, depth);
 	}
 
 	/** Separates one entry or item from the one before it, never doubling a space already there. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -46,6 +47,15 @@ import java.util.stream.IntStream;
  * reported the sample's own {@code TODO} and its {@code [link](sample.md)} as the
  * document's own — while the identical text inside a fence was correctly ignored.
  * <p>
+ * Where that indent is measured from is the enclosing list item, not the margin. A
+ * list item indents its own continuation paragraphs to the column its content
+ * starts at, so the four columns that quote code are four columns past
+ * <em>that</em> — a paragraph continuing a {@code -} item is prose however deep the
+ * item is nested. Measuring from the margin read every such paragraph as code: a
+ * module named only in one went unmentioned as far as
+ * {@link #containsInProse} was concerned, and a token a document forbids could be
+ * written there without the check that forbids it ever seeing it.
+ * <p>
  * The two ways are read in a single pass, because each decides what the other may
  * read. A fence inside an indented block is the delimiter that block illustrates,
  * not one this document opens: a lone {@code ```} shown four columns in is exactly
@@ -72,6 +82,14 @@ public final class MarkdownDocument {
 
 	/** One to six {@code #} characters, then whitespace and any text, or nothing at all. */
 	private static final Pattern ATX_HEADING = Pattern.compile("#{1,6}(\\s.*)?");
+
+	/**
+	 * The marker opening a list item, with the whitespace that separates it from the
+	 * item's content: a bullet, or an ordered marker, indented too little to be code
+	 * itself. What the match is wanted for is its width — the column the item's
+	 * content, and so its continuation paragraphs, are indented to.
+	 */
+	private static final Pattern LIST_MARKER = Pattern.compile("[ \\t]{0,3}(?:[-+*]|\\d{1,9}[.)])(?:[ \\t]+|$)");
 
 	private final List<String> lines;
 	private final boolean[] insideCode;
@@ -234,17 +252,40 @@ public final class MarkdownDocument {
 
 	/** The line's indent in columns, a tab counting on to the next four-column stop. */
 	private static int indentWidth(String line) {
-		int width = 0;
 		int index = 0;
 		while (index < line.length() && isIndent(line.charAt(index))) {
-			width += line.charAt(index) == TAB ? CODE_INDENT - width % CODE_INDENT : 1;
 			index++;
+		}
+		return widthOf(line, index);
+	}
+
+	/**
+	 * The display width of the line's first {@code length} characters, a tab counting
+	 * on to the next four-column stop. Both the indent that quotes code and the marker
+	 * that indents a list item's content are measured in these columns, so a tabbed
+	 * list is read the same way a spaced one is.
+	 */
+	private static int widthOf(String line, int length) {
+		int width = 0;
+		for (int index = 0; index < length; index++) {
+			width += line.charAt(index) == TAB ? CODE_INDENT - width % CODE_INDENT : 1;
 		}
 		return width;
 	}
 
 	private static boolean isIndent(char character) {
 		return character == SPACE || character == TAB;
+	}
+
+	/**
+	 * The column a list item's content is indented to when {@code line} opens one, or
+	 * {@link Scan#NO_LIST} when it opens none. A thematic break is not a list: its
+	 * {@code ---} carries no whitespace after the first dash, which is what separates a
+	 * marker from the content it introduces.
+	 */
+	private static int listContentIndent(String line) {
+		Matcher marker = LIST_MARKER.matcher(line);
+		return marker.lookingAt() ? widthOf(line, marker.end()) : Scan.NO_LIST;
 	}
 
 	/**
@@ -298,15 +339,19 @@ public final class MarkdownDocument {
 
 	/**
 	 * The state one pass over the document carries: the fence delimiter still open,
-	 * and whether an indented line would open a code block. Only a blank line, a line
-	 * already read as code, and the start of the document leave the latter open — an
-	 * indented line below a paragraph is a lazy continuation of it, which is what
-	 * stops an indented code block interrupting one.
+	 * whether an indented line would open a code block, and the list item an indent is
+	 * measured against. Only a blank line, a line already read as code, and the start
+	 * of the document leave the second open — an indented line below a paragraph is a
+	 * lazy continuation of it, which is what stops an indented code block interrupting
+	 * one.
 	 */
-	private record Scan(Delimiter fence, boolean mayIndent) {
+	private record Scan(Delimiter fence, boolean mayIndent, int listIndent) {
+
+		/** No list is open, so an indented line quotes code from the margin. */
+		static final int NO_LIST = -1;
 
 		static Scan start() {
-			return new Scan(null, true);
+			return new Scan(null, true, NO_LIST);
 		}
 
 		/**
@@ -320,25 +365,47 @@ public final class MarkdownDocument {
 				return insideFence(line, mask, index);
 			}
 			if (line.isBlank()) {
-				return start();
+				return new Scan(null, true, listIndent);
 			}
-			if (mayIndent && indentWidth(line) >= CODE_INDENT) {
+			if (mayIndent && indentWidth(line) >= codeIndent()) {
 				mask[index] = true;
-				return start();
+				return new Scan(null, true, listIndent);
 			}
 			return atDelimiter(line, mask, index);
+		}
+
+		/**
+		 * The column an indented code block opens at: four, or four past the content of
+		 * the list item the line sits in. A blank line does not close a list, so this
+		 * still stands over the gap between an item and its continuation paragraph.
+		 */
+		private int codeIndent() {
+			return listIndent == NO_LIST ? CODE_INDENT : listIndent + CODE_INDENT;
 		}
 
 		private Scan insideFence(String line, boolean[] mask, int index) {
 			mask[index] = true;
 			Delimiter delimiter = delimiterOf(line.strip());
-			return new Scan(delimiter != null && delimiter.closes(fence) ? null : fence, true);
+			return new Scan(delimiter != null && delimiter.closes(fence) ? null : fence, true, listIndent);
 		}
 
 		private Scan atDelimiter(String line, boolean[] mask, int index) {
 			Delimiter delimiter = delimiterOf(line.strip());
 			mask[index] = delimiter != null;
-			return new Scan(delimiter, delimiter != null);
+			return new Scan(delimiter, delimiter != null, listAfter(line));
+		}
+
+		/**
+		 * The list this line leaves open: the one its own marker opens, the one it
+		 * continues by staying indented to that item's content, or none when it falls
+		 * back to the margin and so ends the list.
+		 */
+		private int listAfter(String line) {
+			int opened = listContentIndent(line);
+			if (opened != NO_LIST) {
+				return opened;
+			}
+			return indentWidth(line) >= listIndent ? listIndent : NO_LIST;
 		}
 	}
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/BaselineTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/BaselineTest.java
@@ -144,6 +144,25 @@ class BaselineTest {
 		assertTrue(readString(file).contains("${basedir}/CLAUDE.md is over budget"), readString(file));
 	}
 
+	/**
+	 * A rule builds its messages on one line, but it quotes back text it did not write
+	 * — {@code permissionsFormat} echoes whatever string the settings file declared, a
+	 * newline in it included. Written verbatim, such a violation spanned several lines
+	 * of a file that stores one per line, so nothing ever matched it again: it was
+	 * never suppressed, and its fragments were reported as stale for ever after.
+	 */
+	@Test
+	void aViolationCarryingALineBreakIsRecordedAndSuppressedAsOneEntry() {
+		File file = tempDir.resolve("baseline.txt").toFile();
+		List<String> violations = List.of("settings.json entry 'Bash(a\nb)' is not of the form Tool");
+
+		assertDoesNotThrow(() -> Baseline.write(file, violations, projectDir()));
+
+		assertEquals(1, filteredLines(file).size(), readString(file));
+		assertEquals(List.of(), assertDoesNotThrow(() -> Baseline.read(file, projectDir()).newViolations(violations)));
+		assertEquals(List.of(), assertDoesNotThrow(() -> Baseline.read(file, projectDir()).staleEntries(violations)));
+	}
+
 	/** The project base directory a rule would be configured with, as {@code ${project.basedir}}. */
 	private File projectDir() {
 		return tempDir.toFile();

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterTest.java
@@ -418,4 +418,41 @@ class FrontMatterTest {
 		assertTrue(frontMatter.value("f").orElseThrow().length() <= 8192, "the expansion must be capped");
 	}
 
+	/**
+	 * An anchor may name a node that contains it, which composes to a graph with a
+	 * cycle rather than a tree. The walk of such a graph never reaches a leaf to append
+	 * at, so the length cap alone never came into play and it recursed until the stack
+	 * ran out — and a {@link StackOverflowError} is not the {@code YAMLException} the
+	 * parse catches, so it failed the build as an internal error instead of being read
+	 * as the front matter it is.
+	 */
+	@Test
+	void readsAnAnchorThatContainsItselfWithoutExhaustingTheStack() {
+		FrontMatter frontMatter = FrontMatter.parse("""
+				---
+				type: concept
+				description: &loop
+				  - *loop
+				---
+				""").orElseThrow();
+
+		assertEquals(List.of("type", "description"), frontMatter.keys());
+		assertTrue(frontMatter.value("description").orElseThrow().length() <= 8192, "the walk must be capped");
+	}
+
+	/** A mapping can name itself the same way a sequence can. */
+	@Test
+	void readsAMappingThatContainsItselfWithoutExhaustingTheStack() {
+		FrontMatter frontMatter = FrontMatter.parse("""
+				---
+				name: skill
+				generated: &loop
+				  by: *loop
+				---
+				""").orElseThrow();
+
+		assertEquals(List.of("name", "generated"), frontMatter.keys());
+		assertTrue(frontMatter.value("generated").orElseThrow().length() <= 8192, "the walk must be capped");
+	}
+
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
@@ -239,6 +239,103 @@ class MarkdownDocumentTest {
 		assertTrue(document.containsInProse("continued"));
 	}
 
+	/**
+	 * A list item indents its own continuation paragraphs to the column its content
+	 * starts at, so four columns from the margin is prose inside a list rather than
+	 * code. Reading it as code hid what such a paragraph says from every check that
+	 * asks the document what it mentions.
+	 */
+	@Test
+	void treatsAnIndentedParagraphContinuingAListItemAsProse() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				- the modules are:
+
+				    `data`, `code`, and `adopt` are the reactor modules.
+
+				## Maven
+				Body.
+				""");
+
+		assertEquals(List.of(), codeLines(document));
+		assertTrue(document.containsInProse("adopt"));
+	}
+
+	/** Inside a list the code indent is measured from the item's content, not the margin. */
+	@Test
+	void masksABlockIndentedFourColumnsPastAListItemsContent() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				- run it with:
+
+				      mvn install
+
+				## Maven
+				Body.
+				""");
+
+		assertEquals(List.of(4), codeLines(document));
+		assertFalse(document.containsInProse("mvn install"));
+	}
+
+	/** A paragraph back at the margin ends the list, so the indent is measured from it again. */
+	@Test
+	void measuresTheCodeIndentFromTheMarginOnceAListHasEnded() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				- an item.
+
+				A paragraph of its own.
+
+				    TODO left in a sample
+
+				## Maven
+				Body.
+				""");
+
+		assertEquals(List.of(6), codeLines(document));
+		assertFalse(document.containsInProse("TODO"));
+	}
+
+	/** A thematic break carries no whitespace after its first dash, so it opens no list. */
+	@Test
+	void doesNotReadAThematicBreakAsAListItem() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				---
+
+				    TODO left in a sample
+
+				## Maven
+				Body.
+				""");
+
+		assertEquals(List.of(4), codeLines(document));
+		assertFalse(document.containsInProse("TODO"));
+	}
+
+	/** An ordered marker indents its content just as a bullet does. */
+	@Test
+	void treatsAnIndentedParagraphContinuingAnOrderedItemAsProse() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				1. the first step:
+
+				    Run the build afterwards.
+
+				## Maven
+				Body.
+				""");
+
+		assertEquals(List.of(), codeLines(document));
+		assertTrue(document.containsInProse("Run the build"));
+	}
+
 	/** Three spaces is the deepest a heading may be indented and stay one. */
 	@Test
 	void doesNotTreatAThreeSpaceIndentAsCode() {


### PR DESCRIPTION
The conformer marked fenced code first and indented code second, where the rule
it exists to satisfy reads both in one pass. Every invariant held on each pass
alone, so the two only disagreed on the one input that needs both at once: a lone
``` shown four columns in, which is how a document explains what a fence looks
like. The rule reads it as the indented sample it is; the conformer opened a
block on it that nothing closed.

Everything below that line was then code as far as the reshape was concerned. It
appended a closing delimiter of its own at the end of the file, so every section
it went on to add landed after that delimiter — where the rule reads them as code
too. A CLAUDE.md that already conformed came back with a stray fence and three
duplicated sections, both committed and pushed; one that was missing a section
came back still missing it, the adoption failing its own verification on the very
sections it had just written.

Both readers now run the same single-pass scan, which is what keeps a case like
that from being possible on one side only.

The scan also measures the code indent from the enclosing list item's content
rather than from the margin. A list item indents its own continuation paragraphs,
so four columns in a list is prose; reading it as code hid what such a paragraph
says from every check that asks a document what it mentions — a module named only
there counted as undocumented, and a forbidden token written there was never seen
by the check that forbids it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M8J3sWSQ2MzPiTzxqkCUzU