### PR TITLE
refactor(adopt): say each of the run's own rules once

### DIFF
--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -87,7 +87,8 @@ included. Preserve that when changing `BatchAdoption` or `Failures`.
 both entry points — `Main` and the MCP `AdoptTool` — hand to the pipeline factory.
 
 ## Retrying what the network refused
-Both entry points wrap `ProcessCommandRunner` in a `RetryingCommandRunner`, so a
+Both entry points assemble their toolchain with `CommandRunners.forRun(options)`,
+which wraps `ProcessCommandRunner` in a `RetryingCommandRunner`, so a
 `git` or `gh` the network refused is run again — twice by default, after 2s and
 4s (doubling, capped at 30s), and `--retries 0` turns it off. An unattended batch
 otherwise lost a whole repository, `claude init` included, to one connection

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,11 +143,14 @@ What is worth knowing before changing any of it:
 - **Everything shells out through a `CommandRunner`**, so steps are unit-tested
   without spawning processes; `ProcessCommandRunner` bounds every command with a
   timeout, ten minutes by default and overridable with `--timeout <minutes>`
-  (`timeout_minutes`, bounded to a day since the MCP server is long-lived).
+  (`timeout_minutes`). Both are bounded by `AdoptionOptions.MAX_TIMEOUT` — a day,
+  past which neither a long-lived MCP server nor an unattended batch reclaims the
+  command — and the record enforces it, so a caller assembling the pipeline for
+  itself is held to it too.
 - **A command the network refused is tried again**, because an unattended batch
   otherwise lost a repository — after paying for its `claude init` — to one
-  connection reset. `RetryingCommandRunner` decorates the process runner at both
-  entry points, waiting 2s, 4s, 8s (capped at 30s) before further attempts:
+  connection reset. `RetryingCommandRunner` decorates the process runner, waiting
+  2s, 4s, 8s (capped at 30s) before further attempts:
   `--retries <count>` (`retries`), two by default, zero for none, bounded by
   `AdoptionOptions.MAX_RETRIES`. What it retries is narrow, and stated once in
   `TransientFailures`: the program must be `git` or `gh` — both re-runnable, while
@@ -158,6 +161,12 @@ What is worth knowing before changing any of it:
   first attempt as before; a command that *throws* — an unstartable program, a
   timeout — is never retried. A retried attempt is logged with its redacted
   transcript, since a step only reports the command that stopped it.
+- **One place assembles the toolchain.** `CommandRunners.forRun(options)` builds
+  the bounded process runner and its retry decorator, and both entry points call
+  it; an ArchUnit rule confines those two constructors to the `command` package,
+  so the command line and the MCP tool cannot answer a `--timeout` or a
+  `--retries` on terms of their own. A run configured with no retries is wrapped
+  all the same, the decorator being a pass-through then.
 - **`--help` answers with the usage line and adopts nothing**, rather than being
   refused as an unknown option. It goes to the log, whose console appender writes
   to standard error, because the same jar is the MCP server and its stdio

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
@@ -34,7 +34,8 @@ import io.github.adamw7.tools.adopt.step.PullRequestOptions;
  *                        pull request
  * @param commandTimeout  how long any one external command may run before it is
  *                        destroyed, defaulting to
- *                        {@link ProcessCommandRunner#DEFAULT_TIMEOUT}
+ *                        {@link ProcessCommandRunner#DEFAULT_TIMEOUT} and bounded
+ *                        by {@link #MAX_TIMEOUT}
  * @param retries         how many further attempts a {@code git} or {@code gh}
  *                        command the network refused earns, defaulting to
  *                        {@link #DEFAULT_RETRIES} and bounded by
@@ -61,10 +62,24 @@ public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAss
 	 */
 	public static final int MAX_RETRIES = 10;
 
+	/**
+	 * The longest a single command may be given. A day, past which a command that has
+	 * not returned is a stuck one rather than a slow adoption, and waiting out the
+	 * rest of a budget it is never going to use reports nothing the operator can act
+	 * on.
+	 *
+	 * <p>Stated here rather than at each entry point because it is the same answer for
+	 * both: the MCP tool serves its calls inside a long-lived server and the command
+	 * line runs an unattended batch, and neither reclaims a command whose budget
+	 * outlasts the run that set it.
+	 */
+	public static final Duration MAX_TIMEOUT = Duration.ofDays(1);
+
 	public AdoptionOptions {
 		pullRequest = pullRequest == null ? PullRequestOptions.defaults() : pullRequest;
 		ruleVersion = Text.orDefault(ruleVersion, null);
-		commandTimeout = commandTimeout == null ? ProcessCommandRunner.DEFAULT_TIMEOUT : requirePositive(commandTimeout);
+		commandTimeout = commandTimeout == null ? ProcessCommandRunner.DEFAULT_TIMEOUT
+				: requireWithinBounds(commandTimeout);
 		retries = requireWithinBounds(retries);
 	}
 
@@ -89,11 +104,14 @@ public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAss
 	/**
 	 * A run is rejected here rather than at the first command it would have killed,
 	 * so {@code --timeout 0} fails while the operator is still reading the command
-	 * line instead of after a clone.
+	 * line instead of after a clone — and a timeout past {@link #MAX_TIMEOUT} fails
+	 * there too, rather than being honoured by a runner that would then be holding a
+	 * command the run cannot outlast.
 	 */
-	private static Duration requirePositive(Duration commandTimeout) {
-		if (commandTimeout.isNegative() || commandTimeout.isZero()) {
-			throw new IllegalArgumentException("commandTimeout must be positive but was " + commandTimeout);
+	private static Duration requireWithinBounds(Duration commandTimeout) {
+		if (commandTimeout.isNegative() || commandTimeout.isZero() || commandTimeout.compareTo(MAX_TIMEOUT) > 0) {
+			throw new IllegalArgumentException(
+					"commandTimeout must be positive and at most " + MAX_TIMEOUT + " but was " + commandTimeout);
 		}
 		return commandTimeout;
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -71,6 +71,9 @@ public final class CliArguments {
 	private static final String RETRIES_FLAG = "--retries";
 	private static final String REPOS_FLAG = "--repos";
 
+	/** {@link AdoptionOptions#MAX_TIMEOUT} in the units this flag is written in. */
+	private static final long MAX_TIMEOUT_MINUTES = AdoptionOptions.MAX_TIMEOUT.toMinutes();
+
 	@Option(names = "--title", paramLabel = "<title>")
 	private String title;
 
@@ -277,11 +280,15 @@ public final class CliArguments {
 	 * The timeout is read as whole minutes rather than as an ISO-8601 duration,
 	 * because it is set in the units the operator is reasoning about — how long a
 	 * {@code claude init} over their largest repository takes. It is refused while
-	 * they are still reading the command line rather than after a clone.
+	 * they are still reading the command line rather than after a clone, and bounded
+	 * by {@link AdoptionOptions#MAX_TIMEOUT} because a batch left running overnight
+	 * cannot reclaim a command whose budget outlasts it either.
 	 */
 	@Option(names = TIMEOUT_FLAG, paramLabel = "<minutes>")
 	private void timeout(String value) {
-		commandTimeout = Text.isPresent(value) ? Duration.ofMinutes(minutes(value.strip())) : null;
+		commandTimeout = Text.isPresent(value)
+				? Duration.ofMinutes(bounded(TIMEOUT_FLAG, value.strip(), 1, MAX_TIMEOUT_MINUTES, "minutes"))
+				: null;
 	}
 
 	/**
@@ -291,7 +298,9 @@ public final class CliArguments {
 	 */
 	@Option(names = RETRIES_FLAG, paramLabel = "<count>")
 	private void retries(String value) {
-		retries = Text.isPresent(value) ? count(value.strip()) : AdoptionOptions.DEFAULT_RETRIES;
+		retries = Text.isPresent(value)
+				? (int) bounded(RETRIES_FLAG, value.strip(), 0, AdoptionOptions.MAX_RETRIES, "attempts")
+				: AdoptionOptions.DEFAULT_RETRIES;
 	}
 
 	private void addFlaggedRepository(String url) {
@@ -315,39 +324,32 @@ public final class CliArguments {
 		return Text.orDefault(value, null);
 	}
 
-	private static long minutes(String value) {
-		long parsed = parseMinutes(value);
-		if (parsed <= 0) {
-			throw new IllegalArgumentException(
-					TIMEOUT_FLAG + " must be a positive number of minutes, but was " + value + ". " + USAGE);
-		}
-		return parsed;
-	}
-
-	private static long parseMinutes(String value) {
-		try {
-			return Long.parseLong(value);
-		} catch (NumberFormatException e) {
-			throw new IllegalArgumentException(
-					TIMEOUT_FLAG + " must be a whole number of minutes, but was " + value + ". " + USAGE, e);
-		}
-	}
-
-	private static int count(String value) {
-		int parsed = parseCount(value);
-		if (parsed < 0 || parsed > AdoptionOptions.MAX_RETRIES) {
-			throw new IllegalArgumentException(RETRIES_FLAG + " must be between 0 and " + AdoptionOptions.MAX_RETRIES
+	/**
+	 * The whole number a counting flag names, refused unless it falls within the
+	 * bounds that flag allows. Both flags that take one are read here rather than each
+	 * spelling out its own parse and its own range check, so a value neither of them
+	 * accepts is refused in the one wording — naming the flag, what it counts, and the
+	 * range — and followed by the usage line, as every other refusal this parser
+	 * raises is.
+	 *
+	 * @param unit what the number counts, so the refusal reads as the operator's own
+	 *             question rather than as a type error
+	 */
+	private static long bounded(String flag, String value, long minimum, long maximum, String unit) {
+		long parsed = wholeNumber(flag, value, unit);
+		if (parsed < minimum || parsed > maximum) {
+			throw new IllegalArgumentException(flag + " must be between " + minimum + " and " + maximum + " " + unit
 					+ ", but was " + value + ". " + USAGE);
 		}
 		return parsed;
 	}
 
-	private static int parseCount(String value) {
+	private static long wholeNumber(String flag, String value, String unit) {
 		try {
-			return Integer.parseInt(value);
+			return Long.parseLong(value);
 		} catch (NumberFormatException e) {
 			throw new IllegalArgumentException(
-					RETRIES_FLAG + " must be a whole number of attempts, but was " + value + ". " + USAGE, e);
+					flag + " must be a whole number of " + unit + ", but was " + value + ". " + USAGE, e);
 		}
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -6,9 +6,7 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import io.github.adamw7.tools.adopt.command.CommandRunner;
-import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
-import io.github.adamw7.tools.adopt.command.RetryingCommandRunner;
+import io.github.adamw7.tools.adopt.command.CommandRunners;
 
 /**
  * Command-line entry point: parses the arguments with {@link CliArguments} and
@@ -42,19 +40,8 @@ public class Main {
 			return;
 		}
 		AdoptionOptions options = cli.adoptionOptions();
-		runAndReport(cli, checkouts(cli), GitHubRepoAdopter.withDefaultPipeline(runner(options), options));
-	}
-
-	/**
-	 * The toolchain every repository of the run is adopted through: one runner,
-	 * assembled once, bounding each command by the run's timeout and giving a
-	 * {@code git} or {@code gh} the network refused the further attempts the run
-	 * allows. A run configured with {@code --retries 0} is wrapped all the same,
-	 * because the decorator is then a pass-through and the alternative is two ways of
-	 * building the same toolchain.
-	 */
-	private static CommandRunner runner(AdoptionOptions options) {
-		return new RetryingCommandRunner(new ProcessCommandRunner(options.commandTimeout()), options.retries());
+		runAndReport(cli, checkouts(cli),
+				GitHubRepoAdopter.withDefaultPipeline(CommandRunners.forRun(options), options));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandRunners.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandRunners.java
@@ -1,0 +1,35 @@
+package io.github.adamw7.tools.adopt.command;
+
+import io.github.adamw7.tools.adopt.AdoptionOptions;
+
+/**
+ * Assembles the toolchain a real run is driven through: a
+ * {@link ProcessCommandRunner} bounded by the run's timeout, wrapped in a
+ * {@link RetryingCommandRunner} that gives a {@code git} or {@code gh} the network
+ * refused the further attempts the run allows.
+ *
+ * <p>Said once because both entry points need it and neither may answer it
+ * differently — the same reason {@link AdoptionOptions} groups what a run is
+ * configured with. A command line and an MCP call that assembled their own runners
+ * would have been one edit away from a {@code --timeout} the server honours and an
+ * argument the command line quietly drops, and nothing downstream reports a
+ * decorator that was left off: the run simply stops retrying.
+ */
+public final class CommandRunners {
+
+	private CommandRunners() {
+	}
+
+	/**
+	 * A runner configured with no retries is wrapped all the same, because the
+	 * decorator is then a pass-through and the alternative is two ways of building
+	 * the same toolchain — the very thing this method exists to prevent.
+	 *
+	 * @param options how the run is configured, supplying the per-command timeout and
+	 *                the number of further attempts a refused command earns
+	 * @return the runner every step of the run shells out through
+	 */
+	public static CommandRunner forRun(AdoptionOptions options) {
+		return new RetryingCommandRunner(new ProcessCommandRunner(options.commandTimeout()), options.retries());
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -21,9 +21,8 @@ import io.github.adamw7.tools.adopt.GitHubRepoAdopter;
 import io.github.adamw7.tools.adopt.Redaction;
 import io.github.adamw7.tools.adopt.RepositoryUrls;
 import io.github.adamw7.tools.adopt.Workspaces;
-import io.github.adamw7.tools.adopt.command.CommandRunner;
+import io.github.adamw7.tools.adopt.command.CommandRunners;
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
-import io.github.adamw7.tools.adopt.command.RetryingCommandRunner;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 import io.github.adamw7.tools.mcp.McpTool;
 import io.github.adamw7.tools.mcp.ToolArguments;
@@ -64,8 +63,8 @@ public class AdoptTool implements McpTool {
 
 	private static final int DEFAULT_TIMEOUT_MINUTES = (int) ProcessCommandRunner.DEFAULT_TIMEOUT.toMinutes();
 
-	/** A day, past which a stuck command is a stuck server rather than a slow adoption. */
-	private static final int MAX_TIMEOUT_MINUTES = 24 * 60;
+	/** {@link AdoptionOptions#MAX_TIMEOUT} in the units this argument is written in. */
+	private static final int MAX_TIMEOUT_MINUTES = (int) AdoptionOptions.MAX_TIMEOUT.toMinutes();
 
 	private final Pipeline pipeline;
 	private final AdoptionReportWriter reportWriter = new AdoptionReportWriter();
@@ -125,14 +124,12 @@ public class AdoptTool implements McpTool {
 	}
 
 	/**
-	 * One runner adopts every repository of the call, bounding each command by the
-	 * call's timeout and retrying the ones the network refused, exactly as the command
-	 * line assembles it.
+	 * One runner adopts every repository of the call, assembled by the same
+	 * {@link CommandRunners} the command line uses so the two cannot answer a
+	 * {@code timeout_minutes} or a {@code retries} differently.
 	 */
 	private static BatchAdoption.Adoption runDefaultPipeline(AdoptionOptions options) {
-		CommandRunner runner = new RetryingCommandRunner(new ProcessCommandRunner(options.commandTimeout()),
-				options.retries());
-		return GitHubRepoAdopter.withDefaultPipeline(runner, options)::adopt;
+		return GitHubRepoAdopter.withDefaultPipeline(CommandRunners.forRun(options), options)::adopt;
 	}
 
 	@Override
@@ -255,9 +252,10 @@ public class AdoptTool implements McpTool {
 	}
 
 	/**
-	 * The timeout is bounded rather than merely positive: this tool runs inside a
-	 * long-lived server, where a client asking for a week-long timeout would hand it
-	 * a command it can never reclaim.
+	 * Bounded by {@link AdoptionOptions#MAX_TIMEOUT} here as well as there, so a
+	 * client asking for a week-long timeout — which this long-lived server would hand
+	 * a command it can never reclaim — is refused with the argument's name rather than
+	 * with the record's complaint about a field it never sent.
 	 */
 	private Duration commandTimeout(Map<String, Object> arguments) {
 		return Duration.ofMinutes(ToolArguments.optionalBoundedInt(arguments, "timeout_minutes",

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -179,14 +179,9 @@ public class CloneStep extends AbstractCommandStep {
 	 * before they are compared.
 	 */
 	private List<String> unrelatedChanges(AdoptionContext context, CommandRunner runner) {
-		CommandResult result = runner.run(context.repositoryDirectory(),
-				List.of("git", "status", "--porcelain", UNTRACKED_FILES_ALL));
-		if (!result.succeeded()) {
-			throw new AdoptionException(context.repositoryDirectory() + " is a checkout whose status could not be"
-					+ " read, so it cannot be shown to be free of uncommitted work: "
-					+ result.redactedOutput().strip());
-		}
-		return result.output().lines()
+		String transcript = askGit(context, runner, List.of("git", "status", "--porcelain", UNTRACKED_FILES_ALL),
+				"is a checkout whose status could not be read, so it cannot be shown to be free of uncommitted work");
+		return transcript.lines()
 				.filter(line -> STATUS_ENTRY.matcher(line).matches())
 				.flatMap(this::changedPaths)
 				.filter(path -> !AdoptionAssets.WRITTEN_PATHS.contains(path))
@@ -257,12 +252,32 @@ public class CloneStep extends AbstractCommandStep {
 	 * asked to adopt.
 	 */
 	private String originTranscript(AdoptionContext context, CommandRunner runner) {
-		CommandResult result = runner.run(context.repositoryDirectory(),
-				List.of("git", "config", "--get-all", "remote." + AdoptionContext.REMOTE + ".url"));
+		return askGit(context, runner,
+				List.of("git", "config", "--get-all", "remote." + AdoptionContext.REMOTE + ".url"),
+				"is a checkout with no '" + AdoptionContext.REMOTE + "' remote, so it can be neither confirmed to be "
+						+ context.displayUrl() + " nor pushed to it");
+	}
+
+	/**
+	 * Puts a question to git about the checkout being reused, answering with the
+	 * transcript. A query that could not be <em>run</em> leaves a checkout this step
+	 * cannot vouch for rather than an adoption that may go on, so it stops the run —
+	 * and stops it saying what {@link #runOrFail} does not: which directory, what
+	 * could not be established about it, and only then git's own words.
+	 *
+	 * <p>Both questions are asked through here because both have the same failure to
+	 * avoid. Each reads its answer out of the transcript, and a transcript that is
+	 * empty because the command never ran is indistinguishable from one that is empty
+	 * because the answer was "nothing" — a checkout with no {@code origin} read as one
+	 * whose {@code origin} matched, and an unreadable status as a clean working tree.
+	 *
+	 * @param unanswered what a failed query leaves unknown, reported after the
+	 *                   checkout directory and before the redacted transcript
+	 */
+	private String askGit(AdoptionContext context, CommandRunner runner, List<String> command, String unanswered) {
+		CommandResult result = runner.run(context.repositoryDirectory(), command);
 		if (!result.succeeded()) {
-			throw new AdoptionException(context.repositoryDirectory() + " is a checkout with no '"
-					+ AdoptionContext.REMOTE
-					+ "' remote, so it can be neither confirmed to be " + context.displayUrl() + " nor pushed to it: "
+			throw new AdoptionException(context.repositoryDirectory() + " " + unanswered + ": "
 					+ result.redactedOutput().strip());
 		}
 		return result.output();

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionOptionsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/AdoptionOptionsTest.java
@@ -85,6 +85,19 @@ class AdoptionOptionsTest {
 	@Test
 	void keepsATimeoutTheCallerNamed() {
 		assertEquals(Duration.ofMinutes(30), timingOut(Duration.ofMinutes(30)).commandTimeout());
+		assertEquals(AdoptionOptions.MAX_TIMEOUT, timingOut(AdoptionOptions.MAX_TIMEOUT).commandTimeout());
+	}
+
+	/**
+	 * The bound lives here rather than at each entry point, so a caller assembling the
+	 * pipeline for itself is held to it too — a command budget outlasting the run that
+	 * set it is a command nothing reclaims, whether the run is a long-lived MCP server
+	 * or an unattended batch.
+	 */
+	@Test
+	void refusesATimeoutBeyondTheBound() {
+		assertThrows(IllegalArgumentException.class,
+				() -> timingOut(AdoptionOptions.MAX_TIMEOUT.plusMinutes(1)));
 	}
 
 	/** The pull request is copied defensively by its own record, so the options carry that too. */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -510,13 +510,27 @@ class CliArgumentsTest {
 	/**
 	 * A timeout that is not a positive number of minutes is refused while the
 	 * operator is still reading the command line, rather than at the first command
-	 * it would have killed — or, for a zero, never having run one at all.
+	 * it would have killed — or, for a zero, never having run one at all. One past
+	 * {@link AdoptionOptions#MAX_TIMEOUT} is refused there too: a batch left running
+	 * overnight cannot reclaim a command whose budget outlasts it, and a number wide
+	 * enough to overflow the duration it names is refused rather than thrown on.
 	 */
 	@Test
-	void refusesATimeoutThatIsNotAPositiveNumberOfMinutes() {
+	void refusesATimeoutThatIsNotAPositiveNumberOfMinutesWithinTheBound() {
 		assertUsageFailure(new String[] { REPO_URL, "--timeout", "0" });
 		assertUsageFailure(new String[] { REPO_URL, "--timeout", "-5" });
 		assertUsageFailure(new String[] { REPO_URL, "--timeout", "soon" });
+		assertUsageFailure(new String[] { REPO_URL, "--timeout",
+				String.valueOf(AdoptionOptions.MAX_TIMEOUT.toMinutes() + 1) });
+		assertUsageFailure(new String[] { REPO_URL, "--timeout", String.valueOf(Long.MAX_VALUE) });
+	}
+
+	/** The largest budget a run may ask for is one it may actually have. */
+	@Test
+	void acceptsATimeoutAtTheBound() {
+		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--timeout",
+				String.valueOf(AdoptionOptions.MAX_TIMEOUT.toMinutes()) });
+		assertEquals(AdoptionOptions.MAX_TIMEOUT, cli.adoptionOptions().commandTimeout());
 	}
 
 	@Test

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
@@ -8,6 +8,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 import java.io.IOException;
+import java.time.Duration;
 
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ImportOption;
@@ -18,6 +19,8 @@ import com.tngtech.archunit.lang.ArchRule;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
+import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
+import io.github.adamw7.tools.adopt.command.RetryingCommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
 import io.github.adamw7.tools.adopt.step.BuildSystem;
 import io.github.adamw7.tools.mcp.McpTool;
@@ -47,6 +50,7 @@ public class AdoptArchitectureTest {
 	private static final String CLONE_STEP = ADOPT_PACKAGE + ".step.CloneStep";
 	private static final String PUSH_STEP = ADOPT_PACKAGE + ".step.PushStep";
 	private static final String PROCESS_COMMAND_RUNNER = ADOPT_PACKAGE + ".command.ProcessCommandRunner";
+	private static final String COMMAND_RUNNERS = ADOPT_PACKAGE + ".command.CommandRunners";
 
 	@ArchTest
 	static final ArchTests commonCodingConventions = ArchTests.in(CommonCodingConventions.class);
@@ -192,6 +196,23 @@ public class AdoptArchitectureTest {
 			.should().declareThrowableOfType(IOException.class)
 			.because("the pipeline reports failure with the unchecked AdoptionException, so a caller "
 					+ "assembling steps is never made to translate an IOException step by step");
+
+	/**
+	 * The counterpart of {@link #onlyTheAdopterAssemblesThePipeline}, one layer down:
+	 * the adopter is handed a runner, and the runner a real run is driven through is
+	 * assembled in one place too — {@value #COMMAND_RUNNERS}. Both entry points want
+	 * the same two decorated halves, and one that assembled its own would be a
+	 * {@code --timeout} or a {@code --retries} the other silently answers
+	 * differently: a drift nothing downstream reports, since a run that lost the
+	 * retry decorator simply stops retrying.
+	 */
+	@ArchTest
+	static final ArchRule onlyTheCommandPackageAssemblesTheToolchain = noClasses()
+			.that().resideOutsideOfPackage(COMMAND_PACKAGE)
+			.should().callConstructor(ProcessCommandRunner.class, Duration.class)
+			.orShould().callConstructor(RetryingCommandRunner.class, CommandRunner.class, int.class)
+			.because("the command line and the MCP tool must drive a run through one toolchain, assembled by "
+					+ COMMAND_RUNNERS + ", so neither can bound a command or retry a refused one on terms of its own");
 
 	@ArchTest
 	static final ArchRule onlyTheAdopterAssemblesThePipeline = noClasses()


### PR DESCRIPTION
Four places where the module answered one question twice, folded into the
one place that answers it.

The two entry points each assembled their own toolchain, spelling out the
bounded process runner and its retry decorator side by side; either could
have been edited alone, and a run that quietly lost the decorator simply
stops retrying, which nothing downstream reports. CommandRunners.forRun
builds both halves, and an ArchUnit rule confines the two constructors to
the command package so neither entry point can bound a command or retry a
refused one on terms of its own.

The timeout's upper bound was the MCP tool's alone — the command line took
any positive number, so an unattended batch could be handed a command it
outlasts, and a number wide enough to overflow the duration it names threw
an ArithmeticException past the usage line rather than being refused at it.
AdoptionOptions.MAX_TIMEOUT states it once, enforced by the record, so a
caller assembling the pipeline for itself is held to it too.

CliArguments read its two counting flags with four methods that parsed and
range-checked in parallel; one bounded reader answers both, naming the flag,
what it counts, and the range it allows.

CloneStep asked git two questions about a checkout it was reusing, each
with its own run-check-throw: both go through askGit, so neither can read
the empty transcript of a command that never ran as an answer of "nothing".

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014pefQEBV69iwtsBkrPKvrB