### PR TITLE
test(claude-code-enforcer): enforce five real repositories that never adopted the rules

### DIFF
--- a/.claude/skills/enforcer-rules/SKILL.md
+++ b/.claude/skills/enforcer-rules/SKILL.md
@@ -127,6 +127,16 @@ parameter left out fails `EnforcerRuleBuildIT`), and `RepositoryEnforcementIT`
 compares the shipped catalogue against the root pom's profile. Run them with
 `mvn -pl claude-code-enforcer -am -P integration-tests verify`.
 
+**A new rule also meets five real repositories.**
+`ForeignRepositoryEnforcementIT` points the same complete configuration at
+shallow clones of `octocat/Hello-World`, `octocat/Spoon-Knife`,
+`github/gitignore`, `anthropics/claude-code` and
+`anthropics/anthropic-quickstarts` — projects nobody prepared for these rules.
+It does not expect them to pass; it expects every rule to *reach a verdict* on
+each of them, to say why when it fails, and never to break the build on the
+rule's own account. So a new rule must survive a file it did not expect and a
+directory that is not there, and report both as violations rather than throwing.
+
 **Naming trap for a `List<String>` parameter.** Plexus infers a configured
 list's element type from the *child element name*, trying the rule's own package
 first, so a class matching the capitalised child name — `SecretPattern` for
@@ -168,4 +178,6 @@ fails a real build with "Failed to create enforcer rules with name: …". The
 - `claude-code-enforcer/.../rule/ClaudeCodeEnforcerRule.java` — the base contract
 - `claude-code-enforcer/.../architecture/EnforcerArchitectureTest.java` — layering
 - `claude-code-enforcer/.../e2e/EnforcerRuleBuildIT.java` — the pom-to-rule seam
+- `claude-code-enforcer/.../e2e/ForeignRepositoryEnforcementIT.java` — the rules
+  against five real repositories that never adopted them
 - Root `pom.xml` — the `claude-md-enforce` profile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,8 +486,26 @@ module's `*IT`s stay unrun until it gets its own copy. Run them with
   `mvn -N validate -DenforceClaudeMd`, holds the shipped catalogue against the
   profile (`subAgentFormat` and `commandFormat` are the documented exemptions),
   and then breaks a *copy* — a skill losing its `SKILL.md`, the two agent
-  documents disagreeing about the Java version — to prove the wiring bites. Two
-  mechanics: the `*IT`s run at `integration-test`, *before* this module is
+  documents disagreeing about the Java version — to prove the wiring bites.
+  `ForeignRepositoryEnforcementIT` points the same complete configuration at
+  five **real** repositories shallow-cloned from GitHub — `octocat/Hello-World`,
+  `octocat/Spoon-Knife`, `github/gitignore`, `anthropics/claude-code` and
+  `anthropics/anthropic-quickstarts` — because both tests above read files
+  written to be read by these rules, and an adopter's project was not. None of
+  the five passes and none should; what is asserted is that every rule *reaches a
+  verdict* on every one of them (`EnforcerVerdicts` reads maven-enforcer's
+  per-rule `passed`/`failed with message:` lines back out of the log, since an
+  exit code cannot tell a rule that examined a project from one that never ran),
+  that no build goes red on the rules' own account — an unbindable parameter, an
+  exception escaping a rule — that every failure says why, that the four
+  optional-file rules pass where the file really is absent, and that
+  `commandFormat` reads `anthropics/claude-code`'s real `.claude/commands`
+  instead of reporting it absent. A sixth test adopts the contract into a fresh
+  clone and enforces it green, so the rules are shown satisfiable outside the
+  repository that wrote them. The build runs in a directory of its own and only
+  the rule parameters point at a checkout (`RuleConfiguration.against`), so no
+  clone is written to; the shared pom both fixtures build lives in `EnforcerPom`.
+  Two mechanics: the `*IT`s run at `integration-test`, *before* this module is
   installed, so they publish the freshly packaged jar themselves (`install-file`,
   with the flattened pom); and a forked test JVM cannot work out where Maven, the
   local repository or that jar are, so the profile passes each in as an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,10 @@ Skill: `testing-conventions`.
   step, so it never pushes or opens a pull request), and `claude-code-enforcer`'s
   real Maven builds, which exercise the pom-to-rule seam a unit test skips. The
   profile is declared per module — `data`, `code/context`, `adopt`,
-  `claude-code-enforcer` — not in the root pom.
+  `claude-code-enforcer` — not in the root pom. The enforcer's `*IT`s also point
+  every shipped rule at five real repositories cloned from GitHub, to prove a
+  project nobody prepared for the rules gets an actionable verdict rather than a
+  build broken on the rules' own account.
 
 ## Continuous integration and commits
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/EnforcerPom.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/EnforcerPom.java
@@ -1,0 +1,80 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+/**
+ * The {@code pom.xml} that runs a {@code <rules>} block: the maven-enforcer-plugin
+ * the repository itself pins, the rule jar under test as a <em>plugin</em>
+ * dependency — the only class path a maven-enforcer rule is loaded from — and one
+ * {@code validate}-phase execution, so a build costs a second.
+ * <p>
+ * Two end-to-end tests need this build and disagree about only two things: what the
+ * project is called, and where the rules are pointed. {@link FixtureProject} writes
+ * it into a project it has just laid out and points the rules at that project;
+ * {@link ForeignRepositoryEnforcementIT} writes it into a directory of its own and
+ * points them at a repository it has cloned, so the repository under test is left
+ * exactly as {@code git} produced it. A second copy of the template would let those
+ * two builds drift apart — one picking up a plugin version or a dependency the
+ * other never sees — and then a rule proved to bind in one would say nothing about
+ * the other.
+ */
+final class EnforcerPom {
+
+	private static final String TEMPLATE = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+				<modelVersion>4.0.0</modelVersion>
+				<groupId>io.github.adamw7.enforcer.e2e</groupId>
+				<artifactId>%s</artifactId>
+				<version>1.0</version>
+				<packaging>pom</packaging>
+				<build>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-enforcer-plugin</artifactId>
+							<version>%s</version>
+							<dependencies>
+								<dependency>
+									<groupId>%s</groupId>
+									<artifactId>%s</artifactId>
+									<version>%s</version>
+								</dependency>
+							</dependencies>
+							<executions>
+								<execution>
+									<id>enforce-claude-code</id>
+									<phase>validate</phase>
+									<goals>
+										<goal>enforce</goal>
+									</goals>
+									<configuration>
+										<rules>
+			%s
+										</rules>
+									</configuration>
+								</execution>
+							</executions>
+						</plugin>
+					</plugins>
+				</build>
+			</project>
+			""";
+
+	private final BuildEnvironment environment;
+	private final String enforcerPluginVersion;
+
+	EnforcerPom(BuildEnvironment environment, String enforcerPluginVersion) {
+		this.environment = environment;
+		this.enforcerPluginVersion = enforcerPluginVersion;
+	}
+
+	/**
+	 * The pom of a project called {@code artifactId} that enforces {@code rulesXml}.
+	 *
+	 * @param artifactId what the build calls itself, so a log says which of the
+	 *                   end-to-end builds it came from
+	 * @param rulesXml   the {@code <rules>} children, written as a pom writes them
+	 */
+	String enforcing(String artifactId, String rulesXml) {
+		return TEMPLATE.formatted(artifactId, enforcerPluginVersion, BuildEnvironment.GROUP_ID,
+				BuildEnvironment.ARTIFACT_ID, environment.version(), rulesXml);
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/EnforcerVerdicts.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/EnforcerVerdicts.java
@@ -1,0 +1,124 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * What maven-enforcer said about each rule, read back out of a build log.
+ * <p>
+ * A test that only asks whether the build passed cannot tell a rule that examined a
+ * project and found nothing wrong from one that never ran at all, and the second is
+ * the failure worth catching: the whole reason the {@code *IT}s exist is that a rule
+ * can be correct and still be skipped. maven-enforcer reports every rule
+ * individually and evaluates them all even after one has failed —
+ * <pre>
+ * [INFO] Rule 3: io.github...McpConfigFormatRule(mcpConfigFormat) passed
+ * [ERROR] Rule 0: io.github...ClaudeMdFormatRule(claudeMdFormat) failed with message:
+ * [ERROR] CLAUDE.md does not exist at /checkout/CLAUDE.md
+ * </pre>
+ * — so the log carries a verdict per rule, and reading it back turns "the build
+ * failed" into "these rules failed, for these reasons, and every other one passed".
+ * <p>
+ * Verdicts are keyed by the name a pom addresses the rule with, which is the
+ * {@code @Named} name of the class behind it, so a caller names rules the way the
+ * configuration does rather than by class.
+ */
+final class EnforcerVerdicts {
+
+	/**
+	 * The rule line, whichever log level carried it. The class name butts against the
+	 * bracketed name with no space, and the group taken is that name.
+	 */
+	private static final Pattern VERDICT = Pattern.compile("Rule \\d+: \\S+\\((\\w+)\\) (passed|failed)");
+
+	/** The {@code [INFO] }/{@code [ERROR] } prefix Maven writes every line with. */
+	private static final Pattern LOG_LEVEL = Pattern.compile("^\\[[A-Z]+\\]\\s?");
+
+	/** Maven's link to its own help, which closes the block of failure messages. */
+	private static final String HELP_LINK = "-> [Help";
+
+	private static final String PASSED = "passed";
+
+	private final Map<String, String> failures = new LinkedHashMap<>();
+	private final Set<String> passes = new LinkedHashSet<>();
+
+	private String failing;
+	private final List<String> message = new ArrayList<>();
+
+	private EnforcerVerdicts() {
+	}
+
+	/** Every verdict {@code outcome}'s log carries, in the order maven-enforcer reported them. */
+	static EnforcerVerdicts in(BuildOutcome outcome) {
+		EnforcerVerdicts verdicts = new EnforcerVerdicts();
+		outcome.output().lines().forEach(verdicts::read);
+		verdicts.finishFailure();
+		return verdicts;
+	}
+
+	/** Whether the rule reported anything at all, which a rule that never ran does not. */
+	boolean reached(String rule) {
+		return passes.contains(rule) || failures.containsKey(rule);
+	}
+
+	/** Whether the rule passed. A rule that reached no verdict passed nothing. */
+	boolean passed(String rule) {
+		return passes.contains(rule);
+	}
+
+	/** Why the rule failed, or an empty string when it passed or never reported. */
+	String messageOf(String rule) {
+		return failures.getOrDefault(rule, "");
+	}
+
+	/** The rules that failed, for an assertion message that has to name them. */
+	Set<String> failed() {
+		return failures.keySet();
+	}
+
+	private void read(String line) {
+		String text = LOG_LEVEL.matcher(line).replaceFirst("");
+		Matcher verdict = VERDICT.matcher(text);
+		if (verdict.find()) {
+			start(verdict.group(1), PASSED.equals(verdict.group(2)));
+		} else if (text.startsWith(HELP_LINK)) {
+			finishFailure();
+		} else {
+			collect(text);
+		}
+	}
+
+	/**
+	 * A pass is recorded outright, since maven-enforcer says nothing more about it; a
+	 * failure is held open so the lines under it can be gathered as its message.
+	 */
+	private void start(String rule, boolean passed) {
+		finishFailure();
+		if (passed) {
+			passes.add(rule);
+		} else {
+			failing = rule;
+		}
+	}
+
+	/** Only the lines under an open failure are its message; everything else is build noise. */
+	private void collect(String text) {
+		if (failing != null && !text.isBlank()) {
+			message.add(text.strip());
+		}
+	}
+
+	private void finishFailure() {
+		if (failing != null) {
+			failures.put(failing, String.join(System.lineSeparator(), message));
+			failing = null;
+			message.clear();
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/FixtureProject.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/FixtureProject.java
@@ -238,60 +238,15 @@ final class FixtureProject {
 			Nothing here depends on anything.
 			""";
 
-	/**
-	 * The build itself. The rule jar is a plugin dependency rather than a project
-	 * dependency, because that is the only class path a maven-enforcer rule is loaded
-	 * from, and the whole configuration sits in one {@code validate}-phase execution
-	 * so a fixture build costs a second.
-	 */
-	private static final String POM_TEMPLATE = """
-			<project xmlns="http://maven.apache.org/POM/4.0.0">
-				<modelVersion>4.0.0</modelVersion>
-				<groupId>io.github.adamw7.enforcer.e2e</groupId>
-				<artifactId>fixture</artifactId>
-				<version>1.0</version>
-				<packaging>pom</packaging>
-				<build>
-					<plugins>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-enforcer-plugin</artifactId>
-							<version>%s</version>
-							<dependencies>
-								<dependency>
-									<groupId>%s</groupId>
-									<artifactId>%s</artifactId>
-									<version>%s</version>
-								</dependency>
-							</dependencies>
-							<executions>
-								<execution>
-									<id>enforce-claude-code</id>
-									<phase>validate</phase>
-									<goals>
-										<goal>enforce</goal>
-									</goals>
-									<configuration>
-										<rules>
-			%s
-										</rules>
-									</configuration>
-								</execution>
-							</executions>
-						</plugin>
-					</plugins>
-				</build>
-			</project>
-			""";
+	/** What the fixture's build calls itself, so a log says which project it came from. */
+	private static final String ARTIFACT_ID = "fixture";
 
 	private final Path root;
-	private final BuildEnvironment environment;
-	private final String enforcerPluginVersion;
+	private final EnforcerPom pom;
 
 	FixtureProject(Path root, BuildEnvironment environment, String enforcerPluginVersion) {
 		this.root = root;
-		this.environment = environment;
-		this.enforcerPluginVersion = enforcerPluginVersion;
+		this.pom = new EnforcerPom(environment, enforcerPluginVersion);
 	}
 
 	Path root() {
@@ -333,8 +288,7 @@ final class FixtureProject {
 
 	/** Writes the pom that runs {@code rulesXml}, and returns the project to build. */
 	FixtureProject enforcing(String rulesXml) {
-		write("pom.xml", POM_TEMPLATE.formatted(enforcerPluginVersion, BuildEnvironment.GROUP_ID,
-				BuildEnvironment.ARTIFACT_ID, environment.version(), rulesXml));
+		write("pom.xml", pom.enforcing(ARTIFACT_ID, rulesXml));
 		return this;
 	}
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/ForeignRepositoryEnforcementIT.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/ForeignRepositoryEnforcementIT.java
@@ -1,0 +1,377 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+import static io.github.adamw7.tools.test.TestFiles.writeString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Points every shipped rule at five <em>real</em> repositories, cloned from GitHub
+ * over the network, none of which has ever heard of this enforcer.
+ *
+ * <p>{@link EnforcerRuleBuildIT} proves the rules bind and fire, and
+ * {@link RepositoryEnforcementIT} proves the configuration this repository ships
+ * guards this repository. Both work on files written to be read by these rules:
+ * the fixture is laid out correctly on purpose so that breaking one thing proves
+ * one rule, and this checkout satisfies the contract because it was written to.
+ * Neither can answer the question an adopter asks first — what these rules do when
+ * they meet a project nobody prepared for them.
+ *
+ * <p>What is asserted is therefore not that a foreign repository passes: none of
+ * these five does, and none should. It is that every rule <em>reaches a verdict</em>
+ * on every one of them — a pass, or a failure with a message that names what is
+ * wrong — rather than failing the build on the rules' own account with an
+ * unbindable parameter, an internal error, or an exception escaping from a file it
+ * did not expect. A rule that reads a project correctly and a rule that breaks on it
+ * both leave a red build; only the log tells them apart, which is what
+ * {@link EnforcerVerdicts} reads.
+ *
+ * <p>The five are chosen for the shapes they put in front of the rules — an almost
+ * empty repository, a small one, a very large flat one, a real {@code .claude}
+ * directory somebody else wrote, and a real {@code CLAUDE.md} somebody else wrote —
+ * and every clone is shallow, so the whole class costs about as much as one of the
+ * builds it runs. Nothing is written to any of them: the enforcing build runs in a
+ * directory of its own and only the rule parameters point at a checkout.
+ */
+class ForeignRepositoryEnforcementIT {
+
+	/**
+	 * A repository worth pointing the rules at, and what it is that makes it worth
+	 * pointing them at — the second is quoted into every assertion message, so a
+	 * failure says which shape of project defeated a rule rather than only which URL.
+	 *
+	 * @param url   the clone URL, over HTTPS so no key is needed
+	 * @param shape what this repository holds that the fixture cannot imitate
+	 */
+	private record RealRepository(String url, String shape) {
+
+		@Override
+		public String toString() {
+			return GitClone.nameOf(url) + " (" + shape + ")";
+		}
+	}
+
+	private static final List<RealRepository> REPOSITORIES = List.of(
+			new RealRepository("https://github.com/octocat/Hello-World.git",
+					"one README and nothing else, so every rule is pointed at something absent"),
+			new RealRepository("https://github.com/octocat/Spoon-Knife.git",
+					"a small web page with no agent configuration of any kind"),
+			new RealRepository("https://github.com/github/gitignore.git",
+					"thousands of small files in one flat tree"),
+			new RealRepository("https://github.com/anthropics/claude-code.git",
+					"a real .claude/commands directory, and a .claude-plugin holding a "
+							+ "marketplace.json rather than the plugin.json a rule looks for"),
+			new RealRepository("https://github.com/anthropics/anthropic-quickstarts.git",
+					"a real CLAUDE.md, written by someone who never heard of these rules"));
+
+	/**
+	 * The property the harness pom addresses the checkout through. One pom serves all
+	 * five repositories because only this changes between them.
+	 */
+	private static final String REPOSITORY_PROPERTY = "claude.repository";
+
+	private static final String HARNESS_ARTIFACT_ID = "foreign-repository-harness";
+
+	/**
+	 * The rules whose file is optional, which must pass when a project does not ship
+	 * it. Each is paired with the path {@link RuleConfiguration#COMPLETE} points it at,
+	 * relative to the repository, so the expectation is checked only where the file
+	 * really is absent rather than assumed of every repository alike.
+	 */
+	private static final Map<String, String> OPTIONAL_RULE_TARGETS = Map.of(
+			"pluginFormat", ".claude-plugin/plugin.json",
+			"mcpServersValid", ".mcp.json",
+			"mcpConfigFormat", ".mcp.json",
+			"okfBundleFormat", "okf");
+
+	/**
+	 * Ways a build can go red that are the rules' fault rather than the project's. The
+	 * first is Plexus refusing to bind a configuration element — the failure
+	 * {@link EnforcerRuleBuildIT} provokes on purpose with a misspelled parameter — and
+	 * the rest are a rule breaking on input it did not expect instead of reporting it.
+	 */
+	private static final List<String> RULE_SIDE_FAILURES = List.of(
+			"Cannot find '",
+			"NullPointerException",
+			"ClassCastException",
+			"IndexOutOfBoundsException",
+			"StackOverflowError",
+			"OutOfMemoryError",
+			"Internal error in the plugin manager");
+
+	private static final String CLAUDE_MD_FORMAT = "claudeMdFormat";
+	private static final String CLAUDE_MD = "CLAUDE.md";
+
+	private static final String COMMAND_FORMAT = "commandFormat";
+	private static final String COMMANDS_DIRECTORY = ".claude/commands";
+	private static final String ABSENT_COMMANDS = "Commands directory does not exist";
+
+	/** The repository whose {@code .claude} directory somebody else wrote. */
+	private static final RealRepository WITH_AGENT_CONFIGURATION = named("claude-code");
+
+	/**
+	 * A repository with no agent configuration at all, which is the state a project is
+	 * in on the day it adopts one.
+	 */
+	private static final RealRepository WITHOUT_AGENT_CONFIGURATION = named("Spoon-Knife");
+
+	private static BuildEnvironment environment;
+	private static MavenBuild maven;
+	private static String enforcerPluginVersion;
+	private static List<Enforcement> enforcements;
+
+	/**
+	 * Class-scoped, because the clones and the five builds over them are what this
+	 * class costs and every test below reads the same results. The one test that
+	 * changes a checkout takes a fresh clone of its own into {@link #adoption}.
+	 */
+	@TempDir
+	static Path workspace;
+
+	@TempDir
+	Path adoption;
+
+	/** One repository, its checkout, and what the enforcing build over it said. */
+	private record Enforcement(RealRepository repository, Path checkout, BuildOutcome outcome,
+			EnforcerVerdicts verdicts) {
+	}
+
+	@BeforeAll
+	static void enforceEveryRepository() {
+		environment = new BuildEnvironment();
+		RepositoryPom repositoryPom = new RepositoryPom(environment.repositoryRoot());
+		enforcerPluginVersion = repositoryPom.pluginVersion("maven-enforcer-plugin");
+		maven = new MavenBuild(environment);
+		maven.publishRuleUnderTest(repositoryPom.pluginVersion("maven-install-plugin"));
+		enforcements = enforce(harness(), checkouts());
+	}
+
+	/**
+	 * The claim this class exists for. Every rule the module ships is asked about every
+	 * one of the five, and every one of them has to answer: a rule that reached no
+	 * verdict either never ran — a misspelled {@code @Named} name, an execution that
+	 * did not fire — or stopped the build before the ones after it could run, and in
+	 * both cases a project that trusted it is guarded by nothing.
+	 */
+	@Test
+	void everyShippedRuleReachesAVerdictOnEveryRealRepository() {
+		for (Enforcement enforcement : enforcements) {
+			for (String rule : ShippedRules.byName().keySet()) {
+				assertTrue(enforcement.verdicts().reached(rule),
+						() -> rule + " reached no verdict on " + enforcement.repository() + ": "
+								+ enforcement.outcome().describe());
+			}
+		}
+	}
+
+	/**
+	 * A red build is the expected outcome here — none of these repositories ships this
+	 * contract — but it has to be red for the project's reasons, not the rules'. An
+	 * unbindable parameter or an exception thrown out of a rule fails a build with a
+	 * message about the enforcer, which tells the adopter nothing about their project
+	 * and is indistinguishable, from the exit code alone, from a rule working
+	 * perfectly.
+	 */
+	@Test
+	void noRuleFailsARealRepositoryOnItsOwnAccount() {
+		for (Enforcement enforcement : enforcements) {
+			for (String failure : RULE_SIDE_FAILURES) {
+				assertFalse(enforcement.outcome().mentions(failure),
+						() -> "enforcing " + enforcement.repository() + " broke a rule rather than the project ("
+								+ failure + "): " + enforcement.outcome().describe());
+			}
+		}
+	}
+
+	/**
+	 * Every failure has to be actionable, which starts with saying something. A rule
+	 * that failed with an empty message leaves an adopter a red build and no sentence
+	 * to act on, and nothing in the exit code would show it.
+	 */
+	@Test
+	void everyRuleThatFailsARealRepositorySaysWhy() {
+		for (Enforcement enforcement : enforcements) {
+			for (String rule : enforcement.verdicts().failed()) {
+				assertFalse(enforcement.verdicts().messageOf(rule).isBlank(),
+						() -> rule + " failed " + enforcement.repository() + " without saying why: "
+								+ enforcement.outcome().describe());
+			}
+		}
+	}
+
+	/**
+	 * "Says why" is only worth something if the message is about the reader's project,
+	 * so one rule is followed all the way through: none of these five ships a document
+	 * titled {@code # CLAUDE.md} carrying the six required sections, so
+	 * {@code claudeMdFormat} fails every one of them, and whether the document is
+	 * absent or merely someone else's, what it failed with has to name it.
+	 *
+	 * <p>This is also what proves {@link EnforcerVerdicts} recovers the messages rather
+	 * than only the verdicts: a parser that lost them would leave every message empty,
+	 * and an empty message names nothing.
+	 */
+	@Test
+	void aRuleThatFailsARealRepositoryNamesTheDocumentItIsAbout() {
+		for (Enforcement enforcement : enforcements) {
+			assertTrue(enforcement.verdicts().messageOf(CLAUDE_MD_FORMAT).contains(CLAUDE_MD),
+					() -> CLAUDE_MD_FORMAT + " did not fail " + enforcement.repository() + " with a message naming "
+							+ CLAUDE_MD + ": " + enforcement.outcome().describe());
+		}
+	}
+
+	/**
+	 * Four rules target files a project need not have, and the documented behaviour is
+	 * that an absent one is a pass rather than a failure. That is exactly the promise a
+	 * repository adopting the rules one at a time depends on, and these five are where
+	 * it is really tested: the fixture ships all four files, so it can only show what
+	 * happens when they are there.
+	 *
+	 * <p>Each is checked only against the repositories that genuinely lack its file, so
+	 * a repository that grows an {@code .mcp.json} tomorrow moves out of this test's
+	 * scope instead of failing it for the wrong reason.
+	 */
+	@Test
+	void theOptionalRulesPassOnARepositoryThatShipsNoneOfTheirFiles() {
+		for (Enforcement enforcement : enforcements) {
+			OPTIONAL_RULE_TARGETS.forEach((rule, target) -> assertOptionalRulePasses(enforcement, rule, target));
+		}
+	}
+
+	/**
+	 * The one repository here that ships an agent configuration somebody else wrote. Its
+	 * command documents carry front matter this repository never invented — an
+	 * {@code allowed-tools} key the fixture's own commands do not use — and reading
+	 * them is the only thing in this class that puts a rule in front of real, foreign
+	 * front matter.
+	 *
+	 * <p>What is pinned is that the rule read those documents: a verdict reached, and
+	 * not the one it gives a directory that is not there. Whether it then approves of
+	 * them is the repository's business and may change with any commit; that it looked
+	 * is the rule's.
+	 */
+	@Test
+	void theRulesReadAForeignAgentConfigurationRatherThanReportingItAbsent() {
+		Enforcement enforcement = enforcementOf(WITH_AGENT_CONFIGURATION);
+		List<Path> commands = markdownIn(enforcement.checkout().resolve(COMMANDS_DIRECTORY));
+
+		assertFalse(commands.isEmpty(),
+				() -> WITH_AGENT_CONFIGURATION + " no longer ships command definitions under " + COMMANDS_DIRECTORY
+						+ ", so this test needs a repository that does");
+		assertTrue(enforcement.verdicts().reached(COMMAND_FORMAT),
+				() -> COMMAND_FORMAT + " reached no verdict: " + enforcement.outcome().describe());
+		assertFalse(enforcement.verdicts().messageOf(COMMAND_FORMAT).contains(ABSENT_COMMANDS),
+				() -> COMMAND_FORMAT + " reported " + commands.size() + " real command definition(s) absent: "
+						+ enforcement.outcome().describe());
+	}
+
+	/**
+	 * The other half of the claim: the rules are not only survivable but satisfiable
+	 * outside the repository that wrote them. A real checkout is adopted the way a
+	 * project would be — the contract's documents and {@code .claude} configuration
+	 * written into it — and the same complete configuration then passes, with the
+	 * repository's own files, its {@code .git} directory and its history still around
+	 * them.
+	 *
+	 * <p>It takes a clone of its own because it is the one test here that writes into a
+	 * checkout, and the five the other tests share are read as {@code git} produced
+	 * them.
+	 */
+	@Test
+	void aRealRepositorySatisfiesTheContractOnceItIsAdopted() {
+		Path checkout = GitClone.into(adoption, WITHOUT_AGENT_CONFIGURATION.url());
+		FixtureProject adopted = new FixtureProject(checkout, environment, enforcerPluginVersion)
+				.layOutWellFormedProject()
+				.enforcing(RuleConfiguration.complete().xml());
+
+		BuildOutcome outcome = maven.run(adopted.root(), "-N", "validate");
+
+		assertTrue(outcome.succeeded(),
+				() -> "the contract cannot be satisfied in " + WITHOUT_AGENT_CONFIGURATION + ": "
+						+ outcome.describe());
+	}
+
+	private void assertOptionalRulePasses(Enforcement enforcement, String rule, String target) {
+		Path file = enforcement.checkout().resolve(target);
+		if (!Files.exists(file)) {
+			assertTrue(enforcement.verdicts().passed(rule),
+					() -> rule + " must pass on " + enforcement.repository() + ", which has no " + target + ": "
+							+ enforcement.outcome().describe());
+		}
+	}
+
+	/**
+	 * The listed repository of that name. Two tests are about one repository each and
+	 * say which by name rather than by position, so reordering the list cannot quietly
+	 * point them at a different one.
+	 */
+	private static RealRepository named(String name) {
+		return REPOSITORIES.stream()
+				.filter(repository -> GitClone.nameOf(repository.url()).equals(name))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("No repository called " + name + " is listed"));
+	}
+
+	private Enforcement enforcementOf(RealRepository repository) {
+		return enforcements.stream()
+				.filter(enforcement -> enforcement.repository().equals(repository))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException(repository + " was not enforced"));
+	}
+
+	/**
+	 * The build that enforces a checkout, written once and outside every one of them.
+	 * The rules are addressed through a property rather than the project's own
+	 * directory, so the same pom serves each repository in turn and none of them is
+	 * given a {@code pom.xml} it did not have.
+	 */
+	private static Path harness() {
+		Path directory = workspace.resolve("harness");
+		String rules = RuleConfiguration.against("${" + REPOSITORY_PROPERTY + "}").xml();
+		writeString(directory.resolve("pom.xml"),
+				new EnforcerPom(environment, enforcerPluginVersion).enforcing(HARNESS_ARTIFACT_ID, rules));
+		return directory;
+	}
+
+	private static List<Path> checkouts() {
+		Path into = workspace.resolve("checkouts");
+		return REPOSITORIES.stream().map(repository -> GitClone.into(into, repository.url())).toList();
+	}
+
+	private static List<Enforcement> enforce(Path harness, List<Path> checkouts) {
+		List<Enforcement> results = new ArrayList<>();
+		for (int index = 0; index < REPOSITORIES.size(); index++) {
+			results.add(enforce(harness, REPOSITORIES.get(index), checkouts.get(index)));
+		}
+		return results;
+	}
+
+	private static Enforcement enforce(Path harness, RealRepository repository, Path checkout) {
+		BuildOutcome outcome = maven.run(harness, "-N", "validate",
+				"-D" + REPOSITORY_PROPERTY + "=" + checkout);
+		return new Enforcement(repository, checkout, outcome, EnforcerVerdicts.in(outcome));
+	}
+
+	/** The {@code *.md} files directly in a directory, and none when there is no directory. */
+	private static List<Path> markdownIn(Path directory) {
+		if (!Files.isDirectory(directory)) {
+			return List.of();
+		}
+		try (Stream<Path> entries = Files.list(directory)) {
+			return entries.filter(path -> path.getFileName().toString().endsWith(".md")).toList();
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not list " + directory, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/GitClone.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/GitClone.java
@@ -1,0 +1,134 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Clones a real repository, which is the only way to hand the rules a project this
+ * repository did not write. {@link FixtureProject} lays out every file the rules
+ * read and lays them out correctly, so it can prove a rule binds and a violation is
+ * reported — but every input it offers was written by someone who knew what the
+ * rules expect. A repository from GitHub was not, and that is the whole point of
+ * pointing the rules at one.
+ * <p>
+ * The clone is shallow and single-branch: only the working tree matters here, and a
+ * full history would spend minutes fetching commits nothing reads. Nothing is ever
+ * pushed, committed or written back — the checkout is read, and the enforcing build
+ * runs beside it rather than in it — so these clones may be taken as often as the
+ * integration suite likes.
+ */
+final class GitClone {
+
+	/**
+	 * Generous for repositories that are a megabyte or two, and short enough that a
+	 * stalled network fails the test in minutes rather than leaving failsafe's own
+	 * timeout to kill the fork and take the diagnosis with it.
+	 */
+	private static final long TIMEOUT_MINUTES = 3;
+
+	private static final String GIT_SUFFIX = ".git";
+
+	private GitClone() {
+	}
+
+	/**
+	 * Clones {@code url} into a directory of {@code workspace} named after the
+	 * repository, and answers that directory. The workspace is created if it is not
+	 * there, since it is what {@code git} is run from and a process cannot start in a
+	 * directory that does not exist.
+	 */
+	static Path into(Path workspace, String url) {
+		Path checkout = workspace.resolve(nameOf(url));
+		createDirectory(workspace);
+		run(workspace, List.of("git", "clone", "--depth", "1", "--single-branch", url, checkout.toString()));
+		return checkout;
+	}
+
+	/**
+	 * The repository's own name, which is what {@code git clone} would have called the
+	 * directory anyway. It is spelled out here rather than left to git so a caller can
+	 * name the checkout before the clone has run.
+	 */
+	static String nameOf(String url) {
+		String path = url.endsWith(GIT_SUFFIX) ? url.substring(0, url.length() - GIT_SUFFIX.length()) : url;
+		return path.substring(path.lastIndexOf('/') + 1);
+	}
+
+	/**
+	 * Output is merged into a temporary log and read back only to explain a failure:
+	 * a clone that worked has nothing to say, and one that did not is a broken test
+	 * environment rather than a failed expectation, so it is reported as an
+	 * {@link IllegalStateException} carrying what git said.
+	 */
+	private static void run(Path directory, List<String> command) {
+		Path log = temporaryFile();
+		try {
+			Process process = new ProcessBuilder(command)
+					.directory(directory.toFile())
+					.redirectErrorStream(true)
+					.redirectOutput(log.toFile())
+					.start();
+			requireSucceeded(process, command, log);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not run " + command, e);
+		} finally {
+			delete(log);
+		}
+	}
+
+	private static void requireSucceeded(Process process, List<String> command, Path log) {
+		if (exitCodeOf(process, command) != 0) {
+			throw new IllegalStateException(command + " failed: " + read(log));
+		}
+	}
+
+	private static int exitCodeOf(Process process, List<String> command) {
+		try {
+			if (!process.waitFor(TIMEOUT_MINUTES, TimeUnit.MINUTES)) {
+				process.destroyForcibly();
+				throw new IllegalStateException(command + " did not finish within " + TIMEOUT_MINUTES + " minutes");
+			}
+			return process.exitValue();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("Interrupted while waiting for " + command, e);
+		}
+	}
+
+	private static String read(Path log) {
+		try {
+			return new String(Files.readAllBytes(log), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read the clone log " + log, e);
+		}
+	}
+
+	private static void createDirectory(Path directory) {
+		try {
+			Files.createDirectories(directory);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create " + directory, e);
+		}
+	}
+
+	private static Path temporaryFile() {
+		try {
+			return Files.createTempFile("enforcer-clone", ".log");
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create a clone log", e);
+		}
+	}
+
+	private static void delete(Path path) {
+		try {
+			Files.deleteIfExists(path);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not delete " + path, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
@@ -246,6 +246,9 @@ final class RuleConfiguration {
 								</okfBundleFormat>
 			""";
 
+	/** What {@link #COMPLETE} addresses its files through: the project being built. */
+	private static final String PROJECT_BASEDIR = "${project.basedir}";
+
 	private final String xml;
 
 	RuleConfiguration(String xml) {
@@ -255,6 +258,25 @@ final class RuleConfiguration {
 	/** Every shipped rule, with every parameter it accepts, against the well-formed fixture. */
 	static RuleConfiguration complete() {
 		return new RuleConfiguration(COMPLETE);
+	}
+
+	/**
+	 * The same complete block, addressed at {@code baseDir} rather than at the project
+	 * whose build evaluates it. That separation is what lets
+	 * {@link ForeignRepositoryEnforcementIT} enforce a repository it did not write
+	 * without putting a {@code pom.xml} into it: the build runs in a directory of its
+	 * own, and only the rule parameters point at the checkout.
+	 * <p>
+	 * A directory a real repository has no reason to hold — {@code .claude/skills},
+	 * {@code okf} — stays configured on purpose. The claim under test is that a rule
+	 * pointed somewhere a project has nothing says so plainly, and a block that
+	 * quietly dropped those rules would be asserting the opposite.
+	 *
+	 * @param baseDir the directory to address, as a pom writes one: a literal path or
+	 *                a property expression Maven interpolates
+	 */
+	static RuleConfiguration against(String baseDir) {
+		return new RuleConfiguration(COMPLETE.replace(PROJECT_BASEDIR, baseDir));
 	}
 
 	String xml() {


### PR DESCRIPTION
EnforcerRuleBuildIT and RepositoryEnforcementIT both read files written to be
read by these rules: the fixture is well formed on purpose so that breaking one
thing proves one rule, and this checkout satisfies the contract because it was
written to. Neither answers what the rules do when they meet a project nobody
prepared for them, which is the first thing an adopter finds out.

ForeignRepositoryEnforcementIT points the complete rule configuration at
shallow clones of octocat/Hello-World, octocat/Spoon-Knife, github/gitignore,
anthropics/claude-code and anthropics/anthropic-quickstarts — an almost empty
repository, a small one, a very large flat one, a real .claude/commands
directory somebody else wrote, and a real CLAUDE.md somebody else wrote. None
of them passes and none should; what is asserted is that every rule reaches a
verdict on every one, says why when it fails, names the document it is about,
and never fails the build on the rules' own account. The four optional-file
rules are held to passing where the file really is absent, commandFormat is
held to reading anthropics/claude-code's real command definitions rather than
reporting them absent, and a sixth test adopts the contract into a fresh clone
and enforces it green, so the rules are shown satisfiable outside the
repository that wrote them.

EnforcerVerdicts reads maven-enforcer's per-rule passed/failed lines back out
of the build log, because an exit code cannot tell a rule that examined a
project from one that never ran — the failure the *ITs exist to catch.
RuleConfiguration.against addresses the block at a directory other than the
building project's, so the enforcing build runs beside a checkout instead of
in it and no clone is written to. The pom both fixtures build moves to
EnforcerPom so the two builds cannot drift apart.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0158YjEPQJnYSXUBpHHRpScH