### PR TITLE
feat(adopt): retry a git or gh command the network refused

### DIFF
--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -82,9 +82,27 @@ included. Preserve that when changing `BatchAdoption` or `Failures`.
 ## CLI flags
 `--repo`, `--repos`, `--workspace`, `--branch`, `--title`, `--body`,
 `--reviewer`, `--label`, `--assignee`, `--draft`, `--assets`, `--dry-run`,
-`--rule-version`, `--timeout <minutes>`, `--report <file>`, `--help`. They build
-an `AdoptionOptions` (wrapping `PullRequestOptions`) that both entry points —
-`Main` and the MCP `AdoptTool` — hand to the pipeline factory.
+`--rule-version`, `--timeout <minutes>`, `--retries <count>`, `--report <file>`,
+`--help`. They build an `AdoptionOptions` (wrapping `PullRequestOptions`) that
+both entry points — `Main` and the MCP `AdoptTool` — hand to the pipeline factory.
+
+## Retrying what the network refused
+Both entry points wrap `ProcessCommandRunner` in a `RetryingCommandRunner`, so a
+`git` or `gh` the network refused is run again — twice by default, after 2s and
+4s (doubling, capped at 30s), and `--retries 0` turns it off. An unattended batch
+otherwise lost a whole repository, `claude init` included, to one connection
+reset.
+
+`TransientFailures` is the single place that decides, and it is deliberately
+narrow on two axes: the program must be `git` or `gh` — re-runnable, and unlike
+`claude` or a build tool not liable to *discuss* a connection reset in a
+transcript — and the wording must be a transport-level refusal. Everything else
+still fails on the first attempt: a 403 or 404, a rejected non-fast-forward, a
+rate limit that wants minutes rather than seconds, and the git queries whose
+answer *is* a non-zero exit (`rev-parse --verify`, `diff --cached --quiet`).
+Nothing that throws is retried — an unstartable program and a timeout both buy
+only another wait. Add a wording to that list rather than teaching a step to
+retry for itself.
 
 ## Debugging a run: where the logging goes
 Two channels, from `adopt/src/main/resources/log4j2.properties`. The **console**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,9 +107,9 @@ What is worth knowing before changing any of it:
   repository with `--repo` rather than letting `gh` infer it from the remote.
 - **Configuration is one object.** `AdoptionOptions` (wrapping
   `PullRequestOptions`) carries the pull-request metadata, the starter assets,
-  the rule version, the dry-run flag and the per-command timeout, and both entry
-  points hand it to the same pipeline factory, so the CLI and the MCP tool cannot
-  drift. `CliArguments` declares the command line to **picocli**, binding the
+  the rule version, the dry-run flag, the per-command timeout and the retry
+  count, and both entry points hand it to the same pipeline factory, so the CLI
+  and the MCP tool cannot drift. `CliArguments` declares the command line to **picocli**, binding the
   repository, workspace and branch options to methods — the first so a batch
   mixing `--repo` and `--repos` keeps the order it was written in, the other two
   because each shares a field with its positional and the last one named has to
@@ -144,6 +144,20 @@ What is worth knowing before changing any of it:
   without spawning processes; `ProcessCommandRunner` bounds every command with a
   timeout, ten minutes by default and overridable with `--timeout <minutes>`
   (`timeout_minutes`, bounded to a day since the MCP server is long-lived).
+- **A command the network refused is tried again**, because an unattended batch
+  otherwise lost a repository — after paying for its `claude init` — to one
+  connection reset. `RetryingCommandRunner` decorates the process runner at both
+  entry points, waiting 2s, 4s, 8s (capped at 30s) before further attempts:
+  `--retries <count>` (`retries`), two by default, zero for none, bounded by
+  `AdoptionOptions.MAX_RETRIES`. What it retries is narrow, and stated once in
+  `TransientFailures`: the program must be `git` or `gh` — both re-runnable, while
+  `claude` and a build tool are expensive and print prose that may merely *discuss*
+  a reset — and the transcript must report a transport-level refusal in the tools'
+  own words. A 403, a 404, a rejected non-fast-forward, a rate limit that wants
+  minutes, and the git queries that answer through a non-zero exit all fail on the
+  first attempt as before; a command that *throws* — an unstartable program, a
+  timeout — is never retried. A retried attempt is logged with its redacted
+  transcript, since a step only reports the command that stopped it.
 - **`--help` answers with the usage line and adopts nothing**, rather than being
   refused as an unknown option. It goes to the log, whose console appender writes
   to standard error, because the same jar is the MCP server and its stdio

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,10 @@ run `mvn install` from the repository root.
   and open a pull request. The default branch is never written to, clone-URL
   credentials are masked in everything the run reports and are never left in the
   checkout's `.git/config`, `--dry-run` leaves out the push and the pull
-  request entirely, and one run adopts a list of repositories without letting a
-  failure stop the rest. Skill: `adopt-pipeline`.
+  request entirely, a `git` or `gh` the network refused is tried again with a
+  backoff (`--retries`) while every other failure is reported at once, and one
+  run adopts a list of repositories without letting a failure stop the rest.
+  Skill: `adopt-pipeline`.
 - **Markdown reading** (`markdown-common`) — the dependency-free reader both the
   `claudeMdFormat` rule and `adopt`'s conformer parse a document with, so the
   checker and the rewriter cannot disagree about what is code, what is

--- a/README.md
+++ b/README.md
@@ -909,6 +909,19 @@ overridable with `--timeout <minutes>`, for a repository whose `claude init` or
 whose first Maven build against a cold `~/.m2` needs longer, or for a batch that
 should fail fast instead.
 
+A `git` or `gh` command the **network** refused is run again rather than failing
+the repository: twice by default, after 2 seconds and 4 seconds, with
+`--retries <count>` asking for more (up to 10) or `--retries 0` for none. An
+unattended batch otherwise lost a whole repository — `claude init` included, which
+is the expensive part — to a single connection reset, and had to be started again
+by an operator who first had to notice. Only a transport-level refusal is retried,
+in the tools' own words: a host that would not resolve, a connection refused, reset
+or timed out, a remote that hung up, a 5xx from GitHub. An authentication failure,
+a 404, a rejected non-fast-forward push and a rate limit that wants minutes are all
+reported the moment they happen, as is anything `claude` or the project's own build
+tool says — re-running either costs the run minutes and their output is prose that
+may merely mention a network error.
+
 One run can adopt **a list of repositories** rather than a single one: repeat
 `--repo <url>` for each, or point `--repos <file>` at a file naming one
 repository per line (blank lines are skipped and a `#` line is a comment, so a
@@ -984,14 +997,15 @@ derived checkout directory, and the feature-branch name):
 
 ```java
 AdoptionOptions options = AdoptionOptions.defaults();
-CommandRunner runner = new ProcessCommandRunner(options.commandTimeout());
+CommandRunner runner = new RetryingCommandRunner(new ProcessCommandRunner(options.commandTimeout()),
+        options.retries());
 GitHubRepoAdopter.withDefaultPipeline(runner, options)
     .adopt(new AdoptionContext("https://github.com/owner/repo.git", workspace), new AdoptionReport());
 ```
 
 `AdoptionOptions` is how a run is configured — the pull request's metadata, the
-starter assets, the rule version to pin, whether it is a dry run, and how long
-one command may take. Both entry points build one, so the command line and the
+starter assets, the rule version to pin, whether it is a dry run, how long one
+command may take, and how many further attempts one the network refused earns. Both entry points build one, so the command line and the
 MCP tool cannot drift apart on what an omitted option means, and the pipeline
 factory does not grow a parameter per switch.
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
@@ -35,19 +35,45 @@ import io.github.adamw7.tools.adopt.step.PullRequestOptions;
  * @param commandTimeout  how long any one external command may run before it is
  *                        destroyed, defaulting to
  *                        {@link ProcessCommandRunner#DEFAULT_TIMEOUT}
+ * @param retries         how many further attempts a {@code git} or {@code gh}
+ *                        command the network refused earns, defaulting to
+ *                        {@link #DEFAULT_RETRIES} and bounded by
+ *                        {@link #MAX_RETRIES}; zero adopts exactly as an
+ *                        undecorated run does
  */
 public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAssets, String ruleVersion,
-		boolean dryRun, Duration commandTimeout) {
+		boolean dryRun, Duration commandTimeout, int retries) {
+
+	/**
+	 * Two further attempts, which is what a transport-level hiccup takes: the failure
+	 * being waited out is a connection that was refused or reset, and one that has
+	 * survived four and twelve seconds of waiting is an outage the operator has to be
+	 * told about rather than one more attempt can absorb.
+	 */
+	public static final int DEFAULT_RETRIES = 2;
+
+	/**
+	 * The most an operator may ask for. Bounded rather than merely non-negative
+	 * because a run is unattended: every attempt beyond this one waits out
+	 * {@link io.github.adamw7.tools.adopt.command.RetryingCommandRunner#MAX_BACKOFF}
+	 * before it, so a generous number turns a network that is simply down into a batch
+	 * that looks like it is working.
+	 */
+	public static final int MAX_RETRIES = 10;
 
 	public AdoptionOptions {
 		pullRequest = pullRequest == null ? PullRequestOptions.defaults() : pullRequest;
 		ruleVersion = Text.orDefault(ruleVersion, null);
 		commandTimeout = commandTimeout == null ? ProcessCommandRunner.DEFAULT_TIMEOUT : requirePositive(commandTimeout);
+		retries = requireWithinBounds(retries);
 	}
 
-	/** The adoption's own pull request, no assets, published for real, at the default timeout. */
+	/**
+	 * The adoption's own pull request, no assets, published for real, at the default
+	 * timeout and retry count.
+	 */
 	public static AdoptionOptions defaults() {
-		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, false, null);
+		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, false, null, DEFAULT_RETRIES);
 	}
 
 	/**
@@ -70,5 +96,19 @@ public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAss
 			throw new IllegalArgumentException("commandTimeout must be positive but was " + commandTimeout);
 		}
 		return commandTimeout;
+	}
+
+	/**
+	 * Rejected here as well as at each entry point, because this record is what a
+	 * caller assembling the pipeline for itself builds — and a retry count read from
+	 * somewhere neither the command line nor the MCP tool validated would otherwise
+	 * only be noticed by the runner, mid-run.
+	 */
+	private static int requireWithinBounds(int retries) {
+		if (retries < 0 || retries > MAX_RETRIES) {
+			throw new IllegalArgumentException(
+					"retries must be between 0 and " + MAX_RETRIES + " but was " + retries);
+		}
+		return retries;
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -25,9 +25,10 @@ import picocli.CommandLine.ParameterException;
  * naming one per line), the workspace and branch under their own names, the
  * {@link PullRequestOptions} metadata, the starter-assets step, the
  * {@code claude-code-enforcer} version to wire in, a rehearsal that publishes
- * nothing, how long any one external command may take, and a JSON report of the
- * outcome. A blank value counts as not supplied for every optional input; an
- * unknown flag, or one missing its value, fails with the usage line.
+ * nothing, how long any one external command may take, how many further attempts a
+ * command the network refused earns, and a JSON report of the outcome. A blank
+ * value counts as not supplied for every optional input; an unknown flag, or one
+ * missing its value, fails with the usage line.
  *
  * <p>The arguments are matched by picocli rather than by a loop of this module's
  * own, so what the parser accepts is declared in one place instead of being
@@ -61,12 +62,13 @@ public final class CliArguments {
 			+ " [--workspace <directory>] [--branch <name>]"
 			+ " [--title <title>] [--body <body>] [--reviewer <user>]... [--label <label>]..."
 			+ " [--assignee <user>]... [--draft] [--assets] [--rule-version <version>]"
-			+ " [--dry-run] [--timeout <minutes>] [--report <file>] [--help]";
+			+ " [--dry-run] [--timeout <minutes>] [--retries <count>] [--report <file>] [--help]";
 
 	static final String HELP_FLAG = "--help";
 	static final String HELP_SHORTHAND = "-h";
 
 	private static final String TIMEOUT_FLAG = "--timeout";
+	private static final String RETRIES_FLAG = "--retries";
 	private static final String REPOS_FLAG = "--repos";
 
 	@Option(names = "--title", paramLabel = "<title>")
@@ -106,6 +108,7 @@ public final class CliArguments {
 	private Path workspace;
 	private String branchName;
 	private Duration commandTimeout;
+	private int retries = AdoptionOptions.DEFAULT_RETRIES;
 	private String positionalUrl;
 	private boolean flagsNamedARepository;
 
@@ -204,7 +207,7 @@ public final class CliArguments {
 
 	/** How this run is configured, as the pipeline and the command runner read it. */
 	public AdoptionOptions adoptionOptions() {
-		return new AdoptionOptions(pullRequestOptions(), assets, ruleVersion, dryRun, commandTimeout);
+		return new AdoptionOptions(pullRequestOptions(), assets, ruleVersion, dryRun, commandTimeout, retries);
 	}
 
 	public Optional<Path> reportFile() {
@@ -281,6 +284,16 @@ public final class CliArguments {
 		commandTimeout = Text.isPresent(value) ? Duration.ofMinutes(minutes(value.strip())) : null;
 	}
 
+	/**
+	 * Zero is a meaningful answer here rather than a missing one — an operator who
+	 * wants every failure reported the moment it happens says so with
+	 * {@code --retries 0} — so only a blank value falls back to the default.
+	 */
+	@Option(names = RETRIES_FLAG, paramLabel = "<count>")
+	private void retries(String value) {
+		retries = Text.isPresent(value) ? count(value.strip()) : AdoptionOptions.DEFAULT_RETRIES;
+	}
+
 	private void addFlaggedRepository(String url) {
 		flagsNamedARepository = flagsNamedARepository || Text.isPresent(url);
 		addRepository(url);
@@ -317,6 +330,24 @@ public final class CliArguments {
 		} catch (NumberFormatException e) {
 			throw new IllegalArgumentException(
 					TIMEOUT_FLAG + " must be a whole number of minutes, but was " + value + ". " + USAGE, e);
+		}
+	}
+
+	private static int count(String value) {
+		int parsed = parseCount(value);
+		if (parsed < 0 || parsed > AdoptionOptions.MAX_RETRIES) {
+			throw new IllegalArgumentException(RETRIES_FLAG + " must be between 0 and " + AdoptionOptions.MAX_RETRIES
+					+ ", but was " + value + ". " + USAGE);
+		}
+		return parsed;
+	}
+
+	private static int parseCount(String value) {
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException e) {
+			throw new IllegalArgumentException(
+					RETRIES_FLAG + " must be a whole number of attempts, but was " + value + ". " + USAGE, e);
 		}
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
+import io.github.adamw7.tools.adopt.command.RetryingCommandRunner;
 
 /**
  * Command-line entry point: parses the arguments with {@link CliArguments} and
@@ -41,8 +42,19 @@ public class Main {
 			return;
 		}
 		AdoptionOptions options = cli.adoptionOptions();
-		CommandRunner runner = new ProcessCommandRunner(options.commandTimeout());
-		runAndReport(cli, checkouts(cli), GitHubRepoAdopter.withDefaultPipeline(runner, options));
+		runAndReport(cli, checkouts(cli), GitHubRepoAdopter.withDefaultPipeline(runner(options), options));
+	}
+
+	/**
+	 * The toolchain every repository of the run is adopted through: one runner,
+	 * assembled once, bounding each command by the run's timeout and giving a
+	 * {@code git} or {@code gh} the network refused the further attempts the run
+	 * allows. A run configured with {@code --retries 0} is wrapped all the same,
+	 * because the decorator is then a pass-through and the alternative is two ways of
+	 * building the same toolchain.
+	 */
+	private static CommandRunner runner(AdoptionOptions options) {
+		return new RetryingCommandRunner(new ProcessCommandRunner(options.commandTimeout()), options.retries());
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/RetryingCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/RetryingCommandRunner.java
@@ -1,0 +1,148 @@
+package io.github.adamw7.tools.adopt.command;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+/**
+ * A {@link CommandRunner} that runs a command the network refused again, a bounded
+ * number of times, waiting longer before each attempt. It decorates another runner
+ * rather than extending it, so the retry is one seam every step already shells out
+ * through and no step has to know it is there.
+ *
+ * <p>What this buys is a batch that survives its network. An adoption is a long
+ * unattended run over a list of repositories, and a single {@code git clone} met by
+ * a connection reset failed that repository outright — after the run had already
+ * paid for its {@code claude init}, which is the expensive part. The repositories
+ * behind it were never in doubt ({@link io.github.adamw7.tools.adopt.BatchAdoption}
+ * isolates them), but the one that was refused had to be adopted again from the
+ * beginning, by an operator who had to notice first.
+ *
+ * <p>Only the failures {@link TransientFailures} recognises are retried: a
+ * {@code git} or {@code gh} that reports a transport-level refusal. Everything else
+ * — a rejected push, a 403, a query answering through its exit code — is handed
+ * back on the first attempt exactly as an undecorated runner hands it back. A
+ * command that <em>throws</em> is not retried either: the two failures
+ * {@link ProcessCommandRunner} raises are a program that could not be started and
+ * one destroyed on its timeout, and re-running either buys nothing but another
+ * timeout's wait.
+ *
+ * <p>A runner configured with no retries is a pass-through, so the entry points can
+ * always wrap and let {@code --retries 0} answer for itself.
+ */
+public class RetryingCommandRunner implements CommandRunner {
+
+	/**
+	 * How a run waits between attempts. Injected so a test can assert the backoff it
+	 * would have served instead of serving it, which is what keeps these tests inside
+	 * the module's five-second timeout.
+	 */
+	public interface Pause {
+
+		void of(Duration duration);
+	}
+
+	private static final Logger log = LogManager.getLogger(RetryingCommandRunner.class);
+
+	/**
+	 * The wait before the second attempt, doubling before each one after it. Sized for
+	 * the failure being waited out — a proxy hiccup, a load balancer restarting, a DNS
+	 * lookup that missed — rather than for an outage, which no bounded retry recovers
+	 * from and which the operator has to be told about instead.
+	 */
+	static final Duration FIRST_BACKOFF = Duration.ofSeconds(2);
+
+	/** The wait the doubling stops at, so a generous {@code --retries} cannot idle a run for minutes. */
+	static final Duration MAX_BACKOFF = Duration.ofSeconds(30);
+
+	private final CommandRunner delegate;
+	private final int retries;
+	private final Pause pause;
+
+	/**
+	 * @param delegate the runner that actually runs the command
+	 * @param retries  how many further attempts a transient failure earns, zero
+	 *                 leaving the delegate's answer untouched
+	 */
+	public RetryingCommandRunner(CommandRunner delegate, int retries) {
+		this(delegate, retries, RetryingCommandRunner::sleep);
+	}
+
+	/** The seam a test drives, with a pause that records rather than waits. */
+	RetryingCommandRunner(CommandRunner delegate, int retries, Pause pause) {
+		this.delegate = delegate;
+		this.retries = requireNotNegative(retries);
+		this.pause = pause;
+	}
+
+	private static int requireNotNegative(int retries) {
+		if (retries < 0) {
+			throw new IllegalArgumentException("retries must not be negative but was " + retries);
+		}
+		return retries;
+	}
+
+	@Override
+	public CommandResult run(Path workingDirectory, List<String> command) {
+		CommandResult result = delegate.run(workingDirectory, command);
+		int attempts = 1;
+		while (attempts <= retries && TransientFailures.worthRetrying(result)) {
+			waitBefore(attempts, result);
+			result = delegate.run(workingDirectory, command);
+			attempts++;
+		}
+		return reported(result, attempts);
+	}
+
+	/**
+	 * The transcript of the attempt being retried is logged here because nothing else
+	 * will: a step only reports the command that stopped it, so an attempt this runner
+	 * goes on to replace with a successful one would otherwise leave no trace of the
+	 * network having faltered at all. It is redacted for the usual reason — a tool
+	 * handed a credentialled clone URL echoes it back when it cannot use it.
+	 */
+	private void waitBefore(int attempt, CommandResult result) {
+		Duration backoff = backoff(attempt);
+		log.warn("{} failed (exit {}) with what reads as a transient network failure; retrying in {}s ({} of {}): {}",
+				result.describe(), result.exitCode(), backoff.toSeconds(), attempt, retries,
+				result.redactedOutput().strip());
+		pause.of(backoff);
+	}
+
+	/**
+	 * A run that needed more than one attempt says so even when it ended well, so the
+	 * cost of a flaky network is readable in the log of a batch that landed rather
+	 * than only in the one that did not.
+	 */
+	private CommandResult reported(CommandResult result, int attempts) {
+		if (attempts > 1 && result.succeeded()) {
+			log.info("{} succeeded on attempt {} of {}", result.describe(), attempts, retries + 1);
+		}
+		return result;
+	}
+
+	private Duration backoff(int attempt) {
+		Duration doubled = FIRST_BACKOFF.multipliedBy(1L << (attempt - 1));
+		return doubled.compareTo(MAX_BACKOFF) > 0 ? MAX_BACKOFF : doubled;
+	}
+
+	/**
+	 * The pause a real run serves. An interrupt aborts the adoption rather than being
+	 * swallowed into an immediate retry, and leaves the flag set, so a host shutting
+	 * its worker down — an MCP server, a cancelled CI job — is obeyed here as it is
+	 * inside {@link ProcessCommandRunner}.
+	 */
+	private static void sleep(Duration backoff) {
+		try {
+			Thread.sleep(backoff.toMillis());
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new AdoptionException("Interrupted while waiting to retry a command the network refused", e);
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/TransientFailures.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/TransientFailures.java
@@ -1,0 +1,102 @@
+package io.github.adamw7.tools.adopt.command;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Decides whether a failed command is worth running again: one the network
+ * refused, rather than one the repository, the remote, or the operator's
+ * credentials refused. {@link RetryingCommandRunner} asks this and nothing else,
+ * so what an adoption retries is stated once, in the vocabulary of the tools it
+ * drives.
+ *
+ * <p>Two conditions have to hold, and both are narrowing.
+ *
+ * <p>First, the program must be {@code git} or {@code gh}. They are the only
+ * commands the pipeline runs whose work <em>is</em> the network, and both are
+ * re-runnable: a {@code git clone} that fails removes the directory it created, a
+ * {@code git fetch} and a {@code git push} are idempotent, and a repeated
+ * {@code gh pr create} is what {@link io.github.adamw7.tools.adopt.step.PullRequestStep}
+ * already tolerates. The two commands left out are deliberate. A
+ * {@code claude init} reaches the network too, but it is the run's most expensive
+ * command and its transcript is a model's prose — text that may discuss a
+ * connection reset without one having happened. A build tool's transcript carries
+ * whatever the project's own tests print, for the same reason.
+ *
+ * <p>Second, the transcript must report a transport-level refusal in one of the
+ * tools' own words. Everything else fails once, as it does today: an
+ * authentication failure, a 403 or a 404, a rejected non-fast-forward push, and a
+ * query answering "no" through its exit code all pass through untouched — the last
+ * of which matters most, since {@link io.github.adamw7.tools.adopt.step.BranchStep}
+ * and {@link io.github.adamw7.tools.adopt.step.CommitStep} ask git questions whose
+ * answer is a non-zero exit.
+ *
+ * <p>A rate limit is not in the list. GitHub answers a secondary rate limit by
+ * asking for a wait measured in minutes, and retrying it seconds later is what the
+ * limit exists to stop — so it is reported to the operator rather than hammered.
+ */
+public final class TransientFailures {
+
+	/**
+	 * The programs whose failures may be retried, matched against the command as the
+	 * step wrote it. A step names its program plainly and
+	 * {@link ExecutableResolver} expands it to a path afterwards, so this compares
+	 * what the pipeline asked for rather than what the platform resolved it to.
+	 */
+	private static final List<String> NETWORK_TOOLS = List.of("git", "gh");
+
+	/**
+	 * Fragments of {@code git}'s and {@code gh}'s own wording for a network that did
+	 * not answer, matched case-insensitively against the merged transcript. The
+	 * server-side entries stop at the {@code 5} of a status code on purpose: a 5xx is
+	 * the remote failing and worth another attempt, while the 4xx that shares the
+	 * sentence — {@code The requested URL returned error: 403} — is the adoption being
+	 * told no, and retrying it only delays the report.
+	 */
+	private static final List<String> TRANSIENT_WORDING = List.of(
+			"could not resolve host",
+			"temporary failure in name resolution",
+			"no such host",
+			"failed to connect to",
+			"connection refused",
+			"connection reset by peer",
+			"connection timed out",
+			"operation timed out",
+			"timeout was reached",
+			"i/o timeout",
+			"network is unreachable",
+			"the remote end hung up unexpectedly",
+			"unexpected disconnect",
+			"early eof",
+			"rpc failed",
+			"gnutls recv error",
+			"ssl connect error",
+			"ssl_error_syscall",
+			"tls handshake timeout",
+			"the requested url returned error: 5",
+			"server error: 5",
+			"internal server error",
+			"bad gateway",
+			"service unavailable",
+			"gateway timeout");
+
+	private TransientFailures() {
+	}
+
+	/**
+	 * @param result the outcome of one attempt
+	 * @return whether that attempt failed in a way another one could survive
+	 */
+	public static boolean worthRetrying(CommandResult result) {
+		return !result.succeeded() && isNetworkTool(result.command()) && reportsATransientFailure(result.output());
+	}
+
+	private static boolean isNetworkTool(List<String> command) {
+		return !command.isEmpty() && NETWORK_TOOLS.stream().anyMatch(tool -> tool.equalsIgnoreCase(command.get(0)));
+	}
+
+	private static boolean reportsATransientFailure(String output) {
+		String transcript = output.toLowerCase(Locale.ROOT);
+		return TRANSIENT_WORDING.stream().anyMatch(transcript::contains);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -21,7 +21,9 @@ import io.github.adamw7.tools.adopt.GitHubRepoAdopter;
 import io.github.adamw7.tools.adopt.Redaction;
 import io.github.adamw7.tools.adopt.RepositoryUrls;
 import io.github.adamw7.tools.adopt.Workspaces;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
+import io.github.adamw7.tools.adopt.command.RetryingCommandRunner;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 import io.github.adamw7.tools.mcp.McpTool;
 import io.github.adamw7.tools.mcp.ToolArguments;
@@ -107,7 +109,11 @@ public class AdoptTool implements McpTool {
 											+ "workspace, but push nothing and open no pull request")),
 							Map.entry("timeout_minutes", Map.of("type", "integer",
 									"description", "how long any one git/claude/gh/build command may run before it "
-											+ "is killed; defaults to " + DEFAULT_TIMEOUT_MINUTES))),
+											+ "is killed; defaults to " + DEFAULT_TIMEOUT_MINUTES)),
+							Map.entry("retries", Map.of("type", "integer",
+									"description", "how many further attempts a git or gh command the network "
+											+ "refused earns, waiting longer before each; defaults to "
+											+ AdoptionOptions.DEFAULT_RETRIES + ", and 0 reports the first failure"))),
 					"required", List.of()));
 
 	public AdoptTool() {
@@ -118,9 +124,15 @@ public class AdoptTool implements McpTool {
 		this.pipeline = pipeline;
 	}
 
+	/**
+	 * One runner adopts every repository of the call, bounding each command by the
+	 * call's timeout and retrying the ones the network refused, exactly as the command
+	 * line assembles it.
+	 */
 	private static BatchAdoption.Adoption runDefaultPipeline(AdoptionOptions options) {
-		return GitHubRepoAdopter.withDefaultPipeline(new ProcessCommandRunner(options.commandTimeout()),
-				options)::adopt;
+		CommandRunner runner = new RetryingCommandRunner(new ProcessCommandRunner(options.commandTimeout()),
+				options.retries());
+		return GitHubRepoAdopter.withDefaultPipeline(runner, options)::adopt;
 	}
 
 	@Override
@@ -228,7 +240,18 @@ public class AdoptTool implements McpTool {
 	private AdoptionOptions adoptionOptionsFrom(Map<String, Object> arguments) {
 		return new AdoptionOptions(pullRequestOptionsFrom(arguments),
 				ToolArguments.optionalBoolean(arguments, "assets", false), text(arguments, "rule_version"),
-				ToolArguments.optionalBoolean(arguments, "dry_run", false), commandTimeout(arguments));
+				ToolArguments.optionalBoolean(arguments, "dry_run", false), commandTimeout(arguments),
+				retries(arguments));
+	}
+
+	/**
+	 * Bounded by {@link AdoptionOptions#MAX_RETRIES} here as well as there, so a client
+	 * asking for a hundred attempts is refused with the argument's name rather than
+	 * with the record's complaint about a field it never sent.
+	 */
+	private int retries(Map<String, Object> arguments) {
+		return ToolArguments.optionalBoundedInt(arguments, "retries", AdoptionOptions.DEFAULT_RETRIES, 0,
+				AdoptionOptions.MAX_RETRIES);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
@@ -84,6 +84,11 @@ This creates an executable JAR in `adopt/target/tools.adopt-{version}.jar`.
 - `timeout_minutes` (integer, optional): how long any one `git`/`claude`/`gh`/build
   command may run before it is killed. Defaults to 10, and is bounded to a day —
   this server is long-lived, so a command it could never reclaim is refused
+- `retries` (integer, optional): how many further attempts a `git` or `gh`
+  command the network refused earns, waiting 2s, 4s, 8s (capped at 30s) before
+  each. Defaults to 2, bounded to 10, and 0 reports the first failure. Only a
+  transport-level refusal is retried — an authentication failure, a 404, a
+  rejected push and a rate limit are answered as they happen
 
 **Returns** a JSON report. Each commit the adoption makes is named for what it
 commits (`commit:claude-md`, `commit:guard`, `commit:assets`), so a run that

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionOptionsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionOptionsTest.java
@@ -24,6 +24,25 @@ class AdoptionOptionsTest {
 		assertFalse(options.dryRun());
 		assertEquals(Optional.empty(), options.pinnedRuleVersion());
 		assertEquals(ProcessCommandRunner.DEFAULT_TIMEOUT, options.commandTimeout());
+		assertEquals(AdoptionOptions.DEFAULT_RETRIES, options.retries());
+	}
+
+	/**
+	 * A retry count is refused where the options are built, so a caller assembling the
+	 * pipeline for itself hears about it before the run rather than through the runner
+	 * mid-adoption.
+	 */
+	@Test
+	void refusesARetryCountOutsideTheBounds() {
+		assertThrows(IllegalArgumentException.class, () -> retrying(-1));
+		assertThrows(IllegalArgumentException.class, () -> retrying(AdoptionOptions.MAX_RETRIES + 1));
+	}
+
+	/** Zero is an answer, not an absence: every failure is reported the moment it happens. */
+	@Test
+	void keepsARetryCountTheCallerNamed() {
+		assertEquals(0, retrying(0).retries());
+		assertEquals(AdoptionOptions.MAX_RETRIES, retrying(AdoptionOptions.MAX_RETRIES).retries());
 	}
 
 	/**
@@ -32,7 +51,7 @@ class AdoptionOptionsTest {
 	 */
 	@Test
 	void fillsInWhatWasNotSupplied() {
-		AdoptionOptions options = new AdoptionOptions(null, false, null, false, null);
+		AdoptionOptions options = new AdoptionOptions(null, false, null, false, null, AdoptionOptions.DEFAULT_RETRIES);
 		assertEquals(PullRequestOptions.defaults(), options.pullRequest());
 		assertEquals(ProcessCommandRunner.DEFAULT_TIMEOUT, options.commandTimeout());
 	}
@@ -73,17 +92,23 @@ class AdoptionOptionsTest {
 	void carriesThePullRequestMetadataItWasGiven() {
 		PullRequestOptions pullRequest = new PullRequestOptions("Title", "Body", List.of("octocat"), List.of(),
 				List.of(), true);
-		AdoptionOptions options = new AdoptionOptions(pullRequest, true, "2.6.0", true, Duration.ofMinutes(1));
+		AdoptionOptions options = new AdoptionOptions(pullRequest, true, "2.6.0", true, Duration.ofMinutes(1), 1);
 		assertEquals(pullRequest, options.pullRequest());
 		assertTrue(options.includeAssets());
 		assertTrue(options.dryRun());
 	}
 
 	private AdoptionOptions optionsPinning(String ruleVersion) {
-		return new AdoptionOptions(PullRequestOptions.defaults(), false, ruleVersion, false, null);
+		return new AdoptionOptions(PullRequestOptions.defaults(), false, ruleVersion, false, null,
+				AdoptionOptions.DEFAULT_RETRIES);
+	}
+
+	private AdoptionOptions retrying(int retries) {
+		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, false, null, retries);
 	}
 
 	private AdoptionOptions timingOut(Duration commandTimeout) {
-		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, false, commandTimeout);
+		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, false, commandTimeout,
+				AdoptionOptions.DEFAULT_RETRIES);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -520,6 +520,33 @@ class CliArgumentsTest {
 	}
 
 	@Test
+	void readsHowManyFurtherAttemptsARefusedCommandEarns() {
+		assertEquals(5, CliArguments.parse(new String[] { REPO_URL, "--retries", "5" }).adoptionOptions().retries());
+		assertEquals(0, CliArguments.parse(new String[] { REPO_URL, "--retries", "0" }).adoptionOptions().retries());
+	}
+
+	@Test
+	void fallsBackToTheDefaultRetryCountWhenNoneIsNamed() {
+		assertEquals(AdoptionOptions.DEFAULT_RETRIES,
+				CliArguments.parse(new String[] { REPO_URL }).adoptionOptions().retries());
+		assertEquals(AdoptionOptions.DEFAULT_RETRIES,
+				CliArguments.parse(new String[] { REPO_URL, "--retries", "  " }).adoptionOptions().retries());
+	}
+
+	/**
+	 * An unattended run waits out a backoff before each further attempt, so a retry
+	 * count beyond the bound is refused while the operator is still reading the
+	 * command line rather than turning a network that is down into a batch that looks
+	 * like it is working.
+	 */
+	@Test
+	void refusesARetryCountThatIsNotAWholeNumberWithinTheBounds() {
+		assertUsageFailure(new String[] { REPO_URL, "--retries", "-1" });
+		assertUsageFailure(new String[] { REPO_URL, "--retries", "often" });
+		assertUsageFailure(new String[] { REPO_URL, "--retries", String.valueOf(AdoptionOptions.MAX_RETRIES + 1) });
+	}
+
+	@Test
 	void carriesThePullRequestMetadataAndTheAssetsFlagIntoTheAdoptionOptions() {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--title", "My title", "--assets",
 				"--rule-version", " 2.6.0 " });

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/ForeignRepositoryAdoptionIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/ForeignRepositoryAdoptionIT.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.io.TempDir;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
+import io.github.adamw7.tools.adopt.command.RetryingCommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionAssets;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
 import io.github.adamw7.tools.adopt.step.BranchStep;
@@ -152,8 +153,13 @@ class ForeignRepositoryAdoptionIT {
 	 * Generous next to the second or two a clone of these repositories costs, and short
 	 * enough that a stalled network fails the class in minutes. The pipeline's own
 	 * default is sized for a {@code claude init}, which is not among the steps here.
+	 *
+	 * <p>Wrapped as a real run wraps it, so a GitHub that refused one of the five
+	 * clones does not report this class's subject — the guard the adoption writes into
+	 * somebody else's build file — as broken.
 	 */
-	private static final CommandRunner RUNNER = new ProcessCommandRunner(Duration.ofMinutes(5));
+	private static final CommandRunner RUNNER = new RetryingCommandRunner(
+			new ProcessCommandRunner(Duration.ofMinutes(5)), AdoptionOptions.DEFAULT_RETRIES);
 
 	/**
 	 * Class-scoped, because the five clones are what this class costs and every test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -172,7 +172,8 @@ class GitHubRepoAdopterTest {
 
 	@Test
 	void aDryRunPipelineStillInstallsTheAssetsWhenAskedFor() {
-		AdoptionOptions options = new AdoptionOptions(PullRequestOptions.defaults(), true, null, true, null);
+		AdoptionOptions options = new AdoptionOptions(PullRequestOptions.defaults(), true, null, true, null,
+				AdoptionOptions.DEFAULT_RETRIES);
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
 				"commit:claude-md", "enforcer", "commit:guard", "assets", "commit:assets", "verify"),
 				stepNames(options));
@@ -221,10 +222,12 @@ class GitHubRepoAdopterTest {
 	}
 
 	private AdoptionOptions withAssets() {
-		return new AdoptionOptions(PullRequestOptions.defaults(), true, null, false, null);
+		return new AdoptionOptions(PullRequestOptions.defaults(), true, null, false, null,
+				AdoptionOptions.DEFAULT_RETRIES);
 	}
 
 	private AdoptionOptions dryRun() {
-		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, true, null);
+		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, true, null,
+				AdoptionOptions.DEFAULT_RETRIES);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MultiRepoAdoptionIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MultiRepoAdoptionIT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.io.TempDir;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
+import io.github.adamw7.tools.adopt.command.RetryingCommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
 import io.github.adamw7.tools.adopt.step.BranchStep;
 import io.github.adamw7.tools.adopt.step.CloneStep;
@@ -69,7 +70,8 @@ class MultiRepoAdoptionIT {
 	 * {@code claude init} rather than for cloning a sample repository, so a stalled
 	 * network fails the test in minutes instead of hanging the build.
 	 */
-	private final CommandRunner runner = new ProcessCommandRunner(Duration.ofMinutes(2));
+	private final CommandRunner runner = new RetryingCommandRunner(
+			new ProcessCommandRunner(Duration.ofMinutes(2)), AdoptionOptions.DEFAULT_RETRIES);
 
 	private final ObjectMapper mapper = new ObjectMapper();
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/RetryingCommandRunnerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/RetryingCommandRunnerTest.java
@@ -1,0 +1,149 @@
+package io.github.adamw7.tools.adopt.command;
+
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+class RetryingCommandRunnerTest {
+
+	/** A transcript {@link TransientFailures} recognises, so the retry is the thing under test. */
+	private static final String REFUSED = "fatal: unable to access 'https://github.com/o/r.git/':"
+			+ " Failed to connect to github.com port 443: Connection timed out";
+
+	private static final List<String> CLONE = List.of("git", "clone", "https://github.com/o/r.git", "/tmp/r");
+
+	private final Path directory = Path.of(".");
+	private final List<Duration> waits = new ArrayList<>();
+
+	@Test
+	void runsOnceWhenTheCommandSucceeds() {
+		RecordingCommandRunner delegate = new RecordingCommandRunner();
+
+		CommandResult result = retrying(delegate, 2).run(directory, CLONE);
+
+		assertEquals(0, result.exitCode());
+		assertEquals(1, delegate.count());
+		assertEquals(List.of(), waits);
+	}
+
+	@Test
+	void stopsRetryingAsSoonAsAnAttemptSucceeds() {
+		RecordingCommandRunner delegate = failingTimes(1);
+
+		CommandResult result = retrying(delegate, 2).run(directory, CLONE);
+
+		assertEquals(0, result.exitCode());
+		assertEquals(2, delegate.count());
+	}
+
+	/**
+	 * The failure the caller is handed is the last attempt's, so a step reports what
+	 * the network said rather than that a retry ran out.
+	 */
+	@Test
+	void answersTheLastFailureOnceTheRetriesAreSpent() {
+		RecordingCommandRunner delegate = RecordingCommandRunner.failing(128, REFUSED);
+
+		CommandResult result = retrying(delegate, 2).run(directory, CLONE);
+
+		assertEquals(128, result.exitCode());
+		assertEquals(REFUSED, result.output());
+		assertEquals(3, delegate.count());
+	}
+
+	@Test
+	void waitsLongerBeforeEachAttempt() {
+		retrying(RecordingCommandRunner.failing(128, REFUSED), 3).run(directory, CLONE);
+
+		assertEquals(List.of(Duration.ofSeconds(2), Duration.ofSeconds(4), Duration.ofSeconds(8)), waits);
+	}
+
+	/**
+	 * An operator may ask for as many attempts as {@code --retries} allows, and the
+	 * doubling would otherwise leave the last of them idling for minutes.
+	 */
+	@Test
+	void capsTheWaitHoweverManyAttemptsAreAllowed() {
+		retrying(RecordingCommandRunner.failing(128, REFUSED), 8).run(directory, CLONE);
+
+		assertEquals(RetryingCommandRunner.MAX_BACKOFF, waits.get(waits.size() - 1));
+		assertTrue(waits.stream().allMatch(wait -> wait.compareTo(RetryingCommandRunner.MAX_BACKOFF) <= 0),
+				"no wait may exceed the cap: " + waits);
+	}
+
+	@Test
+	void doesNotRetryAFailureTheNetworkDidNotCause() {
+		RecordingCommandRunner delegate = RecordingCommandRunner.failing(1, "remote: Repository not found.");
+
+		CommandResult result = retrying(delegate, 2).run(directory, CLONE);
+
+		assertEquals(1, result.exitCode());
+		assertEquals(1, delegate.count());
+	}
+
+	@Test
+	void passesThroughWhenNoRetriesAreAllowed() {
+		RecordingCommandRunner delegate = RecordingCommandRunner.failing(128, REFUSED);
+
+		CommandResult result = retrying(delegate, 0).run(directory, CLONE);
+
+		assertEquals(128, result.exitCode());
+		assertEquals(1, delegate.count());
+		assertEquals(List.of(), waits);
+	}
+
+	@Test
+	void handsTheDelegateTheWorkingDirectoryAndCommandUnchanged() {
+		RecordingCommandRunner delegate = failingTimes(1);
+
+		retrying(delegate, 1).run(directory, CLONE);
+
+		assertEquals(CLONE, delegate.commandAt(1));
+		assertEquals(directory, delegate.invocations().get(1).workingDirectory());
+	}
+
+	@Test
+	void rejectsANegativeRetryCount() {
+		assertFailure(IllegalArgumentException.class,
+				() -> new RetryingCommandRunner(new RecordingCommandRunner(), -1), "retries must not be negative");
+	}
+
+	/**
+	 * A host shutting its worker down — an MCP server, a cancelled CI job — is obeyed
+	 * while the run is waiting to try again, rather than being made to wait out the
+	 * backoff first.
+	 */
+	@Test
+	void interruptionDuringTheWaitAbortsAndRestoresTheInterruptFlag() {
+		CommandRunner runner = new RetryingCommandRunner(RecordingCommandRunner.failing(128, REFUSED), 1);
+		Thread.currentThread().interrupt();
+		try {
+			assertThrows(AdoptionException.class, () -> runner.run(directory, CLONE));
+			assertTrue(Thread.currentThread().isInterrupted(), "the interrupt flag must be restored");
+		} finally {
+			Thread.interrupted();
+		}
+	}
+
+	private RetryingCommandRunner retrying(CommandRunner delegate, int retries) {
+		return new RetryingCommandRunner(delegate, retries, waits::add);
+	}
+
+	/** A runner refused by the network the first {@code failures} times, and answering after that. */
+	private RecordingCommandRunner failingTimes(int failures) {
+		int[] attempts = { 0 };
+		return new RecordingCommandRunner(command -> ++attempts[0] <= failures
+				? new CommandResult(command, 128, REFUSED)
+				: new CommandResult(command, 0, ""));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/TransientFailuresTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/TransientFailuresTest.java
@@ -1,0 +1,113 @@
+package io.github.adamw7.tools.adopt.command;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class TransientFailuresTest {
+
+	private static final List<String> CLONE = List.of("git", "clone", "https://github.com/octocat/Hello-World.git",
+			"/tmp/workspace/Hello-World");
+
+	private static final List<String> PULL_REQUEST = List.of("gh", "pr", "create");
+
+	@Test
+	void retriesAGitCommandTheNetworkRefused() {
+		assertRetried(CLONE,
+				"fatal: unable to access 'https://github.com/octocat/Hello-World.git/':"
+						+ " Could not resolve host: github.com",
+				"fatal: unable to access 'https://github.com/o/r.git/': Failed to connect to github.com port 443:"
+						+ " Connection timed out",
+				"error: RPC failed; curl 56 Recv failure: Connection reset by peer",
+				"fatal: the remote end hung up unexpectedly",
+				"error: RPC failed; curl 92 HTTP/2 stream was not closed cleanly" + System.lineSeparator()
+						+ "fatal: early EOF",
+				"fatal: unable to access 'https://github.com/o/r.git/': The requested URL returned error: 503");
+	}
+
+	@Test
+	void retriesAGhCommandTheNetworkRefused() {
+		assertRetried(PULL_REQUEST,
+				"error connecting to api.github.com: dial tcp: lookup api.github.com: no such host",
+				"Post \"https://api.github.com/graphql\": net/http: TLS handshake timeout",
+				"HTTP 502: Bad gateway (https://api.github.com/graphql)");
+	}
+
+	@Test
+	void matchesTheToolsWordingWhateverItsCase() {
+		assertRetried(CLONE, "FATAL: COULD NOT RESOLVE HOST: GITHUB.COM");
+	}
+
+	@Test
+	void doesNotRetryACommandThatSucceeded() {
+		assertFalse(TransientFailures.worthRetrying(new CommandResult(CLONE, 0, "Cloning into 'Hello-World'...")));
+	}
+
+	/**
+	 * The failures an adoption is meant to report rather than to sit through. A 403 in
+	 * particular shares its sentence with the 5xx that <em>is</em> retried, so it is
+	 * the case that says the status code is read rather than the wording around it.
+	 */
+	@Test
+	void doesNotRetryAFailureAnotherAttemptCannotSurvive() {
+		assertNotRetried(CLONE,
+				"fatal: unable to access 'https://github.com/o/r.git/': The requested URL returned error: 403",
+				"remote: Repository not found." + System.lineSeparator()
+						+ "fatal: repository 'https://github.com/o/r.git/' not found",
+				"fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+				"! [rejected] claude/adopt-claude-code -> claude/adopt-claude-code (non-fast-forward)");
+	}
+
+	/**
+	 * The pipeline asks git questions whose answer is a non-zero exit with nothing to
+	 * say — is there a local branch, is anything staged — and every one of them must
+	 * be answered on the first attempt.
+	 */
+	@Test
+	void doesNotRetryAQueryAnsweringThroughItsExitCode() {
+		assertNotRetried(List.of("git", "rev-parse", "--verify", "--quiet", "refs/heads/claude/adopt-claude-code"), "");
+	}
+
+	/**
+	 * A model's prose and a project's test output are not the tools' own wording, so a
+	 * transcript that merely discusses a connection reset is not one — and re-running
+	 * either command costs the run minutes.
+	 */
+	@Test
+	void doesNotRetryACommandThatIsNotGitOrGh() {
+		String prose = "The retry logic handles connection reset by peer";
+		assertNotRetried(List.of("claude", "-p", "/init"), prose);
+		assertNotRetried(List.of("mvn", "-B", "verify"), prose);
+		assertNotRetried(List.of("gradlew", "check"), prose);
+	}
+
+	@Test
+	void doesNotRetryACommandWithNoProgramToName() {
+		assertNotRetried(List.of(), "could not resolve host");
+	}
+
+	/**
+	 * A secondary rate limit asks for a wait measured in minutes, so retrying it
+	 * seconds later is what the limit exists to stop.
+	 */
+	@Test
+	void doesNotRetryARateLimit() {
+		assertNotRetried(PULL_REQUEST,
+				"You have exceeded a secondary rate limit. Please wait a few minutes before you try again.");
+	}
+
+	private void assertRetried(List<String> command, String... transcripts) {
+		for (String transcript : transcripts) {
+			assertTrue(TransientFailures.worthRetrying(new CommandResult(command, 128, transcript)), transcript);
+		}
+	}
+
+	private void assertNotRetried(List<String> command, String... transcripts) {
+		for (String transcript : transcripts) {
+			assertFalse(TransientFailures.worthRetrying(new CommandResult(command, 128, transcript)), transcript);
+		}
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AdoptToolTest.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt.mcp;
 
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -244,6 +245,38 @@ class AdoptToolTest {
 		assertTrue(properties instanceof Map<?, ?> declared && declared.containsKey("dry_run")
 				&& declared.containsKey("timeout_minutes"),
 				"a rehearsal and a longer command budget must be askable for: " + properties);
+	}
+
+	@Test
+	void passesTheRetryCountOnToThePipeline() {
+		tool.apply(Map.of("repository_url", REPO_URL, "retries", 5));
+		assertEquals(5, pipeline.adoptionOptions.retries());
+	}
+
+	@Test
+	void fallsBackToTheDefaultRetryCountWhenNoneIsAskedFor() {
+		tool.apply(Map.of("repository_url", REPO_URL));
+		assertEquals(AdoptionOptions.DEFAULT_RETRIES, pipeline.adoptionOptions.retries());
+	}
+
+	/**
+	 * Refused with the argument's own name rather than with the record's complaint
+	 * about a field the client never sent.
+	 */
+	@Test
+	void refusesARetryCountOutsideTheAllowedRange() {
+		assertFailure(IllegalArgumentException.class,
+				() -> tool.apply(Map.of("repository_url", REPO_URL, "retries", -1)), "retries");
+		assertFailure(IllegalArgumentException.class,
+				() -> tool.apply(Map.of("repository_url", REPO_URL, "retries", AdoptionOptions.MAX_RETRIES + 1)),
+				"retries");
+	}
+
+	@Test
+	void declaresTheRetriesArgument() {
+		Object properties = tool.getToolDefinition().inputSchema().get("properties");
+		assertTrue(properties instanceof Map<?, ?> declared && declared.containsKey("retries"),
+				"a run over a flaky network must be able to ask for more attempts: " + properties);
 	}
 
 	@Test


### PR DESCRIPTION
An unattended batch lost a whole repository to one connection reset —
after the run had already paid for its claude init, which is the
expensive part — and had to be started again by an operator who first
had to notice. Both entry points now wrap ProcessCommandRunner in a
RetryingCommandRunner: two further attempts by default (--retries
<count>, retries on the MCP tool), waiting 2s, 4s, 8s, capped at 30s.

What is retried is narrow, and decided once in TransientFailures: the
program must be git or gh — both re-runnable, while claude and a build
tool are expensive and print prose that may merely discuss a reset —
and the transcript must report a transport-level refusal in the tools'
own words. A 403, a 404, a rejected non-fast-forward, a rate limit that
wants minutes, and the git queries that answer through a non-zero exit
all fail on the first attempt as before, and a command that throws is
never retried. Each retried attempt is logged with its redacted
transcript, since a step only reports the command that stopped it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N2HtCqC9trE9LoWrhJcCTc