### PR TITLE
fix(adopt): stop three tests describing POSIX on a host that has no executable bit

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildWrapper.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildWrapper.java
@@ -4,6 +4,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import io.github.adamw7.tools.adopt.Platform;
 import io.github.adamw7.tools.adopt.command.CommandLine;
@@ -30,6 +31,7 @@ final class BuildWrapper {
 
 	private final String fileName;
 	private final boolean windows;
+	private final Predicate<Path> executable;
 
 	/** The wrapper for the host platform: the Windows script there, the POSIX one everywhere else. */
 	BuildWrapper(String posixName, String windowsName) {
@@ -37,8 +39,21 @@ final class BuildWrapper {
 	}
 
 	BuildWrapper(String posixName, String windowsName, boolean windows) {
+		this(posixName, windowsName, windows, Files::isExecutable);
+	}
+
+	/**
+	 * The executable bit is read through {@code executable} rather than straight off
+	 * the filesystem, because the POSIX one a test needs to describe is not a state a
+	 * file can be put into on every host: Windows has no executable bit, so
+	 * {@link Files#isExecutable} answers for a plain file there and the shelled branch
+	 * below could not be reached on the platform whose wrappers most often need it.
+	 * Faking the host with {@code windows} alone left the other half of POSIX real.
+	 */
+	BuildWrapper(String posixName, String windowsName, boolean windows, Predicate<Path> executable) {
 		this.fileName = windows ? windowsName : posixName;
 		this.windows = windows;
+		this.executable = executable;
 	}
 
 	/**
@@ -80,7 +95,7 @@ final class BuildWrapper {
 	 * ever shelled: a {@code .bat}/{@code .cmd} is not a shell script.
 	 */
 	private List<String> launch(String wrapper) {
-		return windows || Files.isExecutable(Path.of(wrapper)) ? List.of(wrapper) : List.of(SHELL, wrapper);
+		return windows || executable.test(Path.of(wrapper)) ? List.of(wrapper) : List.of(SHELL, wrapper);
 	}
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -151,7 +151,7 @@ class BuildSystemsTest {
 	@Test
 	void aWrapperWithoutItsExecutableBitIsLaunchedThroughTheShell(@TempDir Path directory) throws IOException {
 		Path wrapper = Files.writeString(directory.resolve("gradlew"), "#!/bin/sh\n");
-		GradleBuildSystem gradle = new GradleBuildSystem(new BuildWrapper("gradlew", "gradlew.bat", false));
+		GradleBuildSystem gradle = new GradleBuildSystem(withoutTheExecutableBit("gradlew", "gradlew.bat"));
 		assertEquals(List.of("sh", wrapper.toAbsolutePath().toString(), "-q", "enforceClaudeMd"),
 				gradle.verifyCommand(directory));
 	}
@@ -165,7 +165,7 @@ class BuildSystemsTest {
 	void aShelledWrapperIsProbedThroughTheShellToo(@TempDir Path directory) throws IOException {
 		Path wrapper = Files.writeString(directory.resolve("mvnw"), "#!/bin/sh\n");
 		MavenBuildSystem maven = new MavenBuildSystem(new PomEnforcerInstaller("2.6.0"),
-				new BuildWrapper("mvnw", "mvnw.cmd", false));
+				withoutTheExecutableBit("mvnw", "mvnw.cmd"));
 		assertEquals(Optional.of(List.of("sh", wrapper.toAbsolutePath().toString(), "--version")),
 				maven.toolProbe(directory));
 	}
@@ -289,5 +289,15 @@ class BuildSystemsTest {
 		Files.writeString(wrapper, "#!/bin/sh\n");
 		assertTrue(wrapper.toFile().setExecutable(true), "could not make " + wrapper + " executable");
 		return wrapper;
+	}
+
+	/**
+	 * A POSIX host whose wrapper carries no executable bit. Both halves have to be
+	 * said: writing a file without the bit describes it on Linux and macOS, but
+	 * Windows has none to leave off, so {@link java.nio.file.Files#isExecutable}
+	 * answers true there and the wrapper would be expected to launch as a program.
+	 */
+	private BuildWrapper withoutTheExecutableBit(String posixName, String windowsName) {
+		return new BuildWrapper(posixName, windowsName, false, wrapper -> false);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildToolchainStepTest.java
@@ -184,10 +184,18 @@ class BuildToolchainStepTest {
 		RecordingCommandRunner runner = new RecordingCommandRunner();
 		Path wrapper = context.repositoryDirectory().resolve("gradlew").toAbsolutePath();
 
-		new BuildToolchainStep(List.of(new GradleBuildSystem(new BuildWrapper("gradlew", "gradlew.bat", false))))
-				.execute(context, runner);
+		new BuildToolchainStep(List.of(new GradleBuildSystem(withoutTheExecutableBit()))).execute(context, runner);
 
 		assertEquals(List.of("sh", wrapper.toString(), "--version"), runner.commandAt(0));
+	}
+
+	/**
+	 * A POSIX host whose wrapper carries no executable bit. Windows has none to leave
+	 * off, so writing the file without it describes the case only on Linux and macOS
+	 * and the bit has to be answered for rather than read off the filesystem.
+	 */
+	private BuildWrapper withoutTheExecutableBit() {
+		return new BuildWrapper("gradlew", "gradlew.bat", false, wrapper -> false);
 	}
 
 	private Path executableWrapper(AdoptionContext context) throws IOException {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStoreTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStoreTest.java
@@ -367,9 +367,17 @@ class ClaudeTrustStoreTest {
 		}
 	}
 
+	/**
+	 * Written through Jackson rather than concatenated, because the key is a path and
+	 * a Windows one carries backslashes: {@code C:\Users\...} pasted into a JSON
+	 * literal reads as the escapes {@code \U} and {@code \.}, so the document the
+	 * competing writer is supposed to have left was not parseable JSON at all there.
+	 */
 	private String trustDocument(Path directory) {
-		return "{\"projects\":{\"" + directory.toAbsolutePath().normalize()
-				+ "\":{\"hasTrustDialogAccepted\":true}}}";
+		ObjectNode root = MAPPER.createObjectNode();
+		root.putObject("projects").putObject(directory.toAbsolutePath().normalize().toString())
+				.put("hasTrustDialogAccepted", true);
+		return root.toString();
 	}
 
 	private Thread trusting(Path config, Path directory, CyclicBarrier startTogether) {


### PR DESCRIPTION
The Windows build failed five tests in this module, all of them the tests'
own platform assumptions rather than anything the adoption does wrong.

BuildWrapper already shells a wrapper whose executable bit the project never
committed, and already skips that on Windows, where a .cmd is not a shell
script. The three tests covering the shelled branch faked the host with the
constructor's windows flag but left the bit itself real, and Windows has none
to leave off: Files.isExecutable answers true for the plain file they write,
so the branch they exist for was unreachable on the one platform whose
wrappers most often arrive without the bit. The bit is now read through an
injected predicate, so the tests describe POSIX completely and keep covering
the branch everywhere instead of being skipped on Windows.

ClaudeTrustStoreTest built the competing writer's document by concatenating a
path into a JSON literal. A Windows temporary directory carries backslashes,
so C:\Users\... read as the escape \U and the document was not parseable JSON
— the two contention tests failed on the fixture, never on the store. It is
written through Jackson now, which escapes the key.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RavDsqtG9FHPWaBTxMWcfr