### PR TITLE
fix(adopt): close five gaps found reviewing the pipeline's logic

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -144,9 +144,11 @@ public final class CliArguments {
 	}
 
 	/**
-	 * @return every repository to adopt in this run — the positional URL first, then
-	 *         the ones the flags added — without duplicates, since the same
-	 *         repository twice would adopt one checkout a second time
+	 * @return every repository to adopt in this run, in the order the operator named
+	 *         them — the positional and the flags interleaved as they were written,
+	 *         which is the order the options are bound to methods to preserve — and
+	 *         without duplicates, since the same repository twice would adopt one
+	 *         checkout a second time
 	 */
 	public List<String> repositoryUrls() {
 		return RepositoryUrls.distinct(repositoryUrls);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -46,6 +46,18 @@ import io.github.adamw7.tools.adopt.step.VerifyStep;
  */
 public class GitHubRepoAdopter {
 
+	/**
+	 * What the guard commit says it did. It names the guard rather than the artifact
+	 * that supplies one of them, because which guard {@link EnforcerStep} wires in is
+	 * the checkout's build system to decide and is not known when the pipeline is
+	 * assembled: only the Maven path adds the {@code claude-code-enforcer}, while a
+	 * Gradle project gets a task and a project with no build file gets a workflow. A
+	 * message naming the enforcer therefore landed in the history of repositories that
+	 * were given neither — a claim the diff beside it plainly does not support, in a
+	 * commit the adopted project's reviewers read.
+	 */
+	static final String GUARD_COMMIT_MESSAGE = "Adopt Claude Code: add the CLAUDE.md guard";
+
 	private static final Logger log = LogManager.getLogger(GitHubRepoAdopter.class);
 
 	private final CommandRunner runner;
@@ -87,7 +99,7 @@ public class GitHubRepoAdopter {
 				new ClaudeMdConformanceStep(buildSystems),
 				new CommitStep("Adopt Claude Code: add CLAUDE.md", "claude-md"),
 				new EnforcerStep(buildSystems),
-				new CommitStep("Add claude-code-enforcer to the build", "guard"));
+				new CommitStep(GUARD_COMMIT_MESSAGE, "guard"));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -185,10 +185,50 @@ public class ClaudeMdConformer {
 		}
 	}
 
+	/**
+	 * Puts the title on the document's first line, which is where the rule reads it:
+	 * its {@code firstNonBlankLine} check is satisfied by nothing further down.
+	 *
+	 * <p>A title the document already carries lower down is <em>moved</em> rather than
+	 * left where it is, because prepending a second one leaves the file with two
+	 * {@code # CLAUDE.md} headings. The rule accepts that — it only reads the first
+	 * line — so nothing downstream reported the duplicate the adoption had just
+	 * committed to someone else's repository, and the reshape being idempotent meant a
+	 * re-adoption did not clear it either. This is the same shape the byte-order mark
+	 * once produced (see {@link #splitLines}), reached from a document whose title
+	 * simply was not first.
+	 */
 	private void ensureTitle(List<String> lines) {
-		if (!TITLE.equals(firstNonBlank(lines))) {
-			lines.addAll(0, List.of(TITLE, ""));
+		if (TITLE.equals(firstNonBlank(lines))) {
+			return;
 		}
+		misplacedTitles(lines).forEach(index -> removeHeading(lines, index));
+		lines.addAll(0, List.of(TITLE, ""));
+	}
+
+	/**
+	 * The title headings the document carries, latest first so removing one cannot
+	 * shift the index of the next. Only structural lines are offered: a
+	 * {@code # CLAUDE.md} inside a code sample is the sample's, not the document's.
+	 */
+	private List<Integer> misplacedTitles(List<String> lines) {
+		return Outline.of(lines).structural(line -> TITLE.equals(line.strip())).boxed().toList().reversed();
+	}
+
+	/**
+	 * Removes the heading, and the blank line below it only when the line above was
+	 * blank too — otherwise the paragraph that followed the heading would be pulled up
+	 * against the one that preceded it and the two would read as a single paragraph.
+	 */
+	private static void removeHeading(List<String> lines, int index) {
+		lines.remove(index);
+		if (isBlankAt(lines, index) && precededByBlank(lines, index)) {
+			lines.remove(index);
+		}
+	}
+
+	private static boolean precededByBlank(List<String> lines, int index) {
+		return index == 0 || lines.get(index - 1).isBlank();
 	}
 
 	private String firstNonBlank(List<String> lines) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -78,8 +78,17 @@ public class CloneStep extends AbstractCommandStep {
 	 * changes the checkout did not have. A line that is not an entry is therefore
 	 * skipped rather than read as one, the same reading {@link #namesThisRepository}
 	 * takes of that transcript's noise.
+	 *
+	 * <p>At least one of the two letters has to say something, because git never
+	 * reports a path whose index and work tree are both unchanged — leaving it out of
+	 * the output is what "unchanged" means. Accepting two spaces let through any line
+	 * indented by three of them, so a warning that wraps or indents its continuation
+	 * was still read as an entry, and its fourth character onwards taken for a path:
+	 * no path the adoption writes, and so the resume this step promises refused over a
+	 * change the checkout does not have — the very outcome the paragraph above is
+	 * about.
 	 */
-	private static final Pattern STATUS_ENTRY = Pattern.compile("^[ MTADRCU?!]{2} .+");
+	private static final Pattern STATUS_ENTRY = Pattern.compile("^(?! {2})[ MTADRCU?!]{2} .+");
 
 	@Override
 	public String name() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -25,6 +25,26 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
  * execution time: Gradle's configuration cache rejects a task holding a script or
  * {@code Project} reference, which would break {@code check} for every contributor
  * afterwards.
+ *
+ * <p>Registering the task is not enough on its own: a task nothing depends on is a
+ * guard the project's ordinary build never runs. It is hung from
+ * {@value #LIFECYCLE_TASK} through a live {@code matching}/{@code configureEach}
+ * view, so a plugin applied further down the script still wires it in — and a
+ * project that ends up with no {@value #LIFECYCLE_TASK} at all is given one. That
+ * case is not exotic: an Android or aggregator root script routinely declares a
+ * {@code clean} task and nothing else, and the guard was left registered, verified
+ * by {@link VerifyStep} running it directly, and unreachable from any build a
+ * contributor or CI would run — the pull request advertising a guard the project
+ * does not have, which is exactly what {@link PomEnforcerInstaller} refuses to
+ * produce on the Maven path.
+ *
+ * <p>The fallback registration is deferred to {@code afterEvaluate} rather than
+ * made inline, because the name has to be free: claiming {@value #LIFECYCLE_TASK}
+ * while the script is still being read would collide with a plugin applied below
+ * this block and fail the whole build. By {@code afterEvaluate} there is no "below"
+ * left. Applying Gradle's {@code base} plugin to obtain the task instead was
+ * rejected for the same reason — it also registers {@code clean}, which is the one
+ * task those root scripts already declare.
  */
 public class GradleGuardInstaller {
 
@@ -51,10 +71,13 @@ public class GradleGuardInstaller {
 	 */
 	private static final Pattern BLOCK_COMMENT = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
 
+	/** The lifecycle task the guard is hung from, and the one created when the project has none. */
+	static final String LIFECYCLE_TASK = "check";
+
 	private static final String GROOVY_BLOCK = """
 
 			// Added by claude-code-adopt: fail the build when CLAUDE.md is missing or empty.
-			tasks.register('%s') {
+			tasks.register('%1$s') {
 			    def claudeMd = project.file('CLAUDE.md')
 			    doLast {
 			        if (!claudeMd.isFile() || claudeMd.text.trim().isEmpty()) {
@@ -62,13 +85,18 @@ public class GradleGuardInstaller {
 			        }
 			    }
 			}
-			tasks.matching { it.name == 'check' }.configureEach { it.dependsOn('%s') }
-			""".formatted(GUARD_TASK, GUARD_TASK);
+			tasks.matching { it.name == '%2$s' }.configureEach { it.dependsOn('%1$s') }
+			project.afterEvaluate {
+			    if (!tasks.names.contains('%2$s')) {
+			        tasks.register('%2$s') { it.dependsOn('%1$s') }
+			    }
+			}
+			""".formatted(GUARD_TASK, LIFECYCLE_TASK);
 
 	private static final String KOTLIN_BLOCK = """
 
 			// Added by claude-code-adopt: fail the build when CLAUDE.md is missing or empty.
-			tasks.register("%s") {
+			tasks.register("%1$s") {
 			    val claudeMd = project.file("CLAUDE.md")
 			    doLast {
 			        if (!claudeMd.isFile || claudeMd.readText().trim().isEmpty()) {
@@ -76,8 +104,13 @@ public class GradleGuardInstaller {
 			        }
 			    }
 			}
-			tasks.matching { it.name == "check" }.configureEach { dependsOn("%s") }
-			""".formatted(GUARD_TASK, GUARD_TASK);
+			tasks.matching { it.name == "%2$s" }.configureEach { dependsOn("%1$s") }
+			project.afterEvaluate {
+			    if (!tasks.names.contains("%2$s")) {
+			        tasks.register("%2$s") { dependsOn("%1$s") }
+			    }
+			}
+			""".formatted(GUARD_TASK, LIFECYCLE_TASK);
 
 	/**
 	 * @return {@code true} when the guard was appended, {@code false} when the

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -76,8 +76,8 @@ class CliArgumentsTest {
 	}
 
 	/**
-	 * The list is read in the order the operator wrote it — the positional first,
-	 * then each flag as it was met — so the run's report reads in the order they
+	 * The list is read in the order the operator wrote it — the positional and each
+	 * flag interleaved as they were met — so the run's report reads in the order they
 	 * expect.
 	 */
 	@Test
@@ -86,6 +86,18 @@ class CliArgumentsTest {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--repo", OTHER_URL, "--repos", list.toString(),
 				"--repo", FOURTH_URL });
 		assertEquals(List.of(REPO_URL, OTHER_URL, THIRD_URL, FOURTH_URL), cli.repositoryUrls());
+	}
+
+	/**
+	 * The positional takes no precedence over the flags: it is read where it was
+	 * written, not hoisted to the front. Pinning it from a command line that opens
+	 * with a flag is what tells the two readings apart — one that opens with the
+	 * positional cannot.
+	 */
+	@Test
+	void readsAPositionalNamedAfterAFlagAfterIt() {
+		CliArguments cli = CliArguments.parse(new String[] { "--repo", OTHER_URL, REPO_URL });
+		assertEquals(List.of(OTHER_URL, REPO_URL), cli.repositoryUrls());
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -196,6 +197,23 @@ class GitHubRepoAdopterTest {
 		AdoptionStep toolchain = GitHubRepoAdopter.defaultSteps(withAssets()).get(0);
 		RecordingCommandRunner runner = RecordingCommandRunner.failingOn("gh", 127, "gh: not found");
 		assertThrows(AdoptionException.class, () -> toolchain.execute(context, runner));
+	}
+
+	/**
+	 * Which guard {@link io.github.adamw7.tools.adopt.step.EnforcerStep} wires in is the
+	 * checkout's build system to decide and is not known when the pipeline is assembled:
+	 * only a Maven project gets the {@code claude-code-enforcer}, while a Gradle one gets
+	 * a task and a project with no build file gets a workflow. A message naming the
+	 * enforcer therefore landed in the history of repositories given neither, claiming
+	 * something the diff beside it does not support.
+	 */
+	@Test
+	void theGuardCommitDoesNotNameAnArtifactOnlyTheMavenPathAdds() {
+		assertFalse(GitHubRepoAdopter.GUARD_COMMIT_MESSAGE.contains("claude-code-enforcer"),
+				"the guard commit must describe the guard, not one build system's artifact: "
+						+ GitHubRepoAdopter.GUARD_COMMIT_MESSAGE);
+		assertTrue(GitHubRepoAdopter.GUARD_COMMIT_MESSAGE.contains("CLAUDE.md guard"),
+				GitHubRepoAdopter.GUARD_COMMIT_MESSAGE);
 	}
 
 	private List<String> stepNames(AdoptionOptions options) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -151,6 +151,52 @@ class ClaudeMdConformerTest {
 	}
 
 	/**
+	 * The rule reads the title on the first line and nowhere else, so a document
+	 * carrying it lower down still needs one put in front. Prepending it left the file
+	 * with two {@code # CLAUDE.md} headings, which the rule accepts — it never looks
+	 * past the first line — so the duplicate was committed to the adopted repository
+	 * with nothing downstream to report it, and the reshape being idempotent meant a
+	 * re-adoption did not clear it either.
+	 */
+	@Test
+	void movesAMisplacedTitleUpRatherThanAddingASecondOne() {
+		String generated = "A preamble the generator wrote.\n\n# CLAUDE.md\n\nBody here.\n";
+		String conformed = conformer.conform(generated);
+		assertEquals(ClaudeMdConformer.TITLE, conformed.lines().findFirst().orElseThrow());
+		assertEquals(1, conformed.lines().filter(ClaudeMdConformer.TITLE::equals).count(),
+				"the title must be moved, not duplicated:\n" + conformed);
+		assertTrue(conformed.contains("A preamble the generator wrote."), "the preamble survives");
+		assertTrue(conformed.contains("Body here."), "the body survives");
+		assertEquals(conformed, conformer.conform(conformed), "the move must be idempotent");
+	}
+
+	/**
+	 * Only the document's own title moves. One inside a code sample belongs to the
+	 * sample — the rule reads it as code — so removing it would rewrite the sample.
+	 */
+	@Test
+	void leavesATitleInsideACodeFenceWhereItIs() {
+		String generated = "A preamble.\n\n```markdown\n# CLAUDE.md\n```\n";
+		String conformed = conformer.conform(generated);
+		assertEquals(ClaudeMdConformer.TITLE, conformed.lines().findFirst().orElseThrow());
+		assertEquals(2, conformed.lines().filter(ClaudeMdConformer.TITLE::equals).count(),
+				"the sample keeps its line and the document gains a title of its own:\n" + conformed);
+		assertTrue(conformed.contains("```markdown"), "the fence survives");
+	}
+
+	/**
+	 * The blank line below a moved title goes with it only when one above it is left
+	 * behind; otherwise the paragraph that followed the title would be pulled up
+	 * against the one before it and the two would read as a single paragraph.
+	 */
+	@Test
+	void doesNotRunTwoParagraphsTogetherWhenMovingTheTitle() {
+		String conformed = conformer.conform("A preamble.\n# CLAUDE.md\n\nBody here.\n");
+		assertTrue(conformed.contains("A preamble.\n\nBody here."),
+				"the two paragraphs must stay separate:\n" + conformed);
+	}
+
+	/**
 	 * The rule strips a leading byte-order mark before it reads the document, and
 	 * {@link String#strip()} does not — the mark is not whitespace. So a title the rule
 	 * was perfectly happy with read as absent here, and the reshape prepended a second

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -459,6 +459,36 @@ class CloneStepTest {
 		assertFalse(failure.getMessage().contains("warning"), failure.getMessage());
 	}
 
+	/**
+	 * A warning whose continuation is indented reaches the transcript as a line of
+	 * three spaces and then text. git never reports a path whose index and work tree
+	 * are both unchanged, so two blank status letters name no entry — but the pattern
+	 * accepted them, and the continuation's fourth character onwards was taken for a
+	 * path the adoption does not write, refusing the resume all the same.
+	 */
+	@Test
+	void resumesReusedCheckoutWhoseWarningWrapsOntoAnIndentedLine(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git", String.join(
+				System.lineSeparator(),
+				"warning: could not open directory 'vendor/':",
+				"   Permission denied",
+				"?? CLAUDE.md"));
+
+		step.execute(existing, runner);
+
+		assertEquals(3, runner.count());
+	}
+
+	/** A status letter in either column still names an entry, so real work is not waved through. */
+	@Test
+	void refusesReusedCheckoutChangedOnlyInTheWorkTree(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = answering("https://github.com/adamw7/tools.git", " M src/Main.java");
+
+		assertFailure(AdoptionException.class, () -> step.execute(existing, runner), "src/Main.java");
+	}
+
 	@Test
 	void isNamedClone() {
 		assertEquals("clone", step.name());

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
@@ -170,4 +170,51 @@ class GradleGuardInstallerTest {
 		assertFalse(installer.install(buildFile));
 		assertEquals(own, Files.readString(buildFile));
 	}
+
+	/**
+	 * A registered task nothing depends on is a guard the project's ordinary build
+	 * never runs, and {@link VerifyStep} cannot notice — it invokes the task directly,
+	 * so it passes either way and the adoption opens a pull request advertising a guard
+	 * the project does not have. An Android or aggregator root script, which routinely
+	 * declares a {@code clean} task and no lifecycle task at all, is exactly that case.
+	 */
+	@Test
+	void givesAProjectWithNoLifecycleTaskOneToHangTheGuardFrom(@TempDir Path directory) throws IOException {
+		Path buildFile = write(directory, "build.gradle", "task clean(type: Delete) { delete rootProject.buildDir }\n");
+		assertTrue(installer.install(buildFile));
+		String script = Files.readString(buildFile);
+		assertTrue(script.contains("tasks.matching { it.name == 'check' }.configureEach { it.dependsOn('"
+				+ GradleGuardInstaller.GUARD_TASK + "') }"), "the guard hangs from check when there is one: " + script);
+		assertTrue(script.contains("if (!tasks.names.contains('check'))"),
+				"and a check task is created when there is not: " + script);
+		assertTrue(script.contains("tasks.register('check') { it.dependsOn('" + GradleGuardInstaller.GUARD_TASK + "') }"),
+				"the created task must depend on the guard: " + script);
+	}
+
+	/**
+	 * The fallback registration waits for {@code afterEvaluate} because the name has to
+	 * be free: claiming {@code check} while the script is still being read would collide
+	 * with a plugin applied below the appended block and fail the whole build.
+	 */
+	@Test
+	void defersTheFallbackRegistrationUntilTheScriptHasBeenEvaluated(@TempDir Path directory) throws IOException {
+		Path buildFile = write(directory, "build.gradle", "plugins { id 'java' }\n");
+		installer.install(buildFile);
+		String script = Files.readString(buildFile);
+		assertTrue(script.indexOf("project.afterEvaluate") < script.indexOf("tasks.register('check')"),
+				"the fallback must be registered inside afterEvaluate: " + script);
+	}
+
+	@Test
+	void hangsTheKotlinGuardFromCheckAndCreatesOneWhenAbsent(@TempDir Path directory) throws IOException {
+		Path buildFile = write(directory, "build.gradle.kts", "plugins { java }\n");
+		assertTrue(installer.install(buildFile));
+		String script = Files.readString(buildFile);
+		assertTrue(script.contains("tasks.matching { it.name == \"check\" }.configureEach { dependsOn(\""
+				+ GradleGuardInstaller.GUARD_TASK + "\") }"), "the guard hangs from check: " + script);
+		assertTrue(script.contains("if (!tasks.names.contains(\"check\"))"),
+				"and a check task is created when there is not: " + script);
+		assertTrue(script.contains("tasks.register(\"check\") { dependsOn(\"" + GradleGuardInstaller.GUARD_TASK
+				+ "\") }"), "the created task must depend on the guard: " + script);
+	}
 }

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -630,7 +630,7 @@ sequenceDiagram
         A->>W: conform CLAUDE.md, add AGENTS.md
         A->>R: commit "Adopt Claude Code: add CLAUDE.md"
         A->>W: enforcer — wire the guard into the build
-        A->>R: commit "Add claude-code-enforcer to the build"
+        A->>R: commit "Adopt Claude Code: add the CLAUDE.md guard"
         opt --assets
             A->>W: assets — .claude/settings.json, hook, .mcp.json, workflow
             A->>R: commit "Add Claude Code configuration assets"


### PR DESCRIPTION
The adoption could commit a CLAUDE.md carrying two titles, install a
Gradle guard nothing runs, and label the guard commit after an artifact
only the Maven path adds — none of which anything downstream reported.

- ClaudeMdConformer: move a misplaced `# CLAUDE.md` to the first line
  instead of prepending a second one. The rule only reads the first
  line, so the duplicate was accepted, committed to the adopted
  repository, and left there by a re-adoption. A title inside a code
  sample stays where it is, and the blank line below a moved title goes
  with it only when that cannot run two paragraphs together.

- GradleGuardInstaller: give a project with no `check` task one to hang
  the guard from, registered in `afterEvaluate` so the name is free.
  A registered task nothing depends on never runs, and VerifyStep
  invokes it directly, so the pull request advertised a guard the
  project does not have — the outcome PomEnforcerInstaller refuses to
  produce on the Maven path. An Android or aggregator root script,
  which declares only `clean`, is exactly that case; applying Gradle's
  `base` plugin instead would collide with that `clean`.

- GitHubRepoAdopter: name the guard commit after the guard rather than
  after claude-code-enforcer, which only a Maven project is given.

- CloneStep: require a status letter in one of porcelain's two columns.
  Accepting two spaces let any line indented by three of them through,
  so an indented warning continuation was read as an entry naming a
  path the adoption does not write, refusing a resume over a change the
  checkout does not have.

- CliArguments: the repository list is in command-line order, not the
  positional first; say so, and pin it with a case that opens with a
  flag.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015ZzMrcu3hSbasx5btP3R8K