### PR TITLE
fix(claude-code-enforcer, adopt): do not open a fence on an indent below a paragraph

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -5,6 +5,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
@@ -31,7 +34,8 @@ import picocli.CommandLine.ParameterException;
  * its default; an unknown flag, or one missing its value, fails with the usage
  * line rather than being ignored — as does {@code --help}, which asks for that
  * line and so is answered with it instead, whatever else on the command line
- * could not be read.
+ * could not be read. What it is not read as is a value: a {@code --title -h} is a
+ * flag missing its value, and is refused as one.
  *
  * <p>The arguments are matched by picocli rather than by a loop of this module's
  * own: the option names, their values, the three positional slots and the
@@ -105,10 +109,11 @@ public final class CliArguments {
 	public static CliArguments parse(String[] args) {
 		CliArguments cli = new CliArguments();
 		String[] arguments = args == null ? new String[0] : args;
+		CommandLine parser = new CommandLine(cli).setOverwrittenOptionsAllowed(true);
 		try {
-			new CommandLine(cli).setOverwrittenOptionsAllowed(true).parseArgs(arguments);
+			parser.parseArgs(arguments);
 		} catch (ParameterException e) {
-			return helpOrRefusal(cli, arguments, e);
+			return helpOrRefusal(cli, parser, arguments, e);
 		}
 		cli.requireSomethingToAdopt();
 		return cli;
@@ -123,16 +128,49 @@ public final class CliArguments {
 	 * file rather than answered with the line it asked for. The refusal is the answer
 	 * only for a run that was asking to adopt something.
 	 */
-	private static CliArguments helpOrRefusal(CliArguments cli, String[] args, ParameterException e) {
-		if (asksForHelp(args)) {
+	private static CliArguments helpOrRefusal(CliArguments cli, CommandLine parser, String[] args,
+			ParameterException e) {
+		if (asksForHelp(parser, args)) {
 			cli.help = true;
 			return cli;
 		}
 		throw refusal(e);
 	}
 
-	private static boolean asksForHelp(String[] args) {
-		return Stream.of(args).anyMatch(arg -> HELP_FLAG.equals(arg) || HELP_SHORTHAND.equals(arg));
+	/**
+	 * Whether the command line asked for the usage line, rather than merely carrying
+	 * the word somewhere. A help flag written where a value was expected is that
+	 * value — {@code --title -h} names a title, badly — so it is read as the argument
+	 * the operator got wrong and not as a request.
+	 *
+	 * <p>Reading every occurrence as a request answered {@code --repo <url> --title -h}
+	 * with the usage line and exited zero, having adopted nothing: a scripted batch that
+	 * mistyped one flag reported success and left no report to say otherwise. It is the
+	 * one shape this method has to tell apart, because it is also the one picocli
+	 * refuses on purpose — a flag that names something is never followed by another
+	 * flag.
+	 */
+	private static boolean asksForHelp(CommandLine parser, String[] args) {
+		Set<String> valueOptions = optionsTakingAValue(parser);
+		return IntStream.range(0, args.length)
+				.filter(index -> isHelpFlag(args[index]))
+				.anyMatch(index -> index == 0 || !valueOptions.contains(args[index - 1]));
+	}
+
+	private static boolean isHelpFlag(String argument) {
+		return HELP_FLAG.equals(argument) || HELP_SHORTHAND.equals(argument);
+	}
+
+	/**
+	 * The names of the options that consume the argument after them, read from the
+	 * declarations below rather than listed again here, so an option added to this
+	 * command cannot swallow a help flag the parse then answers as a request.
+	 */
+	private static Set<String> optionsTakingAValue(CommandLine parser) {
+		return parser.getCommandSpec().options().stream()
+				.filter(option -> option.arity().max() > 0)
+				.flatMap(option -> Stream.of(option.names()))
+				.collect(Collectors.toSet());
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -497,7 +497,9 @@ public class ClaudeMdConformer {
 	 * fence, where the rule reads them as code too. An already-conforming
 	 * {@code CLAUDE.md} came back with a stray delimiter and three duplicated sections,
 	 * and one that was missing a section came back still missing it — the adoption
-	 * failing its own {@link VerifyStep} on the very sections it had just written.
+	 * failing its own {@link VerifyStep} on the very sections it had just written. The
+	 * indent speaks for the line wherever it sits, whether a code block may open at it
+	 * or it merely continues the paragraph above; see {@link Scan#atIndent}.
 	 *
 	 * @return the fence delimiter still open at the end of the document, or
 	 *         {@code null} when its fences balance
@@ -530,8 +532,9 @@ public class ClaudeMdConformer {
 		/**
 		 * Marks line {@code index} and answers the state the next line is read in. An
 		 * open fence claims the line first, then a blank line, which carries nothing to
-		 * read either way and so is left unmarked; only then may an indent open a block,
-		 * and only a line no indent claimed is read as a fence delimiter.
+		 * read either way and so is left unmarked; then the indent, which speaks for the
+		 * line whether or not a block may open at it, and only a line the indent left
+		 * alone is read as a fence delimiter.
 		 */
 		Scan read(String line, boolean[] mask, int index) {
 			if (fence != null) {
@@ -540,11 +543,33 @@ public class ClaudeMdConformer {
 			if (line.isBlank()) {
 				return new Scan(null, true, listIndent);
 			}
-			if (mayIndent && indentWidth(line) >= codeIndent()) {
-				mask[index] = true;
-				return new Scan(null, true, listIndent);
+			if (indentWidth(line) >= codeIndent()) {
+				return atIndent(mask, index);
 			}
 			return atDelimiter(line, mask, index);
+		}
+
+		/**
+		 * The line is indented too deep to be read as anything but its indent: code
+		 * where a block may open, and otherwise the lazy continuation of the paragraph
+		 * above it — prose either way rather than markup.
+		 * <p>
+		 * That it is not a fence delimiter is the point, and it is the reshape's
+		 * problem as much as the rule's. A fence opener may be indented at most three
+		 * columns past its container, so a {@code ```} shown four columns in below a
+		 * paragraph opens nothing. Falling through to {@link #atDelimiter} read one as a
+		 * fence the document opened and never closed: the reshape then appended a
+		 * closing delimiter of its own, read every heading below the indent as code, and
+		 * appended a second copy of five sections the document already carried — to a
+		 * file it went on to commit, push, and open a pull request for. The rule reads
+		 * the result as conforming, because it made the same mistake, so
+		 * {@link VerifyStep} passed on it. The blank-line case was already answered
+		 * here; only a paragraph directly above the indent reached the delimiter
+		 * reading.
+		 */
+		private Scan atIndent(boolean[] mask, int index) {
+			mask[index] = mayIndent;
+			return new Scan(null, mayIndent, listIndent);
 		}
 
 		/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -438,6 +438,29 @@ class CliArgumentsTest {
 		assertTrue(CliArguments.parse(new String[] { "--not-a-flag", CliArguments.HELP_SHORTHAND }).helpRequested());
 	}
 
+	/**
+	 * A help flag written where a value was expected is that value, not a request:
+	 * {@code --title -h} is a flag missing its value and is refused as one. Reading
+	 * every occurrence as a request answered the run with the usage line and exited
+	 * zero, having adopted nothing — a scripted batch that mistyped one flag reported
+	 * success.
+	 */
+	@Test
+	void doesNotReadAHelpFlagSwallowedByAnotherOptionAsARequest() {
+		assertFailure(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { "--repo", REPO_URL, "--title", CliArguments.HELP_SHORTHAND }),
+				"Usage:");
+		assertFailure(IllegalArgumentException.class,
+				() -> CliArguments.parse(new String[] { REPO_URL, "--branch", CliArguments.HELP_FLAG }),
+				"Usage:");
+	}
+
+	/** A flag that takes no value swallows nothing, so the help flag after it is still a request. */
+	@Test
+	void stillAnswersHelpAfterAFlagThatTakesNoValue() {
+		assertTrue(CliArguments.parse(new String[] { REPO_URL, "--draft", CliArguments.HELP_FLAG }).helpRequested());
+	}
+
 	/** Without {@code --help} on the line, an unreadable argument is still the answer. */
 	@Test
 	void stillRefusesAnUnreadableArgumentWhenNoHelpIsAsked(@TempDir Path dir) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -490,6 +490,62 @@ class ClaudeMdConformerTest {
 		assertEquals(once, conformer.conform(once), "a second reshape must not append the sections again");
 	}
 
+	/**
+	 * A conforming document that shows what a fence looks like, four columns in,
+	 * directly below the sentence introducing it — with no blank line, so no code
+	 * block opens at the indent either. It is a lazy continuation of that paragraph
+	 * and opens nothing.
+	 */
+	private static final String INDENTED_FENCE_BELOW_A_PARAGRAPH = """
+			# CLAUDE.md
+
+			See [AGENTS.md](AGENTS.md) for the companion agent guide.
+
+			## Project
+
+			A block is delimited by three backticks:
+			    ```
+
+			## Java version
+
+			Java 25.
+
+			## Maven
+
+			Root pom is packaging=pom.
+
+			## Principles for Java Development
+
+			SOLID.
+
+			## Testing
+
+			JUnit 5.
+
+			## Dependencies
+
+			Existing only.
+			""";
+
+	/**
+	 * Reading that delimiter as a fence opened a block nothing closed, so the reshape
+	 * saw every heading below it as code: it appended a closing delimiter of its own
+	 * and a second copy of the five sections the document already carried, then
+	 * committed and pushed the result. The rule read it as conforming because it made
+	 * the same mistake, so the verification never caught it.
+	 */
+	@Test
+	void leavesAConformingDocumentWithAnIndentedFenceBelowAParagraphAlone() {
+		assertEquals(INDENTED_FENCE_BELOW_A_PARAGRAPH, conformer.conform(INDENTED_FENCE_BELOW_A_PARAGRAPH));
+	}
+
+	/** Each required section is written once, so no reader meets two of any of them. */
+	@Test
+	void doesNotDuplicateSectionsBelowAnIndentedFence() {
+		List<String> headings = headings(conformer.conform(INDENTED_FENCE_BELOW_A_PARAGRAPH));
+		assertEquals(headings.stream().distinct().toList(), headings, "no heading may be written twice: " + headings);
+	}
+
 	/** Mirrors how the rule finds headings: a heading inside a fence is code, not structure. */
 	private List<String> headingsOutsideFences(String content) {
 		return linesOutsideFences(content).stream().filter(line -> line.startsWith("#")).toList();

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -62,7 +62,8 @@ import java.util.stream.Stream;
  * how a document explains what a fence looks like. Marking the fences first and the
  * indents afterwards left that lone delimiter opening a block nothing closed, and
  * so masked every line below it — the document's remaining headings included — as
- * code.
+ * code. The indent speaks for the line wherever it sits, whether a code block may
+ * open at it or it merely continues the paragraph above.
  */
 public final class MarkdownDocument {
 
@@ -428,8 +429,9 @@ public final class MarkdownDocument {
 		/**
 		 * Marks line {@code index} and answers the state the next line is read in. An
 		 * open fence claims the line first, then a blank line, which carries nothing to
-		 * read either way and so is left unmarked; only then may an indent open a block,
-		 * and only a line no indent claimed is read as a fence delimiter.
+		 * read either way and so is left unmarked; then the indent, which speaks for the
+		 * line whether or not a block may open at it, and only a line the indent left
+		 * alone is read as a fence delimiter.
 		 */
 		Scan read(String line, boolean[] mask, int index) {
 			if (fence != null) {
@@ -438,11 +440,30 @@ public final class MarkdownDocument {
 			if (line.isBlank()) {
 				return new Scan(null, true, listIndent);
 			}
-			if (mayIndent && indentWidth(line) >= codeIndent()) {
-				mask[index] = true;
-				return new Scan(null, true, listIndent);
+			if (indentWidth(line) >= codeIndent()) {
+				return atIndent(mask, index);
 			}
 			return atDelimiter(line, mask, index);
+		}
+
+		/**
+		 * The line is indented too deep to be read as anything but its indent: code
+		 * where a block may open, and otherwise the lazy continuation of the paragraph
+		 * above it — prose either way rather than markup.
+		 * <p>
+		 * That it is not a fence delimiter is the point. A fence opener may be indented
+		 * at most three columns past its container, so a {@code ```} shown four columns
+		 * in below a paragraph opens nothing. Falling through to {@link #atDelimiter}
+		 * read one as a fence the document opened and never closed, and every line
+		 * below it — the document's remaining headings included — was masked as code:
+		 * {@link #hasHeading} then reported sections the document plainly carries as
+		 * missing, and every check that reads the document's own text stopped seeing it.
+		 * The blank-line case was already answered here; only a paragraph directly
+		 * above the indent reached the delimiter reading.
+		 */
+		private Scan atIndent(boolean[] mask, int index) {
+			mask[index] = mayIndent;
+			return new Scan(null, mayIndent, listIndent);
 		}
 
 		/**

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
@@ -376,6 +376,31 @@ class MarkdownDocumentTest {
 		assertTrue(document.hasBody("## Testing"));
 	}
 
+	/**
+	 * The same delimiter directly below a paragraph, with no blank line to open a code
+	 * block at it. It is a lazy continuation of that paragraph — a fence opener may be
+	 * indented at most three columns — so it is neither code nor a fence. Reading it as
+	 * one opened a block nothing closed and masked the whole of the document below it,
+	 * so {@code claudeMdFormat} reported sections the document plainly carries as
+	 * missing.
+	 */
+	@Test
+	void doesNotOpenAFenceOnADelimiterIndentedBelowAParagraph() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				A block is delimited by three backticks:
+				    ```
+
+				## Testing
+				Body.
+				""");
+
+		assertEquals(List.of(), codeLines(document));
+		assertEquals(Set.of("# Title", "## Testing"), document.headings());
+		assertTrue(document.hasBody("## Testing"));
+	}
+
 	/** A balanced pair shown that way is the sample's too, so nothing below it changes. */
 	@Test
 	void readsABalancedFencePairInsideAnIndentedBlockAsThatBlock() {


### PR DESCRIPTION
A ``` indented four columns is not a fence opener — Markdown allows an opener
at most three columns past its container — and directly below a paragraph it is
a lazy continuation of that paragraph rather than a code block either. Both
scans tested the indent only where a code block may open and let every other
indented line fall through to the delimiter reading, so such a line opened a
fence nothing closed and masked the rest of the document as code.

The blank-line case was already right; only a paragraph directly above the
indent reached the delimiter reading. The indent now speaks for the line
wherever it sits: code where a block may open, prose otherwise, never a
delimiter.

In the rule that made claudeMdFormat report sections a document plainly carries
as missing, and stopped the forbidden-token, line-length, file-reference and
memory-import checks seeing anything below the indent. In the conformer it was
worse, because the rule agreed: the reshape appended a closing delimiter of its
own and a second copy of five sections the document already had, then committed,
pushed and opened a pull request for the result, with VerifyStep passing on it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017ibxUKqK9AJLpjvkyqWMHJ