### PR TITLE
fix(adopt): three defects found reading the pipeline's edits

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -50,8 +50,18 @@ public final class RepositoryUrl {
 	 * removes what it finds rather than masking it: the {@code git@} of an
 	 * {@code ssh://git@host/owner/repo} is the account to log in as, not a secret, and
 	 * a URL stripped of it authenticates as whoever is running the adoption instead.
+	 *
+	 * <p>The scheme is matched without regard to case, as {@link #SCHEME} and
+	 * {@link #stripGitSuffix} already read a URL: a scheme is case-insensitive and git
+	 * clones {@code HTTPS://token@host/owner/repo} as readily as the lower-case form.
+	 * Reading only the lower-case one left {@link #withoutCredentials()} answering the
+	 * URL unchanged, so {@code CloneStep} saw nothing to rewrite and the token stayed
+	 * in the checkout's {@code .git/config} — while {@link Redaction}, which matches
+	 * any scheme, masked it everywhere the run <em>reported</em> the URL, leaving
+	 * nothing to notice it by.
 	 */
-	private static final Pattern HTTP_CREDENTIALS = Pattern.compile("(?<=^https?://)[^/\\s]+@");
+	private static final Pattern HTTP_CREDENTIALS = Pattern.compile("(?<=^https?://)[^/\\s]+@",
+			Pattern.CASE_INSENSITIVE);
 
 	private final String value;
 	private final String redacted;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -218,17 +218,40 @@ public class ClaudeMdConformer {
 	 * headings — which the rule accepts, so nothing downstream would report the
 	 * duplicate, and the reshape being idempotent means a re-adoption never clears it.
 	 *
+	 * <p>A document that already opens with the title is not left alone either: it
+	 * needs no title <em>added</em>, but a second one lower down is the same duplicate
+	 * by another route, and returning on the first line alone left it there for good —
+	 * the rule never looks past that line, so nothing downstream reported it, and the
+	 * reshape being idempotent meant no re-adoption cleared it.
+	 *
 	 * <p>The titles are removed latest first, so removing one cannot shift the index
 	 * of the next. Only structural lines are offered: a {@code # CLAUDE.md} inside a
 	 * code sample is the sample's, not the document's.
 	 */
 	private void ensureTitle(List<String> lines) {
 		MarkdownDocument document = MarkdownDocument.of(lines);
+		List<Integer> titles = document.headingIndices(TITLE).boxed().toList();
 		if (TITLE.equals(document.firstNonBlankLine())) {
+			removeHeadings(lines, allButTheFirst(titles));
 			return;
 		}
-		document.headingIndices(TITLE).boxed().toList().reversed().forEach(index -> removeHeading(lines, index));
+		removeHeadings(lines, titles);
 		lines.addAll(0, List.of(TITLE, ""));
+	}
+
+	/**
+	 * The titles a document opening with one has to lose: every one but the title it
+	 * opens with, which is the one the rule reads. An empty list is the document whose
+	 * opening title is not a structural line at all — one indented into a code block,
+	 * which the rule accepts on the same reading and which is the sample's to keep.
+	 */
+	private static List<Integer> allButTheFirst(List<Integer> titles) {
+		return titles.isEmpty() ? titles : titles.subList(1, titles.size());
+	}
+
+	/** Removes the headings latest first, so removing one cannot shift the index of the next. */
+	private static void removeHeadings(List<String> lines, List<Integer> indices) {
+		indices.reversed().forEach(index -> removeHeading(lines, index));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -48,6 +48,9 @@ public class GradleGuardInstaller {
 	private static final String BUILD_FILE_DESCRIPTION = "Gradle build file";
 	private static final String KOTLIN_SUFFIX = ".kts";
 	private static final String LINE_COMMENT = "//";
+	private static final char SINGLE_QUOTE = '\'';
+	private static final char DOUBLE_QUOTE = '"';
+	private static final char ESCAPE = '\\';
 
 	/**
 	 * The shapes that actually register the task in either DSL:
@@ -135,15 +138,56 @@ public class GradleGuardInstaller {
 	 * removed first and by span rather than by line, because it is the form a whole
 	 * declaration is commented out with, and leaving it made the script read as
 	 * already declaring the task — so the guard was never appended and
-	 * {@link VerifyStep} ran a task the build does not have. The line form is dropped
+	 * {@link VerifyStep} ran a task the build does not have. The line form is cut
 	 * afterwards, and the lines are rejoined rather than matched one at a time so a
 	 * registration spread over several lines is still recognised.
+	 *
+	 * <p>A line comment is cut from its delimiter rather than taking the whole line,
+	 * because it does not have to start one: a registration written at the end of a
+	 * line of real code — {@code plugins { id 'java' } // tasks.register('enforceClaudeMd')}
+	 * — was left in the text, so the script read as already declaring the task and got
+	 * no guard. The line is kept in place, blank where it was wholly a comment, rather
+	 * than dropped: dropping it would join the lines either side of it, which is how
+	 * two halves of no declaration at all come to read as one.
 	 */
 	private String withoutComments(String script) {
 		String withoutBlocks = BLOCK_COMMENT.matcher(script).replaceAll("");
 		return withoutBlocks.lines()
-				.filter(line -> !line.strip().startsWith(LINE_COMMENT))
+				.map(GradleGuardInstaller::withoutLineComment)
 				.collect(Collectors.joining("\n"));
+	}
+
+	/**
+	 * The line up to its first {@value #LINE_COMMENT} outside a string literal. The
+	 * literals are honoured because a Gradle script writes {@code url 'https://…'}
+	 * more readily than it writes anything else, and cutting there would drop the rest
+	 * of a line that may carry the declaration being looked for.
+	 */
+	private static String withoutLineComment(String line) {
+		char quote = 0;
+		int index = 0;
+		while (index < line.length()) {
+			if (quote == 0 && line.startsWith(LINE_COMMENT, index)) {
+				return line.substring(0, index);
+			}
+			char character = line.charAt(index);
+			quote = quoteAfter(quote, character);
+			index += quote != 0 && character == ESCAPE ? 2 : 1;
+		}
+		return line;
+	}
+
+	/**
+	 * The string literal still open after this character: the one it closes, the one
+	 * it opens, or none. A backslash inside a literal escapes the character after it,
+	 * a closing quote included, which is why {@link #withoutLineComment} steps over
+	 * two characters there.
+	 */
+	private static char quoteAfter(char quote, char character) {
+		if (quote != 0) {
+			return quote == character ? 0 : quote;
+		}
+		return character == SINGLE_QUOTE || character == DOUBLE_QUOTE ? character : 0;
 	}
 
 	private String blockFor(Path buildFile) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
@@ -267,6 +267,24 @@ class RepositoryUrlTest {
 				RepositoryUrl.of("ssh://git@github.com/owner/repo.git").withoutCredentials());
 	}
 
+	/**
+	 * A scheme is case-insensitive and git clones {@code HTTPS://…} as readily as the
+	 * lower-case form, so the credentials behind one have to be dropped just the same.
+	 * Reading only the lower-case scheme answered the URL unchanged, which
+	 * {@code CloneStep} takes as "there was nothing to rewrite" — so the token stayed
+	 * in the checkout's {@code .git/config}, while {@link Redaction} masked it in
+	 * every line the run printed and left nothing to notice it by.
+	 */
+	@Test
+	void dropsTheCredentialsOfAnUpperCaseScheme() {
+		assertEquals("HTTPS://github.com/owner/repo.git",
+				RepositoryUrl.of("HTTPS://x-access-token:secret@github.com/owner/repo.git").withoutCredentials());
+		assertEquals("Https://github.com/owner/repo.git",
+				RepositoryUrl.of("Https://token@github.com/owner/repo.git").withoutCredentials());
+		assertEquals("HTTP://github.com/owner/repo.git",
+				RepositoryUrl.of("HTTP://user:pass@github.com/owner/repo.git").withoutCredentials());
+	}
+
 	/** A URL refused on its input is quoted back, so it must be masked there too. */
 	@Test
 	void masksTheCredentialsOfARejectedUrl() {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformerTest.java
@@ -208,6 +208,25 @@ class ClaudeMdConformerTest {
 	}
 
 	/**
+	 * The same duplicate by the other route. A document that already opens with the
+	 * title needs none added, but a second one lower down is still two
+	 * {@code # CLAUDE.md} headings in a file the adoption is about to commit —
+	 * and returning on the first line alone left it there, since the rule never looks
+	 * past that line and the reshape is idempotent.
+	 */
+	@Test
+	void dropsASecondTitleFromADocumentThatAlreadyStartsWithOne() {
+		String generated = "# CLAUDE.md\n\nA preamble.\n\n# CLAUDE.md\n\nBody here.\n";
+		String conformed = conformer.conform(generated);
+		assertEquals(ClaudeMdConformer.TITLE, conformed.lines().findFirst().orElseThrow());
+		assertEquals(1, conformed.lines().filter(ClaudeMdConformer.TITLE::equals).count(),
+				"the duplicate must be removed, not kept:\n" + conformed);
+		assertTrue(conformed.contains("A preamble."), "the preamble survives");
+		assertTrue(conformed.contains("Body here."), "the body survives");
+		assertEquals(conformed, conformer.conform(conformed), "the removal must be idempotent");
+	}
+
+	/**
 	 * Only the document's own title moves. One inside a code sample belongs to the
 	 * sample — the rule reads it as code — so removing it would rewrite the sample.
 	 */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
@@ -120,6 +120,36 @@ class GradleGuardInstallerTest {
 	}
 
 	/**
+	 * A line comment does not have to start the line. Dropping whole lines left a
+	 * registration written after real code plainly in the text, so the script read as
+	 * already declaring the task, the guard was never appended, and
+	 * {@link GradleBuildSystem#verifyCommand(Path)} then ran a task the build has not.
+	 */
+	@Test
+	void installsTheGuardWhenTheMentionTrailsRealCode(@TempDir Path directory) throws IOException {
+		Path buildFile = write(directory, "build.gradle",
+				"plugins { id 'java' } // tasks.register('enforceClaudeMd') one day\n");
+		assertTrue(installer.install(buildFile));
+		assertTrue(Files.readString(buildFile).contains("tasks.register('enforceClaudeMd')"));
+	}
+
+	/**
+	 * A {@code //} inside a string literal opens no comment. A Gradle script writes
+	 * {@code url 'https://…'} more readily than it writes anything else, so cutting
+	 * there would drop the rest of a line that may carry the declaration — and the
+	 * guard would be appended to a script that already has one.
+	 */
+	@Test
+	void readsADeclarationSharingALineWithAUrl(@TempDir Path directory) throws IOException {
+		Path buildFile = directory.resolve("build.gradle");
+		String own = "repositories { maven { url 'https://example.com/m2' } }; "
+				+ "tasks.register('enforceClaudeMd') { }\n";
+		Files.writeString(buildFile, own);
+		assertFalse(installer.install(buildFile));
+		assertEquals(own, Files.readString(buildFile));
+	}
+
+	/**
 	 * The block comment is the form a whole declaration is commented out with, since it
 	 * takes the registration's braces and its body in one go. Reading only the line form
 	 * left the task name plainly in the text, so the script was taken to declare the


### PR DESCRIPTION
Each is a case the class's own javadoc already rules on, and the code
answers differently.

RepositoryUrl matched an http(s) URL's credentials case-sensitively while
the same class reads its scheme and its .git suffix without regard to
case. A URL handed in as HTTPS://x-access-token:TOKEN@host/owner/repo
therefore came back from withoutCredentials() unchanged, which CloneStep
takes as "there was nothing to rewrite" — so the token stayed in the
checkout's .git/config, the one place the module exists to keep it out
of. Redaction matches any scheme, so it masked the token in every line
the run printed and left nothing to notice the leak by.

ClaudeMdConformer returned from ensureTitle the moment the document
already opened with the title, leaving a second # CLAUDE.md lower down in
place. That is the same duplicate the method removes when the first title
sits further in, and the rule never looks past the first line — so
nothing downstream reported it and, the reshape being idempotent, no
re-adoption cleared it.

GradleGuardInstaller dropped whole lines to remove line comments, so a
registration written after real code — plugins { id 'java' } //
tasks.register('enforceClaudeMd') — stayed in the text the declaration
search reads. The script then counted as already declaring the task, the
guard was never appended, and VerifyStep ran a task the build has not.
The comment is now cut from its delimiter, honouring string literals so a
line carrying url 'https://…' keeps whatever follows it.

Each fix carries a regression test that fails without it.