### PR TITLE
fix(markdown-common, claude-code-enforcer): close a code span on the run that opened it

### DIFF
--- a/.claude/skills/text-parsers/SKILL.md
+++ b/.claude/skills/text-parsers/SKILL.md
@@ -80,6 +80,15 @@ job now, and `FrontMatterTest` still pins every one of them.
   the remaining definitions' violations with it.
 - `withoutCodeSpans` before matching any markup. Documentation about Markdown
   writes its sample link or import in backticks precisely because it is a sample.
+- A span's delimiter is a **run** of backticks, closed by the next run of
+  *exactly* that length — not by a single backtick. A span whose content carries
+  a backtick can only be written with a longer run (``` ``a ` b`` ```), and
+  closing on the opening run's own second character tore it in half and handed
+  the content back as prose: ``` ``TODO`` ``` tripped the ban it was quoting,
+  ``` ``@docs/setup.md`` ``` was followed to a file nobody named, and a
+  ``` ``<!--`` ``` sample opened a comment nothing closed. A run nothing closes
+  is ordinary text and the scan carries on past it, so an odd backtick neither
+  swallows the line nor hides a real span later on it.
 - `write` refuses a symbolic link, so an auto-fix cannot be redirected through a
   planted link.
 - Strip the byte-order mark on read, once, centrally.

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -195,13 +195,19 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	 * When ordering is enforced, the required sections that are present must appear
 	 * in the same relative order as configured. Absent sections are already
 	 * reported by the section check, so only the present ones are compared here.
+	 * <p>
+	 * A section named twice in the configuration counts once, because that is how
+	 * {@link MarkdownDocument#headingsInOrder} reports the document's side of the
+	 * comparison: the document was expected to carry the repeated heading twice and
+	 * answered with the one heading it has, so a correctly ordered document was
+	 * reported as out of order and no edit to it could settle the complaint.
 	 */
 	private void collectOrderViolations(MarkdownDocument document, List<String> violations) {
 		if (!enforceSectionOrder) {
 			return;
 		}
 		Set<String> headings = document.headings();
-		List<String> expected = requiredSections().stream().filter(headings::contains).toList();
+		List<String> expected = requiredSections().stream().distinct().filter(headings::contains).toList();
 		List<String> actual = document.headingsInOrder(requiredSections());
 		if (!actual.equals(expected)) {
 			violations.add(documentName() + " sections are out of order; expected " + expected + " but found " + actual);

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -199,6 +199,21 @@ class ClaudeMdFormatRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
+	/**
+	 * A span written with a longer run of backticks quotes its content just as firmly,
+	 * and is the only way to quote content carrying a backtick. Closing the run on its
+	 * own second character handed the token back as prose, so a document that had
+	 * quoted the very token it bans was failed for carrying it — and no spelling of
+	 * the quote could have satisfied the rule.
+	 */
+	@Test
+	void ignoresAForbiddenTokenInsideALongerInlineCodeSpan() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nNever leave a ``TODO`` behind.\n");
+		rule.setForbiddenTokens(java.util.List.of("TODO"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
 	/** Commented-out text is inert, so a token an author retired no longer trips the ban. */
 	@Test
 	void ignoresAForbiddenTokenInsideAnHtmlComment() {
@@ -366,6 +381,23 @@ class ClaudeMdFormatRuleTest {
 	}
 
 	/**
+	 * The document's side of the comparison counts a heading once, so the
+	 * configuration's side must too. A section named twice in {@code requiredSections}
+	 * was expected twice and answered with the one heading the document carries, so a
+	 * correctly ordered document was reported as out of order — and no edit to it
+	 * could have settled the complaint, since adding the heading a second time does
+	 * not add it to the answer.
+	 */
+	@Test
+	void doesNotReportOutOfOrderWhenARequiredSectionIsConfiguredTwice() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
+		rule.setRequiredSections(java.util.List.of("## Project", "## Testing", "## Project"));
+		rule.setEnforceSectionOrder(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/**
 	 * A section configured without its {@code ##} is missing whatever the document
 	 * says, so the order check must not answer it with a line of prose and report
 	 * the same document as both missing the section and misordering it.
@@ -433,6 +465,21 @@ class ClaudeMdFormatRuleTest {
 
 		// Stopping at the first closing parenthesis truncated the target and reported
 		// the half of it that naturally does not exist.
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/**
+	 * A link quoted with a longer run of backticks is a sample the document shows, not
+	 * a reference it makes. Reading the run as a single backtick let the link out of
+	 * the span it was quoted in, and the rule went looking on disk for a file the
+	 * document had only ever illustrated.
+	 */
+	@Test
+	void ignoresALinkInsideALongerInlineCodeSpan() {
+		writeString(tempDir.resolve("AGENTS.md"), "# AGENTS.md");
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT + "\nA link is written ``[label](example.md)``.\n");
+		rule.setValidateFileReferences(true);
+
 		assertDoesNotThrow(rule::execute);
 	}
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
@@ -148,6 +148,19 @@ class ImportGraphTest {
 		assertEquals(List.of(), graphFrom(root).importsOf(root));
 	}
 
+	/**
+	 * A span written with a longer run of backticks quotes its content just as firmly.
+	 * Closing the run on its own second character let the path out of the span it was
+	 * shown in, so a sample import was followed to a file nobody meant to name and the
+	 * rule demanded it exist.
+	 */
+	@Test
+	void ignoresImportsInsideLongerInlineCodeSpans() {
+		File root = write("CLAUDE.md", "An import is written ``@docs/setup.md``.\n");
+
+		assertEquals(List.of(), graphFrom(root).importsOf(root));
+	}
+
 	@Test
 	void ignoresAHomeRelativeImport() {
 		File root = write("CLAUDE.md", "Also @~/personal/prefs.md is loaded.\n");

--- a/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownText.java
+++ b/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownText.java
@@ -5,8 +5,10 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
-import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
@@ -17,7 +19,13 @@ import java.util.stream.Stream;
 public final class MarkdownText {
 
 	private static final char BYTE_ORDER_MARK = (char) 0xFEFF;
-	private static final Pattern CODE_SPAN = Pattern.compile("`[^`]*`");
+	private static final char BACKTICK = '`';
+
+	/** What a code span is replaced by, so the words either side of it stay separate. */
+	private static final String SPAN_REPLACEMENT = " ";
+
+	/** No run of backticks closes this one. */
+	private static final int UNCLOSED = -1;
 
 	private MarkdownText() {
 	}
@@ -101,9 +109,82 @@ public final class MarkdownText {
 	 * writes a sample link or import inside backticks precisely because it is an
 	 * example, and a rule that followed it would report the sample's target as a
 	 * missing file.
+	 * <p>
+	 * A span is delimited as Markdown delimits one: a run of backticks is closed by
+	 * the next run of <em>exactly</em> the same length. Both halves of that matter,
+	 * because a span whose own content carries a backtick has to be written with a
+	 * longer run — {@code ``a ` b``} is the only way to quote {@code a ` b} at all.
+	 * Reading the delimiter as a single backtick instead tore such a span in half at
+	 * its second character and handed the content back as prose: a document that
+	 * wrote {@code ``TODO``} was reported as carrying the very token it had quoted,
+	 * a sample import written {@code ``@docs/setup.md``} was followed to a file
+	 * nobody meant to name, and a {@code ``<!--``} shown as an example opened a
+	 * comment nothing closed — masking every line below it, the document's own
+	 * headings included.
+	 * <p>
+	 * A run that no later run of its length closes is ordinary text, and the scan
+	 * carries on from the run after it, so an odd backtick neither swallows the rest
+	 * of the line nor hides a span written further along it.
 	 */
 	public static String withoutCodeSpans(String line) {
-		return CODE_SPAN.matcher(line).replaceAll(" ");
+		List<Backticks> runs = backtickRuns(line);
+		StringBuilder text = new StringBuilder();
+		int copied = 0;
+		int index = 0;
+		while (index < runs.size()) {
+			int closing = closingRun(runs, index);
+			if (closing == UNCLOSED) {
+				index++;
+			} else {
+				text.append(line, copied, runs.get(index).start()).append(SPAN_REPLACEMENT);
+				copied = runs.get(closing).end();
+				index = closing + 1;
+			}
+		}
+		return text.append(line, copied, line.length()).toString();
+	}
+
+	/** One maximal run of backticks: where it starts, and how many it runs. */
+	private record Backticks(int start, int length) {
+
+		int end() {
+			return start + length;
+		}
+	}
+
+	/**
+	 * The line's runs of backticks, in order. They are maximal, so two of them are
+	 * always separated by at least one other character — which is what lets a run be
+	 * compared with the next one by length alone.
+	 */
+	private static List<Backticks> backtickRuns(String line) {
+		List<Backticks> runs = new ArrayList<>();
+		int index = 0;
+		while (index < line.length()) {
+			int length = runLengthAt(line, index);
+			if (length > 0) {
+				runs.add(new Backticks(index, length));
+			}
+			index += Math.max(length, 1);
+		}
+		return runs;
+	}
+
+	private static int runLengthAt(String line, int start) {
+		int end = start;
+		while (end < line.length() && line.charAt(end) == BACKTICK) {
+			end++;
+		}
+		return end - start;
+	}
+
+	/** The first later run of the same length, or {@link #UNCLOSED} when none closes this one. */
+	private static int closingRun(List<Backticks> runs, int opening) {
+		int length = runs.get(opening).length();
+		return IntStream.range(opening + 1, runs.size())
+				.filter(index -> runs.get(index).length() == length)
+				.findFirst()
+				.orElse(UNCLOSED);
 	}
 
 	/**

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownDocumentTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownDocumentTest.java
@@ -771,6 +771,45 @@ class MarkdownDocumentTest {
 		assertTrue(document.containsInProse("TODO"));
 	}
 
+	/**
+	 * A span written with two backticks is quoted just as firmly as one written with
+	 * one. Closing the run on its own second character handed the content back as
+	 * prose, so a document that quoted the token it forbids was reported as carrying
+	 * it — with no spelling of the quote that could have satisfied the rule.
+	 */
+	@Test
+	void doesNotReadATokenInsideALongerInlineCodeSpanAsUnquoted() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				Never leave a ``TODO`` behind.
+				""");
+
+		assertFalse(document.containsUnquoted("TODO"));
+		assertTrue(document.containsInProse("TODO"));
+	}
+
+	/**
+	 * The same reading decides what opens an HTML comment, so a delimiter quoted with
+	 * a longer run is illustrated rather than written. Reading it as a real one opened
+	 * a block nothing closed and masked the document's remaining headings as inert.
+	 */
+	@Test
+	void doesNotOpenACommentOnADelimiterInsideALongerInlineCodeSpan() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				An HTML comment opens with ``<!--``.
+
+				## Testing
+				Body.
+				""");
+
+		assertEquals(List.of(), commentedLines(document));
+		assertEquals(Set.of("# Title", "## Testing"), document.headings());
+		assertTrue(document.hasBody("## Testing"));
+	}
+
 	@Test
 	void readsATokenOutsideACodeSpanOnTheSameLineAsUnquoted() {
 		MarkdownDocument document = MarkdownDocument.parse("""

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownTextTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownTextTest.java
@@ -122,6 +122,55 @@ class MarkdownTextTest {
 	}
 
 	@Test
+	void withoutCodeSpansReplacesASingleBacktickSpan() {
+		assertEquals("never leave a   behind", MarkdownText.withoutCodeSpans("never leave a `TODO` behind"));
+	}
+
+	/**
+	 * A run of two backticks is closed by a run of two, not by the second half of the
+	 * run that opened it. Reading the delimiter as one backtick tore the span apart at
+	 * its second character and handed {@code TODO} back as prose, so a rule forbidding
+	 * that token reported the very document that had quoted it.
+	 */
+	@Test
+	void withoutCodeSpansReplacesASpanWrittenWithALongerRun() {
+		assertEquals("never leave a   behind", MarkdownText.withoutCodeSpans("never leave a ``TODO`` behind"));
+		assertEquals("a   b", MarkdownText.withoutCodeSpans("a ```TODO``` b"));
+	}
+
+	/** The reason a longer run exists: it is the only way to quote content carrying a backtick. */
+	@Test
+	void withoutCodeSpansReplacesASpanCarryingABacktickOfItsOwn() {
+		assertEquals("a   b", MarkdownText.withoutCodeSpans("a ``x ` y`` b"));
+	}
+
+	/** A run of one does not close a run of three, so neither delimiter is read as the other's. */
+	@Test
+	void withoutCodeSpansLeavesARunNoLaterRunOfItsLengthCloses() {
+		assertEquals("a ``` x ` y", MarkdownText.withoutCodeSpans("a ``` x ` y"));
+	}
+
+	/**
+	 * The scan carries on past a run nothing closes rather than stopping at it, so an
+	 * odd backtick earlier in the line does not hide a real span further along it.
+	 */
+	@Test
+	void withoutCodeSpansReadsASpanFollowingAnUnclosedRun() {
+		assertEquals("`` a   b", MarkdownText.withoutCodeSpans("`` a `TODO` b"));
+	}
+
+	@Test
+	void withoutCodeSpansReplacesEverySpanOnTheLine() {
+		assertEquals("  and   and  ", MarkdownText.withoutCodeSpans("`a` and ``b`` and `c`"));
+	}
+
+	@Test
+	void withoutCodeSpansLeavesALineCarryingNoBacktickUnchanged() {
+		assertEquals("plain prose", MarkdownText.withoutCodeSpans("plain prose"));
+		assertEquals("", MarkdownText.withoutCodeSpans(""));
+	}
+
+	@Test
 	void readWrapsAReadFailureWithTheDescription() {
 		Path missing = tempDir.resolve("absent.md");
 


### PR DESCRIPTION
An inline code span was read as single-backtick-delimited, so a span written
with a longer run was torn in half at its own second character and its content
handed back as prose. A longer run is not a stylistic choice: it is the only way
to quote content that carries a backtick, which is exactly what documentation
about Markdown writes.

Every reader that asks withoutCodeSpans what is quoted was answered wrongly, and
each produced the failure that call exists to prevent:

- forbiddenTokens failed a document for the token it had quoted — ``TODO`` was
  reported as carrying TODO, with no spelling of the quote that could satisfy it;
- ImportGraph followed ``@docs/setup.md`` and demanded the sample file exist;
- validateFileReferences resolved ``[label](example.md)`` on disk and reported
  the sample target as missing;
- the comment scan read a ``<!--`` sample as a real delimiter, opening a block
  nothing closed and masking every line below it — the document's own headings
  included.

A span is now closed by the next run of exactly the length that opened it, and a
run nothing closes is ordinary text the scan carries on past, so an odd backtick
neither swallows the rest of the line nor hides a real span later on it. The
scanner replaces the regex because the rule is about matching run lengths, which
a fixed-width pattern cannot express.

Also counts a section named twice in requiredSections once when order is
enforced: the document's side of that comparison already de-duplicates, so a
correctly ordered document was reported as out of order and no edit to it could
have settled the complaint.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012xGj9vUkXpRJHTgWa8bBjp