### PR TITLE
fix(enforcer,adopt): read markdown structure past quoted comment delimiters

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -71,9 +71,13 @@ public class ClaudeMdConformer {
 
 	private static final char BACKTICK = '`';
 	private static final char TILDE = '~';
+	private static final char HEADING_CHAR = '#';
 	private static final int MIN_FENCE_LENGTH = 3;
 	private static final String COMMENT_START = "<!--";
 	private static final String COMMENT_END = "-->";
+
+	/** An inline code span, which quotes whatever it carries rather than writing it; see {@link #asRead}. */
+	private static final Pattern CODE_SPAN = Pattern.compile("`[^`]*`");
 	private static final String STUB_BODY = "See [AGENTS.md](AGENTS.md).";
 
 	private static final char TAB = '\t';
@@ -212,7 +216,7 @@ public class ClaudeMdConformer {
 	 * {@code # CLAUDE.md} inside a code sample is the sample's, not the document's.
 	 */
 	private List<Integer> misplacedTitles(List<String> lines) {
-		return Outline.of(lines).structural(line -> TITLE.equals(line.strip())).boxed().toList().reversed();
+		return Outline.of(lines).structural(line -> declares(line, TITLE)).boxed().toList().reversed();
 	}
 
 	/**
@@ -252,7 +256,7 @@ public class ClaudeMdConformer {
 	 * required section.
 	 */
 	private Set<Integer> reservedHeadings(Outline outline) {
-		return outline.structural(line -> requiredSections.contains(line.strip()))
+		return outline.structural(line -> requiredSections.stream().anyMatch(required -> declares(line, required)))
 				.boxed()
 				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
@@ -279,12 +283,67 @@ public class ClaudeMdConformer {
 	 * A near-miss is the required heading in a different case, or followed by a
 	 * space and extra words — the two shapes {@code claude init} produces
 	 * ({@code ## Project purpose} for {@code ## Project}). The trailing space keeps
-	 * {@code ## Maven} from matching an unrelated {@code ## Mavenish} heading.
+	 * {@code ## Maven} from matching an unrelated {@code ## Mavenish} heading. The
+	 * line is compared as {@link #headingText} writes it, so which spelling a
+	 * near-miss was typed in does not decide whether it is one.
 	 */
 	private static boolean isNearMatch(String stripped, String required) {
-		String actual = stripped.toLowerCase(Locale.ROOT);
+		if (!isHeading(stripped)) {
+			return false;
+		}
+		String actual = headingText(stripped).toLowerCase(Locale.ROOT);
 		String wanted = required.toLowerCase(Locale.ROOT);
-		return isHeading(stripped) && (actual.equals(wanted) || actual.startsWith(wanted + " "));
+		return actual.equals(wanted) || actual.startsWith(wanted + " ");
+	}
+
+	/**
+	 * Whether the line declares the heading {@code required} names — the reading the
+	 * {@code claudeMdFormat} rule takes, mirroring {@code MarkdownDocument}'s
+	 * {@code headingText} in the {@code claude-code-enforcer} module.
+	 * <p>
+	 * A heading is the text it carries rather than the line it was typed on, so the
+	 * whitespace between its {@code #} run and that text — a tab, or two spaces — and
+	 * the closing {@code #} run Markdown lets an author balance it with are spelling.
+	 * Comparing the line verbatim made the reshape and the rule disagree about which
+	 * lines are the required sections: a document whose {@code ##  Testing} the rule
+	 * reads as {@code ## Testing} was reported here as not having the section at all,
+	 * so a second, stubbed copy of it was appended to a file the adoption went on to
+	 * commit and push. Where a document carries the section twice, in two spellings,
+	 * the two also disagreed about <em>which</em> of them the rule would judge, and
+	 * the reshape then stubbed a section the rule was not reading.
+	 */
+	private static boolean declares(String line, String required) {
+		String stripped = line.strip();
+		return isHeading(stripped) && headingText(stripped).equals(required);
+	}
+
+	/**
+	 * The heading a line declares, written canonically: its {@code #} run, then a
+	 * single space and the text it carries, or the run alone when it carries none.
+	 */
+	private static String headingText(String stripped) {
+		int level = headingLevel(stripped);
+		String hashes = stripped.substring(0, level);
+		String text = withoutClosingRun(stripped.substring(level).strip());
+		return text.isEmpty() ? hashes : hashes + SPACE + text;
+	}
+
+	/**
+	 * The heading's text without the {@code #} run that closes it. The run only
+	 * closes a heading when whitespace precedes it, so {@code ## C#} keeps its hash
+	 * while {@code ## Testing ##} loses both of its; a text that is nothing but
+	 * hashes — the {@code ###} of {@code ## ###} — is the closing run itself and
+	 * leaves an empty heading.
+	 */
+	private static String withoutClosingRun(String text) {
+		int end = text.length();
+		while (end > 0 && text.charAt(end - 1) == HEADING_CHAR) {
+			end--;
+		}
+		if (end == text.length()) {
+			return text;
+		}
+		return end == 0 || isIndent(text.charAt(end - 1)) ? text.substring(0, end).strip() : text;
 	}
 
 	/**
@@ -318,7 +377,7 @@ public class ClaudeMdConformer {
 	}
 
 	private static int headingLevel(String heading) {
-		return (int) heading.chars().takeWhile(character -> character == '#').count();
+		return (int) heading.chars().takeWhile(character -> character == HEADING_CHAR).count();
 	}
 
 	/**
@@ -407,9 +466,14 @@ public class ClaudeMdConformer {
 			return matching(match).filter(index -> !comment[index]);
 		}
 
-		/** @return the index of the heading outside code and comments, or {@code -1} when absent */
+		/**
+		 * @return the index of the first line declaring the heading, outside code and
+		 *         comments, or {@code -1} when the document declares it nowhere. The
+		 *         <em>first</em> is what answers, because that is the one the rule reads
+		 *         when a document carries the section twice; see {@link #declares}.
+		 */
 		int indexOfHeading(String heading) {
-			return structural(line -> line.strip().equals(heading)).findFirst().orElse(-1);
+			return structural(line -> declares(line, heading)).findFirst().orElse(-1);
 		}
 
 		/**
@@ -648,9 +712,29 @@ public class ClaudeMdConformer {
 	private static boolean markComments(List<String> lines, boolean[] code, boolean[] mask) {
 		boolean open = false;
 		for (int index = 0; index < lines.size(); index++) {
-			open = applyComment(lines.get(index).strip(), open, code[index], mask, index);
+			open = applyComment(lines.get(index), open, code[index], mask, index);
 		}
 		return open;
+	}
+
+	/**
+	 * The line as the comment scan reads it, mirroring {@code MarkdownDocument} in the
+	 * {@code claude-code-enforcer} module. Outside a comment its inline code spans are
+	 * dropped first, because a delimiter quoted as code is the document illustrating
+	 * one rather than writing one: a {@code CLAUDE.md} whose prose says an HTML
+	 * comment opens with {@code `<!--`} was read as opening one that nothing closes,
+	 * so the reshape appended a closing {@code -->} of its own and then read every
+	 * heading below the mention as inert — appending a second copy of five sections
+	 * the document already carried, to a file it went on to commit, push, and open a
+	 * pull request for. The rule reads the mention the same way, so {@link VerifyStep}
+	 * passed on the result.
+	 *
+	 * <p>Inside a comment there are no code spans to honour: the text is already
+	 * inert, so its backticks are ordinary characters and a {@code -->} among them
+	 * closes the block exactly as one anywhere else on the line does.
+	 */
+	private static String asRead(String line, boolean open) {
+		return (open ? line : CODE_SPAN.matcher(line).replaceAll(" ")).strip();
 	}
 
 	/**
@@ -675,8 +759,9 @@ public class ClaudeMdConformer {
 		if (insideCode) {
 			return open;
 		}
-		mask[index] = open || opensBlock(line);
-		return remainsOpen(line, 0, open);
+		String read = asRead(line, open);
+		mask[index] = open || opensBlock(read);
+		return remainsOpen(read, 0, open);
 	}
 
 	/** Whether the line's own content starts a comment that the same line does not close. */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -809,6 +809,49 @@ class ClaudeMdConformerTest {
 	}
 
 	/**
+	 * A delimiter quoted as code is the document illustrating a comment rather than
+	 * writing one, which is how the rule reads it. Taking it for a real one opened a
+	 * block nothing closed: the reshape appended a closing {@code -->} of its own and
+	 * read every heading below the mention as inert, so an already-conforming
+	 * {@code CLAUDE.md} came back with a stray delimiter and a second, stubbed copy of
+	 * five sections it already carried — committed, pushed, and offered for review.
+	 */
+	@Test
+	void leavesADocumentMentioningACommentDelimiterInAnInlineCodeSpanAlone() {
+		String conforming = ("# CLAUDE.md\n\n" + ClaudeMdConformer.AGENTS_REFERENCE_LINE
+				+ "\n\nAn HTML comment opens with `<!--`.\n\n" + requiredSectionsBody()).stripTrailing() + "\n";
+
+		assertEquals(conforming, conformer.conform(conforming),
+				"a mention of the delimiter is not a comment the reshape has to close");
+	}
+
+	/**
+	 * A heading is the text it carries rather than the line it was typed on, which is
+	 * how the rule reads it: {@code ##  Testing} is the {@code ## Testing} section.
+	 * Comparing the line verbatim reported the section as absent and appended a second,
+	 * stubbed copy of it to a document that already had one.
+	 */
+	@Test
+	void recognisesARequiredSectionWrittenWithAWiderSeparator() {
+		String generated = """
+				# CLAUDE.md
+
+				See AGENTS.md.
+
+				##  Testing
+
+				JUnit 5.
+				""";
+		String conformed = conformer.conform(generated);
+
+		assertEquals(1, headings(conformed).stream()
+				.filter(heading -> heading.replaceAll("\\s+", " ").equals("## Testing")).count(),
+				"the section the document already carries must not be appended again:\n" + conformed);
+		assertFalse(conformed.contains("## Testing\n\n" + ClaudeMdConformer.AGENTS_REFERENCE_LINE),
+				"the section already had a body:\n" + conformed);
+	}
+
+	/**
 	 * A line that merely starts with a hash is prose to the rule, so the section it
 	 * sits in already has a body. Reading it as a shallower heading ended the section
 	 * above it, and a stub was inserted in front of the content the section carried.

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/MarkdownDocument.java
@@ -26,7 +26,8 @@ import java.util.stream.Stream;
  * A heading is also recognised only outside an HTML comment block. A section
  * commented out with {@code <!-- ... -->} is inert text, not structure, so counting
  * it would let a document satisfy a required-section check with the very heading its
- * author had removed.
+ * author had removed. The delimiters that open and close such a block are read only
+ * where a document writes one rather than illustrates one — see {@link #asRead}.
  * <p>
  * A fence is closed only by a run of the <em>same</em> character, at least as long
  * as the one that opened it, carrying no info string. All three conditions matter,
@@ -372,7 +373,7 @@ public final class MarkdownDocument {
 		boolean[] mask = new boolean[lines.size()];
 		boolean open = false;
 		for (int i = 0; i < lines.size(); i++) {
-			open = applyComment(lines.get(i).strip(), open, insideCode[i], mask, i);
+			open = applyComment(lines.get(i), open, insideCode[i], mask, i);
 		}
 		return mask;
 	}
@@ -389,8 +390,29 @@ public final class MarkdownDocument {
 		if (insideCode) {
 			return open;
 		}
-		mask[index] = open || opensBlock(line);
-		return remainsOpen(line, 0, open);
+		String read = asRead(line, open);
+		mask[index] = open || opensBlock(read);
+		return remainsOpen(read, 0, open);
+	}
+
+	/**
+	 * The line as the comment scan reads it. Outside a comment its inline code spans
+	 * are dropped first, because a delimiter quoted as code is the document
+	 * illustrating one rather than writing one — the same reading
+	 * {@link #containsUnquoted} takes, and the reading a fence already gets from
+	 * being matched on whole lines. Documentation about Markdown writes
+	 * {@code `<!--`} in prose precisely because it is an example, and taking it for a
+	 * real delimiter opened a comment nothing closed: every line below it was masked
+	 * as inert, so {@link #hasHeading} reported sections the document plainly carries
+	 * as missing and every check that reads the document's own text stopped seeing
+	 * it — the same silent reclassification a mis-read fence produces.
+	 * <p>
+	 * Inside a comment there are no code spans to honour: the text is already inert,
+	 * so its backticks are ordinary characters and a {@code -->} among them closes
+	 * the block exactly as one anywhere else on the line does.
+	 */
+	private static String asRead(String line, boolean open) {
+		return (open ? line : MarkdownText.withoutCodeSpans(line)).strip();
 	}
 
 	/** True when the line's own content starts a comment that the same line does not close. */

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/MarkdownDocumentTest.java
@@ -607,6 +607,52 @@ class MarkdownDocumentTest {
 		assertFalse(document.containsInProse("TODO"));
 	}
 
+	/**
+	 * A delimiter quoted as code is the document illustrating a comment rather than
+	 * writing one. Reading it as a real one opened a block nothing closed, so every
+	 * line below the mention was masked as inert and the sections the document plainly
+	 * carries were reported as missing — the same silent reclassification a mis-read
+	 * fence produces, reached from a sentence documentation about Markdown routinely
+	 * writes.
+	 */
+	@Test
+	void doesNotOpenACommentOnADelimiterInsideAnInlineCodeSpan() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				An HTML comment opens with `<!--`.
+
+				## Testing
+				Body.
+				""");
+
+		assertEquals(List.of(), commentedLines(document));
+		assertEquals(Set.of("# Title", "## Testing"), document.headings());
+		assertTrue(document.hasBody("## Testing"));
+	}
+
+	/**
+	 * Inside a comment there are no code spans to honour: the text is already inert,
+	 * so its backticks are ordinary characters and the {@code -->} among them closes
+	 * the block exactly as one anywhere else on the line does.
+	 */
+	@Test
+	void closesACommentOnADelimiterWrittenInsideBackticks() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				<!--
+				A note.
+				`-->`
+
+				## Testing
+				Body.
+				""");
+
+		assertEquals(List.of(2, 3, 4), commentedLines(document));
+		assertEquals(Set.of("# Title", "## Testing"), document.headings());
+	}
+
 	@Test
 	void marksTheLinesAnHtmlCommentSpansAsCommented() {
 		MarkdownDocument document = MarkdownDocument.parse("""


### PR DESCRIPTION
Two defects made the CLAUDE.md reader and the adoption's conformer disagree
with each other, and with the document in front of them.

An HTML comment delimiter written inside an inline code span was read as a
real one. Documentation about Markdown writes `<!--` in prose precisely
because it is an example, and taking it for a delimiter opened a block
nothing closed: every line below the mention was masked as inert, so
claudeMdFormat reported sections the document plainly carries as missing,
and the conformer appended a stray `-->` plus a second stubbed copy of five
sections to a file the adoption went on to commit and push. Outside a
comment the scan now drops code spans first, the same reading
containsUnquoted and the link and import scans already take; inside one the
text is already inert, so a `-->` among its backticks still closes it.

The conformer also matched a required heading by the line it was typed on
while the rule matches by the text it carries, so `##  Testing` was reported
as an absent section and a duplicate was appended beneath the one the
document already had. The conformer now canonicalises a heading the way
MarkdownDocument does, and takes the first line declaring it — the one the
rule judges when a document carries the section twice.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016HSjJuac1oZ3soXq7pr1gz