### PR TITLE
refactor(claude-code-enforcer): share the helpers the rules were repeating

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javax.inject.Named;
 
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 import io.github.adamw7.tools.enforcer.text.NameConvention;
 
 /**
@@ -50,7 +51,7 @@ public class CommandFormatRule extends DefinitionFormatRule {
 
 	/** A command answers to its file name, so the convention check compares that name only to itself. */
 	private void collectNamedViolations(File command, String content, List<String> violations) {
-		String baseName = DefinitionFiles.baseName(command);
+		String baseName = ProjectFiles.markdownBaseName(command);
 		NameConvention.collect(baseName, baseName, command.toString(), violations);
 		frontMatterOf(content, command, violations).ifPresent(this::collectFrontMatterViolations);
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFiles.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFiles.java
@@ -1,62 +1,27 @@
 package io.github.adamw7.tools.enforcer.definition;
 
 import java.io.File;
-import java.util.Arrays;
-
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 /**
- * Shared file-system helpers for the definition rules, which all scan a
- * {@code .claude} directory of Markdown definitions. Centralises the
- * {@code .md} handling, the null-safe {@link File#listFiles} wrappers and the
- * "directory must exist" check, so each rule keeps only its own validation
- * logic.
+ * What a skill looks like on disk. A skill is the one Claude Code definition that
+ * is a directory rather than a file, so the {@code SKILL.md} inside it has to be
+ * named by both rules that walk skills — {@link SkillFilesExistRule}, which
+ * validates one, and {@link MultiDefinitionRule}, which visits every definition of
+ * every kind — and naming it here keeps the two from drifting apart.
  * <p>
- * Both listing helpers return their entries sorted by natural {@link File}
- * order. {@link File#listFiles} yields entries in an unspecified,
- * filesystem-dependent order, which would let the rules built on these helpers
- * report violations in a different order run-to-run; sorting here makes every
- * rule's output — and the HTML report — stable and diffable.
+ * The listing, {@code .md} and directory-existence helpers these rules also use
+ * are shared with the rest of the module and live in
+ * {@link io.github.adamw7.tools.enforcer.rule.ProjectFiles}.
  */
 final class DefinitionFiles {
 
-	private static final String MARKDOWN_SUFFIX = ".md";
+	static final String SKILL_FILE_NAME = "SKILL.md";
 
 	private DefinitionFiles() {
 	}
 
-	/** Fails when a configured directory is missing, which is a build-setup mistake. */
-	static void verifyDirectory(File directory, String label) throws EnforcerRuleException {
-		if (!directory.isDirectory()) {
-			throw new EnforcerRuleException(label + " directory does not exist at " + directory);
-		}
-	}
-
-	/** The {@code *.md} files directly in {@code directory}, sorted, never null. */
-	static File[] markdownFiles(File directory) {
-		return sorted(directory.listFiles(DefinitionFiles::isMarkdownFile));
-	}
-
-	/** The immediate subdirectories of {@code directory}, sorted, never null. */
-	static File[] subdirectories(File directory) {
-		return sorted(directory.listFiles(File::isDirectory));
-	}
-
-	private static File[] sorted(File[] files) {
-		if (files == null) {
-			return new File[0];
-		}
-		Arrays.sort(files);
-		return files;
-	}
-
-	/** The file name with the {@code .md} suffix stripped. */
-	static String baseName(File markdown) {
-		String name = markdown.getName();
-		return name.substring(0, name.length() - MARKDOWN_SUFFIX.length());
-	}
-
-	private static boolean isMarkdownFile(File file) {
-		return file.isFile() && file.getName().endsWith(MARKDOWN_SUFFIX);
+	/** The definition a skill directory carries. */
+	static File skillFile(File skillDirectory) {
+		return new File(skillDirectory, SKILL_FILE_NAME);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFormatRule.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 import io.github.adamw7.tools.enforcer.text.FrontMatter;
 
 /**
@@ -59,7 +60,7 @@ abstract class DefinitionFormatRule extends ClaudeCodeEnforcerRule {
 	public final void execute() throws EnforcerRuleException {
 		File directory = definitionDir();
 		requireConfigured(directory, naming.directoryParameter());
-		DefinitionFiles.verifyDirectory(directory, naming.directoryLabel());
+		ProjectFiles.requireDirectory(directory, naming.directoryLabel());
 		List<String> violations = new ArrayList<>();
 		for (File entry : entriesIn(directory)) {
 			collectEntryViolations(entry, violations);
@@ -76,8 +77,8 @@ abstract class DefinitionFormatRule extends ClaudeCodeEnforcerRule {
 	 * definition is a directory instead — a skill, carrying a {@code SKILL.md} —
 	 * says so by overriding.
 	 */
-	protected File[] entriesIn(File directory) {
-		return DefinitionFiles.markdownFiles(directory);
+	protected List<File> entriesIn(File directory) {
+		return ProjectFiles.markdownFilesIn(directory);
 	}
 
 	/** Collects everything wrong with the definition that {@code entry} carries. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/MultiDefinitionRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/MultiDefinitionRule.java
@@ -5,6 +5,7 @@ import java.io.File;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 
 /**
  * Base for the enforcer rules that check a property across <em>every</em> Claude
@@ -20,8 +21,6 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
  * build-setup mistake rather than a content problem.
  */
 abstract class MultiDefinitionRule extends ClaudeCodeEnforcerRule {
-
-	private static final String SKILL_FILE_NAME = "SKILL.md";
 
 	/** The {@code .claude/commands} directory to scan. Injected from the rule configuration. */
 	private File commandsDir;
@@ -69,9 +68,9 @@ abstract class MultiDefinitionRule extends ClaudeCodeEnforcerRule {
 		if (directory == null) {
 			return;
 		}
-		DefinitionFiles.verifyDirectory(directory, label);
-		for (File markdown : DefinitionFiles.markdownFiles(directory)) {
-			visitor.visit(markdown, markdown, DefinitionFiles.baseName(markdown));
+		ProjectFiles.requireDirectory(directory, label);
+		for (File markdown : ProjectFiles.markdownFilesIn(directory)) {
+			visitor.visit(markdown, markdown, ProjectFiles.markdownBaseName(markdown));
 		}
 	}
 
@@ -79,9 +78,9 @@ abstract class MultiDefinitionRule extends ClaudeCodeEnforcerRule {
 		if (directory == null) {
 			return;
 		}
-		DefinitionFiles.verifyDirectory(directory, "Skills");
-		for (File skill : DefinitionFiles.subdirectories(directory)) {
-			visitor.visit(new File(skill, SKILL_FILE_NAME), skill, skill.getName());
+		ProjectFiles.requireDirectory(directory, "Skills");
+		for (File skill : ProjectFiles.subdirectoriesOf(directory)) {
+			visitor.visit(DefinitionFiles.skillFile(skill), skill, skill.getName());
 		}
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 import javax.inject.Named;
 
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 import io.github.adamw7.tools.enforcer.text.NameConvention;
 
 /**
@@ -27,7 +28,7 @@ import io.github.adamw7.tools.enforcer.text.NameConvention;
 @Named("skillFilesExist")
 public class SkillFilesExistRule extends DefinitionFormatRule {
 
-	private static final String SKILL_FILE_NAME = "SKILL.md";
+	private static final String SKILL_FILE_NAME = DefinitionFiles.SKILL_FILE_NAME;
 	private static final List<String> DEFAULT_REQUIRED_KEYS = List.of("name", "description");
 	private static final int DEFAULT_MAX_DESCRIPTION_LENGTH = 1024;
 
@@ -55,13 +56,13 @@ public class SkillFilesExistRule extends DefinitionFormatRule {
 
 	/** A skill is a directory, and the definition it carries is the {@code SKILL.md} inside it. */
 	@Override
-	protected File[] entriesIn(File directory) {
-		return DefinitionFiles.subdirectories(directory);
+	protected List<File> entriesIn(File directory) {
+		return ProjectFiles.subdirectoriesOf(directory);
 	}
 
 	@Override
 	protected void collectEntryViolations(File skillDirectory, List<String> violations) {
-		File skillFile = new File(skillDirectory, SKILL_FILE_NAME);
+		File skillFile = DefinitionFiles.skillFile(skillDirectory);
 		if (!skillFile.isFile()) {
 			violations.add("Missing " + SKILL_FILE_NAME + " in skill directory: " + skillDirectory);
 			return;

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 
 import javax.inject.Named;
 
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
+
 /**
  * Enforcer rule that fails the build when any sub-agent definition under the
  * configured agents directory is malformed. Every {@code *.md} file directly in
@@ -54,7 +56,7 @@ public class SubAgentFormatRule extends DefinitionFormatRule {
 	private void collectFrontMatterViolations(File definition, FrontMatterChecks checks) {
 		checks.requireKeys(Objects.requireNonNullElse(requiredKeys, DEFAULT_REQUIRED_KEYS));
 		checks.rejectDuplicateKeys();
-		checks.checkName(DefinitionFiles.baseName(definition));
+		checks.checkName(ProjectFiles.markdownBaseName(definition));
 		checks.checkDescription(0);
 		checks.checkModel(allowedModels);
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ConsistencyRule.java
@@ -1,0 +1,69 @@
+package io.github.adamw7.tools.enforcer.doc;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+
+/**
+ * Base for the rules that hold one document against another, by comparing what a
+ * list of single-group regular expressions captures from each. Both documents must
+ * exist, because a rule pointed at a file that is not there is a build-setup
+ * mistake; every disagreement is then reported together.
+ * <p>
+ * The two rules built on this are the same check with one flag between them —
+ * whether a fact stated in only one of the documents is a violation — so what they
+ * each supply is their pair of file parameters and the vocabulary in
+ * {@link Comparison}. The comparison itself lives in {@link DocumentConsistency}.
+ */
+abstract class ConsistencyRule extends ClaudeCodeEnforcerRule {
+
+	/**
+	 * How a rule names the pair it compares, and what it makes of a fact only one
+	 * of them states. The four values are one thing — the vocabulary of a
+	 * comparison — so they are supplied together rather than as four positional
+	 * arguments a reader has to count.
+	 *
+	 * @param firstParameter  the configuration parameter naming the first document,
+	 *                        e.g. {@code claudeMdFile}
+	 * @param secondParameter the configuration parameter naming the second document,
+	 *                        e.g. {@code agentsMdFile}
+	 * @param header          the header prefixing the grouped report
+	 * @param requireInBoth   whether a fact present in one document and absent from
+	 *                        the other is a violation: mirror documents require it in
+	 *                        both, while a curated view may simply not repeat it
+	 */
+	record Comparison(String firstParameter, String secondParameter, String header, boolean requireInBoth) {
+	}
+
+	private final Comparison comparison;
+
+	/** Regular expressions, each with one capturing group, whose captured value must agree. */
+	private List<String> consistentPatterns;
+
+	protected ConsistencyRule(Comparison comparison) {
+		this.comparison = comparison;
+	}
+
+	@Override
+	public final void execute() throws EnforcerRuleException {
+		File first = firstFile();
+		File second = secondFile();
+		requireDocument(first, comparison.firstParameter());
+		requireDocument(second, comparison.secondParameter());
+		report(comparison.header(), new DocumentConsistency(consistentPatterns, comparison.requireInBoth())
+				.violations(first, second));
+	}
+
+	/** The document a violation message names first. Injected from the rule configuration. */
+	protected abstract File firstFile();
+
+	/** The document a violation message names second. Injected from the rule configuration. */
+	protected abstract File secondFile();
+
+	void setConsistentPatterns(List<String> consistentPatterns) {
+		this.consistentPatterns = consistentPatterns;
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
@@ -1,7 +1,6 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +10,7 @@ import javax.inject.Named;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 import io.github.adamw7.tools.enforcer.rule.ScanTargets;
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
@@ -32,7 +32,6 @@ import io.github.adamw7.tools.enforcer.text.MarkdownText;
 @Named("contextBudget")
 public class ContextBudgetRule extends ClaudeCodeEnforcerRule {
 
-	private static final String MARKDOWN_EXTENSION = ".md";
 	private static final int CHARS_PER_TOKEN = 4;
 
 	/** Files that must fit the budget. Each configured file must exist. */
@@ -59,7 +58,7 @@ public class ContextBudgetRule extends ClaudeCodeEnforcerRule {
 			requireExists(file, file.getName());
 		}
 		List<String> violations = new ArrayList<>();
-		for (File file : targets.allFiles(ContextBudgetRule::isMarkdown)) {
+		for (File file : targets.allFiles(ProjectFiles::isMarkdown)) {
 			collectBudgetViolations(file, violations);
 		}
 		report("Context budget exceeded:", violations);
@@ -77,10 +76,6 @@ public class ContextBudgetRule extends ClaudeCodeEnforcerRule {
 		if (maxBytes <= 0 && maxLines <= 0 && maxTokens <= 0) {
 			throw new EnforcerRuleException("Configure at least one of maxBytes, maxLines, or maxTokens");
 		}
-	}
-
-	private static boolean isMarkdown(Path path) {
-		return path.getFileName().toString().endsWith(MARKDOWN_EXTENSION);
 	}
 
 	private void collectBudgetViolations(File file, List<String> violations) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRule.java
@@ -1,13 +1,8 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import java.io.File;
-import java.util.List;
 
 import javax.inject.Named;
-
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-
-import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 
 /**
  * Enforcer rule that keeps two documents from contradicting each other. Because
@@ -22,7 +17,7 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
  * are reported together.
  */
 @Named("crossDocConsistency")
-public class CrossDocConsistencyRule extends ClaudeCodeEnforcerRule {
+public class CrossDocConsistencyRule extends ConsistencyRule {
 
 	/** The first document to compare. Injected from the rule configuration. */
 	private File claudeMdFile;
@@ -30,15 +25,19 @@ public class CrossDocConsistencyRule extends ClaudeCodeEnforcerRule {
 	/** The second document to compare. Injected from the rule configuration. */
 	private File agentsMdFile;
 
-	/** Regular expressions, each with one capturing group, whose captured value must agree. */
-	private List<String> consistentPatterns;
+	/** These are mirror documents, so a fact one states and the other omits is a mismatch. */
+	public CrossDocConsistencyRule() {
+		super(new Comparison("claudeMdFile", "agentsMdFile", "Documents are inconsistent:", true));
+	}
 
 	@Override
-	public void execute() throws EnforcerRuleException {
-		requireDocument(claudeMdFile, "claudeMdFile");
-		requireDocument(agentsMdFile, "agentsMdFile");
-		report("Documents are inconsistent:",
-				new DocumentConsistency(consistentPatterns, true).violations(claudeMdFile, agentsMdFile));
+	protected File firstFile() {
+		return claudeMdFile;
+	}
+
+	@Override
+	protected File secondFile() {
+		return agentsMdFile;
 	}
 
 	void setClaudeMdFile(File claudeMdFile) {
@@ -47,9 +46,5 @@ public class CrossDocConsistencyRule extends ClaudeCodeEnforcerRule {
 
 	void setAgentsMdFile(File agentsMdFile) {
 		this.agentsMdFile = agentsMdFile;
-	}
-
-	void setConsistentPatterns(List<String> consistentPatterns) {
-		this.consistentPatterns = consistentPatterns;
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
@@ -80,7 +81,7 @@ final class ImportGraph {
 
 	/** The imports {@code file} declares, in document order, or none when it was never reached. */
 	List<Reference> importsOf(File file) {
-		return references.getOrDefault(normalized(file), List.of());
+		return references.getOrDefault(ProjectFiles.normalized(file), List.of());
 	}
 
 	/**
@@ -88,18 +89,13 @@ final class ImportGraph {
 	 * when no chain of imports reaches it.
 	 */
 	int hopsTo(File file) {
-		return hops.getOrDefault(normalized(file), Integer.MAX_VALUE);
-	}
-
-	/** The absolute, symlink-free-of-dot-segments path a file is keyed by. */
-	static Path normalized(File file) {
-		return file.toPath().toAbsolutePath().normalize();
+		return hops.getOrDefault(ProjectFiles.normalized(file), Integer.MAX_VALUE);
 	}
 
 	/** Breadth-first, so a file is first reached by its shortest chain of imports. */
 	private void explore(File root) {
 		Deque<File> queue = new ArrayDeque<>();
-		hops.put(normalized(root), 0);
+		hops.put(ProjectFiles.normalized(root), 0);
 		queue.add(root);
 		while (!queue.isEmpty()) {
 			expand(queue.poll(), queue);
@@ -107,7 +103,7 @@ final class ImportGraph {
 	}
 
 	private void expand(File file, Deque<File> queue) {
-		Path path = normalized(file);
+		Path path = ProjectFiles.normalized(file);
 		List<Reference> found = referencesIn(file);
 		references.put(path, found);
 		int depth = hops.get(path);
@@ -118,7 +114,7 @@ final class ImportGraph {
 
 	/** A target is queued once, at the first — and so shortest — depth it is reached by. */
 	private void enqueue(Reference reference, int depth, Deque<File> queue) {
-		Path path = normalized(reference.target());
+		Path path = ProjectFiles.normalized(reference.target());
 		if (reference.target().isFile() && !hops.containsKey(path)) {
 			hops.put(path, depth);
 			queue.add(reference.target());
@@ -189,7 +185,7 @@ final class ImportGraph {
 	 * to be started on.
 	 */
 	private File rootedAt(File file, String imported) {
-		return normalized(file).getRoot().resolve(imported.substring(1)).toFile();
+		return ProjectFiles.normalized(file).getRoot().resolve(imported.substring(1)).toFile();
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -15,6 +15,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.doc.ImportGraph.Reference;
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 
 /**
  * Enforcer rule that validates the {@code @path} memory imports of
@@ -81,7 +82,7 @@ public class MemoryImportsRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private void scan(File file, Traversal traversal) {
-		Path path = ImportGraph.normalized(file);
+		Path path = ProjectFiles.normalized(file);
 		traversal.scanned().add(path);
 		traversal.chain().push(path);
 		for (Reference reference : traversal.graph().importsOf(file)) {
@@ -91,7 +92,7 @@ public class MemoryImportsRule extends ClaudeCodeEnforcerRule {
 	}
 
 	private void checkImport(File file, Reference reference, Traversal traversal) {
-		Path path = ImportGraph.normalized(reference.target());
+		Path path = ProjectFiles.normalized(reference.target());
 		if (traversal.chain().contains(path)) {
 			traversal.violations().add(file + " has a circular import: @" + reference.text());
 		} else if (!reference.target().isFile()) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRule.java
@@ -1,13 +1,8 @@
 package io.github.adamw7.tools.enforcer.doc;
 
 import java.io.File;
-import java.util.List;
 
 import javax.inject.Named;
-
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-
-import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 
 /**
  * Enforcer rule that keeps the README from drifting away from the agent docs.
@@ -22,7 +17,7 @@ import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
  * version. All mismatches are reported together.
  */
 @Named("readmeConsistency")
-public class ReadmeConsistencyRule extends ClaudeCodeEnforcerRule {
+public class ReadmeConsistencyRule extends ConsistencyRule {
 
 	/** The README under review. Injected from the rule configuration. */
 	private File readmeFile;
@@ -30,15 +25,19 @@ public class ReadmeConsistencyRule extends ClaudeCodeEnforcerRule {
 	/** The agent docs treated as the source of truth. Injected from the rule configuration. */
 	private File agentDocFile;
 
-	/** Regular expressions, each with one capturing group, whose captured value must agree. */
-	private List<String> consistentPatterns;
+	/** A curated view may leave a fact out, so only a value present in both and disagreeing fails. */
+	public ReadmeConsistencyRule() {
+		super(new Comparison("readmeFile", "agentDocFile", "README has drifted from the agent docs:", false));
+	}
 
 	@Override
-	public void execute() throws EnforcerRuleException {
-		requireDocument(readmeFile, "readmeFile");
-		requireDocument(agentDocFile, "agentDocFile");
-		report("README has drifted from the agent docs:",
-				new DocumentConsistency(consistentPatterns, false).violations(readmeFile, agentDocFile));
+	protected File firstFile() {
+		return readmeFile;
+	}
+
+	@Override
+	protected File secondFile() {
+		return agentDocFile;
 	}
 
 	void setReadmeFile(File readmeFile) {
@@ -47,9 +46,5 @@ public class ReadmeConsistencyRule extends ClaudeCodeEnforcerRule {
 
 	void setAgentDocFile(File agentDocFile) {
 		this.agentDocFile = agentDocFile;
-	}
-
-	void setConsistentPatterns(List<String> consistentPatterns) {
-		this.consistentPatterns = consistentPatterns;
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
@@ -79,17 +79,9 @@ public class McpConfigFormatRule extends JsonFileRule {
 
 	@Override
 	protected void collectViolations(JsonNode mcp, List<String> violations) {
-		if (!mcp.has(MCP_SERVERS_KEY)) {
-			return;
-		}
-		JsonNode servers = JsonNodes.objectAt(mcp, MCP_SERVERS_KEY);
-		if (servers == null) {
-			violations.add("mcp.json 'mcpServers' must be a JSON object");
-			return;
-		}
-		for (String name : JsonNodes.fieldNames(servers)) {
-			collectServerViolations(name, JsonNodes.objectAt(servers, name), violations);
-		}
+		section(mcp, MCP_SERVERS_KEY, violations)
+				.ifPresent(servers -> McpServers.forEach(servers,
+						(name, server) -> collectServerViolations(name, server, violations)));
 	}
 
 	private void collectServerViolations(String name, JsonNode server, List<String> violations) {
@@ -162,9 +154,8 @@ public class McpConfigFormatRule extends JsonFileRule {
 		return EXPANSION.matcher(url).find();
 	}
 
-	/** Every violation names the server whose entry is malformed. */
 	private void add(String name, String problem, List<String> violations) {
-		violations.add("mcp.json server '" + name + "' " + problem);
+		violations.add(McpServers.problem(name, problem));
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServers.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServers.java
@@ -1,0 +1,39 @@
+package io.github.adamw7.tools.enforcer.mcp;
+
+import java.util.function.BiConsumer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+
+/**
+ * The {@code mcpServers} vocabulary both {@code .mcp.json} rules read: how the
+ * declared servers are walked, and how a violation names the one it found. The two
+ * rules check different things about a server — {@link McpServersValidRule} its
+ * transport, {@link McpConfigFormatRule} the fields around it — but they address
+ * the same section the same way, so the traversal and the message prefix live here
+ * rather than once in each.
+ */
+final class McpServers {
+
+	private McpServers() {
+	}
+
+	/**
+	 * Hands each declared server to {@code check}, by name. An entry that is not a
+	 * JSON object arrives as {@code null}, since what to say about one differs
+	 * between the rules: a malformed entry is a violation to the rule that validates
+	 * the transport, and nothing to say for the rule that validates optional fields
+	 * the entry cannot have.
+	 */
+	static void forEach(JsonNode servers, BiConsumer<String, JsonNode> check) {
+		for (String name : JsonNodes.fieldNames(servers)) {
+			check.accept(name, JsonNodes.objectAt(servers, name));
+		}
+	}
+
+	/** Every violation names the server whose entry is malformed. */
+	static String problem(String name, String problem) {
+		return "mcp.json server '" + name + "' " + problem;
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
@@ -73,9 +73,7 @@ public class McpServersValidRule extends JsonFileRule {
 			violations.add("mcp.json is missing the 'mcpServers' object");
 			return;
 		}
-		for (String name : JsonNodes.fieldNames(servers)) {
-			collectServerViolations(name, JsonNodes.objectAt(servers, name), violations);
-		}
+		McpServers.forEach(servers, (name, server) -> collectServerViolations(name, server, violations));
 		Violations.each(requiredServers, name -> !servers.has(name),
 				name -> "mcp.json is missing required server: " + name, violations);
 		Violations.each(forbiddenServers, servers::has,
@@ -124,9 +122,8 @@ public class McpServersValidRule extends JsonFileRule {
 		}
 	}
 
-	/** Every violation names the server whose entry is malformed. */
 	private void add(String name, String problem, List<String> violations) {
-		violations.add("mcp.json server '" + name + "' " + problem);
+		violations.add(McpServers.problem(name, problem));
 	}
 
 	void setMcpFile(File mcpFile) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRule.java
@@ -19,6 +19,7 @@ import javax.inject.Named;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 import io.github.adamw7.tools.enforcer.rule.ScanTargets;
 import io.github.adamw7.tools.enforcer.rule.Violations;
 import io.github.adamw7.tools.enforcer.text.FrontMatter;
@@ -63,7 +64,6 @@ public class OkfBundleFormatRule extends ClaudeCodeEnforcerRule {
 
 	private static final String INDEX = "index.md";
 	private static final String LOG = "log.md";
-	private static final String MARKDOWN_SUFFIX = ".md";
 	private static final String TYPE_KEY = "type";
 	private static final String STATUS_KEY = "status";
 	private static final String STALE_AFTER_KEY = "stale_after";
@@ -133,7 +133,7 @@ public class OkfBundleFormatRule extends ClaudeCodeEnforcerRule {
 
 	private List<File> markdownFiles() {
 		return new ScanTargets(List.of(), List.of(bundleDir))
-				.filesInDirectories(path -> path.getFileName().toString().endsWith(MARKDOWN_SUFFIX));
+				.filesInDirectories(ProjectFiles::isMarkdown);
 	}
 
 	private void collectDocumentViolations(File document, List<String> violations) {
@@ -310,8 +310,8 @@ public class OkfBundleFormatRule extends ClaudeCodeEnforcerRule {
 
 	/** Bundle-relative and always {@code /}-separated, so a message reads the same on every platform. */
 	private String relativePath(File document) {
-		return bundleDir.toPath().toAbsolutePath().normalize()
-				.relativize(document.toPath().toAbsolutePath().normalize())
+		return ProjectFiles.normalized(bundleDir)
+				.relativize(ProjectFiles.normalized(document))
 				.toString().replace(File.separator, SEPARATOR);
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.enforcer.rule;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
@@ -66,6 +67,28 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 	 * in {@code violations}.
 	 */
 	protected abstract void collectViolations(JsonNode root, List<String> violations) throws EnforcerRuleException;
+
+	/**
+	 * The optional object at {@code key}, for a rule that validates one section of a
+	 * larger file: empty when the file declares no such section, which is a pass, and
+	 * empty with a violation collected when it declares one that is not an object,
+	 * because a mistyped section must not slip through unvalidated.
+	 * <p>
+	 * The message names the file the way every other message from this rule does, so
+	 * the three rules that each validate a section of {@code settings.json} or
+	 * {@code .mcp.json} no longer spell the same sentence out three times.
+	 */
+	protected final Optional<JsonNode> section(JsonNode root, String key, List<String> violations) {
+		if (!root.has(key)) {
+			return Optional.empty();
+		}
+		JsonNode section = JsonNodes.objectAt(root, key);
+		if (section == null) {
+			violations.add(description + " '" + key + "' must be a JSON object");
+			return Optional.empty();
+		}
+		return Optional.of(section);
+	}
 
 	/**
 	 * The header that prefixes the grouped violation report. A rule that validates

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ProjectFiles.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ProjectFiles.java
@@ -1,0 +1,86 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * The file-system helpers the rules share: the null-safe {@link File#listFiles}
+ * wrappers, the {@code .md} handling, the "directory must exist" check, and the
+ * normalised path a file is keyed by. Every rule that scans a directory or
+ * compares two paths needs some of these, so they live here rather than once per
+ * feature package — the layering forbids those packages from reaching sideways
+ * into each other, so a helper only one of them owned had to be written twice.
+ * <p>
+ * Listings are returned sorted by natural {@link File} order.
+ * {@link File#listFiles} yields entries in an unspecified, filesystem-dependent
+ * order, which would let a rule report its violations differently run to run and
+ * so churn both the HTML report and a recorded baseline.
+ */
+public final class ProjectFiles {
+
+	private static final String MARKDOWN_SUFFIX = ".md";
+
+	private ProjectFiles() {
+	}
+
+	/** Fails when a configured directory is missing, which is a build-setup mistake. */
+	public static void requireDirectory(File directory, String label) throws EnforcerRuleException {
+		if (!directory.isDirectory()) {
+			throw new EnforcerRuleException(label + " directory does not exist at " + directory);
+		}
+	}
+
+	/** The regular files directly in {@code directory}, sorted; empty when it cannot be listed. */
+	public static List<File> filesIn(File directory) {
+		return listed(directory, File::isFile);
+	}
+
+	/** The {@code *.md} files directly in {@code directory}, sorted; empty when it cannot be listed. */
+	public static List<File> markdownFilesIn(File directory) {
+		return listed(directory, file -> file.isFile() && isMarkdown(file.toPath()));
+	}
+
+	/** The immediate subdirectories of {@code directory}, sorted; empty when it cannot be listed. */
+	public static List<File> subdirectoriesOf(File directory) {
+		return listed(directory, File::isDirectory);
+	}
+
+	/**
+	 * True when {@code path} names a Markdown document. Takes a {@link Path} because
+	 * that is what a {@link ScanTargets} predicate is handed, which is how the rules
+	 * that budget or scan a tree of documents select theirs.
+	 */
+	public static boolean isMarkdown(Path path) {
+		return path.getFileName().toString().endsWith(MARKDOWN_SUFFIX);
+	}
+
+	/** The file name with the {@code .md} suffix stripped. */
+	public static String markdownBaseName(File markdown) {
+		String name = markdown.getName();
+		return name.substring(0, name.length() - MARKDOWN_SUFFIX.length());
+	}
+
+	/** The absolute, dot-segment-free path a file is keyed and compared by. */
+	public static Path normalized(File file) {
+		return normalized(file.toPath());
+	}
+
+	/** The absolute, dot-segment-free path a file is keyed and compared by. */
+	public static Path normalized(Path path) {
+		return path.toAbsolutePath().normalize();
+	}
+
+	private static List<File> listed(File directory, FileFilter filter) {
+		File[] entries = directory.listFiles(filter);
+		if (entries == null) {
+			return List.of();
+		}
+		Arrays.sort(entries);
+		return List.of(entries);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ScanTargets.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ScanTargets.java
@@ -74,7 +74,7 @@ public final class ScanTargets {
 	}
 
 	private static Path key(File file) {
-		return file.toPath().toAbsolutePath().normalize();
+		return ProjectFiles.normalized(file);
 	}
 
 	/** The regular files under the configured directories that {@code accepted} matches. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -67,14 +67,10 @@ public class HookCommandsValidRule extends JsonFileRule {
 
 	@Override
 	protected void collectViolations(JsonNode settings, List<String> violations) {
-		if (!settings.has(HOOKS_KEY)) {
-			return;
-		}
-		JsonNode hooks = JsonNodes.objectAt(settings, HOOKS_KEY);
-		if (hooks == null) {
-			violations.add("settings.json 'hooks' must be a JSON object");
-			return;
-		}
+		section(settings, HOOKS_KEY, violations).ifPresent(hooks -> collectHookViolations(hooks, violations));
+	}
+
+	private void collectHookViolations(JsonNode hooks, List<String> violations) {
 		for (String event : JsonNodes.fieldNames(hooks)) {
 			collectEventViolations(event, JsonNodes.arrayAt(hooks, event), violations);
 		}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookWiring.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookWiring.java
@@ -1,0 +1,137 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
+import io.github.adamw7.tools.enforcer.text.MarkdownText;
+
+/**
+ * The cross-check between the scripts in a hooks directory and the command hooks
+ * {@code settings.json} wires to them: a hook that names a script the directory
+ * does not hold, and — when asked for — a script the directory holds that no hook
+ * names.
+ * <p>
+ * This is a second opinion on files {@link HooksFormatRule} has already read as
+ * scripts, and it answers a different question with different inputs: it reads
+ * settings.json, walks its hooks through {@link HookCommands}, and resolves what
+ * they name through {@link ClaudeProjectDir}. Keeping it beside the rule rather
+ * than inside it leaves the rule to the scripts themselves, and puts the path
+ * canonicalisation the containment check needs where nothing else has to read
+ * past it.
+ * <p>
+ * A settings.json that cannot be decoded is reported rather than thrown: the
+ * rules that own that file fail on it in their own right, so an undecodable one is
+ * never left unreported by this check declining to abort the build over it.
+ */
+final class HookWiring {
+
+	private final File hooksDir;
+	private final File settingsFile;
+	private final File projectDir;
+	private final boolean reportUnreferencedScripts;
+
+	HookWiring(File hooksDir, File settingsFile, File projectDir, boolean reportUnreferencedScripts) {
+		this.hooksDir = hooksDir;
+		this.settingsFile = settingsFile;
+		this.projectDir = projectDir;
+		this.reportUnreferencedScripts = reportUnreferencedScripts;
+	}
+
+	/** Collects everything the wiring between {@code scripts} and the settings file gets wrong. */
+	void collectViolations(List<File> scripts, List<String> violations) {
+		Optional<String> content = MarkdownText.readIfText(settingsFile);
+		if (content.isEmpty()) {
+			violations.add("settings.json cannot be read as text: " + settingsFile);
+			return;
+		}
+		JsonNode settings = JsonNodes.parseObject(content.get(), "settings.json", violations);
+		if (settings == null) {
+			return;
+		}
+		Set<Path> referenced = collectReferencedScripts(settings, violations);
+		collectUnreferencedScripts(scripts, referenced, violations);
+	}
+
+	private Set<Path> collectReferencedScripts(JsonNode settings, List<String> violations) {
+		Set<Path> referenced = new LinkedHashSet<>();
+		for (String command : HookCommands.from(settings)) {
+			addReferencedScript(command, referenced, violations);
+		}
+		return referenced;
+	}
+
+	private void addReferencedScript(String command, Set<Path> referenced, List<String> violations) {
+		for (Path script : scriptsInHooksDir(command)) {
+			referenced.add(script);
+			collectMissingScriptViolation(script, violations);
+		}
+	}
+
+	private void collectMissingScriptViolation(Path script, List<String> violations) {
+		if (!script.toFile().exists()) {
+			violations.add("settings.json references a missing hook script: " + script);
+		}
+	}
+
+	private void collectUnreferencedScripts(List<File> scripts, Set<Path> referenced, List<String> violations) {
+		if (!reportUnreferencedScripts) {
+			return;
+		}
+		for (File script : scripts) {
+			if (!referenced.contains(canonical(script.toPath()))) {
+				violations.add("hook script is not referenced by any settings.json hook: " + script);
+			}
+		}
+	}
+
+	/**
+	 * The absolute paths of the project-local scripts a command runs that land inside
+	 * the hooks directory. A path outside it belongs to another rule's concern, so it
+	 * is dropped rather than reported here.
+	 */
+	private List<Path> scriptsInHooksDir(String command) {
+		Path hooks = canonical(hooksDir.toPath());
+		return new ClaudeProjectDir(projectDir, settingsFile).scriptsIn(command).stream()
+				.map(expanded -> canonical(new File(expanded).toPath()))
+				.filter(resolved -> resolved.startsWith(hooks))
+				.toList();
+	}
+
+	/**
+	 * The real, symlink-resolved path of {@code path}. Symlinks are resolved on the
+	 * portion that exists on disk and the remaining names are appended, so a hook
+	 * script that is a symlink pointing outside the hooks directory no longer
+	 * satisfies the containment check by its lexical location alone, while a missing
+	 * script is still resolved beneath the real hooks directory so it is reported.
+	 */
+	private Path canonical(Path path) {
+		Path absolute = ProjectFiles.normalized(path);
+		Path existing = absolute;
+		while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
+			existing = existing.getParent();
+		}
+		if (existing == null) {
+			return absolute;
+		}
+		return realPath(existing).resolve(existing.relativize(absolute));
+	}
+
+	private Path realPath(Path path) {
+		try {
+			return path.toRealPath();
+		} catch (IOException e) {
+			return ProjectFiles.normalized(path);
+		}
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -1,24 +1,15 @@
 package io.github.adamw7.tools.enforcer.settings;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.inject.Named;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
-import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
@@ -140,102 +131,16 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 	 * A configured settings file that is not there is a build-setup mistake, so it
 	 * always fails, whatever the severity: reporting it as a violation let
 	 * {@code severity=warn} turn the whole wiring cross-check off silently, which is
-	 * the one outcome a rule must not have.
-	 * <p>
-	 * A file that is there but cannot be decoded is reported instead of thrown. This
-	 * rule reads settings.json as a second opinion on the scripts, and the rules that
-	 * own that file — {@code settingsJsonValid} and the two beside it — fail on it in
-	 * their own right, so an undecodable one is never left unreported by this one
-	 * declining to abort the build over it.
+	 * the one outcome a rule must not have. Everything the cross-check itself finds
+	 * is a violation, and is collected by {@link HookWiring}.
 	 */
 	private void collectWiringViolations(List<File> scripts, List<String> violations) throws EnforcerRuleException {
 		if (settingsFile == null) {
 			return;
 		}
 		requireExists(settingsFile, "settings.json");
-		Optional<String> content = MarkdownText.readIfText(settingsFile);
-		if (content.isEmpty()) {
-			violations.add("settings.json cannot be read as text: " + settingsFile);
-			return;
-		}
-		JsonNode settings = JsonNodes.parseObject(content.get(), "settings.json", violations);
-		if (settings == null) {
-			return;
-		}
-		Set<Path> referenced = collectReferencedScripts(settings, violations);
-		collectUnreferencedScripts(scripts, referenced, violations);
-	}
-
-	private Set<Path> collectReferencedScripts(JsonNode settings, List<String> violations) {
-		Set<Path> referenced = new LinkedHashSet<>();
-		for (String command : HookCommands.from(settings)) {
-			addReferencedScript(command, referenced, violations);
-		}
-		return referenced;
-	}
-
-	private void addReferencedScript(String command, Set<Path> referenced, List<String> violations) {
-		for (Path script : scriptsInHooksDir(command)) {
-			referenced.add(script);
-			collectMissingScriptViolation(script, violations);
-		}
-	}
-
-	private void collectMissingScriptViolation(Path script, List<String> violations) {
-		if (!script.toFile().exists()) {
-			violations.add("settings.json references a missing hook script: " + script);
-		}
-	}
-
-	private void collectUnreferencedScripts(List<File> scripts, Set<Path> referenced, List<String> violations) {
-		if (!reportUnreferencedScripts) {
-			return;
-		}
-		for (File script : scripts) {
-			if (!referenced.contains(canonical(script.toPath()))) {
-				violations.add("hook script is not referenced by any settings.json hook: " + script);
-			}
-		}
-	}
-
-	/**
-	 * The absolute paths of the project-local scripts a command runs that land inside
-	 * the hooks directory. A path outside it belongs to another rule's concern, so it
-	 * is dropped rather than reported here.
-	 */
-	private List<Path> scriptsInHooksDir(String command) {
-		Path hooks = canonical(hooksDir.toPath());
-		return new ClaudeProjectDir(projectDir, settingsFile).scriptsIn(command).stream()
-				.map(expanded -> canonical(new File(expanded).toPath()))
-				.filter(resolved -> resolved.startsWith(hooks))
-				.toList();
-	}
-
-	/**
-	 * The real, symlink-resolved path of {@code path}. Symlinks are resolved on the
-	 * portion that exists on disk and the remaining names are appended, so a hook
-	 * script that is a symlink pointing outside the hooks directory no longer
-	 * satisfies the containment check by its lexical location alone, while a missing
-	 * script is still resolved beneath the real hooks directory so it is reported.
-	 */
-	private Path canonical(Path path) {
-		Path absolute = ProjectFiles.normalized(path);
-		Path existing = absolute;
-		while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
-			existing = existing.getParent();
-		}
-		if (existing == null) {
-			return absolute;
-		}
-		return realPath(existing).resolve(existing.relativize(absolute));
-	}
-
-	private Path realPath(Path path) {
-		try {
-			return path.toRealPath();
-		} catch (IOException e) {
-			return ProjectFiles.normalized(path);
-		}
+		new HookWiring(hooksDir, settingsFile, projectDir, reportUnreferencedScripts)
+				.collectViolations(scripts, violations);
 	}
 
 	void setHooksDir(File hooksDir) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -6,7 +6,6 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
 
 /**
@@ -78,27 +78,12 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 	public void execute() throws EnforcerRuleException {
 		requireConfigured(hooksDir, "hooksDir");
 		List<String> violations = new ArrayList<>();
-		List<File> scripts = scriptFiles();
+		List<File> scripts = ProjectFiles.filesIn(hooksDir);
 		for (File script : scripts) {
 			collectScriptViolations(script, violations);
 		}
 		collectWiringViolations(scripts, violations);
 		report("Hook scripts are not well formed:", violations);
-	}
-
-	/**
-	 * The regular files directly under the hooks directory, sorted.
-	 * {@link File#listFiles} yields entries in an unspecified, filesystem-dependent
-	 * order, which would let this rule report the same violations in a different
-	 * order run-to-run and so churn both the HTML report and a recorded baseline.
-	 */
-	private List<File> scriptFiles() {
-		File[] files = hooksDir.listFiles(File::isFile);
-		if (files == null) {
-			return List.of();
-		}
-		Arrays.sort(files);
-		return List.of(files);
 	}
 
 	/**
@@ -234,7 +219,7 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 	 * script is still resolved beneath the real hooks directory so it is reported.
 	 */
 	private Path canonical(Path path) {
-		Path absolute = path.toAbsolutePath().normalize();
+		Path absolute = ProjectFiles.normalized(path);
 		Path existing = absolute;
 		while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
 			existing = existing.getParent();
@@ -249,7 +234,7 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 		try {
 			return path.toRealPath();
 		} catch (IOException e) {
-			return path.toAbsolutePath().normalize();
+			return ProjectFiles.normalized(path);
 		}
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
@@ -79,12 +79,8 @@ public class PermissionsFormatRule extends JsonFileRule {
 
 	@Override
 	protected void collectViolations(JsonNode settings, List<String> violations) throws EnforcerRuleException {
-		if (!settings.has(PERMISSIONS_KEY)) {
-			return;
-		}
-		JsonNode permissions = JsonNodes.objectAt(settings, PERMISSIONS_KEY);
+		JsonNode permissions = section(settings, PERMISSIONS_KEY, violations).orElse(null);
 		if (permissions == null) {
-			violations.add("settings.json 'permissions' must be a JSON object");
 			return;
 		}
 		for (String key : LIST_KEYS) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/DefinitionFilesTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/DefinitionFilesTest.java
@@ -1,18 +1,10 @@
 package io.github.adamw7.tools.enforcer.definition;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
-import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Comparator;
 
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -22,112 +14,14 @@ class DefinitionFilesTest {
 	private Path tempDir;
 
 	@Test
-	void verifyDirectoryPassesForAnExistingDirectory() {
-		assertDoesNotThrow(() -> DefinitionFiles.verifyDirectory(tempDir.toFile(), "Commands"));
+	void skillFileIsTheSkillMarkdownInsideTheSkillDirectory() {
+		File skillDirectory = tempDir.resolve("git-commit").toFile();
+
+		assertEquals(new File(skillDirectory, "SKILL.md"), DefinitionFiles.skillFile(skillDirectory));
 	}
 
 	@Test
-	void verifyDirectoryFailsWithLabelWhenDirectoryIsMissing() {
-		File absent = tempDir.resolve("absent").toFile();
-
-		assertFailure(EnforcerRuleException.class, () -> DefinitionFiles.verifyDirectory(absent, "Agents"),
-				"Agents directory does not exist at", absent.toString());
-	}
-
-	@Test
-	void verifyDirectoryFailsWhenPathIsAFileRatherThanADirectory() {
-		File file = writeString(tempDir.resolve("review.md"), "body").toFile();
-
-		assertFailure(EnforcerRuleException.class, () -> DefinitionFiles.verifyDirectory(file, "Skills"),
-				"Skills directory does not exist at");
-	}
-
-	@Test
-	void markdownFilesReturnsOnlyMarkdownFiles() {
-		writeString(tempDir.resolve("review.md"), "body");
-		writeString(tempDir.resolve("commit.md"), "body");
-		writeString(tempDir.resolve("notes.txt"), "ignored");
-
-		assertArrayEquals(new String[] { "commit.md", "review.md" }, sortedNames(DefinitionFiles.markdownFiles(tempDir.toFile())));
-	}
-
-	@Test
-	void markdownFilesExcludesSubdirectoriesEvenWhenNamedLikeMarkdown() {
-		createDirectory(tempDir.resolve("nested.md"));
-		writeString(tempDir.resolve("real.md"), "body");
-
-		assertArrayEquals(new String[] { "real.md" }, sortedNames(DefinitionFiles.markdownFiles(tempDir.toFile())));
-	}
-
-	@Test
-	void markdownFilesReturnsResultsSortedByName() {
-		writeString(tempDir.resolve("review.md"), "body");
-		writeString(tempDir.resolve("apply.md"), "body");
-		writeString(tempDir.resolve("commit.md"), "body");
-
-		assertArrayEquals(new String[] { "apply.md", "commit.md", "review.md" },
-				names(DefinitionFiles.markdownFiles(tempDir.toFile())));
-	}
-
-	@Test
-	void markdownFilesReturnsEmptyArrayForAnEmptyDirectory() {
-		assertEquals(0, DefinitionFiles.markdownFiles(tempDir.toFile()).length);
-	}
-
-	@Test
-	void markdownFilesReturnsEmptyArrayWhenPathIsNotAListableDirectory() {
-		File file = writeString(tempDir.resolve("review.md"), "body").toFile();
-
-		assertArrayEquals(new File[0], DefinitionFiles.markdownFiles(file));
-	}
-
-	@Test
-	void subdirectoriesReturnsOnlyDirectories() {
-		createDirectory(tempDir.resolve("commands"));
-		createDirectory(tempDir.resolve("agents"));
-		writeString(tempDir.resolve("review.md"), "body");
-
-		assertArrayEquals(new String[] { "agents", "commands" }, sortedNames(DefinitionFiles.subdirectories(tempDir.toFile())));
-	}
-
-	@Test
-	void subdirectoriesReturnsResultsSortedByName() {
-		createDirectory(tempDir.resolve("skills"));
-		createDirectory(tempDir.resolve("agents"));
-		createDirectory(tempDir.resolve("commands"));
-
-		assertArrayEquals(new String[] { "agents", "commands", "skills" },
-				names(DefinitionFiles.subdirectories(tempDir.toFile())));
-	}
-
-	@Test
-	void subdirectoriesReturnsEmptyArrayForAnEmptyDirectory() {
-		assertEquals(0, DefinitionFiles.subdirectories(tempDir.toFile()).length);
-	}
-
-	@Test
-	void subdirectoriesReturnsEmptyArrayWhenPathIsNotAListableDirectory() {
-		File file = writeString(tempDir.resolve("review.md"), "body").toFile();
-
-		assertArrayEquals(new File[0], DefinitionFiles.subdirectories(file));
-	}
-
-	@Test
-	void baseNameStripsTheMarkdownSuffix() {
-		assertEquals("git-commit", DefinitionFiles.baseName(tempDir.resolve("git-commit.md").toFile()));
-	}
-
-	@Test
-	void baseNameStripsOnlyTheTrailingSuffix() {
-		assertEquals("notes.md.backup", DefinitionFiles.baseName(tempDir.resolve("notes.md.backup.md").toFile()));
-	}
-
-	private static String[] sortedNames(File[] files) {
-		return Arrays.stream(files).map(File::getName).sorted(Comparator.naturalOrder()).toArray(String[]::new);
-	}
-
-	/** Names in the array's own order, so a test can assert the helper's sorting rather than re-sort it. */
-	private static String[] names(File[] files) {
-		return Arrays.stream(files).map(File::getName).toArray(String[]::new);
+	void skillFileNamesTheDefinitionEveryRuleWalkingSkillsLooksFor() {
+		assertEquals("SKILL.md", DefinitionFiles.SKILL_FILE_NAME);
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.enforcer.doc.ImportGraph.Reference;
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 
 /**
  * Tests for the import graph behind {@link MemoryImportsRule}. The hop counts are
@@ -202,7 +203,7 @@ class ImportGraphTest {
 
 		// The root the importing file sits on, not the one the build was launched
 		// from — the two differ on a file system with more than one root.
-		assertEquals(tempDir.getRoot().resolve("elsewhere.md"), ImportGraph.normalized(target));
+		assertEquals(tempDir.getRoot().resolve("elsewhere.md"), ProjectFiles.normalized(target));
 	}
 
 	@Test
@@ -246,8 +247,8 @@ class ImportGraphTest {
 		File root = write("CLAUDE.md", "# CLAUDE.md\n");
 		File roundabout = new File(tempDir.toFile(), "docs/../CLAUDE.md");
 
-		assertEquals(ImportGraph.normalized(root), ImportGraph.normalized(roundabout));
-		assertFalse(roundabout.getPath().equals(ImportGraph.normalized(roundabout).toString()));
+		assertEquals(ProjectFiles.normalized(root), ProjectFiles.normalized(roundabout));
+		assertFalse(roundabout.getPath().equals(ProjectFiles.normalized(roundabout).toString()));
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ProjectFilesTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ProjectFilesTest.java
@@ -1,0 +1,179 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
+import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProjectFilesTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void requireDirectoryPassesForAnExistingDirectory() {
+		assertDoesNotThrow(() -> ProjectFiles.requireDirectory(tempDir.toFile(), "Commands"));
+	}
+
+	@Test
+	void requireDirectoryFailsWithLabelWhenDirectoryIsMissing() {
+		File absent = tempDir.resolve("absent").toFile();
+
+		assertFailure(EnforcerRuleException.class, () -> ProjectFiles.requireDirectory(absent, "Agents"),
+				"Agents directory does not exist at", absent.toString());
+	}
+
+	@Test
+	void requireDirectoryFailsWhenPathIsAFileRatherThanADirectory() {
+		File file = writeString(tempDir.resolve("review.md"), "body").toFile();
+
+		assertFailure(EnforcerRuleException.class, () -> ProjectFiles.requireDirectory(file, "Skills"),
+				"Skills directory does not exist at");
+	}
+
+	@Test
+	void filesInReturnsOnlyRegularFiles() {
+		writeString(tempDir.resolve("session-start.sh"), "#!/bin/sh");
+		createDirectory(tempDir.resolve("nested"));
+
+		assertEquals(List.of("session-start.sh"), names(ProjectFiles.filesIn(tempDir.toFile())));
+	}
+
+	@Test
+	void filesInReturnsResultsSortedByName() {
+		writeString(tempDir.resolve("stop.sh"), "#!/bin/sh");
+		writeString(tempDir.resolve("audit.sh"), "#!/bin/sh");
+		writeString(tempDir.resolve("notify.sh"), "#!/bin/sh");
+
+		assertEquals(List.of("audit.sh", "notify.sh", "stop.sh"), names(ProjectFiles.filesIn(tempDir.toFile())));
+	}
+
+	@Test
+	void filesInReturnsEmptyListWhenPathIsNotAListableDirectory() {
+		File file = writeString(tempDir.resolve("review.md"), "body").toFile();
+
+		assertEquals(List.of(), ProjectFiles.filesIn(file));
+	}
+
+	@Test
+	void markdownFilesInReturnsOnlyMarkdownFiles() {
+		writeString(tempDir.resolve("review.md"), "body");
+		writeString(tempDir.resolve("commit.md"), "body");
+		writeString(tempDir.resolve("notes.txt"), "ignored");
+
+		assertEquals(List.of("commit.md", "review.md"), sortedNames(ProjectFiles.markdownFilesIn(tempDir.toFile())));
+	}
+
+	@Test
+	void markdownFilesInExcludesSubdirectoriesEvenWhenNamedLikeMarkdown() {
+		createDirectory(tempDir.resolve("nested.md"));
+		writeString(tempDir.resolve("real.md"), "body");
+
+		assertEquals(List.of("real.md"), sortedNames(ProjectFiles.markdownFilesIn(tempDir.toFile())));
+	}
+
+	@Test
+	void markdownFilesInReturnsResultsSortedByName() {
+		writeString(tempDir.resolve("review.md"), "body");
+		writeString(tempDir.resolve("apply.md"), "body");
+		writeString(tempDir.resolve("commit.md"), "body");
+
+		assertEquals(List.of("apply.md", "commit.md", "review.md"), names(ProjectFiles.markdownFilesIn(tempDir.toFile())));
+	}
+
+	@Test
+	void markdownFilesInReturnsEmptyListForAnEmptyDirectory() {
+		assertEquals(List.of(), ProjectFiles.markdownFilesIn(tempDir.toFile()));
+	}
+
+	@Test
+	void markdownFilesInReturnsEmptyListWhenPathIsNotAListableDirectory() {
+		File file = writeString(tempDir.resolve("review.md"), "body").toFile();
+
+		assertEquals(List.of(), ProjectFiles.markdownFilesIn(file));
+	}
+
+	@Test
+	void subdirectoriesOfReturnsOnlyDirectories() {
+		createDirectory(tempDir.resolve("commands"));
+		createDirectory(tempDir.resolve("agents"));
+		writeString(tempDir.resolve("review.md"), "body");
+
+		assertEquals(List.of("agents", "commands"), sortedNames(ProjectFiles.subdirectoriesOf(tempDir.toFile())));
+	}
+
+	@Test
+	void subdirectoriesOfReturnsResultsSortedByName() {
+		createDirectory(tempDir.resolve("skills"));
+		createDirectory(tempDir.resolve("agents"));
+		createDirectory(tempDir.resolve("commands"));
+
+		assertEquals(List.of("agents", "commands", "skills"), names(ProjectFiles.subdirectoriesOf(tempDir.toFile())));
+	}
+
+	@Test
+	void subdirectoriesOfReturnsEmptyListForAnEmptyDirectory() {
+		assertEquals(List.of(), ProjectFiles.subdirectoriesOf(tempDir.toFile()));
+	}
+
+	@Test
+	void subdirectoriesOfReturnsEmptyListWhenPathIsNotAListableDirectory() {
+		File file = writeString(tempDir.resolve("review.md"), "body").toFile();
+
+		assertEquals(List.of(), ProjectFiles.subdirectoriesOf(file));
+	}
+
+	@Test
+	void isMarkdownAcceptsAMarkdownPath() {
+		assertTrue(ProjectFiles.isMarkdown(tempDir.resolve("CLAUDE.md")));
+	}
+
+	@Test
+	void isMarkdownRejectsAPathWithAnotherExtension() {
+		assertFalse(ProjectFiles.isMarkdown(tempDir.resolve("settings.json")));
+	}
+
+	@Test
+	void markdownBaseNameStripsTheMarkdownSuffix() {
+		assertEquals("git-commit", ProjectFiles.markdownBaseName(tempDir.resolve("git-commit.md").toFile()));
+	}
+
+	@Test
+	void markdownBaseNameStripsOnlyTheTrailingSuffix() {
+		assertEquals("notes.md.backup", ProjectFiles.markdownBaseName(tempDir.resolve("notes.md.backup.md").toFile()));
+	}
+
+	@Test
+	void normalizedResolvesDotSegmentsToOneAbsolutePath() {
+		File roundabout = tempDir.resolve("nested").resolve("..").resolve("CLAUDE.md").toFile();
+
+		assertEquals(ProjectFiles.normalized(tempDir.resolve("CLAUDE.md").toFile()),
+				ProjectFiles.normalized(roundabout));
+	}
+
+	@Test
+	void normalizedMakesARelativePathAbsolute() {
+		assertTrue(ProjectFiles.normalized(new File("CLAUDE.md")).isAbsolute());
+	}
+
+	private static List<String> sortedNames(List<File> files) {
+		return names(files).stream().sorted(Comparator.naturalOrder()).toList();
+	}
+
+	/** Names in the list's own order, so a test can assert the helper's sorting rather than re-sort it. */
+	private static List<String> names(List<File> files) {
+		return files.stream().map(File::getName).toList();
+	}
+}


### PR DESCRIPTION
Four idioms were written out once per rule, in packages the layering keeps
from reaching sideways into each other, so each copy had to be maintained on
its own:

- the "optional JSON section that must be an object" preamble opened
  hookCommandsValid, permissionsFormat and mcpConfigFormat alike, spelling
  the same sentence out three times. JsonFileRule already holds the file
  description those messages interpolate, so it now offers section(...).
- the null-safe, sorted File#listFiles wrapper lived in both DefinitionFiles
  and HooksFormatRule, each carrying its own comment on why order stability
  matters.
- toPath().toAbsolutePath().normalize() appeared at five sites, twice as a
  map key under two different names.
- ".md" was declared three times, and the ScanTargets predicate selecting
  markdown documents twice.

These move into a new rule/ProjectFiles, the generalisation of the file-system
half of DefinitionFiles, which keeps only the SKILL.md a skill directory
carries. The two .mcp.json rules also had byte-identical server-message
helpers and the same traversal, now a package-private McpServers.

No behaviour change: every message, ordering and pass/fail outcome is the one
the rules produced before, and the *ITs still bind every rule and parameter in
a real Maven build.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LALkWhsNudsCvGrhsoxoQb