### PR TITLE
fix(adopt): stop the conformer answering for a document its own edits changed

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -24,7 +24,10 @@ import io.github.adamw7.tools.markdown.MarkdownText;
  * is appended, and a required section left empty gets a stub body because the rule
  * fails an empty section just as it fails a missing one. Code — fenced or indented
  * — and commented-out text are left alone, mirroring how the rule matches, and
- * reshaping an already-conforming document is a no-op.
+ * reshaping an already-conforming document is a no-op. It is also repeated until the
+ * document stops changing, because an edit changes how the lines below it are read
+ * and so can undo a question the same pass had already answered — see
+ * {@link #conform}.
  *
  * <p>Which sections it demands is the caller's to choose, because the guard being
  * wired in differs by build system — see
@@ -87,6 +90,17 @@ public class ClaudeMdConformer {
 	/** The blank lines the reshape may leave at the end, dropped so the document keeps a single one. */
 	private static final Pattern TRAILING_BLANK_LINES = Pattern.compile("\\n\\s*+\\z");
 
+	/**
+	 * How many times {@link #conform} may run the pass before it stops waiting for the
+	 * document to settle. Two is the ordinary cost — one pass that reshapes and one
+	 * that confirms the reshape left nothing behind — and a third is spent only where
+	 * a pass's own edit reclassified a line an earlier part of that same pass had read.
+	 * The bound is what stops a document nothing settles from looping; such a document
+	 * comes back as the last pass left it, and {@link VerifyStep} refuses it before
+	 * anything is pushed.
+	 */
+	private static final int MAX_PASSES = 4;
+
 	private final List<String> requiredSections;
 
 	/** Conforms to the full {@code claudeMdFormat} contract. */
@@ -112,16 +126,58 @@ public class ClaudeMdConformer {
 	}
 
 	/**
+	 * Reshapes until the document stops changing, which is the only way one pass can
+	 * be trusted: an edit made part-way through a pass changes how the lines below it
+	 * are read, so a question the pass had already answered can stop being true before
+	 * the pass ends. Every edit here is one of those. Inserting the {@code AGENTS.md}
+	 * reference puts a blank line above what followed the title, and a blank line is
+	 * what lets the line below it open an indented code block, so a {@code ## Testing}
+	 * that had been a lazy continuation of a paragraph became code. Inserting a stub
+	 * puts a line at the margin, which ends an open list and lowers the column at
+	 * which the lines below quote code, so a fence delimiter indented inside that list
+	 * stopped being one — and the terminator already appended for it then
+	 * <em>opened</em> a block that swallowed everything after it. Renaming a near-miss
+	 * heading moves it to the margin and ends a list the same way. Each of those left
+	 * the reshape reporting work it had done on a document that no longer existed, and
+	 * {@link VerifyStep} failing on the file the adoption had just committed.
+	 *
+	 * <p>What makes repeating the pass an answer rather than a retry is that a pass
+	 * which changes nothing is exactly a document the rule accepts: the pass leaves a
+	 * title alone only where the rule finds one, leaves the reference alone only where
+	 * {@code containsInProse} finds one, and leaves a section alone only where the
+	 * rule's own lookup finds it carrying a body. So the loop ends on the very
+	 * condition the guard checks, and a document that already conforms settles on the
+	 * first pass — which is what keeps the reshape a no-op on re-adoption.
+	 *
 	 * @return {@code content} reshaped so the {@code claudeMdFormat} rule passes,
 	 *         with a single trailing newline
 	 */
 	public String conform(String content) {
+		String conformed = reshape(content);
+		for (int pass = 1; pass < MAX_PASSES; pass++) {
+			String settled = reshape(conformed);
+			if (settled.equals(conformed)) {
+				return conformed;
+			}
+			conformed = settled;
+		}
+		return conformed;
+	}
+
+	/**
+	 * One pass, with the two insertions that go above the document's body — the title
+	 * and the reference — made before a section is looked for. The loop above is what
+	 * makes the result sound whatever this order is, but settling those first is what
+	 * lets the ordinary generated document reshape in one pass rather than two, and a
+	 * pass that finds work left over appends it at the end of the file.
+	 */
+	private String reshape(String content) {
 		List<String> lines = splitLines(content);
 		closeUnterminatedBlocks(lines);
 		ensureTitle(lines);
+		ensureAgentsReference(lines);
 		canonicalizeHeadings(lines);
 		ensureRequiredSections(lines);
-		ensureAgentsReference(lines);
 		return join(lines);
 	}
 
@@ -250,28 +306,51 @@ public class ClaudeMdConformer {
 	}
 
 	/**
-	 * Gives every required section both a heading and a body: an absent section is
-	 * appended with a stub, and a heading the document left bare — typically a
-	 * near-miss renamed in place above — has one inserted beneath it. The rule fails
-	 * an empty section just as it fails a missing one, so both are settled here.
+	 * Gives every required section both a heading and a body: a heading the document
+	 * left bare — typically a near-miss renamed in place above — has a stub inserted
+	 * beneath it, and a section the document does not carry at all is appended with
+	 * one. The rule fails an empty section just as it fails a missing one, so both
+	 * are settled here.
+	 *
+	 * <p>The two are separate passes, with the document's blocks closed again between
+	 * them, because inserting a stub is a mid-document edit and a mid-document edit
+	 * can change what the lines below it are. A stub sits at the margin, which ends an
+	 * open list — and that lowers the column at which the lines below quote code, so a
+	 * fence delimiter indented inside that list stops being one. The terminator
+	 * {@link #closeUnterminatedBlocks} had already appended for it then <em>opened</em>
+	 * a block instead of closing one, and every section appended afterwards landed
+	 * inside it, where the rule reads it as code: the reshape handed
+	 * {@link VerifyStep} a document still missing the sections it had just written.
+	 * Interleaving the two passes has the same flaw one step further on, since a stub
+	 * inserted after a section was appended can bury that section the same way.
+	 * Appending, by contrast, only ever adds below every line that has been read, so
+	 * it can invalidate nothing.
 	 */
 	private void ensureRequiredSections(List<String> lines) {
-		requiredSections.forEach(required -> ensureSection(lines, required));
+		requiredSections.forEach(required -> stubBareSection(lines, required));
+		closeUnterminatedBlocks(lines);
+		requiredSections.forEach(required -> appendAbsentSection(lines, required));
 	}
 
 	/**
-	 * The document is read afresh per section because appending a section or
-	 * inserting a stub shifts the lines the next one is found at, and the sections
-	 * are few enough for that to stay cheap. Missing and empty are two answers to the
-	 * one heading lookup, so it is made once.
+	 * The document is read afresh per section because inserting a stub shifts the
+	 * lines the next one is found at, and the sections are few enough for that to stay
+	 * cheap. Missing and empty are two answers to the one heading lookup, so it is
+	 * made once: a section the document does not declare is left to
+	 * {@link #appendAbsentSection}.
 	 */
-	private void ensureSection(List<String> lines, String required) {
+	private void stubBareSection(List<String> lines, String required) {
 		MarkdownDocument document = MarkdownDocument.of(lines);
 		int index = document.headingIndex(required);
-		if (index < 0) {
-			lines.addAll(List.of("", required, "", STUB_BODY));
-		} else if (!document.hasBodyAt(index)) {
+		if (index >= 0 && !document.hasBodyAt(index)) {
 			lines.addAll(index + 1, List.of("", STUB_BODY));
+		}
+	}
+
+	/** Appends the section and its stub when the document declares the heading nowhere. */
+	private void appendAbsentSection(List<String> lines, String required) {
+		if (MarkdownDocument.of(lines).headingIndex(required) < 0) {
+			lines.addAll(List.of("", required, "", STUB_BODY));
 		}
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
@@ -399,6 +399,145 @@ class ClaudeMdConformerContractTest {
 	}
 
 	/**
+	 * An indented line directly below a paragraph is a lazy continuation of it rather
+	 * than code, so the {@code ## Testing} written there is a heading both readers
+	 * count — until a blank line appears above it, at which point it is an indented
+	 * code block and neither counts it. Adding the {@code AGENTS.md} reference puts
+	 * exactly that blank line there, so a reshape that settled its sections before
+	 * adding the reference read the section as present, appended nothing, and then
+	 * buried the heading it had been relying on. The adoption committed and pushed a
+	 * {@code CLAUDE.md} its own {@link VerifyStep} reports as missing {@code ##
+	 * Testing}.
+	 */
+	@Test
+	void appendsASectionTheAgentsReferenceIsAboutToBury() {
+		String generated = """
+				# CLAUDE.md
+				    ## Testing
+
+				Some prose about the project.
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Run `mvn install`.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Dependencies
+
+				Existing only.
+				""";
+
+		String conformed = conformer.conform(generated);
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformed);
+		assertSettled(conformed);
+	}
+
+	/**
+	 * A fence delimiter indented inside a list item is a delimiter, because the four
+	 * columns that quote code are counted from the item's content rather than from the
+	 * margin. Giving a bare section its stub puts a line at the margin, which ends the
+	 * list and so lowers that column — and the delimiter stops being one. The
+	 * terminator the reshape had already appended for the block it opened was then a
+	 * delimiter <em>opening</em> a block, and the sections appended after it landed
+	 * inside code, so the document came back still missing them.
+	 */
+	@Test
+	void appendsASectionOutsideAFenceItsOwnStubClosed() {
+		String generated = """
+				# CLAUDE.md
+
+				See [AGENTS.md](AGENTS.md) for the guide.
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Run `mvn install`.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				- the headings a generated file needs are:
+				    ## Testing
+				    ## Deployment
+				    ```
+				""";
+
+		String conformed = conformer.conform(generated);
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformed);
+		assertSettled(conformed);
+	}
+
+	/**
+	 * The same reclassification, against the reference rather than a section: the only
+	 * {@code AGENTS.md} mention sits inside a list item, where it is prose, and the
+	 * stub that gives {@code ## Testing} a body ends that list and turns the mention
+	 * into indented code. Whichever order the reshape settles the two in, one of them
+	 * can be undone by the other, which is why it repeats until the document stops
+	 * changing.
+	 */
+	@Test
+	void addsTheReferenceItsOwnStubTurnedIntoCode() {
+		String generated = """
+				# CLAUDE.md
+
+				## Project
+
+				A small command line utility.
+
+				## Java version
+
+				Java 25.
+
+				## Maven
+
+				Run `mvn install`.
+
+				## Principles for Java Development
+
+				SOLID.
+
+				## Dependencies
+
+				Existing only.
+
+				- the headings a generated file needs are:
+				    ## Testing
+				    ## Deployment
+
+				    See [AGENTS.md](AGENTS.md) for the companion guide.
+				""";
+
+		String conformed = conformer.conform(generated);
+
+		assertRuleRejects(generated);
+		assertRuleAccepts(conformed);
+		assertSettled(conformed);
+	}
+
+	/**
 	 * A lone fence delimiter shown four columns in is how a document explains what a
 	 * fence looks like, and the rule reads it as the indented code it is. A conformer
 	 * that marked fences before indents opened a block on it that nothing closed, read
@@ -592,6 +731,17 @@ class ClaudeMdConformerContractTest {
 
 		assertRuleAccepts(conforming);
 		assertRuleAccepts(conformer.conform(conforming));
+	}
+
+	/**
+	 * The reshape's own output has to be a document it then leaves alone. A re-adoption
+	 * runs the reshape over the file the last one committed, so an output the reshape
+	 * would edit again is a diff in every pull request that repository ever gets — and
+	 * the pass that changes nothing is precisely the pass whose result the rule accepts.
+	 */
+	private void assertSettled(String conformed) {
+		assertEquals(conformed, conformer.conform(conformed),
+				"conforming an already conformed document must change nothing:\n" + conformed);
 	}
 
 	private void assertRuleAccepts(String content) {


### PR DESCRIPTION
ClaudeMdConformer decided each question once and moved on, but every edit it
makes changes how the lines below it are read, so an answer could stop being
true before the reshape ended. Two ways it did, both leaving the adoption to
commit and push a CLAUDE.md its own VerifyStep rejects:

- Adding the AGENTS.md reference puts a blank line above what followed the
  title, and a blank line is what lets the line below it open an indented code
  block. A "## Testing" that had been a lazy continuation of a paragraph became
  code, so the sections — settled before the reference was added — counted a
  heading the finished document no longer carries.
- A stub body sits at the margin, which ends an open list and lowers the column
  at which the lines below quote code, so a fence delimiter indented inside that
  list stops being one. The terminator already appended for the block it opened
  then opened a block instead of closing one, and every section appended
  afterwards landed inside code.

Both are now avoided rather than papered over: the reference is settled before
the sections, the stubs are inserted before anything is appended and the
document's blocks closed again in between, and the whole pass repeats until the
document stops changing. That last part is what makes the result sound, because
a pass that changes nothing is exactly a document the rule accepts — it leaves a
title, a reference and a section alone only where the rule's own lookups find
them. Both failures were also non-idempotent, so a re-adoption kept rewriting
the file.

Found by running the real claudeMdFormat rule over the conformer's output for
several hundred thousand generated documents; the three cases that shrank out of
it are pinned in ClaudeMdConformerContractTest, which now also asserts the
reshape leaves its own output alone.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CC6TnyQSW5H15Jekg8mhhH