### PR TITLE
Read enforcer version from pluginManagement when declaration names none

### DIFF
--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -64,11 +64,17 @@ pull request's URL.
 - A step must not depend on `GitHubRepoAdopter` — the pipeline knows its steps,
   not the other way round.
 - Only `CloneStep` and `PushStep` may touch `AdoptionContext#repositoryUrl()` —
-  the two commands that authenticate to the remote. Everything else logs
-  `displayUrl()` or, where a working URL is needed, `checkoutUrl()`. `PushStep`
-  passes the credentials as a `-c remote.origin.pushurl` override, which git
-  applies to that one invocation and writes nowhere. `Redaction` masks
-  credentials in every log, message and report — keep it that way.
+  the classes holding the commands that authenticate to the remote. Everything
+  else logs `displayUrl()` or, where a working URL is needed, `checkoutUrl()`.
+  The two commands that still authenticate after the clone strips the token pass
+  it per invocation and write it nowhere: `PushStep` as a
+  `-c remote.origin.pushurl` override, and `CloneStep`'s resuming fetch as a
+  `-c url.<credentialled>.insteadOf=<origin>` rewrite with
+  `--no-write-fetch-head`. Do not reach for `-c remote.origin.url` or a
+  positional URL — git treats the first as another value of a multi-valued key
+  and resolves the configured one instead, and writes the second into the reflog
+  of every ref the fetch updates. `Redaction` masks credentials in every log,
+  message and report — keep it that way.
 - Register the step in `GitHubRepoAdopter.defaultSteps` (or the optional list it
   belongs to), and unit-test it with a fake `CommandRunner`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,9 @@ What is worth knowing before changing any of it:
   credentials, `.git` suffix, trailing slash and case are set aside; anything
   else, including a checkout with no `origin`, is refused. The checkout is then
   refreshed with `git fetch`, since `BranchStep` starts the feature branch from
-  the remote-tracking refs.
+  the remote-tracking refs — through the credentials the run was given, because
+  the `origin` an earlier run left behind deliberately has none and a plain fetch
+  reaches a private repository as an anonymous caller.
 - **One run adopts a list of repositories** — repeatable `--repo <url>`, `--repos
   <file>` (one URL per line, `#` comments and blank lines skipped), or
   `repository_urls` on the MCP tool (a JSON array or a comma-separated string).
@@ -103,8 +105,17 @@ What is worth knowing before changing any of it:
   report field goes through `Redaction`, which masks the user information of a
   URL carrying a scheme, so a CI runner's
   `https://x-access-token:TOKEN@github.com/...` never reaches disk or an MCP
-  client. `git` is still handed the URL as given. Both `gh` invocations name the
-  repository with `--repo` rather than letting `gh` infer it from the remote.
+  client. `git` is still handed the URL as given, but only per invocation: the
+  clone rewrites the `origin` it just recorded to the credential-free form, and
+  the two commands that still have to authenticate supply the URL themselves —
+  `PushStep` as a `-c remote.origin.pushurl` override, and the resuming fetch as
+  a `-c url.<credentialled>.insteadOf=<origin>` rewrite plus
+  `--no-write-fetch-head`. Both forms are transient. Neither
+  `-c remote.origin.url` nor a positional URL would do: git reads the first as
+  *another* value of a multi-valued key and resolves the configured one instead,
+  and records the second in the reflog of every ref the fetch updates. Both `gh`
+  invocations name the repository with `--repo` rather than letting `gh` infer it
+  from the remote.
 - **Configuration is one object.** `AdoptionOptions` (wrapping
   `PullRequestOptions`) carries the pull-request metadata, the starter assets,
   the rule version, the dry-run flag, the per-command timeout and the retry
@@ -126,7 +137,11 @@ What is worth knowing before changing any of it:
 - **Detection reads the pom's own `build/plugins`** — the one place a rule runs on
   every build, and the very place the installer would add one. A rule declared only
   in `pluginManagement`, a profile, or `reporting` runs on no ordinary build, so the
-  project gets an always-on declaration of its own and keeps the one it had.
+  project gets an always-on declaration of its own and keeps the one it had. The
+  plugin's *version* is the opposite question and reads the opposite way: an
+  enforcer the build declares without one resolves through `pluginManagement`, so
+  that is where the refusal to wire the rule into a plugin older than 3.1.0 —
+  which cannot look a rule up by name — looks when the declaration names none.
 - **A pom is edited as text, never re-serialised** (`PomDocument`): the addition
   is spliced into the bytes the file already held, at the source offsets
   **jsoup**'s XML parser reports for every start and end tag, so the adoption

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -40,7 +40,9 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  *
  * <p>The checkout is then refreshed with {@code git fetch}, because every later
  * decision about the feature branch is taken against the remote-tracking refs a
- * stale checkout has out of date.
+ * stale checkout has out of date. That fetch carries the credentials the run was
+ * given rather than the credential-free {@code origin} left behind for it — see
+ * {@link #fetchCommand}.
  *
  * <p>A freshly cloned checkout records the credential-free form of the URL as its
  * {@code origin}, so the token an adoption is driven with does not outlive the run
@@ -65,6 +67,17 @@ public class CloneStep extends AbstractCommandStep {
 
 	/** What {@code git status --porcelain} puts between a rename's old and new path. */
 	private static final String RENAME_ARROW = " -> ";
+
+	/**
+	 * Keeps a fetch from recording the URL it fetched through in
+	 * {@code .git/FETCH_HEAD}, which is where a credentialled one would outlive the
+	 * run — the same leak {@link #forgetCredentials} closes in {@code .git/config}.
+	 * Nothing here reads that file: the fetch is made for the remote-tracking refs
+	 * {@link BranchStep} resolves. Only the credentialled fetch asks for it, so a git
+	 * too old to know the option is unaffected unless the run is driven by a URL
+	 * carrying credentials.
+	 */
+	private static final String NO_FETCH_HEAD = "--no-write-fetch-head";
 
 	/**
 	 * One entry of {@code git status --porcelain}: the index and work-tree status
@@ -124,8 +137,10 @@ public class CloneStep extends AbstractCommandStep {
 	 * out of what the run <em>says</em>; nothing but this keeps it out of what the run
 	 * <em>leaves behind</em>.
 	 *
-	 * <p>{@link PushStep} is unaffected: it supplies the credentialled URL to the one
-	 * command that needs it, rather than reading it back from the checkout.
+	 * <p>The two commands that still have to authenticate are unaffected, because
+	 * neither reads the URL back from the checkout: {@link PushStep} supplies it as a
+	 * push-URL override, and {@link #fetchCommand} as a rewrite of the remote it
+	 * fetches from — each for that one invocation, and each written nowhere.
 	 *
 	 * <p>Only the remote this step just wrote is rewritten, and only when the URL
 	 * carried credentials at all. A reused checkout's {@code origin} is left exactly as
@@ -292,7 +307,44 @@ public class CloneStep extends AbstractCommandStep {
 	 */
 	private void refresh(AdoptionContext context, CommandRunner runner) {
 		log.info("Fetching {} in {}", AdoptionContext.REMOTE, context.repositoryDirectory());
-		runOrFail(runner, context.repositoryDirectory(), List.of("git", "fetch", AdoptionContext.REMOTE));
+		runOrFail(runner, context.repositoryDirectory(), fetchCommand(context));
+	}
+
+	/**
+	 * Fetches through the credentials the run was given, because the {@code origin}
+	 * a reused checkout carries has none: {@link #forgetCredentials} took them out of
+	 * {@code .git/config} the moment the clone put them there. A plain
+	 * {@code git fetch origin} therefore reaches a private repository as an anonymous
+	 * caller and is refused — so an adoption driven by CI into a workspace it keeps
+	 * between runs failed on the very step that exists to resume it, and failed for
+	 * exactly the repositories a credentialled URL is handed for.
+	 *
+	 * <p>The credentials are supplied the way {@link PushStep} supplies them: to this
+	 * one invocation, written nowhere. They cannot go through
+	 * {@code -c remote.origin.url}, which git reads as <em>another</em> of that key's
+	 * values rather than as a replacement and resolves the configured one first, nor
+	 * through a URL named positionally, which git records verbatim in the reflog of
+	 * every ref it updates. A transient {@code insteadOf} rewrite leaves the fetch
+	 * naming the remote, so the reflog records only {@code fetch origin} — and
+	 * {@link #NO_FETCH_HEAD} keeps the rewritten URL out of {@code .git/FETCH_HEAD},
+	 * the one other place the fetch would have written it down.
+	 *
+	 * <p>The rewrite is keyed on {@link AdoptionContext#checkoutUrl()}, which is the
+	 * {@code origin} of every checkout this step cloned. A checkout somebody else set
+	 * up may name the same repository by another form, which the rewrite does not
+	 * match and so leaves the fetch exactly as it was before — their {@code origin},
+	 * with whatever credentials they configured for it.
+	 */
+	private List<String> fetchCommand(AdoptionContext context) {
+		if (context.checkoutUrl().equals(context.repositoryUrl())) {
+			return List.of("git", "fetch", AdoptionContext.REMOTE);
+		}
+		return List.of("git", "-c", credentialledRewrite(context), "fetch", NO_FETCH_HEAD, AdoptionContext.REMOTE);
+	}
+
+	/** Rewrites the credential-free {@code origin} back to the URL the run was given. */
+	private String credentialledRewrite(AdoptionContext context) {
+		return "url." + context.repositoryUrl() + ".insteadOf=" + context.checkoutUrl();
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -35,8 +35,10 @@ public class PomEnforcerInstaller {
 	 * {@value #CLAUDE_MD_RULE} is looked up by the component name it is published
 	 * under, which the plugin only does from this version; an older one fails the
 	 * build complaining it cannot find a rule the POM plainly declares. A declaration
-	 * this installer writes itself pins {@value #ENFORCER_VERSION}, so only a plugin
-	 * the project pinned can be too old — see {@link #requireRunnableEnforcer}.
+	 * this installer writes itself pins {@value #ENFORCER_VERSION}, so only a version
+	 * the project pinned — in its {@code build} or in the {@code pluginManagement}
+	 * that declaration resolves through — can be too old; see
+	 * {@link #requireRunnableEnforcer}.
 	 */
 	static final String MINIMUM_ENFORCER_VERSION = "3.1.0";
 	private static final String RULE_ARTIFACT_ID = "tools.claude-code-enforcer";
@@ -54,6 +56,18 @@ public class PomEnforcerInstaller {
 
 	/** The one place a plugin both runs from and is added to; see {@link #enforcerPluginOfTheBuild}. */
 	private static final List<String> BUILD_PLUGINS = List.of("build", "plugins");
+
+	/**
+	 * Where a POM pins the version of a plugin its {@code build} declares without one
+	 * — the idiomatic Maven arrangement, and so the version
+	 * {@link #requireRunnableEnforcer} has to read when the declaration itself names
+	 * none.
+	 */
+	private static final List<String> MANAGED_PLUGINS = List.of("build", "pluginManagement", "plugins");
+
+	/** Where the refused version was read from, named so the operator knows which declaration to raise. */
+	private static final String IN_BUILD = "build/plugins";
+	private static final String IN_PLUGIN_MANAGEMENT = "build/pluginManagement";
 
 	/**
 	 * The execution that runs the rule, bound to {@code validate} and not inherited
@@ -202,7 +216,7 @@ public class PomEnforcerInstaller {
 	 * leave the plugin's classpath deciding between two versions of it.
 	 */
 	private void augment(PomDocument pom, Element plugin) {
-		requireRunnableEnforcer(plugin);
+		requireRunnableEnforcer(pom, plugin);
 		if (!declaresRuleDependency(plugin)) {
 			pom.insertUnder(plugin, List.of("dependencies"), ruleDependency());
 		}
@@ -218,16 +232,54 @@ public class PomEnforcerInstaller {
 	 * already runs behave, the same reason {@link CommitStep} refuses an ignored path
 	 * rather than forcing the file in.
 	 *
-	 * <p>Only a version literal is judged. One the POM leaves to a
-	 * {@code pluginManagement} entry, a parent, or a property cannot be read from
-	 * here, and refusing on that would turn the ordinary POM into an unadoptable one;
-	 * see {@link PluginVersion}.
+	 * <p>A declaration that names no version of its own is judged by the one the POM's
+	 * own {@code pluginManagement} pins for it, because that is the version the build
+	 * resolves — and pinning there while declaring the plugin bare in {@code build}
+	 * is how Maven projects are ordinarily written, so reading only the declaration
+	 * left this refusal blind to the common shape of the very thing it refuses. The
+	 * execution was spliced in, committed, and left to {@link VerifyStep} to fail on,
+	 * naming a rule Maven could not find rather than the declaration to raise.
+	 *
+	 * <p>Only a version literal is judged either way. One the POM leaves to a parent
+	 * or to a property cannot be read from here, and refusing on that would turn the
+	 * ordinary POM into an unadoptable one; see {@link PluginVersion}. A declaration
+	 * this installer writes itself always pins {@value #ENFORCER_VERSION}, which no
+	 * {@code pluginManagement} entry overrides, so only a plugin the project already
+	 * had reaches this at all.
 	 */
-	private void requireRunnableEnforcer(Element plugin) {
-		String version = PomDocument.childText(plugin, "version").orElse("");
+	private void requireRunnableEnforcer(PomDocument pom, Element plugin) {
+		versionOf(plugin).ifPresentOrElse(
+				version -> requireRunnable(version, IN_BUILD),
+				() -> managedEnforcerVersion(pom).ifPresent(version -> requireRunnable(version, IN_PLUGIN_MANAGEMENT)));
+	}
+
+	/**
+	 * The version the POM's own {@code pluginManagement} pins for the
+	 * {@value #ENFORCER_ARTIFACT_ID}, which is what a declaration naming none resolves
+	 * to.
+	 */
+	private Optional<String> managedEnforcerVersion(PomDocument pom) {
+		return pom.at(MANAGED_PLUGINS).stream()
+				.flatMap(plugins -> PomDocument.children(plugins, "plugin").stream())
+				.filter(managed -> PomDocument.hasArtifactId(managed, ENFORCER_ARTIFACT_ID))
+				.findFirst()
+				.flatMap(PomEnforcerInstaller::versionOf);
+	}
+
+	/** @return the version literal the element names, or empty when it names none at all */
+	private static Optional<String> versionOf(Element element) {
+		return PomDocument.childText(element, "version").filter(version -> !version.isBlank());
+	}
+
+	/**
+	 * @param version the version the build resolves the plugin at
+	 * @param where   the declaration it was read from, so the refusal names the one to raise
+	 */
+	private void requireRunnable(String version, String where) {
 		if (PluginVersion.isBelow(version, MINIMUM_ENFORCER_VERSION)) {
 			throw new AdoptionException("Cannot wire the " + CLAUDE_MD_RULE + " rule into the "
-					+ ENFORCER_ARTIFACT_ID + " this project pins to " + version + ": the rule is looked up by name,"
+					+ ENFORCER_ARTIFACT_ID + " this project pins to " + version + " in " + where
+					+ ": the rule is looked up by name,"
 					+ " which the plugin only does from " + MINIMUM_ENFORCER_VERSION + ", so the guard would fail"
 					+ " every build that runs it. Raise " + ENFORCER_ARTIFACT_ID + " to "
 					+ MINIMUM_ENFORCER_VERSION + " or later, then adopt the repository again.");

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
@@ -164,10 +164,11 @@ public class AdoptArchitectureTest {
 	static final ArchRule onlyTheCloneAndPushStepsReadTheCredentialledUrl = noClasses()
 			.that().doNotHaveFullyQualifiedName(CLONE_STEP).and().doNotHaveFullyQualifiedName(PUSH_STEP)
 			.should().callMethod(AdoptionContext.class, "repositoryUrl")
-			.because("repositoryUrl() answers the clone URL with its credentials intact; only the two commands "
-					+ "that authenticate to the remote may see them — the clone, and the push, which supplies "
-					+ "them per invocation because the clone no longer leaves them in .git/config — and "
-					+ "everything else reads the redacted displayUrl() or the credential-free checkoutUrl()");
+			.because("repositoryUrl() answers the clone URL with its credentials intact; only the commands "
+					+ "that authenticate to the remote may see them — the clone, the fetch that resumes a "
+					+ "checkout, and the push, the last two supplying them per invocation because the clone no "
+					+ "longer leaves them in .git/config — and everything else reads the redacted displayUrl() "
+					+ "or the credential-free checkoutUrl()");
 
 	@ArchTest
 	static final ArchRule adoptionReachesGitHubThroughItsTools = noClasses()

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/CloneStepTest.java
@@ -64,6 +64,44 @@ class CloneStepTest {
 	}
 
 	/**
+	 * The {@code origin} an earlier run left behind carries no credentials, by design,
+	 * so a plain {@code git fetch origin} reaches a private repository as an anonymous
+	 * caller and is refused — the resume failed for exactly the repositories a
+	 * credentialled URL is handed for. The credentials are supplied to this one
+	 * invocation the way {@link PushStep} supplies them to its own, as a rewrite of the
+	 * remote rather than as a positional URL, which git would record in the reflog of
+	 * every ref the fetch updated.
+	 */
+	@Test
+	void fetchesAReusedCheckoutThroughTheCredentialsTheRunWasGiven(@TempDir Path existingWorkspace)
+			throws IOException {
+		AdoptionContext credentialled = new AdoptionContext(
+				"https://x-access-token:TOKEN@github.com/adamw7/tools.git", existingWorkspace);
+		Files.createDirectories(credentialled.repositoryDirectory().resolve(".git"));
+		RecordingCommandRunner runner = origin("https://github.com/adamw7/tools.git");
+
+		step.execute(credentialled, runner);
+
+		assertEquals(List.of("git", "-c",
+				"url.https://x-access-token:TOKEN@github.com/adamw7/tools.git"
+						+ ".insteadOf=https://github.com/adamw7/tools.git",
+				"fetch", "--no-write-fetch-head", "origin"), runner.commandAt(2));
+	}
+
+	/**
+	 * The rewrite exists only to put credentials back; a run given none fetches exactly
+	 * as it always did, so the option a newer git added is asked for only on the path
+	 * that needs it.
+	 */
+	@Test
+	void fetchesPlainlyWhenTheRunWasGivenNoCredentials(@TempDir Path existingWorkspace) throws IOException {
+		AdoptionContext existing = checkedOut(existingWorkspace);
+		RecordingCommandRunner runner = origin("https://github.com/adamw7/tools.git");
+		step.execute(existing, runner);
+		assertEquals(List.of("git", "fetch", "origin"), runner.commandAt(2));
+	}
+
+	/**
 	 * A checkout the adoption did not create is not the adoption's to reconfigure: its
 	 * {@code origin} is whatever its owner set up, credentials included, and they may
 	 * well push through it themselves once the adoption has finished.

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -548,10 +548,10 @@ class PomEnforcerInstallerTest {
 	}
 
 	/**
-	 * A version left to a property, a {@code pluginManagement} entry, or a parent
-	 * cannot be read from the POM in hand. Refusing on what cannot be read would turn
-	 * an ordinary project into an unadoptable one, and {@link VerifyStep} still runs
-	 * the guard before the branch is pushed.
+	 * A version left to a property or to a parent cannot be read from the POM in hand.
+	 * Refusing on what cannot be read would turn an ordinary project into an
+	 * unadoptable one, and {@link VerifyStep} still runs the guard before the branch is
+	 * pushed.
 	 */
 	@Test
 	void augmentsAnEnforcerWhoseVersionCannotBeReadFromThePom(@TempDir Path dir) throws IOException {
@@ -559,6 +559,75 @@ class PomEnforcerInstallerTest {
 				"a version given as a property must not be read as an old one");
 		assertTrue(install(dir, POM_WITH_ENFORCER).contains("claudeMdFormat"),
 				"a plugin declaring no version at all must not be read as an old one");
+	}
+
+	/**
+	 * Pinning the version in {@code pluginManagement} and declaring the plugin bare in
+	 * {@code build} is how Maven projects are ordinarily written — this repository's
+	 * own poms included — so a refusal that read only the declaration was blind to the
+	 * common shape of the very thing it refuses. The execution was spliced into a
+	 * plugin the build resolves at 3.0.0-M2, committed, and left to {@link VerifyStep}
+	 * to fail on, naming a rule Maven could not find rather than the declaration to
+	 * raise.
+	 */
+	@Test
+	void refusesToWireTheRuleIntoAnEnforcerTheProjectManagesTooFarBack(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, pomManagingEnforcerAt("3.0.0-M2"));
+		AdoptionException failure = assertThrows(AdoptionException.class, () -> installer.install(pom));
+		assertTrue(failure.getMessage().contains("build/pluginManagement"),
+				"the failure must name the declaration to raise: " + failure.getMessage());
+		assertFalse(Files.readString(pom).contains("claudeMdFormat"), "nothing may be written to a refused POM");
+	}
+
+	/** The same shape managed at a version that runs the rule is augmented, not refused. */
+	@Test
+	void augmentsAnEnforcerTheProjectManagesAtARunnableVersion(@TempDir Path dir) throws IOException {
+		assertTrue(install(dir, pomManagingEnforcerAt("3.5.0")).contains("claudeMdFormat"),
+				"a managed version new enough to run the rule must be wired into");
+	}
+
+	/**
+	 * The declaration's own version is what the build resolves, so it answers whether
+	 * or not {@code pluginManagement} pins another — the direction that matters, since
+	 * reading the managed one instead would refuse a project whose build runs a
+	 * perfectly current plugin.
+	 */
+	@Test
+	void readsTheDeclaredVersionRatherThanTheManagedOne(@TempDir Path dir) throws IOException {
+		String declaredNewer = pomManagingEnforcerAt("3.0.0-M2")
+				.replace("<artifactId>maven-enforcer-plugin</artifactId>\n      </plugin>",
+						"<artifactId>maven-enforcer-plugin</artifactId>\n        <version>3.5.0</version>\n      </plugin>");
+		assertTrue(install(dir, declaredNewer).contains("claudeMdFormat"),
+				"the version the build declares must win over the one it merely manages");
+	}
+
+	/**
+	 * A POM whose {@code build} declares the enforcer without a version and whose
+	 * {@code pluginManagement} pins one — the arrangement Maven documents, and the
+	 * version such a declaration actually resolves at.
+	 */
+	private String pomManagingEnforcerAt(String version) {
+		return """
+				<project xmlns="http://maven.apache.org/POM/4.0.0">
+				  <artifactId>demo</artifactId>
+				  <build>
+				    <pluginManagement>
+				      <plugins>
+				        <plugin>
+				          <groupId>org.apache.maven.plugins</groupId>
+				          <artifactId>maven-enforcer-plugin</artifactId>
+				          <version>%s</version>
+				        </plugin>
+				      </plugins>
+				    </pluginManagement>
+				    <plugins>
+				      <plugin>
+				        <artifactId>maven-enforcer-plugin</artifactId>
+				      </plugin>
+				    </plugins>
+				  </build>
+				</project>
+				""".formatted(version);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The `PomEnforcerInstaller` now correctly reads the enforcer plugin version from `pluginManagement` when a `build/plugins` declaration names no version of its own. This is the idiomatic Maven arrangement and was previously causing false refusals to wire the rule into projects using this common pattern.

## Key Changes

- **PomEnforcerInstaller**: Refactored version checking to handle two cases:
  - When a plugin declaration includes an explicit version, use that
  - When it names no version, read the version from `pluginManagement` (the version the build actually resolves)
  - Only refuse if the resolved version is below 3.1.0 (the minimum that can look up rules by name)
  - Error messages now indicate which declaration location (`build/plugins` or `build/pluginManagement`) the refused version came from

- **CloneStep**: Enhanced the `refresh()` method to fetch through the credentials the run was given:
  - A reused checkout's `origin` deliberately has no credentials (stripped by `forgetCredentials`)
  - A plain `git fetch origin` would fail on private repositories as an anonymous caller
  - Credentials are supplied per-invocation via `-c url.<credentialled>.insteadOf=<origin>` rewrite
  - Added `--no-write-fetch-head` to prevent the credentialled URL from being written to `.git/FETCH_HEAD`
  - Mirrors the approach `PushStep` uses: transient, per-invocation, written nowhere

- **Tests**: Added comprehensive test coverage:
  - `refusesToWireTheRuleIntoAnEnforcerTheProjectManagesTooFarBack`: Verifies refusal when `pluginManagement` pins an old version
  - `augmentsAnEnforcerTheProjectManagesAtARunnableVersion`: Verifies augmentation when managed version is new enough
  - `readsTheDeclaredVersionRatherThanTheManagedOne`: Verifies declared version takes precedence over managed version
  - `fetchesAReusedCheckoutThroughTheCredentialsTheRunWasGiven`: Verifies fetch uses credentialled rewrite
  - `fetchesPlainlyWhenTheRunWasGivenNoCredentials`: Verifies plain fetch when no credentials

## Implementation Details

- The refusal now names the specific declaration location to help operators understand which `pom.xml` section to update
- Version reading is extracted into `versionOf()` and `managedEnforcerVersion()` helper methods for clarity
- The fetch command construction is extracted into `fetchCommand()` and `credentialledRewrite()` to keep the logic explicit
- Documentation updated in AGENTS.md and the adopt-pipeline skill to explain the credential handling strategy
- Architecture test updated to reflect that both `CloneStep` and `PushStep` (not just `PushStep`) access the credentialled URL

https://claude.ai/code/session_019X3NmyA9vvhxmh4veNtffH