### PR TITLE
refactor(adopt): remove duplicated expressions and threaded parameters

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -208,7 +208,7 @@ public final class CliArguments {
 	}
 
 	public Optional<Path> reportFile() {
-		return Optional.ofNullable(optionalText(reportFile)).map(Path::of);
+		return Optional.ofNullable(optionalPath(reportFile));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -133,8 +133,7 @@ public final class RepositoryUrl {
 		if (!Text.isPresent(repositoryUrl)) {
 			return "";
 		}
-		String withoutScheme = SCHEME.matcher(repositoryUrl.strip()).replaceFirst("");
-		String path = USER_INFO.matcher(withoutScheme).replaceFirst("").replace(':', '/');
+		String path = USER_INFO.matcher(withoutScheme(repositoryUrl.strip())).replaceFirst("").replace(':', '/');
 		return stripGitSuffix(stripTrailingSlash(path)).toLowerCase(Locale.ROOT);
 	}
 
@@ -150,9 +149,9 @@ public final class RepositoryUrl {
 	 * is never mistaken for that separator.
 	 */
 	private static String lastSegment(String url) {
-		String withoutScheme = SCHEME.matcher(url).replaceFirst("");
-		int separator = Math.max(withoutScheme.lastIndexOf('/'), withoutScheme.lastIndexOf(':'));
-		return withoutScheme.substring(separator + 1);
+		String path = withoutScheme(url);
+		int separator = Math.max(path.lastIndexOf('/'), path.lastIndexOf(':'));
+		return path.substring(separator + 1);
 	}
 
 	/**
@@ -227,12 +226,17 @@ public final class RepositoryUrl {
 	 * the two separators git accepts.
 	 */
 	private static String authorityAndPath(String url) {
-		String withoutScheme = SCHEME.matcher(url).replaceFirst("");
-		return hasScheme(url) ? PORT.matcher(withoutScheme).replaceFirst("$1") : withoutScheme;
+		String path = withoutScheme(url);
+		return path.equals(url) ? path : PORT.matcher(path).replaceFirst("$1");
 	}
 
-	private static boolean hasScheme(String url) {
-		return SCHEME.matcher(url).find();
+	/**
+	 * The URL past its {@link #SCHEME}, or the URL itself when it carries none — which
+	 * is how {@link #authorityAndPath} tells the two apart, since only a URL with a
+	 * scheme may carry a port.
+	 */
+	private static String withoutScheme(String url) {
+		return SCHEME.matcher(url).replaceFirst("");
 	}
 
 	private static boolean isHost(String segment) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BranchStep.java
@@ -56,8 +56,9 @@ public class BranchStep extends AbstractCommandStep {
 		if (hasLocalBranch(context, runner) || !hasRemoteBranch(context, runner)) {
 			return Optional.empty();
 		}
-		log.info("Resuming branch {} from {}", context.branchName(), remoteBranch(context));
-		return Optional.of(remoteBranch(context));
+		String published = remoteBranch(context);
+		log.info("Resuming branch {} from {}", context.branchName(), published);
+		return Optional.of(published);
 	}
 
 	private boolean hasLocalBranch(AdoptionContext context, CommandRunner runner) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -282,11 +282,9 @@ public class ClaudeMdConformer {
 			return;
 		}
 		int index = Math.max(document.headingIndex(TITLE), 0) + 1;
-		List<String> reference = new ArrayList<>(List.of("", AGENTS_REFERENCE_LINE));
-		if (!isBlankAt(lines, index)) {
-			reference.add("");
-		}
-		lines.addAll(index, reference);
+		lines.addAll(index, isBlankAt(lines, index)
+				? List.of("", AGENTS_REFERENCE_LINE)
+				: List.of("", AGENTS_REFERENCE_LINE, ""));
 	}
 
 	private static boolean isBlankAt(List<String> lines, int index) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
@@ -77,8 +77,13 @@ public class ClaudeTrustStore {
 		this(defaultConfigFile());
 	}
 
+	/**
+	 * The path is absolutised once here rather than at each place that needs it, so
+	 * the lock file, the temporary file, and the move all resolve against the same
+	 * directory — and a configuration named relatively still has a parent to create.
+	 */
 	public ClaudeTrustStore(Path configFile) {
-		this.configFile = configFile;
+		this.configFile = configFile.toAbsolutePath();
 	}
 
 	private static Path defaultConfigFile() {
@@ -94,10 +99,9 @@ public class ClaudeTrustStore {
 	 *         when it was already trusted and the file was left unchanged.
 	 */
 	public boolean trust(Path directory) {
-		Path target = configFile.toAbsolutePath();
-		createConfigDirectory(target);
+		createConfigDirectory();
 		synchronized (IN_PROCESS_LOCK) {
-			return trustExclusively(directory, target);
+			return trustExclusively(directory);
 		}
 	}
 
@@ -108,8 +112,8 @@ public class ClaudeTrustStore {
 	 * file is left behind on the way out, since a lock file deleted by the process
 	 * releasing it is a lock the next one takes on an inode of its own.
 	 */
-	private boolean trustExclusively(Path directory, Path target) {
-		Path lockFile = target.resolveSibling(target.getFileName() + LOCK_SUFFIX);
+	private boolean trustExclusively(Path directory) {
+		Path lockFile = configFile.resolveSibling(configFile.getFileName() + LOCK_SUFFIX);
 		try (FileChannel channel = FileChannel.open(lockFile, StandardOpenOption.CREATE,
 				StandardOpenOption.WRITE); FileLock exclusive = channel.lock()) {
 			return update(directory, WRITE_ATTEMPTS);
@@ -238,26 +242,26 @@ public class ClaudeTrustStore {
 	 *         under the update and it has to be built again
 	 */
 	private boolean writeUnlessChanged(ObjectNode root, String observed) {
-		Path target = configFile.toAbsolutePath();
 		try {
-			return replaceUnlessChanged(root, temporaryBeside(target), target, observed);
+			return replaceUnlessChanged(root, temporaryBeside(), observed);
 		} catch (IOException e) {
 			throw new AdoptionException("Could not write Claude config: " + configFile, e);
 		}
 	}
 
 	/** Created before the lock file is opened beside it, and so before anything is read. */
-	private void createConfigDirectory(Path target) {
+	private void createConfigDirectory() {
+		Path directory = configFile.getParent();
 		try {
-			Files.createDirectories(target.getParent());
+			Files.createDirectories(directory);
 		} catch (IOException e) {
-			throw new AdoptionException("Could not create the Claude config directory: " + target.getParent(), e);
+			throw new AdoptionException("Could not create the Claude config directory: " + directory, e);
 		}
 	}
 
 	/** A sibling, so the move stays within one filesystem and can be atomic. */
-	private Path temporaryBeside(Path target) throws IOException {
-		return Files.createTempFile(target.getParent(), ".claude-adopt-", ".json");
+	private Path temporaryBeside() throws IOException {
+		return Files.createTempFile(configFile.getParent(), ".claude-adopt-", ".json");
 	}
 
 	/**
@@ -265,11 +269,10 @@ public class ClaudeTrustStore {
 	 * write that fails leaves the configuration directory as it found it rather than
 	 * scattering half-written documents beside the file {@code claude} reads.
 	 */
-	private boolean replaceUnlessChanged(ObjectNode root, Path temporary, Path target, String observed)
-			throws IOException {
+	private boolean replaceUnlessChanged(ObjectNode root, Path temporary, String observed) throws IOException {
 		try {
 			mapper.writerWithDefaultPrettyPrinter().writeValue(temporary.toFile(), root);
-			return moveUnlessChanged(temporary, target, observed);
+			return moveUnlessChanged(temporary, observed);
 		} catch (IOException | RuntimeException e) {
 			Files.deleteIfExists(temporary);
 			throw e;
@@ -287,12 +290,12 @@ public class ClaudeTrustStore {
 	 *
 	 * @return whether the document was moved over the configuration
 	 */
-	private boolean moveUnlessChanged(Path temporary, Path target, String observed) throws IOException {
+	private boolean moveUnlessChanged(Path temporary, String observed) throws IOException {
 		if (!readText().equals(observed)) {
 			Files.deleteIfExists(temporary);
 			return false;
 		}
-		replace(temporary, target);
+		replace(temporary);
 		return true;
 	}
 
@@ -301,11 +304,11 @@ public class ClaudeTrustStore {
 	 * one, which still beats writing the configuration in place: the document is
 	 * complete on disk before anything of the old one is touched.
 	 */
-	private void replace(Path temporary, Path target) throws IOException {
+	private void replace(Path temporary) throws IOException {
 		try {
-			Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+			Files.move(temporary, configFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
 		} catch (AtomicMoveNotSupportedException e) {
-			Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING);
+			Files.move(temporary, configFile, StandardCopyOption.REPLACE_EXISTING);
 		}
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -191,7 +191,7 @@ final class PomDocument {
 		int depth = parent.parents().size();
 		String fragment = fragment(addition, depth + 1);
 		String closingIndent = newlineIndent(depth);
-		if (isSelfClosing(contentStart)) {
+		if (isSelfClosing(original, parent)) {
 			return edit(parent.sourceRange().startPos(), contentStart,
 					reopened(parent) + fragment + closingIndent + endTag(parent));
 		}
@@ -208,9 +208,14 @@ final class PomDocument {
 		return element.sourceRange().endPos();
 	}
 
-	/** Whether the start tag ending at {@code contentStart} was written {@code <name/>}. */
-	private boolean isSelfClosing(int contentStart) {
-		return original.startsWith(SELF_CLOSING_END, contentStart - SELF_CLOSING_END.length());
+	/**
+	 * Whether the element's start tag was written {@code <name/>}, read from the source
+	 * rather than from the parse — which reports the same implicit end range for a
+	 * self-closing element as for an unclosed one, the distinction
+	 * {@link #requireClosedElements} turns on.
+	 */
+	private static boolean isSelfClosing(String original, Element element) {
+		return original.startsWith(SELF_CLOSING_END, contentStart(element) - SELF_CLOSING_END.length());
 	}
 
 	/**
@@ -312,8 +317,7 @@ final class PomDocument {
 	private static void requireClosedElements(Path file, String original, Element root) {
 		Optional<Element> unclosed = selfAndDescendants(root).stream()
 				.filter(element -> element.endSourceRange().isImplicit())
-				.filter(element -> !original.startsWith(SELF_CLOSING_END,
-						contentStart(element) - SELF_CLOSING_END.length()))
+				.filter(element -> !isSelfClosing(original, element))
 				.findFirst();
 		if (unclosed.isPresent()) {
 			throw new AdoptionException(

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolProbe.java
@@ -40,10 +40,11 @@ final class ToolProbe {
 
 	/**
 	 * @return whether the tool's {@code --version} probe runs and exits zero. The
-	 *         probe's shape lives here so {@link ToolchainStep} and
-	 *         {@link BuildToolchainStep} cannot drift apart on it.
+	 *         probe's shape lives here rather than at the callers, so a tool named by
+	 *         {@link ToolchainStep} is probed exactly as one named by
+	 *         {@link BuildToolchainStep} is.
 	 */
-	boolean isInstalled(String tool, Path directory, CommandRunner runner) {
+	private boolean isInstalled(String tool, Path directory, CommandRunner runner) {
 		boolean installed = succeeds(List.of(tool, VERSION_FLAG), directory, runner);
 		if (installed) {
 			log.info("Found required tool: {}", tool);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
@@ -77,11 +77,15 @@ public class WorkflowGuardInstaller {
 	 * project's own workflow.
 	 */
 	private void warnIfWorkflowIsNotOurs(Path repositoryDirectory, boolean workflowWritten) {
-		Path workflowFile = repositoryDirectory.resolve(WORKFLOW_FILE);
-		if (!workflowWritten && !(Files.isRegularFile(workflowFile)
-				&& AdoptionFiles.read(workflowFile, "workflow file").contains(MARKER))) {
+		if (!workflowWritten && !isAdoptionWorkflow(repositoryDirectory.resolve(WORKFLOW_FILE))) {
 			log.warn("{} already exists and is not the adoption's workflow; left unchanged, so CI may not run {}",
 					WORKFLOW_FILE, SCRIPT_FILE);
 		}
+	}
+
+	/** A workflow this installer wrote carries {@value #MARKER}; anything else is the project's own. */
+	private boolean isAdoptionWorkflow(Path workflowFile) {
+		return Files.isRegularFile(workflowFile)
+				&& AdoptionFiles.read(workflowFile, "workflow file").contains(MARKER);
 	}
 }


### PR DESCRIPTION
Read every line of the module's main sources and simplified where the same
thing was said twice or a value was carried further than it needed to be.
No behaviour changes.

- ClaudeTrustStore: absolutise the config path once in the constructor
  instead of at three call sites, dropping the `target` parameter threaded
  through five private methods. A relatively named config now also has a
  parent directory to create.
- PomDocument: state the "was this written <name/>?" test once, so the edit
  splice and the unclosed-element check cannot read the source differently.
- RepositoryUrl: extract withoutScheme(), used by three parses that each
  spelled the same replaceFirst out; authorityAndPath no longer runs the
  scheme pattern twice.
- WorkflowGuardInstaller: name the marker check, flattening a double negative.
- ToolProbe: isInstalled has no caller outside the class, so make it private
  and correct the javadoc that claimed two steps shared it.
- ClaudeMdConformer: build the reference block without a mutable list.
- BranchStep, CliArguments: reuse a value rather than recomputing it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DzXkP5RKdmz9SFBkj9mVo2