### PR TITLE
fix(claude-code-enforcer): stop the fixer reporting a repair that repaired nothing

### DIFF
--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixer.java
@@ -28,11 +28,17 @@ import java.util.stream.IntStream;
  * with, so repairing two delimiter lines does not rewrite every other line of a
  * CRLF file.
  * <p>
- * A repair that changes nothing is no repair, and is reported as none. Not every
- * block {@link FrontMatter} declines to read is one this fixer can mend — a block
- * whose delimiters are already canonical and whose <em>YAML</em> is malformed is
- * beyond it — and returning that document unchanged would have the caller write the
- * file it already had, and log a fix, on every build.
+ * A mend is reported only once the mended document has been read back and found to
+ * parse, because delimiters are the only thing this fixer knows how to write and a
+ * block can be unreadable for reasons that have nothing to do with them. Its
+ * <em>YAML</em> may be malformed too — a value such as {@code "a" and "b"} whose
+ * quotes do not wrap it, an entry indented with a tab — and canonical delimiters
+ * around such a block leave it exactly as unreadable as it was. Reporting that as a
+ * repair rewrote the author's file and logged {@code Auto-fixed malformed front
+ * matter}, and the same run then failed on the same file for having no parseable
+ * front matter: a fix that was announced, written, and worth nothing. Reading the
+ * result back covers the block nothing was changed in for the same reason, since a
+ * document that did not parse on the way in does not parse on the way out either.
  */
 public final class FrontMatterFixer {
 
@@ -70,7 +76,7 @@ public final class FrontMatterFixer {
 			return Optional.empty();
 		}
 		return repairDelimiters(lines, open).map(fixed -> render(withoutLeadingBlanks(fixed), content))
-				.filter(repaired -> !repaired.equals(content));
+				.filter(repaired -> FrontMatter.parse(repaired).isPresent());
 	}
 
 	/** The lines with any blank lines before the opening delimiter removed, so the block starts on line one. */

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRuleTest.java
@@ -6,6 +6,7 @@ import static io.github.adamw7.tools.test.TestFiles.writeBytes;
 import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -144,6 +145,35 @@ class SubAgentFormatRuleTest {
 
 		assertDoesNotThrow(rule::execute);
 		assertTrue(readString(file).contains("---\n# Reviewer"), readString(file));
+	}
+
+	/**
+	 * Auto-fix writes the author's file, so it may only write one it has made
+	 * readable. This block's delimiters are mendable and its value — quotes that do
+	 * not wrap it — is not, and mending the delimiters alone left the rule failing on
+	 * the file it had just rewritten, under a log line saying the front matter had
+	 * been auto-fixed. The build has to say the same thing it says with auto-fix off,
+	 * over the file the author still has.
+	 */
+	@Test
+	void autoFixLeavesADefinitionItCannotMakeReadableAlone() {
+		Path file = tempDir.resolve("reviewer.md");
+		String original = """
+				----
+				name: reviewer
+				description: "a" and "b"
+				----
+				# Reviewer
+				""";
+		writeString(file, original);
+		SubAgentFormatRule rule = ruleFor(tempDir);
+		CapturingLogger log = new CapturingLogger();
+		rule.setAutoFix(true);
+		rule.setLog(log);
+
+		assertFailure(EnforcerRuleException.class, rule::execute, "front matter");
+		assertEquals(original, readString(file), "the file must be left as its author wrote it");
+		assertTrue(log.infos().isEmpty(), () -> "nothing was fixed, so nothing may be logged as fixed: " + log.infos());
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/text/FrontMatterFixerTest.java
@@ -2,14 +2,48 @@ package io.github.adamw7.tools.enforcer.text;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
 class FrontMatterFixerTest {
+
+	/**
+	 * The lines a generated document is built from: the delimiters this fixer mends,
+	 * the entries that make a region front matter, the values and indentation no
+	 * loader can read, and the prose a block has to stop at.
+	 */
+	private static final List<String> FRAGMENTS = List.of(
+			"---",
+			"----",
+			"-----",
+			"",
+			"   ",
+			"name: reviewer",
+			"description: Reviews code.",
+			"description: \"a\" and \"b\"",
+			"allowed-tools: Bash",
+			"a: b: c",
+			"key:",
+			"\tname: tabbed",
+			"  nested: y",
+			"- item",
+			"# Reviewer",
+			"Some prose.",
+			"Note: prose with a colon");
+
+	/**
+	 * How many generated documents the contract is checked over — enough to reach the
+	 * combinations the fixtures below were each found by, and few enough that the whole
+	 * class still runs in a fraction of the per-test timeout.
+	 */
+	private static final int GENERATED_DOCUMENTS = 2000;
 
 	@Test
 	void leavesWellFormedFrontMatterUntouched() {
@@ -174,12 +208,94 @@ class FrontMatterFixerTest {
 
 	/**
 	 * Malformed YAML inside delimiters that are already canonical is beyond this
-	 * fixer. {@link FrontMatter} declines to read such a block, so the repair is
-	 * attempted and changes nothing — and reporting that as a repair would have the
-	 * caller rewrite the file it already had, and log a fix, on every build.
+	 * fixer. {@link FrontMatter} declines to read such a block, and reporting a repair
+	 * for it would have the caller rewrite the file it already had, and log a fix, on
+	 * every build.
 	 */
 	@Test
 	void reportsNoRepairForABlockItCannotMend() {
 		assertTrue(FrontMatterFixer.repair("---\ndescription: \"a\" and \"b\"\n---\nBody.\n").isEmpty());
+	}
+
+	/**
+	 * The same unreadable block, this time behind delimiters the fixer <em>can</em>
+	 * mend. Writing the canonical delimiters around it changed the file without
+	 * changing what it declares: the block was as unreadable afterwards as before, so
+	 * the caller rewrote the author's file, logged that it had auto-fixed the front
+	 * matter, and then failed the same run on the same file for having none.
+	 */
+	@Test
+	void reportsNoRepairWhenMendingTheDelimitersLeavesTheBlockUnreadable() {
+		String content = """
+				----
+				name: reviewer
+				description: "a" and "b"
+				----
+				# Reviewer
+				""";
+
+		assertEquals(Optional.empty(), FrontMatterFixer.repair(content));
+	}
+
+	/** The same, for the block whose closing delimiter is missing rather than over-dashed. */
+	@Test
+	void reportsNoRepairWhenClosingTheBlockLeavesItUnreadable() {
+		String content = """
+				---
+				name: reviewer
+				description: "a" and "b"
+				# Reviewer
+				""";
+
+		assertEquals(Optional.empty(), FrontMatterFixer.repair(content));
+	}
+
+	/**
+	 * A tab is not YAML indentation, so a block indented with one is unreadable for a
+	 * reason no delimiter carries either — and one written past leading blank lines
+	 * has all three of this fixer's repairs to make before that shows.
+	 */
+	@Test
+	void reportsNoRepairWhenTheBlockItWouldMoveToLineOneIsUnreadable() {
+		String content = """
+
+				----
+				\tname: reviewer
+				description: Reviews code.
+				""";
+
+		assertEquals(Optional.empty(), FrontMatterFixer.repair(content));
+	}
+
+	/**
+	 * The contract itself, over documents built from the lines that make a block
+	 * unreadable and the delimiters that make one mendable — because what a caller
+	 * relies on is not the three fixtures above but the promise they are examples of:
+	 * a reported repair is one the caller may write to the author's file and one the
+	 * checks below it can then read. The fixtures were each found this way, and are
+	 * kept as fixtures so a failure names the document rather than a seed.
+	 * <p>
+	 * The generator draws from a fixed seed sequence, so the same run happens on every
+	 * machine, and the documents are only parsed rather than written anywhere, which is
+	 * what keeps a few thousand of them inside the per-test timeout.
+	 */
+	@Test
+	void everyRepairItReportsIsOneThatParsesAndChangesTheDocument() {
+		for (int seed = 0; seed < GENERATED_DOCUMENTS; seed++) {
+			String generated = documentFrom(seed);
+			Optional<String> repaired = FrontMatterFixer.repair(generated);
+			repaired.ifPresent(fixed -> {
+				assertTrue(FrontMatter.parse(fixed).isPresent(), "a reported repair must parse:\n" + fixed);
+				assertNotEquals(generated, fixed, "a repair that changes nothing is none");
+			});
+		}
+	}
+
+	/** A document of between one and ten {@link #FRAGMENTS}, decided by {@code seed} alone. */
+	private static String documentFrom(int seed) {
+		Random random = new Random(seed);
+		return random.ints(1 + random.nextInt(10), 0, FRAGMENTS.size())
+				.mapToObj(FRAGMENTS::get)
+				.collect(Collectors.joining("\n", "", "\n"));
 	}
 }


### PR DESCRIPTION
FrontMatterFixer promises that what it hands back parses as front matter.
It only checked that the mended document differed from the one it was
given, and delimiters are the only thing it knows how to write: a block
whose YAML is also unreadable — a value such as "a" and "b" whose quotes
do not wrap it, an entry indented with a tab — came back with canonical
delimiters around the same unreadable YAML.

What that cost is a definition rule running with autoFix on. It wrote the
mended document to the author's file and logged "Auto-fixed malformed
front matter in <file>", and the same run then failed on that same file
for having no front matter a YAML loader can read. The announced fix
changed the file, fixed nothing, and re-running the build repeated the
failure without the log line, since the delimiters were canonical by then.

The mended document is now read back, and a repair is reported only when
it parses. That covers the block nothing was changed in for the same
reason, so the "changed nothing" filter it replaces is not lost: a
document that did not parse on the way in does not parse on the way out.

Tests: the three shapes the fixer mends, each with unreadable YAML behind
them; the rule-level cost, asserting the file is left as its author wrote
it and nothing is logged as fixed; and the contract itself over generated
documents, which is how the three shapes were found.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PpgDb3iyEPgcCLr13UBfsD