### PR TITLE
refactor(claude-code-enforcer): say a shared section's vocabulary once

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
@@ -40,12 +40,14 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 @Named("mcpConfigFormat")
 public class McpConfigFormatRule extends JsonFileRule {
 
-	private static final String MCP_SERVERS_KEY = "mcpServers";
-	private static final String COMMAND_KEY = "command";
+	/** The keys shared with {@link McpServersValidRule}, named once in {@link McpServers}. */
+	private static final String MCP_SERVERS_KEY = McpServers.SECTION_KEY;
+	private static final String COMMAND_KEY = McpServers.COMMAND_KEY;
+	private static final String URL_KEY = McpServers.URL_KEY;
+
 	private static final String ARGS_KEY = "args";
 	private static final String ENV_KEY = "env";
 	private static final String HEADERS_KEY = "headers";
-	private static final String URL_KEY = "url";
 	private static final String HTTP_SCHEME = "http";
 	private static final String HTTPS_SCHEME = "https";
 
@@ -85,7 +87,7 @@ public class McpConfigFormatRule extends JsonFileRule {
 			return;
 		}
 		if (server.has(COMMAND_KEY) && server.has(URL_KEY)) {
-			add(name, "declares both a 'command' and a 'url'", violations);
+			McpServers.add(name, "declares both a 'command' and a 'url'", violations);
 		}
 		collectArgsViolations(name, server, violations);
 		collectStringMapViolations(name, server, ENV_KEY, violations);
@@ -99,12 +101,12 @@ public class McpConfigFormatRule extends JsonFileRule {
 			return;
 		}
 		if (!args.isArray()) {
-			add(name, "has an 'args' that is not an array", violations);
+			McpServers.add(name, "has an 'args' that is not an array", violations);
 			return;
 		}
 		for (int i = 0; i < args.size(); i++) {
 			if (!args.get(i).isTextual()) {
-				add(name, "has a non-string entry in 'args'", violations);
+				McpServers.add(name, "has a non-string entry in 'args'", violations);
 			}
 		}
 	}
@@ -115,12 +117,12 @@ public class McpConfigFormatRule extends JsonFileRule {
 			return;
 		}
 		if (!map.isObject()) {
-			add(name, "has a '" + key + "' that is not an object", violations);
+			McpServers.add(name, "has a '" + key + "' that is not an object", violations);
 			return;
 		}
 		for (String field : JsonNodes.fieldNames(map)) {
 			if (!map.get(field).isTextual()) {
-				add(name, "has a non-string value for '" + key + "." + field + "'", violations);
+				McpServers.add(name, "has a non-string value for '" + key + "." + field + "'", violations);
 			}
 		}
 	}
@@ -132,9 +134,9 @@ public class McpConfigFormatRule extends JsonFileRule {
 		}
 		String scheme = schemeOf(url.asText());
 		if (scheme == null) {
-			add(name, "has a malformed 'url': " + url.asText(), violations);
+			McpServers.add(name, "has a malformed 'url': " + url.asText(), violations);
 		} else if (requireHttps && !scheme.equals(HTTPS_SCHEME)) {
-			add(name, "must use an https 'url': " + url.asText(), violations);
+			McpServers.add(name, "must use an https 'url': " + url.asText(), violations);
 		}
 	}
 
@@ -148,10 +150,6 @@ public class McpConfigFormatRule extends JsonFileRule {
 	 */
 	private boolean isExpanded(String url) {
 		return EXPANSION.matcher(url).find();
-	}
-
-	private void add(String name, String problem, List<String> violations) {
-		violations.add(McpServers.problem(name, problem));
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServers.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServers.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.enforcer.mcp;
 
+import java.util.List;
 import java.util.function.BiConsumer;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -15,6 +16,15 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
  * rather than once in each.
  */
 final class McpServers {
+
+	/*
+	 * The keys of a server entry both rules read: one validates the transport those
+	 * two declare, the other the fields around them, so the two must name them
+	 * identically or one would check a key the other never sees.
+	 */
+	static final String SECTION_KEY = "mcpServers";
+	static final String COMMAND_KEY = "command";
+	static final String URL_KEY = "url";
 
 	private McpServers() {
 	}
@@ -32,8 +42,8 @@ final class McpServers {
 		}
 	}
 
-	/** Every violation names the server whose entry is malformed. */
-	static String problem(String name, String problem) {
-		return "mcp.json server '" + name + "' " + problem;
+	/** Collects one violation, named after the server whose entry is malformed. */
+	static void add(String name, String problem, List<String> violations) {
+		violations.add("mcp.json server '" + name + "' " + problem);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
@@ -31,10 +31,12 @@ import io.github.adamw7.tools.enforcer.rule.Violations;
 @Named("mcpServersValid")
 public class McpServersValidRule extends JsonFileRule {
 
-	private static final String MCP_SERVERS_KEY = "mcpServers";
+	/** The keys shared with {@link McpConfigFormatRule}, named once in {@link McpServers}. */
+	private static final String MCP_SERVERS_KEY = McpServers.SECTION_KEY;
+	private static final String COMMAND_KEY = McpServers.COMMAND_KEY;
+	private static final String URL_KEY = McpServers.URL_KEY;
+
 	private static final String TYPE_KEY = "type";
-	private static final String COMMAND_KEY = "command";
-	private static final String URL_KEY = "url";
 	private static final String STDIO_TYPE = "stdio";
 	private static final String SSE_TYPE = "sse";
 	private static final String HTTP_TYPE = "http";
@@ -83,14 +85,14 @@ public class McpServersValidRule extends JsonFileRule {
 	 */
 	private void collectServerViolations(String name, JsonNode server, List<String> violations) {
 		if (server == null) {
-			add(name, "must be a JSON object", violations);
+			McpServers.add(name, "must be a JSON object", violations);
 			return;
 		}
 		String type = JsonNodes.textAt(server, TYPE_KEY, "").strip();
 		if (type.isBlank()) {
 			collectInferredTransportViolations(name, server, violations);
 		} else if (!Objects.requireNonNullElse(allowedTypes, DEFAULT_ALLOWED_TYPES).contains(type)) {
-			add(name, "has an unsupported type: " + type, violations);
+			McpServers.add(name, "has an unsupported type: " + type, violations);
 		} else if (type.equals(STDIO_TYPE)) {
 			collectCommandViolation(name, server, violations);
 		} else {
@@ -102,24 +104,20 @@ public class McpServersValidRule extends JsonFileRule {
 		if (server.has(COMMAND_KEY)) {
 			collectCommandViolation(name, server, violations);
 		} else {
-			add(name, "must declare a 'command' (stdio) or a 'type' with a 'url' (sse/http)", violations);
+			McpServers.add(name, "must declare a 'command' (stdio) or a 'type' with a 'url' (sse/http)", violations);
 		}
 	}
 
 	private void collectCommandViolation(String name, JsonNode server, List<String> violations) {
 		if (JsonNodes.textAt(server, COMMAND_KEY, "").isBlank()) {
-			add(name, "(stdio) is missing a 'command'", violations);
+			McpServers.add(name, "(stdio) is missing a 'command'", violations);
 		}
 	}
 
 	private void collectUrlViolation(String name, String type, JsonNode server, List<String> violations) {
 		if (JsonNodes.textAt(server, URL_KEY, "").isBlank()) {
-			add(name, "(" + type + ") is missing a 'url'", violations);
+			McpServers.add(name, "(" + type + ") is missing a 'url'", violations);
 		}
-	}
-
-	private void add(String name, String problem, List<String> violations) {
-		violations.add(McpServers.problem(name, problem));
 	}
 
 	void setMcpFile(File mcpFile) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/Permissions.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/Permissions.java
@@ -1,0 +1,44 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.github.adamw7.tools.enforcer.rule.JsonNodes;
+
+/**
+ * The {@code permissions} vocabulary both settings rules read: the section, its
+ * three lists, and what counts as an entry of one. {@link SettingsJsonValidRule}
+ * asserts policy on the {@code allow} list while {@link PermissionsFormatRule}
+ * validates the entries of all three, so the two must name the section the same way
+ * and read an entry the same way — or one would assert policy on a list the other
+ * never validated.
+ * <p>
+ * An entry is a string and only a string. A list element of any other type is a
+ * malformation {@code permissionsFormat} reports in its own right, and reading it
+ * as its text besides let a JSON {@code 123} answer for a permission
+ * {@code settingsJsonValid} was configured to require, which no settings file can
+ * actually grant.
+ */
+final class Permissions {
+
+	static final String SECTION_KEY = "permissions";
+	static final String ALLOW_KEY = "allow";
+	static final String DENY_KEY = "deny";
+	static final String ASK_KEY = "ask";
+
+	private Permissions() {
+	}
+
+	/** The textual entries of one permission list, in document order, de-duplicated. */
+	static Set<String> entriesIn(JsonNode permissions, String key) {
+		JsonNode list = JsonNodes.arrayAt(permissions, key);
+		if (list == null) {
+			return Set.of();
+		}
+		return list.valueStream().filter(JsonNode::isTextual).map(JsonNode::asText)
+				.collect(Collectors.toCollection(LinkedHashSet::new));
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
@@ -5,7 +5,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.inject.Named;
 
@@ -39,10 +38,11 @@ import io.github.adamw7.tools.enforcer.rule.Patterns;
 @Named("permissionsFormat")
 public class PermissionsFormatRule extends JsonFileRule {
 
-	private static final String PERMISSIONS_KEY = "permissions";
-	private static final String ALLOW_KEY = "allow";
-	private static final String DENY_KEY = "deny";
-	private static final List<String> LIST_KEYS = List.of(ALLOW_KEY, DENY_KEY, "ask");
+	/** The keys of the permissions section, named once in {@link Permissions} and read the same way here. */
+	private static final String PERMISSIONS_KEY = Permissions.SECTION_KEY;
+	private static final String ALLOW_KEY = Permissions.ALLOW_KEY;
+	private static final String DENY_KEY = Permissions.DENY_KEY;
+	private static final List<String> LIST_KEYS = List.of(ALLOW_KEY, DENY_KEY, Permissions.ASK_KEY);
 
 	/**
 	 * A built-in tool name, or an {@code mcp__server__tool} name whose server and
@@ -140,8 +140,8 @@ public class PermissionsFormatRule extends JsonFileRule {
 	}
 
 	private void collectContradictions(JsonNode permissions, List<String> violations) {
-		Set<String> denied = textEntries(permissions, DENY_KEY);
-		for (String entry : textEntries(permissions, ALLOW_KEY)) {
+		Set<String> denied = Permissions.entriesIn(permissions, DENY_KEY);
+		for (String entry : Permissions.entriesIn(permissions, ALLOW_KEY)) {
 			if (denied.contains(entry)) {
 				violations.add("settings.json permission '" + entry + "' appears in both 'allow' and 'deny'");
 			}
@@ -153,7 +153,7 @@ public class PermissionsFormatRule extends JsonFileRule {
 			return;
 		}
 		List<Pattern> patterns = Patterns.compileAll(forbiddenEntryPatterns, FORBIDDEN_PATTERN_PARAMETER);
-		for (String entry : textEntries(permissions, ALLOW_KEY)) {
+		for (String entry : Permissions.entriesIn(permissions, ALLOW_KEY)) {
 			addForbiddenEntryViolations(entry, patterns, violations);
 		}
 	}
@@ -164,16 +164,6 @@ public class PermissionsFormatRule extends JsonFileRule {
 				add(ALLOW_KEY, "entry '" + entry + "' matches forbidden pattern '" + pattern + "'", violations);
 			}
 		}
-	}
-
-	/** The textual entries of one permission list, in document order, de-duplicated. */
-	private Set<String> textEntries(JsonNode permissions, String key) {
-		JsonNode list = JsonNodes.arrayAt(permissions, key);
-		if (list == null) {
-			return Set.of();
-		}
-		return list.valueStream().filter(JsonNode::isTextual).map(JsonNode::asText)
-				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
 	/** Every violation names the permission list the entry sits in. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.settings;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Named;
 
@@ -26,9 +27,6 @@ import io.github.adamw7.tools.enforcer.rule.Violations;
 @Named("settingsJsonValid")
 public class SettingsJsonValidRule extends JsonFileRule {
 
-	private static final String PERMISSIONS_KEY = "permissions";
-	private static final String ALLOW_KEY = "allow";
-
 	/** The {@code .claude/settings.json} file to validate. Injected from the rule configuration. */
 	private File settingsFile;
 
@@ -52,17 +50,17 @@ public class SettingsJsonValidRule extends JsonFileRule {
 		if (requiredPermissions == null && forbiddenPermissions == null) {
 			return;
 		}
-		List<String> allow = allowList(settings);
+		Set<String> allow = allowList(settings);
 		Violations.each(requiredPermissions, permission -> !allow.contains(permission),
 				permission -> "settings.json is missing required permission: " + permission, violations);
 		Violations.each(forbiddenPermissions, allow::contains,
 				permission -> "settings.json contains forbidden permission: " + permission, violations);
 	}
 
-	private List<String> allowList(JsonNode settings) {
-		JsonNode permissions = JsonNodes.objectAt(settings, PERMISSIONS_KEY);
-		JsonNode allow = permissions != null ? JsonNodes.arrayAt(permissions, ALLOW_KEY) : null;
-		return allow != null ? allow.valueStream().map(JsonNode::asText).toList() : List.of();
+	/** The granted permissions, read exactly as {@code permissionsFormat} reads the same list. */
+	private Set<String> allowList(JsonNode settings) {
+		JsonNode permissions = JsonNodes.objectAt(settings, Permissions.SECTION_KEY);
+		return permissions != null ? Permissions.entriesIn(permissions, Permissions.ALLOW_KEY) : Set.of();
 	}
 
 	void setSettingsFile(File settingsFile) {

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRuleTest.java
@@ -77,6 +77,26 @@ class SettingsJsonValidRuleTest {
 		assertDoesNotThrow(rule::execute);
 	}
 
+	/**
+	 * A permission is a string, and a list element of any other type grants nothing —
+	 * so it must not answer for a required permission either. Reading it as its text
+	 * let a JSON number satisfy a policy no settings file can actually satisfy, and
+	 * it is what {@code permissionsFormat} reports as not being a string at all.
+	 */
+	@Test
+	void doesNotLetANonStringEntrySatisfyARequiredPermission() {
+		SettingsJsonValidRule rule = ruleFor("""
+				{
+				  "permissions": {
+				    "allow": [ 123 ]
+				  }
+				}
+				""");
+		rule.setRequiredPermissions(List.of("123"));
+
+		assertFailure(EnforcerRuleException.class, rule::execute, "missing required permission: 123");
+	}
+
 	private SettingsJsonValidRule ruleFor(String content) {
 		Path file = tempDir.resolve("settings.json");
 		writeString(file, content);


### PR DESCRIPTION
Two rules read the settings file's permissions section, and two read the
.mcp.json servers section, each rule spelling the section out for itself.
The module already answers that shape with a shared vocabulary class —
HookCommands for the hooks the two hook rules read, McpServers for the
traversal both mcp rules use — so the two sections now go the same way.

The permissions duplication was not only in the key names. Two rules read
one list two ways: permissionsFormat takes the textual entries and reports
anything else as not being a string, while settingsJsonValid read every
element as its text, so a JSON 123 in permissions.allow answered for a
required permission "123" that no settings file can actually grant, on the
same line the other rule was reporting as malformed. Permissions.entriesIn
is the one reading, so a policy is asserted on exactly the entries the
format rule validated; a test pins the case that disagreed.

McpServers gains the three keys both mcp rules name — mcpServers, command
and url — and collects the violation itself, replacing the identical
one-line helper each rule had wrapped around its message prefix.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013BgRFG1umJ3hxJeDPXP7am