### PR TITLE
refactor(enforcer): trim rule scaffolding and document the Plexus binding contract

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/PluginFormatRule.java
@@ -50,18 +50,14 @@ public class PluginFormatRule extends JsonFileRule {
 	/** Optional whitelist of allowed manifest keys. When set, unknown keys are reported. */
 	private List<String> allowedKeys;
 
+	/** Not every repository ships a plugin, so an absent manifest is a pass. */
 	public PluginFormatRule() {
-		super("pluginFile", "plugin.json");
+		super("pluginFile", "plugin.json", OPTIONAL);
 	}
 
 	@Override
 	protected File jsonFile() {
 		return pluginFile;
-	}
-
-	/** Not every repository ships a plugin, so an absent manifest is a pass. */
-	@Override
-	protected void handleMissingFile(File file) {
 	}
 
 	@Override

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
@@ -82,17 +82,9 @@ public class ContextBudgetRule extends ClaudeCodeEnforcerRule {
 		if (maxBytes > 0 && file.length() > maxBytes) {
 			violations.add(file + " is " + file.length() + " bytes, over the " + maxBytes + "-byte budget");
 		}
-		if (maxLines > 0 || maxTokens > 0) {
-			collectDecodedViolations(file, violations);
+		if (maxLines <= 0 && maxTokens <= 0) {
+			return;
 		}
-	}
-
-	/**
-	 * The line and token budgets need the file's text, so a file that cannot be
-	 * decoded is reported rather than read. Only the byte budget applies to it, and
-	 * an undecodable file must not abort the build before the rest are measured.
-	 */
-	private void collectDecodedViolations(File file, List<String> violations) {
 		Optional<String> content = MarkdownText.readIfText(file);
 		if (content.isEmpty()) {
 			violations.add(file + " cannot be read as text, so its line and token budgets cannot be measured");
@@ -101,6 +93,12 @@ public class ContextBudgetRule extends ClaudeCodeEnforcerRule {
 		collectContentViolations(file, content.get(), violations);
 	}
 
+	/**
+	 * The line and token budgets, which need the file's text. A file that cannot be
+	 * decoded is reported by the caller rather than read: only the byte budget
+	 * applies to it, and an undecodable file must not abort the build before the
+	 * rest are measured.
+	 */
 	private void collectContentViolations(File file, String content, List<String> violations) {
 		long lines = content.lines().count();
 		if (maxLines > 0 && lines > maxLines) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -76,7 +76,7 @@ public class MemoryImportsRule extends ClaudeCodeEnforcerRule {
 		requireConfigured(claudeMdFile, "claudeMdFile");
 		requireExists(claudeMdFile, "CLAUDE.md");
 		File root = claudeMdFile.getAbsoluteFile();
-		Traversal traversal = Traversal.of(ImportGraph.from(root, this::isIgnored, this::debug));
+		Traversal traversal = Traversal.of(ImportGraph.from(root, this::isIgnored, message -> log().debug(message)));
 		scan(root, traversal);
 		report("Memory imports are not well formed:", traversal.violations());
 	}
@@ -108,11 +108,6 @@ public class MemoryImportsRule extends ClaudeCodeEnforcerRule {
 
 	private boolean isIgnored(String imported) {
 		return ignoredImports != null && ignoredImports.contains(imported);
-	}
-
-	/** Reached only for an import target that cannot be read, so the log is looked up lazily. */
-	private void debug(String message) {
-		log().debug(message);
 	}
 
 	void setClaudeMdFile(File claudeMdFile) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
@@ -58,8 +58,9 @@ public class McpConfigFormatRule extends JsonFileRule {
 	/** When true, a server {@code url} must use {@code https} rather than plain {@code http}. */
 	private boolean requireHttps;
 
+	/** A project-level {@code .mcp.json} is optional in Claude Code, so an absent file is a pass. */
 	public McpConfigFormatRule() {
-		super("mcpFile", "mcp.json");
+		super("mcpFile", "mcp.json", OPTIONAL);
 	}
 
 	@Override
@@ -70,11 +71,6 @@ public class McpConfigFormatRule extends JsonFileRule {
 	@Override
 	protected String header() {
 		return "mcp.json server configuration is not well formed:";
-	}
-
-	/** A project-level {@code .mcp.json} is optional in Claude Code, so an absent file is a pass. */
-	@Override
-	protected void handleMissingFile(File file) {
 	}
 
 	@Override

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
@@ -52,18 +52,14 @@ public class McpServersValidRule extends JsonFileRule {
 	/** Optional override for the allowed transport types. */
 	private List<String> allowedTypes;
 
+	/** A project-level {@code .mcp.json} is optional in Claude Code, so an absent file is a pass. */
 	public McpServersValidRule() {
-		super("mcpFile", "mcp.json");
+		super("mcpFile", "mcp.json", OPTIONAL);
 	}
 
 	@Override
 	protected File jsonFile() {
 		return mcpFile;
-	}
-
-	/** A project-level {@code .mcp.json} is optional in Claude Code, so an absent file is a pass. */
-	@Override
-	protected void handleMissingFile(File file) {
 	}
 
 	@Override

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -38,6 +39,16 @@ import io.github.adamw7.tools.markdown.MarkdownText;
  * {@code -Dclaude.enforcer.writeBaseline=true}, which writes the baseline and
  * passes — then commit the file. The HTML report and the failure message reflect
  * only the un-suppressed violations.
+ * <p>
+ * A rule's configuration parameters are its <em>fields</em>: Plexus binds a
+ * {@code <claudeMdFile>} element to a field of that name, searching the class and
+ * its superclasses, and it never sees the package-private setters here because it
+ * looks only at public methods. So every concrete rule declares a field named
+ * exactly as its pom element, and a base class that needs it reads it back through
+ * an abstract accessor — {@link MarkdownFormatRule#documentFile()},
+ * {@link JsonFileRule#jsonFile()}. Hoisting those fields into a base under one
+ * shared name compiles, unit-tests green, and then fails every real build with
+ * "Cannot find 'claudeMdFile' in class"; the {@code *IT}s are what catch it.
  */
 public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 
@@ -240,19 +251,14 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	public final String toString() {
 		StringJoiner parameters = new StringJoiner(", ", getClass().getSimpleName() + "[", "]");
 		for (Class<?> type = getClass(); type != ClaudeCodeEnforcerRule.class; type = type.getSuperclass()) {
-			appendParameters(type, parameters);
+			Arrays.stream(type.getDeclaredFields()).filter(ClaudeCodeEnforcerRule::isFileParameter)
+					.forEach(field -> appendParameter(field, parameters));
 		}
 		return parameters.toString();
 	}
 
-	private void appendParameters(Class<?> type, StringJoiner parameters) {
-		for (Field field : type.getDeclaredFields()) {
-			appendParameter(field, parameters);
-		}
-	}
-
 	private void appendParameter(Field field, StringJoiner parameters) {
-		Object value = isFileParameter(field) ? valueOf(field) : null;
+		Object value = valueOf(field);
 		if (value != null) {
 			parameters.add(field.getName() + "=" + value);
 		}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -21,23 +21,34 @@ import com.fasterxml.jackson.databind.JsonNode;
  * messages at construction, and contributes the file itself, the report header,
  * and the document-specific checks against the parsed {@link JsonNode}. A
  * misconfigured rule or a missing or empty file always fails, because that is a
- * build-setup mistake; a rule whose file is optional overrides
- * {@link #handleMissingFile} to pass instead.
+ * build-setup mistake; a rule whose file is optional says so with {@link #OPTIONAL}
+ * and passes on an absent one instead.
  */
 public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 
+	/** Constructor flag for a rule whose file need not be there, so an absent one is a pass. */
+	protected static final boolean OPTIONAL = true;
+
 	private final String fileParameter;
 	private final String description;
+	private final boolean optional;
+
+	/** A rule whose file must exist, the usual case. */
+	protected JsonFileRule(String fileParameter, String description) {
+		this(fileParameter, description, false);
+	}
 
 	/**
 	 * @param fileParameter the configuration parameter name, used in the "not
 	 *                      configured" message, e.g. {@code settingsFile}
 	 * @param description   human-readable file name used in messages, e.g.
 	 *                      {@code settings.json}
+	 * @param optional      {@link #OPTIONAL} when an absent file is a pass
 	 */
-	protected JsonFileRule(String fileParameter, String description) {
+	protected JsonFileRule(String fileParameter, String description, boolean optional) {
 		this.fileParameter = fileParameter;
 		this.description = description;
+		this.optional = optional;
 	}
 
 	@Override
@@ -45,9 +56,7 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 		File file = jsonFile();
 		requireConfigured(file, fileParameter);
 		if (!file.isFile()) {
-			handleMissingFile(file);
-			log().debug(() -> description + " is absent at " + file + ", which this rule accepts; nothing to check");
-			report(header(), List.of());
+			reportAbsentFile(file);
 			return;
 		}
 		List<String> violations = new ArrayList<>();
@@ -56,6 +65,19 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 			collectViolations(root, violations);
 		}
 		report(header(), violations);
+	}
+
+	/**
+	 * Fails on a required file and passes on an optional one. The pass still goes
+	 * through {@link #report}, so a configured HTML report reflects this run rather
+	 * than keeping a previous, failing one on disk.
+	 */
+	private void reportAbsentFile(File file) throws EnforcerRuleException {
+		if (!optional) {
+			requireExists(file, description);
+		}
+		log().debug(() -> description + " is absent at " + file + ", which this rule accepts; nothing to check");
+		report(header(), List.of());
 	}
 
 	/** The JSON file to validate. Injected from the rule configuration. */
@@ -106,16 +128,5 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 				"Open " + description + " and confirm it parses as valid JSON.",
 				"Correct every structural item listed above so it matches what the rule expects.",
 				"Re-run the build to confirm " + description + " is well formed.");
-	}
-
-	/**
-	 * How to react when the file is absent. The default fails the build, because a
-	 * missing required file is a build-setup mistake. A rule whose file is optional
-	 * overrides this to return, and the absent file is then reported as a pass — so
-	 * a configured HTML report reflects that run rather than keeping the previous
-	 * one's failure.
-	 */
-	protected void handleMissingFile(File file) throws EnforcerRuleException {
-		requireExists(file, description);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonNodes.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonNodes.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.rule;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.StreamReadFeature;
@@ -55,20 +56,22 @@ public final class JsonNodes {
 
 	/** The child object at {@code key}, or null when it is absent or not an object. */
 	public static JsonNode objectAt(JsonNode node, String key) {
-		JsonNode child = node.get(key);
-		return child != null && child.isObject() ? child : null;
+		return ofKind(node.get(key), JsonNode::isObject);
 	}
 
 	/** The child array at {@code key}, or null when it is absent or not an array. */
 	public static JsonNode arrayAt(JsonNode node, String key) {
-		JsonNode child = node.get(key);
-		return child != null && child.isArray() ? child : null;
+		return ofKind(node.get(key), JsonNode::isArray);
 	}
 
 	/** The array element at {@code index}, or null when it is not an object. */
 	public static JsonNode objectAt(JsonNode array, int index) {
-		JsonNode element = array.get(index);
-		return element != null && element.isObject() ? element : null;
+		return ofKind(array.get(index), JsonNode::isObject);
+	}
+
+	/** The node when it is present and of the expected kind, else null. */
+	private static JsonNode ofKind(JsonNode node, Predicate<JsonNode> expected) {
+		return node != null && expected.test(node) ? node : null;
 	}
 
 	/** The text at {@code key}, or {@code defaultValue} when it is absent or null. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
@@ -84,11 +84,8 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 		List<String> lines = readTextLines(file);
 		return IntStream.range(0, lines.size())
 				.boxed()
-				.flatMap(index -> scanLine(file, lines.get(index), index + 1, patterns));
-	}
-
-	private Stream<String> scanLine(File file, String line, int lineNumber, List<CredentialPattern> patterns) {
-		return patterns.stream().flatMap(pattern -> matches(file, line, lineNumber, pattern));
+				.flatMap(index -> patterns.stream()
+						.flatMap(pattern -> matches(file, lines.get(index), index + 1, pattern)));
 	}
 
 	private Stream<String> matches(File file, String line, int lineNumber, CredentialPattern pattern) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
@@ -3,7 +3,9 @@ package io.github.adamw7.tools.enforcer.text;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 
 /**
  * Repairs the unambiguous ways a Claude Code front matter block is commonly
@@ -121,21 +123,17 @@ public final class FrontMatterFixer {
 	}
 
 	private static int firstNonBlankIndex(List<String> lines) {
-		for (int i = 0; i < lines.size(); i++) {
-			if (!lines.get(i).isBlank()) {
-				return i;
-			}
-		}
-		return -1;
+		return indexOf(lines, 0, line -> !line.isBlank());
 	}
 
 	private static int nextDelimiterLike(List<String> lines, int from) {
-		for (int i = from; i < lines.size(); i++) {
-			if (isDelimiterLike(lines.get(i))) {
-				return i;
-			}
-		}
-		return -1;
+		return indexOf(lines, from, FrontMatterFixer::isDelimiterLike);
+	}
+
+	/** The first index at or after {@code from} whose line {@code matches}, or -1 when none does. */
+	private static int indexOf(List<String> lines, int from, Predicate<String> matches) {
+		return IntStream.range(from, lines.size()).filter(index -> matches.test(lines.get(index)))
+				.findFirst().orElse(-1);
 	}
 
 	private static boolean isDelimiterLike(String line) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/JsonFileRuleTest.java
@@ -44,8 +44,7 @@ class JsonFileRuleTest {
 
 	@Test
 	void passesWhenAnOptionalFileIsMissing() {
-		TestJsonRule rule = new TestJsonRule();
-		rule.setOptional(true);
+		TestJsonRule rule = new OptionalTestJsonRule();
 		rule.setFile(tempDir.resolve("absent.json").toFile());
 
 		assertDoesNotThrow(rule::execute);
@@ -130,8 +129,7 @@ class JsonFileRuleTest {
 		assertThrows(EnforcerRuleException.class, failing::execute);
 
 		Files.delete(tempDir.resolve("test.json"));
-		TestJsonRule optional = new TestJsonRule();
-		optional.setOptional(true);
+		TestJsonRule optional = new OptionalTestJsonRule();
 		optional.setFile(tempDir.resolve("test.json").toFile());
 		optional.setReportFile(report);
 
@@ -155,23 +153,22 @@ class JsonFileRuleTest {
 	 * {@link #collectViolations} so the shared scaffolding can be asserted in
 	 * isolation from any real document checks.
 	 */
-	private static final class TestJsonRule extends JsonFileRule {
+	private static sealed class TestJsonRule extends JsonFileRule permits OptionalTestJsonRule {
 
-		private File file;
-		private boolean optional;
 		private final List<String> injectedViolations = new ArrayList<>();
+		private File file;
 		private JsonNode parsedRoot;
 
 		TestJsonRule() {
 			super("testFile", "test.json");
 		}
 
-		void setFile(File file) {
-			this.file = file;
+		TestJsonRule(boolean optional) {
+			super("testFile", "test.json", optional);
 		}
 
-		void setOptional(boolean optional) {
-			this.optional = optional;
+		void setFile(File file) {
+			this.file = file;
 		}
 
 		void addViolation(String violation) {
@@ -184,16 +181,17 @@ class JsonFileRuleTest {
 		}
 
 		@Override
-		protected void handleMissingFile(File missing) throws EnforcerRuleException {
-			if (!optional) {
-				super.handleMissingFile(missing);
-			}
-		}
-
-		@Override
 		protected void collectViolations(JsonNode root, List<String> violations) {
 			this.parsedRoot = root;
 			violations.addAll(injectedViolations);
+		}
+	}
+
+	/** The same rule declared with an optional file, which is now a constructor choice. */
+	private static final class OptionalTestJsonRule extends TestJsonRule {
+
+		OptionalTestJsonRule() {
+			super(OPTIONAL);
 		}
 	}
 }


### PR DESCRIPTION
Replace JsonFileRule's overridable handleMissingFile hook with an OPTIONAL
constructor flag, so a rule whose file may be absent says so on its super(...)
line instead of overriding a method; drops the hook and its three overrides.

Fold the duplicated line scans in FrontMatterFixer into one indexOf helper,
the three near-identical typed lookups in JsonNodes into one, ContextBudgetRule's
decode step into its caller, NoSecretsRule's three-step scan chain into two, and
MemoryImportsRule's one-line log wrapper into a lambda.

Record in ClaudeCodeEnforcerRule why every rule declares its own configuration
field: Plexus binds a pom element to a field by name and never sees the
package-private setters, so hoisting those fields into a shared base compiles and
unit-tests green, then fails every real build with "Cannot find 'claudeMdFile' in
class". The EnforcerRuleBuildIT builds are what catch it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NfUi3QN4qNMCCxSEgQ3oZG