### PR TITLE
fix(adopt): stop the conformed CLAUDE.md pointing in a circle

### DIFF
--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -17,8 +17,9 @@ module's rules are unusually strict because it shells out to `git`, `gh` and
    is logged in). Fails before any expensive work. A dry run is checked with
    `ToolchainStep.forDryRun()` — `git` and `claude` only, since `gh` is used by
    the pull request the run leaves out.
-2. `CloneStep` — clones into the workspace. **The only step allowed to read the
-   credentialled URL.**
+2. `CloneStep` — clones into the workspace, then rewrites the checkout's `origin`
+   to `checkoutUrl()`, the same URL without its credentials, so the token git
+   wrote into `.git/config` does not outlive the run.
 3. `BuildToolchainStep` — the *cloned project's* build tool, checked as soon as
    the clone reveals which one it is.
 4. `BranchStep` — feature branch (`claude/adopt-claude-code` by default). The
@@ -62,9 +63,12 @@ pull request's URL.
 - Fields are **immutable** (step state is final).
 - A step must not depend on `GitHubRepoAdopter` — the pipeline knows its steps,
   not the other way round.
-- Only `CloneStep` may touch `AdoptionContext#repositoryUrl()`; everything else
-  logs `displayUrl()`. `Redaction` masks credentials in every log, message and
-  report — keep it that way.
+- Only `CloneStep` and `PushStep` may touch `AdoptionContext#repositoryUrl()` —
+  the two commands that authenticate to the remote. Everything else logs
+  `displayUrl()` or, where a working URL is needed, `checkoutUrl()`. `PushStep`
+  passes the credentials as a `-c remote.origin.pushurl` override, which git
+  applies to that one invocation and writes nowhere. `Redaction` masks
+  credentials in every log, message and report — keep it that way.
 - Register the step in `GitHubRepoAdopter.defaultSteps` (or the optional list it
   belongs to), and unit-test it with a fake `CommandRunner`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,9 +410,11 @@ Per-module rules:
   a process is spawned, and a step knows only the `CommandRunner` contract, never
   `ProcessCommandRunner`; a step never reaches back to `GitHubRepoAdopter`,
   `BatchAdoption`, `CliArguments` or `Main`, and holds no mutable field, since
-  one instance adopts every repository of a batch; only `CloneStep` calls
-  `AdoptionContext.repositoryUrl()` (everything else reads the redacted
-  `displayUrl()`); the adoption speaks no network protocol of its own outside the
+  one instance adopts every repository of a batch; only `CloneStep` and
+  `PushStep` call `AdoptionContext.repositoryUrl()` — the two commands that
+  authenticate to the remote — while everything else reads the redacted
+  `displayUrl()` or the credential-free `checkoutUrl()`; the adoption speaks no
+  network protocol of its own outside the
   MCP package; `mcp` is a delivery mechanism nothing depends on and the only
   place that knows Spring; implementations are pinned to their contracts by name
   (`*Step`, `*BuildSystem`, `*CommandRunner`, `*Tool`); the only public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ run `mvn install` from the repository root.
   project's own build tool, branch, trust the checkout, `claude init` and conform
   the generated `CLAUDE.md`, wire a build-tool-aware guard in, verify it, push,
   and open a pull request. The default branch is never written to, clone-URL
-  credentials are masked everywhere, `--dry-run` leaves out the push and the pull
+  credentials are masked in everything the run reports and are never left in the
+  checkout's `.git/config`, `--dry-run` leaves out the push and the pull
   request entirely, and one run adopts a list of repositories without letting a
   failure stop the rest. Skill: `adopt-pipeline`.
 - **Markdown reading** (`markdown-common`) — the dependency-free reader both the

--- a/README.md
+++ b/README.md
@@ -1030,7 +1030,12 @@ The default pipeline runs these steps in order:
    perfectly well. A URL naming no owner has no repository to ask about and falls
    back to `gh api user`.
 2. **`CloneStep`** — clones the target repository into the workspace with
-   `git clone`, giving the remaining steps a working checkout.
+   `git clone`, giving the remaining steps a working checkout. A freshly cloned
+   checkout then has its `origin` rewritten to the same URL without its
+   credentials: `git clone` records the URL it was handed verbatim, so a run
+   driven by a CI token would otherwise leave that token in the workspace's
+   `.git/config` in plaintext for as long as the workspace survives. A checkout
+   the adoption is reusing is left as its owner configured it.
 3. **`BuildToolchainStep`** — probes the *adopted project's* build tool, now that
    the clone has revealed which one it is. `ToolchainStep` cannot: the checkout
    does not exist yet. Without this a machine without the project's `mvn` or
@@ -1104,8 +1109,11 @@ The default pipeline runs these steps in order:
    failing the adoption locally if the file is missing or malformed rather than
    after the pull request lands.
 13. **`PushStep`** — pushes the feature branch to origin and sets its upstream
-    (`git push -u origin <branch>`). Left out of a `--dry-run` pipeline, together
-    with the step below it.
+    (`git push -u origin <branch>`). The run's own credentials are supplied to
+    that one command as a `-c remote.origin.pushurl` override, since `CloneStep`
+    deliberately leaves none in the checkout; git applies the override to the
+    single invocation and stores it nowhere. Left out of a `--dry-run` pipeline,
+    together with the step below it.
 14. **`PullRequestStep`** — opens a pull request from the branch with
    `gh pr create`, targeting the repository's default branch as the base. The
    pull request metadata is supplied through `PullRequestOptions` — title, body,

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionContext.java
@@ -50,6 +50,11 @@ public final class AdoptionContext {
 		return repository.redacted();
 	}
 
+	/** @see RepositoryUrl#withoutCredentials() */
+	public String checkoutUrl() {
+		return repository.withoutCredentials();
+	}
+
 	/** @see RepositoryUrl#slug() */
 	public Optional<String> repositorySlug() {
 		return repository.slug();

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -43,8 +43,19 @@ public final class RepositoryUrl {
 	 */
 	private static final Pattern USER_INFO = Pattern.compile("^[^/]*@");
 
+	/**
+	 * The credentials of an {@code http(s)} URL: everything between the {@code ://}
+	 * and the last {@code @} before the path, the same reading {@link Redaction}
+	 * takes. Only those two schemes are matched, because {@link #withoutCredentials()}
+	 * removes what it finds rather than masking it: the {@code git@} of an
+	 * {@code ssh://git@host/owner/repo} is the account to log in as, not a secret, and
+	 * a URL stripped of it authenticates as whoever is running the adoption instead.
+	 */
+	private static final Pattern HTTP_CREDENTIALS = Pattern.compile("(?<=^https?://)[^/\\s]+@");
+
 	private final String value;
 	private final String redacted;
+	private final String withoutCredentials;
 	private final String name;
 	private final String slug;
 	private final String identity;
@@ -52,6 +63,7 @@ public final class RepositoryUrl {
 	private RepositoryUrl(String value) {
 		this.value = value;
 		this.redacted = Redaction.of(value);
+		this.withoutCredentials = HTTP_CREDENTIALS.matcher(value).replaceFirst("");
 		this.name = repositoryName(value);
 		this.slug = repositorySlug(value);
 		this.identity = identity(value);
@@ -80,6 +92,22 @@ public final class RepositoryUrl {
 	 */
 	public String redacted() {
 		return redacted;
+	}
+
+	/**
+	 * The URL with its credentials removed rather than masked, so it still clones and
+	 * fetches: {@link #redacted()} answers {@code https://***@host/owner/repo}, which
+	 * names a host called {@code ***@host} and is no use to git. This is the form the
+	 * checkout records as its {@code origin}, because a credentialled URL written
+	 * there outlives the run as plaintext in {@code .git/config} — the adoption is
+	 * handed {@code https://x-access-token:TOKEN@github.com/owner/repo.git} by CI, and
+	 * the workspace it leaves behind is not where that token should live.
+	 *
+	 * @return the URL without its user information for {@code http} and {@code https},
+	 *         and unchanged for every other form
+	 */
+	public String withoutCredentials() {
+		return withoutCredentials;
 	}
 
 	/** The repository name the checkout directory is created under. */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -71,7 +71,18 @@ public class ClaudeMdConformer {
 
 	static final String AGENTS_REFERENCE_LINE = "See [AGENTS.md](AGENTS.md) for the companion agent guide.";
 
-	private static final String STUB_BODY = "See [AGENTS.md](AGENTS.md).";
+	/**
+	 * What a required section the project has nothing to say under is given, since the
+	 * rule fails an empty section as firmly as a missing one. It used to read "See
+	 * [AGENTS.md](AGENTS.md)." — which pointed at the companion file
+	 * {@link AdoptionAssets} installs beside it, and that file points back here and
+	 * calls {@code CLAUDE.md} the source of truth. Every adopted repository's pull
+	 * request therefore opened with six sections whose whole content was a reference to
+	 * a document that referred the reader straight back, and a maintainer reading it
+	 * had no way to tell an unanswered section from an answered one. Saying plainly
+	 * that nothing is recorded yet is both true and actionable.
+	 */
+	static final String STUB_BODY = "_Not documented yet — replace this line with the project's own guidance._";
 
 	/** The blank lines the reshape may leave at the end, dropped so the document keeps a single one. */
 	private static final Pattern TRAILING_BLANK_LINES = Pattern.compile("\\n\\s*+\\z");
@@ -86,9 +97,9 @@ public class ClaudeMdConformer {
 	/**
 	 * Conforms only as far as the guard being wired in actually demands. Stamping the
 	 * {@code claudeMdFormat} sections onto every adopted repository put Java and Maven
-	 * headings, each stubbed with a pointer to {@code AGENTS.md}, into projects that
-	 * are neither — where nothing then checked them, the Gradle and GitHub Actions
-	 * guards asking only that the file exist and carry something.
+	 * headings, each carrying nothing but {@link #STUB_BODY}, into projects that are
+	 * neither — where nothing then checked them, the Gradle and GitHub Actions guards
+	 * asking only that the file exist and carry something.
 	 *
 	 * @param requiredSections the headings to canonicalize, append and give a body to,
 	 *                         empty for a guard that demands no particular section. A

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -41,6 +41,10 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * <p>The checkout is then refreshed with {@code git fetch}, because every later
  * decision about the feature branch is taken against the remote-tracking refs a
  * stale checkout has out of date.
+ *
+ * <p>A freshly cloned checkout records the credential-free form of the URL as its
+ * {@code origin}, so the token an adoption is driven with does not outlive the run
+ * in {@code .git/config} — see {@link #forgetCredentials}.
  */
 public class CloneStep extends AbstractCommandStep {
 
@@ -108,6 +112,34 @@ public class CloneStep extends AbstractCommandStep {
 		List<String> command = List.of("git", "clone", context.repositoryUrl(),
 				context.repositoryDirectory().toString());
 		runOrFail(runner, context.workspace(), command);
+		forgetCredentials(context, runner);
+	}
+
+	/**
+	 * Rewrites the {@code origin} git just recorded to the credential-free form of the
+	 * same URL, because {@code git clone} writes the URL it was handed into
+	 * {@code .git/config} verbatim — so an adoption driven by CI, whose URL carries
+	 * {@code x-access-token:TOKEN}, left that token in plaintext in the workspace, for
+	 * as long as the workspace survives. Masking it in the logs and the report keeps it
+	 * out of what the run <em>says</em>; nothing but this keeps it out of what the run
+	 * <em>leaves behind</em>.
+	 *
+	 * <p>{@link PushStep} is unaffected: it supplies the credentialled URL to the one
+	 * command that needs it, rather than reading it back from the checkout.
+	 *
+	 * <p>Only the remote this step just wrote is rewritten, and only when the URL
+	 * carried credentials at all. A reused checkout's {@code origin} is left exactly as
+	 * its owner configured it — it is not the adoption's to edit, and the operator may
+	 * well push through it themselves afterwards.
+	 */
+	private void forgetCredentials(AdoptionContext context, CommandRunner runner) {
+		if (context.checkoutUrl().equals(context.repositoryUrl())) {
+			return;
+		}
+		log.info("Recording {} as the checkout's {}, so the clone credentials are not left in .git/config",
+				context.displayUrl(), AdoptionContext.REMOTE);
+		runOrFail(runner, context.repositoryDirectory(),
+				List.of("git", "remote", "set-url", AdoptionContext.REMOTE, context.checkoutUrl()));
 	}
 
 	private void reuse(AdoptionContext context, CommandRunner runner) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PushStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PushStep.java
@@ -12,10 +12,20 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * Pushes the adoption feature branch to the repository's origin with
  * {@code git push -u origin <branch>}, setting the upstream so the freshly
  * created branch is published and can be the head of a pull request.
+ *
+ * <p>The credentials the run was given are supplied to that one command rather
+ * than read back from the checkout, because {@link CloneStep} deliberately does
+ * not leave them there. They are passed as a {@code -c remote.origin.pushurl}
+ * override, which git applies to this invocation alone and writes nowhere: pushing
+ * to the URL positionally would publish the branch just as well but leaves git
+ * unable to set an upstream, since a URL is not a remote to track.
  */
 public class PushStep extends AbstractCommandStep {
 
 	private static final Logger log = LogManager.getLogger(PushStep.class);
+
+	/** The configuration key git resolves a push through, in preference to the remote's URL. */
+	private static final String PUSH_URL = "remote." + AdoptionContext.REMOTE + ".pushurl=";
 
 	@Override
 	public String name() {
@@ -25,7 +35,8 @@ public class PushStep extends AbstractCommandStep {
 	@Override
 	public void execute(AdoptionContext context, CommandRunner runner) {
 		log.info("Pushing branch {} from {}", context.branchName(), context.repositoryDirectory());
-		List<String> command = List.of("git", "push", "-u", AdoptionContext.REMOTE, context.branchName());
+		List<String> command = List.of("git", "-c", PUSH_URL + context.repositoryUrl(),
+				"push", "-u", AdoptionContext.REMOTE, context.branchName());
 		runOrFail(runner, context.repositoryDirectory(), command);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionContextTest.java
@@ -91,6 +91,14 @@ class AdoptionContextTest {
 		assertEquals("https://***@github.com/owner/repo.git", context.displayUrl());
 	}
 
+	/** What the checkout is left recording: a usable URL that carries no secret. */
+	@Test
+	void answersACredentialFreeUrlForTheCheckoutToKeep() {
+		AdoptionContext context = new AdoptionContext("https://x-access-token:secret@github.com/owner/repo.git",
+				Path.of("/tmp/workspace"));
+		assertEquals("https://github.com/owner/repo.git", context.checkoutUrl());
+	}
+
 	/**
 	 * A step deciding whether a checkout it found is the repository under adoption
 	 * asks the context, so the credentialled clone URL stays where only the clone

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
@@ -226,6 +226,45 @@ class RepositoryUrlTest {
 	void aUrlWithoutCredentialsReadsTheSameEitherWay() {
 		RepositoryUrl url = RepositoryUrl.of("https://github.com/owner/repo.git");
 		assertEquals(url.value(), url.redacted());
+		assertEquals(url.value(), url.withoutCredentials());
+	}
+
+	/**
+	 * What the checkout records as its {@code origin}: the credentials are removed
+	 * rather than masked, because the masked form names a host called {@code ***@…}
+	 * that git cannot fetch from.
+	 */
+	@Test
+	void dropsTheCredentialsForTheUrlTheCheckoutKeeps() {
+		RepositoryUrl url = RepositoryUrl.of("https://x-access-token:secret@github.com/owner/repo.git");
+		assertEquals("https://github.com/owner/repo.git", url.withoutCredentials());
+		assertEquals("https://github.com/owner/repo.git",
+				RepositoryUrl.of("https://token@github.com/owner/repo.git").withoutCredentials());
+	}
+
+	/**
+	 * A password may carry an unencoded {@code @}, which makes the credentials run to
+	 * the <em>last</em> one before the path — the same reading {@link Redaction} takes.
+	 * Stopping at the first would leave the tail of the password in the URL written to
+	 * {@code .git/config}, which is the one place this exists to keep it out of.
+	 */
+	@Test
+	void dropsAPasswordCarryingAnAtSign() {
+		assertEquals("https://github.com/owner/repo.git",
+				RepositoryUrl.of("https://user:p@ss@github.com/owner/repo.git").withoutCredentials());
+	}
+
+	/**
+	 * An SSH URL's user is the account to log in as, not a secret, so it is kept: a
+	 * {@code git@} dropped from one would authenticate as whoever is running the
+	 * adoption and be refused by the host.
+	 */
+	@Test
+	void keepsTheUserOfAnSshUrl() {
+		assertEquals("git@github.com:owner/repo.git",
+				RepositoryUrl.of("git@github.com:owner/repo.git").withoutCredentials());
+		assertEquals("ssh://git@github.com/owner/repo.git",
+				RepositoryUrl.of("ssh://git@github.com/owner/repo.git").withoutCredentials());
 	}
 
 	/** A URL refused on its input is quoted back, so it must be masked there too. */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
@@ -45,6 +45,7 @@ public class AdoptArchitectureTest {
 	private static final String SPRING_PACKAGE = "org.springframework..";
 
 	private static final String CLONE_STEP = ADOPT_PACKAGE + ".step.CloneStep";
+	private static final String PUSH_STEP = ADOPT_PACKAGE + ".step.PushStep";
 	private static final String PROCESS_COMMAND_RUNNER = ADOPT_PACKAGE + ".command.ProcessCommandRunner";
 
 	@ArchTest
@@ -156,11 +157,13 @@ public class AdoptArchitectureTest {
 					+ "the batch, or the command line could no longer be reordered or reused");
 
 	@ArchTest
-	static final ArchRule onlyTheCloneStepReadsTheCredentialledUrl = noClasses()
-			.that().doNotHaveFullyQualifiedName(CLONE_STEP)
+	static final ArchRule onlyTheCloneAndPushStepsReadTheCredentialledUrl = noClasses()
+			.that().doNotHaveFullyQualifiedName(CLONE_STEP).and().doNotHaveFullyQualifiedName(PUSH_STEP)
 			.should().callMethod(AdoptionContext.class, "repositoryUrl")
-			.because("repositoryUrl() answers the clone URL with its credentials intact; only the git clone "
-					+ "command may see them, and everything else reads the redacted displayUrl()");
+			.because("repositoryUrl() answers the clone URL with its credentials intact; only the two commands "
+					+ "that authenticate to the remote may see them — the clone, and the push, which supplies "
+					+ "them per invocation because the clone no longer leaves them in .git/config — and "
+					+ "everything else reads the redacted displayUrl() or the credential-free checkoutUrl()");
 
 	@ArchTest
 	static final ArchRule adoptionReachesGitHubThroughItsTools = noClasses()

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -73,10 +73,27 @@ class ClaudeMdConformerTest {
 				Run `mvn install`.
 				""";
 		String conformed = conformer.conform(generated);
-		assertTrue(conformed.contains("## Project\n\nSee [AGENTS.md](AGENTS.md)."),
+		assertTrue(conformed.contains("## Project\n\n" + ClaudeMdConformer.STUB_BODY),
 				"the emptied section must be given a body:\n" + conformed);
 		ClaudeMdConformer.REQUIRED_SECTIONS.forEach(section -> assertTrue(hasBody(conformed, section),
 				section + " must have a body:\n" + conformed));
+	}
+
+	/**
+	 * The stub used to read "See [AGENTS.md](AGENTS.md).", while the {@code AGENTS.md}
+	 * installed beside it refers the reader back to {@code CLAUDE.md} and calls it the
+	 * source of truth. Every adopted repository's pull request therefore arrived with
+	 * six sections that said nothing and pointed in a circle, and a maintainer could
+	 * not tell a section nobody had answered from one that had been.
+	 */
+	@Test
+	void stubsSayNothingIsRecordedRatherThanPointingAtTheCompanionFile() {
+		String conformed = conformer.conform("# CLAUDE.md\n");
+		assertFalse(conformed.contains("## Project\n\nSee [AGENTS.md](AGENTS.md)."),
+				"a stub must not send the reader to the file that sends them back:\n" + conformed);
+		assertTrue(conformed.contains(ClaudeMdConformer.STUB_BODY), "the stub must still be there:\n" + conformed);
+		assertEquals(1, conformed.lines().filter(line -> line.contains("AGENTS.md")).count(),
+				"AGENTS.md is named once, by the reference line the rule demands:\n" + conformed);
 	}
 
 	@Test
@@ -85,7 +102,7 @@ class ClaudeMdConformerTest {
 		String conformed = conformer.conform(generated);
 		assertEquals(ClaudeMdConformer.REQUIRED_SECTIONS.size(), conformed.split("Content\\.", -1).length - 1,
 				"every original body must survive exactly once:\n" + conformed);
-		assertFalse(conformed.contains("Content.\n\nSee [AGENTS.md](AGENTS.md)."),
+		assertFalse(conformed.contains("Content.\n\n" + ClaudeMdConformer.STUB_BODY),
 				"a section that already has a body must not be given a stub");
 	}
 
@@ -317,7 +334,7 @@ class ClaudeMdConformerTest {
 				Java 25.
 				""";
 		String conformed = conformer.conform(generated);
-		assertFalse(conformed.contains("## Project\n\nSee [AGENTS.md](AGENTS.md)."),
+		assertFalse(conformed.contains("## Project\n\n" + ClaudeMdConformer.STUB_BODY),
 				"a section whose body is a code block must not be given a stub:\n" + conformed);
 	}
 
@@ -335,7 +352,7 @@ class ClaudeMdConformerTest {
 				JUnit 5.
 				""";
 		String conformed = conformer.conform(generated);
-		assertFalse(conformed.contains("## Testing\n\nSee [AGENTS.md](AGENTS.md)."),
+		assertFalse(conformed.contains("## Testing\n\n" + ClaudeMdConformer.STUB_BODY),
 				"a section carrying a sub-heading must not be given a stub:\n" + conformed);
 	}
 
@@ -804,7 +821,7 @@ class ClaudeMdConformerTest {
 		String conformed = conformer.conform(generated);
 		assertTrue(hasStructuralBody(conformed, "## Testing"),
 				"the section below the fence is structure, not a comment:\n" + conformed);
-		assertFalse(conformed.contains("## Testing\n\n" + "See [AGENTS.md](AGENTS.md)."),
+		assertFalse(conformed.contains("## Testing\n\n" + ClaudeMdConformer.STUB_BODY),
 				"the section already had a body:\n" + conformed);
 	}
 
@@ -872,7 +889,7 @@ class ClaudeMdConformerTest {
 				A repo.
 				""";
 		String conformed = conformer.conform(generated);
-		assertFalse(conformed.contains("## Testing\n\n" + "See [AGENTS.md](AGENTS.md)."),
+		assertFalse(conformed.contains("## Testing\n\n" + ClaudeMdConformer.STUB_BODY),
 				"the section already had a body and needs no stub:\n" + conformed);
 		assertTrue(conformed.contains("#1 rule: run mvn install every time."),
 				"the prose keeps its place:\n" + conformed);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -36,6 +36,50 @@ class CloneStepTest {
 	}
 
 	/**
+	 * {@code git clone} writes the URL it was handed into {@code .git/config} verbatim,
+	 * so a run driven by CI — whose URL carries {@code x-access-token:TOKEN} — used to
+	 * leave that token in the workspace in plaintext, long after the adoption that
+	 * needed it had finished. The remote is rewritten to the same URL without its
+	 * credentials, which still fetches; {@link PushStep} supplies them to the one
+	 * command that authenticates.
+	 */
+	@Test
+	void rewritesTheClonedOriginSoTheCredentialsAreNotLeftInTheCheckout() {
+		AdoptionContext credentialled = new AdoptionContext(
+				"https://x-access-token:TOKEN@github.com/adamw7/tools.git", workspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		step.execute(credentialled, runner);
+		assertEquals(List.of("git", "remote", "set-url", "origin", "https://github.com/adamw7/tools.git"),
+				runner.commandAt(1));
+		assertEquals(credentialled.repositoryDirectory(), runner.invocations().get(1).workingDirectory());
+		assertFalse(runner.commandAt(1).toString().contains("TOKEN"), "the rewritten remote must carry no token");
+	}
+
+	/** A URL that carried no credentials records exactly what it was given, in one command. */
+	@Test
+	void leavesTheClonedOriginAloneWhenTheUrlCarriedNoCredentials() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		step.execute(context, runner);
+		assertEquals(1, runner.invocations().size(), "nothing to rewrite:\n" + runner.invocations());
+	}
+
+	/**
+	 * A checkout the adoption did not create is not the adoption's to reconfigure: its
+	 * {@code origin} is whatever its owner set up, credentials included, and they may
+	 * well push through it themselves once the adoption has finished.
+	 */
+	@Test
+	void leavesAReusedCheckoutsOriginAlone(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = new AdoptionContext(
+				"https://x-access-token:TOKEN@github.com/adamw7/tools.git", existingWorkspace);
+		Files.createDirectories(existing.repositoryDirectory().resolve(".git"));
+		RecordingCommandRunner runner = origin("https://github.com/adamw7/tools.git");
+		step.execute(existing, runner);
+		assertFalse(runner.invocations().stream().anyMatch(invocation -> invocation.command().contains("set-url")),
+				"a reused checkout's remote must be left as its owner configured it:\n" + runner.invocations());
+	}
+
+	/**
 	 * The checkout is the run's one output that never reaches GitHub, so a caller that
 	 * named no workspace — and a dry run, which publishes nothing at all — has nothing
 	 * else to be pointed at.

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PushStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PushStepTest.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.adopt.step;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -21,8 +22,41 @@ class PushStepTest {
 	void pushesFeatureBranchWithUpstreamInCheckout() {
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		step.execute(context, runner);
-		assertEquals(List.of("git", "push", "-u", "origin", "claude/adopt-claude-code"), runner.commandAt(0));
+		assertEquals(List.of("git", "-c", "remote.origin.pushurl=https://github.com/adamw7/demo.git",
+				"push", "-u", "origin", "claude/adopt-claude-code"), runner.commandAt(0));
 		assertEquals(context.repositoryDirectory(), runner.invocations().get(0).workingDirectory());
+	}
+
+	/**
+	 * The push is the one command that has to authenticate as the operator, and
+	 * {@link CloneStep} deliberately leaves no credentials in the checkout for it to
+	 * pick up — so it must carry them itself, or an adoption driven by a token would
+	 * clone and commit perfectly well and then be refused at the last step.
+	 */
+	@Test
+	void carriesTheRunsCredentialsToTheRemote() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new PushStep().execute(credentialled(), runner);
+		assertEquals("remote.origin.pushurl=https://x-access-token:TOKEN@github.com/adamw7/demo.git",
+				runner.commandAt(0).get(2));
+	}
+
+	/**
+	 * Passed as a per-invocation {@code -c} override rather than written to the
+	 * checkout's configuration: git applies it to this push alone, so the token still
+	 * does not outlive the run.
+	 */
+	@Test
+	void neverConfiguresTheCredentialsIntoTheCheckout() {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		new PushStep().execute(credentialled(), runner);
+		assertEquals(1, runner.invocations().size(), "the push is the only command: nothing configures the remote");
+		assertEquals(List.of("git", "-c"), runner.commandAt(0).subList(0, 2),
+				"the override belongs to the invocation, not to .git/config");
+	}
+
+	private AdoptionContext credentialled() {
+		return new AdoptionContext("https://x-access-token:TOKEN@github.com/adamw7/demo.git", Path.of("/tmp/workspace"));
 	}
 
 	@Test

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -627,7 +627,7 @@ sequenceDiagram
     loop each repository URL
         B->>A: adopt(context, report)
         A->>R: toolchain — git / claude / gh present, gh logged in
-        A->>R: clone (credentialled URL, masked in logs)
+        A->>R: clone (credentialled URL, masked in logs, dropped from origin)
         R->>G: git clone
         G-->>W: checkout
         A->>W: build-toolchain — detect Maven / Gradle / fallback


### PR DESCRIPTION
A required section the project had nothing to say under was stubbed with
"See [AGENTS.md](AGENTS.md).", while the AGENTS.md installed beside it
refers the reader back and names CLAUDE.md the source of truth. Every
adopted repository's pull request therefore arrived with six sections
whose whole content was a round trip, and nothing distinguished a section
nobody had answered from one that had been.

The stub now says plainly that nothing is recorded yet, which is both true
and actionable; the enforcer still passes it, an empty section being what
the rule fails.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PzkzPfk4Fbbq2iEvtqrVPN