### PR TITLE
feat(claude-code-enforcer): wire the last two rules by shipping what they read

### DIFF
--- a/.claude/agents/build-verifier.md
+++ b/.claude/agents/build-verifier.md
@@ -1,0 +1,89 @@
+---
+name: build-verifier
+description: Runs this repository's Maven verification for a change — the full build, one module, one test, the two-phase doc check, coverage or mutation testing — and reports the verdict with only the output that explains a failure. Use when a change needs checking and the whole build log would otherwise land in the conversation.
+model: sonnet
+tools: Bash, Read, Grep, Glob
+---
+
+# Build Verifier
+
+Run the verification a change actually needs and report what it said. A build
+here prints thousands of lines whose value is one verdict and, when it fails, the
+twenty lines around the failure — so the reading happens in this sub-agent's
+context and only the answer goes back.
+
+You verify. You do not fix: report the failure and let the caller decide.
+
+## Pick the command from what changed
+
+| What changed | Command |
+| --- | --- |
+| Anything, before handing work over | `mvn -B package` — what CI runs |
+| One module | `mvn -pl <module> -am install` |
+| A rule in `claude-code-enforcer`, or any of `CLAUDE.md` / `AGENTS.md` / `README.md` / `.claude` | the two-phase check below |
+| Code generation in `protogen-maven-plugin` | `mvn clean install` — `clean` matters, see below |
+| Test coverage is in question | `mvn -Pcoverage verify` |
+| Mutation coverage is in question | `mvn -Ppitest install` |
+| An MCP server, `adopt`, or an enforcer rule end to end | `mvn -P integration-tests verify` |
+
+Run from the repository root unless a step below says otherwise.
+
+## The traps that make a run meaningless
+
+**The doc check needs two phases.** A maven-enforcer rule must resolve as a JAR
+before the build that uses it runs, so one command runs the *previous* rule
+against the new expectations:
+
+```bash
+mvn -pl claude-code-enforcer -am install   # publish the rule under test
+mvn -N validate -DenforceClaudeMd          # then check the documents
+```
+
+**`-pl` is always paired with `-am`.** `mvn -pl data test` fails before compiling
+anything: `ReactorModuleConvergence` rejects a reactor missing its modules'
+parents, and sibling `-SNAPSHOT`s do not resolve from the local repository until
+they are installed. A failure that names a missing parent or an unresolved
+sibling is this mistake, not the change under test — re-run with `-am` before
+reporting anything.
+
+**A single test needs one of two forms**, because `-Dtest` applies to every
+module in the reactor and surefire fails the upstream ones where nothing matches:
+
+```bash
+cd data && mvn test -Dtest='KeyFinderTest#repeatedRowIsADuplicate'
+mvn -pl data -am test -Dtest=KeyFinderTest -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+The first needs `mvn install -DskipTests` to have run once, since a module
+directory resolves its siblings from the local repository rather than the
+reactor.
+
+**`clean` after removing a generated source**, or a stale builder left in
+`target/` masks the change.
+
+**A test that timed out is a finding, not a flake.** Unit tests carry a 5-second
+per-test timeout (8 s under coverage). Report the timeout with the test name;
+do not re-run hoping for a different answer.
+
+**A unit test cannot open a socket.** `NetworkOffExtension` engages a kill-switch
+before any test runs, so a connection refused in the `test` phase means the test
+tried to reach the network, not that the network is down. The `*IT`s are
+unaffected.
+
+## What to report
+
+Lead with the verdict — the command you ran and whether it passed. Then, only if
+it failed:
+
+- the module and the test or rule that failed, by name;
+- the assertion message or the enforcer violation lines, quoted;
+- the compiler or stack-trace lines that name a file in this repository;
+- your one-line reading of what it means.
+
+Leave out reactor summaries, download lines, plugin banners and passing modules.
+If several things failed, list each once, most upstream first — a downstream
+module failing because an upstream one did not compile is one failure, not two.
+
+If the build did not run at all — no JDK 25, Maven not 3.9.x, a resolution error
+— say that instead of reporting a verdict. It is a different answer, and the
+caller needs to know their change was never checked.

--- a/.claude/agents/doc-drift-auditor.md
+++ b/.claude/agents/doc-drift-auditor.md
@@ -1,0 +1,77 @@
+---
+name: doc-drift-auditor
+description: Reads CLAUDE.md, AGENTS.md, README.md and the poms together and reports the facts that have drifted apart but that no enforcer rule pins — counts, catalogue tables, command lists, module descriptions. Use after adding a module, skill, rule, MCP tool or profile, and before a release.
+tools: Read, Grep, Glob, Bash
+---
+
+# Doc Drift Auditor
+
+The documentation here is a build artifact, but the build only pins what a rule
+was configured to pin. Everything else — how many skills there are, what a
+catalogue table lists, which commands a section recommends — drifts silently and
+is found by a reader, usually an agent acting on a stale instruction.
+
+Read the documents against each other and against the code, and report what no
+longer agrees. Report only: leave the fixing to the caller, who knows which side
+is the truth.
+
+## What the build already pins — do not re-report it
+
+These have a rule, so a mismatch fails the build and is not drift:
+
+- **`crossDocConsistency`** — the Java version, captured by `Java (\d+)` in both
+  `CLAUDE.md` and `AGENTS.md`.
+- **`readmeConsistency`** — the protobuf major version, `proto(\d)`, between
+  `README.md` and `AGENTS.md`.
+- **`moduleMapConsistency`** — every `<module>` of the root pom is *mentioned* in
+  `CLAUDE.md` and `AGENTS.md`. Presence only: that a module is named proves
+  nothing about what the sentence next to it claims.
+- **`skillFilesExist`**, **`uniqueNames`**, **`uniqueDescriptions`** — each skill,
+  sub-agent and command has a well-formed definition with a name and description
+  nobody else uses.
+- **`contextBudget`** — `CLAUDE.md` fits 32 KB.
+
+## Where drift actually lives
+
+Work through these, cheapest first:
+
+1. **Counts written as words.** `grep` for `thirteen`, `three`, `four`, `five`,
+   `nine` and their neighbours in `CLAUDE.md` and `AGENTS.md`, then count the
+   thing on disk: skill directories under `.claude/skills`, sub-agents under
+   `.claude/agents`, commands under `.claude/commands`, MCP servers (a `Main.java`
+   under an `mcp` package), modules in the root pom. A count is the first thing to
+   rot and the cheapest to check.
+2. **Catalogue tables against the code.** `AGENTS.md`'s rule catalogue must have a
+   row per `@Named` rule in `claude-code-enforcer`; its skill table a row per
+   skill directory. A rule or skill that exists and is not in the table is
+   invisible to a reader, and a row for something deleted is worse.
+3. **The rules the profile wires.** Compare the `<rules>` block of the root pom's
+   `claude-md-enforce` profile against the catalogue's claims about what is wired,
+   optional, or deliberately left out.
+4. **Commands that are quoted.** Every `mvn` invocation in the documents should
+   name a profile, module or property the poms actually define — a `-P` that no
+   pom declares runs and quietly does nothing.
+5. **File references.** Links and paths named in prose must exist. `claudeMdFormat`
+   can check this when `validateFileReferences` is on; verify how it is configured
+   before assuming a broken path would have failed the build.
+6. **Sections that describe the same thing twice.** `CLAUDE.md` summarises what
+   `AGENTS.md` states in full. Where the summary says something the full text no
+   longer does, `AGENTS.md` wins — that is the stated contract — so report it as
+   the summary being stale.
+
+## How to report
+
+One finding per line, each carrying:
+
+- the file and, where you can, the line;
+- what each side says, quoted, so the caller can see the disagreement;
+- which side you believe is stale, and why — usually because the code or the pom
+  agrees with the other.
+
+Order by consequence: a wrong command an agent would run, then a wrong count or
+catalogue row, then prose that reads oddly. If two documents disagree and neither
+matches the code, say so plainly rather than picking one.
+
+Finding nothing is a real result. Say what you checked — the counts, the tables,
+the profile, the commands — so the caller can tell an audit that passed from one
+that never looked.

--- a/.claude/commands/doc-check.md
+++ b/.claude/commands/doc-check.md
@@ -1,0 +1,43 @@
+---
+description: Run the two-phase CLAUDE.md enforcement check and explain any rule that failed.
+allowed-tools: Bash(mvn *), Read, Edit, Grep, Glob
+---
+
+Run this repository's documentation contract check the way
+`.github/workflows/maven.yml` runs it, and act on the result.
+
+Both commands, in this order — the first publishes the rule, the second uses it:
+
+```bash
+mvn -pl claude-code-enforcer -am install
+mvn -N validate -DenforceClaudeMd
+```
+
+Running only the second checks the new documents with the *previously installed*
+rules, which is how a rule change appears to pass when it does not. If you
+changed nothing under `claude-code-enforcer`, the first command is still cheap
+insurance against a stale local artifact.
+
+Then:
+
+- **Everything passed** — say so, and name how many rules reported a pass. A rule
+  that never ran also never fails, so the count is the evidence.
+- **A rule failed** — read the violation lines rather than the summary. Each one
+  names the file and the value it objected to. Fix the *document*, not the rule:
+  these rules encode a contract that was agreed before the document was written,
+  and a rule bent to fit a document guards nothing afterwards. If the rule really
+  is wrong, say so explicitly and stop, rather than editing it in passing.
+- **The build failed before the rules ran** — a missing JDK 25, a Maven outside
+  3.9.x, or an unresolved `tools.claude-code-enforcer` artifact. That is a
+  toolchain problem; report it as such, because the documents were not checked.
+
+Two failures are worth naming precisely, because their message points away from
+their cause:
+
+- `contextBudget` on `CLAUDE.md` means the file outgrew 32 KB. The fix is moving
+  detail into `AGENTS.md` or a skill, never trimming the required sections.
+- `moduleMapConsistency` after adding a module means the module is not mentioned
+  in both `CLAUDE.md` and `AGENTS.md` — add it to the module map in each.
+
+Load the `doc-contract` skill before editing any of the three documents, and the
+`enforcer-rules` skill before touching a rule.

--- a/.claude/commands/module-build.md
+++ b/.claude/commands/module-build.md
@@ -1,0 +1,46 @@
+---
+description: Build or test one module of this reactor with the flags it actually needs.
+argument-hint: <module> [test|install|verify]
+allowed-tools: Bash(mvn *), Read, Grep, Glob
+---
+
+Build the module named in `$ARGUMENTS`, at the lifecycle phase it names (default
+`install`).
+
+```bash
+mvn -pl <module> -am <phase>
+```
+
+**`-pl` is always paired with `-am`.** Without it the build fails before
+compiling anything: the root pom's `ReactorModuleConvergence` rule rejects a
+reactor whose modules' parents are absent from it, and sibling `-SNAPSHOT`s such
+as `mcp-common` do not resolve from the local repository until they are
+installed. If you see a missing parent or an unresolved sibling, that is this
+mistake and not the module's code.
+
+Resolve the module name against the root pom's `<modules>` before running
+anything. Two are worth knowing:
+
+- `code` is an aggregator; its real modules are `code/protogen-maven-plugin`,
+  `code/protogen-maven-plugin-test` and `code/context`.
+- `data-test` is deliberately outside the root reactor, so it is built from its
+  own directory rather than with `-pl`.
+
+If the request is really one test rather than a module, use one of these instead
+— `-Dtest` applies to every module in the reactor, so surefire fails the upstream
+ones where nothing matches:
+
+```bash
+cd <module> && mvn test -Dtest='SomeTest#someMethod'
+mvn -pl <module> -am test -Dtest=SomeTest -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+The first form needs `mvn install -DskipTests` to have run once, since a module
+directory resolves its siblings from the local repository rather than the
+reactor.
+
+Add `clean` when the change removed a code-generation source, so a stale
+generated builder in `target/` cannot mask it.
+
+Report the verdict and, on a failure, the module and test that failed with the
+assertion message — not the reactor summary.

--- a/.claude/commands/new-enforcer-rule.md
+++ b/.claude/commands/new-enforcer-rule.md
@@ -1,0 +1,56 @@
+---
+description: Add a claude-code-enforcer rule end to end — class, Sisu index, tests, IT fixture, pom wiring and docs.
+argument-hint: <ruleName> [what it should check]
+---
+
+Add the enforcer rule described by `$ARGUMENTS`. Load the `enforcer-rules` skill
+first; it carries the detail this checklist only names.
+
+A rule is not done when it compiles and its unit test is green — a rule can be
+flawless and still guard nothing, because the ways it silently never runs all lie
+outside the class. Work through every step:
+
+1. **The class** — `claude-code-enforcer/src/main/java/.../enforcer/<package>/`,
+   `@Named("<ruleName>")`, extending `ClaudeCodeEnforcerRule`, or
+   `DefinitionFormatRule` / `MultiDefinitionRule` when it validates definitions.
+   One package-private setter per parameter. Collect every violation into a
+   `List<String>` and hand it to `report(...)` — never throw at the first, and
+   never emit a `\n` inside one violation, which no baseline could match again.
+2. **The Sisu index** — add the class to
+   `src/main/resources/META-INF/sisu/javax.inject.Named`. It is hand-maintained: a
+   rule missing from it compiles, unit-tests green, then fails a real build with
+   "Failed to create enforcer rules with name".
+3. **Layering** — `text` depends on nothing, `rule` may use `text`, and the
+   feature packages may use both but never each other. Shared logic goes down,
+   not sideways; `EnforcerArchitectureTest` fails if it goes sideways.
+4. **Naming** — keep any helper class clear of the singular of a list parameter
+   in the same package. Plexus infers a list's element type from the child element
+   name and would instantiate the helper instead of `String`, which fails only in
+   a real build.
+5. **Unit tests** beside the rule, fixtures in a `@TempDir` via `TestFiles`.
+   Assert on the message, not just the throw. Cover: passes when correct, fails
+   once per violation kind, passes on an empty directory, and the build-setup
+   cases that always fail. Use `CapturingLogger` for what `severity=warn` logged.
+6. **The IT fixture** — `RuleConfiguration.complete()` must configure the rule
+   with **every** parameter it accepts; `EnforcerRuleBuildIT` checks that block
+   against the compiled classes and fails if a rule or parameter is missing.
+7. **Survive a repository nobody prepared** — `ForeignRepositoryEnforcementIT`
+   points the same configuration at five real clones. The rule must reach a
+   verdict on a file it did not expect and a directory that is not there, and
+   report both rather than throwing.
+8. **Wire it** into the root pom's `claude-md-enforce` profile, one child element
+   per parameter. A rule taking a definition directory can only be wired once that
+   directory exists — add the directory and the wiring in the same change.
+   `RepositoryEnforcementIT` compares the shipped catalogue against the profile,
+   so an unwired rule needs a documented exemption there.
+9. **Document it** — a row in the rule catalogue of `AGENTS.md` and a mention in
+   the `## CLAUDE.md enforcement` list of `CLAUDE.md`. That catalogue is what
+   contributors read.
+
+Then verify, in this order:
+
+```bash
+mvn -pl claude-code-enforcer -am install
+mvn -N validate -DenforceClaudeMd
+mvn -pl claude-code-enforcer -am -P integration-tests verify
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -679,7 +679,43 @@ A new skill needs no wiring: `skillFilesExist`, `uniqueNames` and
 `uniqueDescriptions` already point at `.claude/skills`, so it is validated the
 moment it lands. Its `description` must not duplicate another's — Claude routes
 by matching intent against these descriptions, so one duplicate shadows the
-other.
+other, and the two uniqueness rules compare skills, sub-agents and commands
+together rather than each directory on its own.
+
+### Sub-agents
+
+`.claude/agents/` holds **two** sub-agents, each a `*.md` file whose front matter
+declares a `name` matching the file name and a `description`. Both exist for the
+same reason: the job reads far more than it answers, so the reading belongs in a
+context that is thrown away.
+
+| Sub-agent | Does |
+| --- | --- |
+| `build-verifier` | runs the right Maven command for a change — the two-phase doc check, `-pl` paired with `-am`, the single-test forms — and reports the verdict plus only the output that explains a failure |
+| `doc-drift-auditor` | reads `CLAUDE.md`, `AGENTS.md`, `README.md` and the poms together and reports the facts that drifted but that no rule pins: counts, catalogue tables, quoted commands |
+
+Neither fixes anything; both report. A `model` may be declared, and
+`subAgentFormat` is wired with the aliases Claude Code accepts (`opus`,
+`sonnet`, `haiku`, `inherit`), so a typo such as `claud-opus` fails the build
+rather than silently falling back.
+
+### Commands
+
+`.claude/commands/` holds **three** slash commands. A command answers to its file
+name, so that name — not a front matter `name` — must be lower-case kebab-case;
+front matter itself is optional.
+
+| Command | Runs |
+| --- | --- |
+| `/doc-check` | the two-phase enforcement check, with what each common failure actually means |
+| `/module-build` | one module at a chosen phase, with the `-pl`/`-am` pairing and the single-test forms |
+| `/new-enforcer-rule` | the end-to-end checklist for adding a rule: class, Sisu index, tests, IT fixture, pom wiring, docs |
+
+Each covers a procedure whose steps are easy to leave out and whose omission
+fails late — a rule missing from the Sisu index unit-tests green, and a doc check
+run in one phase validates the *previous* rule. `commandFormat` is wired with
+`allowedFrontMatterKeys`, so a mistyped `argument-hnt` is reported rather than
+ignored.
 
 ### Settings and hooks
 
@@ -705,12 +741,15 @@ Personal overrides belong in `.claude/settings.local.json`, which is gitignored;
 
 ### What this repository does not ship
 
-Four agent-configuration files are absent by choice: `.mcp.json` (the three
+Two agent-configuration files are absent by choice: `.mcp.json` (the three
 servers here are *published* for other projects to configure, not consumed by
-this one), `.claude-plugin/plugin.json`, `.claude/agents` and `.claude/commands`.
-The first two rules are wired and pass on the absent file, so they start
-enforcing the day one is added; `subAgentFormat` and `commandFormat` cannot be
-wired until their directory exists — add the directory and the rule together.
+this one) and `.claude-plugin/plugin.json`. Both rules are wired and pass on the
+absent file, so they start enforcing the day one is added.
+
+`.claude/agents` and `.claude/commands` were absent for the same reason until the
+definitions above were written, and their rules could not be wired before that:
+a *configured* definition directory must exist. Add the directory and the rule
+together, as that change did.
 
 ## CLAUDE.md enforcement
 
@@ -749,8 +788,10 @@ Skill: `enforcer-rules`.
 Rules whose target is optional (`mcpServersValid`, `mcpConfigFormat`,
 `okfBundleFormat`, `pluginFormat`, `noSecrets`, `hooksFormat`) pass on the absent
 file and start enforcing the moment one appears. A *configured* definition
-directory, by contrast, must exist — which is why `subAgentFormat` and
-`commandFormat` stay unwired here.
+directory, by contrast, must exist, so `skillFilesExist`, `subAgentFormat` and
+`commandFormat` can only be wired once `.claude/skills`, `.claude/agents` and
+`.claude/commands` are there — every rule this module ships is wired here today,
+and `RepositoryEnforcementIT` fails if one stops being.
 
 ### What every rule shares
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,12 @@ scopes — keep changes focused, and add or update tests alongside the code.
   `adopt-pipeline`, `mcp-server`, `enforcer-rules`; across the repo:
   `doc-contract`, `git-commit`, `java-code-review`, `maven-conventions`,
   `solid-principles`, `testing-conventions`, `text-parsers`.
+- `.claude/agents/` holds two sub-agents for the jobs that read far more than
+  they answer: `build-verifier` (runs the right Maven command and reports the
+  verdict plus only the failing output) and `doc-drift-auditor` (reports what the
+  documents disagree on that no rule pins).
+- `.claude/commands/` holds three slash commands for the procedures whose omitted
+  step fails late: `/doc-check`, `/module-build`, `/new-enforcer-rule`.
 - `.claude/settings.json` allows the `mvn` and archive-inspection Bash commands
   and wires the `SessionStart` hook; `.claude/hooks/session-start.sh` provisions
   the JDK and warms the Maven cache in web/remote sessions.
@@ -256,14 +262,15 @@ inconsistent. Skills: `doc-contract` (editing the docs), `enforcer-rules`
   shared with AGENTS.md (the Java version) and `readmeConsistency` pins the
   README against AGENTS.md (the protobuf major version).
 - The remaining rules — `agentsMdFormat`, `memoryImports`, `noSecrets`,
-  `skillFilesExist`, `uniqueNames`, `uniqueDescriptions`, `settingsJsonValid`,
-  `permissionsFormat`, `hookCommandsValid`, `hooksFormat`,
-  `localSettingsIgnored`, `mcpServersValid`, `mcpConfigFormat`, `pluginFormat`,
-  `okfBundleFormat` — cover AGENTS.md and the agent configuration. The last four
-  target files this repository does not ship: they pass on the absent file and
-  start enforcing the moment one is added. `subAgentFormat` and `commandFormat`
-  ship but stay unwired, because a *configured* definition directory must exist —
-  add the directory and the rule together.
+  `skillFilesExist`, `subAgentFormat`, `commandFormat`, `uniqueNames`,
+  `uniqueDescriptions`, `settingsJsonValid`, `permissionsFormat`,
+  `hookCommandsValid`, `hooksFormat`, `localSettingsIgnored`, `mcpServersValid`,
+  `mcpConfigFormat`, `pluginFormat`, `okfBundleFormat` — cover AGENTS.md and the
+  agent configuration. The last four target files this repository does not ship:
+  they pass on the absent file and start enforcing the moment one is added. The
+  three definition rules are the opposite — a *configured* directory must exist,
+  so `.claude/skills`, `.claude/agents` and `.claude/commands` were each added
+  together with the rule reading them.
 - Every rule offers `severity` (`error` by default, or `warn` to log without
   failing), an optional `reportFile` for an HTML report, and an optional
   `baselineFile` that suppresses already-accepted violations.

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RepositoryEnforcementIT.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RepositoryEnforcementIT.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
+
 /**
  * Enforces this repository's own documentation contract the way
  * {@code .github/workflows/maven.yml} does — {@code mvn -N validate
@@ -50,12 +52,14 @@ class RepositoryEnforcementIT {
 			"pom.xml", "CLAUDE.md", "AGENTS.md", "README.md", ".gitignore", ".claude");
 
 	/**
-	 * The rules that ship unwired on purpose. Both take a definition directory that
-	 * must exist when configured, so wiring one before the repository has the
-	 * directory would fail the build as a setup mistake; they are wired the day the
-	 * directory is added.
+	 * The rules that ship unwired on purpose — none today. The two that were
+	 * exempted, {@code subAgentFormat} and {@code commandFormat}, take a definition
+	 * directory that must exist when configured, so they were wired the day
+	 * {@code .claude/agents} and {@code .claude/commands} were added. A rule may be
+	 * listed here again only with a reason of that kind; the assertion below is what
+	 * stops the list growing quietly.
 	 */
-	private static final Set<String> DELIBERATELY_UNWIRED = Set.of("subAgentFormat", "commandFormat");
+	private static final Set<String> DELIBERATELY_UNWIRED = Set.of();
 
 	private static BuildEnvironment environment;
 	private static MavenBuild maven;
@@ -89,10 +93,9 @@ class RepositoryEnforcementIT {
 	}
 
 	/**
-	 * A rule nobody wires guards nothing, and the two that ship unwired do so for a
-	 * documented reason. Comparing the shipped catalogue against the profile turns
-	 * "someone forgot to wire it" into a failure, and equally stops the exemption
-	 * list from quietly growing.
+	 * A rule nobody wires guards nothing. Comparing the shipped catalogue against the
+	 * profile turns "someone forgot to wire it" into a failure, and equally stops the
+	 * exemption list from quietly growing back.
 	 */
 	@Test
 	void everyShippedRuleIsWiredIntoTheBuildOrDeliberatelyLeftOut() {
@@ -123,6 +126,46 @@ class RepositoryEnforcementIT {
 		assertTrue(outcome.mentions("(skillFilesExist) failed"), outcome::describe);
 		assertTrue(outcome.mentions("Missing SKILL.md in skill directory: "), outcome::describe);
 		assertTrue(outcome.mentions(skill.getFileName().toString()), outcome::describe);
+	}
+
+	/**
+	 * {@code subAgentFormat} is wired at {@code ${project.basedir}/.claude/agents}.
+	 * That the rule passed proves only that the directory exists, since a configured
+	 * one that does not is a build-setup failure — it does not prove the sub-agents
+	 * are the files being read. Renaming one in its own front matter is the mistake
+	 * the rule exists for, and only a rule reading that file reports it.
+	 */
+	@Test
+	void theWiredConfigurationCatchesASubAgentRenamedInItsFrontMatterAlone() {
+		Path repository = copyOfRepository();
+		Path agent = firstMarkdownIn(repository.resolve(".claude/agents"));
+		String fileName = ProjectFiles.markdownBaseName(agent.toFile());
+		write(agent, read(agent).replace("name: " + fileName, "name: renamed-elsewhere"));
+
+		BuildOutcome outcome = enforce(repository);
+
+		assertFalse(outcome.succeeded(), outcome::describe);
+		assertTrue(outcome.mentions("(subAgentFormat) failed"), outcome::describe);
+		assertTrue(outcome.mentions("must match '" + fileName + "'"), outcome::describe);
+	}
+
+	/**
+	 * The same claim for {@code commandsDir}, made through the one thing a command
+	 * cannot get wrong quietly: a slash command answers to its file name, so a name
+	 * outside the convention is a command nobody can invoke. Renaming the file leaves
+	 * its content untouched, so this stays true however the commands are rewritten.
+	 */
+	@Test
+	void theWiredConfigurationCatchesACommandFileNamedOutsideTheConvention() {
+		Path repository = copyOfRepository();
+		Path command = firstMarkdownIn(repository.resolve(".claude/commands"));
+		rename(command, "Not_Kebab_Case.md");
+
+		BuildOutcome outcome = enforce(repository);
+
+		assertFalse(outcome.succeeded(), outcome::describe);
+		assertTrue(outcome.mentions("(commandFormat) failed"), outcome::describe);
+		assertTrue(outcome.mentions("name 'Not_Kebab_Case' must be lower-case kebab-case"), outcome::describe);
 	}
 
 	/**
@@ -171,6 +214,21 @@ class RepositoryEnforcementIT {
 	}
 
 	/**
+	 * The definition a directory of commands or sub-agents lists first, chosen the
+	 * same way and for the same reason as {@link #firstSkillIn}: by order rather than
+	 * by name, so renaming one does not rename it here too.
+	 */
+	private Path firstMarkdownIn(Path directory) {
+		try (Stream<Path> files = Files.list(directory)) {
+			return files.filter(file -> file.getFileName().toString().endsWith(".md"))
+					.min(Comparator.comparing(Path::getFileName))
+					.orElseThrow(() -> new IllegalStateException("There are no definitions under " + directory));
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not list " + directory, e);
+		}
+	}
+
+	/**
 	 * Copied with the file attributes, because one of the things the wired rules
 	 * check is that a hook script is executable — a copy that dropped the mode bits
 	 * would fail for a reason the repository is not guilty of.
@@ -215,6 +273,14 @@ class RepositoryEnforcementIT {
 			Files.delete(file);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not delete " + file, e);
+		}
+	}
+
+	private void rename(Path file, String newName) {
+		try {
+			Files.move(file, file.resolveSibling(newName));
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not rename " + file, e);
 		}
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -709,10 +709,47 @@
 										<skillFilesExist>
 											<skillsDir>${project.basedir}/.claude/skills</skillsDir>
 										</skillFilesExist>
+										<!-- A configured definition directory must exist, so
+										     these two could only be wired once .claude/agents
+										     and .claude/commands did — which is why the
+										     directories and this wiring arrived together. -->
+										<subAgentFormat>
+											<agentsDir>${project.basedir}/.claude/agents</agentsDir>
+											<allowedModels>
+												<allowedModel>opus</allowedModel>
+												<allowedModel>sonnet</allowedModel>
+												<allowedModel>haiku</allowedModel>
+												<allowedModel>inherit</allowedModel>
+											</allowedModels>
+										</subAgentFormat>
+										<commandFormat>
+											<commandsDir>${project.basedir}/.claude/commands</commandsDir>
+											<allowedFrontMatterKeys>
+												<allowedFrontMatterKey>description</allowedFrontMatterKey>
+												<allowedFrontMatterKey>argument-hint</allowedFrontMatterKey>
+												<allowedFrontMatterKey>allowed-tools</allowedFrontMatterKey>
+												<allowedFrontMatterKey>model</allowedFrontMatterKey>
+												<allowedFrontMatterKey>disable-model-invocation</allowedFrontMatterKey>
+											</allowedFrontMatterKeys>
+											<allowedModels>
+												<allowedModel>opus</allowedModel>
+												<allowedModel>sonnet</allowedModel>
+												<allowedModel>haiku</allowedModel>
+												<allowedModel>inherit</allowedModel>
+											</allowedModels>
+										</commandFormat>
+										<!-- Both uniqueness rules see all three kinds at once:
+										     a command sharing a name or a description with a
+										     skill shadows it, and neither directory alone would
+										     show that. -->
 										<uniqueNames>
+											<commandsDir>${project.basedir}/.claude/commands</commandsDir>
+											<agentsDir>${project.basedir}/.claude/agents</agentsDir>
 											<skillsDir>${project.basedir}/.claude/skills</skillsDir>
 										</uniqueNames>
 										<uniqueDescriptions>
+											<commandsDir>${project.basedir}/.claude/commands</commandsDir>
+											<agentsDir>${project.basedir}/.claude/agents</agentsDir>
 											<skillsDir>${project.basedir}/.claude/skills</skillsDir>
 										</uniqueDescriptions>
 										<settingsJsonValid>
@@ -768,6 +805,8 @@
 											</files>
 											<directories>
 												<directory>${project.basedir}/.claude/hooks</directory>
+												<directory>${project.basedir}/.claude/agents</directory>
+												<directory>${project.basedir}/.claude/commands</directory>
 											</directories>
 										</noSecrets>
 										<contextBudget>


### PR DESCRIPTION
subAgentFormat and commandFormat have shipped since they were written and
guarded nothing, because a configured definition directory must exist and
this repository had neither .claude/agents nor .claude/commands. That is
the one exemption RepositoryEnforcementIT allowed, so the rules could only
be wired together with the definitions they read.

The definitions are not placeholders. Both sub-agents do a job whose
reading dwarfs its answer, which is the case for spending a context on it:
build-verifier runs the right Maven command for a change — the two-phase
doc check, -pl paired with -am, the single-test forms — and reports the
verdict plus only the output explaining a failure; doc-drift-auditor reads
the three documents against the poms and reports what disagrees but no rule
pins, which is everything past the Java version, the protobuf version and
the module names. The three commands cover the procedures whose omitted
step fails late: a rule missing from the Sisu index unit-tests green, and a
doc check run in one phase validates the previously installed rule.

Wiring the two directories also completes the two uniqueness rules, which
had only ever seen .claude/skills. They compare all three kinds at once, so
a command sharing a name or a description with a skill shadows it and
neither directory alone would show that; noSecrets takes the new
directories for the same reason it already had the hooks.

The exemption set in RepositoryEnforcementIT is now empty, so every shipped
rule is wired and a new one cannot be added without either wiring it or
recording why not. Two regression tests replace what the exemption used to
stand in for: a pass proves only that a configured directory exists, so one
renames a sub-agent in its front matter alone and the other renames a
command file outside the naming convention, and each expects its rule to be
the one that objects.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LePG3YFskeypyrr1Xgjju9