### PR TITLE
refactor(adopt, claude-code-enforcer): stop the tests re-deriving what the code already answers

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractWrappedBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractWrappedBuildSystem.java
@@ -15,25 +15,36 @@ import java.util.Optional;
  */
 abstract class AbstractWrappedBuildSystem implements BuildSystem {
 
+	private final String name;
 	private final String tool;
 	private final List<String> verifyArguments;
 	private final BuildWrapper wrapper;
 
 	/**
-	 * @param tool            the program to launch when the checkout ships no wrapper,
-	 *                        and the name this build system reports
+	 * The name and the program are taken separately because they are not always the
+	 * same word: Maven builds are run with {@code mvn} but the build system is called
+	 * {@code maven}, in the log line naming what a checkout builds with and in the
+	 * advice {@link BuildSystem#toolAdvice()} gives. Declaring the program as both let
+	 * the base report a name no subclass wanted, which Maven then had to override —
+	 * so the one build system whose two differ was also the one whose name this class
+	 * did not decide.
+	 *
+	 * @param name            what this build system is called in a message
+	 * @param tool            the program to launch when the checkout ships no wrapper
 	 * @param verifyArguments the arguments that run the wired-in guard
 	 * @param wrapper         the wrapper script to prefer over {@code tool}
 	 */
-	protected AbstractWrappedBuildSystem(String tool, List<String> verifyArguments, BuildWrapper wrapper) {
+	protected AbstractWrappedBuildSystem(String name, String tool, List<String> verifyArguments,
+			BuildWrapper wrapper) {
+		this.name = name;
 		this.tool = tool;
 		this.verifyArguments = List.copyOf(verifyArguments);
 		this.wrapper = wrapper;
 	}
 
 	@Override
-	public String name() {
-		return tool;
+	public final String name() {
+		return name;
 	}
 
 	@Override

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
@@ -33,8 +33,9 @@ public class GradleBuildSystem extends AbstractWrappedBuildSystem {
 		this(new BuildWrapper("gradlew", "gradlew.bat"));
 	}
 
+	/** Gradle's name and its program are the one word, unlike Maven's. */
 	GradleBuildSystem(BuildWrapper wrapper) {
-		super(GRADLE, VERIFY_ARGUMENTS, wrapper);
+		super(GRADLE, GRADLE, VERIFY_ARGUMENTS, wrapper);
 	}
 
 	@Override

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -19,6 +19,7 @@ import java.util.Optional;
  */
 public class MavenBuildSystem extends AbstractWrappedBuildSystem {
 
+	private static final String NAME = "maven";
 	private static final String MAVEN = "mvn";
 	private static final List<String> VERIFY_ARGUMENTS = List.of("-q", "-N", "validate");
 
@@ -44,13 +45,8 @@ public class MavenBuildSystem extends AbstractWrappedBuildSystem {
 	}
 
 	MavenBuildSystem(PomEnforcerInstaller installer, BuildWrapper wrapper) {
-		super(MAVEN, VERIFY_ARGUMENTS, wrapper);
+		super(NAME, MAVEN, VERIFY_ARGUMENTS, wrapper);
 		this.installer = installer;
-	}
-
-	@Override
-	public String name() {
-		return "maven";
 	}
 
 	@Override

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerContractTest.java
@@ -1,12 +1,10 @@
 package io.github.adamw7.tools.adopt.step;
 
+import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Random;
@@ -92,6 +90,47 @@ class ClaudeMdConformerContractTest {
 	 * rule over it.
 	 */
 	private static final int GENERATED_DOCUMENTS = 250;
+
+	/**
+	 * A document the rule accepts and the reshape therefore has to leave exactly as
+	 * it is. The cases about what the reshape leaves alone each vary one section's
+	 * body — see {@link #conformingWith} — so what such a case is about is the body
+	 * it names rather than the twenty-five conforming lines around it, which were
+	 * spelled out again per case and drifted into three near-copies of one document.
+	 */
+	private static final String CONFORMING = """
+			# CLAUDE.md
+
+			See [AGENTS.md](AGENTS.md) for the full agent guide.
+
+			## Project
+
+			A small command line utility.
+
+			## Java version
+
+			Java 25.
+
+			## Maven
+
+			Run `mvn install`.
+
+			## Principles for Java Development
+
+			SOLID.
+
+			## Testing
+
+			JUnit 5.
+
+			## Dependencies
+
+			Ask before adding a new one.
+			""";
+
+	/** The {@link #CONFORMING} bodies a case may replace, each the whole content of its section. */
+	private static final String PROJECT_BODY = "A small command line utility.";
+	private static final String MAVEN_BODY = "Run `mvn install`.";
 
 	private final ClaudeMdConformer conformer = new ClaudeMdConformer();
 
@@ -630,39 +669,12 @@ class ClaudeMdConformerContractTest {
 	 */
 	@Test
 	void leavesADocumentCarryingAnIndentedFenceSampleUnchanged() {
-		String conforming = """
-				# CLAUDE.md
-
-				See [AGENTS.md](AGENTS.md) for the full agent guide.
-
-				## Project
-
-				A small command line utility.
-
-				## Java version
-
-				Java 25.
-
-				## Maven
-
+		String conforming = conformingWith(MAVEN_BODY, """
 				A fenced block opens with a line like this:
 
 				    ```
 
-				and closes with the same run.
-
-				## Principles for Java Development
-
-				SOLID.
-
-				## Testing
-
-				JUnit 5.
-
-				## Dependencies
-
-				Ask before adding a new one.
-				""";
+				and closes with the same run.""");
 
 		assertRuleAccepts(conforming);
 		assertEquals(conforming, conformer.conform(conforming));
@@ -674,37 +686,10 @@ class ClaudeMdConformerContractTest {
 	 */
 	@Test
 	void leavesADocumentWhoseSectionBodyContinuesAListItemUnchanged() {
-		String conforming = """
-				# CLAUDE.md
-
-				See [AGENTS.md](AGENTS.md) for the full agent guide.
-
-				## Project
-
+		String conforming = conformingWith(PROJECT_BODY, """
 				- the modules are:
 
-				    `data`, `code`, and `adopt` are the reactor modules.
-
-				## Java version
-
-				Java 25.
-
-				## Maven
-
-				Run `mvn install`.
-
-				## Principles for Java Development
-
-				SOLID.
-
-				## Testing
-
-				JUnit 5.
-
-				## Dependencies
-
-				Ask before adding a new one.
-				""";
+				    `data`, `code`, and `adopt` are the reactor modules.""");
 
 		assertRuleAccepts(conforming);
 		assertEquals(conforming, conformer.conform(conforming));
@@ -718,37 +703,7 @@ class ClaudeMdConformerContractTest {
 	 */
 	@Test
 	void leavesADocumentOpeningWithAByteOrderMarkAcceptableAndTitledOnce() {
-		String conforming = """
-				# CLAUDE.md
-
-				See [AGENTS.md](AGENTS.md) for the full agent guide.
-
-				## Project
-
-				A small command line utility.
-
-				## Java version
-
-				Java 25.
-
-				## Maven
-
-				Run `mvn install`.
-
-				## Principles for Java Development
-
-				SOLID.
-
-				## Testing
-
-				JUnit 5.
-
-				## Dependencies
-
-				Ask before adding a new one.
-				""";
-
-		String conformed = conformer.conform("\uFEFF" + conforming);
+		String conformed = conformer.conform("\uFEFF" + CONFORMING);
 		assertRuleAccepts(conformed);
 		assertEquals(1, conformed.lines().filter("# CLAUDE.md"::equals).count(),
 				"the rule reads the title through the mark, so the reshape must not add another:\n" + conformed);
@@ -756,38 +711,8 @@ class ClaudeMdConformerContractTest {
 
 	@Test
 	void leavesADocumentThatAlreadySatisfiesTheRuleAcceptable() {
-		String conforming = """
-				# CLAUDE.md
-
-				See [AGENTS.md](AGENTS.md) for the full agent guide.
-
-				## Project
-
-				A small command line utility.
-
-				## Java version
-
-				Java 25.
-
-				## Maven
-
-				Run `mvn install`.
-
-				## Principles for Java Development
-
-				SOLID.
-
-				## Testing
-
-				JUnit 5.
-
-				## Dependencies
-
-				Ask before adding a new one.
-				""";
-
-		assertRuleAccepts(conforming);
-		assertRuleAccepts(conformer.conform(conforming));
+		assertRuleAccepts(CONFORMING);
+		assertRuleAccepts(conformer.conform(CONFORMING));
 	}
 
 	/**
@@ -848,12 +773,17 @@ class ClaudeMdConformerContractTest {
 	}
 
 	private ClaudeMdFormatRule ruleFor(String content) {
-		Path file = tempDir.resolve("CLAUDE.md");
-		try {
-			Files.writeString(file, content);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not write " + file, e);
-		}
-		return ClaudeMdFormatRule.validating(file.toFile());
+		return ClaudeMdFormatRule.validating(writeString(tempDir.resolve("CLAUDE.md"), content).toFile());
+	}
+
+	/**
+	 * {@link #CONFORMING} with one section's body replaced, so a case about how a
+	 * particular body is read shows only that body.
+	 *
+	 * @param body        the body to replace, one of the constants above
+	 * @param replacement what the section carries instead
+	 */
+	private static String conformingWith(String body, String replacement) {
+		return CONFORMING.replace(body, replacement);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -4,18 +4,47 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.markdown.MarkdownDocument;
 
 class ClaudeMdConformerTest {
 
 	private final ClaudeMdConformer conformer = new ClaudeMdConformer();
 
+	/**
+	 * The headings a reshaped document carries, read with {@link MarkdownDocument} —
+	 * the very reader {@link ClaudeMdConformer} rewrites through and the
+	 * {@code claudeMdFormat} rule judges the result with. So a heading inside a fence,
+	 * an indented sample or an HTML comment is code here exactly as it is there, and a
+	 * heading is the text it names rather than the line it was typed on.
+	 *
+	 * <p>These tests used to spell that reading out again in a hundred lines of
+	 * fence and comment tracking of their own, which is a third implementation of a
+	 * question two production classes already answer together — kept equal to them
+	 * only by being edited alongside them. What keeps the reshape honest against an
+	 * <em>independent</em> reader is {@link ClaudeMdConformerContractTest}, which runs
+	 * the real rule over the real output.
+	 *
+	 * <p>Duplicates are kept, unlike {@link MarkdownDocument#headings()}, because a
+	 * section written twice is exactly what some of these tests are about.
+	 */
 	private List<String> headings(String content) {
-		return content.lines().map(String::strip).filter(line -> line.startsWith("#")).toList();
+		MarkdownDocument document = MarkdownDocument.parse(content);
+		return document.structuralLines(line -> MarkdownDocument.headingOf(line).isPresent())
+				.mapToObj(document::line)
+				.map(MarkdownDocument::headingOf)
+				.flatMap(Optional::stream)
+				.toList();
+	}
+
+	/** Whether the section carries a body, as the rule counts one. */
+	private boolean hasBody(String content, String section) {
+		return MarkdownDocument.parse(content).hasBody(section);
 	}
 
 	@Test
@@ -104,17 +133,6 @@ class ClaudeMdConformerTest {
 				"every original body must survive exactly once:\n" + conformed);
 		assertFalse(conformed.contains("Content.\n\n" + ClaudeMdConformer.STUB_BODY),
 				"a section that already has a body must not be given a stub");
-	}
-
-	/**
-	 * Mirrors the enforcer rule's own check: the section must carry something other
-	 * than blank lines before the next heading at its level or shallower.
-	 */
-	private boolean hasBody(String content, String section) {
-		List<String> lines = content.lines().map(String::strip).toList();
-		int start = lines.indexOf(section);
-		return start >= 0 && lines.stream().skip(start + 1L).dropWhile(String::isEmpty).findFirst()
-				.filter(line -> !line.startsWith("## ")).isPresent();
 	}
 
 	@Test
@@ -440,14 +458,8 @@ class ClaudeMdConformerTest {
 				A repo.
 				""";
 		String conformed = conformer.conform(generated);
-		assertTrue(referencesAgentsMdOutsideFences(conformed),
+		assertTrue(MarkdownDocument.parse(conformed).containsInProse(ClaudeMdConformer.AGENTS_REFERENCE),
 				"a mention that only exists as a code sample does not satisfy the rule:\n" + conformed);
-	}
-
-	/** Mirrors how the rule looks for the reference: fenced lines do not count. */
-	private boolean referencesAgentsMdOutsideFences(String content) {
-		return linesOutsideFences(content).stream()
-				.anyMatch(line -> line.contains(ClaudeMdConformer.AGENTS_REFERENCE));
 	}
 
 	@Test
@@ -491,7 +503,7 @@ class ClaudeMdConformerTest {
 	@Test
 	void closesAnUnterminatedFenceSoAppendedSectionsStayDocumentStructure() {
 		String conformed = conformer.conform(UNTERMINATED_FENCE);
-		assertTrue(headingsOutsideFences(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
+		assertTrue(headings(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
 				"every appended section must be a heading, not code:\n" + conformed);
 		assertTrue(conformed.contains("class Foo {}"), "the code block keeps its content:\n" + conformed);
 	}
@@ -563,11 +575,6 @@ class ClaudeMdConformerTest {
 		assertEquals(headings.stream().distinct().toList(), headings, "no heading may be written twice: " + headings);
 	}
 
-	/** Mirrors how the rule finds headings: a heading inside a fence is code, not structure. */
-	private List<String> headingsOutsideFences(String content) {
-		return linesOutsideFences(content).stream().filter(line -> line.startsWith("#")).toList();
-	}
-
 	/**
 	 * A {@code ````} wrapper holding a {@code ```} sample is one code block to the
 	 * rule, which ends a fence only on a run at least as long as the one that opened
@@ -595,9 +602,9 @@ class ClaudeMdConformerTest {
 				````
 				""";
 		String conformed = conformer.conform(generated);
-		assertTrue(headingsOutsideFences(conformed).contains("## Testing"),
+		assertTrue(headings(conformed).contains("## Testing"),
 				"the sample's heading is code, so the real section must still be appended:\n" + conformed);
-		assertTrue(headingsOutsideFences(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS), conformed);
+		assertTrue(headings(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS), conformed);
 	}
 
 	/**
@@ -626,7 +633,7 @@ class ClaudeMdConformerTest {
 				Java 25.
 				""";
 		String conformed = conformer.conform(generated);
-		assertTrue(headingsOutsideFences(conformed).contains("## Maven"),
+		assertTrue(headings(conformed).contains("## Maven"),
 				"the sample's heading is code, so the real section must still be appended:\n" + conformed);
 		assertTrue(conformed.contains("```java\n## Maven\n"), "the sample must survive verbatim:\n" + conformed);
 	}
@@ -648,54 +655,9 @@ class ClaudeMdConformerTest {
 				class Foo {}
 				""";
 		String conformed = conformer.conform(generated);
-		assertTrue(headingsOutsideFences(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
+		assertTrue(headings(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
 				"every appended section must be a heading, not code:\n" + conformed);
 		assertEquals(conformed, conformer.conform(conformed), "a second reshape must not append the sections again");
-	}
-
-	/**
-	 * The document's lines that sit outside a code fence, stripped. The one place
-	 * these tests read fences, so the two questions they ask of a reshaped document —
-	 * which headings it carries, and whether it references {@code AGENTS.md} — cannot
-	 * come to different answers about what is code.
-	 *
-	 * <p>Deliberately written the way the enforcer's {@code MarkdownDocument} reads
-	 * fences rather than the way {@link ClaudeMdConformer} does, so these tests judge
-	 * the reshape against the rule it has to satisfy instead of against its own
-	 * reading of the document. A fence is closed only by a run of the same character,
-	 * at least as long as the one that opened it, carrying no info string.
-	 */
-	private List<String> linesOutsideFences(String content) {
-		List<String> outside = new ArrayList<>();
-		String open = null;
-		for (String line : content.lines().map(String::strip).toList()) {
-			open = collect(outside, line, open);
-		}
-		return outside;
-	}
-
-	/**
-	 * Records the line unless it is code — the delimiters included, as the rule masks
-	 * them too — and answers with the fence run still open after it.
-	 */
-	private String collect(List<String> outside, String line, String open) {
-		String run = fenceRun(line);
-		if (open == null) {
-			addUnlessCode(outside, line, run != null);
-			return run;
-		}
-		return closes(run, line, open) ? null : open;
-	}
-
-	private void addUnlessCode(List<String> outside, String line, boolean code) {
-		if (!code) {
-			outside.add(line);
-		}
-	}
-
-	private boolean closes(String run, String line, String open) {
-		return run != null && run.charAt(0) == open.charAt(0) && run.length() >= open.length()
-				&& line.substring(run.length()).isBlank();
 	}
 
 	/**
@@ -721,7 +683,7 @@ class ClaudeMdConformerTest {
 				Intro.
 				""";
 		String conformed = conformer.conform(generated);
-		assertTrue(structuralLines(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
+		assertTrue(headings(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
 				"every required section must be a heading the rule can see:\n" + conformed);
 		assertTrue(conformed.contains("Removed for now."), "the commented-out text keeps its content:\n" + conformed);
 		assertEquals(conformed, conformer.conform(conformed), "a second reshape must not append the sections again");
@@ -749,7 +711,7 @@ class ClaudeMdConformerTest {
 				""";
 		String conformed = conformer.conform(generated);
 		assertTrue(conformed.contains("## Testing strategy"), "the commented heading must be left alone:\n" + conformed);
-		assertTrue(structuralLines(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
+		assertTrue(headings(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
 				"the real section must still be appended:\n" + conformed);
 	}
 
@@ -776,7 +738,7 @@ class ClaudeMdConformerTest {
 				A repo.
 				""";
 		String conformed = conformer.conform(generated);
-		assertTrue(hasStructuralBody(conformed, "## Testing"),
+		assertTrue(hasBody(conformed, "## Testing"),
 				"a section whose only content is commented out needs a stub:\n" + conformed);
 	}
 
@@ -797,7 +759,7 @@ class ClaudeMdConformerTest {
 				## Testing
 				""";
 		String conformed = conformer.conform(generated);
-		assertTrue(structuralLines(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
+		assertTrue(headings(conformed).containsAll(ClaudeMdConformer.REQUIRED_SECTIONS),
 				"every appended section must be a heading, not commented-out text:\n" + conformed);
 		assertEquals(conformed, conformer.conform(conformed), "a second reshape must not append the sections again");
 	}
@@ -819,7 +781,7 @@ class ClaudeMdConformerTest {
 				JUnit 5.
 				""";
 		String conformed = conformer.conform(generated);
-		assertTrue(hasStructuralBody(conformed, "## Testing"),
+		assertTrue(hasBody(conformed, "## Testing"),
 				"the section below the fence is structure, not a comment:\n" + conformed);
 		assertFalse(conformed.contains("## Testing\n\n" + ClaudeMdConformer.STUB_BODY),
 				"the section already had a body:\n" + conformed);
@@ -893,48 +855,5 @@ class ClaudeMdConformerTest {
 				"the section already had a body and needs no stub:\n" + conformed);
 		assertTrue(conformed.contains("#1 rule: run mvn install every time."),
 				"the prose keeps its place:\n" + conformed);
-	}
-
-	/**
-	 * The document's lines that can carry structure, read the way the enforcer's
-	 * {@code MarkdownDocument} reads them: outside code fences and outside HTML
-	 * comments alike. The counterpart of {@link #linesOutsideFences} for the tests
-	 * that ask what the rule would recognise as a heading.
-	 */
-	private List<String> structuralLines(String content) {
-		List<String> structural = new ArrayList<>();
-		boolean open = false;
-		for (String line : linesOutsideFences(content)) {
-			open = collectStructural(structural, line, open);
-		}
-		return structural;
-	}
-
-	/** Records the line unless a comment covers it, and answers whether one is still open after it. */
-	private boolean collectStructural(List<String> structural, String line, boolean open) {
-		if (open) {
-			return !line.contains("-->");
-		}
-		boolean opens = line.startsWith("<!--") && !line.contains("-->");
-		addUnlessCode(structural, line, opens);
-		return opens;
-	}
-
-	/** Whether the section carries a body the rule would count: prose outside fences and comments. */
-	private boolean hasStructuralBody(String content, String section) {
-		List<String> lines = structuralLines(content);
-		int start = lines.indexOf(section);
-		return start >= 0 && lines.stream().skip(start + 1L).dropWhile(String::isEmpty).findFirst()
-				.filter(line -> !line.startsWith("## ")).isPresent();
-	}
-
-	/** The leading run of fence characters a line declares, or {@code null} when it declares none. */
-	private String fenceRun(String line) {
-		if (line.isEmpty() || (line.charAt(0) != '`' && line.charAt(0) != '~')) {
-			return null;
-		}
-		char character = line.charAt(0);
-		String run = line.substring(0, (int) line.chars().takeWhile(candidate -> candidate == character).count());
-		return run.length() < 3 ? null : run;
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/BuildOutcome.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/BuildOutcome.java
@@ -1,11 +1,12 @@
 package io.github.adamw7.tools.enforcer.e2e;
 
 /**
- * What a Maven build said and whether it passed — the whole of what an end-to-end
- * test can observe, since a fixture build runs in its own process.
+ * What a process {@link LoggedProcess} ran said and whether it passed — the whole
+ * of what an end-to-end test can observe, since a fixture build, like the clone
+ * that fetches the project it is pointed at, runs in its own process.
  *
- * @param exitCode the process exit code, zero when the build succeeded
- * @param output   the merged standard output and standard error of the build
+ * @param exitCode the process exit code, zero when it succeeded
+ * @param output   the merged standard output and standard error of the process
  */
 record BuildOutcome(int exitCode, String output) {
 

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/GitClone.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/GitClone.java
@@ -2,11 +2,9 @@ package io.github.adamw7.tools.enforcer.e2e;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Clones a real repository, which is the only way to hand the rules a project this
@@ -32,6 +30,8 @@ final class GitClone {
 	private static final long TIMEOUT_MINUTES = 3;
 
 	private static final String GIT_SUFFIX = ".git";
+
+	private static final LoggedProcess GIT = new LoggedProcess("enforcer-clone", TIMEOUT_MINUTES);
 
 	private GitClone() {
 	}
@@ -60,51 +60,15 @@ final class GitClone {
 	}
 
 	/**
-	 * Output is merged into a temporary log and read back only to explain a failure:
-	 * a clone that worked has nothing to say, and one that did not is a broken test
-	 * environment rather than a failed expectation, so it is reported as an
-	 * {@link IllegalStateException} carrying what git said.
+	 * What git said is read back only to explain a failure: a clone that worked has
+	 * nothing to say, and one that did not is a broken test environment rather than a
+	 * failed expectation, so it is reported as an {@link IllegalStateException}
+	 * carrying that output.
 	 */
 	private static void run(Path directory, List<String> command) {
-		Path log = temporaryFile();
-		try {
-			Process process = new ProcessBuilder(command)
-					.directory(directory.toFile())
-					.redirectErrorStream(true)
-					.redirectOutput(log.toFile())
-					.start();
-			requireSucceeded(process, command, log);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not run " + command, e);
-		} finally {
-			delete(log);
-		}
-	}
-
-	private static void requireSucceeded(Process process, List<String> command, Path log) {
-		if (exitCodeOf(process, command) != 0) {
-			throw new IllegalStateException(command + " failed: " + read(log));
-		}
-	}
-
-	private static int exitCodeOf(Process process, List<String> command) {
-		try {
-			if (!process.waitFor(TIMEOUT_MINUTES, TimeUnit.MINUTES)) {
-				process.destroyForcibly();
-				throw new IllegalStateException(command + " did not finish within " + TIMEOUT_MINUTES + " minutes");
-			}
-			return process.exitValue();
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			throw new IllegalStateException("Interrupted while waiting for " + command, e);
-		}
-	}
-
-	private static String read(Path log) {
-		try {
-			return new String(Files.readAllBytes(log), StandardCharsets.UTF_8);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read the clone log " + log, e);
+		BuildOutcome outcome = GIT.run(directory, command);
+		if (!outcome.succeeded()) {
+			throw new IllegalStateException(command + " failed: " + outcome.output());
 		}
 	}
 
@@ -113,22 +77,6 @@ final class GitClone {
 			Files.createDirectories(directory);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not create " + directory, e);
-		}
-	}
-
-	private static Path temporaryFile() {
-		try {
-			return Files.createTempFile("enforcer-clone", ".log");
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not create a clone log", e);
-		}
-	}
-
-	private static void delete(Path path) {
-		try {
-			Files.deleteIfExists(path);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not delete " + path, e);
 		}
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/LoggedProcess.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/LoggedProcess.java
@@ -1,0 +1,112 @@
+package io.github.adamw7.tools.enforcer.e2e;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Runs one external process for the end-to-end tests and answers what it did. Both
+ * things this package forks — the {@link MavenBuild} that meets a rule the way a
+ * contributor does, and the {@link GitClone} that fetches a project this repository
+ * did not write — need the same four guarantees, and each used to spell them out
+ * again:
+ * <ul>
+ * <li>output is merged and redirected to a temporary log <em>outside</em> the
+ * directory the process runs in, because a fixture build must never leave a file in
+ * the project it was pointed at;</li>
+ * <li>the wait is bounded, so a process that stops responding fails its test in
+ * minutes rather than leaving surefire's fork timeout to kill the fork and take the
+ * log — the only diagnosis there is — with it;</li>
+ * <li>an interrupt re-sets the flag before it is reported, so a cancelled run does
+ * not leave the thread looking uninterrupted; and</li>
+ * <li>the log is deleted on every path, the failing one included.</li>
+ * </ul>
+ * The two differ only in how long they may take and in what they make of the
+ * outcome, so those are what they supply.
+ */
+final class LoggedProcess {
+
+	private final String logPrefix;
+	private final long timeoutMinutes;
+
+	/**
+	 * @param logPrefix      names the temporary log, so a log left behind by a killed
+	 *                       JVM says which kind of process wrote it
+	 * @param timeoutMinutes how long the process may run before it is destroyed
+	 */
+	LoggedProcess(String logPrefix, long timeoutMinutes) {
+		this.logPrefix = logPrefix;
+		this.timeoutMinutes = timeoutMinutes;
+	}
+
+	/**
+	 * Runs {@code command} in {@code directory} and answers its exit code together
+	 * with everything it printed.
+	 */
+	BuildOutcome run(Path directory, List<String> command) {
+		Path log = temporaryFile();
+		try {
+			Process process = new ProcessBuilder(command)
+					.directory(directory.toFile())
+					.redirectErrorStream(true)
+					.redirectOutput(log.toFile())
+					.start();
+			return new BuildOutcome(exitCodeOf(process, command), read(log));
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not run " + command, e);
+		} finally {
+			delete(log);
+		}
+	}
+
+	/**
+	 * A process that never returns is killed here and reported as what it is, rather
+	 * than hanging the whole test run.
+	 */
+	private int exitCodeOf(Process process, List<String> command) {
+		try {
+			if (!process.waitFor(timeoutMinutes, TimeUnit.MINUTES)) {
+				process.destroyForcibly();
+				throw new IllegalStateException(command + " did not finish within " + timeoutMinutes + " minutes");
+			}
+			return process.exitValue();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("Interrupted while waiting for " + command, e);
+		}
+	}
+
+	/**
+	 * Decoded leniently: a forked tool writes the platform's encoding, and a byte
+	 * that does not decode is noise in a log, never a reason to fail a test that has
+	 * an assertion of its own to make.
+	 */
+	private String read(Path log) {
+		try {
+			return new String(Files.readAllBytes(log), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read the process log " + log, e);
+		}
+	}
+
+	private Path temporaryFile() {
+		try {
+			return Files.createTempFile(logPrefix, ".log");
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not create a log for " + logPrefix, e);
+		}
+	}
+
+	/** Shared with the callers, which have temporary working directories of their own to clear up. */
+	static void delete(Path path) {
+		try {
+			Files.deleteIfExists(path);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not delete " + path, e);
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/MavenBuild.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/MavenBuild.java
@@ -2,12 +2,10 @@ package io.github.adamw7.tools.enforcer.e2e;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Runs a real Maven build in a real process, which is the only way to observe an
@@ -35,6 +33,8 @@ final class MavenBuild {
 
 	private static final String INSTALL_PLUGIN = "org.apache.maven.plugins:maven-install-plugin";
 
+	private static final LoggedProcess MAVEN = new LoggedProcess("enforcer-e2e", TIMEOUT_MINUTES);
+
 	private final BuildEnvironment environment;
 
 	MavenBuild(BuildEnvironment environment) {
@@ -61,7 +61,7 @@ final class MavenBuild {
 				INSTALL_PLUGIN + ":" + installPluginVersion + ":install-file",
 				"-Dfile=" + environment.jar(),
 				"-DpomFile=" + environment.pom());
-		delete(workingDirectory);
+		LoggedProcess.delete(workingDirectory);
 		if (!outcome.succeeded()) {
 			throw new IllegalStateException("Could not publish " + environment.jar() + ": " + outcome.describe());
 		}
@@ -80,62 +80,7 @@ final class MavenBuild {
 				"--no-transfer-progress",
 				"-Dmaven.repo.local=" + environment.localRepository()));
 		command.addAll(List.of(arguments));
-		return execute(directory, command);
-	}
-
-	private BuildOutcome execute(Path directory, List<String> command) {
-		Path log = temporaryFile();
-		try {
-			Process process = new ProcessBuilder(command)
-					.directory(directory.toFile())
-					.redirectErrorStream(true)
-					.redirectOutput(log.toFile())
-					.start();
-			return new BuildOutcome(exitCodeOf(process, command), read(log));
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not run " + command, e);
-		} finally {
-			delete(log);
-		}
-	}
-
-	/**
-	 * A build that never returns would otherwise hang the whole test run until
-	 * surefire's fork timeout kills it, taking the log with it, so it is killed here
-	 * and reported as what it is.
-	 */
-	private int exitCodeOf(Process process, List<String> command) {
-		try {
-			if (!process.waitFor(TIMEOUT_MINUTES, TimeUnit.MINUTES)) {
-				process.destroyForcibly();
-				throw new IllegalStateException(command + " did not finish within " + TIMEOUT_MINUTES + " minutes");
-			}
-			return process.exitValue();
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			throw new IllegalStateException("Interrupted while waiting for " + command, e);
-		}
-	}
-
-	/**
-	 * Decoded leniently: Maven writes the platform's encoding, and a byte that does
-	 * not decode is noise in a log, never a reason to fail a test that has an
-	 * assertion of its own to make.
-	 */
-	private String read(Path log) {
-		try {
-			return new String(Files.readAllBytes(log), StandardCharsets.UTF_8);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read the build log " + log, e);
-		}
-	}
-
-	private Path temporaryFile() {
-		try {
-			return Files.createTempFile("enforcer-e2e", ".log");
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not create a build log", e);
-		}
+		return MAVEN.run(directory, command);
 	}
 
 	/** A directory with no pom in it, so a project-free goal is not handed a project. */
@@ -144,14 +89,6 @@ final class MavenBuild {
 			return Files.createTempDirectory("enforcer-e2e");
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not create a working directory", e);
-		}
-	}
-
-	private void delete(Path path) {
-		try {
-			Files.deleteIfExists(path);
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not delete " + path, e);
 		}
 	}
 }


### PR DESCRIPTION
The two modules' production code holds no duplicated logic left to remove — a
window scan over both `src/main` trees finds only the per-rule Plexus setters,
which `ClaudeCodeEnforcerRule` documents as deliberately per-rule. The
duplication that was left is in the tests, and in one place where a base class
reported a name no subclass wanted.

adopt:

- `ClaudeMdConformerTest` carried its own fence, indent and HTML-comment
  tracking — a third reading of "which lines are code" beside the two that
  `ClaudeMdConformer` and `claudeMdFormat` already share through
  `MarkdownDocument`, kept equal to them only by being edited alongside them. It
  now asks that reader, which is both shorter and stricter: a heading in an
  indented sample no longer satisfies an assertion about an appended section,
  and a heading is compared by the text it names rather than the line it was
  typed on. `ClaudeMdConformerContractTest` remains the independent oracle,
  running the real rule over the real output.

- `ClaudeMdConformerContractTest` spelled one conforming document out four
  times, twice byte-identically. The cases that vary it now name the section
  body they change, so what each is about is that body rather than the
  twenty-five lines around it; both variants are byte-identical to the fixtures
  they replace. Its file writing goes through `test-common`'s `TestFiles`.

- `AbstractWrappedBuildSystem` took the program name and reported it as the
  build system's name, so Maven — the one build system whose two words differ,
  `mvn` against `maven` — had to override `name()` to correct it. It now takes
  both and the override is gone.

claude-code-enforcer:

- `GitClone` and `MavenBuild` each carried the same fork-and-capture code:
  merged output to a temporary log outside the working directory, a bounded
  wait, `destroyForcibly` on timeout, the interrupt flag re-set, and the log
  deleted on every path. That is now `LoggedProcess`, which they configure with
  a timeout and a log prefix.

Verified: full `mvn -B package`, the root doc check, and both modules'
integration tests — real forked Maven builds and real clones from GitHub.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nan8F1ZSTm57gemd9eJP5b