### PR TITLE
fix(markdown-common): read a line's comment delimiters without recursing on each

### DIFF
--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
@@ -8,6 +8,9 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.Test;
@@ -35,6 +38,60 @@ import io.github.adamw7.tools.enforcer.doc.ClaudeMdFormatRule;
  * @see ClaudeMdFormatRule#validating(java.io.File)
  */
 class ClaudeMdConformerContractTest {
+
+	/**
+	 * The lines the two readers have to agree about: the required headings and the
+	 * near-misses {@code claude init} writes instead, the two ways Markdown quotes
+	 * code and the delimiters that open each, the list item an indent is measured
+	 * from, the comment delimiters that make text inert, and the prose that has to
+	 * survive all of it. A generated document is a sequence of these.
+	 */
+	private static final List<String> FRAGMENTS = List.of(
+			"# CLAUDE.md",
+			"# my-project",
+			"## Project",
+			"## Project purpose",
+			"## Java version",
+			"## Maven",
+			"## Maven module structure",
+			"## Principles for Java Development",
+			"## Principles for Java development",
+			"## Testing",
+			"## Testing ##",
+			"##  Testing",
+			"## Dependencies",
+			"## Overview",
+			"### A sub-section",
+			"#1 rule: run mvn install",
+			"Some prose about the project.",
+			"See [AGENTS.md](AGENTS.md) for the guide.",
+			"An `AGENTS.md` is written beside it.",
+			"",
+			"```",
+			"```java",
+			"````",
+			"~~~",
+			"    ```",
+			"    ## Testing",
+			"    See [AGENTS.md](AGENTS.md) for the companion guide.",
+			"    indented prose",
+			"\t## Testing",
+			"- the headings a generated file needs are:",
+			"1. an ordered item",
+			"    ## Deployment",
+			"<!--",
+			"-->",
+			"<!-- ## Testing -->",
+			"Superseded: <!--",
+			"mvn install");
+
+	/**
+	 * How many generated documents the contract is checked over. Enough to walk the
+	 * combinations the fixtures above were each found by, and few enough to stay well
+	 * inside the per-test timeout — every one of them writes a file and runs the real
+	 * rule over it.
+	 */
+	private static final int GENERATED_DOCUMENTS = 250;
 
 	private final ClaudeMdConformer conformer = new ClaudeMdConformer();
 
@@ -731,6 +788,43 @@ class ClaudeMdConformerContractTest {
 
 		assertRuleAccepts(conforming);
 		assertRuleAccepts(conformer.conform(conforming));
+	}
+
+	/**
+	 * The same contract over documents nobody wrote by hand. Every case above is a
+	 * shape the reshape was once wrong about, and each was found on a real repository
+	 * rather than by reading the code: the two readings drift where a heading, a
+	 * fence, an indent, a list item and a comment delimiter <em>meet</em>, and which
+	 * combinations do that is not something a fixture list can be argued to cover.
+	 * Building documents out of exactly those fragments walks the combinations
+	 * instead.
+	 * <p>
+	 * The seeds are fixed, so a failure names a document that can be pasted back into
+	 * a case of its own — which is what such a failure should become. Settling is
+	 * asserted alongside acceptance because a reshape that keeps editing an accepted
+	 * document puts a fresh diff in every pull request the repository ever gets.
+	 */
+	@Test
+	void conformsGeneratedDocumentsBuiltFromTheFragmentsTheTwoReadersDisagreeOver() {
+		for (int seed = 0; seed < GENERATED_DOCUMENTS; seed++) {
+			String generated = documentFrom(seed);
+			String conformed = conformer.conform(generated);
+			assertRuleAccepts(conformed);
+			assertEquals(conformed, conformer.conform(conformed),
+					"seed " + seed + " does not settle; conformed from:\n" + generated);
+		}
+	}
+
+	/**
+	 * A document of between one and thirty {@link #FRAGMENTS}, drawn by a generator
+	 * the seed alone decides, so the same seed is the same document on every run and
+	 * on every machine.
+	 */
+	private static String documentFrom(int seed) {
+		Random random = new Random(seed);
+		return random.ints(1 + random.nextInt(30), 0, FRAGMENTS.size())
+				.mapToObj(FRAGMENTS::get)
+				.collect(Collectors.joining("\n", "", "\n"));
 	}
 
 	/**

--- a/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownDocument.java
+++ b/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownDocument.java
@@ -514,7 +514,7 @@ public final class MarkdownDocument {
 		}
 		String read = asRead(line, open);
 		mask[index] = open || opensBlock(read);
-		return remainsOpen(read, 0, open);
+		return remainsOpen(read, open);
 	}
 
 	/**
@@ -539,18 +539,37 @@ public final class MarkdownDocument {
 
 	/** True when the line's own content starts a comment that the same line does not close. */
 	private static boolean opensBlock(String line) {
-		return line.startsWith(COMMENT_START) && remainsOpen(line, 0, false);
+		return line.startsWith(COMMENT_START) && remainsOpen(line, false);
 	}
 
 	/**
-	 * Whether a comment is open once {@code line} has been read from {@code from},
+	 * Whether a comment is open once the whole of {@code line} has been read,
 	 * following each delimiter in turn: an open comment looks for its {@code -->},
 	 * a closed one for the next {@code <!--}.
+	 * <p>
+	 * The delimiters are followed in a loop rather than by recursing on the rest of
+	 * the line, because the line is content this reader does not control: a document
+	 * carrying a few thousand delimiters on one line — a generated or minified line
+	 * is all it takes — recursed once per delimiter and overflowed the stack. A
+	 * {@link StackOverflowError} is no kind of verdict: it aborts the Maven build as
+	 * an internal error rather than as the violation a rule exists to report, and it
+	 * is not a {@code RuntimeException}, so the adoption's batch loop — which keeps
+	 * one repository's failure from stopping the rest — does not catch it either.
 	 */
-	private static boolean remainsOpen(String line, int from, boolean open) {
-		String delimiter = open ? COMMENT_END : COMMENT_START;
-		int next = line.indexOf(delimiter, from);
-		return next < 0 ? open : remainsOpen(line, next + delimiter.length(), !open);
+	private static boolean remainsOpen(String line, boolean open) {
+		boolean inside = open;
+		int next = line.indexOf(commentDelimiter(inside));
+		while (next >= 0) {
+			int after = next + commentDelimiter(inside).length();
+			inside = !inside;
+			next = line.indexOf(commentDelimiter(inside), after);
+		}
+		return inside;
+	}
+
+	/** What the scan looks for next: an open comment its end, a closed one the next start. */
+	private static String commentDelimiter(boolean open) {
+		return open ? COMMENT_END : COMMENT_START;
 	}
 
 	/**

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownDocumentTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownDocumentTest.java
@@ -971,6 +971,52 @@ class MarkdownDocumentTest {
 		assertTrue(MarkdownDocument.headingOf("body").isEmpty());
 	}
 
+	/**
+	 * A line carrying thousands of comment delimiters is read without recursing once
+	 * per delimiter. The reader is pointed at documents it does not control — the
+	 * {@code CLAUDE.md} of any repository the adoption is handed — and a generated or
+	 * minified line is all it takes to reach this count. Following the delimiters by
+	 * recursion overflowed the stack from a few thousand pairs onward, which is no
+	 * kind of verdict: it aborts the build as an internal error rather than as a
+	 * violation, and being an {@link Error} rather than a {@link RuntimeException} it
+	 * escapes the adoption's batch loop and stops every repository behind it too.
+	 */
+	@Test
+	void readsALineOfManyCommentDelimitersWithoutExhaustingTheStack() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				%s
+
+				## Testing
+				body
+				""".formatted("<!-- sample -->".repeat(20_000)));
+
+		assertTrue(document.hasHeading("## Testing"));
+		assertTrue(document.hasBody("## Testing"));
+		assertEquals(List.of(), commentedLines(document));
+		assertTrue(document.openCommentTerminator().isEmpty());
+	}
+
+	/**
+	 * The same line left open by a final delimiter still hides what follows it, so the
+	 * loop that replaced the recursion carries the same answer out of the line.
+	 */
+	@Test
+	void aLineOfManyCommentDelimitersLeftOpenStillHidesWhatFollows() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				%s<!--
+
+				## Testing
+				body
+				""".formatted("<!-- sample -->".repeat(20_000)));
+
+		assertFalse(document.hasHeading("## Testing"));
+		assertEquals("-->", document.openCommentTerminator().orElseThrow());
+	}
+
 	private static String terminatorOf(String content) {
 		return MarkdownDocument.parse(content).openFenceTerminator().orElseThrow();
 	}


### PR DESCRIPTION
The HTML-comment scan followed each delimiter on a line by recursing on the
rest of that line, so a line carrying a few thousand `<!-- -->` pairs
overflowed the stack: from ~5000 pairs onward, MarkdownDocument.parse threw
StackOverflowError.

The reader is pointed at documents nobody here controls — the CLAUDE.md,
AGENTS.md and README.md of any repository the adoption is handed — and a
generated or minified line is all it takes to reach that count. A
StackOverflowError is no kind of verdict: it aborts the Maven build as an
internal error rather than as the violation a rule exists to report, and being
an Error rather than a RuntimeException it also escapes BatchAdoption's catch,
so one repository's odd document stops every repository behind it.

Follow the delimiters in a loop instead. The `from` parameter went with the
recursion, and the delimiter a given state looks for is named once.

Both regression tests fail with StackOverflowError on the previous reader and
pass in 4 ms on this one.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AXpxpxU5p1Xc2cGxANh7ky