### PR TITLE
test(protogen-maven-plugin): assert what the generator writes, not just that it compiles

### DIFF
--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/CodeMojo.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/CodeMojo.java
@@ -53,7 +53,15 @@ public class CodeMojo extends AbstractMojo {
 		}
 	}
 
-	private void extendClassPath() {
+	/**
+	 * Puts the project's runtime classpath on the thread context classloader,
+	 * which is what {@link MessagesFinder} scans through, so a project's own
+	 * generated messages are visible to the scan. Package-private so the
+	 * behaviour can be exercised directly: {@link #execute()} restores the
+	 * original classloader before it returns, leaving no other point from which
+	 * the extension can be observed.
+	 */
+	void extendClassPath() {
 		try {
 			Set<URL> urls = new HashSet<>();
 

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/MojoTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/MojoTest.java
@@ -1,5 +1,9 @@
 package io.github.adamw7.tools.code;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -7,6 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -15,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
@@ -45,6 +52,11 @@ public class MojoTest {
 	
 	private static final Logger log = LogManager.getLogger(MojoTest.class.getName());
 
+	private static final String PROTO2_PKG = "io.github.adamw7.tools.code.protos";
+	private static final String PROTO2_OUTPUT = "com.sth.generated";
+	private static final String PROTO3_PKG = "io.github.adamw7.tools.code.proto3";
+	private static final String PROTO3_OUTPUT = "com.sth.generated.proto3";
+
 	protected static String GENERATED_SOURCES;
 	protected static String TARGET;
 
@@ -58,11 +70,7 @@ public class MojoTest {
 
 	@Test
 	public void happyPath() {
-		CodeMojo mojo = new CodeMojo();
-		mojo.generatedSourcesDir = GENERATED_SOURCES;
-		mojo.pkgs = new String[] { "io.github.adamw7.tools.code.protos" };
-		mojo.outputpackage = "com.sth.generated";
-		mojo.runtimeClasspathElements = List.of();
+		CodeMojo mojo = mojoFor(PROTO2_PKG, PROTO2_OUTPUT);
 
 		mojo.execute();
 		File dir = new File(GENERATED_SOURCES);
@@ -70,15 +78,53 @@ public class MojoTest {
 		assertTrue(dirSet.contains("com"));
 
 		compileSources(GENERATED_SOURCES + File.separator + mojo.outputpackage.replace(".", File.separator));
+	}
+
+	/**
+	 * Address has two required fields and nothing else, so the whole chain the
+	 * plugin exists to generate fits in one assertion set: the builder starts at
+	 * the first required field, each setter hands back the interface for the next
+	 * one, and only the last of them exposes the optional interface that declares
+	 * {@code build()}. Generating fewer classes than this, or wiring one setter to
+	 * the wrong interface, is what would let a caller build a message with a
+	 * required field missing — the failure the plugin shifts to compile time.
+	 */
+	@Test
+	public void requiredSettersChainThroughEveryRequiredFieldBeforeBuild() throws IOException {
+		mojoFor(PROTO2_PKG, PROTO2_OUTPUT).execute();
+
+		assertDeclares("AddressBuilder", "public class AddressBuilder implements AddressStreetIfc {");
+		assertDeclares("AddressStreetIfc", "AddressNumberIfc setStreet(String street);");
+		assertDeclares("AddressNumberIfc", "AddressOptionalIfc setNumber(int number);");
+		assertDeclares("AddressOptionalIfc", "Address build();");
+	}
+
+	/**
+	 * The chain above only holds if every link is written out. A generator that
+	 * emitted the builder alone would still compile, so the file set is asserted
+	 * as a whole rather than left to the compiler.
+	 */
+	@Test
+	public void generatesAnInterfaceAndAnImplementationForEveryRequiredField() throws IOException {
+		mojoFor(PROTO2_PKG, PROTO2_OUTPUT).execute();
+
+		assertEquals(
+				List.of("AddressBuilder.java", "AddressNumberIfc.java", "AddressNumberImpl.java",
+						"AddressOptionalIfc.java", "AddressOptionalImpl.java", "AddressStreetIfc.java"),
+				generatedFilesNamed("Address"));
+	}
+
+	@Test
+	public void generatesOneofAccessorsOnTheOptionalInterface() throws IOException {
+		mojoFor(PROTO2_PKG, PROTO2_OUTPUT).execute();
+
+		assertDeclares("SampleMessageOptionalIfc", "SampleMessage.TestOneofCase getTestOneofCase();");
+		assertDeclares("SampleMessageOptionalIfc", "SampleMessageOptionalIfc clearTestOneof();");
 	}
 
 	@Test
 	public void proto3GeneratesAndCompiles() {
-		CodeMojo mojo = new CodeMojo();
-		mojo.generatedSourcesDir = GENERATED_SOURCES;
-		mojo.pkgs = new String[] { "io.github.adamw7.tools.code.proto3" };
-		mojo.outputpackage = "com.sth.generated.proto3";
-		mojo.runtimeClasspathElements = List.of();
+		CodeMojo mojo = mojoFor(PROTO3_PKG, PROTO3_OUTPUT);
 
 		mojo.execute();
 		File dir = new File(GENERATED_SOURCES);
@@ -88,13 +134,26 @@ public class MojoTest {
 		compileSources(GENERATED_SOURCES + File.separator + mojo.outputpackage.replace(".", File.separator));
 	}
 
+	/**
+	 * proto3 has no {@code required}, so the chain is built from the fields that
+	 * carry no presence — the map and repeated ones — and those are exactly the
+	 * fields that must not get a has-accessor.
+	 */
+	@Test
+	public void proto3ChainsPresencelessFieldsAndDeclaresNoHasAccessorForThem() throws IOException {
+		mojoFor(PROTO3_PKG, PROTO3_OUTPUT).execute();
+
+		assertDeclares(PROTO3_OUTPUT, "Proto3SampleBuilder",
+				"public class Proto3SampleBuilder implements Proto3SampleScoresIfc {");
+		assertDeclares(PROTO3_OUTPUT, "Proto3SampleRolesIfc",
+				"Proto3SampleOptionalIfc setRoles(java.util.List<String> roles);");
+		assertFalse(asOneLine(generatedSource(PROTO3_OUTPUT, "Proto3SampleRolesIfc")).contains("hasRoles()"),
+				"a repeated field has no presence, so no has-accessor may be declared for it");
+	}
+
 	@Test
 	public void restoresContextClassLoader() {
-		CodeMojo mojo = new CodeMojo();
-		mojo.generatedSourcesDir = GENERATED_SOURCES;
-		mojo.pkgs = new String[] { "io.github.adamw7.tools.code.protos" };
-		mojo.outputpackage = "com.sth.generated";
-		mojo.runtimeClasspathElements = List.of();
+		CodeMojo mojo = mojoFor(PROTO2_PKG, PROTO2_OUTPUT);
 
 		ClassLoader beforeExecution = Thread.currentThread().getContextClassLoader();
 		mojo.execute();
@@ -108,17 +167,82 @@ public class MojoTest {
 		// A regular file where the output directory should go makes generation blow up
 		// after the classloader has already been swapped in.
 		Path blockingFile = Files.createFile(tempDir.resolve("not-a-directory"));
-		CodeMojo mojo = new CodeMojo();
+		CodeMojo mojo = mojoFor(PROTO2_PKG, PROTO2_OUTPUT);
 		mojo.generatedSourcesDir = blockingFile.toString();
-		mojo.pkgs = new String[] { "io.github.adamw7.tools.code.protos" };
-		mojo.outputpackage = "com.sth.generated";
-		mojo.runtimeClasspathElements = List.of();
 
 		ClassLoader beforeExecution = Thread.currentThread().getContextClassLoader();
 		assertThrows(UncheckedIOException.class, mojo::execute);
 
 		assertSame(beforeExecution, Thread.currentThread().getContextClassLoader(),
 				"A failing execution must restore the build thread's classloader too");
+	}
+
+	/**
+	 * The goal scans for messages through the thread context classloader, so the
+	 * runtime classpath has to be on it before the scan or a project's own
+	 * generated messages are invisible. The extension is undone before
+	 * {@link CodeMojo#execute()} returns, which leaves calling it directly as the
+	 * only place the result can be observed.
+	 */
+	@Test
+	public void extendsTheContextClassPathWithTheRuntimeElements(@TempDir Path classpathElement) {
+		CodeMojo mojo = mojoFor(PROTO2_PKG, PROTO2_OUTPUT);
+		// A null element is what a Maven project with an unresolved artifact hands over.
+		mojo.runtimeClasspathElements = Arrays.asList(classpathElement.toString(), null);
+
+		ClassLoader beforeExtension = Thread.currentThread().getContextClassLoader();
+		try {
+			mojo.extendClassPath();
+
+			ClassLoader extended = Thread.currentThread().getContextClassLoader();
+			assertNotSame(beforeExtension, extended, "the scan must run through the extended classpath");
+			URL[] urls = assertInstanceOf(URLClassLoader.class, extended).getURLs();
+			assertEquals(1, urls.length, "the null element must be skipped rather than turned into a URL");
+			assertTrue(urls[0].getPath().contains(classpathElement.getFileName().toString()),
+					"the runtime classpath element must be on the classloader; was: " + urls[0]);
+		} finally {
+			Thread.currentThread().setContextClassLoader(beforeExtension);
+		}
+	}
+
+	private CodeMojo mojoFor(String inputPkg, String outputPkg) {
+		CodeMojo mojo = new CodeMojo();
+		mojo.generatedSourcesDir = GENERATED_SOURCES;
+		mojo.pkgs = new String[] { inputPkg };
+		mojo.outputpackage = outputPkg;
+		mojo.runtimeClasspathElements = List.of();
+		return mojo;
+	}
+
+	private void assertDeclares(String simpleName, String declaration) throws IOException {
+		assertDeclares(PROTO2_OUTPUT, simpleName, declaration);
+	}
+
+	private void assertDeclares(String outputPkg, String simpleName, String declaration) throws IOException {
+		String source = generatedSource(outputPkg, simpleName);
+		assertTrue(asOneLine(source).contains(declaration),
+				simpleName + " does not declare: " + declaration + System.lineSeparator() + source);
+	}
+
+	private String generatedSource(String outputPkg, String simpleName) throws IOException {
+		return Files.readString(outputDir(outputPkg).resolve(simpleName + ".java"));
+	}
+
+	/** The generated file names starting with the message's name, sorted so a failure reads the same way twice. */
+	private List<String> generatedFilesNamed(String messageName) throws IOException {
+		try (Stream<Path> entries = Files.list(outputDir(PROTO2_OUTPUT))) {
+			return entries.map(path -> path.getFileName().toString())
+					.filter(name -> name.startsWith(messageName)).sorted().toList();
+		}
+	}
+
+	private static Path outputDir(String outputPkg) {
+		return Path.of(GENERATED_SOURCES, outputPkg.split("\\."));
+	}
+
+	/** Collapses the formatter's line breaks and indentation, so an assertion reads as one line of Java. */
+	private static String asOneLine(String code) {
+		return code.replaceAll("\\s+", " ").strip();
 	}
 
 	private void compileSources(String dir) {

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/gen/CodeTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/gen/CodeTest.java
@@ -1,0 +1,211 @@
+package io.github.adamw7.tools.code.gen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.Edition;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.GeneratedMessage;
+
+/**
+ * The contracts {@link Code} states in its own guard clauses, driven through
+ * synthetic descriptors rather than through the {@code .proto} fixtures.
+ *
+ * <p>Every guard here is a refusal, and a refusal needs a message that violates
+ * it. protoc will not produce one — it emits only valid proto2, proto3 and
+ * editions files, and an editions fixture added to {@code src/test/proto} would
+ * be picked up by every other test's package scan and fail those instead. So the
+ * message classes below are stubs: abstract, never instantiated, and reached the
+ * way {@code Code} reaches a real one, by invoking a static {@code getDescriptor}
+ * reflectively. That is enough to hand the generator a descriptor no fixture
+ * could carry.
+ */
+public class CodeTest {
+
+	private static final String OUTPUT_PKG = "com/x/out";
+
+	/** Carries the syntax {@code Code} accepts today, so the accepting branch is asserted and not assumed. */
+	public abstract static class Proto2Message extends GeneratedMessage {
+		public static Descriptor getDescriptor() {
+			return descriptorWith("proto2");
+		}
+	}
+
+	/** A file written before {@code syntax} was declared at all, which is proto2 by definition. */
+	public abstract static class UndeclaredSyntaxMessage extends GeneratedMessage {
+		public static Descriptor getDescriptor() {
+			return descriptorWith("");
+		}
+	}
+
+	/** protoc emits this for an {@code edition = "2023"} file — a real syntax the generator does not support. */
+	public abstract static class EditionsMessage extends GeneratedMessage {
+		public static Descriptor getDescriptor() {
+			return descriptorWith("editions");
+		}
+	}
+
+	public abstract static class UnknownSyntaxMessage extends GeneratedMessage {
+		public static Descriptor getDescriptor() {
+			return descriptorWith("proto1");
+		}
+	}
+
+	public abstract static class NullDescriptorMessage extends GeneratedMessage {
+		public static Descriptor getDescriptor() {
+			return null;
+		}
+	}
+
+	public abstract static class WrongDescriptorTypeMessage extends GeneratedMessage {
+		public static Object getDescriptor() {
+			return "not a descriptor";
+		}
+	}
+
+	@Test
+	public void generatesTheBuilderTrioForASupportedSyntax(@TempDir Path generatedSources) throws IOException {
+		generate(generatedSources, Proto2Message.class);
+
+		assertEquals(List.of("SampleBuilder.java", "SampleOptionalIfc.java", "SampleOptionalImpl.java"),
+				generatedFileNames(generatedSources));
+	}
+
+	@Test
+	public void acceptsAFileThatDeclaresNoSyntax(@TempDir Path generatedSources) throws IOException {
+		generate(generatedSources, UndeclaredSyntaxMessage.class);
+
+		assertFalse(generatedFileNames(generatedSources).isEmpty(),
+				"an absent syntax means proto2, which the generator supports");
+	}
+
+	@Test
+	public void refusesEditionsSyntax(@TempDir Path generatedSources) {
+		IllegalStateException refusal = assertThrows(IllegalStateException.class,
+				() -> generate(generatedSources, EditionsMessage.class));
+
+		assertEquals("Only proto2 and proto3 syntax are supported. The input contains: editions",
+				refusal.getMessage());
+	}
+
+	@Test
+	public void refusesUnrecognisedSyntax(@TempDir Path generatedSources) {
+		IllegalStateException refusal = assertThrows(IllegalStateException.class,
+				() -> generate(generatedSources, UnknownSyntaxMessage.class));
+
+		assertEquals("Only proto2 and proto3 syntax are supported. The input contains: proto1",
+				refusal.getMessage());
+	}
+
+	@Test
+	public void refusesAMessageWhoseDescriptorIsNull(@TempDir Path generatedSources) {
+		IllegalStateException refusal = assertThrows(IllegalStateException.class,
+				() -> generate(generatedSources, NullDescriptorMessage.class));
+
+		assertEquals("getDescriptor method return null", refusal.getMessage());
+	}
+
+	@Test
+	public void refusesAMessageWhoseDescriptorIsOfTheWrongType(@TempDir Path generatedSources) {
+		IllegalStateException refusal = assertThrows(IllegalStateException.class,
+				() -> generate(generatedSources, WrongDescriptorTypeMessage.class));
+
+		assertTrue(refusal.getMessage().startsWith("Wrong return type of the getDescriptor method:"),
+				"the refusal names the type that was returned; was: " + refusal.getMessage());
+	}
+
+	@Test
+	public void writesEveryGeneratedSourceWithContent(@TempDir Path generatedSources) throws IOException {
+		generate(generatedSources, Proto2Message.class);
+
+		for (Path source : generatedFiles(generatedSources)) {
+			String code = Files.readString(source);
+			assertFalse(code.isBlank(), source.getFileName() + " was written empty");
+			assertTrue(code.startsWith("package com.x.out;"),
+					source.getFileName() + " must open with its package declaration; was: " + firstLine(code));
+		}
+	}
+
+	/**
+	 * A builder removed from the {@code .proto} must not survive in the output
+	 * directory, where it would go on compiling and hide the removal — the reason
+	 * the output package is cleared rather than overwritten.
+	 */
+	@Test
+	public void clearsStaleOutputBeforeGenerating(@TempDir Path generatedSources) throws IOException {
+		Path outputDir = generatedSources.resolve(OUTPUT_PKG);
+		Path nested = outputDir.resolve("nested");
+		Files.createDirectories(nested);
+		Path staleBuilder = outputDir.resolve("RemovedMessageBuilder.java");
+		Path staleNested = nested.resolve("AlsoRemoved.java");
+		Files.writeString(staleBuilder, "public class RemovedMessageBuilder {}");
+		Files.writeString(staleNested, "public class AlsoRemoved {}");
+
+		generate(generatedSources, Proto2Message.class);
+
+		assertFalse(Files.exists(staleBuilder), "a builder left from an earlier run must not survive");
+		assertFalse(Files.exists(staleNested), "the clear-out must reach nested directories too");
+		assertFalse(Files.exists(nested), "the nested directory itself must go with its contents");
+	}
+
+	private void generate(Path generatedSources, Class<? extends GeneratedMessage> message) {
+		new Code(generatedSources.toString(), OUTPUT_PKG.replace('/', '.')).genBuilders(Set.of(message));
+	}
+
+	private List<String> generatedFileNames(Path generatedSources) throws IOException {
+		return generatedFiles(generatedSources).stream().map(path -> path.getFileName().toString()).sorted().toList();
+	}
+
+	private List<Path> generatedFiles(Path generatedSources) throws IOException {
+		Path outputDir = generatedSources.resolve(OUTPUT_PKG);
+		if (Files.notExists(outputDir)) {
+			return List.of();
+		}
+		try (Stream<Path> entries = Files.list(outputDir)) {
+			return entries.filter(Files::isRegularFile).toList();
+		}
+	}
+
+	private static String firstLine(String code) {
+		return code.lines().findFirst().orElse("");
+	}
+
+	/**
+	 * A one-message file carrying exactly the syntax asked for. The edition has to
+	 * be set alongside {@code syntax = "editions"} or protobuf rejects the file
+	 * before {@link Code} ever sees it.
+	 */
+	private static Descriptor descriptorWith(String syntax) {
+		FileDescriptorProto.Builder file = FileDescriptorProto.newBuilder()
+				.setName("synthetic-" + (syntax.isEmpty() ? "undeclared" : syntax) + ".proto")
+				.setPackage("synthetic")
+				.addMessageType(DescriptorProto.newBuilder().setName("Sample"));
+		if (!syntax.isEmpty()) {
+			file.setSyntax(syntax);
+		}
+		if ("editions".equals(syntax)) {
+			file.setEdition(Edition.EDITION_2023);
+		}
+		try {
+			return FileDescriptor.buildFrom(file.build(), new FileDescriptor[0]).getMessageTypes().getFirst();
+		} catch (DescriptorValidationException e) {
+			throw new IllegalStateException("Could not build a synthetic " + syntax + " descriptor", e);
+		}
+	}
+}


### PR DESCRIPTION
MojoTest checked that a directory named `com` appeared and that the output
compiled with the JDK compiler. Anything that still compiles therefore passed,
and mutation testing showed how much that covers: PIT left `generateRequired`
returning an empty list, `codeAsString` returning "", `FileWriter::write`
removed and the call to `checkSyntax` removed all alive, at a score comfortably
over the module's 84 threshold. The required-field enforcement the plugin exists
to provide could generate nothing at all and the build stayed green.

Assert the generated source instead. Address has two required fields and nothing
else, so the whole chain fits in one test: the builder starts at the first
required field, each setter returns the interface for the next, and only the
last exposes the optional interface carrying `build()`. The file set is asserted
as a whole too, since a generator emitting the builder alone would still compile.
Alongside it, the oneof accessors and proto3's presence-aware chain — where the
fields that carry no presence must not get a has-accessor.

Add CodeTest for the guards no `.proto` fixture can reach. protoc emits only
valid files, and an editions fixture under src/test/proto would be picked up by
every other test's package scan and fail those instead, so the refusals are
driven through synthetic descriptors held by abstract stub classes that are never
instantiated. That covers the editions and unrecognised-syntax refusals, the null
and wrong-type descriptor guards, the accepting branch for a file that declares
no syntax at all, and the clear-out that stops a builder removed from the .proto
surviving in the output directory where it would go on compiling.

Make CodeMojo.extendClassPath package-private, matching AbstractMcpConfiguration
.safeApply and ClaudeTrustStore.readText: execute() restores the original
classloader before returning, so calling it directly is the only place the
extension can be observed. Its test also passes the null element a project with
an unresolved artifact hands over.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FjsgsfQ2vtPm25CNn1Xcsi