### PR TITLE
refactor(adopt): cut the module's line count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,9 +109,12 @@ What is worth knowing before changing any of it:
   `PullRequestOptions`) carries the pull-request metadata, the starter assets,
   the rule version, the dry-run flag and the per-command timeout, and both entry
   points hand it to the same pipeline factory, so the CLI and the MCP tool cannot
-  drift. `CliArguments` declares the command line to **picocli**, binding each
-  option to a method so a batch mixing `--repo` and `--repos` keeps the order it
-  was written in; refusals are re-raised as an `IllegalArgumentException`
+  drift. `CliArguments` declares the command line to **picocli**, binding the
+  repository, workspace and branch options to methods — the first so a batch
+  mixing `--repo` and `--repos` keeps the order it was written in, the other two
+  because each shares a field with its positional and the last one named has to
+  win — and everything else straight to a field; refusals are re-raised as an
+  `IllegalArgumentException`
   carrying the hand-written usage line, with the parser's own message masked
   through `Redaction` and its exception left unchained — it quotes the argument it
   could not place, which for this command can be a credentialled clone URL.

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionRun.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionRun.java
@@ -28,10 +28,8 @@ public record AdoptionRun(String repositoryUrl, String branchName, AdoptionRepor
 
 	/**
 	 * Whether a whole run landed. The fold lives here because the answer is read in
-	 * three places that must agree — the CLI's exit status, the MCP result's
-	 * success flag, and the {@code succeeded} field of the report itself — and a
-	 * report that contradicted the exit code would be the worst of the three to
-	 * debug.
+	 * three places that must agree: the CLI's exit status, the MCP result's success
+	 * flag, and the {@code succeeded} field of the report itself.
 	 *
 	 * @param runs the runs of one batch, which succeeds only when every one of them did
 	 */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
@@ -64,12 +64,9 @@ public final class BatchAdoption {
 
 	/**
 	 * The URL is redacted up front so a repository that fails its claim — and so
-	 * never has a context to ask — is still reported without its credentials.
-	 *
-	 * <p>The repository is taken by position rather than by value so the line
-	 * announcing it can say which of how many it is. Every line below it names a
-	 * step, not a repository, and a batch of twenty is otherwise read by counting
-	 * the "Adopting Claude Code into ..." lines above wherever the reader is.
+	 * never has a context to ask — is still reported without its credentials. The
+	 * repository is taken by position so the line announcing it can say which of how
+	 * many it is; every line below it names a step, not a repository.
 	 */
 	private AdoptionRun adoptOne(List<String> repositoryUrls, int index, Checkouts checkouts) {
 		String repositoryUrl = repositoryUrls.get(index);
@@ -87,8 +84,7 @@ public final class BatchAdoption {
 	/**
 	 * Closes the batch with what the operator has to act on: how much of it landed,
 	 * what it cost, and — when some of it did not — which repositories to re-run.
-	 * A partly failed batch is the case this class exists to produce, and its
-	 * failures are scattered through however many repositories' worth of steps
+	 * Those failures are scattered through however many repositories' worth of steps
 	 * separate them, so naming them together at the end is the difference between
 	 * reading the run and searching it.
 	 */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Checkouts.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Checkouts.java
@@ -13,17 +13,14 @@ import java.util.Map;
  * <p>Two repositories that would clone into the same checkout directory are
  * rejected rather than adopted. A checkout is named after the repository alone, so
  * {@code owner/tools} and {@code other-owner/tools} claim one directory, as do a
- * repository's {@code .../repo} and {@code .../repo.git} forms. The second
- * adoption would otherwise run every step against the first repository's working
- * tree and report its pull request as the second's.
+ * repository's {@code .../repo} and {@code .../repo.git} forms; the second adoption
+ * would otherwise run every step against the first repository's working tree.
  *
  * <p>Contexts are claimed one repository at a time rather than built for the whole
  * run up front, because both failures a claim can raise — a URL that names no
  * repository, and a checkout directory already taken — belong to the repository
  * that raised them. Building them all up front made either one abort the batch
- * before its first clone and leave the run with no report at all, which is exactly
- * what {@link BatchAdoption} keeps from happening for every failure the pipeline
- * itself raises.
+ * before its first clone and leave the run with no report at all.
  */
 public final class Checkouts {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -19,55 +19,39 @@ import picocli.CommandLine.ParameterException;
 
 /**
  * Parses the adoption command line. The first three non-flag arguments are the
- * positional repository URL, workspace directory, and feature-branch name the
- * entry point has always accepted; the flags expose the rest of the pipeline's
- * configuration: further repositories for the same run (repeatable
- * {@code --repo}, or {@code --repos <file>} for a file naming one per line), the
- * workspace and branch under their own names, the {@link PullRequestOptions}
- * metadata ({@code --title}, {@code --body}, repeatable
- * {@code --reviewer}/{@code --label}/{@code --assignee}, {@code --draft}), the
- * starter-assets step ({@code --assets}), the {@code claude-code-enforcer}
- * version to wire in ({@code --rule-version}), a rehearsal that publishes nothing
- * ({@code --dry-run}), how long any one external command may take
- * ({@code --timeout <minutes>}), and a JSON report of the outcome
- * ({@code --report <file>}). A blank workspace or branch positional falls back to
- * its default; an unknown flag, or one missing its value, fails with the usage
- * line rather than being ignored — as does {@code --help}, which asks for that
- * line and so is answered with it instead, whatever else on the command line
- * could not be read. What it is not read as is a value: a {@code --title -h} is a
- * flag missing its value, and is refused as one.
+ * positional repository URL, workspace directory, and feature-branch name; the
+ * flags expose the rest of the pipeline's configuration — further repositories for
+ * the same run (repeatable {@code --repo}, or {@code --repos <file>} for a file
+ * naming one per line), the workspace and branch under their own names, the
+ * {@link PullRequestOptions} metadata, the starter-assets step, the
+ * {@code claude-code-enforcer} version to wire in, a rehearsal that publishes
+ * nothing, how long any one external command may take, and a JSON report of the
+ * outcome. A blank value counts as not supplied for every optional input; an
+ * unknown flag, or one missing its value, fails with the usage line.
  *
  * <p>The arguments are matched by picocli rather than by a loop of this module's
- * own: the option names, their values, the three positional slots and the
- * refusals are all declared, so what the parser accepts is readable in one place
- * instead of being spelled out twice — once in the loop and once in the usage
- * line. Each option is bound to a method rather than to a field, because picocli
- * calls a method option once per occurrence, in the order the operator wrote it.
- * That order is the one thing a batch cannot lose: a run mixing {@code --repo}
- * with {@code --repos} adopts its repositories, and reports them, in the order
- * they were named.
- *
- * <p>The positional slots keep their meaning whatever else is on the command line
- * — the first is always a repository URL, never a workspace — so a run driven
- * entirely by {@code --repo}/{@code --repos} names its workspace and branch with
- * {@code --workspace} and {@code --branch}. A flag and its positional write the
- * same value, so naming one twice is the last one winning rather than an error:
- * that is what {@code setOverwrittenOptionsAllowed} buys, and it is the same
- * setting that lets the repeatable flags be named again and again.
+ * own, so what the parser accepts is declared in one place instead of being
+ * spelled out twice. {@code --repo} and {@code --repos} are bound to methods
+ * because picocli calls a method option once per occurrence, in the order the
+ * operator wrote it: that order is the one thing a batch cannot lose, since a run
+ * mixing the two adopts and reports its repositories in the order they were named.
+ * The workspace and branch are bound to methods too, because a flag and its
+ * positional write the one field and the last one named has to win — which is what
+ * {@code setOverwrittenOptionsAllowed} buys, and the same setting that lets the
+ * repeatable flags be named again and again.
  *
  * <p>A flag that names something is never followed by another flag, and picocli
  * refuses one that is: {@code --branch --draft} named a branch called
- * {@code --draft}, created it, and pushed it, with the draft the operator asked
- * for silently dropped. {@code --title} and {@code --body} take free-form prose,
- * and prose that merely looks like a flag is still prose — the refusal is for a
- * value that is an option of this command, not for any word opening with dashes.
+ * {@code --draft}, created it, and pushed it, with the draft silently dropped.
+ * {@code --title} and {@code --body} take free-form prose, and prose that merely
+ * looks like a flag is still prose — the refusal is for a value that is an option
+ * of this command, not for any word opening with dashes.
  *
  * <p>The usage line is written out rather than generated from the declarations
- * below. picocli can render a synopsis, but it orders one by reflecting over the
- * methods, and the JVM does not promise the order it reports them in — the line
- * an operator reads would then differ between runs. This one is ordered to be
- * read: the positionals first, then the flags that name what to adopt, then the
- * pull request's metadata.
+ * below, because picocli orders a generated synopsis by reflecting over the
+ * members and the JVM does not promise the order it reports them in. This one is
+ * ordered to be read: the positionals first, then the flags that name what to
+ * adopt, then the pull request's metadata.
  */
 @Command(name = "adopt")
 public final class CliArguments {
@@ -85,21 +69,43 @@ public final class CliArguments {
 	private static final String TIMEOUT_FLAG = "--timeout";
 	private static final String REPOS_FLAG = "--repos";
 
+	@Option(names = "--title", paramLabel = "<title>")
+	private String title;
+
+	@Option(names = "--body", paramLabel = "<body>")
+	private String body;
+
+	@Option(names = "--reviewer", paramLabel = "<user>")
+	private List<String> reviewers = new ArrayList<>();
+
+	@Option(names = "--label", paramLabel = "<label>")
+	private List<String> labels = new ArrayList<>();
+
+	@Option(names = "--assignee", paramLabel = "<user>")
+	private List<String> assignees = new ArrayList<>();
+
+	@Option(names = "--rule-version", paramLabel = "<version>")
+	private String ruleVersion;
+
+	@Option(names = "--report", paramLabel = "<file>")
+	private String reportFile;
+
+	@Option(names = "--draft")
+	private boolean draft;
+
+	@Option(names = "--assets")
+	private boolean assets;
+
+	@Option(names = "--dry-run")
+	private boolean dryRun;
+
+	@Option(names = { HELP_FLAG, HELP_SHORTHAND })
+	private boolean help;
+
 	private final List<String> repositoryUrls = new ArrayList<>();
 	private Path workspace;
 	private String branchName;
-	private String title;
-	private String body;
-	private final List<String> reviewers = new ArrayList<>();
-	private final List<String> labels = new ArrayList<>();
-	private final List<String> assignees = new ArrayList<>();
-	private boolean draft;
-	private boolean assets;
-	private String ruleVersion;
-	private boolean dryRun;
 	private Duration commandTimeout;
-	private Path reportFile;
-	private boolean help;
 	private String positionalUrl;
 	private boolean flagsNamedARepository;
 
@@ -122,11 +128,10 @@ public final class CliArguments {
 	/**
 	 * A command line that asked for the usage line is answered with it even when
 	 * another of its arguments could not be read. picocli calls an option's method as
-	 * it parses, so an unreadable {@code --repos} file, a {@code --timeout} that is not
-	 * a number, or a misspelled flag is raised while {@code --help} is still only a flag
-	 * further along the list — and {@code --help --repos missing.txt} was refused for the
-	 * file rather than answered with the line it asked for. The refusal is the answer
-	 * only for a run that was asking to adopt something.
+	 * it parses, so an unreadable {@code --repos} file or a {@code --timeout} that is
+	 * not a number is raised while {@code --help} is still only a flag further along
+	 * the list. The refusal is the answer only for a run that was asking to adopt
+	 * something.
 	 */
 	private static CliArguments helpOrRefusal(CliArguments cli, CommandLine parser, String[] args,
 			ParameterException e) {
@@ -141,14 +146,9 @@ public final class CliArguments {
 	 * Whether the command line asked for the usage line, rather than merely carrying
 	 * the word somewhere. A help flag written where a value was expected is that
 	 * value — {@code --title -h} names a title, badly — so it is read as the argument
-	 * the operator got wrong and not as a request.
-	 *
-	 * <p>Reading every occurrence as a request answered {@code --repo <url> --title -h}
-	 * with the usage line and exited zero, having adopted nothing: a scripted batch that
-	 * mistyped one flag reported success and left no report to say otherwise. It is the
-	 * one shape this method has to tell apart, because it is also the one picocli
-	 * refuses on purpose — a flag that names something is never followed by another
-	 * flag.
+	 * the operator got wrong and not as a request. Reading every occurrence as a
+	 * request answered {@code --repo <url> --title -h} with the usage line and exited
+	 * zero, having adopted nothing.
 	 */
 	private static boolean asksForHelp(CommandLine parser, String[] args) {
 		Set<String> valueOptions = optionsTakingAValue(parser);
@@ -163,7 +163,7 @@ public final class CliArguments {
 
 	/**
 	 * The names of the options that consume the argument after them, read from the
-	 * declarations below rather than listed again here, so an option added to this
+	 * declarations above rather than listed again here, so an option added to this
 	 * command cannot swallow a help flag the parse then answers as a request.
 	 */
 	private static Set<String> optionsTakingAValue(CommandLine parser) {
@@ -183,10 +183,8 @@ public final class CliArguments {
 
 	/**
 	 * @return every repository to adopt in this run, in the order the operator named
-	 *         them — the positional and the flags interleaved as they were written,
-	 *         which is the order the options are bound to methods to preserve — and
-	 *         without duplicates, since the same repository twice would adopt one
-	 *         checkout a second time
+	 *         them, and without duplicates — the same repository twice would adopt
+	 *         one checkout a second time
 	 */
 	public List<String> repositoryUrls() {
 		return RepositoryUrls.distinct(repositoryUrls);
@@ -210,27 +208,20 @@ public final class CliArguments {
 	}
 
 	public Optional<Path> reportFile() {
-		return Optional.ofNullable(reportFile);
+		return Optional.ofNullable(optionalText(reportFile)).map(Path::of);
 	}
 
 	/**
-	 * The refusal to raise for an argument picocli would not accept. A failure
-	 * raised by one of the methods below — an unreadable repository list, a blank
-	 * flag value — is already the failure this module means, and picocli wraps it
-	 * only because it was the one calling; it travels on unchanged so a caller
-	 * still sees an {@link AdoptionException} for a file it could not read. Anything
-	 * else is the parser's own complaint about the command line, which is answered
-	 * with the usage line as every other bad argument is.
+	 * The refusal to raise for an argument picocli would not accept. A failure raised
+	 * by one of the methods below — an unreadable repository list, a bad timeout — is
+	 * already the failure this module means, and travels on unchanged. Anything else
+	 * is the parser's own complaint, answered with the usage line.
 	 *
-	 * <p>The parser's complaint quotes the argument it could not place, and one of the
-	 * arguments this command takes is a clone URL carrying credentials: a fourth
-	 * positional — an operator writing two repositories where the slots hold one — was
-	 * refused with {@code Unmatched argument at index 3:
-	 * 'https://x-access-token:TOKEN@github.com/owner/repo.git'}, which is the last thing
-	 * the run prints. It goes through {@link Redaction}, as every other message the
-	 * adoption raises about a URL does. The parser's own exception is deliberately
-	 * <em>not</em> chained: it carries the unmasked text as its message, which the
-	 * stack trace of an uncaught refusal would print straight back out.
+	 * <p>That complaint quotes the argument it could not place, and one of the
+	 * arguments this command takes is a clone URL carrying credentials, so it goes
+	 * through {@link Redaction}. The parser's exception is deliberately <em>not</em>
+	 * chained: it carries the unmasked text as its message, which the stack trace of
+	 * an uncaught refusal would print straight back out.
 	 */
 	private static RuntimeException refusal(ParameterException e) {
 		if (e.getCause() instanceof RuntimeException raised) {
@@ -279,64 +270,15 @@ public final class CliArguments {
 		branchName = optionalText(value);
 	}
 
-	@Option(names = "--title", paramLabel = "<title>")
-	private void title(String value) {
-		title = value;
-	}
-
-	@Option(names = "--body", paramLabel = "<body>")
-	private void body(String value) {
-		body = value;
-	}
-
-	@Option(names = "--reviewer", paramLabel = "<user>")
-	private void reviewer(String value) {
-		reviewers.add(value);
-	}
-
-	@Option(names = "--label", paramLabel = "<label>")
-	private void label(String value) {
-		labels.add(value);
-	}
-
-	@Option(names = "--assignee", paramLabel = "<user>")
-	private void assignee(String value) {
-		assignees.add(value);
-	}
-
-	@Option(names = "--rule-version", paramLabel = "<version>")
-	private void ruleVersion(String value) {
-		ruleVersion = optionalText(value);
-	}
-
+	/**
+	 * The timeout is read as whole minutes rather than as an ISO-8601 duration,
+	 * because it is set in the units the operator is reasoning about — how long a
+	 * {@code claude init} over their largest repository takes. It is refused while
+	 * they are still reading the command line rather than after a clone.
+	 */
 	@Option(names = TIMEOUT_FLAG, paramLabel = "<minutes>")
 	private void timeout(String value) {
-		commandTimeout = optionalTimeout(value);
-	}
-
-	@Option(names = "--report", paramLabel = "<file>")
-	private void report(String value) {
-		reportFile = optionalPath(value);
-	}
-
-	@Option(names = "--draft")
-	private void draft(boolean on) {
-		draft = on;
-	}
-
-	@Option(names = "--assets")
-	private void assets(boolean on) {
-		assets = on;
-	}
-
-	@Option(names = "--dry-run")
-	private void dryRun(boolean on) {
-		dryRun = on;
-	}
-
-	@Option(names = { HELP_FLAG, HELP_SHORTHAND })
-	private void help(boolean on) {
-		help = on;
+		commandTimeout = Text.isPresent(value) ? Duration.ofMinutes(minutes(value.strip())) : null;
 	}
 
 	private void addFlaggedRepository(String url) {
@@ -344,38 +286,23 @@ public final class CliArguments {
 		addRepository(url);
 	}
 
-	/**
-	 * A blank repository is dropped rather than adopted — the rule {@link Text}
-	 * defines for every optional input, and the one every optional flag value
-	 * follows too — leaving the run with whatever the other arguments named.
-	 */
+	/** A blank repository is dropped rather than adopted, as every optional input is. */
 	private void addRepository(String url) {
 		if (Text.isPresent(url)) {
 			repositoryUrls.add(url.strip());
 		}
 	}
 
-	private Path optionalPath(String value) {
+	private static Path optionalPath(String value) {
 		String path = optionalText(value);
 		return path == null ? null : Path.of(path);
 	}
 
-	private String optionalText(String value) {
+	private static String optionalText(String value) {
 		return Text.orDefault(value, null);
 	}
 
-	/**
-	 * The timeout is read as whole minutes rather than as an ISO-8601 duration,
-	 * because it is set in the units the operator is reasoning about — how long a
-	 * {@code claude init} over their largest repository takes. A blank value counts
-	 * as not supplied, like every other optional flag's, and falls back to the
-	 * pipeline's default.
-	 */
-	private Duration optionalTimeout(String value) {
-		return Text.isPresent(value) ? Duration.ofMinutes(minutes(value.strip())) : null;
-	}
-
-	private long minutes(String value) {
+	private static long minutes(String value) {
 		long parsed = parseMinutes(value);
 		if (parsed <= 0) {
 			throw new IllegalArgumentException(
@@ -384,7 +311,7 @@ public final class CliArguments {
 		return parsed;
 	}
 
-	private long parseMinutes(String value) {
+	private static long parseMinutes(String value) {
 		try {
 			return Long.parseLong(value);
 		} catch (NumberFormatException e) {
@@ -412,25 +339,19 @@ public final class CliArguments {
 	}
 
 	/**
-	 * Rejects a first positional that names no repository owner when the flags already
-	 * named repositories — {@code --repos list.txt /tmp/workspace}, where the operator
-	 * meant the workspace the flags left unnamed. The positional slot keeps its
-	 * meaning whatever else is on the command line, so that path is read as a
-	 * repository URL and fails several steps later on a clone of a directory that is
-	 * not a repository. Saying so here names the argument and the flag meant instead.
+	 * Rejects a first positional that names no repository owner when the flags
+	 * already named repositories — {@code --repos list.txt /tmp/workspace}, where the
+	 * operator meant the workspace the flags left unnamed. The positional keeps its
+	 * meaning whatever else is on the command line, so that path would otherwise be
+	 * cloned and fail several steps later; saying so here names the argument and the
+	 * flag meant instead. The check is only worth making when the flags supplied a
+	 * repository, since a run whose only repository is the positional has nothing
+	 * else it could be.
 	 *
-	 * <p>The check is only worth making when the flags supplied a repository, since a
-	 * run whose only repository is the positional has nothing else it could be. A
-	 * local path really is adoptable — only a URL with a host names an owner — so a
-	 * batch of local repositories names them all with {@code --repo}.
-	 *
-	 * <p>The argument is named through {@link Redaction}, as every other message the
-	 * adoption raises about a URL is. A URL naming no owner can still carry
-	 * credentials — {@code https://x-access-token:TOKEN@github.com/repo}, whose
-	 * userinfo and host collapse into one segment where the owner should be — and this
-	 * message is the last thing a run prints before it stops, so reporting the
-	 * argument verbatim wrote the token to the operator's terminal and to whatever
-	 * captured it.
+	 * <p>The argument is named through {@link Redaction}: a URL naming no owner can
+	 * still carry credentials — {@code https://x-access-token:TOKEN@github.com/repo},
+	 * whose userinfo and host collapse into one segment — and this message is the
+	 * last thing a run prints before it stops.
 	 */
 	private void requirePositionalNamesARepository() {
 		if (positionalUrl != null && flagsNamedARepository && namesNoOwner(positionalUrl)) {
@@ -442,13 +363,10 @@ public final class CliArguments {
 
 	/**
 	 * An argument {@link RepositoryUrl} cannot parse at all names no owner either —
-	 * and no repository, so no adoption was ever going to be made of it whichever
-	 * argument the operator meant it to be. Answering the question rather than
-	 * letting the parse failure out is what puts the refusal above in front of them:
-	 * a {@code /tmp/workspace//} whose trailing slashes leave no last segment, or a
-	 * {@code C:\workspaces\ws} on Windows, was refused with the parser's own
-	 * "repositoryUrl must end in a repository name" — which names neither the
-	 * argument that was misread nor the flag that was meant.
+	 * and no repository — so answering the question here is what puts the refusal
+	 * above in front of the operator, rather than the parse failure's "repositoryUrl
+	 * must end in a repository name", which names neither the argument that was
+	 * misread nor the flag that was meant.
 	 */
 	private boolean namesNoOwner(String url) {
 		try {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Elapsed.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Elapsed.java
@@ -3,20 +3,15 @@ package io.github.adamw7.tools.adopt;
 import java.time.Duration;
 
 /**
- * A stopwatch for the log: started when the work starts, and read as text when
- * the line saying how it went is written. An adoption is a sequence of commands
- * that each take between a millisecond and ten minutes, so how long a step took
- * is the one fact a transcript of it cannot be reconstructed from — and the
+ * A stopwatch for the log: started when the work starts, and read as text when the
+ * line saying how it went is written. An adoption is a sequence of commands that
+ * each take between a millisecond and ten minutes, so how long a step took is the
  * question an operator asks first of a run that felt slow.
  *
  * <p>Elapsed time is measured with {@link System#nanoTime()} rather than the wall
- * clock, so a step's duration is not rewritten by a clock correction or a
- * daylight-saving jump landing mid-command.
- *
- * <p>{@link #toString()} is what a log line interpolates, and it reads the
- * stopwatch as it is called: {@link Duration#toString()} answers ISO-8601 —
- * {@code PT4M12.317S} — which a reader scanning a run for the step that cost it
- * has to decode before it means anything.
+ * clock, so a step's duration is not rewritten by a clock correction landing
+ * mid-command. {@link #toString()} is what a log line interpolates, in place of the
+ * ISO-8601 {@link Duration#toString()} a reader would have to decode.
  */
 public final class Elapsed {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -50,11 +50,9 @@ public class GitHubRepoAdopter {
 	 * What the guard commit says it did. It names the guard rather than the artifact
 	 * that supplies one of them, because which guard {@link EnforcerStep} wires in is
 	 * the checkout's build system to decide and is not known when the pipeline is
-	 * assembled: only the Maven path adds the {@code claude-code-enforcer}, while a
-	 * Gradle project gets a task and a project with no build file gets a workflow. A
-	 * message naming the enforcer therefore landed in the history of repositories that
-	 * were given neither — a claim the diff beside it plainly does not support, in a
-	 * commit the adopted project's reviewers read.
+	 * assembled: only the Maven path adds the {@code claude-code-enforcer}. A message
+	 * naming the enforcer landed in the history of repositories given a Gradle task or
+	 * a workflow instead — a claim the diff beside it does not support.
 	 */
 	static final String GUARD_COMMIT_MESSAGE = "Adopt Claude Code: add the CLAUDE.md guard";
 
@@ -121,13 +119,10 @@ public class GitHubRepoAdopter {
 	/**
 	 * A dry run ends at the verification, so the pipeline is assembled without the
 	 * two steps that write to GitHub rather than with steps that decide for
-	 * themselves to do nothing. The report then says what a dry run really did: the
-	 * steps it completed stop at {@code verify}, instead of listing a {@code push}
-	 * and a {@code pull-request} that only pretended to run.
-	 *
-	 * <p>Everything before the verification still happens for real — the checkout is
-	 * cloned, branched, and committed on — so the operator has the adoption's commits
-	 * in the workspace to read before any of it is published.
+	 * themselves to do nothing. The report then says what a dry run really did,
+	 * stopping at {@code verify} instead of listing a {@code push} and a
+	 * {@code pull-request} that only pretended to run. Everything before it still
+	 * happens for real, so the operator has the adoption's commits to read.
 	 */
 	private static List<AdoptionStep> publicationSteps(AdoptionOptions options) {
 		if (options.dryRun()) {
@@ -160,11 +155,9 @@ public class GitHubRepoAdopter {
 
 	/**
 	 * Each step is announced with its position in the pipeline and closed with what
-	 * it cost, because the two questions an operator has of a run that is still
-	 * going are how much of it is left and whether the step it is on is working or
-	 * stuck. The pipeline is assembled per run — an {@link AssetsStep} on request, no
-	 * publication steps on a dry run — so the count is the run's own, not a constant
-	 * a reader could have learnt once.
+	 * it cost, because the two questions an operator has of a run that is still going
+	 * are how much of it is left and whether the step it is on is working or stuck.
+	 * The pipeline is assembled per run, so the count is the run's own.
 	 *
 	 * <p>A failing step is named here as well, without its stack trace: the exception
 	 * carries the failure and {@link BatchAdoption} logs it once, but nothing in that

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -18,12 +18,11 @@ import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
  * under the workspace, named after the repository.
  *
  * <p>When {@code --report} names a file, the run's {@link AdoptionReport} is
- * written there as JSON, for a failed run as well as a successful one, so it can
- * say how far the adoption got and why it stopped. A run over several
- * repositories writes the batch document {@link AdoptionReportWriter} describes.
+ * written there as JSON, for a failed run as well as a successful one. A run over
+ * several repositories writes the batch document {@link AdoptionReportWriter}
+ * describes.
  *
- * <p>{@code --help} is answered with the usage line and nothing is adopted, so the
- * flag every operator reaches for first is not refused as an unknown option. The
+ * <p>{@code --help} is answered with the usage line and nothing is adopted. The
  * line goes to the log, which the console appender writes to standard error: the
  * same jar is the adoption MCP server, whose stdio transport owns standard output.
  *

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -22,20 +22,16 @@ public final class RepositoryUrl {
 	private static final String GIT_SUFFIX = ".git";
 
 	/**
-	 * The port ending a URL's authority: a {@code ':'} followed by digits and then
-	 * either the path or the end of the URL. It is dropped before the URL is split
-	 * into segments, because splitting on {@code ':'} — which the scp-like form needs
-	 * — otherwise reads the port as a path segment of its own. A
-	 * {@code https://ghe.example.com:8443/owner/repo} then yielded the segments
-	 * {@code [ghe.example.com, 8443, owner, repo]}, whose third-from-last is the port
-	 * rather than the host, so {@link #repositorySlug} concluded the URL named no
-	 * owner: {@code gh} lost its {@code --repo}, the toolchain check fell back to its
-	 * weaker credentials probe, and the command line refused the URL outright.
+	 * The port ending a URL's authority, dropped before the URL is split into
+	 * segments: splitting on {@code ':'} — which the scp-like form needs — otherwise
+	 * reads the port as a path segment of its own, so
+	 * {@code https://ghe.example.com:8443/owner/repo} yielded a third-from-last
+	 * segment that is the port rather than the host and {@link #repositorySlug}
+	 * concluded the URL named no owner.
 	 *
 	 * <p>Only a URL carrying a scheme is treated this way. The scp-like
-	 * {@code git@host:owner/repo} has no scheme and cannot carry a port at all — that
-	 * is what {@code ssh://} exists for — so its {@code ':'} always separates a path,
-	 * even before an owner that happens to be all digits.
+	 * {@code git@host:owner/repo} cannot carry a port at all — that is what
+	 * {@code ssh://} exists for — so its {@code ':'} always separates a path.
 	 */
 	private static final Pattern PORT = Pattern.compile("^([^/]*):\\d+(?=/|$)");
 
@@ -110,11 +106,10 @@ public final class RepositoryUrl {
 	 * {@code .../alice/tools} and {@code .../bob/tools} are two.
 	 *
 	 * <p>Anything that does not reduce to the same text is answered as a different
-	 * repository. The comparison is deliberately conservative in that direction,
-	 * because the caller is deciding whether a checkout it found is the one it was
-	 * asked to adopt: refusing a checkout that was in fact the right one costs a
-	 * clone, while accepting the wrong one commits to it, pushes it, and opens its
-	 * pull request.
+	 * repository. The comparison errs in that direction deliberately, because the
+	 * caller is deciding whether a checkout it found is the one it was asked to
+	 * adopt: refusing a checkout that was in fact the right one costs a clone, while
+	 * accepting the wrong one commits to it, pushes it, and opens its pull request.
 	 *
 	 * @param otherUrl the URL to compare against, typically a checkout's recorded
 	 *                 {@code origin}; blank or {@code null} names no repository and
@@ -128,8 +123,7 @@ public final class RepositoryUrl {
 	 * A port is deliberately <em>not</em> dropped here, unlike in
 	 * {@link #authorityAndPath}: two URLs differing only in their port name two
 	 * servers, and answering them as one repository is the direction this comparison
-	 * must never err in — the caller goes on to commit to that checkout, push it, and
-	 * open its pull request. Reading the port as a path segment keeps them apart.
+	 * must never err in.
 	 *
 	 * @return the comparable form of a clone URL, or the empty string for text that
 	 *         names no repository at all — which never equals the identity of a
@@ -151,11 +145,9 @@ public final class RepositoryUrl {
 
 	/**
 	 * The URL's final path segment, ended by either separator git accepts — so the
-	 * scp-like {@code git@host:repo}, whose {@code ':'} is the path separator it is,
-	 * names the checkout directory {@code repo} rather than {@code git@host:repo}.
-	 * This is the same reading of {@code ':'} that {@link #repositorySlug} already
-	 * takes; the scheme is dropped first so its own {@code "://"} is never mistaken
-	 * for that separator.
+	 * scp-like {@code git@host:repo} names the checkout directory {@code repo} rather
+	 * than {@code git@host:repo}. The scheme is dropped first so its own {@code "://"}
+	 * is never mistaken for that separator.
 	 */
 	private static String lastSegment(String url) {
 		String withoutScheme = SCHEME.matcher(url).replaceFirst("");
@@ -167,8 +159,7 @@ public final class RepositoryUrl {
 	 * A URL whose last segment is empty or a directory alias — {@code .../repo//},
 	 * {@code .../.git}, or a bare {@code ..} — would resolve the checkout onto the
 	 * workspace itself or above it, so the clone would land beside the other
-	 * repositories the workspace holds. Rejecting it fails the adoption on its input
-	 * rather than several steps later on a checkout directory nobody intended.
+	 * repositories the workspace holds.
 	 */
 	private static String requireName(String name, String repositoryUrl) {
 		if (name.isEmpty() || ".".equals(name) || "..".equals(name) || isPath(name) || isUserInfo(name)) {
@@ -180,17 +171,15 @@ public final class RepositoryUrl {
 
 	/**
 	 * A last segment that ends at an {@code @} is the URL's user information and
-	 * nothing else — {@code https://token@} names credentials and no repository at
-	 * all. Only a URL with no path past its authority reaches this, since every other
-	 * form has a separator after the {@code @} for {@link #lastSegment} to cut at, so
-	 * a checkout directory legitimately containing an {@code @} is unaffected.
+	 * nothing else — {@code https://token@} names credentials and no repository. Only
+	 * a URL with no path past its authority reaches this, so a checkout directory
+	 * legitimately containing an {@code @} is unaffected.
 	 *
 	 * <p>What it protects is {@link #identity}, which strips exactly that user
 	 * information: such a URL reduced to the empty identity that
-	 * {@link #isSameRepositoryAs} answers for text naming no repository, so the two
-	 * compared equal and a checkout of <em>any</em> other repository — or one whose
-	 * {@code origin} could not be read at all — was accepted as this one, then
-	 * branched, committed, and pushed.
+	 * {@link #isSameRepositoryAs} answers for text naming no repository, so a checkout
+	 * of <em>any</em> other repository was accepted as this one, then branched,
+	 * committed, and pushed.
 	 */
 	private static boolean isUserInfo(String name) {
 		return name.endsWith("@");
@@ -200,8 +189,7 @@ public final class RepositoryUrl {
 	 * A repository name never carries a backslash, so a last segment that does is a
 	 * path rather than a name — a Windows-style {@code C:\repos\tools}, or a segment
 	 * carrying a {@code ..} traversal. Resolving one against the workspace would put
-	 * the checkout outside it on a platform that reads {@code '\'} as a separator, so
-	 * it is refused for the same reason an empty or alias segment is.
+	 * the checkout outside it on a platform that reads {@code '\'} as a separator.
 	 */
 	private static boolean isPath(String name) {
 		return name.indexOf('\\') >= 0;
@@ -211,7 +199,7 @@ public final class RepositoryUrl {
 	 * Derives {@code owner/repository} from the clone URL, covering the forms git
 	 * accepts: {@code https://host/owner/repo.git}, {@code ssh://git@host/owner/repo},
 	 * and the scp-like {@code git@host:owner/repo} — hence splitting on both
-	 * separators, so that form's {@code ':'} is the path separator it is.
+	 * separators.
 	 *
 	 * <p>A URL only names an owner when a host-looking segment precedes the last two.
 	 * Without that check a plain filesystem path such as {@code /tmp/workspace/repo}
@@ -258,9 +246,8 @@ public final class RepositoryUrl {
 	/**
 	 * The suffix is matched case-insensitively, because git clones
 	 * {@code .../repo.GIT} as readily as {@code .../repo.git} and both name the one
-	 * repository. Keeping the case would name the checkout {@code repo.GIT} and ask
-	 * GitHub about {@code owner/repo.GIT}, which answers 404 and stops the adoption
-	 * on its very first step.
+	 * repository. Keeping the case would ask GitHub about {@code owner/repo.GIT},
+	 * which answers 404 and stops the adoption on its very first step.
 	 */
 	private static String stripGitSuffix(String segment) {
 		int suffixStart = segment.length() - GIT_SUFFIX.length();

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/BoundedTranscript.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/BoundedTranscript.java
@@ -9,21 +9,16 @@ package io.github.adamw7.tools.adopt.command;
  * what a transcript grows by.
  *
  * <p>Bounding it here rather than at the caller matters because the transcript does
- * not stop at the log. {@link io.github.adamw7.tools.adopt.step.AbstractCommandStep}
- * puts a failing command's whole output into the {@link
- * io.github.adamw7.tools.adopt.AdoptionException} it raises, which becomes the
- * {@code failure} field of the JSON report written to disk and answered to MCP
- * clients — so an unbounded transcript is an unbounded response, held in memory for
- * as long as the command's timeout allows.
+ * not stop at the log: a failing command's whole output becomes the {@code failure}
+ * field of the JSON report written to disk and answered to MCP clients, so an
+ * unbounded transcript is an unbounded response.
  *
- * <p>A transcript that fits is answered verbatim, byte for byte, so the common case
- * keeps the child's own line terminators and its trailing newline. Only one that
+ * <p>A transcript that fits is answered verbatim, byte for byte. Only one that
  * overflowed is cut, and then <em>only at line boundaries</em>: a clone URL's
  * credentials are masked by {@link io.github.adamw7.tools.adopt.Redaction} matching
  * the user information that follows a {@code ://}, so a cut through the middle of
- * such a URL would leave the token behind with nothing left to recognise it by.
- * Cutting whole lines cannot split one. A region carrying no line feed at all is
- * therefore dropped whole rather than cut mid-line.
+ * such a URL would leave the token behind with nothing left to recognise it by. A
+ * region carrying no line feed at all is dropped whole rather than cut mid-line.
  */
 final class BoundedTranscript {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandLine.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandLine.java
@@ -6,18 +6,12 @@ import java.util.List;
 /**
  * Builds the argument list of one command to hand to a {@link CommandRunner}.
  *
- * <p>Nearly every adoption step assembles its command the same way: a fixed
- * program and its leading arguments, then arguments that depend on the run — a
+ * <p>Nearly every adoption step assembles its command the same way: a fixed program
+ * and its leading arguments, then arguments that depend on the run — a
  * {@code --repo} the URL may not name, a {@code --draft} only a draft pull request
- * carries, a {@code --reviewer} per requested reviewer. Written out directly that
- * is a mutable list seeded from a {@link List#of} literal, a run of {@code add}
- * calls guarded by {@code if}s and {@code forEach}es, and a closing
- * {@link List#copyOf} — the same six lines in every step, with the command itself
- * buried in them.
- *
- * <p>Collecting it here leaves each step naming only its own arguments, and makes
- * the immutable result the single way to finish rather than something each step
- * has to remember.
+ * carries, a {@code --reviewer} per requested reviewer. Collecting that here leaves
+ * each step naming only its own arguments, and makes the immutable result the
+ * single way to finish rather than something each step has to remember.
  */
 public final class CommandLine {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -28,10 +28,9 @@ import io.github.adamw7.tools.adopt.Redaction;
  * <p>Every command is traced at debug — what was run, where, how it exited and
  * how long it took — because this is the one place the adoption learns anything
  * from the outside world, and the steps above it report only the commands that
- * stopped the run. A tolerated failure, a clone skipped because the checkout was
- * already there, a step that decided it had nothing to do: none of those leave a
- * trace anywhere else, so a run that did less than it was expected to reads
- * exactly like one that did everything.
+ * stopped the run. A tolerated failure or a step that decided it had nothing to do
+ * leaves no trace anywhere else, so a run that did less than it was expected to
+ * reads exactly like one that did everything.
  */
 public class ProcessCommandRunner implements CommandRunner {
 
@@ -79,18 +78,14 @@ public class ProcessCommandRunner implements CommandRunner {
 	}
 
 	/**
-	 * The transcript of a command that exited non-zero is logged here as well as
-	 * being handed back, because whether it reaches a message at all is the
-	 * caller's decision: a step running through
+	 * The transcript of a command that exited non-zero is logged here as well as being
+	 * handed back, because whether it reaches a message at all is the caller's
+	 * decision: a step running through
 	 * {@link io.github.adamw7.tools.adopt.step.AbstractCommandStep#runTolerating}
-	 * discards a tolerated failure whole, and the tool's own account of what it
-	 * refused to do — the one thing that says which of the tolerated cases this
-	 * was — went with it.
-	 *
-	 * <p>Redacting it is not optional: a tool handed a credentialled clone URL
-	 * echoes it back when it cannot use it, so the transcript carries a token as
-	 * readily as the command does. The guard keeps that scan off the path a
-	 * disabled log takes.
+	 * discards a tolerated failure whole, along with the tool's own account of what it
+	 * refused to do. Redacting it is not optional — a tool handed a credentialled
+	 * clone URL echoes it back — and the guard keeps that scan off the path a disabled
+	 * log takes.
 	 */
 	private void logOutcome(CommandResult result, Elapsed elapsed) {
 		log.debug("Exited {} after {}: {}", result.exitCode(), elapsed, result.describe());

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -52,9 +52,7 @@ public class AdoptTool implements McpTool {
 	 * Builds the adoption a call runs, from the arguments that call supplied. The
 	 * seam is a factory rather than the adoption itself so the pipeline — and the
 	 * command runner behind it — is assembled once and then adopts every repository
-	 * of the batch, exactly as the command line does; assembling it per repository
-	 * would hand each one its own step instances. Tests substitute a recording
-	 * adoption and clone nothing.
+	 * of the batch, exactly as the command line does.
 	 */
 	public interface Pipeline {
 		BatchAdoption.Adoption create(AdoptionOptions options);
@@ -138,13 +136,11 @@ public class AdoptTool implements McpTool {
 	}
 
 	/**
-	 * The call's arguments as they may be logged. A {@code repository_url} is the
-	 * one argument a client supplies with credentials in it — an adoption driven by
-	 * CI is handed {@code https://x-access-token:TOKEN@github.com/owner/repo.git} —
-	 * and this server is long-lived, so logging the map as it arrived wrote that
-	 * token to the log of every call. The pipeline below redacts the URL from its own
-	 * logs, messages, and report; the arguments have to be redacted here, before they
-	 * reach it.
+	 * The call's arguments as they may be logged. A {@code repository_url} is the one
+	 * argument a client supplies with credentials in it, and this server is
+	 * long-lived, so logging the map as it arrived wrote that token to the log of
+	 * every call. The pipeline redacts the URL from its own logs; the arguments have
+	 * to be redacted here, before they reach it.
 	 */
 	static String describe(Map<String, Object> arguments) {
 		return Redaction.of(String.valueOf(arguments));
@@ -213,11 +209,9 @@ public class AdoptTool implements McpTool {
 
 	/**
 	 * The three list arguments are read through {@link #textList} rather than as
-	 * plain text, because a client that sends a JSON array — the natural shape, and
-	 * the one {@code repository_urls} takes on this very tool — would otherwise have
-	 * the list's {@code toString()} split on its commas and reach {@code gh} as
-	 * {@code --reviewer "[octocat"}, failing the last step of an otherwise complete
-	 * adoption.
+	 * plain text, because a client that sends a JSON array would otherwise have the
+	 * list's {@code toString()} split on its commas and reach {@code gh} as
+	 * {@code --reviewer "[octocat"}, failing the last step of a complete adoption.
 	 */
 	private PullRequestOptions pullRequestOptionsFrom(Map<String, Object> arguments) {
 		return new PullRequestOptions(text(arguments, "title"), text(arguments, "body"),

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractWrappedBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractWrappedBuildSystem.java
@@ -1,0 +1,49 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Base for the build systems launched through a tool the checkout may ship a
+ * wrapper for — {@code mvnw} for Maven, {@code gradlew} for Gradle. Both verify
+ * the guard by running that tool with a fixed set of arguments, and both have to
+ * probe whatever {@link #verifyCommand(Path)} will launch rather than the program
+ * name, so a wrapper that has to go through a shell is probed as it will be run.
+ * Saying that once keeps the probe and the verification from drifting apart in one
+ * build system but not the other.
+ */
+abstract class AbstractWrappedBuildSystem implements BuildSystem {
+
+	private final String tool;
+	private final List<String> verifyArguments;
+	private final BuildWrapper wrapper;
+
+	/**
+	 * @param tool            the program to launch when the checkout ships no wrapper,
+	 *                        and the name this build system reports
+	 * @param verifyArguments the arguments that run the wired-in guard
+	 * @param wrapper         the wrapper script to prefer over {@code tool}
+	 */
+	protected AbstractWrappedBuildSystem(String tool, List<String> verifyArguments, BuildWrapper wrapper) {
+		this.tool = tool;
+		this.verifyArguments = List.copyOf(verifyArguments);
+		this.wrapper = wrapper;
+	}
+
+	@Override
+	public String name() {
+		return tool;
+	}
+
+	@Override
+	public List<String> verifyCommand(Path repositoryDirectory) {
+		return wrapper.commandIn(repositoryDirectory, tool, verifyArguments);
+	}
+
+	/** Probes whatever {@link #verifyCommand(Path)} will launch — the wrapper, however it has to be run. */
+	@Override
+	public Optional<List<String>> toolProbe(Path repositoryDirectory) {
+		return Optional.of(wrapper.probeIn(repositoryDirectory, tool));
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -25,12 +25,11 @@ public interface BuildSystem {
 	 * the build system that writes it so {@link AdoptionAssets} can account for the
 	 * adoption's own files without keeping a second copy of each name.
 	 *
-	 * <p>Deliberately not defaulted. {@link AdoptionAssets#WRITTEN_PATHS} is what
+	 * <p>Deliberately not defaulted: {@link AdoptionAssets#WRITTEN_PATHS} is what
 	 * {@link CloneStep} tells the adoption's work apart with and what
-	 * {@link CommitStep} refuses an ignored path over, so a build system that wrote a
-	 * file this list did not name would have it silently dropped from the branch. A
-	 * default of "none" would let a new build system be added without anyone noticing
-	 * that gap; requiring an answer makes the compiler ask.
+	 * {@link CommitStep} refuses an ignored path over, so a file this list did not
+	 * name would be silently dropped from the branch. Requiring an answer makes the
+	 * compiler ask a new build system for one.
 	 *
 	 * @return the paths, listed whether or not the checkout happens to carry them
 	 */
@@ -79,13 +78,9 @@ public interface BuildSystem {
 	 * more than one word to launch its tool — a wrapper the checkout committed
 	 * without its executable bit goes through {@code sh}, whose own
 	 * {@code --version} is not portable — and probing only the program would then
-	 * answer for the shell rather than for the build tool.
-	 *
-	 * <p>A build system whose verification names no command at all has nothing to
-	 * probe, and is answered as such rather than with the
-	 * {@link IndexOutOfBoundsException} that reading its first word would raise —
-	 * this is the extension point a new build system is added through, so it says
-	 * what it expects instead of failing an adoption several steps in.
+	 * answer for the shell rather than for the build tool. A verification that names
+	 * no command has nothing to probe, and is answered as such rather than with the
+	 * {@link IndexOutOfBoundsException} reading its first word would raise.
 	 *
 	 * @return the probe command, or empty when the verification needs nothing beyond
 	 *         the shell

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildWrapper.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildWrapper.java
@@ -55,9 +55,8 @@ final class BuildWrapper {
 	 * built from the same launcher {@link #commandIn} uses so what
 	 * {@link BuildToolchainStep} checks is what {@link VerifyStep} will run. Probing
 	 * the launcher rather than the wrapper's file name matters for a wrapper that has
-	 * to go through {@link #SHELL}: {@code sh --version} is not portable — under
-	 * {@code dash} it exits non-zero — so a probe of the program alone would report
-	 * a wrapper that runs perfectly well as one that could not be run.
+	 * to go through {@link #SHELL}, since {@code sh --version} is not portable and a
+	 * probe of the program alone would report a working wrapper as unrunnable.
 	 */
 	List<String> probeIn(Path repositoryDirectory, String fallback) {
 		return commandIn(repositoryDirectory, fallback, List.of(ToolProbe.VERSION_FLAG));
@@ -73,16 +72,12 @@ final class BuildWrapper {
 
 	/**
 	 * A wrapper whose executable bit the project never committed — the usual state of
-	 * one added from Windows, where git records no such bit — cannot be launched as a
-	 * program at all: the checkout is refused with "Permission denied", which
-	 * {@link BuildToolchainStep} reports as a wrapper that could not be run and which
-	 * aborted the adoption of a repository whose build was fine. Running it through
-	 * {@code sh} is what the project's own CI does with it, and needs no change to
-	 * the checkout — where a {@code chmod} would leave a mode change in the adoption's
-	 * commit that nobody asked for.
-	 *
-	 * <p>Only the POSIX wrapper is ever shelled: the Windows {@code .bat}/{@code .cmd}
-	 * carries no executable bit to miss and is not a shell script.
+	 * one added from Windows — cannot be launched as a program at all, so
+	 * {@link BuildToolchainStep} aborted the adoption of a repository whose build was
+	 * fine. Running it through {@code sh} is what the project's own CI does with it,
+	 * and needs no change to the checkout, where a {@code chmod} would leave a mode
+	 * change in the adoption's commit that nobody asked for. Only the POSIX wrapper is
+	 * ever shelled: a {@code .bat}/{@code .cmd} is not a shell script.
 	 */
 	private List<String> launch(String wrapper) {
 		return windows || Files.isExecutable(Path.of(wrapper)) ? List.of(wrapper) : List.of(SHELL, wrapper);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -127,10 +127,8 @@ public class ClaudeInitStep extends AbstractCommandStep {
 	/**
 	 * The CLI's own transcript is carried into the failure, because a run that exits
 	 * cleanly without writing the file has said why in it — it declined, it asked a
-	 * question headless mode could not answer, it wrote somewhere else — and that
-	 * transcript is otherwise discarded, {@link #runOrFail} only reporting the output
-	 * of a command that failed. Without it the adoption stops on a message that names
-	 * the missing file and nothing that would explain it.
+	 * question headless mode could not answer, it wrote somewhere else — and
+	 * {@link #runOrFail} only reports the output of a command that failed.
 	 */
 	private void requireGenerated(AdoptionContext context, CommandResult result) {
 		if (!Files.isRegularFile(context.repositoryDirectory().resolve(CLAUDE_MD))) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
@@ -89,12 +89,10 @@ public class ClaudeMdConformanceStep implements AdoptionStep {
 	/**
 	 * Reshapes to the contract of the guard {@link EnforcerStep} is about to wire
 	 * into this very checkout, detected from the same build-system list that step is
-	 * given, so the two never disagree about what the file has to carry.
-	 *
-	 * <p>A list detection comes up empty on — one configured without a catch-all,
-	 * since {@link BuildSystems#DEFAULTS} always matches — leaves no guard to satisfy
-	 * and so demands no section, the same answer as a guard that only wants the file
-	 * to be there.
+	 * given, so the two never disagree about what the file has to carry. A list
+	 * detection comes up empty on — one configured without a catch-all, since
+	 * {@link BuildSystems#DEFAULTS} always matches — leaves no guard to satisfy and so
+	 * demands no section.
 	 */
 	private ClaudeMdConformer conformer(Path checkout) {
 		return new ClaudeMdConformer(BuildSystems.detect(buildSystems, checkout)

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -29,36 +29,27 @@ import io.github.adamw7.tools.markdown.MarkdownText;
  * <p>Which sections it demands is the caller's to choose, because the guard being
  * wired in differs by build system — see
  * {@link BuildSystem#requiredClaudeMdSections()}. The title and the
- * {@code AGENTS.md} reference are settled either way: the step writes a companion
- * {@code AGENTS.md} for every adopted repository, and a document that never points
- * at it leaves the pair pointing only one way.
+ * {@code AGENTS.md} reference are settled either way, since the step writes a
+ * companion {@code AGENTS.md} for every adopted repository.
  *
  * <p>How the document is <em>read</em> — which lines are code, which sit inside an
- * HTML comment, and what heading a line declares — is not this class's to decide.
- * It asks {@link MarkdownDocument}, the same reader the {@code claudeMdFormat}
- * rule judges the result with. Those readings used to be spelled out here a second
- * time, and every way the two spellings drifted apart produced one shape of bug:
- * this class acted on lines the rule holds to be code, or appended a section the
- * rule already reads as present, and the adoption then failed the very check it
- * exists to satisfy — after committing and pushing the file. Sharing the reader is
- * what makes that class of disagreement unrepresentable rather than merely tested
- * for.
+ * HTML comment, and what heading a line declares — is {@link MarkdownDocument}'s to
+ * decide, the same reader the {@code claudeMdFormat} rule judges the result with.
+ * Spelling those readings out here a second time made the two drift apart, and
+ * every drift produced one shape of bug: this class acted on lines the rule holds
+ * to be code, or appended a section the rule already reads as present, and the
+ * adoption failed the very check it exists to satisfy — after pushing the file.
  */
 public class ClaudeMdConformer {
 
 	/*
 	 * These mirror io.github.adamw7.tools.enforcer.doc.ClaudeMdFormatRule in the
-	 * claude-code-enforcer module: the title, the AGENTS.md reference, and the
-	 * required section headings the wired-in claudeMdFormat rule checks for. They
-	 * are duplicated here rather than imported because the adopt module does not
-	 * depend on the enforcer module — a pipeline that shipped an enforcer rule
-	 * would force the maven-enforcer API on every consumer. The shared reader below
-	 * is what both modules do get to import, since it carries neither.
-	 *
-	 * The copy is not trusted to stay in step: ClaudeMdConformerContractTest runs
-	 * the real rule over this class's output, on a test-scoped dependency, so a
-	 * rule that asks for one more section fails this module's build rather than
-	 * some adopted repository's.
+	 * claude-code-enforcer module. They are duplicated rather than imported because
+	 * the adopt module does not depend on the enforcer module — a pipeline that
+	 * shipped an enforcer rule would force the maven-enforcer API on every consumer.
+	 * The copy is not trusted to stay in step: ClaudeMdConformerContractTest runs the
+	 * real rule over this class's output, so a rule that asks for one more section
+	 * fails this module's build rather than some adopted repository's.
 	 */
 	static final String TITLE = "# CLAUDE.md";
 	static final String AGENTS_REFERENCE = "AGENTS.md";
@@ -68,8 +59,7 @@ public class ClaudeMdConformer {
 	 * conform to <em>where that rule is the guard being wired in</em> — the Maven
 	 * path, {@link MavenBuildSystem#requiredClaudeMdSections()}. They are Java and
 	 * Maven sections because the rule is a Java project's rule; a build system whose
-	 * guard asks only that the file exist and carry something does not want them, and
-	 * says so by requiring none.
+	 * guard asks only that the file exist and carry something requires none.
 	 */
 	static final List<String> REQUIRED_SECTIONS = List.of(
 			"## Project",
@@ -95,22 +85,16 @@ public class ClaudeMdConformer {
 
 	/**
 	 * Conforms only as far as the guard being wired in actually demands. Stamping the
-	 * {@code claudeMdFormat} sections onto every adopted repository put
-	 * {@code ## Java version}, {@code ## Maven} and
-	 * {@code ## Principles for Java Development} — each stubbed with a pointer to
-	 * {@code AGENTS.md} — into the {@code CLAUDE.md} of projects that are neither
-	 * Java nor Maven, where nothing then checked them: the Gradle and GitHub Actions
-	 * guards ask only that the file exist and carry something. The reshape is worth
-	 * making only where a guard would otherwise reject the file, so what to require
-	 * is the build system's to say.
-	 *
-	 * <p>A heading named twice is kept once. Each required section is settled against
-	 * the document as it stood before the pass, so a list repeating one would have
-	 * had a second near-miss renamed to it — leaving the document carrying the
-	 * heading twice, which is not what asking for it twice could have meant.
+	 * {@code claudeMdFormat} sections onto every adopted repository put Java and Maven
+	 * headings, each stubbed with a pointer to {@code AGENTS.md}, into projects that
+	 * are neither — where nothing then checked them, the Gradle and GitHub Actions
+	 * guards asking only that the file exist and carry something.
 	 *
 	 * @param requiredSections the headings to canonicalize, append and give a body to,
-	 *                         empty for a guard that demands no particular section
+	 *                         empty for a guard that demands no particular section. A
+	 *                         heading named twice is kept once: each is settled against
+	 *                         the document as it stood before the pass, so a repeated
+	 *                         one would have had a second near-miss renamed to it.
 	 */
 	public ClaudeMdConformer(List<String> requiredSections) {
 		this.requiredSections = List.copyOf(new LinkedHashSet<>(requiredSections));
@@ -135,13 +119,10 @@ public class ClaudeMdConformer {
 	 * because {@link String#lines()} drops the empty line a document's trailing
 	 * newline leaves and this reshape appends to the list it splits.
 	 *
-	 * <p>A leading byte-order mark is dropped, the same reading the rule takes before
-	 * it sees the document. Keeping it left the title line as a {@code U+FEFF} in
-	 * front of {@code # CLAUDE.md}, which {@link String#strip()} does not shorten —
-	 * the mark is not whitespace — so the reshape concluded the title was missing and
-	 * prepended a second one. The rule accepted the result either way, having
-	 * stripped the mark itself, so nothing downstream reported the duplicated title
-	 * the adoption had just committed.
+	 * <p>A leading byte-order mark is dropped, the same reading the rule takes.
+	 * Keeping it left the mark in front of {@code # CLAUDE.md} — which
+	 * {@link String#strip()} does not shorten — so the reshape concluded the title was
+	 * missing and prepended a second one, which the rule accepted either way.
 	 */
 	private List<String> splitLines(String content) {
 		String normalized = LineTerminators.normalized(MarkdownText.stripByteOrderMark(content));
@@ -150,10 +131,9 @@ public class ClaudeMdConformer {
 
 	/**
 	 * Closes a fence and an HTML comment the document opened and never closed, so
-	 * everything appended below lands outside the block. A section appended inside an
-	 * open comment is inert text the rule does not see, so the adoption would fail its
-	 * own {@link VerifyStep} on a section it had just added. A document whose fences
-	 * and comments balance is left untouched, keeping the reshape idempotent.
+	 * everything appended below lands outside the block: a section appended inside an
+	 * open comment is inert text the rule does not see. A document whose fences and
+	 * comments balance is left untouched, keeping the reshape idempotent.
 	 *
 	 * <p>The fence is closed first, because a comment inside a fenced code block is
 	 * sample text rather than a comment — the same precedence the rule reads them
@@ -165,17 +145,11 @@ public class ClaudeMdConformer {
 	}
 
 	/**
-	 * Puts the title on the document's first line, which is where the rule reads it:
-	 * its {@code firstNonBlankLine} check is satisfied by nothing further down.
-	 *
-	 * <p>A title the document already carries lower down is <em>moved</em> rather than
-	 * left where it is, because prepending a second one leaves the file with two
-	 * {@code # CLAUDE.md} headings. The rule accepts that — it only reads the first
-	 * line — so nothing downstream reported the duplicate the adoption had just
-	 * committed to someone else's repository, and the reshape being idempotent meant a
-	 * re-adoption did not clear it either. This is the same shape the byte-order mark
-	 * once produced (see {@link #splitLines}), reached from a document whose title
-	 * simply was not first.
+	 * Puts the title on the document's first line, which is where the rule reads it.
+	 * A title the document already carries lower down is <em>moved</em> rather than
+	 * left where it is, since prepending a second one leaves two {@code # CLAUDE.md}
+	 * headings — which the rule accepts, so nothing downstream would report the
+	 * duplicate, and the reshape being idempotent means a re-adoption never clears it.
 	 *
 	 * <p>The titles are removed latest first, so removing one cannot shift the index
 	 * of the next. Only structural lines are offered: a {@code # CLAUDE.md} inside a
@@ -292,21 +266,15 @@ public class ClaudeMdConformer {
 
 	/**
 	 * The reference is separated from what follows it only when that line is not
-	 * already blank. A document conformed to no required sections keeps the body
-	 * {@code claude init} wrote, blank line and all, and closing the insertion with
-	 * one of its own left a double blank in the first commit of every repository
-	 * whose guard demands no section.
+	 * already blank, since a document conformed to no required sections keeps the body
+	 * {@code claude init} wrote, blank line and all.
 	 *
 	 * <p>An existing mention only counts where the rule counts one: its
 	 * {@code containsInProse} reads the lines that carry document structure, so a
 	 * mention inside a code sample or an HTML comment satisfies it no more than a
 	 * commented-out heading satisfies a required section. Asking the looser question
-	 * — outside fences alone — let a generated document whose only {@code AGENTS.md}
-	 * sat in a comment or an indented sample keep the reference it never had, and the
-	 * adoption then failed its own {@link VerifyStep} on the one line it exists to
-	 * add. It is the rule's own method that answers here, so the two cannot disagree.
-	 *
-	 * <p>A document with no title line at all takes the reference at the top.
+	 * let a document whose only {@code AGENTS.md} sat in a comment keep a reference it
+	 * never had. A document with no title line at all takes the reference at the top.
 	 */
 	private void ensureAgentsReference(List<String> lines) {
 		MarkdownDocument document = MarkdownDocument.of(lines);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
@@ -32,24 +32,18 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  *
  * <p>The read and the write are one exclusive section, because they are a
  * read-modify-write of a file this process does not own. Two adoptions running at
- * once — the MCP server serves calls in parallel — each read the document, each
- * add their own directory, and each write the whole of it back, so the later write
- * dropped the earlier one's entry. The adoption that lost it went on to run
- * {@code claude} in a directory that was never trusted, where it blocked on the
- * interactive prompt until the command timeout killed it. Atomicity of the write
- * alone cannot prevent that: the two writes are each complete, and the second is
- * simply built on a document read before the first landed.
+ * once — the MCP server serves calls in parallel — would each build on a document
+ * read before the other's write landed, so the later write drops the earlier one's
+ * entry and that adoption runs {@code claude} in a directory that was never
+ * trusted. Atomicity of the write alone cannot prevent it: both writes are
+ * complete, the second is simply built on stale text.
  *
  * <p>That lock reaches every adoption and nothing else. {@code claude} writes this
- * file too — an interactive session, or the {@code claude init} the adoption is
- * about to run — and knows nothing of a lock this module invented, so it cannot be
- * shut out of the read-modify-write the way another adoption can. What is done
- * instead is to make the window it can land in small and to notice when it did:
- * the configuration is read again immediately before the move, and an update built
- * on a document that has since been replaced is thrown away and built again on the
- * new one. Serialising the document — the slow part, and the whole of the window
- * before — therefore happens outside it, leaving a read and a move; a write that
- * would have dropped {@code claude}'s own change is retried rather than landing.
+ * file too and knows nothing of a lock this module invented, so its write is
+ * noticed rather than excluded: the configuration is read again immediately before
+ * the move, and an update built on a document that has since been replaced is
+ * thrown away and built again on the new one. Serialising the document — the slow
+ * part — therefore happens outside that window, leaving a read and a move.
  */
 public class ClaudeTrustStore {
 
@@ -64,8 +58,7 @@ public class ClaudeTrustStore {
 	 * process rather than the thread, so it excludes a second adoption process but
 	 * not a second thread of this one — which
 	 * {@link java.nio.channels.OverlappingFileLockException} would answer rather than
-	 * make wait. Both guards are needed, and this one is taken first. Neither reaches
-	 * {@code claude}, which takes no lock of ours; see {@link #moveUnlessChanged}.
+	 * make wait. Both guards are needed, and this one is taken first.
 	 */
 	private static final Object IN_PROCESS_LOCK = new Object();
 
@@ -73,8 +66,7 @@ public class ClaudeTrustStore {
 	 * How many times the read-modify-write is rebuilt when another writer lands
 	 * inside it. Each attempt is a read and a move, so an adoption only exhausts
 	 * these against something rewriting the configuration continuously — at which
-	 * point saying so beats writing over it. Package-visible so a test can pin the
-	 * count: one attempt too many is a silent extra write to a live file.
+	 * point saying so beats writing over it.
 	 */
 	static final int WRITE_ATTEMPTS = 3;
 
@@ -167,10 +159,9 @@ public class ClaudeTrustStore {
 
 	/**
 	 * A field the document does not carry is created, and one that is already an
-	 * object is used as-is. A field carrying anything else is refused rather than
-	 * replaced, for the same reason {@link #asObjectOrFresh} refuses a non-object
-	 * document: writing over it would discard whatever it held, and this is Claude
-	 * Code's own per-user state rather than a file the adoption owns.
+	 * object is used as-is. Anything else is refused rather than replaced: writing
+	 * over it would discard whatever it held, and this is Claude Code's own per-user
+	 * state rather than a file the adoption owns.
 	 */
 	private ObjectNode objectChild(ObjectNode parent, String name) {
 		JsonNode existing = parent.get(name);
@@ -187,13 +178,10 @@ public class ClaudeTrustStore {
 	/**
 	 * The configuration as text: the one read an update is built from, and the one it
 	 * is checked against just before the move. A file that is not there reads as the
-	 * empty string, which {@link #parse} starts fresh from and which a file appearing
-	 * in the meantime no longer equals — so a {@code claude} that created the
-	 * configuration inside the window is caught by the same comparison as one that
-	 * rewrote it.
-	 *
-	 * <p>Package-visible so a test can put a competing writer in that window; there
-	 * is no other way to land one between two reads this method makes.
+	 * empty string, which a file appearing in the meantime no longer equals — so a
+	 * {@code claude} that created the configuration inside the window is caught by
+	 * the same comparison as one that rewrote it. Package-visible so a test can put a
+	 * competing writer in that window.
 	 */
 	String readText() {
 		if (!Files.isRegularFile(configFile)) {
@@ -242,10 +230,8 @@ public class ClaudeTrustStore {
 	 * Writes the document to a sibling temporary file and moves it over the
 	 * configuration, so a reader only ever sees the old file or the new one.
 	 * Truncating {@code ~/.claude.json} in place risked the whole of Claude Code's
-	 * per-user state — its project list, history, and onboarding — on the write
-	 * completing: a crash part-way through left a truncated document behind, and
-	 * this is a live file that an interactive session, or the {@code claude init}
-	 * the adoption is about to run, may be writing at the same moment.
+	 * per-user state on the write completing, and this is a live file an interactive
+	 * session may be writing at the same moment.
 	 *
 	 * @param observed the configuration the document was built on
 	 * @return whether it landed, or {@code false} when the configuration changed
@@ -294,15 +280,10 @@ public class ClaudeTrustStore {
 	 * Reads the configuration one last time and moves the new document over it only
 	 * if it is still the one the update was built on. This is what the lock cannot do
 	 * for {@code claude}: it takes no lock of ours, so the only way to keep its write
-	 * is to notice it. The check sits here, after the serialisation, so the span
-	 * between deciding what to write and writing it is a read and a move rather than
-	 * the whole read-modify-write — narrow enough that losing the race takes a writer
-	 * landing inside it, and cheap enough to simply try again when one does.
-	 *
-	 * <p>The temporary file is removed on the stale path too. It carries a document
-	 * that is never going to land, and leaving it beside the configuration would
-	 * scatter exactly the half-finished files {@link #replaceUnlessChanged} exists to
-	 * clean up.
+	 * is to notice it. The check sits after the serialisation, so the span between
+	 * deciding what to write and writing it is a read and a move rather than the whole
+	 * read-modify-write. The temporary file is removed on the stale path too, since it
+	 * carries a document that is never going to land.
 	 *
 	 * @return whether the document was moved over the configuration
 	 */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -52,12 +52,10 @@ public class CloneStep extends AbstractCommandStep {
 	/**
 	 * Makes {@code git status} name every untracked file rather than collapsing a
 	 * wholly-untracked directory into a single entry. Without it a checkout whose
-	 * {@code .claude/} the adoption had just created was reported as the one path
-	 * {@code .claude/}, which is not among {@link AdoptionAssets#WRITTEN_PATHS} — so a
-	 * resumed adoption was refused for changes that were its own. That is the common
-	 * case rather than a corner of one: a repository being adopted has no
-	 * {@code .claude/} to begin with, and the fallback guard's {@code .github/} is
-	 * often new too.
+	 * {@code .claude/} the adoption had just created was reported as that one path,
+	 * which is not among {@link AdoptionAssets#WRITTEN_PATHS} — so a resumed adoption
+	 * was refused for changes that were its own. That is the common case: a repository
+	 * being adopted has no {@code .claude/} to begin with.
 	 */
 	private static final String UNTRACKED_FILES_ALL = "--untracked-files=all";
 
@@ -69,24 +67,13 @@ public class CloneStep extends AbstractCommandStep {
 	 * letters — the alphabet git documents for the format — then the space before the
 	 * path.
 	 *
-	 * <p>The transcript merges the command's standard error into its standard output,
-	 * exactly as {@link #originTranscript} does, so it is not reliably status entries
-	 * and nothing else: a git that warns — about an unreadable system config, or a
-	 * directory it could not open — puts that line in there too. Reading every line as
-	 * an entry took the warning's fourth character onwards for a path, found it among
-	 * no path the adoption writes, and refused the resume this step promises for
-	 * changes the checkout did not have. A line that is not an entry is therefore
-	 * skipped rather than read as one, the same reading {@link #namesThisRepository}
-	 * takes of that transcript's noise.
-	 *
-	 * <p>At least one of the two letters has to say something, because git never
-	 * reports a path whose index and work tree are both unchanged — leaving it out of
-	 * the output is what "unchanged" means. Accepting two spaces let through any line
-	 * indented by three of them, so a warning that wraps or indents its continuation
-	 * was still read as an entry, and its fourth character onwards taken for a path:
-	 * no path the adoption writes, and so the resume this step promises refused over a
-	 * change the checkout does not have — the very outcome the paragraph above is
-	 * about.
+	 * <p>The transcript merges standard error into standard output, so it is not
+	 * reliably status entries and nothing else: a git that warns puts that line in
+	 * there too. Reading every line as an entry took the warning's fourth character
+	 * onwards for a path and refused the resume this step promises. At least one of
+	 * the two letters therefore has to say something — git never reports a path whose
+	 * index and work tree are both unchanged — because accepting two spaces let
+	 * through any line indented by three of them.
 	 */
 	private static final Pattern STATUS_ENTRY = Pattern.compile("^(?! {2})[ MTADRCU?!]{2} .+");
 
@@ -97,11 +84,9 @@ public class CloneStep extends AbstractCommandStep {
 
 	/**
 	 * Records the checkout before doing anything to it, so a run that fails part-way
-	 * still says where the working tree it left behind is. It is recorded here because
-	 * this is the step that owns the checkout, and it is worth recording at all because
-	 * nothing else answers the question: a caller that named no workspace was given a
-	 * temporary one, and a dry run — which pushes nothing and opens no pull request —
-	 * leaves that directory as the only thing there is to read.
+	 * still says where the working tree it left behind is. Nothing else answers the
+	 * question: a caller that named no workspace was given a temporary one, and a dry
+	 * run leaves that directory as the only thing there is to read.
 	 */
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner, AdoptionReport report) {
@@ -180,10 +165,8 @@ public class CloneStep extends AbstractCommandStep {
 	 * The paths one entry changes. A rename or a copy is reported as
 	 * {@code old -> new} and changes <em>both</em> sides, so both are asked about:
 	 * reading only the destination waved the whole entry through whenever that
-	 * destination happened to be a path the adoption writes, and a
-	 * {@code git mv docs/CLAUDE.md CLAUDE.md} a contributor had staged was then swept
-	 * into {@link CommitStep}'s {@code git add -A} and pushed to the feature branch —
-	 * the very outcome this guard exists to prevent. A plain entry names one path.
+	 * destination happened to be a path the adoption writes, so a contributor's staged
+	 * {@code git mv docs/CLAUDE.md CLAUDE.md} was swept into the adoption's commit.
 	 */
 	private Stream<String> changedPaths(String statusLine) {
 		String path = statusLine.substring(STATUS_PREFIX);
@@ -218,14 +201,11 @@ public class CloneStep extends AbstractCommandStep {
 	}
 
 	/**
-	 * The transcript merges the command's standard error into its standard output, so
-	 * the {@code origin} URL is not reliably the whole of it: a git that warns —
-	 * about an unreadable system config, say — puts that line in there too, and
-	 * reading the transcript as one URL then failed a checkout that was the right one
-	 * all along, naming the warning as the repository it supposedly held. Every line
-	 * is therefore asked in turn, which keeps the conservative reading
-	 * {@link AdoptionContext#isSameRepository} is built on: noise names no repository,
-	 * so a transcript carrying nothing else still answers no.
+	 * The transcript merges standard error into standard output, so the {@code origin}
+	 * URL is not reliably the whole of it and reading it as one URL failed a checkout
+	 * that was the right one all along. Every line is asked in turn, which keeps the
+	 * conservative reading {@link AdoptionContext#isSameRepository} is built on: noise
+	 * names no repository, so a transcript carrying nothing else still answers no.
 	 */
 	private boolean namesThisRepository(AdoptionContext context, String transcript) {
 		return transcript.lines().map(String::strip).anyMatch(context::isSameRepository);
@@ -239,11 +219,10 @@ public class CloneStep extends AbstractCommandStep {
 	 * <p>The remote is read from the configuration rather than with {@code git remote
 	 * get-url}, which expands the {@code url.<base>.insteadOf} rewrites the caller's
 	 * git may configure and so answers a URL the checkout never recorded. A rewrite
-	 * onto a mirror or a proxy names a different host and path from the one the run
-	 * was given, so the reused checkout was refused as a different repository — and
-	 * the adoption of the very repository it held aborted at its second step, in
-	 * exactly the environments that configure one. Only the raw configured value
-	 * can be compared with the URL the run was asked to adopt.
+	 * onto a mirror names a different host and path, so the reused checkout was
+	 * refused as a different repository in exactly the environments that configure
+	 * one. Only the raw configured value can be compared with the URL the run was
+	 * asked to adopt.
 	 */
 	private String originTranscript(AdoptionContext context, CommandRunner runner) {
 		CommandResult result = runner.run(context.repositoryDirectory(),

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CommitStep.java
@@ -31,10 +31,9 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * {@link #requireNothingTheAdoptionWroteIsIgnored}.
  *
  * <p>The pipeline runs this step two or three times, so each one is qualified with
- * what it commits. A report whose {@code completedSteps} read {@code commit} three
- * times said only how far the run got by counting; qualified, it says which of the
- * adoption's commits landed — the reading that matters for a run that stopped
- * part-way, which is the only kind of report anyone reads closely.
+ * what it commits: a report whose {@code completedSteps} read {@code commit} three
+ * times said only how far the run got by counting, while a qualified one says which
+ * of the adoption's commits landed.
  */
 public class CommitStep extends AbstractCommandStep {
 
@@ -90,16 +89,10 @@ public class CommitStep extends AbstractCommandStep {
 	 * passing — while the branch that is pushed carries nothing of it.
 	 *
 	 * <p>Nothing downstream could catch that. A repository ignoring {@code CLAUDE.md}
-	 * was adopted, reported as complete with every step passed, and left with the
-	 * guard the adoption had just wired in failing on a clean checkout of its own pull
-	 * request — the one outcome {@link VerifyStep} exists to prevent. One ignoring
-	 * {@code .claude/} had its starter assets logged as installed and committed none
-	 * of them. Neither shows up in {@code git status}, which is exactly what ignoring
-	 * a path means.
-	 *
-	 * <p>Failing is the answer rather than forcing the files in: the pattern is the
-	 * project's own decision about its repository, and the adoption is in no position
-	 * to overrule it.
+	 * was adopted, reported as complete, and left with the guard the adoption had just
+	 * wired in failing on a clean checkout of its own pull request — the one outcome
+	 * {@link VerifyStep} exists to prevent. Failing is the answer rather than forcing
+	 * the files in: the pattern is the project's own decision about its repository.
 	 */
 	private void requireNothingTheAdoptionWroteIsIgnored(AdoptionContext context, CommandRunner runner) {
 		List<String> ignored = ignoredPaths(context, runner);
@@ -135,11 +128,10 @@ public class CommitStep extends AbstractCommandStep {
 
 	/**
 	 * {@code git diff --quiet} answers with its exit code: zero for nothing staged, and
-	 * {@value #STAGED_CHANGES} for something. Anything above that is the command failing
-	 * rather than answering — a checkout it could not read, a repository it could not
-	 * open — and reading every non-zero code as "there is something to commit" turned
-	 * that into a {@code git commit} failure two lines later, naming the commit rather
-	 * than the query that could not be run.
+	 * {@value #STAGED_CHANGES} for something. Anything above that is the command
+	 * failing rather than answering, and reading every non-zero code as "there is
+	 * something to commit" turned it into a {@code git commit} failure two lines
+	 * later, naming the commit rather than the query that could not be run.
 	 */
 	private boolean hasStagedChanges(AdoptionContext context, CommandRunner runner) {
 		CommandResult result = runner.run(context.repositoryDirectory(),

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
@@ -28,12 +28,9 @@ final class EnforcerRuleVersion {
 	 * The released rule version to wire in. Resolving it lazily — only once a POM is
 	 * actually being edited — keeps merely constructing the default
 	 * {@link BuildSystems#DEFAULTS} list, or adopting a repository that builds with
-	 * something other than Maven, from depending on the running build's version.
-	 *
-	 * <p>Re-read for each repository of a batch rather than remembered, so this class
-	 * keeps the immutability every step here is held to: caching a classpath read
-	 * that costs nothing beside the clone and the {@code claude init} it sits between
-	 * would buy back no time worth holding mutable state for.
+	 * something other than Maven, from depending on the running build's version. It is
+	 * re-read per repository rather than cached, so this class keeps the immutability
+	 * every step here is held to.
 	 */
 	static String release() {
 		return requireRelease(fromBuildMetadata());

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
@@ -61,11 +61,9 @@ public class FallbackBuildSystem implements BuildSystem {
 	/**
 	 * The guard runs through {@code sh}, so that is what is probed. Answering "nothing
 	 * to check" instead assumed every host has a shell on its {@code PATH}, which a
-	 * Windows one generally has not: the {@code sh.exe} Git for Windows ships sits
-	 * under the install's {@code usr/bin} and is only on the {@code PATH} if the
-	 * operator opted into the Unix tools. The adoption then ran to
-	 * {@link VerifyStep} — past the clone, the {@code claude init}, and both commits —
-	 * before failing on a shell it could have missed at its second step.
+	 * Windows one generally has not, so the adoption ran to {@link VerifyStep} — past
+	 * the clone, the {@code claude init}, and both commits — before failing on a shell
+	 * it could have missed at its second step.
 	 */
 	@Override
 	public Optional<List<String>> toolProbe(Path repositoryDirectory) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
@@ -18,9 +18,9 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  * than with a {@code gradle} off the {@code PATH}. Most Gradle projects ship only
  * the wrapper, so this is the ordinary case rather than the exception: without it
  * {@link BuildToolchainStep} found no {@code gradle} to probe and aborted the
- * adoption. See {@link BuildWrapper}.
+ * adoption. See {@link AbstractWrappedBuildSystem}.
  */
-public class GradleBuildSystem implements BuildSystem {
+public class GradleBuildSystem extends AbstractWrappedBuildSystem {
 
 	static final String GRADLE = "gradle";
 	private static final List<String> VERIFY_ARGUMENTS = List.of("-q", GradleGuardInstaller.GUARD_TASK);
@@ -28,19 +28,13 @@ public class GradleBuildSystem implements BuildSystem {
 	static final String KOTLIN_BUILD_FILE = "build.gradle.kts";
 
 	private final GradleGuardInstaller installer = new GradleGuardInstaller();
-	private final BuildWrapper wrapper;
 
 	public GradleBuildSystem() {
 		this(new BuildWrapper("gradlew", "gradlew.bat"));
 	}
 
 	GradleBuildSystem(BuildWrapper wrapper) {
-		this.wrapper = wrapper;
-	}
-
-	@Override
-	public String name() {
-		return "gradle";
+		super(GRADLE, VERIFY_ARGUMENTS, wrapper);
 	}
 
 	@Override
@@ -63,17 +57,6 @@ public class GradleBuildSystem implements BuildSystem {
 		Path buildFile = locate(repositoryDirectory)
 				.orElseThrow(() -> new AdoptionException("No Gradle build file in " + repositoryDirectory));
 		return installer.install(buildFile);
-	}
-
-	@Override
-	public List<String> verifyCommand(Path repositoryDirectory) {
-		return wrapper.commandIn(repositoryDirectory, GRADLE, VERIFY_ARGUMENTS);
-	}
-
-	/** Probes whatever {@link #verifyCommand(Path)} will launch — the wrapper, however it has to be run. */
-	@Override
-	public Optional<List<String>> toolProbe(Path repositoryDirectory) {
-		return Optional.of(wrapper.probeIn(repositoryDirectory, GRADLE));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -30,21 +30,16 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
  * guard the project's ordinary build never runs. It is hung from
  * {@value #LIFECYCLE_TASK} through a live {@code matching}/{@code configureEach}
  * view, so a plugin applied further down the script still wires it in — and a
- * project that ends up with no {@value #LIFECYCLE_TASK} at all is given one. That
- * case is not exotic: an Android or aggregator root script routinely declares a
- * {@code clean} task and nothing else, and the guard was left registered, verified
- * by {@link VerifyStep} running it directly, and unreachable from any build a
- * contributor or CI would run — the pull request advertising a guard the project
- * does not have, which is exactly what {@link PomEnforcerInstaller} refuses to
- * produce on the Maven path.
+ * project that ends up with no {@value #LIFECYCLE_TASK} at all is given one. An
+ * Android or aggregator root script routinely declares a {@code clean} task and
+ * nothing else, and the guard was left registered but unreachable from any build a
+ * contributor or CI would run.
  *
- * <p>The fallback registration is deferred to {@code afterEvaluate} rather than
+ * <p>That fallback registration is deferred to {@code afterEvaluate} rather than
  * made inline, because the name has to be free: claiming {@value #LIFECYCLE_TASK}
  * while the script is still being read would collide with a plugin applied below
- * this block and fail the whole build. By {@code afterEvaluate} there is no "below"
- * left. Applying Gradle's {@code base} plugin to obtain the task instead was
- * rejected for the same reason — it also registers {@code clean}, which is the one
- * task those root scripts already declare.
+ * this block. Applying Gradle's {@code base} plugin to obtain the task instead was
+ * rejected for the same reason — it also registers {@code clean}.
  */
 public class GradleGuardInstaller {
 
@@ -138,14 +133,11 @@ public class GradleGuardInstaller {
 	/**
 	 * Both ways either DSL lets a registration be commented out. The block form is
 	 * removed first and by span rather than by line, because it is the form a whole
-	 * declaration is commented out with — a {@code /*} … {@code *}{@code /} around
-	 * {@code tasks.register('enforceClaudeMd')} left the name plainly in the text, so
-	 * the script was read as already declaring the task and the guard was never
-	 * appended; {@link VerifyStep} then ran a task the build does not have.
-	 *
-	 * <p>The line form is dropped afterwards, and the lines are rejoined rather than
-	 * matched one at a time so a registration spread over several lines is still
-	 * recognised.
+	 * declaration is commented out with, and leaving it made the script read as
+	 * already declaring the task — so the guard was never appended and
+	 * {@link VerifyStep} ran a task the build does not have. The line form is dropped
+	 * afterwards, and the lines are rejoined rather than matched one at a time so a
+	 * registration spread over several lines is still recognised.
 	 */
 	private String withoutComments(String script) {
 		String withoutBlocks = BLOCK_COMMENT.matcher(script).replaceAll("");

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -15,9 +15,9 @@ import java.util.Optional;
  * <p>A checkout that ships an {@code mvnw} is verified with that wrapper rather
  * than with a {@code mvn} off the {@code PATH}, so the guard runs under the Maven
  * version the project pinned and a host with no Maven installed can still adopt
- * it. See {@link BuildWrapper}.
+ * it. See {@link AbstractWrappedBuildSystem}.
  */
-public class MavenBuildSystem implements BuildSystem {
+public class MavenBuildSystem extends AbstractWrappedBuildSystem {
 
 	private static final String MAVEN = "mvn";
 	private static final List<String> VERIFY_ARGUMENTS = List.of("-q", "-N", "validate");
@@ -25,7 +25,6 @@ public class MavenBuildSystem implements BuildSystem {
 	static final String POM = "pom.xml";
 
 	private final PomEnforcerInstaller installer;
-	private final BuildWrapper wrapper;
 
 	public MavenBuildSystem() {
 		this(Optional.empty());
@@ -45,8 +44,8 @@ public class MavenBuildSystem implements BuildSystem {
 	}
 
 	MavenBuildSystem(PomEnforcerInstaller installer, BuildWrapper wrapper) {
+		super(MAVEN, VERIFY_ARGUMENTS, wrapper);
 		this.installer = installer;
-		this.wrapper = wrapper;
 	}
 
 	@Override
@@ -79,16 +78,5 @@ public class MavenBuildSystem implements BuildSystem {
 	@Override
 	public List<String> requiredClaudeMdSections() {
 		return ClaudeMdConformer.REQUIRED_SECTIONS;
-	}
-
-	@Override
-	public List<String> verifyCommand(Path repositoryDirectory) {
-		return wrapper.commandIn(repositoryDirectory, MAVEN, VERIFY_ARGUMENTS);
-	}
-
-	/** Probes whatever {@link #verifyCommand(Path)} will launch — the wrapper, however it has to be run. */
-	@Override
-	public Optional<List<String>> toolProbe(Path repositoryDirectory) {
-		return Optional.of(wrapper.probeIn(repositoryDirectory, MAVEN));
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PluginVersion.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PluginVersion.java
@@ -10,16 +10,15 @@ import java.util.stream.Stream;
  * too old to run the rule being wired into it.
  *
  * <p>Only the numeric prefix is read, so {@code 3.0.0-M3} compares as
- * {@code 3.0.0}. That is the safe direction for the one question asked: a
- * qualifier only ever precedes the release it qualifies, so a milestone of the
- * minimum reads as the release and is not refused, while every version genuinely
- * below it still is.
+ * {@code 3.0.0}: a qualifier only ever precedes the release it qualifies, so a
+ * milestone of the minimum reads as the release and is not refused, while every
+ * version genuinely below it still is.
  *
  * <p>A literal carrying no leading number at all — an unsubstituted
  * {@code ${enforcer.version}}, or the empty text of a version the POM leaves to a
- * {@code pluginManagement} entry or a parent — is <em>not</em> below anything.
- * Refusing what cannot be read here would turn an ordinary POM into an unadoptable
- * one, and {@link VerifyStep} still runs the guard before any of it is pushed.
+ * parent — is <em>not</em> below anything. Refusing what cannot be read here would
+ * turn an ordinary POM into an unadoptable one, and {@link VerifyStep} still runs
+ * the guard before any of it is pushed.
  */
 final class PluginVersion {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -30,16 +30,14 @@ import io.github.adamw7.tools.adopt.AdoptionFiles;
  * they nest, and where each of them sits in the source text — while the edit itself
  * is text spliced into the bytes the file already held. Writing an edited tree out
  * whole cannot keep that promise however carefully the serialiser is configured,
- * because the details it reformats are not in the tree to begin with: a start tag
- * spread over several lines and an empty element written {@code <rule />} both come
- * back normalised. Keeping the edit textual also means added elements inherit the
- * POM's default namespace rather than having to be qualified.
+ * because the details it reformats are not in the tree to begin with. Keeping the
+ * edit textual also means added elements inherit the POM's default namespace rather
+ * than having to be qualified.
  *
  * <p>The reading is jsoup's, whose XML parser reports the source range of every
- * start and end tag it reads — the one thing a plain DOM parse cannot answer, and
- * the reason this class used to pair a JAXP parse with a lexical scan of its own.
- * jsoup resolves no DTDs and no external entities at all, so the secure-processing
- * configuration that parse needed has nothing left to switch off.
+ * start and end tag it reads — the one thing a plain DOM parse cannot answer. jsoup
+ * resolves no DTDs and no external entities at all, so the secure-processing
+ * configuration a JAXP parse needed has nothing left to switch off.
  *
  * <p>Added markup arrives one element per line, indented by
  * {@link #FRAGMENT_INDENT} per nesting level, and is re-indented to the document's
@@ -306,11 +304,10 @@ final class PomDocument {
 	/**
 	 * Refuses a POM that left an element open. jsoup repairs what it reads rather than
 	 * rejecting it, so an unclosed element comes back closed at the point its parent
-	 * ends — an end tag that is not in the file, reported as an implicit range — and an
-	 * edit spliced at that offset would land inside an element it was never meant to
-	 * touch. An element written {@code <name/>} reports the same implicit range for the
-	 * end tag it legitimately has none of, so the source has the last word on which of
-	 * the two it is.
+	 * ends — an implicit range — and an edit spliced at that offset would land inside
+	 * an element it was never meant to touch. An element written {@code <name/>}
+	 * reports the same implicit range for the end tag it legitimately has none of, so
+	 * the source has the last word on which of the two it is.
 	 */
 	private static void requireClosedElements(Path file, String original, Element root) {
 		Optional<Element> unclosed = selfAndDescendants(root).stream()

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -83,11 +83,8 @@ public class PomEnforcerInstaller {
 	}
 
 	/**
-	 * Pins an explicitly supplied version instead of the running build's. It is
-	 * checked here, before anything is cloned, because a version named on the command
-	 * line is worth rejecting immediately rather than at the one step that edits a
-	 * POM; the reason a snapshot cannot be wired in does not change for being asked
-	 * for on purpose.
+	 * Pins an explicitly supplied version instead of the running build's, checked here
+	 * — before anything is cloned — rather than at the one step that edits a POM.
 	 *
 	 * @param ruleVersion a released {@code claude-code-enforcer} version
 	 */
@@ -125,28 +122,18 @@ public class PomEnforcerInstaller {
 
 	/**
 	 * Asks the plugins of the POM's own {@code build} — the one place a rule runs on
-	 * every build, and the very place {@link #enforcerPluginOfTheBuild} would add one.
-	 * The guard is looked for exactly where it would be written, so what is inspected
-	 * and what is edited cannot disagree.
+	 * every build, and the very place {@link #enforcerPluginOfTheBuild} would add one,
+	 * so what is inspected and what is edited cannot disagree.
 	 *
 	 * <p>A rule declared anywhere else is not one an ordinary build runs, so it is not
-	 * a guard this installer may stand down for. A {@code pluginManagement} entry binds
-	 * nothing at all; a {@code profile} binds only while that profile is activated, and
-	 * a {@code reporting} plugin does not run in the build lifecycle. Counting any of
-	 * them left the project with no guard on the build its contributors and its CI
-	 * actually run, and nothing downstream said so — {@link VerifyStep}'s
-	 * {@code mvn -N validate} passes precisely because the rule never ran — so the
-	 * adoption opened a pull request claiming a guard the default build does not have.
-	 * That is the outcome {@link #enforcerPluginOfTheBuild} already refuses to produce
-	 * when <em>adding</em>; accepting it when <em>detecting</em> produced it anyway.
-	 *
-	 * <p>A project that deliberately gated the rule behind a profile therefore ends up
-	 * running it on every build too. That is the direction to err in: an extra run of a
-	 * rule the project chose is visible and removable, while a guard nobody runs reads
-	 * as adopted and is not.
-	 *
-	 * <p>What counts as already running it is the rule being configured, not the
-	 * artifact that supplies it being on the plugin — see {@link #runsClaudeMdRule}.
+	 * a guard this installer may stand down for: {@code pluginManagement} binds
+	 * nothing, a {@code profile} binds only while activated, and a {@code reporting}
+	 * plugin does not run in the lifecycle. Counting any of them left the project with
+	 * no guard on the build it actually runs, and nothing downstream said so —
+	 * {@link VerifyStep}'s {@code mvn -N validate} passes precisely because the rule
+	 * never ran. A project that gated the rule behind a profile therefore ends up
+	 * running it on every build too, which is the direction to err in: an extra run is
+	 * visible and removable, a guard nobody runs reads as adopted and is not.
 	 */
 	private boolean alreadyRunsTheRule(PomDocument pom) {
 		return buildPlugins(pom).anyMatch(this::runsClaudeMdRule);
@@ -154,14 +141,11 @@ public class PomEnforcerInstaller {
 
 	/**
 	 * Whether the plugin actually configures the {@code claudeMdFormat} rule, rather
-	 * than merely carrying the artifact that supplies it. The two are not the same
-	 * question: {@value #RULE_ARTIFACT_ID} ships a rule per document and per piece of
-	 * agent configuration, so a project that wired in {@code noSecrets} or
-	 * {@code settingsJsonValid} has the dependency and no {@code CLAUDE.md} guard at
-	 * all. Reading the dependency as the guard left that project's POM untouched, and
-	 * {@link VerifyStep} confirmed nothing — its {@code mvn -N validate} passes on the
-	 * rule the project already had — so the adoption ran to the end and opened a pull
-	 * request claiming a guard the build does not run.
+	 * than merely carrying the artifact that supplies it. {@value #RULE_ARTIFACT_ID}
+	 * ships a rule per document and per piece of agent configuration, so a project
+	 * that wired in {@code noSecrets} has the dependency and no {@code CLAUDE.md}
+	 * guard at all — and reading the dependency as the guard left that POM untouched
+	 * while {@link VerifyStep} passed on the rule the project already had.
 	 *
 	 * <p>The rule is looked for at any depth below the plugin, because it is
 	 * configured either on an execution or on the plugin itself, and only directly
@@ -186,13 +170,10 @@ public class PomEnforcerInstaller {
 
 	/**
 	 * The {@code maven-enforcer-plugin} of the POM's own {@code build}, and only that
-	 * one. An execution spliced into {@code pluginManagement} only configures a plugin
-	 * the build never runs, and one spliced into a profile runs only when that profile
-	 * is activated. Neither enforces anything, and neither shows up as a failure —
-	 * {@link VerifyStep}'s {@code mvn -N validate} would pass without the rule ever
-	 * executing and the adoption would advertise a guard the project does not have. A
-	 * POM whose only enforcer sits somewhere else therefore gets its own declaration
-	 * in {@code build/plugins}.
+	 * one: an execution spliced into {@code pluginManagement} configures a plugin the
+	 * build never runs, and one spliced into a profile runs only when that profile is
+	 * activated. A POM whose only enforcer sits somewhere else therefore gets its own
+	 * declaration in {@code build/plugins}.
 	 */
 	private Optional<Element> enforcerPluginOfTheBuild(PomDocument pom) {
 		return buildPlugins(pom).filter(plugin -> PomDocument.hasArtifactId(plugin, ENFORCER_ARTIFACT_ID))
@@ -202,9 +183,7 @@ public class PomEnforcerInstaller {
 	/**
 	 * The plugins the POM's own {@code build} binds, which every build runs. Said once
 	 * because {@link #alreadyRunsTheRule} and {@link #enforcerPluginOfTheBuild} ask
-	 * about the same place for the same reason, and a guard looked for somewhere other
-	 * than where it would be written is a guard the installer can stand down for
-	 * without one ever being run.
+	 * about the same place for the same reason.
 	 */
 	private Stream<Element> buildPlugins(PomDocument pom) {
 		return pom.at(BUILD_PLUGINS).stream()
@@ -233,14 +212,11 @@ public class PomEnforcerInstaller {
 	/**
 	 * Refuses to splice the execution into a {@value #ENFORCER_ARTIFACT_ID} the
 	 * project pinned below {@value #MINIMUM_ENFORCER_VERSION}, which cannot resolve
-	 * the rule by name. Adding it anyway left the adoption advertising a guard that
-	 * fails every build it runs in — for a reason no reader of the pull request would
-	 * connect to the plugin version a line above it.
-	 *
-	 * <p>Raising the project's pinned version instead is not the adoption's call to
-	 * make: it is the version the project chose for the rules it already runs, and
-	 * bumping it under them would change how those behave — the same reason
-	 * {@link CommitStep} refuses an ignored path rather than forcing the file in.
+	 * the rule by name: adding it anyway left the adoption advertising a guard that
+	 * fails every build it runs in. Raising the project's pinned version instead is
+	 * not the adoption's call — bumping it would change how the rules the project
+	 * already runs behave, the same reason {@link CommitStep} refuses an ignored path
+	 * rather than forcing the file in.
 	 *
 	 * <p>Only a version literal is judged. One the POM leaves to a
 	 * {@code pluginManagement} entry, a parent, or a property cannot be read from

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestOptions.java
@@ -18,11 +18,10 @@ import io.github.adamw7.tools.adopt.Text;
  * <p>Each list entry is stripped, and a blank one is dropped rather than carried:
  * every entry becomes an argument of its own — {@code gh pr create --reviewer
  * <entry>} — so a blank one reached {@code gh} as an empty argument and failed the
- * adoption at its very last step, with the branch already pushed. The MCP tool
- * already read its arguments this way; doing it here rather than at each entry
- * point is what keeps the command line from disagreeing with it about what an
- * omitted value means. Duplicates are left alone, as {@code gh} treats naming a
- * reviewer twice as naming them once.
+ * adoption at its very last step, with the branch already pushed. Doing it here
+ * rather than at each entry point keeps the command line and the MCP tool from
+ * disagreeing about what an omitted value means. Duplicates are left alone, as
+ * {@code gh} treats naming a reviewer twice as naming them once.
  *
  * @param title     the pull request's title, or blank for {@value #DEFAULT_TITLE}
  * @param body      the pull request's body, or blank for the adoption's own
@@ -49,9 +48,7 @@ public record PullRequestOptions(String title, String body, List<String> reviewe
 	/**
 	 * An absent list is read as naming nobody, the same answer a blank title gets from
 	 * {@link Text#orDefault}: this is the record's promise that its lists are never
-	 * {@code null}, so it cannot be the one place a caller has to satisfy it first. A
-	 * {@code null} reached here as a message-less {@link NullPointerException} out of a
-	 * constructor whose documentation says the lists are defensively copied.
+	 * {@code null}, so it cannot be the one place a caller has to satisfy it first.
 	 *
 	 * @return the entries that name something, stripped — the rule {@link Text} defines
 	 *         for every optional input

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PullRequestStep.java
@@ -48,10 +48,9 @@ public class PullRequestStep extends AbstractCommandStep {
 	 * the branches, the GraphQL error names the head) and "No commits between ...".
 	 *
 	 * <p>Each fragment names a pull request, because the transcript these are matched
-	 * against is the whole of {@code gh}'s merged output. A bare "already exists"
-	 * also matched a failure that had nothing to do with an open pull request — a
-	 * label {@code gh} could not add, a ref the push had already published — and left
-	 * the adoption reported as complete with no pull request opened and none to find.
+	 * against is the whole of {@code gh}'s merged output: a bare "already exists" also
+	 * matched a failure that had nothing to do with one — a label {@code gh} could not
+	 * add — and left the adoption reported as complete with no pull request to find.
 	 */
 	private static final List<String> TOLERATED_FAILURES = List.of("a pull request for branch",
 			"a pull request already exists", "no commits between");
@@ -134,12 +133,9 @@ public class PullRequestStep extends AbstractCommandStep {
 	 * the log of an adoption that went on to create a duplicate needs to see which
 	 * of the two it was.
 	 *
-	 * <p>The transcript is redacted for the same reason
-	 * {@link AbstractCommandStep#runOrFail} redacts the one it fails with: a
-	 * {@code gh} left without a {@code --repo} reads the checkout's remote through
-	 * {@code git}, and a {@code git} that cannot use it echoes the credentialled URL
-	 * back — {@code fatal: could not read Username for 'https://...@github.com'}.
-	 * This warning is written to the log, which outlives the run.
+	 * <p>The transcript is redacted because a {@code gh} left without a {@code --repo}
+	 * reads the checkout's remote through {@code git}, which echoes a credentialled
+	 * URL back when it cannot use it — and this warning outlives the run.
 	 *
 	 * @return the URL of the branch's open pull request, or empty when none is open
 	 *         or {@code gh} could not be queried
@@ -181,9 +177,8 @@ public class PullRequestStep extends AbstractCommandStep {
 	 * may carry surrounding noise (update notices merged in from stderr), so parsing
 	 * starts at an opening bracket. Every bracket is tried rather than only the first,
 	 * because a diagnostic printed <em>before</em> the payload can itself contain one;
-	 * stopping there would parse the noise, conclude no pull request is open, and
-	 * create a duplicate {@code gh} rejects — failing an adoption that was only being
-	 * re-run.
+	 * stopping there parsed the noise, concluded no pull request is open, and created
+	 * a duplicate {@code gh} rejects.
 	 *
 	 * @return the first element's {@code url}, or empty when no bracket starts a
 	 *         JSON array, the array is empty, or it carries no textual URL

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
@@ -67,9 +67,7 @@ public class ToolchainStep implements AdoptionStep {
 	 * The check for a run that will not publish. Holding a rehearsal to the
 	 * credentials of the one capability it has been told not to exercise failed
 	 * {@code --dry-run} on its very first step, for want of a {@code gh} the run was
-	 * never going to call — on a host with no GitHub CLI installed, and on a token
-	 * that cannot read the repository, both of which leave the rest of the pipeline
-	 * perfectly runnable. Dropping {@code gh} from the list also settles the login
+	 * never going to call. Dropping {@code gh} from the list also settles the login
 	 * probe, which asks about GitHub only while the pull request is still ahead.
 	 */
 	public static ToolchainStep forDryRun() {
@@ -109,12 +107,10 @@ public class ToolchainStep implements AdoptionStep {
 
 	/**
 	 * Asks about the repository the run is going to open a pull request on, rather
-	 * than about the token's owner. {@code gh api user} is a user-scoped call, and a
-	 * GitHub App installation token — what a CI run is handed, and the credential
-	 * behind the {@code x-access-token:TOKEN@github.com} clone URLs the adoption is
-	 * built to accept — is refused by it with "Resource not accessible by
-	 * integration". Probing with it therefore aborted, on its very first step, every
-	 * adoption driven by the CI credential that would have opened the pull request
+	 * than about the token's owner. {@code gh api user} is a user-scoped call that a
+	 * GitHub App installation token — what a CI run is handed — is refused by with
+	 * "Resource not accessible by integration", so probing with it aborted every
+	 * adoption driven by the credential that would have opened the pull request
 	 * perfectly well.
 	 *
 	 * <p>Reading the repository is also the stronger question: it covers a token


### PR DESCRIPTION
Bind the flat CLI options straight to fields instead of one method each.
picocli only needs a method where the call order matters (`--repo`,
`--repos`) or where a flag shares a field with its positional
(`--workspace`, `--branch`); the other eleven were one-line setters.

Pull the wrapper-launched build systems' shared halves up into
AbstractWrappedBuildSystem, so `verifyCommand` and `toolProbe` are stated
once rather than in both MavenBuildSystem and GradleBuildSystem.

Compress the javadoc to the fact it encodes. The module carried 39%
comment lines against 14-28% elsewhere in the repo, most of the excess
being multi-paragraph retellings of the incident a guard came from; each
now keeps what breaks if the guard is changed and drops the narrative.

Correct the AGENTS.md account of how CliArguments binds its options.

No behaviour change: 763 adopt tests and the full reactor build stay green.