### PR TITLE
refactor(markdown-common): share one Markdown reader between the enforcer and adopt

### DIFF
--- a/.claude/skills/java-code-review/SKILL.md
+++ b/.claude/skills/java-code-review/SKILL.md
@@ -102,13 +102,19 @@ reader's invariants and the adversarial-input checklist.
 
 ### 2.2 Two implementations of one format, drifting
 
-`ClaudeMdConformer` duplicates `claudeMdFormat`'s reading of a Markdown document
-because `adopt` must not ship the maven-enforcer API. #536 was four defects from
-that copy drifting: the conformer produced a document the rule it exists to
-satisfy rejects, so the adoption failed its own `VerifyStep` on a file it had just
-reshaped to pass. #557 is the same shape one level up — detection asked whether a
-pom *depended on* the enforcer artifact rather than whether it *configures the
-rule*.
+`ClaudeMdConformer` used to duplicate `claudeMdFormat`'s reading of a Markdown
+document, because `adopt` must not ship the maven-enforcer API. #536 was four
+defects from that copy drifting: the conformer produced a document the rule it
+exists to satisfy rejects, so the adoption failed its own `VerifyStep` on a file
+it had just reshaped to pass. #557 is the same shape one level up — detection
+asked whether a pom *depended on* the enforcer artifact rather than whether it
+*configures the rule*.
+
+The reading now lives once, in `markdown-common`, which both modules depend on.
+That is the fix this defect shape usually wants: when two implementations must
+agree, look for the third place they could both depend on before reaching for a
+test that compares them. What survives as a copy is the *required sections* list
+— data, guarded by `ClaudeMdConformerContractTest`.
 
 **Ask:**
 - Is there a second implementation of this format, constant, or predicate

--- a/.claude/skills/maven-conventions/SKILL.md
+++ b/.claude/skills/maven-conventions/SKILL.md
@@ -67,6 +67,17 @@ profile, is the most common source of avoidable build friction here.
   fails the build on a dependency outside `java..`.
 - **A typo in `-P` fails the build**, not the run: the root `enforce` execution
   runs `requireProfileIdsExist`.
+- **The `claude-md-enforce` profile activates on the root project only**, by
+  requiring a `CLAUDE.md` beside the pom as well as the `enforceClaudeMd`
+  property. A profile in a parent is inherited, so without that second condition
+  every module takes on the profile's `maven-enforcer-plugin` declaration — and
+  Maven orders a project after every plugin dependency it declares, giving each
+  module a reactor edge to `claude-code-enforcer`. Maven quietly tolerates a
+  cycle closed by a plugin edge, so that stayed invisible until a reactor module
+  became a real dependency of the enforcer (`markdown-common`); the cycle then
+  closed through a dependency edge and `mvn -B package -DenforceClaudeMd` could
+  not sort the reactor at all. **Do not put a reactor artifact in a plugin's
+  `<dependencies>` in an inherited profile.**
 - **A module that is not a reusable library** (example, test harness,
   distribution) opts out of publishing with `<maven.deploy.skip>` and
   `<central.skipPublishing>` in its `<properties>` — never by redeclaring the

--- a/.claude/skills/maven-conventions/SKILL.md
+++ b/.claude/skills/maven-conventions/SKILL.md
@@ -57,9 +57,14 @@ profile, is the most common source of avoidable build friction here.
   `shellcheck` and works offline. Skip it with `-Dskip.shellcheck=true` when you
   just want a fast loop.
 - **Java 25** is required: JDK 25 on `PATH` with `JAVA_HOME` set.
-- The root reactor modules are: `claude-code-enforcer`, `test-common`,
-  `mcp-common`, `data`, `code`, `adopt`, `grpc-example`, `assembly`. `data-test`
-  is built separately (not in the root `<modules>`).
+- The root reactor modules are: `markdown-common`, `claude-code-enforcer`,
+  `test-common`, `mcp-common`, `data`, `code`, `adopt`, `grpc-example`,
+  `assembly`. `data-test` is built separately (not in the root `<modules>`).
+- **`markdown-common` takes no dependencies.** It is shared by the enforcer rule
+  and by `adopt` precisely so both read a document identically; anything added
+  there travels to every consumer of either, including repositories that resolve
+  the enforcer rule as a maven-enforcer-plugin dependency. Its architecture test
+  fails the build on a dependency outside `java..`.
 - **A typo in `-P` fails the build**, not the run: the root `enforce` execution
   runs `requireProfileIdsExist`.
 - **A module that is not a reusable library** (example, test harness,

--- a/.claude/skills/text-parsers/README.md
+++ b/.claude/skills/text-parsers/README.md
@@ -7,10 +7,10 @@
 ## Description
 
 Carries the invariants of this repo's text readers — the hand-rolled
-`MarkdownDocument`, `MarkdownText`, `ImportGraph` and `CommandTokens`, the
-`ClaudeMdConformer` copy of them, and the SnakeYAML-backed `FrontMatter` —
-together with the adversarial input that has broken each one, so a change starts
-from that list instead of rediscovering it.
+`MarkdownDocument` and `MarkdownText` that `claude-code-enforcer` and `adopt`
+share through `markdown-common`, plus `ImportGraph`, `CommandTokens` and the
+SnakeYAML-backed `FrontMatter` — together with the adversarial input that has
+broken each one, so a change starts from that list instead of rediscovering it.
 
 ---
 

--- a/.claude/skills/text-parsers/SKILL.md
+++ b/.claude/skills/text-parsers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: text-parsers
-description: Work on this repo's text readers — MarkdownDocument, MarkdownText, ImportGraph, CommandTokens, the ClaudeMdConformer copy of them, and the SnakeYAML-backed FrontMatter — and the adversarial input that has broken each. Use when changing how a document, YAML front matter, a memory import or a hook command is read, when a rule fires on valid input or passes invalid input, or when the user says "fence", "front matter", "heading detection", "memory import", or "hook command".
+description: Work on this repo's text readers — the shared MarkdownDocument and MarkdownText in markdown-common, ImportGraph, CommandTokens, the SnakeYAML-backed FrontMatter, and how ClaudeMdConformer reads through them — and the adversarial input that has broken each. Use when changing how a document, YAML front matter, a memory import or a hook command is read, when a rule fires on valid input or passes invalid input, or when the user says "fence", "front matter", "heading detection", "memory import", or "hook command".
 ---
 
 # Text Parsers Skill
@@ -9,7 +9,10 @@ The `claude-code-enforcer` rules and the `adopt` conformer read Markdown, YAML
 front matter, `@path` imports and shell hook commands with small readers of their
 own. Those readers carry the largest share of this repository's shipped defects:
 `FrontMatter` and `CommandTokens` have each been fixed in six or seven separate
-commits, `MarkdownDocument` and `ClaudeMdConformer` in four or five.
+commits, `MarkdownDocument` in four or five — several of those twice over, once
+in the reader and once in the copy `ClaudeMdConformer` used to carry, which is
+why the Markdown reader now lives in `markdown-common` with a single caller-facing
+copy.
 
 Every one of those fixes was the same thing — real input the reader had not been
 written for. This skill is the accumulated list, so the next change starts from
@@ -118,22 +121,33 @@ Splits a hook command the way a shell would.
   `--out target/log.txt` to exist fails a build over a file the hook is about to
   write.
 
-## The two-readers problem
+## The checker and the rewriter
 
-`ClaudeMdConformer` in `adopt` spells out a second copy of `MarkdownDocument`'s
-fence and comment reading, plus `claudeMdFormat`'s required sections. It has to —
+Two callers read a `CLAUDE.md` and must agree about it: `claudeMdFormat` judges
+one, and `adopt`'s `ClaudeMdConformer` reshapes one so that judgement passes.
+They share `markdown-common`, a module carrying nothing but the reader, because
 `adopt` is a plain library and must not put the maven-enforcer API on every
-consumer's classpath.
+consumer's classpath — so it cannot depend on `claude-code-enforcer` to get it.
 
-**A copy is only safe when a test proves it agrees.** The pattern here is
-`ClaudeMdConformerContractTest`: it runs the *real* rule, on a test-scoped
-dependency, over the conformer's output, and asserts the raw fixture is rejected
-first so a conformer that stopped reshaping cannot pass by doing nothing.
+The conformer used to spell out its own copy of the fence and comment reading.
+Every way the two copies drifted apart produced one shape of bug: the conformer
+acted on lines the rule holds to be code, or appended a section the rule already
+reads as present, and the adoption then failed its own `VerifyStep` — after
+committing and pushing the file. **Read a document through `MarkdownDocument`;
+never re-derive a mask, a fence or a heading on either side.**
+
+What the conformer still copies is `claudeMdFormat`'s *required sections* — data,
+not reading. `ClaudeMdConformerContractTest` holds that copy honest: it runs the
+*real* rule, on a test-scoped dependency, over the conformer's output, and
+asserts the raw fixture is rejected first so a conformer that stopped reshaping
+cannot pass by doing nothing.
 
 When you touch either side:
 
-1. Change the enforcer reader.
-2. Mirror it in the conformer.
+1. Change the shared reader in `markdown-common`. Both sides move together, which
+   is the whole point of the module.
+2. If the change is to the *required sections*, mirror the constant in the
+   conformer — that is the one thing still written twice.
 3. Add the case to the contract test — **fixture rejected before, accepted after**.
 
 Skipping step 3 is what shipped #536: four defects where the conformer produced a
@@ -141,13 +155,15 @@ document the rule it exists to satisfy rejects, so the adoption failed its own
 `VerifyStep` on a file it had just reshaped to pass it — on someone else's
 repository, after the branch was pushed.
 
-**Mirroring the invariant is not enough; mirror the *algorithm*.** The conformer
-once read fences and indents in two passes where the rule read them in one. Every
-row of the table above still held on each pass alone, and the contract test had a
+**Why the reader is shared rather than mirrored.** Mirroring the invariant was
+never enough; the *algorithm* had to match too. The conformer once read fences
+and indents in two passes where the rule read them in one. Every row of the table
+above still held on each pass alone, and the contract test had a
 case for a fenced sample and a case for an indented one — but none for a fence
 *inside* an indented sample, which is the only input the two orderings disagree
-on. Both readers now run the same single-pass `Scan`, which is what makes a case
-like that impossible to have on one side only.
+on. There is now one single-pass `Scan` rather than two that have to be kept
+equal, which is what makes a divergence like that unrepresentable instead of
+merely tested for.
 
 ## Adversarial input checklist
 
@@ -201,8 +217,11 @@ in its column before calling it done.
   dependency needs asking first (see `CLAUDE.md`, *Dependencies*).
 
 ## References
+- `markdown-common/src/main/java/io/github/adamw7/tools/markdown/`
+  — `MarkdownDocument`, `MarkdownText`; shared by the enforcer and by `adopt`,
+  and dependency-free so it can be
 - `claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/`
-  — `MarkdownDocument`, `FrontMatter`, `MarkdownText`, `FrontMatterFixer`
+  — `FrontMatter`, `FrontMatterFixer`, `NameConvention`
 - `.../enforcer/doc/ImportGraph.java`, `.../enforcer/settings/CommandTokens.java`
 - `adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java`
   and `ClaudeMdConformerContractTest`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,8 @@ unwrapped.
 
 ```
 tools (root pom, packaging=pom)
+├── markdown-common             # shared Markdown reader: lines plus the code and
+│                               #   HTML-comment masks (dependency-free)
 ├── claude-code-enforcer        # custom maven-enforcer rules validating CLAUDE.md,
 │                               #   AGENTS.md, README.md and the .claude config
 ├── test-common                 # shared ArchUnit rule libraries and assertions (test-jar)
@@ -200,9 +202,21 @@ tools (root pom, packaging=pom)
 └── data-test                   # standalone test module for the data module
 ```
 
-Root reactor modules are `claude-code-enforcer`, `test-common`, `mcp-common`,
-`data`, `code`, `adopt`, `grpc-example` and `assembly`. `data-test` is built
-separately (it is not in the root `<modules>` list).
+Root reactor modules are `markdown-common`, `claude-code-enforcer`,
+`test-common`, `mcp-common`, `data`, `code`, `adopt`, `grpc-example` and
+`assembly`. `data-test` is built separately (it is not in the root `<modules>`
+list).
+
+`markdown-common` exists because two modules read the same document and must
+agree about it: `claude-code-enforcer`'s `claudeMdFormat` rule judges a
+`CLAUDE.md`, and `adopt`'s `ClaudeMdConformer` reshapes one so that rule passes.
+`adopt` cannot depend on `claude-code-enforcer` to share the reader — that would
+put the maven-enforcer API and a shipped rule on every consumer's classpath — so
+each carried a copy, and every way the copies drifted apart let the adoption
+commit and push a file that then failed its own verification. Keep the module
+free of dependencies beyond the JDK; its architecture test pins that, because
+anything added there travels to both consumers and to every repository that
+resolves the enforcer rule.
 
 Base Java package: `io.github.adamw7` (`io.github.adamw7.context` for the context
 module, `io.github.adamw7.tools.*` elsewhere).
@@ -487,6 +501,7 @@ module's `*IT`s stay unrun until it gets its own copy. Run them with
   | Module | Threshold | Measured when set |
   | --- | --- | --- |
   | `code/context` | 92 | 95% |
+  | `markdown-common` | 91 | 94% |
   | `adopt` | 88 | 91% |
   | `claude-code-enforcer` | 88 | 91% |
   | `code/protogen-maven-plugin` | 84 | 87% |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,13 +43,18 @@ run `mvn install` from the repository root.
   credentials are masked everywhere, `--dry-run` leaves out the push and the pull
   request entirely, and one run adopts a list of repositories without letting a
   failure stop the rest. Skill: `adopt-pipeline`.
+- **Markdown reading** (`markdown-common`) — the dependency-free reader both the
+  `claudeMdFormat` rule and `adopt`'s conformer parse a document with, so the
+  checker and the rewriter cannot disagree about what is code, what is
+  commented out, and what heading a line declares. Add no dependency to it.
 
-Module map (root reactor: `claude-code-enforcer`, `test-common`, `mcp-common`,
-`data`, `code`, `adopt`, `grpc-example`, `assembly`; `data-test` is built
-separately):
+Module map (root reactor: `markdown-common`, `claude-code-enforcer`,
+`test-common`, `mcp-common`, `data`, `code`, `adopt`, `grpc-example`,
+`assembly`; `data-test` is built separately):
 
 ```
 tools (root pom, packaging=pom)
+├── markdown-common        # shared Markdown reader (lines + code/comment masks), dependency-free
 ├── claude-code-enforcer   # custom maven-enforcer rules validating CLAUDE.md/AGENTS.md & agent config
 ├── test-common            # shared ArchUnit rule libraries and test assertions (test-jar)
 ├── mcp-common             # shared MCP server scaffolding

--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -89,6 +89,17 @@
 	</profiles>
 
 	<dependencies>
+		<!-- Reads the generated CLAUDE.md for ClaudeMdConformer. It is the same
+		     reader the claudeMdFormat rule judges the reshaped file with, which is
+		     the point: the conformer used to carry a copy of it, and every way the
+		     two drifted apart let the adoption commit and push a file that then
+		     failed its own VerifyStep. The module is dependency-free, so sharing it
+		     costs the pipeline nothing it did not already carry. -->
+		<dependency>
+			<groupId>io.github.adamw7</groupId>
+			<artifactId>tools.markdown-common</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.mcp-common</artifactId>

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -5,11 +5,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.function.Predicate;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+
+import io.github.adamw7.tools.markdown.MarkdownDocument;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * Reshapes the {@code CLAUDE.md} that {@link ClaudeInitStep} generated so it
@@ -32,6 +32,17 @@ import java.util.stream.IntStream;
  * {@code AGENTS.md} reference are settled either way: the step writes a companion
  * {@code AGENTS.md} for every adopted repository, and a document that never points
  * at it leaves the pair pointing only one way.
+ *
+ * <p>How the document is <em>read</em> — which lines are code, which sit inside an
+ * HTML comment, and what heading a line declares — is not this class's to decide.
+ * It asks {@link MarkdownDocument}, the same reader the {@code claudeMdFormat}
+ * rule judges the result with. Those readings used to be spelled out here a second
+ * time, and every way the two spellings drifted apart produced one shape of bug:
+ * this class acted on lines the rule holds to be code, or appended a section the
+ * rule already reads as present, and the adoption then failed the very check it
+ * exists to satisfy — after committing and pushing the file. Sharing the reader is
+ * what makes that class of disagreement unrepresentable rather than merely tested
+ * for.
  */
 public class ClaudeMdConformer {
 
@@ -41,7 +52,8 @@ public class ClaudeMdConformer {
 	 * required section headings the wired-in claudeMdFormat rule checks for. They
 	 * are duplicated here rather than imported because the adopt module does not
 	 * depend on the enforcer module — a pipeline that shipped an enforcer rule
-	 * would force the maven-enforcer API on every consumer.
+	 * would force the maven-enforcer API on every consumer. The shared reader below
+	 * is what both modules do get to import, since it carries neither.
 	 *
 	 * The copy is not trusted to stay in step: ClaudeMdConformerContractTest runs
 	 * the real rule over this class's output, on a test-scoped dependency, so a
@@ -69,43 +81,7 @@ public class ClaudeMdConformer {
 
 	static final String AGENTS_REFERENCE_LINE = "See [AGENTS.md](AGENTS.md) for the companion agent guide.";
 
-	private static final char BACKTICK = '`';
-	private static final char TILDE = '~';
-	private static final char HEADING_CHAR = '#';
-	private static final int MIN_FENCE_LENGTH = 3;
-	private static final String COMMENT_START = "<!--";
-	private static final String COMMENT_END = "-->";
-
-	/** An inline code span, which quotes whatever it carries rather than writing it; see {@link #asRead}. */
-	private static final Pattern CODE_SPAN = Pattern.compile("`[^`]*`");
 	private static final String STUB_BODY = "See [AGENTS.md](AGENTS.md).";
-
-	private static final char TAB = '\t';
-	private static final char SPACE = ' ';
-
-	/** The mark a UTF-8 document may open with; see {@link #splitLines}. */
-	private static final char BYTE_ORDER_MARK = '\uFEFF';
-
-	/** The indent Markdown reads as a code block, and the width a tab advances to. */
-	private static final int CODE_INDENT = 4;
-
-	/**
-	 * One to six {@code #} characters, then whitespace and any text, or nothing at
-	 * all — the ATX heading the rule recognises. Reading a heading any more loosely
-	 * than the rule does makes the reshape act on prose the rule holds to be body: a
-	 * {@code #1 rule: run mvn install} was taken for a level-one heading that ended
-	 * the section above it, so a section that already had a body was given a stub in
-	 * front of the prose it already carried.
-	 */
-	private static final Pattern ATX_HEADING = Pattern.compile("#{1,6}(\\s.*)?");
-
-	/**
-	 * The marker opening a list item, with the whitespace that separates it from the
-	 * item's content: a bullet, or an ordered marker, indented too little to be code
-	 * itself. What the match is wanted for is its width — the column the item's content,
-	 * and so its continuation paragraphs, are indented to.
-	 */
-	private static final Pattern LIST_MARKER = Pattern.compile("[ \\t]{0,3}(?:[-+*]|\\d{1,9}[.)])(?:[ \\t]+|$)");
 
 	/** The blank lines the reshape may leave at the end, dropped so the document keeps a single one. */
 	private static final Pattern TRAILING_BLANK_LINES = Pattern.compile("\\n\\s*+\\z");
@@ -128,11 +104,16 @@ public class ClaudeMdConformer {
 	 * making only where a guard would otherwise reject the file, so what to require
 	 * is the build system's to say.
 	 *
+	 * <p>A heading named twice is kept once. Each required section is settled against
+	 * the document as it stood before the pass, so a list repeating one would have
+	 * had a second near-miss renamed to it — leaving the document carrying the
+	 * heading twice, which is not what asking for it twice could have meant.
+	 *
 	 * @param requiredSections the headings to canonicalize, append and give a body to,
 	 *                         empty for a guard that demands no particular section
 	 */
 	public ClaudeMdConformer(List<String> requiredSections) {
-		this.requiredSections = List.copyOf(requiredSections);
+		this.requiredSections = List.copyOf(new LinkedHashSet<>(requiredSections));
 	}
 
 	/**
@@ -150,43 +131,37 @@ public class ClaudeMdConformer {
 	}
 
 	/**
-	 * A leading byte-order mark is dropped, the same reading {@code MarkdownText} takes
-	 * before the rule sees the document. Keeping it left the title line as a
-	 * {@code U+FEFF} in front of {@code # CLAUDE.md}, which {@link String#strip()} does
-	 * not shorten — the mark is not whitespace — so the reshape concluded the title was
-	 * missing and prepended a second one. The rule accepted the result either way,
-	 * having stripped the mark itself, so nothing downstream reported the duplicated
-	 * title the adoption had just committed.
+	 * The lines are split here rather than left to {@link MarkdownDocument#parse},
+	 * because {@link String#lines()} drops the empty line a document's trailing
+	 * newline leaves and this reshape appends to the list it splits.
+	 *
+	 * <p>A leading byte-order mark is dropped, the same reading the rule takes before
+	 * it sees the document. Keeping it left the title line as a {@code U+FEFF} in
+	 * front of {@code # CLAUDE.md}, which {@link String#strip()} does not shorten —
+	 * the mark is not whitespace — so the reshape concluded the title was missing and
+	 * prepended a second one. The rule accepted the result either way, having
+	 * stripped the mark itself, so nothing downstream reported the duplicated title
+	 * the adoption had just committed.
 	 */
 	private List<String> splitLines(String content) {
-		return new ArrayList<>(List.of(LineTerminators.normalized(withoutByteOrderMark(content)).split("\n", -1)));
-	}
-
-	private static String withoutByteOrderMark(String content) {
-		return content.isEmpty() || content.charAt(0) != BYTE_ORDER_MARK ? content : content.substring(1);
+		String normalized = LineTerminators.normalized(MarkdownText.stripByteOrderMark(content));
+		return new ArrayList<>(List.of(normalized.split("\n", -1)));
 	}
 
 	/**
 	 * Closes a fence and an HTML comment the document opened and never closed, so
-	 * everything appended below lands outside the block. The fence is closed with a
-	 * delimiter that actually closes it, so a {@code ````} wrapper is not left open by
-	 * a {@code ```} line. A section appended inside an open comment is inert text the
-	 * rule does not see, so the adoption would fail its own {@link VerifyStep} on a
-	 * section it had just added. A document whose fences and comments balance is left
-	 * untouched, keeping the reshape idempotent.
+	 * everything appended below lands outside the block. A section appended inside an
+	 * open comment is inert text the rule does not see, so the adoption would fail its
+	 * own {@link VerifyStep} on a section it had just added. A document whose fences
+	 * and comments balance is left untouched, keeping the reshape idempotent.
 	 *
 	 * <p>The fence is closed first, because a comment inside a fenced code block is
 	 * sample text rather than a comment — the same precedence the rule reads them
-	 * with — and the outline is taken afresh afterwards so the added line counts.
+	 * with — and the document is read afresh afterwards so the added line counts.
 	 */
 	private void closeUnterminatedBlocks(List<String> lines) {
-		Delimiter openFence = Outline.of(lines).openFence();
-		if (openFence != null) {
-			lines.add(openFence.closing());
-		}
-		if (Outline.of(lines).openComment()) {
-			lines.add(COMMENT_END);
-		}
+		MarkdownDocument.of(lines).openFenceTerminator().ifPresent(lines::add);
+		MarkdownDocument.of(lines).openCommentTerminator().ifPresent(lines::add);
 	}
 
 	/**
@@ -201,22 +176,18 @@ public class ClaudeMdConformer {
 	 * re-adoption did not clear it either. This is the same shape the byte-order mark
 	 * once produced (see {@link #splitLines}), reached from a document whose title
 	 * simply was not first.
+	 *
+	 * <p>The titles are removed latest first, so removing one cannot shift the index
+	 * of the next. Only structural lines are offered: a {@code # CLAUDE.md} inside a
+	 * code sample is the sample's, not the document's.
 	 */
 	private void ensureTitle(List<String> lines) {
-		if (TITLE.equals(firstNonBlank(lines))) {
+		MarkdownDocument document = MarkdownDocument.of(lines);
+		if (TITLE.equals(document.firstNonBlankLine())) {
 			return;
 		}
-		misplacedTitles(lines).forEach(index -> removeHeading(lines, index));
+		document.headingIndices(TITLE).boxed().toList().reversed().forEach(index -> removeHeading(lines, index));
 		lines.addAll(0, List.of(TITLE, ""));
-	}
-
-	/**
-	 * The title headings the document carries, latest first so removing one cannot
-	 * shift the index of the next. Only structural lines are offered: a
-	 * {@code # CLAUDE.md} inside a code sample is the sample's, not the document's.
-	 */
-	private List<Integer> misplacedTitles(List<String> lines) {
-		return Outline.of(lines).structural(line -> declares(line, TITLE)).boxed().toList().reversed();
 	}
 
 	/**
@@ -235,19 +206,16 @@ public class ClaudeMdConformer {
 		return index == 0 || lines.get(index - 1).isBlank();
 	}
 
-	private String firstNonBlank(List<String> lines) {
-		return lines.stream().map(String::strip).filter(line -> !line.isEmpty()).findFirst().orElse("");
-	}
-
 	/**
-	 * Renaming a heading in place leaves the line count untouched, so one outline
-	 * serves every required section here — unlike {@link #ensureSection}, which
-	 * inserts lines and has to read the document afresh each time.
+	 * Renaming a heading in place leaves the line count untouched and cannot turn a
+	 * structural line into code, so one reading of the document serves every required
+	 * section here — unlike {@link #ensureSection}, which inserts lines and has to
+	 * read the document afresh each time.
 	 */
 	private void canonicalizeHeadings(List<String> lines) {
-		Outline outline = Outline.of(lines);
-		Set<Integer> claimed = reservedHeadings(outline);
-		requiredSections.forEach(required -> canonicalize(outline, required, claimed));
+		MarkdownDocument document = MarkdownDocument.of(lines);
+		Set<Integer> claimed = reservedHeadings(document);
+		requiredSections.forEach(required -> canonicalize(lines, document, required, claimed));
 	}
 
 	/**
@@ -255,25 +223,26 @@ public class ClaudeMdConformer {
 	 * a near-match search never renames a heading that is already serving another
 	 * required section.
 	 */
-	private Set<Integer> reservedHeadings(Outline outline) {
-		return outline.structural(line -> requiredSections.stream().anyMatch(required -> declares(line, required)))
+	private Set<Integer> reservedHeadings(MarkdownDocument document) {
+		return document
+				.structuralLines(line -> MarkdownDocument.headingOf(line).filter(requiredSections::contains).isPresent())
 				.boxed()
 				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
-	private void canonicalize(Outline outline, String required, Set<Integer> claimed) {
-		if (outline.indexOfHeading(required) >= 0) {
+	private void canonicalize(List<String> lines, MarkdownDocument document, String required, Set<Integer> claimed) {
+		if (document.headingIndex(required) >= 0) {
 			return;
 		}
-		int index = firstNearMatch(outline, required, claimed);
+		int index = firstNearMatch(document, required, claimed);
 		if (index >= 0) {
-			outline.lines().set(index, required);
+			lines.set(index, required);
 			claimed.add(index);
 		}
 	}
 
-	private int firstNearMatch(Outline outline, String required, Set<Integer> claimed) {
-		return outline.structural(line -> isNearMatch(line.strip(), required))
+	private int firstNearMatch(MarkdownDocument document, String required, Set<Integer> claimed) {
+		return document.structuralLines(line -> isNearMatch(line, required))
 				.filter(index -> !claimed.contains(index))
 				.findFirst()
 				.orElse(-1);
@@ -284,66 +253,15 @@ public class ClaudeMdConformer {
 	 * space and extra words — the two shapes {@code claude init} produces
 	 * ({@code ## Project purpose} for {@code ## Project}). The trailing space keeps
 	 * {@code ## Maven} from matching an unrelated {@code ## Mavenish} heading. The
-	 * line is compared as {@link #headingText} writes it, so which spelling a
-	 * near-miss was typed in does not decide whether it is one.
+	 * line is compared as {@link MarkdownDocument#headingOf} writes it, so which
+	 * spelling a near-miss was typed in does not decide whether it is one.
 	 */
-	private static boolean isNearMatch(String stripped, String required) {
-		if (!isHeading(stripped)) {
-			return false;
-		}
-		String actual = headingText(stripped).toLowerCase(Locale.ROOT);
+	private static boolean isNearMatch(String line, String required) {
 		String wanted = required.toLowerCase(Locale.ROOT);
-		return actual.equals(wanted) || actual.startsWith(wanted + " ");
-	}
-
-	/**
-	 * Whether the line declares the heading {@code required} names — the reading the
-	 * {@code claudeMdFormat} rule takes, mirroring {@code MarkdownDocument}'s
-	 * {@code headingText} in the {@code claude-code-enforcer} module.
-	 * <p>
-	 * A heading is the text it carries rather than the line it was typed on, so the
-	 * whitespace between its {@code #} run and that text — a tab, or two spaces — and
-	 * the closing {@code #} run Markdown lets an author balance it with are spelling.
-	 * Comparing the line verbatim made the reshape and the rule disagree about which
-	 * lines are the required sections: a document whose {@code ##  Testing} the rule
-	 * reads as {@code ## Testing} was reported here as not having the section at all,
-	 * so a second, stubbed copy of it was appended to a file the adoption went on to
-	 * commit and push. Where a document carries the section twice, in two spellings,
-	 * the two also disagreed about <em>which</em> of them the rule would judge, and
-	 * the reshape then stubbed a section the rule was not reading.
-	 */
-	private static boolean declares(String line, String required) {
-		String stripped = line.strip();
-		return isHeading(stripped) && headingText(stripped).equals(required);
-	}
-
-	/**
-	 * The heading a line declares, written canonically: its {@code #} run, then a
-	 * single space and the text it carries, or the run alone when it carries none.
-	 */
-	private static String headingText(String stripped) {
-		int level = headingLevel(stripped);
-		String hashes = stripped.substring(0, level);
-		String text = withoutClosingRun(stripped.substring(level).strip());
-		return text.isEmpty() ? hashes : hashes + SPACE + text;
-	}
-
-	/**
-	 * The heading's text without the {@code #} run that closes it. The run only
-	 * closes a heading when whitespace precedes it, so {@code ## C#} keeps its hash
-	 * while {@code ## Testing ##} loses both of its; a text that is nothing but
-	 * hashes — the {@code ###} of {@code ## ###} — is the closing run itself and
-	 * leaves an empty heading.
-	 */
-	private static String withoutClosingRun(String text) {
-		int end = text.length();
-		while (end > 0 && text.charAt(end - 1) == HEADING_CHAR) {
-			end--;
-		}
-		if (end == text.length()) {
-			return text;
-		}
-		return end == 0 || isIndent(text.charAt(end - 1)) ? text.substring(0, end).strip() : text;
+		return MarkdownDocument.headingOf(line)
+				.map(heading -> heading.toLowerCase(Locale.ROOT))
+				.filter(actual -> actual.equals(wanted) || actual.startsWith(wanted + " "))
+				.isPresent();
 	}
 
 	/**
@@ -357,27 +275,19 @@ public class ClaudeMdConformer {
 	}
 
 	/**
-	 * The outline is taken afresh per section because appending a section or
+	 * The document is read afresh per section because appending a section or
 	 * inserting a stub shifts the lines the next one is found at, and the sections
-	 * are few enough for that to stay cheap.
+	 * are few enough for that to stay cheap. Missing and empty are two answers to the
+	 * one heading lookup, so it is made once.
 	 */
 	private void ensureSection(List<String> lines, String required) {
-		Outline outline = Outline.of(lines);
-		int index = outline.indexOfHeading(required);
+		MarkdownDocument document = MarkdownDocument.of(lines);
+		int index = document.headingIndex(required);
 		if (index < 0) {
 			lines.addAll(List.of("", required, "", STUB_BODY));
-		} else if (!outline.hasBody(index)) {
+		} else if (!document.hasBodyAt(index)) {
 			lines.addAll(index + 1, List.of("", STUB_BODY));
 		}
-	}
-
-	/** A deeper sub-heading continues the section; one at its level or shallower ends it. */
-	private static boolean isBodyLine(String line, int level) {
-		return !isHeading(line) || headingLevel(line) > level;
-	}
-
-	private static int headingLevel(String heading) {
-		return (int) heading.chars().takeWhile(character -> character == HEADING_CHAR).count();
 	}
 
 	/**
@@ -394,14 +304,16 @@ public class ClaudeMdConformer {
 	 * — outside fences alone — let a generated document whose only {@code AGENTS.md}
 	 * sat in a comment or an indented sample keep the reference it never had, and the
 	 * adoption then failed its own {@link VerifyStep} on the one line it exists to
-	 * add.
+	 * add. It is the rule's own method that answers here, so the two cannot disagree.
+	 *
+	 * <p>A document with no title line at all takes the reference at the top.
 	 */
 	private void ensureAgentsReference(List<String> lines) {
-		Outline outline = Outline.of(lines);
-		if (outline.structural(line -> line.contains(AGENTS_REFERENCE)).findAny().isPresent()) {
+		MarkdownDocument document = MarkdownDocument.of(lines);
+		if (document.containsInProse(AGENTS_REFERENCE)) {
 			return;
 		}
-		int index = outline.titleIndex() + 1;
+		int index = Math.max(document.headingIndex(TITLE), 0) + 1;
 		List<String> reference = new ArrayList<>(List.of("", AGENTS_REFERENCE_LINE));
 		if (!isBlankAt(lines, index)) {
 			reference.add("");
@@ -411,394 +323,6 @@ public class ClaudeMdConformer {
 
 	private static boolean isBlankAt(List<String> lines, int index) {
 		return index < lines.size() && lines.get(index).isBlank();
-	}
-
-	private static boolean isHeading(String stripped) {
-		return ATX_HEADING.matcher(stripped).matches();
-	}
-
-	/**
-	 * The document as the reshape reads it: the lines themselves, which of them are
-	 * code, and which sit inside an HTML comment. The three travel together because
-	 * every search the reshape makes is against one of those masks, and a mask taken
-	 * from lines other than the ones it is applied to would quietly mis-answer — so a
-	 * reshape that inserts or removes lines takes a fresh outline rather than carrying
-	 * this one on.
-	 *
-	 * <p>Renaming a line in place keeps the outline valid, since the masks are
-	 * indexed by line number and the count has not moved.
-	 *
-	 * @param code        which lines Markdown quotes as code, fenced or indented
-	 * @param openFence   the delimiter of a fence the document never closed, or
-	 *                    {@code null} when its fences balance
-	 * @param openComment whether the document left an HTML comment unterminated
-	 */
-	private record Outline(List<String> lines, boolean[] code, boolean[] comment, Delimiter openFence,
-			boolean openComment) {
-
-		/**
-		 * The code mask is settled before the comment scan runs, because a comment
-		 * inside code is sample text rather than a comment and so that scan needs the
-		 * code verdict for the very line it is on.
-		 */
-		static Outline of(List<String> lines) {
-			boolean[] code = new boolean[lines.size()];
-			Delimiter openFence = markCode(lines, code);
-			boolean[] comment = new boolean[lines.size()];
-			boolean openComment = markComments(lines, code, comment);
-			return new Outline(lines, code, comment, openFence, openComment);
-		}
-
-		/** The indices of the lines outside code whose text matches, in document order. */
-		IntStream matching(Predicate<String> match) {
-			return IntStream.range(0, lines.size()).filter(index -> !code[index] && match.test(lines.get(index)));
-		}
-
-		/**
-		 * The indices of the lines that can carry document structure — outside code and
-		 * outside HTML comments alike — whose text matches. A heading is only ever
-		 * looked for, and only ever renamed, on one of these, because that is where the
-		 * rule recognises one: a section commented out with {@code <!-- ... -->} is
-		 * inert text, and counting it left the real section unwritten while the rule
-		 * went on demanding it.
-		 */
-		IntStream structural(Predicate<String> match) {
-			return matching(match).filter(index -> !comment[index]);
-		}
-
-		/**
-		 * @return the index of the first line declaring the heading, outside code and
-		 *         comments, or {@code -1} when the document declares it nowhere. The
-		 *         <em>first</em> is what answers, because that is the one the rule reads
-		 *         when a document carries the section twice; see {@link #declares}.
-		 */
-		int indexOfHeading(String heading) {
-			return structural(line -> declares(line, heading)).findFirst().orElse(-1);
-		}
-
-		/**
-		 * The title is the first non-blank line by the time this is asked, and both a
-		 * fence marker and the blank line an indented block opens below would themselves
-		 * be lines before it, so the title can never be one the mask covers. A document
-		 * with no title line at all falls back to the top.
-		 */
-		int titleIndex() {
-			return Math.max(indexOfHeading(TITLE), 0);
-		}
-
-		/**
-		 * Mirrors how the rule decides a section is non-empty: before the next heading
-		 * at its own level or shallower, the section must carry prose, a code block, or
-		 * a deeper sub-heading. Blank lines are neither, so the scan looks past them and
-		 * the first line that decides settles the section.
-		 */
-		boolean hasBody(int headingIndex) {
-			int level = headingLevel(lines.get(headingIndex).strip());
-			return IntStream.range(headingIndex + 1, lines.size())
-					.filter(this::decidesBody)
-					.limit(1)
-					.anyMatch(index -> code[index] || isBodyLine(lines.get(index).strip(), level));
-		}
-
-		/**
-		 * Whether the line settles the question of the section's body. A blank line
-		 * does not, and neither does a commented-out one: a section whose only content
-		 * is inside an HTML comment reads as empty to the rule, which is what commenting
-		 * it out meant, so the reshape has to give it a stub rather than conclude it
-		 * already has a body and leave the adoption to fail its own {@link VerifyStep}.
-		 */
-		private boolean decidesBody(int index) {
-			return code[index] || (!comment[index] && !lines.get(index).isBlank());
-		}
-	}
-
-	/**
-	 * One fence delimiter line: the character it is written with, how many of them it
-	 * runs, and whether anything follows them — the info string of an opening
-	 * delimiter, such as the {@code java} of {@code ```java}.
-	 *
-	 * <p>This mirrors {@code MarkdownDocument} in the {@code claude-code-enforcer}
-	 * module, the reader the wired-in {@code claudeMdFormat} rule uses, and is held
-	 * to it by the same contract test as {@link #REQUIRED_SECTIONS}. Reading fences
-	 * any more loosely
-	 * than the rule does makes the reshape act on lines the rule holds to be code: a
-	 * {@code ## Testing} inside a code sample was taken for the section the document
-	 * already had, so the real one was never appended and the adoption failed its own
-	 * {@link VerifyStep} — and a heading inside a sample was renamed in place,
-	 * rewriting the sample.
-	 */
-	private record Delimiter(char character, int length, boolean info) {
-
-		/**
-		 * Whether this line closes the block {@code open} started. A closing delimiter
-		 * uses the same character, is at least as long, and carries no info string, so a
-		 * shorter or annotated fence nested inside the block is content rather than its
-		 * end.
-		 */
-		boolean closes(Delimiter open) {
-			return character == open.character() && length >= open.length() && !info;
-		}
-
-		/** The delimiter line that closes this one: the same run, carrying no info string. */
-		String closing() {
-			return String.valueOf(character).repeat(length);
-		}
-	}
-
-	/**
-	 * Marks every line Markdown quotes as code, both ways it allows, in one left to
-	 * right pass — so a fence's own lines are spoken for before an indent is read into
-	 * them, and an indented block's lines before a fence is. This mirrors
-	 * {@code MarkdownDocument} in the {@code claude-code-enforcer} module, as
-	 * {@link Delimiter} does; keep the two in sync.
-	 *
-	 * <p>The single pass is the whole point, because each way decides what the other
-	 * may read. Marking the fences first and the indents afterwards made a lone
-	 * {@code ```} shown four columns in — which is exactly how a document explains what
-	 * a fence looks like — open a block nothing closed. The reshape then read every
-	 * heading below it as code: it appended a closing fence of its own at the end of
-	 * the document and every section it went on to add landed <em>after</em> that
-	 * fence, where the rule reads them as code too. An already-conforming
-	 * {@code CLAUDE.md} came back with a stray delimiter and three duplicated sections,
-	 * and one that was missing a section came back still missing it — the adoption
-	 * failing its own {@link VerifyStep} on the very sections it had just written. The
-	 * indent speaks for the line wherever it sits, whether a code block may open at it
-	 * or it merely continues the paragraph above; see {@link Scan#atIndent}.
-	 *
-	 * @return the fence delimiter still open at the end of the document, or
-	 *         {@code null} when its fences balance
-	 */
-	private static Delimiter markCode(List<String> lines, boolean[] mask) {
-		Scan scan = Scan.start();
-		for (int index = 0; index < lines.size(); index++) {
-			scan = scan.read(lines.get(index), mask, index);
-		}
-		return scan.fence();
-	}
-
-	/**
-	 * The state one pass over the document carries: the fence delimiter still open,
-	 * whether an indented line would open a code block, and the list item an indent is
-	 * measured against. Only a blank line, a line already read as code, and the start
-	 * of the document leave the second open — an indented line below a paragraph is a
-	 * lazy continuation of it rather than code. This mirrors {@code MarkdownDocument}'s
-	 * scan in the {@code claude-code-enforcer} module; keep the two in sync.
-	 */
-	private record Scan(Delimiter fence, boolean mayIndent, int listIndent) {
-
-		/** No list is open, so an indented line quotes code from the margin. */
-		static final int NO_LIST = -1;
-
-		static Scan start() {
-			return new Scan(null, true, NO_LIST);
-		}
-
-		/**
-		 * Marks line {@code index} and answers the state the next line is read in. An
-		 * open fence claims the line first, then a blank line, which carries nothing to
-		 * read either way and so is left unmarked; then the indent, which speaks for the
-		 * line whether or not a block may open at it, and only a line the indent left
-		 * alone is read as a fence delimiter.
-		 */
-		Scan read(String line, boolean[] mask, int index) {
-			if (fence != null) {
-				return insideFence(line, mask, index);
-			}
-			if (line.isBlank()) {
-				return new Scan(null, true, listIndent);
-			}
-			if (indentWidth(line) >= codeIndent()) {
-				return atIndent(mask, index);
-			}
-			return atDelimiter(line, mask, index);
-		}
-
-		/**
-		 * The line is indented too deep to be read as anything but its indent: code
-		 * where a block may open, and otherwise the lazy continuation of the paragraph
-		 * above it — prose either way rather than markup.
-		 * <p>
-		 * That it is not a fence delimiter is the point, and it is the reshape's
-		 * problem as much as the rule's. A fence opener may be indented at most three
-		 * columns past its container, so a {@code ```} shown four columns in below a
-		 * paragraph opens nothing. Falling through to {@link #atDelimiter} read one as a
-		 * fence the document opened and never closed: the reshape then appended a
-		 * closing delimiter of its own, read every heading below the indent as code, and
-		 * appended a second copy of five sections the document already carried — to a
-		 * file it went on to commit, push, and open a pull request for. The rule reads
-		 * the result as conforming, because it made the same mistake, so
-		 * {@link VerifyStep} passed on it. The blank-line case was already answered
-		 * here; only a paragraph directly above the indent reached the delimiter
-		 * reading.
-		 */
-		private Scan atIndent(boolean[] mask, int index) {
-			mask[index] = mayIndent;
-			return new Scan(null, mayIndent, listIndent);
-		}
-
-		/**
-		 * The column an indented code block opens at: four, or four past the content of
-		 * the list item the line sits in, since a list item indents its own continuation
-		 * paragraphs to that column. A blank line does not close a list, so this still
-		 * stands over the gap between an item and its continuation.
-		 */
-		private int codeIndent() {
-			return listIndent == NO_LIST ? CODE_INDENT : listIndent + CODE_INDENT;
-		}
-
-		private Scan insideFence(String line, boolean[] mask, int index) {
-			mask[index] = true;
-			Delimiter delimiter = delimiterOf(line.strip());
-			return new Scan(delimiter != null && delimiter.closes(fence) ? null : fence, true, listIndent);
-		}
-
-		private Scan atDelimiter(String line, boolean[] mask, int index) {
-			Delimiter delimiter = delimiterOf(line.strip());
-			mask[index] = delimiter != null;
-			return new Scan(delimiter, delimiter != null, listAfter(line));
-		}
-
-		/**
-		 * The list this line leaves open: the one its own marker opens, the one it
-		 * continues by staying indented to that item's content, or none when it falls
-		 * back to the margin and so ends the list.
-		 */
-		private int listAfter(String line) {
-			int opened = listContentIndent(line);
-			if (opened != NO_LIST) {
-				return opened;
-			}
-			return indentWidth(line) >= listIndent ? listIndent : NO_LIST;
-		}
-	}
-
-	/** The line's indent in columns, a tab counting on to the next four-column stop. */
-	private static int indentWidth(String line) {
-		int index = 0;
-		while (index < line.length() && isIndent(line.charAt(index))) {
-			index++;
-		}
-		return widthOf(line, index);
-	}
-
-	/**
-	 * The display width of the line's first {@code length} characters, a tab counting
-	 * on to the next four-column stop. Both the indent that quotes code and the marker
-	 * that indents a list item's content are measured in these columns.
-	 */
-	private static int widthOf(String line, int length) {
-		int width = 0;
-		for (int index = 0; index < length; index++) {
-			width += line.charAt(index) == TAB ? CODE_INDENT - width % CODE_INDENT : 1;
-		}
-		return width;
-	}
-
-	private static boolean isIndent(char character) {
-		return character == SPACE || character == TAB;
-	}
-
-	/**
-	 * The column a list item's content is indented to when {@code line} opens one, or
-	 * {@link Scan#NO_LIST} when it opens none. A thematic break is not a list: its
-	 * {@code ---} carries no whitespace after the first dash, which is what separates a
-	 * marker from the content it introduces.
-	 */
-	private static int listContentIndent(String line) {
-		Matcher marker = LIST_MARKER.matcher(line);
-		return marker.lookingAt() ? widthOf(line, marker.end()) : Scan.NO_LIST;
-	}
-
-	private static boolean markComments(List<String> lines, boolean[] code, boolean[] mask) {
-		boolean open = false;
-		for (int index = 0; index < lines.size(); index++) {
-			open = applyComment(lines.get(index), open, code[index], mask, index);
-		}
-		return open;
-	}
-
-	/**
-	 * The line as the comment scan reads it, mirroring {@code MarkdownDocument} in the
-	 * {@code claude-code-enforcer} module. Outside a comment its inline code spans are
-	 * dropped first, because a delimiter quoted as code is the document illustrating
-	 * one rather than writing one: a {@code CLAUDE.md} whose prose says an HTML
-	 * comment opens with {@code `<!--`} was read as opening one that nothing closes,
-	 * so the reshape appended a closing {@code -->} of its own and then read every
-	 * heading below the mention as inert — appending a second copy of five sections
-	 * the document already carried, to a file it went on to commit, push, and open a
-	 * pull request for. The rule reads the mention the same way, so {@link VerifyStep}
-	 * passed on the result.
-	 *
-	 * <p>Inside a comment there are no code spans to honour: the text is already
-	 * inert, so its backticks are ordinary characters and a {@code -->} among them
-	 * closes the block exactly as one anywhere else on the line does.
-	 */
-	private static String asRead(String line, boolean open) {
-		return (open ? line : CODE_SPAN.matcher(line).replaceAll(" ")).strip();
-	}
-
-	/**
-	 * Marks whether the line is commented out and returns whether a comment is still
-	 * open after it. A comment that opens and closes on one line masks nothing —
-	 * {@code <!-- ## Testing -->} is not a heading to begin with — while a block
-	 * comment hides the lines it spans from every heading search.
-	 *
-	 * <p>Whether a comment remains open is read from every delimiter on the line
-	 * rather than from its first characters, the reading the rule takes: a comment
-	 * opened after text — {@code Superseded: <!--} — hides the lines below it, and a
-	 * line that closes one comment and opens another leaves one open. Asking only
-	 * whether the line began with {@value #COMMENT_START} left those lines visible to
-	 * the reshape and invisible to the rule, so a required section the document had
-	 * commented out was counted as present, never appended, and the adoption failed
-	 * its own {@link VerifyStep}.
-	 *
-	 * @param insideCode whether the line is code, because a comment inside a code
-	 *                   block is sample text rather than a comment: the code wins
-	 */
-	private static boolean applyComment(String line, boolean open, boolean insideCode, boolean[] mask, int index) {
-		if (insideCode) {
-			return open;
-		}
-		String read = asRead(line, open);
-		mask[index] = open || opensBlock(read);
-		return remainsOpen(read, 0, open);
-	}
-
-	/** Whether the line's own content starts a comment that the same line does not close. */
-	private static boolean opensBlock(String line) {
-		return line.startsWith(COMMENT_START) && remainsOpen(line, 0, false);
-	}
-
-	/**
-	 * Whether a comment is open once {@code line} has been read from {@code from},
-	 * following each delimiter in turn: an open comment looks for its
-	 * {@value #COMMENT_END}, a closed one for the next {@value #COMMENT_START}.
-	 */
-	private static boolean remainsOpen(String line, int from, boolean open) {
-		String delimiter = open ? COMMENT_END : COMMENT_START;
-		int next = line.indexOf(delimiter, from);
-		return next < 0 ? open : remainsOpen(line, next + delimiter.length(), !open);
-	}
-
-	/** @return the fence delimiter the line declares, or {@code null} when it declares none */
-	private static Delimiter delimiterOf(String line) {
-		if (line.isEmpty() || !isFenceCharacter(line.charAt(0))) {
-			return null;
-		}
-		char character = line.charAt(0);
-		int length = runLength(line, character);
-		if (length < MIN_FENCE_LENGTH) {
-			return null;
-		}
-		return new Delimiter(character, length, !line.substring(length).isBlank());
-	}
-
-	private static boolean isFenceCharacter(char character) {
-		return character == BACKTICK || character == TILDE;
-	}
-
-	private static int runLength(String line, char character) {
-		return (int) line.chars().takeWhile(candidate -> candidate == character).count();
 	}
 
 	/** Joins the lines under a single trailing newline, dropping any blank lines the reshape left at the end. */

--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -60,6 +60,18 @@
 	     because it is consumed as a maven-enforcer-plugin dependency resolved
 	     from a repository outside the reactor. -->
 	<dependencies>
+		<!-- Reads a Markdown document into its lines plus the code and HTML-comment
+		     masks every structural check is made against. It is a module of its own
+		     because the adopt pipeline's ClaudeMdConformer reshapes a CLAUDE.md so
+		     the claudeMdFormat rule below passes, and the two have to read the
+		     document identically; adopt cannot depend on this module to get that,
+		     since it would put the maven-enforcer API and a shipped rule on every
+		     consumer's classpath. -->
+		<dependency>
+			<groupId>io.github.adamw7</groupId>
+			<artifactId>tools.markdown-common</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.enforcer</groupId>
 			<artifactId>enforcer-api</artifactId>

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionContent.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/DefinitionContent.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 import org.apache.maven.enforcer.rule.api.EnforcerLogger;
 
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * The text of one Claude Code definition, ready to be validated: read, checked for

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/FrontMatterAutoFix.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/FrontMatterAutoFix.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.apache.maven.enforcer.rule.api.EnforcerLogger;
 
 import io.github.adamw7.tools.enforcer.text.FrontMatterFixer;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * Bridges {@link FrontMatterFixer} to the definition rules that read a Markdown

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRule.java
@@ -9,7 +9,7 @@ import javax.inject.Named;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.text.FrontMatter;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * Enforcer rule that fails the build when two Claude Code definitions share the

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
@@ -6,7 +6,7 @@ import java.util.List;
 import javax.inject.Named;
 
 import io.github.adamw7.tools.enforcer.rule.MarkdownFormatRule;
-import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
+import io.github.adamw7.tools.markdown.MarkdownDocument;
 
 /**
  * Enforcer rule that fails the build when {@code CLAUDE.md} is missing or does

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
@@ -12,7 +12,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 import io.github.adamw7.tools.enforcer.rule.ScanTargets;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * Enforcer rule that keeps agent context files within a size budget.

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/DocumentConsistency.java
@@ -11,7 +11,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.doc.BoundedCharSequence.BacktrackLimitExceededException;
 import io.github.adamw7.tools.enforcer.rule.Patterns;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * Compares two documents against a list of single-group regular expressions and

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
@@ -16,8 +16,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
-import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownDocument;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * The {@code @path} memory imports reachable from a root document, together with

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRule.java
@@ -23,8 +23,8 @@ import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 import io.github.adamw7.tools.enforcer.rule.ScanTargets;
 import io.github.adamw7.tools.enforcer.rule.Violations;
 import io.github.adamw7.tools.enforcer.text.FrontMatter;
-import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownDocument;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * Enforcer rule that fails the build when a bundle in Google's Open Knowledge

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -12,7 +12,7 @@ import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerLogger;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * Base for every Claude Code enforcer rule. It owns the one behaviour they all

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -12,8 +12,8 @@ import java.util.regex.Pattern;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
-import io.github.adamw7.tools.enforcer.text.MarkdownDocument;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownDocument;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * Base for enforcer rules that validate a Markdown document follows an expected
@@ -174,11 +174,18 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 		}
 	}
 
+	/**
+	 * Missing and empty are two answers to one lookup, so the heading is located
+	 * once per section and the body question asked of the index it found. Asking
+	 * {@code hasHeading} and then {@code hasBody} walked the document twice per
+	 * section to answer a question the first walk had already settled.
+	 */
 	private void collectSectionViolations(MarkdownDocument document, List<String> violations) {
 		for (String section : requiredSections()) {
-			if (!document.hasHeading(section)) {
+			int index = document.headingIndex(section);
+			if (index < 0) {
 				violations.add(documentName() + " is missing required section heading: " + section);
-			} else if (!document.hasBody(section)) {
+			} else if (!document.hasBodyAt(index)) {
 				violations.add(documentName() + " has an empty section: " + section);
 			}
 		}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
@@ -14,7 +14,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.enforcer.rule.Patterns;
 import io.github.adamw7.tools.enforcer.rule.ScanTargets;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * Enforcer rule that fails the build when a configured file contains what looks

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookWiring.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookWiring.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * The cross-check between the scripts in a hooks directory and the command hooks

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -11,7 +11,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
 import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * Enforcer rule that fails the build when a hook script under

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRule.java
@@ -10,7 +10,7 @@ import javax.inject.Named;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
-import io.github.adamw7.tools.enforcer.text.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownText;
 
 /**
  * Enforcer rule that fails the build when {@code .gitignore} does not cover the

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
@@ -37,6 +37,10 @@ import io.github.adamw7.tools.test.architecture.CommonCodingConventions;
  * do at build time: read the project, and nothing else — no process, no network,
  * and no write outside the report, the baseline and the front-matter fix a rule
  * was asked for. Only production classes are analysed.
+ * <p>
+ * The Markdown reader itself lives in {@code markdown-common} and is held to its
+ * own rules there, because the {@code adopt} pipeline reads documents through the
+ * same one and cannot depend on this module to get it.
  */
 @AnalyzeClasses(packages = EnforcerArchitectureTest.ENFORCER_PACKAGE, importOptions = ImportOption.DoNotIncludeTests.class)
 public class EnforcerArchitectureTest {
@@ -49,7 +53,6 @@ public class EnforcerArchitectureTest {
 	private static final String JSON_NODES = ENFORCER_PACKAGE + ".rule.JsonNodes";
 	private static final String BASELINE = ENFORCER_PACKAGE + ".rule.Baseline";
 	private static final String HTML_REPORT = ENFORCER_PACKAGE + ".rule.HtmlReport";
-	private static final String MARKDOWN_TEXT = ENFORCER_PACKAGE + ".text.MarkdownText";
 	private static final String FILE_MUTATIONS =
 			"write|writeString|newBufferedWriter|newOutputStream|createFile|createDirectory|createDirectories"
 					+ "|delete|deleteIfExists|move|copy";
@@ -169,10 +172,10 @@ public class EnforcerArchitectureTest {
 	static final ArchRule rulesDoNotWriteToTheProjectTheyCheck = noClasses()
 			.that().doNotHaveFullyQualifiedName(BASELINE)
 			.and().doNotHaveFullyQualifiedName(HTML_REPORT)
-			.and().doNotHaveFullyQualifiedName(MARKDOWN_TEXT)
 			.should().callMethodWhere(target(owner(type(Files.class))).and(target(nameMatching(FILE_MUTATIONS))))
-			.because("a check reports what it found; the three places that write are the ones a build asked "
-					+ "for — the HTML report, the recorded baseline, and the front-matter fix")
+			.because("a check reports what it found; the two places that write here are the ones a build "
+					+ "asked for — the HTML report and the recorded baseline. The front-matter fix writes "
+					+ "through markdown-common's MarkdownText, which its own module holds to the same rule")
 			.allowEmptyShould(true);
 
 	/**

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRuleTest.java
@@ -1,9 +1,9 @@
 package io.github.adamw7.tools.enforcer.definition;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.createDirectory;
+import static io.github.adamw7.tools.test.TestFiles.readString;
+import static io.github.adamw7.tools.test.TestFiles.writeBytes;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.definition;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRuleTest.java
@@ -1,9 +1,9 @@
 package io.github.adamw7.tools.enforcer.definition;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.createDirectory;
+import static io.github.adamw7.tools.test.TestFiles.readString;
+import static io.github.adamw7.tools.test.TestFiles.writeBytes;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
@@ -1,9 +1,9 @@
 package io.github.adamw7.tools.enforcer.definition;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.createDirectory;
+import static io.github.adamw7.tools.test.TestFiles.readString;
+import static io.github.adamw7.tools.test.TestFiles.writeBytes;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueDescriptionsRuleTest.java
@@ -1,8 +1,8 @@
 package io.github.adamw7.tools.enforcer.definition;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.createDirectory;
+import static io.github.adamw7.tools.test.TestFiles.writeBytes;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/UniqueNamesRuleTest.java
@@ -1,7 +1,7 @@
 package io.github.adamw7.tools.enforcer.definition;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.createDirectory;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.doc;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.doc;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRuleTest.java
@@ -1,7 +1,7 @@
 package io.github.adamw7.tools.enforcer.doc;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeBytes;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static io.github.adamw7.tools.test.TestStrings.occurrences;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/CrossDocConsistencyRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.doc;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.doc;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.doc;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.doc;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ReadmeConsistencyRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.doc;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/FixtureProject.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/FixtureProject.java
@@ -1,7 +1,7 @@
 package io.github.adamw7.tools.enforcer.e2e;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.readString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 
 import java.nio.file.Path;
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.mcp;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.mcp;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRuleTest.java
@@ -1,7 +1,7 @@
 package io.github.adamw7.tools.enforcer.okf;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.createDirectory;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/BaselineTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/BaselineTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.rule;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
+import static io.github.adamw7.tools.test.TestFiles.readString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -12,6 +12,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.test.TestFiles;
 
 class BaselineTest {
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.rule;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ProjectFilesTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ProjectFilesTest.java
@@ -1,7 +1,7 @@
 package io.github.adamw7.tools.enforcer.rule;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.createDirectory;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.secret;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static io.github.adamw7.tools.test.TestStrings.occurrences;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.settings;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRuleTest.java
@@ -1,8 +1,8 @@
 package io.github.adamw7.tools.enforcer.settings;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.assumeSymlink;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.createDirectory;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.assumeSymlink;
+import static io.github.adamw7.tools.test.TestFiles.createDirectory;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
-import io.github.adamw7.tools.enforcer.rule.TestFiles;
+import io.github.adamw7.tools.test.TestFiles;
 
 class HooksFormatRuleTest {
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.settings;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.settings;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRuleTest.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.enforcer.settings;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -98,6 +98,7 @@ flowchart TB
 
         subgraph shared ["Shared foundations"]
             enforcer["<b>claude-code-enforcer</b><br/><i>maven-enforcer rules</i><br/>Fails the build on malformed<br/>CLAUDE.md / AGENTS.md / README /<br/>skills / settings / .mcp.json"]
+            markdownCommon["<b>markdown-common</b><br/><i>Shared library</i><br/>MarkdownDocument · MarkdownText:<br/>lines plus the code and comment masks"]
             testCommon["<b>test-common</b><br/><i>test-jar</i><br/>Shared ArchUnit rule libraries:<br/>coding · naming · test conventions"]
             mcpCommon["<b>mcp-common</b><br/><i>Shared library</i><br/>MCP scaffolding: AbstractMcpConfiguration ·<br/>McpTool · ToolDefinition · TransportConfigurer"]
         end
@@ -155,6 +156,8 @@ flowchart TB
     ownBuild -.->|"runs the architecture tests"| testCommon
 
     adopt -->|"wires the rule into<br/>the adopted build"| enforcer
+    adopt -->|"reads the generated<br/>CLAUDE.md"| markdownCommon
+    enforcer -->|"reads the document<br/>it judges"| markdownCommon
     context -->|"scans"| projectSrc
     data -->|"reads (JDBC / DuckDB)"| db
     data -->|"reads / streams"| files
@@ -553,9 +556,12 @@ flowchart TB
         end
 
         subgraph textSupport ["text — parsing support"]
-            text["<b>MarkdownDocument · FrontMatter ·<br/>FrontMatterFixer · NameConvention</b>"]
+            text["<b>FrontMatter · FrontMatterFixer ·<br/>NameConvention</b>"]
         end
     end
+
+    markdown["<b>markdown-common</b><br/><i>Shared library</i><br/>MarkdownDocument · MarkdownText<br/>also read by adopt's ClaudeMdConformer"]
+    text --> markdown
 
     docsFiles["📄 CLAUDE.md · AGENTS.md · README.md"]
     config["🗂️ .claude/ · .mcp.json ·<br/>.claude-plugin/plugin.json"]

--- a/markdown-common/pom.xml
+++ b/markdown-common/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>io.github.adamw7</groupId>
+		<artifactId>tools</artifactId>
+		<version>${revision}</version>
+	</parent>
+	<artifactId>tools.markdown-common</artifactId>
+	<packaging>jar</packaging>
+	<name>Shared Markdown reader</name>
+	<description>Reads a Markdown document into its lines plus the masks marking which of them are code and which sit inside an HTML comment, so a checker and a rewriter agree on what the document says.</description>
+	<properties>
+		<!-- Mutation-score floor for this module, a few points under what it
+		     measures today so an equivalent refactor cannot turn the build red.
+		     See the root pom's pitest.mutationThreshold. -->
+		<pitest.mutationThreshold>91</pitest.mutationThreshold>
+	</properties>
+	<!-- Deliberately dependency-free beyond the JDK. Two modules read Markdown the
+	     same way and must keep agreeing about it: claude-code-enforcer's
+	     claudeMdFormat rule judges a CLAUDE.md, and adopt's ClaudeMdConformer
+	     reshapes one so that rule passes. They used to carry a copy of this reader
+	     each, because adopt cannot depend on claude-code-enforcer without putting
+	     the maven-enforcer API and a shipped rule on every consumer's classpath.
+	     Carving the reader out is what lets both depend on the same one instead —
+	     which only works while it stays free of either module's dependencies, so
+	     add nothing here without a very good reason. -->
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.adamw7</groupId>
+			<artifactId>tools.test-common</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownDocument.java
+++ b/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownDocument.java
@@ -1,8 +1,10 @@
-package io.github.adamw7.tools.enforcer.text;
+package io.github.adamw7.tools.markdown;
 
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -14,6 +16,19 @@ import java.util.stream.Stream;
  * code and which sit inside an HTML comment. Parsing the masks once, at
  * construction, lets the structural checks share them instead of each rebuilding
  * them.
+ * <p>
+ * Two kinds of caller read a document through this class, and they must agree
+ * about it: one that <em>judges</em> a document — the {@code claudeMdFormat}
+ * enforcer rule asking whether a {@code CLAUDE.md} carries a required section —
+ * and one that <em>reshapes</em> a document so that judgement passes, which is
+ * what the adoption pipeline's {@code ClaudeMdConformer} does before it commits a
+ * generated {@code CLAUDE.md}. Every reading below was at some point spelled out
+ * twice, once for each, and every way the two spellings drifted apart produced the
+ * same shape of bug: the rewriter acted on lines the rule holds to be code, or
+ * concluded a section was missing that the rule reads as present, and the adoption
+ * then failed the very check it exists to satisfy — after committing and pushing
+ * the file. That is why the reader is one class in a module of its own rather than
+ * a copy on each side.
  * <p>
  * Headings are recognised on whole lines outside code, so a heading mentioned in a
  * sample or in prose is not treated as document structure. The mask includes a
@@ -96,18 +111,34 @@ public final class MarkdownDocument {
 	private final List<String> lines;
 	private final boolean[] insideCode;
 	private final boolean[] insideComment;
+	private final Delimiter openFence;
+	private final boolean openComment;
 
-	private MarkdownDocument(List<String> lines, boolean[] insideCode, boolean[] insideComment) {
+	private MarkdownDocument(List<String> lines, CodeScan code, CommentScan comment) {
 		this.lines = lines;
-		this.insideCode = insideCode;
-		this.insideComment = insideComment;
+		this.insideCode = code.mask();
+		this.openFence = code.openFence();
+		this.insideComment = comment.mask();
+		this.openComment = comment.open();
 	}
 
 	/** Parses {@code content} into lines, a code mask, and an HTML-comment mask. */
 	public static MarkdownDocument parse(String content) {
-		List<String> lines = content.lines().toList();
-		boolean[] insideCode = codeMask(lines);
-		return new MarkdownDocument(lines, insideCode, commentMask(lines, insideCode));
+		return of(content.lines().toList());
+	}
+
+	/**
+	 * Parses lines a caller has already split, for one that rewrites a document and
+	 * so cannot let the split be re-decided under it: {@link String#lines()} drops
+	 * the empty line a document's trailing newline leaves, which a rewriter that
+	 * appends to those lines has to keep. The lines are copied, so the document is a
+	 * snapshot of the list as it is now — a caller that inserts or removes lines
+	 * parses again rather than carrying this one on.
+	 */
+	public static MarkdownDocument of(List<String> lines) {
+		List<String> snapshot = List.copyOf(lines);
+		CodeScan code = codeScan(snapshot);
+		return new MarkdownDocument(snapshot, code, commentScan(snapshot, code.mask()));
 	}
 
 	public int lineCount() {
@@ -139,17 +170,46 @@ public final class MarkdownDocument {
 		return MarkdownText.firstNonBlankLine(lines.stream());
 	}
 
-	/** The indices of the lines outside code, in document order. */
-	private IntStream outsideCode() {
-		return IntStream.range(0, lines.size()).filter(index -> !insideCode[index]);
+	/**
+	 * The delimiter line that closes a fence this document opened and never closed,
+	 * or empty when its fences balance. The run is as long as the one that opened
+	 * the block and carries no info string, so a {@code ````} wrapper is not left
+	 * open by a {@code ```} line.
+	 * <p>
+	 * A rewriter asks this before it appends anything, because a section appended
+	 * inside an open fence is code as far as every check above is concerned — the
+	 * document would come back still missing the section that had just been added
+	 * to it.
+	 */
+	public Optional<String> openFenceTerminator() {
+		return Optional.ofNullable(openFence).map(Delimiter::closing);
 	}
 
 	/**
-	 * The indices of the lines that can carry document structure: outside code and
-	 * outside HTML comments alike. A heading is only recognised on one of these.
+	 * The delimiter that closes an HTML comment this document opened and never
+	 * closed, or empty when its comments balance. Asked for the same reason as
+	 * {@link #openFenceTerminator}: text appended inside an open comment is inert,
+	 * so a check reads it as absent.
 	 */
+	public Optional<String> openCommentTerminator() {
+		return openComment ? Optional.of(COMMENT_END) : Optional.empty();
+	}
+
+	/**
+	 * The indices of the lines that can carry document structure — outside code and
+	 * outside HTML comments alike — whose raw text {@code match} accepts, in
+	 * document order. A heading is only ever recognised, and only ever rewritten, on
+	 * one of these: a section commented out with {@code <!-- ... -->} is inert text,
+	 * and counting it lets a document satisfy a required-section check with the very
+	 * heading its author had removed.
+	 */
+	public IntStream structuralLines(Predicate<String> match) {
+		return structuralLines().filter(index -> match.test(lines.get(index)));
+	}
+
 	private IntStream structuralLines() {
-		return outsideCode().filter(index -> !insideComment[index]);
+		return IntStream.range(0, lines.size())
+				.filter(index -> !insideCode[index] && !insideComment[index]);
 	}
 
 	/**
@@ -195,14 +255,22 @@ public final class MarkdownDocument {
 	 */
 	private Stream<String> headingTexts() {
 		return structuralLines()
-				.mapToObj(index -> lines.get(index).strip())
-				.filter(MarkdownDocument::isHeading)
-				.map(MarkdownDocument::headingText);
+				.mapToObj(index -> lines.get(index))
+				.map(MarkdownDocument::headingOf)
+				.flatMap(Optional::stream);
 	}
 
-	/** True when {@code heading} appears as a real heading outside code fences. */
+	/**
+	 * True when {@code heading} appears as a real heading outside code fences.
+	 * <p>
+	 * Answered by the same lookup {@link #hasBody} and {@link #headingIndex} use.
+	 * It used to ask {@link #headings()} instead, which is a second implementation
+	 * of one question: two readings of what counts as a heading, kept equal only by
+	 * being edited together, and a whole document walked to answer a question the
+	 * first match settles.
+	 */
 	public boolean hasHeading(String heading) {
-		return headings().contains(heading);
+		return headingIndex(heading) >= 0;
 	}
 
 	/**
@@ -210,6 +278,10 @@ public final class MarkdownDocument {
 	 * at its own level or shallower, by any prose, a code block, or a deeper
 	 * sub-heading. A deeper heading is content that belongs to the section; a
 	 * sibling or parent heading ends it.
+	 * <p>
+	 * A caller that has to tell a missing section from an empty one asks
+	 * {@link #headingIndex} and then {@link #hasBodyAt}, so the document is walked
+	 * once for the pair rather than once for each.
 	 */
 	public boolean hasBody(String heading) {
 		int index = headingIndex(heading);
@@ -235,18 +307,43 @@ public final class MarkdownDocument {
 		return headingTexts().filter(required::remove).toList();
 	}
 
-	private int headingIndex(String section) {
-		return structuralLines().filter(index -> declares(index, section)).findFirst().orElse(-1);
+	/**
+	 * @return the index of the first line declaring {@code section}, outside code and
+	 *         comments, or {@code -1} when the document declares it nowhere. The
+	 *         <em>first</em> is what answers, because that is the one every other
+	 *         reading here takes when a document carries the section twice — a
+	 *         rewriter that stubbed a later copy would be editing a section no check
+	 *         is judging.
+	 */
+	public int headingIndex(String section) {
+		return headingIndices(section).findFirst().orElse(-1);
 	}
 
-	/** True when the line at {@code index} is the heading {@code section} names. */
-	private boolean declares(int index, String section) {
-		String line = lines.get(index).strip();
-		return isHeading(line) && headingText(line).equals(section);
+	/**
+	 * Every structural line declaring {@code section}, in document order. A document
+	 * that carries a heading more than once is a document a rewriter has to see
+	 * whole: only the first counts as the section, so the rest are duplicates it may
+	 * have to remove.
+	 */
+	public IntStream headingIndices(String section) {
+		return structuralLines(line -> declares(line, section));
 	}
 
-	/** The first line that settles the question decides it; a section nothing settles has no body. */
-	private boolean hasBodyAt(int headingIndex) {
+	/** True when {@code line} is the heading {@code section} names. */
+	private static boolean declares(String line, String section) {
+		return headingOf(line).filter(section::equals).isPresent();
+	}
+
+	/**
+	 * True when the heading at {@code headingIndex} is followed, before the next
+	 * heading at its own level or shallower, by any prose, a code block, or a deeper
+	 * sub-heading. The index form is for a caller that has already located the
+	 * heading — see {@link #hasBody}.
+	 * <p>
+	 * The first line that settles the question decides it; a section nothing settles
+	 * has no body.
+	 */
+	public boolean hasBodyAt(int headingIndex) {
 		int sectionLevel = headingLevel(lines.get(headingIndex).strip());
 		return IntStream.range(headingIndex + 1, lines.size())
 				.filter(this::decidesBody)
@@ -274,12 +371,29 @@ public final class MarkdownDocument {
 	}
 
 	/**
-	 * The heading a line declares, written canonically: its {@code #} run, then a
-	 * single space and the text it carries, or the run alone when it carries none.
-	 * A heading is the text it names, not the line it was typed on, so the whitespace
-	 * separating the two — a tab counts — and the closing {@code #} run Markdown
-	 * allows are spelling rather than content.
+	 * The heading {@code line} declares, written canonically — its {@code #} run,
+	 * then a single space and the text it carries, or the run alone when it carries
+	 * none — or empty when the line declares no heading at all.
+	 * <p>
+	 * A heading is the text it names, not the line it was typed on, so the
+	 * surrounding whitespace, the separator between the run and the text (a tab
+	 * counts), and the closing {@code #} run Markdown lets an author balance a
+	 * heading with are spelling rather than content. Comparing raw lines instead
+	 * made a checker and a rewriter disagree about which lines are the required
+	 * sections: a {@code ##  Testing} this reads as {@code ## Testing} was reported
+	 * as no section at all, so a second, stubbed copy of it was appended to a file
+	 * the adoption went on to commit and push.
+	 * <p>
+	 * Whether the line is <em>structure</em> is a separate question this does not
+	 * answer — a {@code ## Testing} inside a code sample still reads as a heading
+	 * here. Callers pair this with {@link #structuralLines} rather than asking it of
+	 * an arbitrary line, which is what {@link #headingIndices} does.
 	 */
+	public static Optional<String> headingOf(String line) {
+		String stripped = line.strip();
+		return isHeading(stripped) ? Optional.of(headingText(stripped)) : Optional.empty();
+	}
+
 	private static String headingText(String line) {
 		int level = headingLevel(line);
 		String hashes = line.substring(0, level);
@@ -309,18 +423,26 @@ public final class MarkdownDocument {
 		return runLength(heading, HEADING_CHAR);
 	}
 
+	/** What one pass over the document found: the mask, and the fence it left open. */
+	private record CodeScan(boolean[] mask, Delimiter openFence) {
+	}
+
+	/** What one pass over the document found: the mask, and whether a comment is still open. */
+	private record CommentScan(boolean[] mask, boolean open) {
+	}
+
 	/**
 	 * Marks every line Markdown reads as code, both ways it is quoted, in one left
 	 * to right pass, so a fence's own lines are spoken for before an indent is read
 	 * into them and an indented block's lines before a fence is.
 	 */
-	private static boolean[] codeMask(List<String> lines) {
+	private static CodeScan codeScan(List<String> lines) {
 		boolean[] mask = new boolean[lines.size()];
 		Scan scan = Scan.start();
 		for (int i = 0; i < lines.size(); i++) {
 			scan = scan.read(lines.get(i), mask, i);
 		}
-		return mask;
+		return new CodeScan(mask, scan.fence());
 	}
 
 	/** The line's indent in columns, a tab counting on to the next four-column stop. */
@@ -369,13 +491,13 @@ public final class MarkdownDocument {
 	 * and satisfied it at the same time. A comment inside code is sample text, so
 	 * the code wins.
 	 */
-	private static boolean[] commentMask(List<String> lines, boolean[] insideCode) {
+	private static CommentScan commentScan(List<String> lines, boolean[] insideCode) {
 		boolean[] mask = new boolean[lines.size()];
 		boolean open = false;
 		for (int i = 0; i < lines.size(); i++) {
 			open = applyComment(lines.get(i), open, insideCode[i], mask, i);
 		}
-		return mask;
+		return new CommentScan(mask, open);
 	}
 
 	/**
@@ -560,6 +682,11 @@ public final class MarkdownDocument {
 		 */
 		boolean closes(Delimiter open) {
 			return character == open.character() && length >= open.length() && !info;
+		}
+
+		/** The delimiter line that closes this one: the same run, carrying no info string. */
+		String closing() {
+			return String.valueOf(character).repeat(length);
 		}
 	}
 }

--- a/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownText.java
+++ b/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownText.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer.text;
+package io.github.adamw7.tools.markdown;
 
 import java.io.File;
 import java.io.IOException;
@@ -106,12 +106,12 @@ public final class MarkdownText {
 		return CODE_SPAN.matcher(line).replaceAll(" ");
 	}
 
-	/** The first line that is not blank, stripped of surrounding whitespace, or empty if none. */
-	public static String firstNonBlankLine(String content) {
-		return firstNonBlankLine(content.lines());
-	}
-
-	/** The first line that is not blank, stripped of surrounding whitespace, or empty if none. */
+	/**
+	 * The first line that is not blank, stripped of surrounding whitespace, or empty
+	 * if none. Takes the lines rather than the content, because every caller already
+	 * holds them: a document has split its own, and a caller that has not can pass
+	 * {@code content.lines()}.
+	 */
 	public static String firstNonBlankLine(Stream<String> lines) {
 		return lines.map(String::strip).filter(line -> !line.isEmpty()).findFirst().orElse("");
 	}

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownDocumentTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownDocumentTest.java
@@ -1,9 +1,10 @@
-package io.github.adamw7.tools.enforcer.text;
+package io.github.adamw7.tools.markdown;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
@@ -796,6 +797,148 @@ class MarkdownDocumentTest {
 				""");
 
 		assertFalse(document.containsUnquoted("TODO"));
+	}
+
+	/*
+	 * From here on: the API a rewriter reads a document through. A checker asks what
+	 * a document says; a rewriter also has to ask where it says it, and what the
+	 * document left open — so it can append below the block rather than inside it.
+	 */
+
+	@Test
+	void alreadySplitLinesKeepTheTrailingEmptyLineStringLinesWouldDrop() {
+		List<String> lines = List.of("# Title", "", "body", "");
+
+		MarkdownDocument document = MarkdownDocument.of(lines);
+
+		assertEquals(4, document.lineCount());
+		assertEquals("", document.line(3));
+		// The same content through parse() loses the trailing entry, which is why a
+		// rewriter that appends to its own list splits for itself.
+		assertEquals(3, MarkdownDocument.parse("# Title\n\nbody\n").lineCount());
+	}
+
+	@Test
+	void aDocumentIsASnapshotSoLaterEditsToTheListDoNotReachIt() {
+		List<String> lines = new ArrayList<>(List.of("# Title", "body"));
+		MarkdownDocument document = MarkdownDocument.of(lines);
+
+		lines.add("## Added");
+
+		assertEquals(2, document.lineCount());
+		assertEquals(-1, document.headingIndex("## Added"));
+	}
+
+	@Test
+	void balancedFencesAndCommentsLeaveNothingToClose() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				```
+				int x;
+				```
+
+				<!-- a note -->
+				""");
+
+		assertTrue(document.openFenceTerminator().isEmpty());
+		assertTrue(document.openCommentTerminator().isEmpty());
+	}
+
+	@Test
+	void anUnclosedFenceIsClosedByARunAsLongAsTheOneThatOpenedIt() {
+		assertEquals("```", terminatorOf("# Title\n\n```\nint x;\n"));
+		assertEquals("````", terminatorOf("# Title\n\n````\n```\nint x;\n"));
+		assertEquals("~~~", terminatorOf("# Title\n\n~~~\nint x;\n"));
+	}
+
+	/**
+	 * The info string is what opened the block, so it must not come back on the line
+	 * that closes it: a {@code ```java} terminator opens a second fence rather than
+	 * ending the first.
+	 */
+	@Test
+	void theClosingDelimiterCarriesNoInfoString() {
+		assertEquals("```", terminatorOf("# Title\n\n```java\nint x;\n"));
+	}
+
+	@Test
+	void anUnterminatedCommentIsClosedByItsOwnDelimiter() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				<!--
+				removed
+				""");
+
+		assertEquals("-->", document.openCommentTerminator().orElseThrow());
+	}
+
+	@Test
+	void structuralLinesSkipCodeAndCommentedOutText() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+				## Testing
+
+				```
+				## Testing
+				```
+
+				<!--
+				## Testing
+				-->
+				""");
+
+		assertEquals(List.of(1), matching(document, "## Testing"));
+	}
+
+	@Test
+	void headingIndicesReportEveryDeclarationAndTheIndexReportsTheFirst() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				##  Testing ##
+				body
+
+				## Testing
+				more
+				""");
+
+		// Both spellings declare the same heading, so both are reported.
+		assertEquals(List.of(2, 5), document.headingIndices("## Testing").boxed().toList());
+		assertEquals(2, document.headingIndex("## Testing"));
+		assertEquals(-1, document.headingIndex("## Absent"));
+	}
+
+	@Test
+	void hasBodyAtAnswersForTheHeadingAtThatIndex() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				## Empty
+				## Filled
+				body
+				""");
+
+		assertFalse(document.hasBodyAt(document.headingIndex("## Empty")));
+		assertTrue(document.hasBodyAt(document.headingIndex("## Filled")));
+	}
+
+	@Test
+	void headingOfWritesTheHeadingCanonicallyAndIsEmptyForProse() {
+		assertEquals("## Testing", MarkdownDocument.headingOf("  ##\tTesting ##  ").orElseThrow());
+		assertEquals("## C#", MarkdownDocument.headingOf("## C#").orElseThrow());
+		assertTrue(MarkdownDocument.headingOf("#1 rule: run mvn install").isEmpty());
+		assertTrue(MarkdownDocument.headingOf("body").isEmpty());
+	}
+
+	private static String terminatorOf(String content) {
+		return MarkdownDocument.parse(content).openFenceTerminator().orElseThrow();
+	}
+
+	/** The indices of the structural lines whose text is exactly {@code heading}. */
+	private static List<Integer> matching(MarkdownDocument document, String heading) {
+		return document.structuralLines(line -> line.strip().equals(heading)).boxed().toList();
 	}
 
 	/** The indices of the lines the document masks as code, in document order. */

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownTextTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownTextTest.java
@@ -1,9 +1,9 @@
-package io.github.adamw7.tools.enforcer.text;
+package io.github.adamw7.tools.markdown;
 
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.assumeSymlink;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.readString;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeBytes;
-import static io.github.adamw7.tools.enforcer.rule.TestFiles.writeString;
+import static io.github.adamw7.tools.test.TestFiles.assumeSymlink;
+import static io.github.adamw7.tools.test.TestFiles.readString;
+import static io.github.adamw7.tools.test.TestFiles.writeBytes;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,34 +26,26 @@ class MarkdownTextTest {
 
 	@Test
 	void firstNonBlankLineSkipsLeadingBlanksAndStrips() {
-		assertEquals("# Title", MarkdownText.firstNonBlankLine("\n   \n   # Title  \nbody"));
+		assertEquals("# Title", MarkdownText.firstNonBlankLine("\n   \n   # Title  \nbody".lines()));
 	}
 
 	@Test
 	void firstNonBlankLineIsEmptyWhenAllBlank() {
-		assertEquals("", MarkdownText.firstNonBlankLine("\n   \n\t\n"));
+		assertEquals("", MarkdownText.firstNonBlankLine("\n   \n\t\n".lines()));
 	}
 
 	@Test
 	void firstNonBlankLineIsEmptyForEmptyContent() {
-		assertEquals("", MarkdownText.firstNonBlankLine(""));
+		assertEquals("", MarkdownText.firstNonBlankLine("".lines()));
 	}
 
 	@Test
-	void streamOverloadMatchesTheStringOverload() {
-		String content = "\n   \n   # Title  \nbody";
-
-		assertEquals(MarkdownText.firstNonBlankLine(content),
-				MarkdownText.firstNonBlankLine(content.lines()));
-	}
-
-	@Test
-	void streamOverloadStripsAndPicksTheFirstContentLine() {
+	void firstNonBlankLineStripsAndPicksTheFirstContentLine() {
 		assertEquals("# Title", MarkdownText.firstNonBlankLine(Stream.of("", "   ", "  # Title  ", "body")));
 	}
 
 	@Test
-	void streamOverloadIsEmptyWhenNoContentLine() {
+	void firstNonBlankLineIsEmptyWhenNoContentLine() {
 		assertEquals("", MarkdownText.firstNonBlankLine(Stream.of("", "   ", "\t")));
 	}
 

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/architecture/MarkdownCommonArchitectureTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/architecture/MarkdownCommonArchitectureTest.java
@@ -1,0 +1,46 @@
+package io.github.adamw7.tools.markdown.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import com.tngtech.archunit.lang.ArchRule;
+
+import io.github.adamw7.tools.test.architecture.CommonCodingConventions;
+
+/**
+ * Architecture rules for the shared Markdown reader. What this module exists for
+ * is to be depended on from both sides of a document — the
+ * {@code claude-code-enforcer} rule that judges a {@code CLAUDE.md} and the
+ * {@code adopt} conformer that reshapes one — so the rules here pin the property
+ * that makes that possible: it depends on nothing but the JDK.
+ * <p>
+ * A dependency added here is inherited by every consumer, including the adopted
+ * repositories that resolve the enforcer rule as a maven-enforcer-plugin
+ * dependency. Only production classes are analysed.
+ */
+@AnalyzeClasses(packages = "io.github.adamw7.tools.markdown", importOptions = ImportOption.DoNotIncludeTests.class)
+public class MarkdownCommonArchitectureTest {
+
+	@ArchTest
+	static final ArchTests commonCodingConventions = ArchTests.in(CommonCodingConventions.class);
+
+	@ArchTest
+	static final ArchRule theReaderIsFrameworkFree = noClasses()
+			.should().dependOnClassesThat().resideOutsideOfPackages("java..", "javax.annotation..",
+					"io.github.adamw7.tools.markdown..")
+			.because("both a maven-enforcer rule and a plain adoption library read Markdown through this "
+					+ "module; a dependency here would travel to every consumer of either, which is exactly "
+					+ "what kept the reader duplicated on both sides in the first place");
+
+	@ArchTest
+	static final ArchRule theReaderDoesNotWriteWhereItWasNotAsked = noClasses()
+			.that().haveSimpleNameNotEndingWith("MarkdownText")
+			.should().dependOnClassesThat().haveFullyQualifiedName("java.nio.file.Files")
+			.because("MarkdownText owns the file access, so a reader of an already-loaded document cannot "
+					+ "quietly reach the disk; every check that reads a project goes through the one class "
+					+ "its callers can point at a path")
+			.allowEmptyShould(true);
+}

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/architecture/TestConventionsArchitectureTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/architecture/TestConventionsArchitectureTest.java
@@ -1,0 +1,22 @@
+package io.github.adamw7.tools.markdown.architecture;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+
+import io.github.adamw7.tools.test.architecture.CommonTestConventions;
+
+/**
+ * Applies the shared {@link CommonTestConventions} to this module's own test
+ * code, so the constraints that keep the unit suite fast and honest cannot be
+ * bypassed by how a test is written. Unlike the production architecture rules,
+ * this class analyses only the test classes via
+ * {@link ImportOption.OnlyIncludeTests}.
+ */
+@AnalyzeClasses(packages = "io.github.adamw7.tools.markdown", importOptions = ImportOption.OnlyIncludeTests.class)
+public class TestConventionsArchitectureTest {
+
+	@ArchTest
+	static final ArchTests commonTestConventions = ArchTests.in(CommonTestConventions.class);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
 		</developer>
 	</developers>
 	<modules>
+		<module>markdown-common</module>
 		<module>claude-code-enforcer</module>
 		<module>test-common</module>
 		<module>mcp-common</module>

--- a/pom.xml
+++ b/pom.xml
@@ -655,16 +655,36 @@
 			     The rule must be installed into the local repo first (see
 			     AGENTS.md "CLAUDE.md enforcement"). -->
 			<id>claude-md-enforce</id>
+			<!-- Both conditions must hold, so this activates in the root project
+			     alone: it is the only one with a CLAUDE.md beside its pom. A profile
+			     declared in a parent is inherited, so every module would otherwise
+			     evaluate this one and take on the plugin below — and with it a reactor
+			     edge to claude-code-enforcer, because Maven orders a project after
+			     every plugin dependency it declares. Maven tolerates a cycle whose
+			     closing edge comes from a plugin, which is why an inherited profile
+			     went unnoticed while no reactor module was a real dependency of the
+			     enforcer. markdown-common is one, so the cycle closed through a
+			     dependency edge instead and `mvn -B package -DenforceClaudeMd` could
+			     not sort the reactor at all. Scoping the profile to the project that
+			     owns the documents keeps a module's build order independent of a
+			     profile it never uses. -->
 			<activation>
 				<property>
 					<name>enforceClaudeMd</name>
 				</property>
+				<file>
+					<exists>${basedir}/CLAUDE.md</exists>
+				</file>
 			</activation>
 			<build>
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-enforcer-plugin</artifactId>
+						<!-- Belt and braces beside the profile's file activation: even
+						     were this plugin to reach a child module, it would carry no
+						     execution there. -->
+						<inherited>false</inherited>
 						<dependencies>
 							<dependency>
 								<groupId>io.github.adamw7</groupId>
@@ -675,9 +695,6 @@
 						<executions>
 							<execution>
 								<id>enforce-claude-md</id>
-								<!-- CLAUDE.md lives only at the repository root, so run
-								     this at the root reactor module only. -->
-								<inherited>false</inherited>
 								<goals>
 									<goal>enforce</goal>
 								</goals>

--- a/test-common/src/test/java/io/github/adamw7/tools/test/TestFiles.java
+++ b/test-common/src/test/java/io/github/adamw7/tools/test/TestFiles.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.enforcer.rule;
+package io.github.adamw7.tools.test;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 


### PR DESCRIPTION
ClaudeMdConformer carried a near-verbatim copy of the enforcer's
MarkdownDocument: the single-pass fence/indent Scan, the fence Delimiter,
the HTML-comment mask, the indent and list-column arithmetic, and the
canonical heading text — roughly 470 of its 808 lines. The copy existed
because adopt must not depend on claude-code-enforcer, which would put the
maven-enforcer API and a shipped rule on every consumer's classpath.

That reason does not apply to the reader itself, which touches neither: it
is now its own dependency-free module, and both sides depend on it. The
class of bug the copy produced — the conformer acting on lines the rule
holds to be code, or appending a section the rule already reads as present,
so the adoption failed its own VerifyStep after pushing the file — is now
unrepresentable rather than merely covered by a contract test.

MarkdownDocument grows the API a rewriter needs: of(List) for a caller that
splits its own lines, openFenceTerminator/openCommentTerminator for what the
document left open, structuralLines(Predicate), headingIndices/headingIndex,
hasBodyAt and the static headingOf.

Two smaller cleanups in the same reader:

- hasHeading asked headings() — a second implementation of what counts as a
  heading, and a whole-document walk to answer what the first match settles.
  It now shares headingIndex, and MarkdownFormatRule locates each required
  section once instead of walking twice per section to tell missing from
  empty.
- Dropped the single-use outsideCode() intermediate and the
  firstNonBlankLine(String) overload, which had no production caller.

TestFiles moves to test-common, since the moved tests need it too.

Full reactor build, the 20 doc rules under -DenforceClaudeMd, the
integration tests (including the real Maven builds that resolve the rule jar
with its new transitive dependency), coverage and PIT all pass. adopt's
mutation score rises 91% -> 95%; the new module measures 94% against a 91
floor.