### PR TITLE
chore(config): lint the session hook, gate shellcheck, tighten two rules

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -15,12 +15,31 @@ fi
 
 JAVA_HOME_25=$(find /usr/lib/jvm -maxdepth 1 -name "java-25-openjdk*" -type d | head -1)
 
-echo "export JAVA_HOME=${JAVA_HOME_25}" >> "${CLAUDE_ENV_FILE}"
-echo "export PATH=${JAVA_HOME_25}/bin:\$PATH" >> "${CLAUDE_ENV_FILE}"
+# SessionStart fires on resume as well as startup, and a resumed session can land
+# in a re-provisioned container with no JDK 25, so the hook has to keep doing this
+# work rather than run once. Every step below is therefore idempotent: appending
+# the exports again would grow the env file by two lines on each resume.
+if ! grep -qs "^export JAVA_HOME=${JAVA_HOME_25}$" "${CLAUDE_ENV_FILE}"; then
+  {
+    echo "export JAVA_HOME=${JAVA_HOME_25}"
+    echo "export PATH=${JAVA_HOME_25}/bin:\$PATH"
+  } >> "${CLAUDE_ENV_FILE}"
+fi
 
+# The exports are written before the slow warm below, so a hook killed by its
+# timeout still leaves later tool calls with a JDK on the PATH.
 export JAVA_HOME="${JAVA_HOME_25}"
 export PATH="${JAVA_HOME_25}/bin:${PATH}"
 
-# Pre-download all Maven dependencies to local repo for faster builds
-cd "${CLAUDE_PROJECT_DIR}"
-mvn dependency:go-offline -q
+# Pre-download all Maven dependencies to local repo for faster builds. The marker
+# sits in the local repository the warm fills, so it is absent exactly when the
+# repository needs filling: a resume in the same container skips a warm that has
+# already happened, and a re-provisioned container does it again. A warm that
+# fails leaves no marker and is retried rather than recorded as done.
+warmed_marker="${HOME}/.m2/.tools-dependencies-warmed"
+if [[ ! -f "${warmed_marker}" ]]; then
+  cd "${CLAUDE_PROJECT_DIR}"
+  mvn dependency:go-offline -q
+  mkdir -p "$(dirname "${warmed_marker}")"
+  touch "${warmed_marker}"
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,8 +341,9 @@ is why the per-test timeout is 5 s rather than tighter. The workflows also pass
 `-ntp` explicitly, so quiet CI logs do not depend on `.mvn/maven.config` being
 picked up.
 
-**Shellcheck.** The root pom lints `scripts/**/*.sh` with
-`dev.dimlight:shellcheck-maven-plugin`, configured with
+**Shellcheck.** The root pom lints `scripts/**/*.sh` and
+`.claude/hooks/**/*.sh` with `dev.dimlight:shellcheck-maven-plugin`, configured
+with
 `<binaryResolutionMethod>embedded</binaryResolutionMethod>`: the `shellcheck`
 binary rides in as an ordinary Maven Central artifact inside the plugin jar, so
 nothing is fetched from GitHub and no `shellcheck` needs to be installed — the
@@ -351,6 +352,17 @@ Code web/remote sessions). The plugin's default method downloads the binary from
 GitHub releases; where that host is blocked the build fails on the root pom with
 `Input is not in the XZ format` before any Java module is reached. Skip the lint
 with `-Dskip.shellcheck=true`.
+
+`<failBuildIfWarnings>true</failBuildIfWarnings>` is what makes the lint a gate.
+The plugin defaults it to `false`, which prints shellcheck's findings as Maven
+warnings and then passes: a probe script carrying an unquoted expansion and an
+unassigned variable was reported line by line and the build still succeeded, so
+the lint had been running for a log nobody reads. Both source directories are
+clean, so the flag costs nothing today and fails the build on the next finding.
+The hooks directory is linted because a mistake there breaks a *session* rather
+than a build, and is found by whoever opened that session: `hooksFormat` checks
+the shebang and the executable bit, and only shellcheck reads what the script
+actually does.
 
 **The pull-request build.** `.github/workflows/maven.yml` installs the enforcer
 rule (`mvn -B -pl claude-code-enforcer -am install -DskipTests`, tests skipped
@@ -699,6 +711,13 @@ by matching intent against these descriptions, so one duplicate shadows the
 other, and the two uniqueness rules compare skills, sub-agents and commands
 together rather than each directory on its own.
 
+`skillFilesExist` is wired with `allowedFrontMatterKeys`, as `commandFormat` is:
+`name`, `description`, `allowed-tools`, `model` and `license` — the keys Claude
+Code accepts, not the two used here, so a skill may grow an `allowed-tools`
+without touching the pom. Without the list a mistyped `descripton:` is simply an
+unread key, and a skill whose description never loads is a skill that never
+loads.
+
 ### Sub-agents
 
 `.claude/agents/` holds **two** sub-agents, each a `*.md` file whose front matter
@@ -752,6 +771,22 @@ then installs `openjdk-25-jdk` when no JDK 25 is present, exports `JAVA_HOME` an
 repository with `mvn dependency:go-offline`. Keep it `set -euo pipefail`,
 executable, and opening with a `#!` shebang — `hooksFormat` requires the shebang
 and the executable bit, and the root pom lints it with shellcheck.
+
+Keep it **idempotent**, too. `SessionStart` fires on resume as well as startup,
+and a resumed session can land in a re-provisioned container with no JDK, so the
+hook cannot be a run-once script — it re-runs and must not accumulate. The
+exports are appended only when the env file does not already carry them, and the
+dependency warm is guarded by a marker inside the local repository it fills, so
+it is skipped on a resume into the same container and repeated when the container
+is new; a warm that fails leaves no marker and is retried rather than recorded as
+done. The exports are written *before* the warm, so a hook killed by its timeout
+still leaves a JDK on the `PATH`.
+
+`hooksFormat` is wired with `reportUnreferencedScripts`, which catches the silent
+direction of the wiring: a script that no hook names never runs, and nothing
+about it looks wrong — it has its shebang, its executable bit and its shellcheck
+pass. The other direction, a hook naming a script that is not there, is checked
+by default.
 
 Personal overrides belong in `.claude/settings.local.json`, which is gitignored;
 `localSettingsIgnored` fails the build if that entry disappears.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,11 +141,13 @@ Other things worth knowing:
 - `.mvn/maven.config` passes `--no-transfer-progress` and `-T1C`, so every build
   from the repo root is quiet and runs one thread per core; use `-T1` for a
   serial build.
-- The root pom lints `scripts/**/*.sh` with `shellcheck-maven-plugin` using the
-  binary embedded in the plugin jar, so the lint needs no installed `shellcheck`
-  and works offline. Skip it with `-Dskip.shellcheck=true`. Those scripts are
-  developer-environment helpers outside the build, kept as parallel
-  `scripts/linux` and `scripts/windows` variants.
+- The root pom lints `scripts/**/*.sh` and `.claude/hooks/**/*.sh` with
+  `shellcheck-maven-plugin` using the binary embedded in the plugin jar, so the
+  lint needs no installed `shellcheck` and works offline, and a finding **fails
+  the build** (`failBuildIfWarnings`) rather than passing as a warning. Skip it
+  with `-Dskip.shellcheck=true`. The `scripts` ones are developer-environment
+  helpers outside the build, kept as parallel `scripts/linux` and
+  `scripts/windows` variants.
 
 ## Principles for Java Development
 

--- a/pom.xml
+++ b/pom.xml
@@ -541,7 +541,8 @@
 		</pluginManagement>
 		<plugins>
 			<plugin>
-				<!-- Lint scripts/**/*.sh with shellcheck. binaryResolutionMethod
+				<!-- Lint scripts/**/*.sh and .claude/hooks/**/*.sh with shellcheck.
+				     binaryResolutionMethod
 				     "embedded" runs the shellcheck binary bundled inside the plugin
 				     jar (pulled from Maven Central like any other artifact), so the
 				     build needs no shellcheck on the PATH and downloads nothing at
@@ -561,9 +562,29 @@
 						</goals>
 						<configuration>
 							<binaryResolutionMethod>embedded</binaryResolutionMethod>
+							<!-- The plugin defaults to reporting shellcheck's findings as
+							     build warnings and passing anyway, so the lint ran for a
+							     log nobody reads: a probe script with an unquoted
+							     expansion and an unassigned variable was reported in full
+							     and the build still succeeded. Both source directories are
+							     clean today, so the lint gates from here on. -->
+							<failBuildIfWarnings>true</failBuildIfWarnings>
 							<sourceDirs>
 								<sourceDir>
 									<directory>${project.basedir}/scripts</directory>
+									<includes>
+										<include>**/*.sh</include>
+									</includes>
+								</sourceDir>
+								<!-- The session-start hook is a shell script the runtime
+								     executes before any tool call, so a mistake in it fails
+								     a session rather than a build and is found by whoever
+								     opened that session. hooksFormat checks the shebang and
+								     the executable bit; only shellcheck reads what the
+								     script does, which is why the hook is linted with the
+								     same binary as scripts/ rather than trusted. -->
+								<sourceDir>
+									<directory>${project.basedir}/.claude/hooks</directory>
 									<includes>
 										<include>**/*.sh</include>
 									</includes>
@@ -706,8 +727,22 @@
 										<agentsMdFormat>
 											<agentsMdFile>${project.basedir}/AGENTS.md</agentsMdFile>
 										</agentsMdFormat>
+										<!-- allowedFrontMatterKeys lists the keys Claude Code
+										     accepts in a SKILL.md, not the two this repository
+										     currently uses, so a skill may grow an
+										     `allowed-tools` without touching this pom while a
+										     mistyped `descripton` is still reported. Skills
+										     route by description, so a key that silently does
+										     nothing costs a skill its loading. -->
 										<skillFilesExist>
 											<skillsDir>${project.basedir}/.claude/skills</skillsDir>
+											<allowedFrontMatterKeys>
+												<allowedFrontMatterKey>name</allowedFrontMatterKey>
+												<allowedFrontMatterKey>description</allowedFrontMatterKey>
+												<allowedFrontMatterKey>allowed-tools</allowedFrontMatterKey>
+												<allowedFrontMatterKey>model</allowedFrontMatterKey>
+												<allowedFrontMatterKey>license</allowedFrontMatterKey>
+											</allowedFrontMatterKeys>
 										</skillFilesExist>
 										<!-- A configured definition directory must exist, so
 										     these two could only be wired once .claude/agents
@@ -759,10 +794,18 @@
 											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
 											<projectDir>${project.basedir}</projectDir>
 										</hookCommandsValid>
+										<!-- reportUnreferencedScripts is the half of the
+										     wiring cross-check that catches the silent
+										     direction: a script no hook names never runs, and
+										     nothing about it looks wrong — it has its shebang,
+										     its executable bit and its shellcheck pass. The
+										     other direction (a hook naming a missing script)
+										     is on by default. -->
 										<hooksFormat>
 											<hooksDir>${project.basedir}/.claude/hooks</hooksDir>
 											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
 											<projectDir>${project.basedir}</projectDir>
+											<reportUnreferencedScripts>true</reportUnreferencedScripts>
 										</hooksFormat>
 										<mcpServersValid>
 											<mcpFile>${project.basedir}/.mcp.json</mcpFile>


### PR DESCRIPTION
The agent configuration review found that several of this repository's own
enforcer options were wired without the parameters that give them teeth, and
that one documented guarantee was not actually in place.

- shellcheck now lints .claude/hooks/**/*.sh as well as scripts/**/*.sh.
  AGENTS.md claimed the session hook was linted; only scripts/ was configured,
  so the hook's shellcheck disable directive was guarding nothing.
- failBuildIfWarnings=true. The plugin defaults it to false, so the lint printed
  findings as Maven warnings and passed: a probe script with an unquoted
  expansion and an unassigned variable was reported in full and the build still
  succeeded. Both source directories are clean, so this costs nothing today.
- hooksFormat gains reportUnreferencedScripts, catching a hook script that no
  settings.json hook names — one that never runs while looking entirely correct.
- skillFilesExist gains allowedFrontMatterKeys, as commandFormat already had, so
  a mistyped key in a SKILL.md is reported rather than silently unread.
- session-start.sh is idempotent. SessionStart fires on resume as well as
  startup, so the old script appended a second pair of exports to CLAUDE_ENV_FILE
  and re-ran a full dependency warm every time. The exports are now written once
  and the warm is guarded by a marker in the local repository it fills.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KmXhL5zftG7DF2WMeNGNwH