### PR TITLE
test(adopt): open the two seams whose failures nothing could reach

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -64,6 +64,18 @@ public class ProcessCommandRunner implements CommandRunner {
 		return timeout;
 	}
 
+	/**
+	 * The bound every command started here is given. Package-visible so
+	 * {@link CommandRunners} can be asserted to have carried the run's own
+	 * {@code --timeout} down to the runner that enforces it: the only other way this
+	 * value shows is a command being destroyed on it, so a run bounded by the default
+	 * when the operator asked for something else reads exactly like one that was
+	 * configured correctly, until a command outlives what was actually set.
+	 */
+	Duration timeout() {
+		return timeout;
+	}
+
 	@Override
 	public CommandResult run(Path workingDirectory, List<String> command) {
 		log.debug("Running in {}: {}", workingDirectory, CommandResult.describe(command));

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/RetryingCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/RetryingCommandRunner.java
@@ -87,6 +87,29 @@ public class RetryingCommandRunner implements CommandRunner {
 		return retries;
 	}
 
+	/**
+	 * How many further attempts a refused command earns here. Package-visible so
+	 * {@link CommandRunners} can be asserted to have carried the run's own
+	 * {@code --retries} into the decorator that serves them: a run wired with fewer
+	 * than were asked for behaves exactly like one whose network faltered a little
+	 * more, and neither this runner nor the step above it reports the difference.
+	 */
+	int retries() {
+		return retries;
+	}
+
+	/**
+	 * The runner this one decorates. Package-visible so the toolchain
+	 * {@link CommandRunners} assembles can be asserted to still have both halves.
+	 * Losing the decorated half is the failure that shows least: an undecorated
+	 * runner answers every command exactly as this one answers a command the network
+	 * did not refuse, so a run only differs on the transport failure this class
+	 * exists to absorb — by which point the batch has already failed the repository.
+	 */
+	CommandRunner delegate() {
+		return delegate;
+	}
+
 	@Override
 	public CommandResult run(Path workingDirectory, List<String> command) {
 		CommandResult result = delegate.run(workingDirectory, command);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
@@ -78,8 +78,17 @@ final class EnforcerRuleVersion {
 	 * adopted POM as if it were a version. Both delimiters are rejected — the
 	 * resource is written with {@code @...@}, which is what this build filters, and
 	 * {@code ${...}} is what it would carry had that configuration changed.
+	 *
+	 * <p>Package-visible because the stream is the only seam these refusals have.
+	 * {@link #fromBuildMetadata()} reads one resource off this class's own
+	 * classpath, and that resource is correct in every build that runs these tests —
+	 * so a test driving the version through it can only ever take the path that
+	 * succeeds, leaving the three failures this method words for nobody to reach.
+	 * They are the failures worth reaching: each one is what stands between a broken
+	 * build of {@code tools} and a literal {@code @enforcer.rule.version@} wired
+	 * into a stranger's {@code pom.xml} by a pull request the adoption opened.
 	 */
-	private static String read(InputStream stream) throws IOException {
+	static String read(InputStream stream) throws IOException {
 		if (stream == null) {
 			throw new AdoptionException("Build metadata not on the classpath: " + BUILD_PROPERTIES
 					+ " (build the module so its resources are filtered)");

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/CommandRunnersTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/CommandRunnersTest.java
@@ -1,0 +1,99 @@
+package io.github.adamw7.tools.adopt.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionOptions;
+import io.github.adamw7.tools.adopt.step.PullRequestOptions;
+
+/**
+ * The toolchain a real run is driven through is assembled in one place so the
+ * command line and the MCP tool cannot answer {@code --timeout} or
+ * {@code --retries} differently. An ArchUnit rule keeps either entry point from
+ * assembling one of its own, but that rule only says who may build the toolchain,
+ * never what it has to come out as — and every way this assembly can go wrong is
+ * silent at run time. A missing decorator behaves exactly like a network that
+ * never faltered, and a timeout that did not arrive shows only when a command
+ * outlives the bound nobody set.
+ */
+class CommandRunnersTest {
+
+	/**
+	 * A number that is neither of the two the run would otherwise end up with — not
+	 * the default, and not the zero an unwired {@code int} field carries — so the
+	 * assertion fails on a value that was defaulted as loudly as on one dropped.
+	 */
+	private static final int RETRIES = 4;
+
+	/** Likewise distinct from {@link ProcessCommandRunner#DEFAULT_TIMEOUT}. */
+	private static final Duration TIMEOUT = Duration.ofMinutes(3);
+
+	@Test
+	void retriesOnTopOfTheRunnerThatSpawnsTheProcess() {
+		CommandRunner runner = CommandRunners.forRun(options(TIMEOUT, RETRIES));
+
+		RetryingCommandRunner retrying = assertInstanceOf(RetryingCommandRunner.class, runner);
+		assertInstanceOf(ProcessCommandRunner.class, retrying.delegate());
+	}
+
+	@Test
+	void carriesTheRunsTimeoutToTheRunnerThatEnforcesIt() {
+		CommandRunner runner = CommandRunners.forRun(options(TIMEOUT, RETRIES));
+
+		assertEquals(TIMEOUT, processRunnerIn(runner).timeout());
+	}
+
+	@Test
+	void carriesTheRunsRetriesToTheDecoratorThatServesThem() {
+		CommandRunner runner = CommandRunners.forRun(options(TIMEOUT, RETRIES));
+
+		assertEquals(RETRIES, retryingRunnerIn(runner).retries());
+	}
+
+	/**
+	 * A run allowing no retries is wrapped all the same, so the decorator is a
+	 * pass-through rather than there being a second way to build the toolchain — the
+	 * very drift assembling it in one place exists to prevent.
+	 */
+	@Test
+	void wrapsEvenWhenTheRunAllowsNoRetries() {
+		CommandRunner runner = CommandRunners.forRun(options(TIMEOUT, 0));
+
+		assertEquals(0, retryingRunnerIn(runner).retries());
+	}
+
+	/**
+	 * A run that names no timeout is bounded by the runner's own default rather than
+	 * by nothing, which is what {@link AdoptionOptions} substitutes for the absent
+	 * value and what this assembly has to pass on unchanged.
+	 */
+	@Test
+	void boundsARunThatNamesNoTimeoutByTheDefault() {
+		CommandRunner runner = CommandRunners.forRun(AdoptionOptions.defaults());
+
+		assertEquals(ProcessCommandRunner.DEFAULT_TIMEOUT, processRunnerIn(runner).timeout());
+	}
+
+	@Test
+	void servesTheDefaultRetriesForARunThatNamesNone() {
+		CommandRunner runner = CommandRunners.forRun(AdoptionOptions.defaults());
+
+		assertEquals(AdoptionOptions.DEFAULT_RETRIES, retryingRunnerIn(runner).retries());
+	}
+
+	private RetryingCommandRunner retryingRunnerIn(CommandRunner runner) {
+		return assertInstanceOf(RetryingCommandRunner.class, runner);
+	}
+
+	private ProcessCommandRunner processRunnerIn(CommandRunner runner) {
+		return assertInstanceOf(ProcessCommandRunner.class, retryingRunnerIn(runner).delegate());
+	}
+
+	private AdoptionOptions options(Duration commandTimeout, int retries) {
+		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, false, commandTimeout, retries);
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersionTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersionTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.function.Supplier;
 
@@ -52,6 +54,68 @@ class EnforcerRuleVersionTest {
 	void theDefaultVersionGoesThroughTheReleaseGuard() {
 		assertEquals(outcomeOf(() -> EnforcerRuleVersion.requireRelease(EnforcerRuleVersion.fromBuildMetadata())),
 				outcomeOf(EnforcerRuleVersion::release));
+	}
+
+	/**
+	 * The metadata is filtered into the jar by this module's own build, so a run
+	 * whose classpath has no such resource is one assembled by something other than
+	 * that build — a repackaged jar, a shaded one, a classloader that never saw the
+	 * resources. Saying so beats the {@link NullPointerException} an unchecked read
+	 * would raise several frames away from the cause.
+	 */
+	@Test
+	void metadataMissingFromTheClasspathIsRefused() {
+		assertFailure(AdoptionException.class, () -> EnforcerRuleVersion.read(null),
+				EnforcerRuleVersion.BUILD_PROPERTIES);
+	}
+
+	/**
+	 * The delimiter this build actually writes. An unsubstituted token reaching the
+	 * adopted POM would be a dependency no repository can resolve, and it would get
+	 * there through a pull request opened on somebody else's project.
+	 */
+	@Test
+	void anUnfilteredAtToken() {
+		assertUnfiltered("@enforcer.rule.version@");
+	}
+
+	/** The delimiter the resource would carry had this build's filtering been reconfigured. */
+	@Test
+	void anUnfilteredPropertyReference() {
+		assertUnfiltered("${enforcer.rule.version}");
+	}
+
+	/** A resource carrying the key with nothing behind it names no version at all. */
+	@Test
+	void aBlankVersionIsRefused() {
+		assertUnfiltered("   ");
+	}
+
+	/** A resource that was filtered but carries some other key answers no version either. */
+	@Test
+	void metadataWithoutTheVersionKeyIsRefused() throws IOException {
+		assertFailure(AdoptionException.class, () -> EnforcerRuleVersion.read(metadata("some.other.key=2.6.0")),
+				EnforcerRuleVersion.RULE_VERSION_KEY);
+	}
+
+	/**
+	 * The surrounding whitespace a properties file carries is not part of the
+	 * version, and wiring it into the POM would pin a dependency on a version string
+	 * no repository holds.
+	 */
+	@Test
+	void aFilteredVersionIsReadWithoutItsSurroundingWhitespace() throws IOException {
+		assertEquals("2.6.0", EnforcerRuleVersion.read(metadata(EnforcerRuleVersion.RULE_VERSION_KEY + "=  2.6.0  ")));
+	}
+
+	private void assertUnfiltered(String version) {
+		assertFailure(AdoptionException.class,
+				() -> EnforcerRuleVersion.read(metadata(EnforcerRuleVersion.RULE_VERSION_KEY + "=" + version)),
+				EnforcerRuleVersion.BUILD_PROPERTIES);
+	}
+
+	private InputStream metadata(String content) {
+		return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
 	}
 
 	private String outcomeOf(Supplier<String> version) {


### PR DESCRIPTION
Two classes were written with the seam their own tests needed and then
sealed it, so the failure each carefully composes a message for is one no
test can provoke. Both are silent at run time, which is what makes them
worth reaching from a test rather than from a reader.

CommandRunners.forRun assembles the toolchain a real run is driven
through, added so the command line and the MCP tool could not answer
--timeout or --retries differently. It had no test at all — the one class
in the module at zero coverage that is not a Spring entry point. The
ArchUnit rule that came with it says who may build the toolchain, never
what it has to come out as, and nothing else can observe either half: the
timeout and the retry count are private fields of two classes behind a
bare CommandRunner. So the drift the class exists to prevent was exactly
the drift the suite could not see. RetryingCommandRunner.delegate() and
retries() and ProcessCommandRunner.timeout() are package-visible for that
assertion, each documented with what it costs to leave unasserted: a
decorator left off answers every command exactly as a run whose network
never faltered, and a timeout that did not arrive shows only when a
command outlives the bound nobody set. Removing the decorator fails six
of the six new tests; dropping the configured timeout fails one.

EnforcerRuleVersion.read took an InputStream and was private, so the only
way in was fromBuildMetadata reading one resource off this class's own
classpath — correct in every build that runs these tests. Its three
refusals were unreachable, and they are the ones standing between a
broken build of tools and a literal @enforcer.rule.version@ wired into a
stranger's pom.xml by a pull request the adoption opened. The method is
package-visible now, and the tests hand it metadata that is absent,
unfiltered with either delimiter, blank, and missing the key. Dropping
the unfiltered-token guard fails two of them; branch coverage of the
class goes from 9 of 14 to 13 of 14.

No production behaviour changes: the three accessors are new, and the
visibility widening is the only edit to an existing member.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WUXe1drEiqcAHczdAd26va