### PR TITLE
refactor(markdown-common,grpc-example): drop two unused wrappers, scope log4j to test

### DIFF
--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -42,9 +42,11 @@ class ClaudeMdConformerTest {
 				.toList();
 	}
 
-	/** Whether the section carries a body, as the rule counts one. */
+	/** Whether the section carries a body, asked exactly as the rule asks it. */
 	private boolean hasBody(String content, String section) {
-		return MarkdownDocument.parse(content).hasBody(section);
+		MarkdownDocument document = MarkdownDocument.parse(content);
+		int index = document.headingIndex(section);
+		return index >= 0 && document.hasBodyAt(index);
 	}
 
 	@Test

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -134,13 +134,21 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!--
+			This module's src/main carries only .proto: the sole Java that logs is the
+			GreeterClient/GreeterServer pair under src/test, so both artifacts are test
+			scope. At compile scope they were published as dependencies of a jar that
+			cannot use them.
+		-->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownDocument.java
+++ b/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownDocument.java
@@ -261,34 +261,6 @@ public final class MarkdownDocument {
 	}
 
 	/**
-	 * True when {@code heading} appears as a real heading outside code fences.
-	 * <p>
-	 * Answered by the same lookup {@link #hasBody} and {@link #headingIndex} use.
-	 * It used to ask {@link #headings()} instead, which is a second implementation
-	 * of one question: two readings of what counts as a heading, kept equal only by
-	 * being edited together, and a whole document walked to answer a question the
-	 * first match settles.
-	 */
-	public boolean hasHeading(String heading) {
-		return headingIndex(heading) >= 0;
-	}
-
-	/**
-	 * True when {@code heading} is present and is followed, before the next heading
-	 * at its own level or shallower, by any prose, a code block, or a deeper
-	 * sub-heading. A deeper heading is content that belongs to the section; a
-	 * sibling or parent heading ends it.
-	 * <p>
-	 * A caller that has to tell a missing section from an empty one asks
-	 * {@link #headingIndex} and then {@link #hasBodyAt}, so the document is walked
-	 * once for the pair rather than once for each.
-	 */
-	public boolean hasBody(String heading) {
-		int index = headingIndex(heading);
-		return index >= 0 && hasBodyAt(index);
-	}
-
-	/**
 	 * The headings from {@code wanted} that are present, in the order they first
 	 * appear in the document, each listed once. A required heading that appears
 	 * more than once is reported by its first occurrence, so the order comparison
@@ -337,8 +309,9 @@ public final class MarkdownDocument {
 	/**
 	 * True when the heading at {@code headingIndex} is followed, before the next
 	 * heading at its own level or shallower, by any prose, a code block, or a deeper
-	 * sub-heading. The index form is for a caller that has already located the
-	 * heading — see {@link #hasBody}.
+	 * sub-heading. A caller locates the heading with {@link #headingIndex} first, so
+	 * a missing section and an empty one are told apart by one walk of the document
+	 * rather than by one walk each.
 	 * <p>
 	 * The first line that settles the question decides it; a section nothing settles
 	 * has no body.
@@ -525,7 +498,7 @@ public final class MarkdownDocument {
 	 * being matched on whole lines. Documentation about Markdown writes
 	 * {@code `<!--`} in prose precisely because it is an example, and taking it for a
 	 * real delimiter opened a comment nothing closed: every line below it was masked
-	 * as inert, so {@link #hasHeading} reported sections the document plainly carries
+	 * as inert, so {@link #headingIndex} reported sections the document plainly carries
 	 * as missing and every check that reads the document's own text stopped seeing
 	 * it — the same silent reclassification a mis-read fence produces.
 	 * <p>
@@ -619,7 +592,7 @@ public final class MarkdownDocument {
 		 * in below a paragraph opens nothing. Falling through to {@link #atDelimiter}
 		 * read one as a fence the document opened and never closed, and every line
 		 * below it — the document's remaining headings included — was masked as code:
-		 * {@link #hasHeading} then reported sections the document plainly carries as
+		 * {@link #headingIndex} then reported sections the document plainly carries as
 		 * missing, and every check that reads the document's own text stopped seeing it.
 		 * The blank-line case was already answered here; only a paragraph directly
 		 * above the indent reached the delimiter reading.

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownDocumentTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownDocumentTest.java
@@ -88,7 +88,7 @@ class MarkdownDocumentTest {
 				""");
 
 		assertEquals(List.of(0, 1, 2), codeLines(document));
-		assertTrue(document.hasHeading("## Section"));
+		assertTrue(hasHeading(document, "## Section"));
 	}
 
 	@Test
@@ -102,7 +102,7 @@ class MarkdownDocumentTest {
 				""");
 
 		assertEquals(List.of(0, 1, 2), codeLines(document));
-		assertTrue(document.hasHeading("# After"));
+		assertTrue(hasHeading(document, "# After"));
 	}
 
 	@Test
@@ -111,7 +111,7 @@ class MarkdownDocumentTest {
 		MarkdownDocument document = MarkdownDocument.parse("```\nint x;\n```   \n\n## Section\n");
 
 		assertEquals(List.of(0, 1, 2), codeLines(document));
-		assertTrue(document.hasHeading("## Section"));
+		assertTrue(hasHeading(document, "## Section"));
 	}
 
 	@Test
@@ -125,7 +125,7 @@ class MarkdownDocumentTest {
 				""");
 
 		assertEquals(List.of(2, 3, 4), codeLines(document));
-		assertFalse(document.hasHeading("## Section"));
+		assertFalse(hasHeading(document, "## Section"));
 	}
 
 	@Test
@@ -349,7 +349,7 @@ class MarkdownDocumentTest {
 				""");
 
 		assertEquals(List.of(), codeLines(document));
-		assertTrue(document.hasHeading("## Testing"));
+		assertTrue(hasHeading(document, "## Testing"));
 	}
 
 	/**
@@ -374,7 +374,7 @@ class MarkdownDocumentTest {
 
 		assertEquals(List.of(4), codeLines(document));
 		assertEquals(Set.of("# Title", "## Testing"), document.headings());
-		assertTrue(document.hasBody("## Testing"));
+		assertTrue(hasBody(document, "## Testing"));
 	}
 
 	/**
@@ -399,7 +399,7 @@ class MarkdownDocumentTest {
 
 		assertEquals(List.of(), codeLines(document));
 		assertEquals(Set.of("# Title", "## Testing"), document.headings());
-		assertTrue(document.hasBody("## Testing"));
+		assertTrue(hasBody(document, "## Testing"));
 	}
 
 	/** A balanced pair shown that way is the sample's too, so nothing below it changes. */
@@ -436,7 +436,7 @@ class MarkdownDocumentTest {
 				Body.
 				""");
 
-		assertTrue(document.hasBody("## Maven"));
+		assertTrue(hasBody(document, "## Maven"));
 	}
 
 	@Test
@@ -456,7 +456,7 @@ class MarkdownDocumentTest {
 		// "#1 rule:" is prose, not an ATX heading. Counting it as one would end the
 		// Maven section at its first line and report the section as empty.
 		assertEquals(Set.of("# Title", "## Maven", "## Testing"), document.headings());
-		assertTrue(document.hasBody("## Maven"));
+		assertTrue(hasBody(document, "## Maven"));
 	}
 
 	@Test
@@ -551,8 +551,8 @@ class MarkdownDocumentTest {
 				Body.
 				""");
 
-		assertFalse(document.hasBody("## Maven"));
-		assertTrue(document.hasBody("## Testing"));
+		assertFalse(hasBody(document, "## Maven"));
+		assertTrue(hasBody(document, "## Testing"));
 	}
 
 	/**
@@ -629,7 +629,7 @@ class MarkdownDocumentTest {
 
 		assertEquals(List.of(), commentedLines(document));
 		assertEquals(Set.of("# Title", "## Testing"), document.headings());
-		assertTrue(document.hasBody("## Testing"));
+		assertTrue(hasBody(document, "## Testing"));
 	}
 
 	/**
@@ -684,7 +684,7 @@ class MarkdownDocumentTest {
 				""");
 
 		assertEquals(Set.of("# Title", "## Testing"), document.headings());
-		assertTrue(document.hasBody("## Testing"));
+		assertTrue(hasBody(document, "## Testing"));
 	}
 
 	/** Only whitespace makes a trailing run a closing one, so a hash inside the text stays in it. */
@@ -718,7 +718,7 @@ class MarkdownDocumentTest {
 		MarkdownDocument document = MarkdownDocument.parse("# Title\n\n##\tTesting\nBody.\n");
 
 		assertEquals(Set.of("# Title", "## Testing"), document.headings());
-		assertTrue(document.hasBody("## Testing"));
+		assertTrue(hasBody(document, "## Testing"));
 	}
 
 	/**
@@ -807,7 +807,7 @@ class MarkdownDocumentTest {
 
 		assertEquals(List.of(), commentedLines(document));
 		assertEquals(Set.of("# Title", "## Testing"), document.headings());
-		assertTrue(document.hasBody("## Testing"));
+		assertTrue(hasBody(document, "## Testing"));
 	}
 
 	@Test
@@ -992,8 +992,8 @@ class MarkdownDocumentTest {
 				body
 				""".formatted("<!-- sample -->".repeat(20_000)));
 
-		assertTrue(document.hasHeading("## Testing"));
-		assertTrue(document.hasBody("## Testing"));
+		assertTrue(hasHeading(document, "## Testing"));
+		assertTrue(hasBody(document, "## Testing"));
 		assertEquals(List.of(), commentedLines(document));
 		assertTrue(document.openCommentTerminator().isEmpty());
 	}
@@ -1013,12 +1013,27 @@ class MarkdownDocumentTest {
 				body
 				""".formatted("<!-- sample -->".repeat(20_000)));
 
-		assertFalse(document.hasHeading("## Testing"));
+		assertFalse(hasHeading(document, "## Testing"));
 		assertEquals("-->", document.openCommentTerminator().orElseThrow());
 	}
 
 	private static String terminatorOf(String content) {
 		return MarkdownDocument.parse(content).openFenceTerminator().orElseThrow();
+	}
+
+	/**
+	 * Whether the document declares {@code heading}, and whether that heading carries
+	 * a body, asked the way the rules and the conformer ask them: locate the heading
+	 * once, then question the index it found. Both used to be methods on the document
+	 * itself, which walked it a second time for the pair.
+	 */
+	private static boolean hasHeading(MarkdownDocument document, String heading) {
+		return document.headingIndex(heading) >= 0;
+	}
+
+	private static boolean hasBody(MarkdownDocument document, String heading) {
+		int index = document.headingIndex(heading);
+		return index >= 0 && document.hasBodyAt(index);
 	}
 
 	/** The indices of the structural lines whose text is exactly {@code heading}. */


### PR DESCRIPTION
MarkdownDocument.hasHeading and hasBody had no production caller left.
Both rules that used to ask them — MarkdownFormatRule and the adoption's
ClaudeMdConformer — now locate the heading with headingIndex and question
the index with hasBodyAt, so a missing section and an empty one cost one
walk of the document instead of two. The wrappers survived only for the
tests still calling them, which now ask the pair the way production does.
Three javadoc references to the removed methods point at headingIndex,
which is what carries their meaning now.

grpc-example declares log4j-api and log4j-core at compile scope, but its
src/main holds only .proto — the only Java that logs is the client and
server pair under src/test. Both move to test scope, so the published jar
stops carrying dependencies it cannot use.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FTQcmXu6pJVybiCFb8bsPx