### PR TITLE
fix(adopt): a token in a refusal, and a guard nobody runs

### DIFF
--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -51,7 +51,8 @@ public interface AdoptionStep {
 }
 ```
 Implement the three-argument variant only when the step contributes a fact to
-the report (e.g. `PullRequestStep` and the PR URL).
+the report: `CloneStep` records the checkout directory, `PullRequestStep` the
+pull request's URL.
 
 ### Adding a step — the checklist ArchUnit enforces
 - Class name **ends with `Step`** and lives in `…adopt.step`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,12 +112,18 @@ What is worth knowing before changing any of it:
   drift. `CliArguments` declares the command line to **picocli**, binding each
   option to a method so a batch mixing `--repo` and `--repos` keeps the order it
   was written in; refusals are re-raised as an `IllegalArgumentException`
-  carrying the hand-written usage line.
+  carrying the hand-written usage line, with the parser's own message masked
+  through `Redaction` and its exception left unchained — it quotes the argument it
+  could not place, which for this command can be a credentialled clone URL.
+  `--help` is answered with the usage line even when another argument on the same
+  line could not be read.
 - **The wired rule version may not be a `-SNAPSHOT`** (`EnforcerRuleVersion`): it
   resolves only from the adopting machine's local repository and would leave the
   adopted project's CI unable to build.
-- **Detection reads what a pom *binds***, in the build or a profile — not a
-  `pluginManagement` entry, which pins a version and runs nothing.
+- **Detection reads the pom's own `build/plugins`** — the one place a rule runs on
+  every build, and the very place the installer would add one. A rule declared only
+  in `pluginManagement`, a profile, or `reporting` runs on no ordinary build, so the
+  project gets an always-on declaration of its own and keeps the one it had.
 - **A pom is edited as text, never re-serialised** (`PomDocument`): the addition
   is spliced into the bytes the file already held, at the source offsets
   **jsoup**'s XML parser reports for every start and end tag, so the adoption

--- a/README.md
+++ b/README.md
@@ -895,7 +895,9 @@ the branch is never pushed and no pull request is opened. The pipeline is
 assembled *without* those two steps rather than with steps that decide to do
 nothing, so the report's `completedSteps` ends at `verify` and says what really
 happened. The checkout is left in the workspace for the adoption's commits to be
-read before any of it is published:
+read before any of it is published, and the report's `checkout` says where it is
+— which is the only way to find the temporary workspace a run that named none was
+given:
 
 ```bash
 mvn -pl adopt exec:java \
@@ -943,6 +945,7 @@ single-repository run writes unwrapped:
   "repositories" : [ {
     "repositoryUrl" : "https://github.com/owner/repo.git",
     "branch" : "claude/adopt-claude-code",
+    "checkout" : "/tmp/claude-adopt-4711/repo",
     "pullRequestUrl" : "https://github.com/owner/repo/pull/42",
     "succeeded" : true,
     "failure" : null,
@@ -950,6 +953,7 @@ single-repository run writes unwrapped:
   }, {
     "repositoryUrl" : "https://github.com/owner/other.git",
     "branch" : "claude/adopt-claude-code",
+    "checkout" : "/tmp/claude-adopt-4711/other",
     "pullRequestUrl" : null,
     "succeeded" : false,
     "failure" : "clone: repository not found",
@@ -1073,10 +1077,15 @@ The default pipeline runs these steps in order:
    carries — a repository with its own `claude-md-guard.yml` or its own
    `enforceClaudeMd` registration keeps it. Supporting a new build tool is a
    matter of adding a `BuildSystem` implementation rather than branching inside
-   the step. For Maven that already-declared check spans the whole POM rather than
-   only its `build/plugins`: a project running the rule behind an opt-in profile,
-   or declaring it in `pluginManagement`, is left alone instead of being given a
-   second, always-on copy. The POM edit is spliced into the bytes the file already
+   the step. For Maven that already-declared check asks the POM's own
+   `build/plugins` — the one place a rule runs on every build, and the very place
+   the installer would add one, so what it inspects and what it edits cannot
+   disagree. A rule declared only in `pluginManagement`, only inside a profile, or
+   only under `reporting` is not one an ordinary build runs, so the project is
+   given an always-on declaration of its own and the one it had is left verbatim.
+   Standing down for any of those left the build its contributors and its CI
+   actually run with no guard at all, which `VerifyStep` cannot catch — its
+   `mvn -N validate` passes precisely because the rule never ran. The POM edit is spliced into the bytes the file already
    holds, at the source offsets `PomDocument` reads back from **jsoup**'s XML
    parser, so the adoption commit shows the added block and nothing else — writing
    a parsed document out whole would normalise details a DOM does not record,

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReport.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReport.java
@@ -6,10 +6,10 @@ import java.util.Optional;
 
 /**
  * The machine-readable outcome of an adoption run: the steps that completed, in
- * order, and the URL of the pull request the run opened (or found already open).
- * {@link GitHubRepoAdopter#adopt} fills one in and returns it, so callers can
- * report what happened without scraping logs. The pull-request URL is absent until
- * a step records it.
+ * order, the checkout they were made in, and the URL of the pull request the run
+ * opened (or found already open). {@link GitHubRepoAdopter#adopt} fills one in and
+ * returns it, so callers can report what happened without scraping logs. The
+ * checkout and the pull-request URL are absent until a step records them.
  *
  * <p>A run that fails part-way is reported too: the steps that did complete stay
  * recorded and the failing step's message becomes the run's failure, so an
@@ -18,11 +18,17 @@ import java.util.Optional;
 public final class AdoptionReport {
 
 	private final List<String> completedSteps = new ArrayList<>();
+	private String checkout;
 	private String pullRequestUrl;
 	private String failure;
 
 	public void recordStep(String name) {
 		completedSteps.add(name);
+	}
+
+	/** @param directory the checkout the adoption works in, as an absolute path */
+	public void recordCheckout(String directory) {
+		this.checkout = directory;
 	}
 
 	public void recordPullRequestUrl(String url) {
@@ -35,6 +41,17 @@ public final class AdoptionReport {
 
 	public List<String> completedSteps() {
 		return List.copyOf(completedSteps);
+	}
+
+	/**
+	 * @return the directory the adoption's checkout was made in, or empty when the run
+	 *         stopped before it claimed one. It is the run's one output that does not
+	 *         reach GitHub, so a dry run — which pushes nothing and opens no pull
+	 *         request — has nothing else to point a caller at, and a caller that named
+	 *         no workspace could not otherwise find the temporary one it was given.
+	 */
+	public Optional<String> checkout() {
+		return Optional.ofNullable(checkout);
 	}
 
 	public Optional<String> pullRequestUrl() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
@@ -10,10 +10,14 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Renders the outcome of an adoption run as JSON, to a string or to a file:
- * repository, branch, pull-request URL, whether the run succeeded, and the steps
- * that completed. An absent pull-request URL, and a successful run's
- * {@code failure}, are serialised as JSON {@code null} so the document's shape
- * stays stable for consumers.
+ * repository, branch, the checkout the adoption was made in, pull-request URL,
+ * whether the run succeeded, and the steps that completed. An absent checkout or
+ * pull-request URL, and a successful run's {@code failure}, are serialised as JSON
+ * {@code null} so the document's shape stays stable for consumers.
+ *
+ * <p>The checkout is in the document because it is the one output a run has that
+ * does not reach GitHub: a dry run publishes nothing, and a caller that named no
+ * workspace was given a temporary one it has no other way to find.
  *
  * <p>A run over several repositories is wrapped in a batch document instead: an
  * overall {@code succeeded}, true only when every repository was adopted, plus a
@@ -52,6 +56,7 @@ public class AdoptionReportWriter {
 		ObjectNode node = mapper.createObjectNode();
 		node.put("repositoryUrl", run.repositoryUrl());
 		node.put("branch", run.branchName());
+		node.put("checkout", run.report().checkout().orElse(null));
 		node.put("pullRequestUrl", run.report().pullRequestUrl().orElse(null));
 		node.put("succeeded", run.succeeded());
 		node.put("failure", run.failure().orElse(null));

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 import picocli.CommandLine;
@@ -29,7 +30,8 @@ import picocli.CommandLine.ParameterException;
  * ({@code --report <file>}). A blank workspace or branch positional falls back to
  * its default; an unknown flag, or one missing its value, fails with the usage
  * line rather than being ignored — as does {@code --help}, which asks for that
- * line and so is answered with it instead.
+ * line and so is answered with it instead, whatever else on the command line
+ * could not be read.
  *
  * <p>The arguments are matched by picocli rather than by a loop of this module's
  * own: the option names, their values, the three positional slots and the
@@ -102,14 +104,35 @@ public final class CliArguments {
 
 	public static CliArguments parse(String[] args) {
 		CliArguments cli = new CliArguments();
+		String[] arguments = args == null ? new String[0] : args;
 		try {
-			new CommandLine(cli).setOverwrittenOptionsAllowed(true)
-					.parseArgs(args == null ? new String[0] : args);
+			new CommandLine(cli).setOverwrittenOptionsAllowed(true).parseArgs(arguments);
 		} catch (ParameterException e) {
-			throw refusal(e);
+			return helpOrRefusal(cli, arguments, e);
 		}
 		cli.requireSomethingToAdopt();
 		return cli;
+	}
+
+	/**
+	 * A command line that asked for the usage line is answered with it even when
+	 * another of its arguments could not be read. picocli calls an option's method as
+	 * it parses, so an unreadable {@code --repos} file, a {@code --timeout} that is not
+	 * a number, or a misspelled flag is raised while {@code --help} is still only a flag
+	 * further along the list — and {@code --help --repos missing.txt} was refused for the
+	 * file rather than answered with the line it asked for. The refusal is the answer
+	 * only for a run that was asking to adopt something.
+	 */
+	private static CliArguments helpOrRefusal(CliArguments cli, String[] args, ParameterException e) {
+		if (asksForHelp(args)) {
+			cli.help = true;
+			return cli;
+		}
+		throw refusal(e);
+	}
+
+	private static boolean asksForHelp(String[] args) {
+		return Stream.of(args).anyMatch(arg -> HELP_FLAG.equals(arg) || HELP_SHORTHAND.equals(arg));
 	}
 
 	/**
@@ -158,12 +181,22 @@ public final class CliArguments {
 	 * still sees an {@link AdoptionException} for a file it could not read. Anything
 	 * else is the parser's own complaint about the command line, which is answered
 	 * with the usage line as every other bad argument is.
+	 *
+	 * <p>The parser's complaint quotes the argument it could not place, and one of the
+	 * arguments this command takes is a clone URL carrying credentials: a fourth
+	 * positional — an operator writing two repositories where the slots hold one — was
+	 * refused with {@code Unmatched argument at index 3:
+	 * 'https://x-access-token:TOKEN@github.com/owner/repo.git'}, which is the last thing
+	 * the run prints. It goes through {@link Redaction}, as every other message the
+	 * adoption raises about a URL does. The parser's own exception is deliberately
+	 * <em>not</em> chained: it carries the unmasked text as its message, which the
+	 * stack trace of an uncaught refusal would print straight back out.
 	 */
 	private static RuntimeException refusal(ParameterException e) {
 		if (e.getCause() instanceof RuntimeException raised) {
 			return raised;
 		}
-		return new IllegalArgumentException(e.getMessage() + ". " + USAGE, e);
+		return new IllegalArgumentException(Redaction.of(e.getMessage()) + ". " + USAGE);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
@@ -79,20 +79,23 @@ This creates an executable JAR in `adopt/target/tools.adopt-{version}.jar`.
 - `dry_run` (boolean, optional): rehearse the adoption — clone, branch, commit,
   wire in the guard, and verify it, but push nothing and open no pull request.
   The pipeline is assembled without those two steps, so `completedSteps` ends at
-  `verify` and the checkout is left in the workspace to be read. Worth reaching
-  for before letting a call write to GitHub
+  `verify` and the checkout is left to be read at the `checkout` path the report
+  answers with. Worth reaching for before letting a call write to GitHub
 - `timeout_minutes` (integer, optional): how long any one `git`/`claude`/`gh`/build
   command may run before it is killed. Defaults to 10, and is bounded to a day —
   this server is long-lived, so a command it could never reclaim is refused
 
 **Returns** a JSON report. Each commit the adoption makes is named for what it
 commits (`commit:claude-md`, `commit:guard`, `commit:assets`), so a run that
-stopped part-way says which of them landed:
+stopped part-way says which of them landed. `checkout` is where the adoption's
+working tree is — the run's one output that never reaches GitHub, and the only
+way to find the temporary directory a call that named no `workspace` was given:
 
 ```json
 {
   "repositoryUrl" : "https://github.com/owner/repo.git",
   "branch" : "claude/adopt-claude-code",
+  "checkout" : "/tmp/claude-adopt-4711/repo",
   "pullRequestUrl" : "https://github.com/owner/repo/pull/42",
   "succeeded" : true,
   "failure" : null,

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -79,6 +79,9 @@ public class ClaudeMdConformer {
 	private static final char TAB = '\t';
 	private static final char SPACE = ' ';
 
+	/** The mark a UTF-8 document may open with; see {@link #splitLines}. */
+	private static final char BYTE_ORDER_MARK = '\uFEFF';
+
 	/** The indent Markdown reads as a code block, and the width a tab advances to. */
 	private static final int CODE_INDENT = 4;
 
@@ -142,8 +145,21 @@ public class ClaudeMdConformer {
 		return join(lines);
 	}
 
+	/**
+	 * A leading byte-order mark is dropped, the same reading {@code MarkdownText} takes
+	 * before the rule sees the document. Keeping it left the title line as a
+	 * {@code U+FEFF} in front of {@code # CLAUDE.md}, which {@link String#strip()} does
+	 * not shorten — the mark is not whitespace — so the reshape concluded the title was
+	 * missing and prepended a second one. The rule accepted the result either way,
+	 * having stripped the mark itself, so nothing downstream reported the duplicated
+	 * title the adoption had just committed.
+	 */
 	private List<String> splitLines(String content) {
-		return new ArrayList<>(List.of(LineTerminators.normalized(content).split("\n", -1)));
+		return new ArrayList<>(List.of(LineTerminators.normalized(withoutByteOrderMark(content)).split("\n", -1)));
+	}
+
+	private static String withoutByteOrderMark(String content) {
+		return content.isEmpty() || content.charAt(0) != BYTE_ORDER_MARK ? content : content.substring(1);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.AdoptionReport;
 import io.github.adamw7.tools.adopt.Redaction;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
@@ -83,6 +84,20 @@ public class CloneStep extends AbstractCommandStep {
 	@Override
 	public String name() {
 		return "clone";
+	}
+
+	/**
+	 * Records the checkout before doing anything to it, so a run that fails part-way
+	 * still says where the working tree it left behind is. It is recorded here because
+	 * this is the step that owns the checkout, and it is worth recording at all because
+	 * nothing else answers the question: a caller that named no workspace was given a
+	 * temporary one, and a dry run — which pushes nothing and opens no pull request —
+	 * leaves that directory as the only thing there is to read.
+	 */
+	@Override
+	public void execute(AdoptionContext context, CommandRunner runner, AdoptionReport report) {
+		report.recordCheckout(context.repositoryDirectory().toAbsolutePath().toString());
+		execute(context, runner);
 	}
 
 	@Override

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
@@ -46,6 +46,9 @@ public class CommitStep extends AbstractCommandStep {
 	/** The step name an unqualified commit reports, and the prefix a qualified one carries. */
 	static final String NAME = "commit";
 
+	/** The exit code {@code git diff --quiet} reports differences with; see {@link #hasStagedChanges}. */
+	private static final int STAGED_CHANGES = 1;
+
 	private final String message;
 	private final String name;
 
@@ -130,10 +133,22 @@ public class CommitStep extends AbstractCommandStep {
 				.toList();
 	}
 
+	/**
+	 * {@code git diff --quiet} answers with its exit code: zero for nothing staged, and
+	 * {@value #STAGED_CHANGES} for something. Anything above that is the command failing
+	 * rather than answering — a checkout it could not read, a repository it could not
+	 * open — and reading every non-zero code as "there is something to commit" turned
+	 * that into a {@code git commit} failure two lines later, naming the commit rather
+	 * than the query that could not be run.
+	 */
 	private boolean hasStagedChanges(AdoptionContext context, CommandRunner runner) {
 		CommandResult result = runner.run(context.repositoryDirectory(),
 				List.of("git", "diff", "--cached", "--quiet"));
-		return !result.succeeded();
+		if (result.exitCode() > STAGED_CHANGES) {
+			throw new AdoptionException(name() + " could not ask git what is staged in "
+					+ context.repositoryDirectory() + ": " + result.redactedOutput().strip());
+		}
+		return result.exitCode() == STAGED_CHANGES;
 	}
 
 	private void commit(AdoptionContext context, CommandRunner runner) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -42,6 +42,15 @@ public class GradleGuardInstaller {
 	private static final Pattern DECLARATION = Pattern.compile(
 			"(?:register|create)\\s*\\(\\s*[\"']" + GUARD_TASK + "[\"']|\\btask\\s+" + GUARD_TASK + "\\b");
 
+	/**
+	 * A terminated {@code /*} … {@code *}{@code /} comment, however many lines it spans.
+	 * The shortest match is taken so two comments on one line stay two, and an
+	 * unterminated one is left in the script: it is a syntax error either way, and
+	 * swallowing the rest of the file would read every real declaration below it as
+	 * commented out.
+	 */
+	private static final Pattern BLOCK_COMMENT = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
+
 	private static final String GROOVY_BLOCK = """
 
 			// Added by claude-code-adopt: fail the build when CLAUDE.md is missing or empty.
@@ -90,15 +99,26 @@ public class GradleGuardInstaller {
 	 * than left without the one {@link GradleBuildSystem#verifyCommand(Path)} runs.
 	 */
 	private boolean declaresGuard(String script) {
-		return DECLARATION.matcher(withoutCommentLines(script)).find();
+		return DECLARATION.matcher(withoutComments(script)).find();
 	}
 
 	/**
-	 * The lines are rejoined rather than matched one at a time so a registration
-	 * spread over several lines is still recognised.
+	 * Both ways either DSL lets a registration be commented out. The block form is
+	 * removed first and by span rather than by line, because it is the form a whole
+	 * declaration is commented out with — a {@code /*} … {@code *}{@code /} around
+	 * {@code tasks.register('enforceClaudeMd')} left the name plainly in the text, so
+	 * the script was read as already declaring the task and the guard was never
+	 * appended; {@link VerifyStep} then ran a task the build does not have.
+	 *
+	 * <p>The line form is dropped afterwards, and the lines are rejoined rather than
+	 * matched one at a time so a registration spread over several lines is still
+	 * recognised.
 	 */
-	private String withoutCommentLines(String script) {
-		return script.lines().filter(line -> !line.strip().startsWith(LINE_COMMENT)).collect(Collectors.joining("\n"));
+	private String withoutComments(String script) {
+		String withoutBlocks = BLOCK_COMMENT.matcher(script).replaceAll("");
+		return withoutBlocks.lines()
+				.filter(line -> !line.strip().startsWith(LINE_COMMENT))
+				.collect(Collectors.joining("\n"));
 	}
 
 	private String blockFor(Path buildFile) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -90,28 +90,6 @@ final class PomDocument {
 	}
 
 	/**
-	 * Every {@code plugin} the POM binds to a build, wherever that build sits: the
-	 * project's own or a profile's. A project can wire a plugin somewhere other than
-	 * its build — behind an opt-in profile, most often — and a check that only looked
-	 * there would conclude the plugin is absent and add a second declaration of it.
-	 *
-	 * <p>A {@code pluginManagement} entry is deliberately not one of them. It says
-	 * which version to use if the plugin is ever bound and nothing more, so a rule
-	 * declared only there is a rule no build ever runs.
-	 */
-	List<Element> boundPlugins() {
-		return selfAndDescendants(root).stream()
-				.filter(element -> "plugin".equals(localName(element)))
-				.filter(element -> !isManaged(element))
-				.toList();
-	}
-
-	/** Whether the element sits under a {@code pluginManagement}, at any depth. */
-	private static boolean isManaged(Element element) {
-		return element.parents().stream().anyMatch(parent -> "pluginManagement".equals(localName(parent)));
-	}
-
-	/**
 	 * The element the nested {@code path} names below the root, or empty when the POM
 	 * does not carry every level of it. The counterpart of {@link #insertUnder}: a
 	 * caller asks about the very place it would add to, so what it inspects and what

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.jsoup.nodes.Element;
 
@@ -123,23 +124,32 @@ public class PomEnforcerInstaller {
 	}
 
 	/**
-	 * Asks every plugin the POM <em>binds</em>, not only its {@code build/plugins},
-	 * because a project that already runs the rule may well wire it behind an opt-in
-	 * profile. Looking only at the build would report such a POM as unguarded and
-	 * wire in a second, always-on copy of a rule the project already runs on its own
-	 * terms.
+	 * Asks the plugins of the POM's own {@code build} — the one place a rule runs on
+	 * every build, and the very place {@link #enforcerPluginOfTheBuild} would add one.
+	 * The guard is looked for exactly where it would be written, so what is inspected
+	 * and what is edited cannot disagree.
 	 *
-	 * <p>What it does not ask is {@code pluginManagement}, which binds nothing: a
-	 * rule declared only there never runs, so treating it as a guard left the project
-	 * with none and the pull request still claiming one — the same silent outcome
-	 * {@link #enforcerPluginOfTheBuild} refuses to produce from the other direction,
-	 * since {@link VerifyStep}'s {@code mvn -N validate} passes either way.
+	 * <p>A rule declared anywhere else is not one an ordinary build runs, so it is not
+	 * a guard this installer may stand down for. A {@code pluginManagement} entry binds
+	 * nothing at all; a {@code profile} binds only while that profile is activated, and
+	 * a {@code reporting} plugin does not run in the build lifecycle. Counting any of
+	 * them left the project with no guard on the build its contributors and its CI
+	 * actually run, and nothing downstream said so — {@link VerifyStep}'s
+	 * {@code mvn -N validate} passes precisely because the rule never ran — so the
+	 * adoption opened a pull request claiming a guard the default build does not have.
+	 * That is the outcome {@link #enforcerPluginOfTheBuild} already refuses to produce
+	 * when <em>adding</em>; accepting it when <em>detecting</em> produced it anyway.
+	 *
+	 * <p>A project that deliberately gated the rule behind a profile therefore ends up
+	 * running it on every build too. That is the direction to err in: an extra run of a
+	 * rule the project chose is visible and removable, while a guard nobody runs reads
+	 * as adopted and is not.
 	 *
 	 * <p>What counts as already running it is the rule being configured, not the
 	 * artifact that supplies it being on the plugin — see {@link #runsClaudeMdRule}.
 	 */
 	private boolean alreadyRunsTheRule(PomDocument pom) {
-		return pom.boundPlugins().stream().anyMatch(this::runsClaudeMdRule);
+		return buildPlugins(pom).anyMatch(this::runsClaudeMdRule);
 	}
 
 	/**
@@ -176,21 +186,29 @@ public class PomEnforcerInstaller {
 
 	/**
 	 * The {@code maven-enforcer-plugin} of the POM's own {@code build}, and only that
-	 * one. Where the rule is <em>looked for</em> is every plugin the POM binds — see
-	 * {@link #alreadyRunsTheRule} — but where it is <em>added</em> cannot be: an
-	 * execution spliced into {@code pluginManagement} only configures a plugin the
-	 * build never runs, and one spliced into a profile runs only when that profile is
-	 * activated. Neither enforces anything, and neither shows up as a failure —
+	 * one. An execution spliced into {@code pluginManagement} only configures a plugin
+	 * the build never runs, and one spliced into a profile runs only when that profile
+	 * is activated. Neither enforces anything, and neither shows up as a failure —
 	 * {@link VerifyStep}'s {@code mvn -N validate} would pass without the rule ever
 	 * executing and the adoption would advertise a guard the project does not have. A
 	 * POM whose only enforcer sits somewhere else therefore gets its own declaration
 	 * in {@code build/plugins}.
 	 */
 	private Optional<Element> enforcerPluginOfTheBuild(PomDocument pom) {
-		return pom.at(BUILD_PLUGINS).stream()
-				.flatMap(plugins -> PomDocument.children(plugins, "plugin").stream())
-				.filter(plugin -> PomDocument.hasArtifactId(plugin, ENFORCER_ARTIFACT_ID))
+		return buildPlugins(pom).filter(plugin -> PomDocument.hasArtifactId(plugin, ENFORCER_ARTIFACT_ID))
 				.findFirst();
+	}
+
+	/**
+	 * The plugins the POM's own {@code build} binds, which every build runs. Said once
+	 * because {@link #alreadyRunsTheRule} and {@link #enforcerPluginOfTheBuild} ask
+	 * about the same place for the same reason, and a guard looked for somewhere other
+	 * than where it would be written is a guard the installer can stand down for
+	 * without one ever being run.
+	 */
+	private Stream<Element> buildPlugins(PomDocument pom) {
+		return pom.at(BUILD_PLUGINS).stream()
+				.flatMap(plugins -> PomDocument.children(plugins, "plugin").stream());
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
@@ -46,8 +46,20 @@ public record PullRequestOptions(String title, String body, List<String> reviewe
 		assignees = supplied(assignees);
 	}
 
-	/** @return the entries that name something, stripped — the rule {@link Text} defines for every optional input */
+	/**
+	 * An absent list is read as naming nobody, the same answer a blank title gets from
+	 * {@link Text#orDefault}: this is the record's promise that its lists are never
+	 * {@code null}, so it cannot be the one place a caller has to satisfy it first. A
+	 * {@code null} reached here as a message-less {@link NullPointerException} out of a
+	 * constructor whose documentation says the lists are defensively copied.
+	 *
+	 * @return the entries that name something, stripped — the rule {@link Text} defines
+	 *         for every optional input
+	 */
 	private static List<String> supplied(List<String> values) {
+		if (values == null) {
+			return List.of();
+		}
 		return values.stream().filter(Text::isPresent).map(String::strip).toList();
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportTest.java
@@ -14,9 +14,17 @@ class AdoptionReportTest {
 	void startsEmpty() {
 		AdoptionReport report = new AdoptionReport();
 		assertTrue(report.completedSteps().isEmpty());
+		assertTrue(report.checkout().isEmpty());
 		assertTrue(report.pullRequestUrl().isEmpty());
 		assertTrue(report.failure().isEmpty());
 		assertTrue(report.succeeded());
+	}
+
+	@Test
+	void recordsCheckout() {
+		AdoptionReport report = new AdoptionReport();
+		report.recordCheckout("/tmp/claude-adopt-1234/repo");
+		assertEquals("/tmp/claude-adopt-1234/repo", report.checkout().orElseThrow());
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportWriterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionReportWriterTest.java
@@ -46,6 +46,25 @@ class AdoptionReportWriterTest {
 		assertTrue(node.get("completedSteps").isEmpty());
 	}
 
+	/**
+	 * A dry run publishes nothing and a caller that named no workspace was given a
+	 * temporary one, so without this field neither has anything to be pointed at: the
+	 * checkout the adoption committed to is the whole of what such a run produced.
+	 */
+	@Test
+	void serialisesTheCheckoutTheAdoptionWorkedIn() throws IOException {
+		AdoptionReport report = new AdoptionReport();
+		report.recordCheckout("/tmp/claude-adopt-1234/repo");
+		JsonNode node = mapper.readTree(writer.toJson(List.of(run(context, report))));
+		assertEquals("/tmp/claude-adopt-1234/repo", node.get("checkout").asText());
+	}
+
+	@Test
+	void serialisesAMissingCheckoutAsNull() throws IOException {
+		JsonNode node = mapper.readTree(writer.toJson(List.of(run(context))));
+		assertTrue(node.get("checkout").isNull(), "a run that never claimed one keeps the document's shape");
+	}
+
 	@Test
 	void serialisesASuccessfulRunAsSucceededWithNoFailure() throws IOException {
 		AdoptionReport report = new AdoptionReport();

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.adopt;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -410,6 +411,45 @@ class CliArgumentsTest {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, CliArguments.HELP_FLAG });
 		assertTrue(cli.helpRequested());
 		assertEquals(List.of(REPO_URL), cli.repositoryUrls());
+	}
+
+	/**
+	 * picocli calls an option's method as it parses, so an argument it cannot read is
+	 * raised while {@code --help} is still only a flag further along the line. The
+	 * operator asking what the flags are was answered with the failure of one of them.
+	 */
+	@Test
+	void answersHelpEvenWhenAnotherArgumentCouldNotBeRead(@TempDir Path dir) {
+		String missing = dir.resolve("absent.txt").toString();
+		assertTrue(CliArguments.parse(new String[] { CliArguments.HELP_FLAG, "--repos", missing }).helpRequested());
+		assertTrue(CliArguments.parse(new String[] { "--timeout", "soon", CliArguments.HELP_FLAG }).helpRequested());
+		assertTrue(CliArguments.parse(new String[] { "--not-a-flag", CliArguments.HELP_SHORTHAND }).helpRequested());
+	}
+
+	/** Without {@code --help} on the line, an unreadable argument is still the answer. */
+	@Test
+	void stillRefusesAnUnreadableArgumentWhenNoHelpIsAsked(@TempDir Path dir) {
+		String missing = dir.resolve("absent.txt").toString();
+		assertFailure(AdoptionException.class, () -> CliArguments.parse(new String[] { "--repos", missing }),
+				"Could not read the repository URL list");
+	}
+
+	/**
+	 * The parser quotes the argument it could not place, and one of this command's
+	 * arguments is a clone URL carrying credentials. A fourth positional — an operator
+	 * writing two repositories where the slots hold one — was refused with the token
+	 * spelled out, and that refusal is the last thing the run prints. The parser's own
+	 * exception must not be chained either: its message carries the same text, which
+	 * the stack trace of an uncaught refusal prints straight back out.
+	 */
+	@Test
+	void masksCredentialsInTheRefusalOfAnArgumentTheParserCannotPlace() {
+		String credentialled = "https://x-access-token:s3cr3t@github.com/owner/repo.git";
+		RuntimeException refusal = assertFailure(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { credentialled, "/tmp/ws", "main", credentialled }),
+				"***@github.com", CliArguments.USAGE);
+		assertFalse(refusal.getMessage().contains("s3cr3t"), refusal.getMessage());
+		assertNull(refusal.getCause(), "the parser's exception carries the unmasked argument as its message");
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
@@ -514,6 +514,50 @@ class ClaudeMdConformerContractTest {
 		assertEquals(conforming, conformer.conform(conforming));
 	}
 
+	/**
+	 * The rule strips a leading byte-order mark before reading; {@link String#strip()}
+	 * does not, the mark being no kind of whitespace. So a conformer that did not strip
+	 * one either read the title as absent and prepended a second — and the rule accepted
+	 * that too, which is why only comparing the two readings catches it.
+	 */
+	@Test
+	void leavesADocumentOpeningWithAByteOrderMarkAcceptableAndTitledOnce() {
+		String conforming = """
+				# CLAUDE.md
+
+				See [AGENTS.md](AGENTS.md) for the full agent guide.
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Run `mvn install`.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Testing
+
+				JUnit 5.
+
+				## Dependencies
+
+				Ask before adding a new one.
+				""";
+
+		String conformed = conformer.conform("\uFEFF" + conforming);
+		assertRuleAccepts(conformed);
+		assertEquals(1, conformed.lines().filter("# CLAUDE.md"::equals).count(),
+				"the rule reads the title through the mark, so the reshape must not add another:\n" + conformed);
+	}
+
 	@Test
 	void leavesADocumentThatAlreadySatisfiesTheRuleAcceptable() {
 		String conforming = """

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -150,6 +150,22 @@ class ClaudeMdConformerTest {
 		assertEquals(ClaudeMdConformer.TITLE, conformed.lines().findFirst().orElseThrow());
 	}
 
+	/**
+	 * The rule strips a leading byte-order mark before it reads the document, and
+	 * {@link String#strip()} does not — the mark is not whitespace. So a title the rule
+	 * was perfectly happy with read as absent here, and the reshape prepended a second
+	 * one, leaving the adoption's first commit carrying the title twice with nothing
+	 * downstream to report it.
+	 */
+	@Test
+	void recognisesATitleBehindAByteOrderMark() {
+		String conforming = conforming();
+		String conformed = conformer.conform("\uFEFF" + conforming);
+		assertEquals(1, conformed.lines().filter(ClaudeMdConformer.TITLE::equals).count(),
+				"the title must be recognised, not added a second time:\n" + conformed);
+		assertEquals(conforming, conformed, "nothing but the mark itself may change");
+	}
+
 	@Test
 	void ignoresHeadingsInsideCodeFencesWhenCanonicalising() {
 		String generated = """
@@ -192,10 +208,15 @@ class ClaudeMdConformerTest {
 
 	@Test
 	void leavesAnAlreadyConformingDocumentUnchanged() {
-		String conforming = ("# CLAUDE.md\n\n" + ClaudeMdConformer.AGENTS_REFERENCE_LINE + "\n\n"
-				+ requiredSectionsBody()).stripTrailing() + "\n";
+		String conforming = conforming();
 		String conformed = conformer.conform(conforming);
 		assertEquals(conforming, conformed, "a conforming document must be a no-op");
+	}
+
+	/** A document the reshape has nothing to do to, for the tests that are about what it leaves alone. */
+	private String conforming() {
+		return ("# CLAUDE.md\n\n" + ClaudeMdConformer.AGENTS_REFERENCE_LINE + "\n\n"
+				+ requiredSectionsBody()).stripTrailing() + "\n";
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.AdoptionReport;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 
@@ -32,6 +33,27 @@ class CloneStepTest {
 		assertEquals(List.of("git", "clone", "https://github.com/adamw7/tools.git",
 				workspace.resolve("tools").toString()), runner.commandAt(0));
 		assertEquals(workspace, runner.invocations().get(0).workingDirectory());
+	}
+
+	/**
+	 * The checkout is the run's one output that never reaches GitHub, so a caller that
+	 * named no workspace — and a dry run, which publishes nothing at all — has nothing
+	 * else to be pointed at.
+	 */
+	@Test
+	void reportsTheCheckoutItWorksIn() {
+		AdoptionReport report = new AdoptionReport();
+		step.execute(context, new RecordingCommandRunner(), report);
+		assertEquals(workspace.resolve("tools").toAbsolutePath().toString(), report.checkout().orElseThrow());
+	}
+
+	/** Recorded before the clone runs, so a run that stopped part-way still says where it stopped. */
+	@Test
+	void reportsTheCheckoutEvenWhenTheCloneFails() {
+		AdoptionReport report = new AdoptionReport();
+		RecordingCommandRunner runner = RecordingCommandRunner.failing(128, "fatal: repository not found");
+		assertThrows(AdoptionException.class, () -> step.execute(context, runner, report));
+		assertEquals(workspace.resolve("tools").toAbsolutePath().toString(), report.checkout().orElseThrow());
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CommitStepTest.java
@@ -31,6 +31,22 @@ class CommitStepTest {
 		assertEquals(List.of("git", "commit", "-m", "my message"), runner.commandAt(5));
 	}
 
+	/**
+	 * {@code git diff --quiet} answers with its exit code: zero for nothing staged, one
+	 * for something. A higher code is the command failing rather than answering, and
+	 * reading every non-zero one as "there is something to commit" reported it as a
+	 * {@code git commit} that failed — naming the commit rather than the query that
+	 * could not be run.
+	 */
+	@Test
+	void reportsAStagingAreaItCouldNotReadRatherThanCommittingAnyway() {
+		RecordingCommandRunner runner = new RecordingCommandRunner(this::unreadableStagingArea);
+		assertFailure(AdoptionException.class, () -> new CommitStep("my message").execute(context, runner),
+				"could not ask git what is staged", "not a git repository");
+		assertTrue(runner.invocations().stream().noneMatch(invocation -> invocation.command().contains("commit")),
+				"a query that could not be run must not be read as work to commit");
+	}
+
 	@Test
 	void suppliesAFallbackIdentityWhenGitHasNone() {
 		RecordingCommandRunner runner = new RecordingCommandRunner(this::stagedChangesWithoutIdentity);
@@ -154,6 +170,13 @@ class CommitStepTest {
 		}
 		if (command.contains("config")) {
 			return new CommandResult(command, 1, "");
+		}
+		return new CommandResult(command, 0, "");
+	}
+
+	private CommandResult unreadableStagingArea(List<String> command) {
+		if (command.contains("diff")) {
+			return new CommandResult(command, 128, "fatal: not a git repository");
 		}
 		return new CommandResult(command, 0, "");
 	}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
@@ -120,6 +120,36 @@ class GradleGuardInstallerTest {
 	}
 
 	/**
+	 * The block comment is the form a whole declaration is commented out with, since it
+	 * takes the registration's braces and its body in one go. Reading only the line form
+	 * left the task name plainly in the text, so the script was taken to declare the
+	 * task already and the guard was never appended — and
+	 * {@link GradleBuildSystem#verifyCommand(Path)} then ran a task the build has not.
+	 */
+	@Test
+	void installsTheGuardWhenADeclarationIsInsideABlockComment(@TempDir Path directory) throws IOException {
+		Path buildFile = write(directory, "build.gradle",
+				"/*\ntasks.register('enforceClaudeMd') {\n    doLast { }\n}\n*/\nplugins { id 'java' }\n");
+		assertTrue(installer.install(buildFile));
+		assertTrue(Files.readString(buildFile).contains("tasks.register('enforceClaudeMd')"));
+	}
+
+	/**
+	 * An unterminated block comment is a syntax error whichever way it is read, so the
+	 * script is left as it is rather than having everything below the {@code /*} treated
+	 * as commented out — which would append a second registration to a script that
+	 * plainly declares one.
+	 */
+	@Test
+	void stillSeesADeclarationBelowAnUnterminatedBlockComment(@TempDir Path directory) throws IOException {
+		Path buildFile = directory.resolve("build.gradle");
+		String own = "/* work in progress\ntasks.register('enforceClaudeMd') {\n    doLast { }\n}\n";
+		Files.writeString(buildFile, own);
+		assertFalse(installer.install(buildFile));
+		assertEquals(own, Files.readString(buildFile));
+	}
+
+	/**
 	 * A project that registers the task itself keeps its own version: appending a
 	 * second registration of the same name would fail the Gradle build outright.
 	 */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -401,17 +401,29 @@ class PomEnforcerInstallerTest {
 	}
 
 	/**
-	 * A project may well run the guard from somewhere other than its {@code build}:
-	 * behind an opt-in profile, most often, so ordinary builds are unaffected.
-	 * Looking only at {@code build/plugins} reports such a POM as unguarded and wires
-	 * in a second, always-on copy of a rule the project already runs on its own
-	 * terms.
+	 * A rule behind an opt-in profile is not one an ordinary build runs, so it is not a
+	 * guard the installer may stand down for. Counting it left the project with no
+	 * guard on the build its contributors and its CI actually run, and nothing said so:
+	 * {@link VerifyStep}'s {@code mvn -N validate} passes precisely because the rule
+	 * never ran, so the adoption opened a pull request claiming a guard the default
+	 * build does not have — the outcome the installer already refuses to produce when
+	 * it <em>adds</em>, reached by the way it <em>detects</em> instead.
+	 *
+	 * <p>The profile keeps its own declaration verbatim, so the project runs the rule
+	 * twice under that profile. That is the direction to err in: an extra run of a rule
+	 * the project chose is visible and removable, while a guard nobody runs reads as
+	 * adopted and is not.
 	 */
 	@Test
-	void leavesAPomThatWiresTheRuleInsideAProfileAlone(@TempDir Path dir) throws IOException {
+	void wiresTheRuleIntoTheBuildWhenAProfileIsTheOnlyPlaceItRuns(@TempDir Path dir) throws IOException {
 		Path pom = write(dir, POM_WITH_RULE_IN_A_PROFILE);
-		assertFalse(installer.install(pom), "the rule is already wired in, in the profile");
-		assertEquals(POM_WITH_RULE_IN_A_PROFILE, Files.readString(pom), "the POM must not have been touched");
+		assertTrue(installer.install(pom), "a profiled rule runs only when the profile is activated");
+		String result = Files.readString(pom);
+		assertTrue(result.contains("<build>"), "the POM had no build of its own and needs one to run the rule from");
+		assertTrue(result.contains(CLAUDE_RULE_DECLARATION), "the profile's own declaration must be left verbatim");
+		assertEquals(2, occurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
+				"the build needs its own declaration alongside the profile's:\n" + result);
+		assertTrue(result.contains("<claudeMdFile>"), "the added rule must be the configured, always-on one");
 	}
 
 	/**
@@ -447,11 +459,12 @@ class PomEnforcerInstallerTest {
 	}
 
 	/**
-	 * A profile binds the rule on its own terms and is therefore respected;
-	 * {@code pluginManagement} binds nothing at all. Counting a managed declaration as
-	 * a guard left the project with none, silently: nothing was added, and
+	 * {@code pluginManagement} binds nothing at all: it says which version to use if
+	 * the plugin is ever bound, and no more. Counting a managed declaration as a guard
+	 * left the project with none, silently — nothing was added, and
 	 * {@link VerifyStep}'s {@code mvn -N validate} passed because the rule never ran,
-	 * so the pull request advertised a guard that did not exist.
+	 * so the pull request advertised a guard that did not exist. It is the same reason
+	 * a profiled rule does not count either.
 	 */
 	@Test
 	void wiresTheRuleInWhenTheOnlyDeclarationIsManaged(@TempDir Path dir) throws IOException {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestOptionsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PullRequestOptionsTest.java
@@ -34,6 +34,20 @@ class PullRequestOptionsTest {
 		assertTrue(options.draft());
 	}
 
+	/**
+	 * The record documents its lists as defensively copied and never {@code null}, so
+	 * an absent one is read as naming nobody — the answer a blank title already gets.
+	 * A {@code null} used to come back out as a message-less
+	 * {@link NullPointerException} from the very constructor making that promise.
+	 */
+	@Test
+	void readsAnAbsentListAsNamingNobody() {
+		PullRequestOptions options = new PullRequestOptions("Title", "Body", null, null, null, false);
+		assertTrue(options.reviewers().isEmpty());
+		assertTrue(options.labels().isEmpty());
+		assertTrue(options.assignees().isEmpty());
+	}
+
 	@Test
 	void trimsTitleAndBody() {
 		PullRequestOptions options = options("  Title  ", "  Body  ");


### PR DESCRIPTION
The command line refused an argument picocli could not place by quoting that
argument back, and one of the arguments this command takes is a clone URL with
credentials in it. An operator writing two repositories where the positional
slots hold one was answered with `Unmatched argument at index 3:
'https://x-access-token:TOKEN@github.com/owner/repo.git'` — the last thing the
run prints, on the terminal and in whatever captured it. That is the third path
a credential has been found on here, and the second on this very class: the
neighbouring check on a positional that names no owner already masks the
argument for exactly this reason. The parser's message now goes through
Redaction, and its exception is no longer chained, because it carries the
unmasked text as its own message and the stack trace of an uncaught refusal
prints that straight back out.

Detection of an already-wired CLAUDE.md guard asked every plugin the POM binds,
which includes one inside a profile. A rule bound only there runs when that
profile is activated and on no ordinary build, so the installer stood down, the
verification passed precisely because the rule never ran, and the adoption
opened a pull request claiming a guard the default build does not have. That is
the outcome the installer already refuses to produce when it adds — it will not
splice an execution into a profile or into pluginManagement for those same
reasons — so the two directions disagreed, and the accepting one produced the
outcome anyway. Detection now reads the pom's own build/plugins, which is the
very place the addition would go. A project that gated the rule behind a profile
gets an always-on declaration beside the one it keeps: an extra run of a rule
the project chose is visible and removable, while a guard nobody runs reads as
adopted and is not.

The report now says which directory the adoption worked in. It is the run's one
output that never reaches GitHub, and a dry run — which pushes nothing and opens
no pull request — has nothing else to offer: the MCP tool documented its
checkout as there to be read while answering with no way to find it, since a
call that names no workspace is given a temporary directory. CloneStep records
it before touching the checkout, so a run that stopped part-way still says where
the working tree it left behind is.

Four smaller readings that were each a shade off:

PullRequestOptions promised lists that are defensively copied and never null,
then threw a message-less NullPointerException out of the constructor making
that promise. An absent list now names nobody, the answer a blank title already
gets.

The conformer did not strip a leading byte-order mark, where the rule it exists
to satisfy strips one before reading. String.strip does not shorten it — a
byte-order mark is not whitespace — so a title the rule was perfectly happy with
read as absent and a second one was prepended. The rule accepted that too, which
is why the contract test could not catch it and the adoption's first commit
carried the title twice.

The Gradle guard recognised a registration commented out with `//` but not one
inside a block comment, which is the form a whole declaration is commented out
with. The script read as already declaring the task, the guard was never
appended, and the verification then ran a task the build does not have.

`git diff --cached --quiet` answers with its exit code: zero for nothing staged,
one for something, more than that for a command that failed rather than
answered. Reading every non-zero code as "there is something to commit" reported
an unreadable checkout as a commit that failed, naming the commit rather than
the query.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0192biDY7CuM68jDcbaAk9JK