### PR TITLE
fix(claude-code-enforcer): close six gaps in the rules' reading of hooks and Markdown

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -21,11 +21,12 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * leading UTF-8 BOM is tolerated), and contain every required section heading as a
  * real, non-empty heading.
  * <p>
- * Headings are matched on whole lines outside code, so a heading mentioned in a
- * sample — fenced or indented — or in prose does not satisfy a requirement, and a
- * partial match such as {@code # CLAUDE.md-extended} does not satisfy
- * {@code # CLAUDE.md}. All structural problems are collected and reported
- * together.
+ * Headings are matched outside code, so a heading mentioned in a sample — fenced or
+ * indented — or in prose does not satisfy a requirement, and a partial match such as
+ * {@code # CLAUDE.md-extended} does not satisfy {@code # CLAUDE.md}. They are
+ * matched by the text they carry rather than by the line they were typed on, so a
+ * heading balanced with a closing {@code #} run satisfies the requirement its plain
+ * spelling does. All structural problems are collected and reported together.
  * <p>
  * Several optional checks, each disabled by default, can be switched on from the
  * rule configuration: {@code forbiddenTokens} that must not appear outside code,
@@ -205,7 +206,7 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 			return;
 		}
 		for (String token : forbiddenTokens) {
-			if (document.containsInProse(token)) {
+			if (document.containsUnquoted(token)) {
 				violations.add(documentName() + " must not contain forbidden token: " + token);
 			}
 		}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/CommandTokens.java
@@ -91,6 +91,25 @@ final class CommandTokens {
 			"case", "in", "esac",
 			"{", "}", "!");
 
+	/**
+	 * The programs that run the command their arguments name rather than being that
+	 * command themselves. A hook wired as {@code exec .claude/hooks/session-start.sh}
+	 * runs that script exactly as the bare path does, and reading the first word
+	 * blindly took {@code exec} for the program — so the script went unresolved, a
+	 * rename of it passed the missing-script check, and
+	 * {@code reportUnreferencedScripts} reported a script the hook really does run as
+	 * referenced by nothing.
+	 * <p>
+	 * They are listed apart from the reserved words because they are programs rather
+	 * than shell grammar, even though what a reader does with them is the same: skip
+	 * over them to reach what runs. Only the wrappers whose <em>next</em> word is the
+	 * command are listed. One that takes an option carrying a value — {@code sudo -u}
+	 * — would need its options described the way an {@link Interpreter}'s are, and
+	 * skipping it without that would name the option as the program.
+	 */
+	private static final Set<String> COMMAND_WRAPPERS = Set.of(
+			"exec", "command", "builtin", "nohup", "env", "time");
+
 	private CommandTokens() {
 	}
 
@@ -128,9 +147,13 @@ final class CommandTokens {
 		return Stream.concat(Stream.of(program), interpretedScript(program, words.subList(1, words.size())).stream());
 	}
 
-	/** True for a word that precedes the program rather than being it: an assignment or a reserved word. */
+	/**
+	 * True for a word that precedes the program rather than being it: an assignment,
+	 * a reserved word, or a wrapper that runs what follows it.
+	 */
 	private static boolean isPrefix(String token) {
-		return ASSIGNMENT.matcher(token).matches() || RESERVED_WORDS.contains(token);
+		return ASSIGNMENT.matcher(token).matches() || RESERVED_WORDS.contains(token)
+				|| COMMAND_WRAPPERS.contains(token);
 	}
 
 	/** The script an interpreter is handed, or nothing when the program is not one. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -44,7 +44,9 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
  * renamed on disk but not in settings;
  * {@code reportUnreferencedScripts} also reports a script no hook references. The
  * {@code hooksDir} parameter must be configured, but an absent directory is a pass
- * because hooks are optional. All problems found are reported together.
+ * because hooks are optional; a {@code settingsFile} that is configured and absent
+ * fails outright, because that is a build-setup mistake. All problems found are
+ * reported together.
  */
 @Named("hooksFormat")
 public class HooksFormatRule extends ClaudeCodeEnforcerRule {
@@ -105,18 +107,18 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 	 * file must not abort the build before the remaining scripts are checked.
 	 */
 	private void collectScriptViolations(File script, List<String> violations) {
-		Optional<String> text = MarkdownText.readIfText(script);
+		Optional<String> text = MarkdownText.readIfTextWithByteOrderMark(script);
 		if (text.isEmpty()) {
 			violations.add("hook script cannot be read as a text script: " + script);
 			return;
 		}
-		String content = text.get();
-		if (content.isBlank()) {
+		String raw = text.get();
+		if (MarkdownText.stripByteOrderMark(raw).isBlank()) {
 			violations.add("hook script is empty: " + script);
 			return;
 		}
-		if (requireShebang && !content.startsWith(SHEBANG)) {
-			violations.add("hook script must start with a '#!' shebang line: " + script);
+		if (requireShebang) {
+			collectShebangViolation(script, raw, violations);
 		}
 		if (requireExecutable && !script.canExecute()) {
 			violations.add("hook script is not executable: " + script);
@@ -126,22 +128,52 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 		}
 	}
 
+	/**
+	 * The shebang is read from the raw text, byte-order mark and all. The kernel
+	 * reads bytes, so a mark in front of the {@code #!} makes the script unrunnable
+	 * — and reading the stripped text reported exactly that script, the one this
+	 * rule exists to catch before it is committed, as well formed. A script with no
+	 * shebang at all is still reported as the missing shebang it is, so the message
+	 * names the problem the author has rather than the one behind it.
+	 */
+	private void collectShebangViolation(File script, String raw, List<String> violations) {
+		if (!MarkdownText.stripByteOrderMark(raw).startsWith(SHEBANG)) {
+			violations.add("hook script must start with a '#!' shebang line: " + script);
+		} else if (MarkdownText.startsWithByteOrderMark(raw)) {
+			violations.add("hook script has a byte-order mark before its '#!' shebang line, so it cannot be run: "
+					+ script);
+		}
+	}
+
 	private String extensionOf(File script) {
 		String name = script.getName();
 		int dot = name.lastIndexOf('.');
 		return dot < 0 ? "" : name.substring(dot + 1);
 	}
 
-	private void collectWiringViolations(List<File> scripts, List<String> violations) {
+	/**
+	 * A configured settings file that is not there is a build-setup mistake, so it
+	 * always fails, whatever the severity: reporting it as a violation let
+	 * {@code severity=warn} turn the whole wiring cross-check off silently, which is
+	 * the one outcome a rule must not have.
+	 * <p>
+	 * A file that is there but cannot be decoded is reported instead of thrown. This
+	 * rule reads settings.json as a second opinion on the scripts, and the rules that
+	 * own that file — {@code settingsJsonValid} and the two beside it — fail on it in
+	 * their own right, so an undecodable one is never left unreported by this one
+	 * declining to abort the build over it.
+	 */
+	private void collectWiringViolations(List<File> scripts, List<String> violations) throws EnforcerRuleException {
 		if (settingsFile == null) {
 			return;
 		}
-		if (!settingsFile.isFile()) {
-			violations.add("settings.json does not exist at " + settingsFile);
+		requireExists(settingsFile, "settings.json");
+		Optional<String> content = MarkdownText.readIfText(settingsFile);
+		if (content.isEmpty()) {
+			violations.add("settings.json cannot be read as text: " + settingsFile);
 			return;
 		}
-		String content = MarkdownText.read(settingsFile, "settings.json");
-		JsonNode settings = JsonNodes.parseObject(content, "settings.json", violations);
+		JsonNode settings = JsonNodes.parseObject(content.get(), "settings.json", violations);
 		if (settings == null) {
 			return;
 		}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.enforcer.text;
 
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -8,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * A parsed Markdown document: its lines plus the masks marking which of them are
@@ -155,17 +155,47 @@ public final class MarkdownDocument {
 	 * outside code and outside HTML comments alike. A commented-out mention is inert
 	 * both ways round — it must not satisfy a check that demands the token, and must
 	 * not trip one that forbids it.
+	 * <p>
+	 * An inline code span does count as a mention, because naming a file in
+	 * backticks is how prose names a file: a document that says "see
+	 * {@code `AGENTS.md`}" has referenced it. A check that <em>forbids</em> a token
+	 * cannot read a span that way and asks {@link #containsUnquoted} instead.
 	 */
 	public boolean containsInProse(String token) {
 		return structuralLines().anyMatch(index -> lines.get(index).contains(token));
 	}
 
-	/** The heading lines outside fenced code blocks and HTML comments, in document order. */
+	/**
+	 * True when {@code token} appears on a line that carries document structure and
+	 * outside an inline code span. A token quoted as code is the document
+	 * illustrating the token rather than writing one, exactly as a fenced sample is:
+	 * a document that forbids {@code TODO} must still be able to say "never leave a
+	 * {@code `TODO`} behind", which the line-level reading of {@link #containsInProse}
+	 * reported as the very thing it forbids.
+	 */
+	public boolean containsUnquoted(String token) {
+		return structuralLines()
+				.anyMatch(index -> MarkdownText.withoutCodeSpans(lines.get(index)).contains(token));
+	}
+
+	/** The headings outside fenced code blocks and HTML comments, in document order. */
 	public Set<String> headings() {
+		return headingTexts().collect(Collectors.toCollection(LinkedHashSet::new));
+	}
+
+	/**
+	 * The heading each structural line declares, in document order, canonical rather
+	 * than verbatim. A heading is matched by the text it carries, so the closing
+	 * {@code #} run Markdown lets an author balance a heading with — {@code ## Testing
+	 * ##} — and the tab a heading may be separated by are not part of it. Comparing
+	 * the raw line reported a document that has {@code ## Testing} written that way as
+	 * missing the section, and attributed the section's content to the one above it.
+	 */
+	private Stream<String> headingTexts() {
 		return structuralLines()
 				.mapToObj(index -> lines.get(index).strip())
 				.filter(MarkdownDocument::isHeading)
-				.collect(Collectors.toCollection(LinkedHashSet::new));
+				.map(MarkdownDocument::headingText);
 	}
 
 	/** True when {@code heading} appears as a real heading outside code fences. */
@@ -190,18 +220,27 @@ public final class MarkdownDocument {
 	 * more than once is reported by its first occurrence, so the order comparison
 	 * matches the de-duplicated set of present sections rather than reporting a
 	 * spurious out-of-order failure.
+	 * <p>
+	 * Only a heading answers, which is what keeps this in step with
+	 * {@link #headings()}. Reading every structural line let an entry of
+	 * {@code wanted} that is not a heading at all — a section configured as
+	 * {@code Testing} rather than {@code ## Testing} — be answered by a line of prose,
+	 * so the same document was reported both as missing that section and as having it
+	 * out of order.
 	 */
 	public List<String> headingsInOrder(List<String> wanted) {
 		Set<String> required = new LinkedHashSet<>(wanted);
-		List<String> ordered = new ArrayList<>();
-		structuralLines().mapToObj(index -> lines.get(index).strip())
-				.filter(required::remove)
-				.forEach(ordered::add);
-		return ordered;
+		return headingTexts().filter(required::remove).toList();
 	}
 
 	private int headingIndex(String section) {
-		return structuralLines().filter(index -> lines.get(index).strip().equals(section)).findFirst().orElse(-1);
+		return structuralLines().filter(index -> declares(index, section)).findFirst().orElse(-1);
+	}
+
+	/** True when the line at {@code index} is the heading {@code section} names. */
+	private boolean declares(int index, String section) {
+		String line = lines.get(index).strip();
+		return isHeading(line) && headingText(line).equals(section);
 	}
 
 	/** The first line that settles the question decides it; a section nothing settles has no body. */
@@ -230,6 +269,38 @@ public final class MarkdownDocument {
 
 	private static boolean isHeading(String line) {
 		return ATX_HEADING.matcher(line).matches();
+	}
+
+	/**
+	 * The heading a line declares, written canonically: its {@code #} run, then a
+	 * single space and the text it carries, or the run alone when it carries none.
+	 * A heading is the text it names, not the line it was typed on, so the whitespace
+	 * separating the two — a tab counts — and the closing {@code #} run Markdown
+	 * allows are spelling rather than content.
+	 */
+	private static String headingText(String line) {
+		int level = headingLevel(line);
+		String hashes = line.substring(0, level);
+		String text = withoutClosingRun(line.substring(level).strip());
+		return text.isEmpty() ? hashes : hashes + SPACE + text;
+	}
+
+	/**
+	 * The heading's text without the {@code #} run that closes it. The run only
+	 * closes a heading when whitespace precedes it, so {@code ## C#} keeps its hash
+	 * while {@code ## Testing ##} loses both of its; a text that is nothing but
+	 * hashes — the {@code ###} of {@code ## ###} — is the closing run itself and
+	 * leaves an empty heading.
+	 */
+	private static String withoutClosingRun(String text) {
+		int end = text.length();
+		while (end > 0 && text.charAt(end - 1) == HEADING_CHAR) {
+			end--;
+		}
+		if (end == text.length()) {
+			return text;
+		}
+		return end == 0 || isIndent(text.charAt(end - 1)) ? text.substring(0, end).strip() : text;
 	}
 
 	private static int headingLevel(String heading) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownText.java
@@ -43,8 +43,20 @@ public final class MarkdownText {
 	 * error rather than as the violation the rule exists to report.
 	 */
 	public static Optional<String> readIfText(File file) {
+		return readIfTextWithByteOrderMark(file).map(MarkdownText::stripByteOrderMark);
+	}
+
+	/**
+	 * Reads {@code file} the way {@link #readIfText} does but keeps a leading
+	 * byte-order mark, for a rule that must judge the file as the program that runs
+	 * it will read it rather than as a document. A shell script is the case in
+	 * point: the kernel reads bytes, so a mark in front of the {@code #!} line makes
+	 * the script unrunnable, and a reader that strips the mark first can never see
+	 * that — it reported such a script as well formed.
+	 */
+	public static Optional<String> readIfTextWithByteOrderMark(File file) {
 		try {
-			return Optional.of(stripByteOrderMark(Files.readString(file.toPath())));
+			return Optional.of(Files.readString(file.toPath()));
 		} catch (IOException e) {
 			return Optional.empty();
 		}
@@ -72,10 +84,15 @@ public final class MarkdownText {
 
 	/** Removes a single leading UTF-8 byte-order mark, if present. */
 	public static String stripByteOrderMark(String content) {
-		if (!content.isEmpty() && content.charAt(0) == BYTE_ORDER_MARK) {
+		if (startsWithByteOrderMark(content)) {
 			return content.substring(1);
 		}
 		return content;
+	}
+
+	/** True when {@code content} still carries the mark {@link #stripByteOrderMark} removes. */
+	public static boolean startsWithByteOrderMark(String content) {
+		return !content.isEmpty() && content.charAt(0) == BYTE_ORDER_MARK;
 	}
 
 	/**

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.doc;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -186,6 +187,18 @@ class ClaudeMdFormatRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
+	/**
+	 * A token quoted as code is the document illustrating it, exactly as a fenced
+	 * sample is — so a document may say what it bans without banning itself.
+	 */
+	@Test
+	void ignoresAForbiddenTokenInsideAnInlineCodeSpan() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nNever leave a `TODO` behind.\n");
+		rule.setForbiddenTokens(java.util.List.of("TODO"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
 	/** Commented-out text is inert, so a token an author retired no longer trips the ban. */
 	@Test
 	void ignoresAForbiddenTokenInsideAnHtmlComment() {
@@ -349,6 +362,31 @@ class ClaudeMdFormatRuleTest {
 
 		// The sections are in the configured order; a repeated "## Testing" must be
 		// counted once by its first occurrence, not flagged as out of order.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/**
+	 * A section configured without its {@code ##} is missing whatever the document
+	 * says, so the order check must not answer it with a line of prose and report
+	 * the same document as both missing the section and misordering it.
+	 */
+	@Test
+	void reportsOnlyTheMissingSectionWhenARequiredEntryIsNotAHeading() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
+		rule.setRequiredSections(java.util.List.of("Testing"));
+		rule.setEnforceSectionOrder(true);
+
+		EnforcerRuleException exception = assertFailure(EnforcerRuleException.class, rule::execute,
+				"missing required section heading: Testing");
+		assertFalse(exception.getMessage().contains("out of order"), exception.getMessage());
+	}
+
+	/** A heading balanced with a closing hash run is the section it names. */
+	@Test
+	void acceptsARequiredSectionClosedByATrailingHashRun() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("## Testing", "## Testing ##"));
+		rule.setEnforceSectionOrder(true);
+
 		assertDoesNotThrow(rule::execute);
 	}
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/CommandTokensTest.java
@@ -274,4 +274,47 @@ class CommandTokensTest {
 	void stillReadsAReservedWordSpelledAsAPath() {
 		assertEquals(List.of("./then"), CommandTokens.scriptCandidatesOf("./then --flag"));
 	}
+
+	/**
+	 * {@code exec} replaces the shell with what follows it, so the script it hands on
+	 * is the one the hook runs. Reading {@code exec} as the program left that script
+	 * unresolved: a rename of it passed the missing-script check, and
+	 * {@code reportUnreferencedScripts} called it referenced by nothing.
+	 */
+	@Test
+	void skipsExecToReachTheScriptItRuns() {
+		assertEquals(List.of(".claude/hooks/session-start.sh"),
+				CommandTokens.scriptCandidatesOf("exec .claude/hooks/session-start.sh"));
+	}
+
+	@Test
+	void skipsEveryWrapperThatRunsTheCommandAfterIt() {
+		assertEquals(List.of("a.sh"), CommandTokens.scriptCandidatesOf("command a.sh"));
+		assertEquals(List.of("a.sh"), CommandTokens.scriptCandidatesOf("builtin a.sh"));
+		assertEquals(List.of("a.sh"), CommandTokens.scriptCandidatesOf("nohup a.sh"));
+		assertEquals(List.of("a.sh"), CommandTokens.scriptCandidatesOf("env a.sh"));
+		assertEquals(List.of("a.sh"), CommandTokens.scriptCandidatesOf("time a.sh"));
+	}
+
+	/** A wrapper and an assignment are skipped over alike, in whichever order they are written. */
+	@Test
+	void skipsAnAssignmentPassedThroughAWrapper() {
+		assertEquals(List.of("a.sh"), CommandTokens.scriptCandidatesOf("env LOG_LEVEL=debug a.sh"));
+	}
+
+	@Test
+	void skipsAWrapperInEverySegmentOfAChainedCommand() {
+		assertEquals(List.of("a.sh", "b.sh"), CommandTokens.scriptCandidatesOf("exec a.sh; nohup b.sh"));
+	}
+
+	/** {@code time} names what follows it, but a file really called {@code time} is a program. */
+	@Test
+	void stillReadsAWrapperSpelledAsAPath() {
+		assertEquals(List.of("./time"), CommandTokens.scriptCandidatesOf("./time a.sh"));
+	}
+
+	@Test
+	void yieldsNoProgramForAWrapperAlone() {
+		assertEquals(List.of(), CommandTokens.scriptCandidatesOf("exec; nohup"));
+	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -63,6 +63,36 @@ class HooksFormatRuleTest {
 		assertFailure(EnforcerRuleException.class, ruleFor()::execute, "not executable");
 	}
 
+	/**
+	 * The kernel reads bytes: a mark before the {@code #!} makes the script
+	 * unrunnable, however well formed the text behind the mark reads.
+	 */
+	@Test
+	void failsWhenAByteOrderMarkPrecedesTheShebang() {
+		writeScript("session-start.sh", (char) 0xFEFF + "#!/bin/sh\necho hi\n", true);
+
+		assertFailure(EnforcerRuleException.class, ruleFor()::execute, "byte-order mark", "session-start.sh");
+	}
+
+	/** A script with no shebang is named for the shebang it lacks, mark or no mark. */
+	@Test
+	void reportsTheMissingShebangRatherThanTheMarkWhenThereIsNoShebangAtAll() {
+		writeScript("session-start.sh", (char) 0xFEFF + "echo hi\n", true);
+
+		EnforcerRuleException exception = assertFailure(EnforcerRuleException.class, ruleFor()::execute, "shebang");
+		assertFalse(exception.getMessage().contains("byte-order mark"), exception.getMessage());
+	}
+
+	@Test
+	void passesForAByteOrderMarkWhenTheShebangCheckIsOff() {
+		writeScript("session-start.sh", (char) 0xFEFF + "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setRequireShebang(false);
+		rule.setRequireExecutable(false);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
 	@Test
 	void failsWhenScriptIsEmpty() {
 		writeScript("session-start.sh", "   \n", true);
@@ -298,6 +328,38 @@ class HooksFormatRuleTest {
 		assertFailure(EnforcerRuleException.class, rule::execute, "settings.json does not exist");
 	}
 
+	/**
+	 * A configured settings file that is not there is a build-setup mistake, so warn
+	 * severity must not turn it — and with it the whole wiring cross-check — into a
+	 * line in the log.
+	 */
+	@Test
+	void failsForAnAbsentSettingsFileEvenAtWarnSeverity() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(tempDir.resolve("absent.json").toFile());
+		rule.setSeverity("warn");
+
+		assertFailure(EnforcerRuleException.class, rule::execute, "settings.json does not exist");
+	}
+
+	/**
+	 * A settings file that is there but is not text is reported, not thrown: the
+	 * rules that own settings.json fail on it in their own right, so this one
+	 * aborting the build as an internal error would only lose the script violations
+	 * beside it.
+	 */
+	@Test
+	void reportsASettingsFileThatCannotBeDecodedAsText() {
+		writeScript("session-start.sh", "#!/bin/sh\n", true);
+		Path settings = tempDir.resolve(".claude/settings.json");
+		TestFiles.writeBytes(settings, new byte[] { (byte) 0xFF, (byte) 0xFE, 0x00, (byte) 0x80 });
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settings.toFile());
+
+		assertFailure(EnforcerRuleException.class, rule::execute, "settings.json cannot be read as text");
+	}
+
 	@Test
 	void failsWhenTheSettingsFileIsNotValidJson() {
 		writeScript("session-start.sh", "#!/bin/sh\n", true);
@@ -388,6 +450,25 @@ class HooksFormatRuleTest {
 		rule.setReportUnreferencedScripts(true);
 
 		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void countsAScriptRunThroughExecAsAReference() {
+		writeScript("a.sh", "#!/bin/sh\necho a\n", true);
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("exec .claude/hooks/a.sh"));
+		rule.setReportUnreferencedScripts(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/** The other half of reading {@code exec}: the script behind it is resolved, so a rename is caught. */
+	@Test
+	void failsWhenExecRunsAMissingHookScript() {
+		HooksFormatRule rule = ruleFor();
+		rule.setSettingsFile(settingsReferencing("exec $CLAUDE_PROJECT_DIR/.claude/hooks/gone.sh"));
+
+		assertFailure(EnforcerRuleException.class, rule::execute, "references a missing hook script", "gone.sh");
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
@@ -596,6 +596,137 @@ class MarkdownDocumentTest {
 		assertEquals(List.of(2, 3, 4), commentedLines(document));
 	}
 
+	/**
+	 * A heading is the text it carries, so the closing {@code #} run Markdown lets an
+	 * author balance it with is spelling. Matching the raw line reported a document
+	 * that has the section as missing it, and gave the section's content to the one
+	 * above it.
+	 */
+	@Test
+	void readsAHeadingClosedByATrailingHashRun() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title #
+
+				## Testing ##
+				Body.
+				""");
+
+		assertEquals(Set.of("# Title", "## Testing"), document.headings());
+		assertTrue(document.hasBody("## Testing"));
+	}
+
+	/** Only whitespace makes a trailing run a closing one, so a hash inside the text stays in it. */
+	@Test
+	void keepsATrailingHashThatNoWhitespacePrecedes() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				## C#
+				Body.
+				""");
+
+		assertEquals(Set.of("# Title", "## C#"), document.headings());
+	}
+
+	@Test
+	void readsAHeadingThatIsNothingButItsClosingRun() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				## ###
+				Body.
+				""");
+
+		assertEquals(Set.of("# Title", "##"), document.headings());
+	}
+
+	/** A tab separates a heading from its text as a space does, so the two name one heading. */
+	@Test
+	void readsAHeadingSeparatedByATab() {
+		MarkdownDocument document = MarkdownDocument.parse("# Title\n\n##\tTesting\nBody.\n");
+
+		assertEquals(Set.of("# Title", "## Testing"), document.headings());
+		assertTrue(document.hasBody("## Testing"));
+	}
+
+	/**
+	 * The order comparison reads headings alone. Reading every structural line let a
+	 * wanted entry that is no heading — a section configured without its {@code ##} —
+	 * be answered by a line of prose, so a document was reported both as missing the
+	 * section and as having it out of order.
+	 */
+	@Test
+	void headingsInOrderIgnoresAProseLineThatMatchesAWantedEntry() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				Testing
+
+				## Testing
+				Body.
+				""");
+
+		assertEquals(List.of("## Testing"), document.headingsInOrder(List.of("Testing", "## Testing")));
+	}
+
+	@Test
+	void headingsInOrderListsTheWantedHeadingsAsTheDocumentOrdersThem() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				## Maven
+				Body.
+
+				## Testing ##
+				Body.
+				""");
+
+		// The document's order, not the wanted list's, and a closed heading counts.
+		assertEquals(List.of("## Maven", "## Testing"),
+				document.headingsInOrder(List.of("## Testing", "## Maven")));
+	}
+
+	/** A token quoted as code is the document illustrating it, exactly as a fenced sample is. */
+	@Test
+	void doesNotReadATokenInsideAnInlineCodeSpanAsUnquoted() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				Never leave a `TODO` behind.
+				""");
+
+		assertFalse(document.containsUnquoted("TODO"));
+		assertTrue(document.containsInProse("TODO"));
+	}
+
+	@Test
+	void readsATokenOutsideACodeSpanOnTheSameLineAsUnquoted() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				A `TODO` marker: TODO finish this.
+				""");
+
+		assertTrue(document.containsUnquoted("TODO"));
+	}
+
+	@Test
+	void doesNotReadATokenInsideACodeFenceOrAnHtmlCommentAsUnquoted() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				```
+				TODO in a sample
+				```
+
+				<!--
+				TODO removed
+				-->
+				""");
+
+		assertFalse(document.containsUnquoted("TODO"));
+	}
+
 	/** The indices of the lines the document masks as code, in document order. */
 	private static List<Integer> codeLines(MarkdownDocument document) {
 		return IntStream.range(0, document.lineCount()).filter(document::isInsideCode).boxed().toList();

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownTextTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownTextTest.java
@@ -2,10 +2,13 @@ package io.github.adamw7.tools.enforcer.text;
 
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.assumeSymlink;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
 import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
@@ -77,6 +80,32 @@ class MarkdownTextTest {
 		writeString(file, BYTE_ORDER_MARK + "# Title\nbody");
 
 		assertEquals("# Title\nbody", MarkdownText.read(file.toFile(), "doc.md"));
+	}
+
+	@Test
+	void startsWithByteOrderMarkAnswersForBothSpellings() {
+		assertTrue(MarkdownText.startsWithByteOrderMark(BYTE_ORDER_MARK + "#!/bin/sh"));
+		assertFalse(MarkdownText.startsWithByteOrderMark("#!/bin/sh"));
+		assertFalse(MarkdownText.startsWithByteOrderMark(""));
+	}
+
+	/** A rule judging a script has to see the mark the kernel sees, so this read keeps it. */
+	@Test
+	void readIfTextWithByteOrderMarkKeepsTheMarkThatReadIfTextStrips() {
+		Path file = tempDir.resolve("hook.sh");
+		writeString(file, BYTE_ORDER_MARK + "#!/bin/sh\n");
+
+		assertEquals(BYTE_ORDER_MARK + "#!/bin/sh\n",
+				MarkdownText.readIfTextWithByteOrderMark(file.toFile()).orElseThrow());
+		assertEquals("#!/bin/sh\n", MarkdownText.readIfText(file.toFile()).orElseThrow());
+	}
+
+	@Test
+	void readIfTextWithByteOrderMarkIsEmptyForAFileThatIsNotText() {
+		Path file = tempDir.resolve("logo.png");
+		writeBytes(file, new byte[] { (byte) 0x89, 0x50, (byte) 0xFF, (byte) 0xFE });
+
+		assertTrue(MarkdownText.readIfTextWithByteOrderMark(file.toFile()).isEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
Six defects found reviewing the rule logic, each one letting a real problem
through or failing a document that is fine:

- CommandTokens read a command wrapper as the program it wraps, so a hook
  wired as `exec .claude/hooks/session-start.sh` left its script unresolved:
  a rename of that script passed the missing-script check, and
  reportUnreferencedScripts called the script the hook really runs
  unreferenced. exec, command, builtin, nohup, env and time now join the
  words a reader skips over to reach what runs.
- HooksFormatRule read the shebang from text whose byte-order mark had
  already been stripped, so a script the kernel refuses to run passed the
  check that exists to catch it before it is committed. The mark is now kept
  for that check and reported as the reason the script cannot run.
- A forbidden token inside an inline code span was reported as the token it
  illustrates, so a document could not say what it bans. containsUnquoted
  reads a span the way a fenced sample is already read; containsInProse keeps
  counting one, because naming a file in backticks is how prose names a file.
- A heading closed by a trailing hash run, or separated by a tab, was matched
  against the raw line, so a document with `## Testing ##` was reported as
  missing that section and the section's body was given to the one above it.
  Headings are now matched by the text they carry.
- headingsInOrder read every structural line rather than the headings, so a
  required section configured without its `##` could be answered by a line of
  prose and the same document reported as both missing it and misordering it.
- A configured settings.json that is absent now fails outright rather than
  being reported as a violation, which let severity=warn turn the whole hook
  wiring cross-check off silently; one that is present but undecodable is
  reported instead of aborting the build as an internal error.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01354gZXLNqcpxqWCw4D7u2N