### PR TITLE
feat(adopt, claude-code-enforcer): say what a run actually did

### DIFF
--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -82,6 +82,23 @@ included. Preserve that when changing `BatchAdoption` or `Failures`.
 an `AdoptionOptions` (wrapping `PullRequestOptions`) that both entry points —
 `Main` and the MCP `AdoptTool` — hand to the pipeline factory.
 
+## Debugging a run: where the logging goes
+Two channels, from `adopt/src/main/resources/log4j2.properties`. The **console**
+(standard error, threshold-filtered to `info`) is progress: `Repository 2 of 5`,
+`Step 4/12: branch`, what each step cost, and the closing count of repositories
+that landed. **`logs/adopt.log`** adds the adoption's own `debug` —
+`io.github.adamw7.tools.adopt` is set to it while the root stays at `info`, so the
+embedded Spring Boot MCP server does not bury the trace — carrying every
+`git`/`claude`/`gh` invocation with its working directory, exit code and duration,
+plus the redacted transcript of the ones that failed.
+
+Reach for that file first when a run "did nothing": `runTolerating` swallows a
+non-zero exit by design, so the command trace is the only place a tolerated
+refusal is recorded. Durations come from `Elapsed`; log through it rather than
+formatting a `Duration` yourself. Anything reporting a command or its output goes
+through `CommandResult.describe()` / `redactedOutput()`, never the raw values — a
+clone URL's credentials come back in the tool's own error text.
+
 ## Testing
 - Step tests use a fake `CommandRunner`: **a test must never spawn a real
   process** (pinned by `TestConventionsArchitectureTest`).

--- a/.claude/skills/enforcer-rules/SKILL.md
+++ b/.claude/skills/enforcer-rules/SKILL.md
@@ -67,6 +67,15 @@ parsing again.
 | `requireConfigured` / `requireExists` / `requireDocument` | Missing parameter or file — always fails, whatever the severity |
 | `requireContent` | Read a required file and fail when blank |
 | `howToFix()` | Override to give the HTML report rule-specific remediation steps |
+| `log()` | Logging — **never `getLog()`**, which is null outside a Maven session |
+
+`report(...)` already debug-logs the rule, its configured input files and the
+violation count. Add a `log().debug(...)` of your own for what that cannot say:
+how much you scanned, or that you passed because an optional input was absent —
+otherwise a rule that checked nothing is indistinguishable from one that checked
+everything. maven-enforcer injects the logger and nothing else does, so `getLog()`
+is null in a unit test; `log()` falls back to a silent logger, which is what makes
+logging safe on any path.
 
 Shared configuration every rule inherits: `severity` (`error` default, `warn`
 logs only), `reportFile` (self-contained HTML), `baselineFile` +
@@ -102,8 +111,9 @@ untrusted text is fine; emitting a deliberate `\n` in a message is not.
   unchecked so a fixture reads as one expression.
 - Assert on the *message*, not just the throw: check
   `EnforcerRuleException#getMessage()` names the offending file and value.
-- `CapturingLogger` lets a test assert what `severity=warn` logged instead of
-  threw.
+- `CapturingLogger` records `warnings()`, `infos()` and `debugs()`, so a test can
+  assert what `severity=warn` logged instead of threw, and what the rule's debug
+  trace said it checked. Every level reports itself enabled.
 - Cover: passes when correct, fails per violation kind, passes on an empty
   directory, and the always-fails build-setup cases (missing parameter/file).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,16 @@ What is worth knowing before changing any of it:
   refused as an unknown option. It goes to the log, whose console appender writes
   to standard error, because the same jar is the MCP server and its stdio
   transport owns standard output.
+- **The console and the log file carry different things.** The console is
+  threshold-filtered to `info` and shows progress: the repository being adopted
+  and which of how many, `Step 4/12: branch`, what each step cost, and a closing
+  count of the repositories that landed. `logs/adopt.log` additionally carries the
+  adoption's own `debug` (`io.github.adamw7.tools.adopt` is set to it; the root
+  stays at `info` so the embedded Spring Boot MCP server does not bury it) —
+  every `git`/`claude`/`gh` invocation with its working directory, exit code and
+  duration, and the redacted transcript of the ones that failed. That trace exists
+  because a step may *tolerate* a non-zero exit, which otherwise leaves a run that
+  quietly did nothing looking exactly like one that did everything.
 
 An **MCP server** (`io.github.adamw7.tools.adopt.mcp`) exposes the pipeline as an
 `adopt_repo` tool answering with the JSON `AdoptionReport` (completed steps, the
@@ -676,6 +686,18 @@ together (never stopping at the first) and offers:
   Maven runs every module from wherever it was invoked, so without it the token
   falls back to the working directory and a baseline recorded from the root
   suppresses nothing when the build starts elsewhere.
+- **A debug trace of what each rule was pointed at** — `mvn -X` prints one line
+  per rule naming its configured input files and how many violations survived the
+  baseline, plus the scan counts (`Skills: checking 13 definition(s) in …`) and
+  the accepted absences (`mcp.json is absent at …; nothing to check`).
+  maven-enforcer's own verdict names only the class, so a rule that read a
+  document and one that passed because it was pointed at nothing read alike. Log
+  through the base class's `log()`, never `getLog()`: the enforcer injects a
+  logger and nothing else does, so `getLog()` is null wherever a rule is built
+  directly and `log()` falls back to a silent one.
+- **A `severity=warn` violation says it was tolerated** — the warning carries the
+  rule and its inputs and states that the build was not failed, so it is not read
+  as one more `[WARNING]` worded exactly like the failure it would have been.
 
 `claudeMdFormat` and `agentsMdFormat` share a `MarkdownFormatRule` base doing the
 existence, BOM, title and section checks, with optional `forbiddenTokens`,

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionReportWriter.java
@@ -3,6 +3,9 @@ package io.github.adamw7.tools.adopt;
 import java.nio.file.Path;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -26,6 +29,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class AdoptionReportWriter {
 
+	private static final Logger log = LogManager.getLogger(AdoptionReportWriter.class);
+
 	private final ObjectMapper mapper = new ObjectMapper();
 
 	public String toJson(List<AdoptionRun> runs) {
@@ -36,8 +41,16 @@ public class AdoptionReportWriter {
 		}
 	}
 
+	/**
+	 * The path is logged because a run that failed writes one too, and the operator
+	 * reading the failure on the console is the one who has to be told there is a
+	 * document saying how far it got. {@code --report} otherwise confirms nothing:
+	 * a run that stopped before the file was named looks exactly like one that
+	 * wrote it.
+	 */
 	public void write(Path file, List<AdoptionRun> runs) {
 		AdoptionFiles.write(file, toJson(runs), "the adoption report");
+		log.info("Wrote the adoption report to {}", file);
 	}
 
 	private ObjectNode toNode(List<AdoptionRun> runs) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -51,23 +52,52 @@ public final class BatchAdoption {
 	 * @return one run per repository, in the order the repositories were given
 	 */
 	public List<AdoptionRun> adoptAll(List<String> repositoryUrls, Checkouts checkouts) {
-		log.info("Adopting Claude Code into {} repositories", repositoryUrls.size());
-		return repositoryUrls.stream().map(url -> adoptOne(url, checkouts)).toList();
+		log.info("Adopting Claude Code into {} repositories on branch {}", repositoryUrls.size(),
+				checkouts.branchName());
+		Elapsed elapsed = Elapsed.started();
+		List<AdoptionRun> runs = IntStream.range(0, repositoryUrls.size())
+				.mapToObj(index -> adoptOne(repositoryUrls, index, checkouts))
+				.toList();
+		logSummary(runs, elapsed);
+		return runs;
 	}
 
 	/**
 	 * The URL is redacted up front so a repository that fails its claim — and so
 	 * never has a context to ask — is still reported without its credentials.
+	 *
+	 * <p>The repository is taken by position rather than by value so the line
+	 * announcing it can say which of how many it is. Every line below it names a
+	 * step, not a repository, and a batch of twenty is otherwise read by counting
+	 * the "Adopting Claude Code into ..." lines above wherever the reader is.
 	 */
-	private AdoptionRun adoptOne(String repositoryUrl, Checkouts checkouts) {
+	private AdoptionRun adoptOne(List<String> repositoryUrls, int index, Checkouts checkouts) {
+		String repositoryUrl = repositoryUrls.get(index);
 		AdoptionReport report = new AdoptionReport();
 		String displayUrl = Redaction.of(repositoryUrl);
+		log.info("Repository {} of {}: {}", index + 1, repositoryUrls.size(), displayUrl);
 		try {
 			adoption.adopt(checkouts.claim(repositoryUrl), report);
 		} catch (RuntimeException e) {
 			recordFailure(displayUrl, report, e);
 		}
 		return new AdoptionRun(displayUrl, checkouts.branchName(), report);
+	}
+
+	/**
+	 * Closes the batch with what the operator has to act on: how much of it landed,
+	 * what it cost, and — when some of it did not — which repositories to re-run.
+	 * A partly failed batch is the case this class exists to produce, and its
+	 * failures are scattered through however many repositories' worth of steps
+	 * separate them, so naming them together at the end is the difference between
+	 * reading the run and searching it.
+	 */
+	private void logSummary(List<AdoptionRun> runs, Elapsed elapsed) {
+		List<String> failed = runs.stream().filter(run -> !run.succeeded()).map(AdoptionRun::repositoryUrl).toList();
+		log.info("Adopted {} of {} repositories in {}", runs.size() - failed.size(), runs.size(), elapsed);
+		if (!failed.isEmpty()) {
+			log.warn("Adoption failed for {} of {} repositories: {}", failed.size(), runs.size(), failed);
+		}
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Elapsed.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Elapsed.java
@@ -1,0 +1,66 @@
+package io.github.adamw7.tools.adopt;
+
+import java.time.Duration;
+
+/**
+ * A stopwatch for the log: started when the work starts, and read as text when
+ * the line saying how it went is written. An adoption is a sequence of commands
+ * that each take between a millisecond and ten minutes, so how long a step took
+ * is the one fact a transcript of it cannot be reconstructed from — and the
+ * question an operator asks first of a run that felt slow.
+ *
+ * <p>Elapsed time is measured with {@link System#nanoTime()} rather than the wall
+ * clock, so a step's duration is not rewritten by a clock correction or a
+ * daylight-saving jump landing mid-command.
+ *
+ * <p>{@link #toString()} is what a log line interpolates, and it reads the
+ * stopwatch as it is called: {@link Duration#toString()} answers ISO-8601 —
+ * {@code PT4M12.317S} — which a reader scanning a run for the step that cost it
+ * has to decode before it means anything.
+ */
+public final class Elapsed {
+
+	private static final long MILLIS_PER_SECOND = 1000;
+	private static final long SECONDS_PER_MINUTE = 60;
+
+	private final long startedAtNanos;
+
+	private Elapsed(long startedAtNanos) {
+		this.startedAtNanos = startedAtNanos;
+	}
+
+	/** @return a stopwatch started now */
+	public static Elapsed started() {
+		return new Elapsed(System.nanoTime());
+	}
+
+	/** @return how long it has been since this stopwatch was started */
+	public Duration duration() {
+		return Duration.ofNanos(System.nanoTime() - startedAtNanos);
+	}
+
+	/** @return the elapsed time as a log line reads it, e.g. {@code 317ms}, {@code 42s} or {@code 4m 12s} */
+	@Override
+	public String toString() {
+		return describe(duration());
+	}
+
+	/**
+	 * Each magnitude is given the unit that carries the information at that scale.
+	 * A {@code git rev-parse} is worth a millisecond count, a {@code claude init}
+	 * is not — {@code 252317ms} says nothing {@code 4m 12s} does not say better —
+	 * and rounding the short commands to whole seconds would report every one of
+	 * them as {@code 0s}.
+	 */
+	static String describe(Duration duration) {
+		long millis = duration.toMillis();
+		if (millis < MILLIS_PER_SECOND) {
+			return millis + "ms";
+		}
+		long seconds = duration.toSeconds();
+		if (seconds < SECONDS_PER_MINUTE) {
+			return seconds + "s";
+		}
+		return duration.toMinutes() + "m " + seconds % SECONDS_PER_MINUTE + "s";
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -149,22 +149,38 @@ public class GitHubRepoAdopter {
 	 * @return the same report, once every step has completed
 	 */
 	public AdoptionReport adopt(AdoptionContext context, AdoptionReport report) {
-		log.info("Adopting Claude Code into {}", context.displayUrl());
-		for (AdoptionStep step : steps) {
-			runStep(step, context, report);
+		log.info("Adopting Claude Code into {} in {} steps", context.displayUrl(), steps.size());
+		Elapsed elapsed = Elapsed.started();
+		for (int index = 0; index < steps.size(); index++) {
+			runStep(steps.get(index), index + 1, context, report);
 		}
-		log.info("Adoption complete for {}", context.displayUrl());
+		log.info("Adoption complete for {} in {}", context.displayUrl(), elapsed);
 		return report;
 	}
 
-	private void runStep(AdoptionStep step, AdoptionContext context, AdoptionReport report) {
-		log.info("Step: {}", step.name());
+	/**
+	 * Each step is announced with its position in the pipeline and closed with what
+	 * it cost, because the two questions an operator has of a run that is still
+	 * going are how much of it is left and whether the step it is on is working or
+	 * stuck. The pipeline is assembled per run — an {@link AssetsStep} on request, no
+	 * publication steps on a dry run — so the count is the run's own, not a constant
+	 * a reader could have learnt once.
+	 *
+	 * <p>A failing step is named here as well, without its stack trace: the exception
+	 * carries the failure and {@link BatchAdoption} logs it once, but nothing in that
+	 * account says which stage produced it or how far it had got.
+	 */
+	private void runStep(AdoptionStep step, int ordinal, AdoptionContext context, AdoptionReport report) {
+		log.info("Step {}/{}: {}", ordinal, steps.size(), step.name());
+		Elapsed elapsed = Elapsed.started();
 		try {
 			step.execute(context, runner, report);
 		} catch (RuntimeException e) {
+			log.warn("Step {} failed after {}", step.name(), elapsed);
 			report.recordFailure(describe(step, e));
 			throw e;
 		}
+		log.info("Step {} completed in {}", step.name(), elapsed);
 		report.recordStep(step.name());
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -6,7 +6,11 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.Elapsed;
 import io.github.adamw7.tools.adopt.Redaction;
 
 /**
@@ -20,8 +24,18 @@ import io.github.adamw7.tools.adopt.Redaction;
  * <p>The child's standard input is closed as soon as it starts, so a tool that
  * reads from it — a {@code git} or {@code gh} credential prompt — sees
  * end-of-stream and fails fast instead of blocking until the timeout kills it.
+ *
+ * <p>Every command is traced at debug — what was run, where, how it exited and
+ * how long it took — because this is the one place the adoption learns anything
+ * from the outside world, and the steps above it report only the commands that
+ * stopped the run. A tolerated failure, a clone skipped because the checkout was
+ * already there, a step that decided it had nothing to do: none of those leave a
+ * trace anywhere else, so a run that did less than it was expected to reads
+ * exactly like one that did everything.
  */
 public class ProcessCommandRunner implements CommandRunner {
+
+	private static final Logger log = LogManager.getLogger(ProcessCommandRunner.class);
 
 	/**
 	 * How long a command may run when the caller names no timeout of its own. Sized
@@ -53,11 +67,36 @@ public class ProcessCommandRunner implements CommandRunner {
 
 	@Override
 	public CommandResult run(Path workingDirectory, List<String> command) {
+		log.debug("Running in {}: {}", workingDirectory, CommandResult.describe(command));
+		Elapsed elapsed = Elapsed.started();
 		ProcessBuilder builder = new ProcessBuilder(resolver.resolve(command))
 				.directory(workingDirectory.toFile())
 				.redirectErrorStream(true);
 		Process process = start(builder, command);
-		return awaitOrDestroy(process, command);
+		CommandResult result = awaitOrDestroy(process, command);
+		logOutcome(result, elapsed);
+		return result;
+	}
+
+	/**
+	 * The transcript of a command that exited non-zero is logged here as well as
+	 * being handed back, because whether it reaches a message at all is the
+	 * caller's decision: a step running through
+	 * {@link io.github.adamw7.tools.adopt.step.AbstractCommandStep#runTolerating}
+	 * discards a tolerated failure whole, and the tool's own account of what it
+	 * refused to do — the one thing that says which of the tolerated cases this
+	 * was — went with it.
+	 *
+	 * <p>Redacting it is not optional: a tool handed a credentialled clone URL
+	 * echoes it back when it cannot use it, so the transcript carries a token as
+	 * readily as the command does. The guard keeps that scan off the path a
+	 * disabled log takes.
+	 */
+	private void logOutcome(CommandResult result, Elapsed elapsed) {
+		log.debug("Exited {} after {}: {}", result.exitCode(), elapsed, result.describe());
+		if (!result.succeeded() && log.isDebugEnabled()) {
+			log.debug("Output of the failed command:{}{}", System.lineSeparator(), result.redactedOutput());
+		}
 	}
 
 	/**

--- a/adopt/src/main/resources/log4j2.properties
+++ b/adopt/src/main/resources/log4j2.properties
@@ -41,6 +41,23 @@ appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %level - %msg%n
 
+# The console shows the adoption's progress, never its command trace. An operator
+# watching a run wants the step it is on; the git/claude/gh invocations, their exit
+# codes and the transcript of the ones that failed belong in the file, which is what
+# is read afterwards to work out why a run did what it did.
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = info
+appender.console.filter.threshold.onMatch = ACCEPT
+appender.console.filter.threshold.onMismatch = DENY
+
+# The adoption's own classes log at debug so the file carries that trace by default:
+# a failed adoption is usually reported after the fact, by someone who cannot re-run
+# it with a flag against the state that produced it. The root stays at info, because
+# this jar is also a Spring Boot MCP server and the framework's debug output would
+# bury the trace it was raised for.
+logger.adopt.name = io.github.adamw7.tools.adopt
+logger.adopt.level = debug
+
 # Configure root logger
 rootLogger.level = info
 rootLogger.appenderRef.rolling.ref = fileLogger

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/ElapsedTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/ElapsedTest.java
@@ -1,0 +1,58 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class ElapsedTest {
+
+	@Test
+	void readsSubSecondDurationsInMilliseconds() {
+		assertEquals("0ms", Elapsed.describe(Duration.ZERO));
+		assertEquals("317ms", Elapsed.describe(Duration.ofMillis(317)));
+		assertEquals("999ms", Elapsed.describe(Duration.ofMillis(999)));
+	}
+
+	/** Rounding the short commands to whole seconds would report every one of them as 0s. */
+	@Test
+	void switchesToSecondsAtOneSecond() {
+		assertEquals("1s", Elapsed.describe(Duration.ofMillis(1000)));
+		assertEquals("1s", Elapsed.describe(Duration.ofMillis(1999)));
+		assertEquals("59s", Elapsed.describe(Duration.ofSeconds(59)));
+	}
+
+	@Test
+	void switchesToMinutesAndSecondsAtOneMinute() {
+		assertEquals("1m 0s", Elapsed.describe(Duration.ofSeconds(60)));
+		assertEquals("4m 12s", Elapsed.describe(Duration.ofSeconds(252)));
+		assertEquals("70m 1s", Elapsed.describe(Duration.ofSeconds(4201)));
+	}
+
+	/** Sub-second precision is dropped once a duration is worth minutes, not lost from the minutes. */
+	@Test
+	void ignoresTheFractionOfASecondBeyondAMinute() {
+		assertEquals("2m 30s", Elapsed.describe(Duration.ofSeconds(150).plusMillis(750)));
+	}
+
+	@Test
+	void measuresFromWhenItWasStarted() {
+		Elapsed elapsed = Elapsed.started();
+
+		assertFalse(elapsed.duration().isNegative(), "a stopwatch cannot run backwards");
+		assertTrue(elapsed.duration().compareTo(Duration.ofMinutes(1)) < 0,
+				"a stopwatch just started cannot already read a minute");
+	}
+
+	/** The log lines interpolate the stopwatch itself, so its text is what toString answers. */
+	@Test
+	void readsAsItsOwnDescription() {
+		Elapsed elapsed = Elapsed.started();
+
+		assertEquals(Elapsed.describe(elapsed.duration()).replaceAll("\\d+", "n"),
+				elapsed.toString().replaceAll("\\d+", "n"));
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionFormatRule.java
@@ -61,8 +61,10 @@ abstract class DefinitionFormatRule extends ClaudeCodeEnforcerRule {
 		File directory = definitionDir();
 		requireConfigured(directory, naming.directoryParameter());
 		ProjectFiles.requireDirectory(directory, naming.directoryLabel());
+		List<File> entries = entriesIn(directory);
+		log().debug(() -> naming.directoryLabel() + ": checking " + entries.size() + " definition(s) in " + directory);
 		List<String> violations = new ArrayList<>();
-		for (File entry : entriesIn(directory)) {
+		for (File entry : entries) {
 			collectEntryViolations(entry, violations);
 		}
 		report(naming.header(), violations);
@@ -89,7 +91,7 @@ abstract class DefinitionFormatRule extends ClaudeCodeEnforcerRule {
 	 * when a violation was collected instead of content worth checking further.
 	 */
 	protected final Optional<String> contentOf(File file, List<String> violations) {
-		return DefinitionContent.of(file, naming.definitionLabel(), autoFix, getLog(), violations);
+		return DefinitionContent.of(file, naming.definitionLabel(), autoFix, log(), violations);
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -112,7 +112,7 @@ public class MemoryImportsRule extends ClaudeCodeEnforcerRule {
 
 	/** Reached only for an import target that cannot be read, so the log is looked up lazily. */
 	private void debug(String message) {
-		getLog().debug(message);
+		log().debug(message);
 	}
 
 	void setClaudeMdFile(File claudeMdFile) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -5,9 +5,11 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
+import java.util.Objects;
 import java.util.StringJoiner;
 
 import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.text.MarkdownText;
@@ -83,15 +85,49 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 		writeReport(header, newViolations);
 		logSuppressed(violations.size() - newViolations.size());
 		logStaleEntries(baseline.staleEntries(violations));
+		logOutcome(newViolations);
 		if (newViolations.isEmpty()) {
 			return;
 		}
 		String message = format(header, newViolations);
 		if (isWarn()) {
-			getLog().warn(message);
+			log().warn(message + System.lineSeparator() + downgradeNotice());
 		} else {
 			throw new EnforcerRuleException(message);
 		}
+	}
+
+	/**
+	 * The logger, never null. maven-enforcer injects one before it runs a rule and
+	 * nothing else does, so a rule constructed directly has none;
+	 * {@link SilentEnforcerLogger} stands in for it, which is what lets a rule log
+	 * on any path rather than only where a Maven session is guaranteed.
+	 */
+	protected final EnforcerLogger log() {
+		return Objects.requireNonNullElse(getLog(), SilentEnforcerLogger.INSTANCE);
+	}
+
+	/**
+	 * One line per rule naming what it was pointed at and what it found there.
+	 * maven-enforcer already reports each rule's verdict, but by class and
+	 * configured name alone: nothing in {@code Rule 8: ...McpServersValidRule
+	 * (mcpServersValid) passed} distinguishes the rule that read a file from the one
+	 * that passed because its optional file is absent, or because a directory
+	 * parameter points somewhere empty. The rule names its own inputs through
+	 * {@link #toString()}, so {@code mvn -X} shows what each verdict was reached on.
+	 */
+	private void logOutcome(List<String> violations) {
+		log().debug(() -> this + " found " + violations.size() + " violation(s)");
+	}
+
+	/**
+	 * Says why a warning did not stop the build, and which rule to configure to make
+	 * it. A downgraded violation is otherwise one more {@code [WARNING]} among a
+	 * build's many, worded exactly like the failure it would have been, leaving a
+	 * reader to guess whether the build tolerated it deliberately.
+	 */
+	private String downgradeNotice() {
+		return "  (" + this + " has severity 'warn', so the build was not failed)";
 	}
 
 	private boolean isWriteBaselineRequested() {
@@ -100,18 +136,18 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 
 	private void recordBaseline(List<String> violations) throws EnforcerRuleException {
 		Baseline.write(baselineFile, violations, baseDir);
-		getLog().info("Recorded " + violations.size() + " violation(s) to the baseline " + baselineFile);
+		log().info("Recorded " + violations.size() + " violation(s) to the baseline " + baselineFile);
 	}
 
 	private void logSuppressed(int suppressed) {
 		if (suppressed > 0) {
-			getLog().info(suppressed + " violation(s) suppressed by the baseline " + baselineFile);
+			log().info(suppressed + " violation(s) suppressed by the baseline " + baselineFile);
 		}
 	}
 
 	private void logStaleEntries(List<String> staleEntries) {
 		if (!staleEntries.isEmpty()) {
-			getLog().info(staleEntries.size() + " baseline entry/entries no longer match and can be removed from "
+			log().info(staleEntries.size() + " baseline entry/entries no longer match and can be removed from "
 					+ baselineFile);
 		}
 	}
@@ -121,6 +157,7 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 			return;
 		}
 		new HtmlReport(header, violations, howToFix()).writeTo(reportFile);
+		log().debug(() -> this + " wrote its report to " + reportFile);
 	}
 
 	/**
@@ -238,7 +275,7 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 			field.setAccessible(true);
 			return field.get(this);
 		} catch (ReflectiveOperationException | RuntimeException e) {
-			getLog().debug("Could not read rule parameter " + field.getName() + ": " + e.getMessage());
+			log().debug("Could not read rule parameter " + field.getName() + ": " + e.getMessage());
 			return null;
 		}
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -46,6 +46,7 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 		requireConfigured(file, fileParameter);
 		if (!file.isFile()) {
 			handleMissingFile(file);
+			log().debug(() -> description + " is absent at " + file + ", which this rule accepts; nothing to check");
 			report(header(), List.of());
 			return;
 		}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/SilentEnforcerLogger.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/SilentEnforcerLogger.java
@@ -1,0 +1,88 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import java.util.function.Supplier;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+
+/**
+ * The logger a rule uses when it was never given one: every level disabled and
+ * every message dropped.
+ * <p>
+ * maven-enforcer injects a logger before it runs a rule, but nothing else does.
+ * A rule constructed directly — by a unit test, or by any caller embedding these
+ * checks outside a Maven session — has a null logger, so a rule that logged what
+ * it checked would throw on the logging rather than report on what it checked.
+ * That is why the two debug lines this module already had were confined to paths
+ * a test is unlikely to reach. Falling back to this instance removes the
+ * constraint: a rule may log wherever logging is useful, and the caller that
+ * wants to see it supplies a logger.
+ *
+ * @see ClaudeCodeEnforcerRule#log()
+ */
+final class SilentEnforcerLogger implements EnforcerLogger {
+
+	static final EnforcerLogger INSTANCE = new SilentEnforcerLogger();
+
+	private SilentEnforcerLogger() {
+	}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return false;
+	}
+
+	@Override
+	public void debug(CharSequence message) {
+	}
+
+	@Override
+	public void debug(Supplier<CharSequence> message) {
+	}
+
+	@Override
+	public boolean isInfoEnabled() {
+		return false;
+	}
+
+	@Override
+	public void info(CharSequence message) {
+	}
+
+	@Override
+	public void info(Supplier<CharSequence> message) {
+	}
+
+	@Override
+	public boolean isWarnEnabled() {
+		return false;
+	}
+
+	@Override
+	public void warn(CharSequence message) {
+	}
+
+	@Override
+	public void warn(Supplier<CharSequence> message) {
+	}
+
+	@Override
+	public void warnOrError(CharSequence message) {
+	}
+
+	@Override
+	public void warnOrError(Supplier<CharSequence> message) {
+	}
+
+	@Override
+	public boolean isErrorEnabled() {
+		return false;
+	}
+
+	@Override
+	public void error(CharSequence message) {
+	}
+
+	@Override
+	public void error(Supplier<CharSequence> message) {
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
@@ -58,10 +58,9 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 		ScanTargets targets = new ScanTargets(files, directories);
 		targets.requireConfigured();
 		requirePatterns(patterns);
-		List<String> violations = targets.allFiles().stream()
-				.filter(File::isFile)
-				.flatMap(file -> scan(file, patterns))
-				.toList();
+		List<File> scanned = targets.allFiles().stream().filter(File::isFile).toList();
+		log().debug(() -> "Scanning " + scanned.size() + " file(s) for " + patterns.size() + " credential pattern(s)");
+		List<String> violations = scanned.stream().flatMap(file -> scan(file, patterns)).toList();
 		report("Files contain what look like secrets:", violations);
 	}
 
@@ -108,7 +107,7 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 	private List<String> readTextLines(File file) {
 		Optional<String> content = MarkdownText.readIfText(file);
 		if (content.isEmpty()) {
-			getLog().debug("Skipping undecodable file " + file);
+			log().debug("Skipping undecodable file " + file);
 		}
 		return content.map(text -> text.lines().toList()).orElseGet(List::of);
 	}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/CapturingLogger.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/CapturingLogger.java
@@ -7,15 +7,30 @@ import java.util.function.Supplier;
 import org.apache.maven.enforcer.rule.api.EnforcerLogger;
 
 /**
- * A test double for {@link EnforcerLogger} that records the warnings a rule
- * emits, so warn-severity behaviour can be asserted without a Maven runtime.
+ * A test double for {@link EnforcerLogger} that records what a rule emits, so
+ * warn-severity behaviour and the debug trace of what a rule checked can both be
+ * asserted without a Maven runtime.
+ * <p>
+ * Every level reports itself as enabled, because a rule that guards a message
+ * behind {@code isDebugEnabled()} would otherwise never produce the message the
+ * assertion is looking for.
  */
 public class CapturingLogger implements EnforcerLogger {
 
 	private final List<String> warnings = new ArrayList<>();
+	private final List<String> infos = new ArrayList<>();
+	private final List<String> debugs = new ArrayList<>();
 
 	public List<String> warnings() {
 		return warnings;
+	}
+
+	public List<String> infos() {
+		return infos;
+	}
+
+	public List<String> debugs() {
+		return debugs;
 	}
 
 	@Override
@@ -40,28 +55,32 @@ public class CapturingLogger implements EnforcerLogger {
 
 	@Override
 	public boolean isDebugEnabled() {
-		return false;
+		return true;
 	}
 
 	@Override
 	public void debug(CharSequence message) {
+		debugs.add(String.valueOf(message));
 	}
 
 	@Override
 	public void debug(Supplier<CharSequence> message) {
+		debugs.add(String.valueOf(message.get()));
 	}
 
 	@Override
 	public boolean isInfoEnabled() {
-		return false;
+		return true;
 	}
 
 	@Override
 	public void info(CharSequence message) {
+		infos.add(String.valueOf(message));
 	}
 
 	@Override
 	public void info(Supplier<CharSequence> message) {
+		infos.add(String.valueOf(message.get()));
 	}
 
 	@Override

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRuleLoggingTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRuleLoggingTest.java
@@ -1,0 +1,155 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * What every rule says about itself, held by the base class: the debug line that
+ * makes a passing run readable, the notice that explains a downgraded warning,
+ * and the guarantee that a rule built without a Maven session can log at all.
+ */
+class ClaudeCodeEnforcerRuleLoggingTest {
+
+	@TempDir
+	private Path tempDir;
+
+	/**
+	 * The regression that matters most: maven-enforcer injects a logger and nothing
+	 * else does, so a rule that logged on an ordinary path used to throw a
+	 * NullPointerException the moment anything but Maven ran it.
+	 */
+	@Test
+	void logsWithoutALoggerInjected() {
+		LoggingTestRule rule = new LoggingTestRule();
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWithoutALoggerInjectedOnTheViolationItFound() {
+		LoggingTestRule rule = new LoggingTestRule();
+		rule.addViolation("something is wrong");
+
+		assertThrows(EnforcerRuleException.class, rule::execute);
+	}
+
+	/**
+	 * maven-enforcer reports the verdict; what it cannot report is which inputs the
+	 * verdict was reached on, which is the whole difference between a rule that read
+	 * a document and one that passed because it was pointed at nothing.
+	 */
+	@Test
+	void debugLogsWhatItWasPointedAtWhenItFindsNothing() {
+		LoggingTestRule rule = new LoggingTestRule();
+		File checked = tempDir.resolve("checked.md").toFile();
+		rule.setCheckedFile(checked);
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.debugs().contains("LoggingTestRule[checkedFile=" + checked + "] found 0 violation(s)"),
+				logger.debugs().toString());
+	}
+
+	@Test
+	void debugLogsHowManyViolationsItFound() {
+		LoggingTestRule rule = new LoggingTestRule();
+		rule.addViolation("first");
+		rule.addViolation("second");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertThrows(EnforcerRuleException.class, rule::execute);
+		assertTrue(logger.debugs().contains("LoggingTestRule[] found 2 violation(s)"), logger.debugs().toString());
+	}
+
+	/**
+	 * A downgraded violation is one more {@code [WARNING]} in a build full of them,
+	 * worded exactly like the failure it would have been, so it has to say both that
+	 * it was tolerated and which rule to configure to stop tolerating it.
+	 */
+	@Test
+	void warningSaysWhyItDidNotFailTheBuild() {
+		LoggingTestRule rule = new LoggingTestRule();
+		rule.addViolation("something is wrong");
+		rule.setSeverity("warn");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertEquals(1, logger.warnings().size());
+		String warning = logger.warnings().get(0);
+		assertTrue(warning.contains("something is wrong"), warning);
+		assertTrue(warning.contains("LoggingTestRule[] has severity 'warn', so the build was not failed"), warning);
+	}
+
+	@Test
+	void debugLogsWhereItWroteItsReport() {
+		LoggingTestRule rule = new LoggingTestRule();
+		File report = tempDir.resolve("report.html").toFile();
+		rule.setReportFile(report);
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.debugs().contains("LoggingTestRule[] wrote its report to " + report),
+				logger.debugs().toString());
+	}
+
+	/** The count is what survived the baseline, not what the rule collected. */
+	@Test
+	void debugLogsThePassLeftBehindOnceTheBaselineHasSuppressedEverything() {
+		LoggingTestRule rule = new LoggingTestRule();
+		rule.addViolation("known problem");
+		rule.setBaselineFile(tempDir.resolve("baseline.txt").toFile());
+		rule.setWriteBaseline(true);
+		assertDoesNotThrow(rule::execute);
+
+		LoggingTestRule rerun = new LoggingTestRule();
+		rerun.addViolation("known problem");
+		rerun.setBaselineFile(tempDir.resolve("baseline.txt").toFile());
+		CapturingLogger logger = new CapturingLogger();
+		rerun.setLog(logger);
+
+		assertDoesNotThrow(rerun::execute);
+		assertTrue(logger.debugs().contains("LoggingTestRule[] found 0 violation(s)"), logger.debugs().toString());
+		assertTrue(logger.infos().stream().anyMatch(info -> info.contains("1 violation(s) suppressed")),
+				logger.infos().toString());
+	}
+
+	/**
+	 * Minimal concrete rule that reports exactly the violations it is handed, so the
+	 * base class's own logging can be asserted without a document to go wrong.
+	 */
+	private static final class LoggingTestRule extends ClaudeCodeEnforcerRule {
+
+		private final List<String> violations = new ArrayList<>();
+
+		/** Named so {@link #toString()} has a configured input to report. */
+		private File checkedFile;
+
+		void addViolation(String violation) {
+			violations.add(violation);
+		}
+
+		void setCheckedFile(File checkedFile) {
+			this.checkedFile = checkedFile;
+		}
+
+		@Override
+		public void execute() throws EnforcerRuleException {
+			report("Test rule is not satisfied:", List.copyOf(violations));
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/SilentEnforcerLoggerTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/SilentEnforcerLoggerTest.java
@@ -1,0 +1,55 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+import org.junit.jupiter.api.Test;
+
+class SilentEnforcerLoggerTest {
+
+	private final EnforcerLogger log = SilentEnforcerLogger.INSTANCE;
+
+	/**
+	 * A rule asks before building an expensive message, so every level has to answer
+	 * that there is no point: a logger that dropped the message but claimed to be
+	 * enabled would still make the rule pay for it.
+	 */
+	@Test
+	void reportsEveryLevelDisabled() {
+		assertFalse(log.isDebugEnabled());
+		assertFalse(log.isInfoEnabled());
+		assertFalse(log.isWarnEnabled());
+		assertFalse(log.isErrorEnabled());
+	}
+
+	@Test
+	void dropsEveryMessageItIsGiven() {
+		assertDoesNotThrow(() -> {
+			log.debug("debug");
+			log.info("info");
+			log.warn("warn");
+			log.warnOrError("warnOrError");
+			log.error("error");
+		});
+	}
+
+	/**
+	 * The suppliers are never invoked, so a rule that logs the result of work it
+	 * would rather not do does not do it.
+	 */
+	@Test
+	void neverInvokesASuppliedMessage() {
+		assertDoesNotThrow(() -> {
+			log.debug(SilentEnforcerLoggerTest::unwanted);
+			log.info(SilentEnforcerLoggerTest::unwanted);
+			log.warn(SilentEnforcerLoggerTest::unwanted);
+			log.warnOrError(SilentEnforcerLoggerTest::unwanted);
+			log.error(SilentEnforcerLoggerTest::unwanted);
+		});
+	}
+
+	private static CharSequence unwanted() {
+		throw new IllegalStateException("a dropped message must not be built");
+	}
+}


### PR DESCRIPTION
Both modules ran nearly silently on the paths that matter most.

adopt logged a step name and nothing else. ProcessCommandRunner — the one
place the pipeline learns anything from the outside world — logged nothing
at all, so a tolerated non-zero exit, a skipped clone, or a step that
decided it had nothing to do left no trace: a run that did less than
expected read exactly like one that did everything. It now traces every
invocation at debug with its working directory, exit code, duration and
(redacted) transcript on failure. Steps carry an ordinal and what they
cost, the batch announces each repository as N of M and closes with a
summary naming the ones to re-run, and --report confirms where it wrote.
The console is threshold-filtered to info while io.github.adamw7.tools.adopt
logs at debug, so logs/adopt.log carries the trace without the embedded
Spring Boot MCP server burying it. Durations go through a new Elapsed
rather than ISO-8601.

The enforcer's rules were silent too, and could not easily stop being:
maven-enforcer injects the logger and nothing else does, so getLog() is
null wherever a rule is built directly — the two debug lines that existed
were latent NPEs confined to paths a test rarely reaches. A silent
fallback behind log() removes that, and the rules now debug-log what they
were pointed at and found, what they scanned, and the absences they
accept, which maven-enforcer's class-only verdict cannot distinguish. A
severity=warn violation now says it was tolerated and by which rule.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U3oXZqWrc7DNgoVDu9L5fB