### PR TITLE
feat(claude-code-enforcer): refuse an unreadable severity, default the shared reporting parameters build-wide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,22 @@ passes → push → open a pull request with `gh pr create`.
 
 What is worth knowing before changing any of it:
 
+- **The guard checks the whole configuration by default.** A Maven project gets
+  `claudeCodeProject` wired into its `pom.xml`, so the `AGENTS.md` the run
+  installs — and, with `--assets`, the `.claude` directory of settings and hooks —
+  is checked by the same build that checks the `CLAUDE.md`. Wiring one rule left
+  what the adoption itself wrote unguarded: a malformed `settings.json`, a skill
+  with no definition, or a credential committed into a hook all passed. `--rules
+  minimal` wires the document rule alone, for a repository whose maintainers want
+  nothing else of theirs read. Either counts as already guarded, so re-adopting a
+  repository adopted before the composite existed leaves its guard alone rather
+  than splicing a second execution in beside it.
+- **The guard demands the sections the document was conformed to.** They are
+  written into the POM rather than left to the rule's defaults, read from the one
+  accessor the reshape also reads, so the document and the guard beside it cannot
+  make different demands — and a project whose `CLAUDE.md` is not a Java
+  project's is held to its own headings. `--section` names them; without it the
+  detected build system decides.
 - **The guard is build-tool aware**, behind a `BuildSystem` abstraction: a Maven
   project gets the `claude-code-enforcer` rule wired into its `pom.xml` and
   verified with `mvn -N validate`; a Gradle project (Groovy or Kotlin DSL) gets
@@ -77,6 +93,14 @@ What is worth knowing before changing any of it:
   Windows.
 - **`claude init` is skipped for a checkout that already has a `CLAUDE.md`**: the
   CLI's output is not reproducible, so regenerating would discard edits.
+- **`claude init` is retried on its outcome, not its transcript.** It is the run's
+  most expensive command and was the only one with no recovery: `TransientFailures`
+  leaves `claude` out because its transcript is a model's prose and may discuss a
+  connection reset without one having happened. That objection is about the
+  transcript, so what is judged instead is whether the file exists — a run that
+  produced it has succeeded whatever it exited with, and one that did not has
+  produced nothing to lose. The memory file is moved aside and restored around
+  each attempt, since a second attempt must meet the checkout the first one did.
 - **A reused checkout is confirmed to be the repository under adoption** by
   comparing what its `origin` names with the URL given, read with `git config
   --get-all remote.origin.url` rather than `git remote get-url`, which expands
@@ -96,6 +120,29 @@ What is worth knowing before changing any of it:
   Each repository gets its own checkout (claimed inside its own adoption) and its
   own report, and one that fails does not stop the rest; `Main` raises the
   failures together afterwards so the process still exits non-zero.
+- **`--parallel <n>`** adopts several at once (up to 8). The batch was sequential
+  because the tools' output interleaved into a log nobody could attribute, which
+  is a solvable problem rather than a reason: each adoption puts its repository
+  into the logging context of its own thread and both appender patterns print it.
+  The repositories were already independent; `Checkouts` claims through a
+  concurrent map so the test-and-set that stops two of them cloning into one
+  directory produces a claim and a refusal rather than two claims. A batch of one,
+  or a parallelism of one, starts no pool and runs on the calling thread.
+- **A checkout whose adoption landed is removed**, unless `--keep-workspace`. A
+  batch makes one full clone per repository and nothing used to remove them, so a
+  fifty-repository run left fifty behind under a temporary directory nobody named.
+  A failed adoption's checkout is kept — it is the only record of how far the run
+  got — and so is a dry run's, which is all a dry run produces. A checkout that
+  cannot be removed is a warning, not a reason to report the repository as failed.
+- **`--verify-only`** answers "is this repository still adopted, and does its
+  guard still pass?" without adopting anything: it clones, reads, and writes
+  nothing, needing only `git`. It is a pipeline of its own rather than an adoption
+  with its writing steps disabled, for the same reason a dry run is. Its extra
+  step is `check-adopted`, which exists because the guard's own command cannot
+  answer the question — a build with no guard wired in passes `mvn -N validate`
+  precisely because nothing ran, so a repository that was never adopted, or whose
+  guard a later commit removed, verified exactly like one that was. Both halves,
+  the document and the guard, are reported together.
 - **`--dry-run`** assembles the pipeline *without* `PushStep` and
   `PullRequestStep` rather than with steps that decide to do nothing, and asks
   the toolchain check only for the `git` and `claude` a rehearsal really runs. A
@@ -851,6 +898,7 @@ Skill: `enforcer-rules`.
 | `noSecrets` | the configured files and directories for literal credentials — Anthropic, AWS, GitHub and Slack token formats plus private key blocks by default; `secretPatterns` adds custom regexes, or replaces the defaults when `useDefaultPatterns` is off. Each match is reported with file, line and kind but only the first characters, so the report never republishes the secret. |
 | `localSettingsIgnored` | the configured `.gitignore` covers each `ignoredPaths` entry (by default `.claude/settings.local.json`), honouring negations, anchoring, directory patterns and `*`/`?`/`**` globs. |
 | `pluginFormat` | `.claude-plugin/plugin.json`, when present: valid JSON with every `requiredKeys` entry, a kebab-case `name`, a dotted `version` and a non-empty `description` — each declared as a JSON string — and `allowedKeys` reporting typos. |
+| `claudeCodeProject` | all of the above, from a `projectDir` alone. It resolves each input by the conventional path Claude Code itself uses, runs only the parts whose input is present, and prefixes every violation with the part that found it. `skippedRules` switches a part off by that name, `claudeMdSections`/`claudeMdReference` pass the document contract through, `claudeMdBudgetBytes` sizes `CLAUDE.md` (32 KB by default, zero to skip), and `autoFix` reaches the document parts. `crossDocConsistency` and `readmeConsistency` are deliberately not included: they take the patterns a particular project needs kept in step, and no convention supplies those. |
 
 Rules whose target is optional (`mcpServersValid`, `mcpConfigFormat`,
 `okfBundleFormat`, `pluginFormat`, `noSecrets`, `hooksFormat`) pass on the absent
@@ -869,7 +917,11 @@ directory it cannot walk, fail as a verdict naming the file rather than as an
 offers:
 
 - **`severity`** — `error` (default, fails the build) or `warn` (logs the same
-  violations), so a new rule can be adopted gradually.
+  violations), so a new rule can be adopted gradually. Anything else is refused as
+  a build-setup mistake: read as the default, a `<severity>warning</severity>`
+  failed the build while the author who wrote it believed the rule had been
+  downgraded, which is the one misconfiguration whose symptom is
+  indistinguishable from the rule working.
 - **`reportFile`** — a self-contained HTML report of what failed and why plus
   per-rule "How to fix" steps, written on pass and fail alike so it always
   reflects the latest run.
@@ -882,6 +934,19 @@ offers:
   Maven runs every module from wherever it was invoked, so without it the token
   falls back to the working directory and a baseline recorded from the root
   suppresses nothing when the build starts elsewhere.
+- **Build-wide defaults for all three** — `-Dclaude.enforcer.severity`,
+  `-Dclaude.enforcer.reportDir` and `-Dclaude.enforcer.baselineDir`. They are the
+  three parameters that are the same answer for every rule a project wires, and a
+  full catalogue is around twenty of them; spelled per rule that is sixty elements
+  to keep in step. A parameter configured on the rule itself still wins, so a
+  build can downgrade the catalogue and insist on one rule. A directory names each
+  rule's file after the rule — two rules sharing one report would overwrite each
+  other's verdict, and one shared baseline would let a violation accepted for one
+  suppress an identical message from another — and the reports written into one
+  gain an `index.html` linking them.
+- **Asking to record a baseline with no `baselineFile`** is refused rather than
+  ignored. It used to read as "no baseline, so check normally", which told the
+  operator the build failed on the very violations they had just asked to accept.
 - **A debug trace of what each rule was pointed at** — `mvn -X` prints one line
   per rule naming its configured input files and how many violations survived the
   baseline, plus the scan counts (`Skills: checking 13 definition(s) in …`) and
@@ -898,7 +963,22 @@ offers:
 `claudeMdFormat` and `agentsMdFormat` share a `MarkdownFormatRule` base doing the
 existence, BOM, title and section checks, with optional `forbiddenTokens`,
 `enforceSectionOrder`, `maxLineLength` and `validateFileReferences` (local links
-must resolve, read both as written and percent-decoded).
+must resolve, read both as written and percent-decoded). The title, the required
+sections and (for `claudeMdFormat`) the companion document to reference are all
+overridable, so a project whose documents are not this one's keeps the structural
+checking on its own headings; `<requiredReference/>` left empty drops the
+companion check for a project that keeps none.
+
+They also take `autoFix` (off by default), which repairs the structure it would
+otherwise only report: a missing title, a heading that is a near miss for a
+required one, an absent or empty section, and a missing companion reference are
+mechanical edits with one correct answer. The reshape is
+`markdown-common`'s `MarkdownConformer`, working to the same `MarkdownContract`
+the rule then checks against and reading the document through the same
+`MarkdownDocument` — which is also what the adoption pipeline's conformer uses, so
+the repair and the check cannot come to disagree. Only the structure is repaired:
+a forbidden token, an over-long line and a broken file reference are still
+reported, because what a link ought to point at is the author's to say.
 
 The front-matter rules (`skillFilesExist`, `subAgentFormat`, `commandFormat`)
 share a `DefinitionFormatRule` base owning the directory requirement, the scan
@@ -909,6 +989,45 @@ closer, the rule rewrites the file in place and continues against the corrected
 content. The repair only acts when the document opens with a dashes line
 enclosing real `key: value` entries, so a lone `---` thematic break is never
 mistaken for front matter.
+
+Each input file is read and parsed once per build, whatever asks for it:
+`CLAUDE.md` is read by five rules and `settings.json` by four, and sharing the
+result costs them none of their independence — what is shared is the file's
+content, not any rule's reading of it. An entry is keyed by the path with its
+modification time and size, so a file `autoFix` rewrote mid-build misses rather
+than serving what it held before the fix.
+
+### Running the rules without Maven
+
+A maven-enforcer rule has to be resolvable as a JAR before the build that uses it
+runs, which is the two-phase bootstrap below. That is the right cost for a check
+that gates a build and the wrong one for a pre-commit hook, a project built with
+Gradle or with nothing, or anyone wanting to know what the rules make of a
+repository before wiring anything. The jar is therefore also a command line,
+running the same `claudeCodeProject` composite a pom would configure:
+
+```bash
+java -cp tools.claude-code-enforcer.jar:enforcer-api.jar \
+     io.github.adamw7.tools.enforcer.cli.Main . --fix --skip okfBundleFormat
+```
+
+`enforcer-api` is on the classpath because it is a `provided` dependency of the
+rule jar — Maven supplies it in the wiring that matters, and a standalone run has
+to bring it. Every option is a parameter of that rule (`--skip`, `--fix`,
+`--warn`, `--budget`, `--report`, `--debug`), so the command line and a pom
+configure one thing rather than two that could drift; an unrecognised option is
+refused rather than ignored. Failure is reported by throwing, as everywhere else
+here, so the process exits non-zero without the class ending a JVM it does not
+own.
+
+The command line is analysed apart from the shared coding conventions, because
+one of them cannot hold there: an entry point invoked as `java -jar` has no host
+process to report through, and giving this module a logging framework to satisfy
+the rule would put one on the plugin class path of every build that wires a rule.
+`CommonCodingConventions` is explicit that such a rule must be exempted visibly
+rather than relaxed for everyone, so `..enforcer.cli` carries its own
+`CommandLineArchitectureTest` restating what does apply — including that only
+`Main` reaches a stream.
 
 ### Two things that will bite you
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,9 +274,18 @@ inconsistent. Skills: `doc-contract` (editing the docs), `enforcer-rules`
   three definition rules are the opposite — a *configured* directory must exist,
   so `.claude/skills`, `.claude/agents` and `.claude/commands` were each added
   together with the rule reading them.
+- `claudeCodeProject` runs all of the above from a `projectDir` alone, finding
+  each input by convention and skipping the parts a project has nothing for. It
+  is what another project wires; this repository keeps the rules listed
+  individually, because its profile is the worked example and two of its rules
+  take patterns no convention supplies.
 - Every rule offers `severity` (`error` by default, or `warn` to log without
-  failing), an optional `reportFile` for an HTML report, and an optional
-  `baselineFile` that suppresses already-accepted violations.
+  failing — anything else is refused), an optional `reportFile` for an HTML
+  report, and an optional `baselineFile` that suppresses already-accepted
+  violations. All three have build-wide defaults: `-Dclaude.enforcer.severity`,
+  `-Dclaude.enforcer.reportDir`, `-Dclaude.enforcer.baselineDir`.
+- `claudeMdFormat` and `agentsMdFormat` take `autoFix`, which repairs the
+  structural problems they would otherwise only report.
 
 The check is opt-in via the `claude-md-enforce` profile and needs a two-phase
 build, since a maven-enforcer rule must be resolvable as a JAR before the build
@@ -288,7 +297,10 @@ mvn -N validate -DenforceClaudeMd          # 2. quick root-only doc check
 ```
 
 `.github/workflows/maven.yml` is the only CI workflow that opts in; ordinary
-builds are unaffected.
+builds are unaffected. The same rules run without Maven at all —
+`java -cp tools.claude-code-enforcer.jar:enforcer-api.jar
+io.github.adamw7.tools.enforcer.cli.Main <project-directory>` — which is the path
+for a pre-commit hook or a project built with something else.
 
 ## Dependencies
 

--- a/adopt/src/main/filtered-resources/adopt-build.properties
+++ b/adopt/src/main/filtered-resources/adopt-build.properties
@@ -9,3 +9,9 @@
 # parent configures resource filtering with useDefaultDelimiters=false and the
 # @ delimiter, so ${...} tokens are left untouched and only @...@ is substituted.
 enforcer.rule.version=@project.version@
+
+# The maven-enforcer-plugin version wired into an adopted project that has no
+# declaration of its own, taken from the same property the root pom manages the
+# plugin with, so the version this project builds against and the version it asks
+# a stranger's build to use cannot drift apart.
+enforcer.plugin.version=@maven-enforcer-plugin.version@

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
@@ -1,9 +1,12 @@
 package io.github.adamw7.tools.adopt;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
+import io.github.adamw7.tools.adopt.step.GuardOptions;
+import io.github.adamw7.tools.adopt.step.GuardRules;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 
 /**
@@ -41,9 +44,19 @@ import io.github.adamw7.tools.adopt.step.PullRequestOptions;
  *                        {@link #DEFAULT_RETRIES} and bounded by
  *                        {@link #MAX_RETRIES}; zero adopts exactly as an
  *                        undecorated run does
+ * @param guardRules      how much of the adopted repository's Claude Code
+ *                        configuration the wired guard checks, defaulting to all of
+ *                        it — the adoption installs an {@code AGENTS.md}, and with
+ *                        {@code --assets} a {@code .claude} directory, so a guard
+ *                        that read only {@code CLAUDE.md} left what the run itself
+ *                        wrote unchecked
+ * @param claudeMdSections the headings the guard demands and the reshape conforms
+ *                        to, empty to use the ones the detected build system asks
+ *                        for
  */
 public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAssets, String ruleVersion,
-		boolean dryRun, Duration commandTimeout, int retries) {
+		boolean dryRun, Duration commandTimeout, int retries, GuardRules guardRules,
+		List<String> claudeMdSections) {
 
 	/**
 	 * Two further attempts, which is what a transport-level hiccup takes: the failure
@@ -77,6 +90,8 @@ public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAss
 
 	public AdoptionOptions {
 		pullRequest = pullRequest == null ? PullRequestOptions.defaults() : pullRequest;
+		guardRules = guardRules == null ? GuardRules.PROJECT : guardRules;
+		claudeMdSections = claudeMdSections == null ? List.of() : List.copyOf(claudeMdSections);
 		ruleVersion = Text.orDefault(ruleVersion, null);
 		commandTimeout = commandTimeout == null ? ProcessCommandRunner.DEFAULT_TIMEOUT
 				: requireWithinBounds(commandTimeout);
@@ -84,11 +99,33 @@ public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAss
 	}
 
 	/**
+	 * The options without a guard named, which is every caller that does not care
+	 * which rules the adopted build ends up running: the whole configuration is
+	 * checked, on the sections the detected build system asks for.
+	 */
+	public AdoptionOptions(PullRequestOptions pullRequest, boolean includeAssets, String ruleVersion,
+			boolean dryRun, Duration commandTimeout, int retries) {
+		this(pullRequest, includeAssets, ruleVersion, dryRun, commandTimeout, retries, GuardRules.PROJECT,
+				List.of());
+	}
+
+	/**
 	 * The adoption's own pull request, no assets, published for real, at the default
 	 * timeout and retry count.
 	 */
 	public static AdoptionOptions defaults() {
-		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, false, null, DEFAULT_RETRIES);
+		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, false, null, DEFAULT_RETRIES,
+				GuardRules.PROJECT, List.of());
+	}
+
+	/**
+	 * What the guard wired into an adopted project is made of, gathered from the
+	 * options that describe it. The pipeline is assembled from this rather than from
+	 * the three fields separately, so the reshape and the guard it has to satisfy
+	 * cannot be built from different answers.
+	 */
+	public GuardOptions guard() {
+		return new GuardOptions(ruleVersion, guardRules, claudeMdSections);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
@@ -53,10 +53,13 @@ import io.github.adamw7.tools.adopt.step.PullRequestOptions;
  * @param claudeMdSections the headings the guard demands and the reshape conforms
  *                        to, empty to use the ones the detected build system asks
  *                        for
+ * @param verifyOnly      whether the run only reports whether each repository is
+ *                        still adopted and its guard still passes, cloning and
+ *                        reading but writing nothing at all
  */
 public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAssets, String ruleVersion,
 		boolean dryRun, Duration commandTimeout, int retries, GuardRules guardRules,
-		List<String> claudeMdSections) {
+		List<String> claudeMdSections, boolean verifyOnly) {
 
 	/**
 	 * Two further attempts, which is what a transport-level hiccup takes: the failure
@@ -106,7 +109,15 @@ public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAss
 	public AdoptionOptions(PullRequestOptions pullRequest, boolean includeAssets, String ruleVersion,
 			boolean dryRun, Duration commandTimeout, int retries) {
 		this(pullRequest, includeAssets, ruleVersion, dryRun, commandTimeout, retries, GuardRules.PROJECT,
-				List.of());
+				List.of(), false);
+	}
+
+	/** The options without a verification asked for, which is every adoption. */
+	public AdoptionOptions(PullRequestOptions pullRequest, boolean includeAssets, String ruleVersion,
+			boolean dryRun, Duration commandTimeout, int retries, GuardRules guardRules,
+			List<String> claudeMdSections) {
+		this(pullRequest, includeAssets, ruleVersion, dryRun, commandTimeout, retries, guardRules,
+				claudeMdSections, false);
 	}
 
 	/**
@@ -115,7 +126,7 @@ public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAss
 	 */
 	public static AdoptionOptions defaults() {
 		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, false, null, DEFAULT_RETRIES,
-				GuardRules.PROJECT, List.of());
+				GuardRules.PROJECT, List.of(), false);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
@@ -18,6 +18,10 @@ import org.apache.logging.log4j.Logger;
  * shells out to {@code git}, {@code claude}, and {@code gh}, whose output a
  * parallel batch would interleave.
  *
+ * <p>Each repository's checkout is settled once its adoption is over, by the
+ * {@link CheckoutRetention} the run was given: a batch makes one full clone per
+ * repository, and nothing used to remove them.
+ *
  * <p>Claiming a repository's checkout is part of its own adoption rather than a
  * preparation the whole run shares, so a URL that names no repository, or one
  * whose checkout directory another repository of the run already claimed, is that
@@ -40,9 +44,20 @@ public final class BatchAdoption {
 	private static final Logger log = LogManager.getLogger(BatchAdoption.class);
 
 	private final Adoption adoption;
+	private final CheckoutRetention retention;
 
 	public BatchAdoption(Adoption adoption) {
+		this(adoption, CheckoutRetention.ALWAYS);
+	}
+
+	/**
+	 * @param retention what becomes of each repository's checkout once its adoption
+	 *                  is over. A batch makes one full clone per repository and
+	 *                  nothing used to remove them.
+	 */
+	public BatchAdoption(Adoption adoption, CheckoutRetention retention) {
 		this.adoption = adoption;
+		this.retention = retention;
 	}
 
 	/**
@@ -74,11 +89,25 @@ public final class BatchAdoption {
 		String displayUrl = Redaction.of(repositoryUrl);
 		log.info("Repository {} of {}: {}", index + 1, repositoryUrls.size(), displayUrl);
 		try {
-			adoption.adopt(checkouts.claim(repositoryUrl), report);
+			AdoptionContext context = checkouts.claim(repositoryUrl);
+			adopt(context, report);
 		} catch (RuntimeException e) {
 			recordFailure(displayUrl, report, e);
 		}
 		return new AdoptionRun(displayUrl, checkouts.branchName(), report);
+	}
+
+	/**
+	 * Adopts one repository and then settles its checkout, on the failure path as
+	 * well as the successful one — a claim that threw has no context and so no
+	 * checkout to settle, which is why the claim sits outside this.
+	 */
+	private void adopt(AdoptionContext context, AdoptionReport report) {
+		try {
+			adoption.adopt(context, report);
+		} finally {
+			retention.apply(context.repositoryDirectory(), report.succeeded());
+		}
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
@@ -1,10 +1,15 @@
 package io.github.adamw7.tools.adopt;
 
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.stream.IntStream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 
 /**
  * Adopts a list of repositories one after another, with a fresh
@@ -14,9 +19,16 @@ import org.apache.logging.log4j.Logger;
  * independent — an expired {@code gh} login or a missing build tool says nothing
  * about the next repository — so the failure is recorded in that repository's
  * report and the run moves on, leaving the caller to decide what a partly failed
- * batch means. Repositories are adopted sequentially because every adoption
- * shells out to {@code git}, {@code claude}, and {@code gh}, whose output a
- * parallel batch would interleave.
+ * batch means.
+ *
+ * <p>That independence is also what lets a batch run several repositories at once.
+ * It used to be sequential for one reason: every adoption shells out to
+ * {@code git}, {@code claude} and {@code gh}, and a parallel batch interleaved
+ * their output into a log nobody could attribute. That is a solvable problem
+ * rather than a reason, and it is solved by putting the repository into the
+ * logging context of the thread adopting it, so every line a run emits says which
+ * repository it belongs to. A batch of one, or a {@code parallelism} of one, still
+ * runs on the calling thread and starts no pool at all.
  *
  * <p>Each repository's checkout is settled once its adoption is over, by the
  * {@link CheckoutRetention} the run was given: a batch makes one full clone per
@@ -43,8 +55,27 @@ public final class BatchAdoption {
 
 	private static final Logger log = LogManager.getLogger(BatchAdoption.class);
 
+	/**
+	 * The key each adoption's log lines are attributed by. Named here because the
+	 * appender patterns in {@code log4j2.properties} read it, and a value put under
+	 * one key and read under another attributes nothing.
+	 */
+	public static final String REPOSITORY_CONTEXT_KEY = "repository";
+
+	/** One repository at a time, on the calling thread. */
+	public static final int SEQUENTIAL = 1;
+
+	/**
+	 * The most an operator may ask for. Each thread runs a clone, a {@code claude
+	 * init} and a build, so the limit that matters is the host's and the remote's
+	 * patience rather than its cores; past this a batch is mostly waiting on GitHub,
+	 * which answers by rate limiting the run.
+	 */
+	public static final int MAX_PARALLELISM = 8;
+
 	private final Adoption adoption;
 	private final CheckoutRetention retention;
+	private final int parallelism;
 
 	public BatchAdoption(Adoption adoption) {
 		this(adoption, CheckoutRetention.ALWAYS);
@@ -56,8 +87,26 @@ public final class BatchAdoption {
 	 *                  nothing used to remove them.
 	 */
 	public BatchAdoption(Adoption adoption, CheckoutRetention retention) {
+		this(adoption, retention, SEQUENTIAL);
+	}
+
+	/**
+	 * @param parallelism how many repositories are adopted at once, bounded by
+	 *                    {@link #MAX_PARALLELISM}; {@link #SEQUENTIAL} runs them one
+	 *                    at a time on the calling thread
+	 */
+	public BatchAdoption(Adoption adoption, CheckoutRetention retention, int parallelism) {
 		this.adoption = adoption;
 		this.retention = retention;
+		this.parallelism = requireWithinBounds(parallelism);
+	}
+
+	private static int requireWithinBounds(int parallelism) {
+		if (parallelism < SEQUENTIAL || parallelism > MAX_PARALLELISM) {
+			throw new IllegalArgumentException("parallelism must be between " + SEQUENTIAL + " and "
+					+ MAX_PARALLELISM + " but was " + parallelism);
+		}
+		return parallelism;
 	}
 
 	/**
@@ -67,14 +116,56 @@ public final class BatchAdoption {
 	 * @return one run per repository, in the order the repositories were given
 	 */
 	public List<AdoptionRun> adoptAll(List<String> repositoryUrls, Checkouts checkouts) {
-		log.info("Adopting Claude Code into {} repositories on branch {}", repositoryUrls.size(),
-				checkouts.branchName());
+		log.info("Adopting Claude Code into {} repositories on branch {}{}", repositoryUrls.size(),
+				checkouts.branchName(), parallelism > SEQUENTIAL ? ", " + parallelism + " at a time" : "");
 		Elapsed elapsed = Elapsed.started();
-		List<AdoptionRun> runs = IntStream.range(0, repositoryUrls.size())
-				.mapToObj(index -> adoptOne(repositoryUrls, index, checkouts))
-				.toList();
+		List<AdoptionRun> runs = run(repositoryUrls, checkouts);
 		logSummary(runs, elapsed);
 		return runs;
+	}
+
+	/**
+	 * A batch small enough to need no pool does not start one, so the ordinary
+	 * single-repository run is exactly the run it always was — same thread, same
+	 * stack, nothing to shut down.
+	 */
+	private List<AdoptionRun> run(List<String> repositoryUrls, Checkouts checkouts) {
+		if (parallelism == SEQUENTIAL || repositoryUrls.size() == 1) {
+			return IntStream.range(0, repositoryUrls.size())
+					.mapToObj(index -> adoptOne(repositoryUrls, index, checkouts))
+					.toList();
+		}
+		return inParallel(repositoryUrls, checkouts);
+	}
+
+	/**
+	 * Adopts several repositories at once, answering in the order they were given
+	 * rather than the order they finished: a run is read repository by repository,
+	 * against the list the operator handed in.
+	 *
+	 * <p>Nothing here has to handle a failing adoption, because
+	 * {@link #adoptOne} already records one and returns; a task that threw anyway
+	 * would be a defect in this class rather than in a repository, so it is allowed
+	 * to end the batch.
+	 */
+	private List<AdoptionRun> inParallel(List<String> repositoryUrls, Checkouts checkouts) {
+		try (ExecutorService executor = Executors.newFixedThreadPool(parallelism)) {
+			List<Future<AdoptionRun>> futures = IntStream.range(0, repositoryUrls.size())
+					.mapToObj(index -> executor.submit(() -> adoptOne(repositoryUrls, index, checkouts)))
+					.toList();
+			return futures.stream().map(BatchAdoption::completed).toList();
+		}
+	}
+
+	private static AdoptionRun completed(Future<AdoptionRun> future) {
+		try {
+			return future.get();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new AdoptionException("Interrupted while adopting a batch of repositories", e);
+		} catch (ExecutionException e) {
+			throw new AdoptionException("A repository's adoption ended unexpectedly", e.getCause());
+		}
 	}
 
 	/**
@@ -87,14 +178,23 @@ public final class BatchAdoption {
 		String repositoryUrl = repositoryUrls.get(index);
 		AdoptionReport report = new AdoptionReport();
 		String displayUrl = Redaction.of(repositoryUrl);
-		log.info("Repository {} of {}: {}", index + 1, repositoryUrls.size(), displayUrl);
+		ThreadContext.put(REPOSITORY_CONTEXT_KEY, displayUrl);
 		try {
-			AdoptionContext context = checkouts.claim(repositoryUrl);
-			adopt(context, report);
+			log.info("Repository {} of {}: {}", index + 1, repositoryUrls.size(), displayUrl);
+			adoptClaimed(repositoryUrl, displayUrl, checkouts, report);
+		} finally {
+			ThreadContext.remove(REPOSITORY_CONTEXT_KEY);
+		}
+		return new AdoptionRun(displayUrl, checkouts.branchName(), report);
+	}
+
+	private void adoptClaimed(String repositoryUrl, String displayUrl, Checkouts checkouts,
+			AdoptionReport report) {
+		try {
+			adopt(checkouts.claim(repositoryUrl), report);
 		} catch (RuntimeException e) {
 			recordFailure(displayUrl, report, e);
 		}
-		return new AdoptionRun(displayUrl, checkouts.branchName(), report);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CheckoutRetention.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CheckoutRetention.java
@@ -1,0 +1,90 @@
+package io.github.adamw7.tools.adopt;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * What becomes of a repository's checkout once its adoption is over.
+ *
+ * <p>A checkout is a full clone, and a run over a list of repositories makes one
+ * per repository. Nothing removed them, so a fifty-repository batch left fifty
+ * clones behind — under a temporary directory the operator never named and would
+ * not think to look in. The adoption's own product is a pushed branch and a pull
+ * request; the checkout is scaffolding.
+ *
+ * <p>It is scaffolding worth keeping in exactly two cases, which is why this is a
+ * choice rather than an unconditional delete. A checkout whose adoption
+ * <em>failed</em> is the only record of how far the run got, and reading it is the
+ * first thing an operator does. A dry run's checkout is the whole point of the
+ * dry run: it commits the adoption locally and pushes nothing, so deleting it
+ * would leave the operator with nothing to inspect.
+ */
+public enum CheckoutRetention {
+
+	/** Keep every checkout, whatever happened: a dry run, or {@code --keep-workspace}. */
+	ALWAYS,
+
+	/**
+	 * Keep only the checkouts whose adoption failed, which are the ones with
+	 * something left to say.
+	 */
+	ON_FAILURE;
+
+	private static final Logger log = LogManager.getLogger(CheckoutRetention.class);
+
+	/**
+	 * @param keepWorkspace whether the operator asked for every checkout to be kept
+	 * @param dryRun        whether the run pushes nothing, in which case the checkout
+	 *                      is the only thing it produced
+	 */
+	public static CheckoutRetention of(boolean keepWorkspace, boolean dryRun) {
+		return keepWorkspace || dryRun ? ALWAYS : ON_FAILURE;
+	}
+
+	/**
+	 * Removes the checkout when this policy says to, and never fails the run for it:
+	 * an adoption that succeeded has succeeded, and a directory that could not be
+	 * removed is a warning rather than a reason to report the repository as failed.
+	 *
+	 * @param checkout  the directory to remove
+	 * @param succeeded whether the adoption of that repository landed
+	 */
+	public void apply(Path checkout, boolean succeeded) {
+		if (this == ALWAYS || !succeeded) {
+			log.debug("Leaving the checkout {} in place", checkout);
+			return;
+		}
+		remove(checkout);
+	}
+
+	private void remove(Path checkout) {
+		try {
+			deleteRecursively(checkout);
+			log.info("Removed the checkout {}", checkout);
+		} catch (IOException | RuntimeException e) {
+			log.warn("Could not remove the checkout {}: {}", checkout, e.getMessage());
+		}
+	}
+
+	/**
+	 * Deepest entries first, because a directory is only removable once it is empty.
+	 * An absent checkout is nothing to remove — a run that failed before its clone
+	 * never made one.
+	 */
+	private static void deleteRecursively(Path checkout) throws IOException {
+		if (!Files.exists(checkout)) {
+			return;
+		}
+		try (Stream<Path> entries = Files.walk(checkout)) {
+			for (Path entry : entries.sorted(Comparator.reverseOrder()).toList()) {
+				Files.deleteIfExists(entry);
+			}
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Checkouts.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Checkouts.java
@@ -1,8 +1,8 @@
 package io.github.adamw7.tools.adopt;
 
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Gives every repository of a run its own checkout: one workspace, one branch
@@ -27,8 +27,14 @@ public final class Checkouts {
 	private final Path workspace;
 	private final String branchName;
 
-	/** The checkout each repository of the run has taken, so a second claim on one is caught. */
-	private final Map<Path, String> urlsByCheckout = new HashMap<>();
+	/**
+	 * The checkout each repository of the run has taken, so a second claim on one is
+	 * caught. Concurrent because a parallel batch claims from several threads at once,
+	 * and {@link Map#putIfAbsent} on this map is the atomic test-and-set the claim
+	 * relies on: two threads racing for one directory must produce a claim and a
+	 * refusal, never two claims.
+	 */
+	private final Map<Path, String> urlsByCheckout = new ConcurrentHashMap<>();
 
 	/**
 	 * @param workspace  the directory every clone is created under

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -64,7 +64,8 @@ public final class CliArguments {
 			+ " [--title <title>] [--body <body>] [--reviewer <user>]... [--label <label>]..."
 			+ " [--assignee <user>]... [--draft] [--assets] [--rule-version <version>]"
 			+ " [--rules <minimal|project>] [--section <heading>]..."
-			+ " [--dry-run] [--timeout <minutes>] [--retries <count>] [--report <file>] [--help]";
+			+ " [--dry-run] [--keep-workspace] [--timeout <minutes>] [--retries <count>]"
+			+ " [--report <file>] [--help]";
 
 	static final String HELP_FLAG = "--help";
 	static final String HELP_SHORTHAND = "-h";
@@ -120,6 +121,16 @@ public final class CliArguments {
 
 	@Option(names = "--assets")
 	private boolean assets;
+
+	/**
+	 * Keeps every checkout, whatever the outcome. Without it a checkout whose
+	 * adoption landed is removed — its product is a pushed branch and a pull request,
+	 * and a batch that made fifty full clones left fifty behind. A failed adoption's
+	 * checkout is kept either way, and so is a dry run's, which is the only thing a
+	 * dry run produces.
+	 */
+	@Option(names = "--keep-workspace")
+	private boolean keepWorkspace;
 
 	@Option(names = "--dry-run")
 	private boolean dryRun;
@@ -241,6 +252,11 @@ public final class CliArguments {
 	 */
 	private GuardRules guardRules() {
 		return rules == null || rules.isBlank() ? GuardRules.PROJECT : GuardRules.of(rules);
+	}
+
+	/** What becomes of each repository's checkout once its adoption is over. */
+	public CheckoutRetention checkoutRetention() {
+		return CheckoutRetention.of(keepWorkspace, dryRun);
 	}
 
 	public Optional<Path> reportFile() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import io.github.adamw7.tools.adopt.step.GuardRules;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -62,6 +63,7 @@ public final class CliArguments {
 			+ " [--workspace <directory>] [--branch <name>]"
 			+ " [--title <title>] [--body <body>] [--reviewer <user>]... [--label <label>]..."
 			+ " [--assignee <user>]... [--draft] [--assets] [--rule-version <version>]"
+			+ " [--rules <minimal|project>] [--section <heading>]..."
 			+ " [--dry-run] [--timeout <minutes>] [--retries <count>] [--report <file>] [--help]";
 
 	static final String HELP_FLAG = "--help";
@@ -88,6 +90,24 @@ public final class CliArguments {
 
 	@Option(names = "--assignee", paramLabel = "<user>")
 	private List<String> assignees = new ArrayList<>();
+
+	/**
+	 * How much of the adopted repository's configuration the guard checks. Named
+	 * rather than inferred, and refused when it names neither rule set, because a
+	 * misspelt value read as the default would quietly change what somebody else's
+	 * build enforces.
+	 */
+	@Option(names = "--rules", paramLabel = "<minimal|project>")
+	private String rules;
+
+	/**
+	 * A {@code CLAUDE.md} heading the guard is to demand, repeatable. Naming any
+	 * replaces the set the detected build system would have asked for, so a project
+	 * whose document is not a Java project's is reshaped to its own headings and
+	 * guarded on them.
+	 */
+	@Option(names = "--section", paramLabel = "<heading>")
+	private List<String> sections = new ArrayList<>();
 
 	@Option(names = "--rule-version", paramLabel = "<version>")
 	private String ruleVersion;
@@ -210,7 +230,17 @@ public final class CliArguments {
 
 	/** How this run is configured, as the pipeline and the command runner read it. */
 	public AdoptionOptions adoptionOptions() {
-		return new AdoptionOptions(pullRequestOptions(), assets, ruleVersion, dryRun, commandTimeout, retries);
+		return new AdoptionOptions(pullRequestOptions(), assets, ruleVersion, dryRun, commandTimeout, retries,
+				guardRules(), sections);
+	}
+
+	/**
+	 * @return the rule set named, or the default when none was. A blank value counts
+	 *         as none, so an omitted option and an empty one agree; anything else that
+	 *         is not a rule set is refused by {@link GuardRules#of}.
+	 */
+	private GuardRules guardRules() {
+		return rules == null || rules.isBlank() ? GuardRules.PROJECT : GuardRules.of(rules);
 	}
 
 	public Optional<Path> reportFile() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -64,12 +64,14 @@ public final class CliArguments {
 			+ " [--title <title>] [--body <body>] [--reviewer <user>]... [--label <label>]..."
 			+ " [--assignee <user>]... [--draft] [--assets] [--rule-version <version>]"
 			+ " [--rules <minimal|project>] [--section <heading>]..."
-			+ " [--dry-run] [--verify-only] [--keep-workspace] [--timeout <minutes>] [--retries <count>]"
+			+ " [--dry-run] [--verify-only] [--keep-workspace] [--parallel <count>]"
+			+ " [--timeout <minutes>] [--retries <count>]"
 			+ " [--report <file>] [--help]";
 
 	static final String HELP_FLAG = "--help";
 	static final String HELP_SHORTHAND = "-h";
 
+	private static final String PARALLEL_FLAG = "--parallel";
 	private static final String TIMEOUT_FLAG = "--timeout";
 	private static final String RETRIES_FLAG = "--retries";
 	private static final String REPOS_FLAG = "--repos";
@@ -140,6 +142,14 @@ public final class CliArguments {
 	 */
 	@Option(names = "--verify-only")
 	private boolean verifyOnly;
+
+	/**
+	 * How many repositories are adopted at once. Every line a run emits carries the
+	 * repository it belongs to, so a parallel batch stays readable; see
+	 * {@link BatchAdoption}.
+	 */
+	@Option(names = PARALLEL_FLAG, paramLabel = "<count>")
+	private String parallel;
 
 	@Option(names = "--dry-run")
 	private boolean dryRun;
@@ -261,6 +271,35 @@ public final class CliArguments {
 	 */
 	private GuardRules guardRules() {
 		return rules == null || rules.isBlank() ? GuardRules.PROJECT : GuardRules.of(rules);
+	}
+
+	/**
+	 * @return how many repositories to adopt at once, bounded here as well as in
+	 *         {@link BatchAdoption} so a bad value fails while the operator is still
+	 *         reading the command line rather than after the first clone
+	 */
+	public int parallelism() {
+		if (parallel == null || parallel.isBlank()) {
+			return BatchAdoption.SEQUENTIAL;
+		}
+		return requireWithinBounds(parsed(parallel));
+	}
+
+	private int parsed(String count) {
+		try {
+			return Integer.parseInt(count.strip());
+		} catch (NumberFormatException e) {
+			throw new IllegalArgumentException(PARALLEL_FLAG + " takes a number of repositories, not '"
+					+ count.strip() + "'", e);
+		}
+	}
+
+	private int requireWithinBounds(int count) {
+		if (count < BatchAdoption.SEQUENTIAL || count > BatchAdoption.MAX_PARALLELISM) {
+			throw new IllegalArgumentException(PARALLEL_FLAG + " must be between " + BatchAdoption.SEQUENTIAL
+					+ " and " + BatchAdoption.MAX_PARALLELISM + " but was " + count);
+		}
+		return count;
 	}
 
 	/** What becomes of each repository's checkout once its adoption is over. */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -64,7 +64,7 @@ public final class CliArguments {
 			+ " [--title <title>] [--body <body>] [--reviewer <user>]... [--label <label>]..."
 			+ " [--assignee <user>]... [--draft] [--assets] [--rule-version <version>]"
 			+ " [--rules <minimal|project>] [--section <heading>]..."
-			+ " [--dry-run] [--keep-workspace] [--timeout <minutes>] [--retries <count>]"
+			+ " [--dry-run] [--verify-only] [--keep-workspace] [--timeout <minutes>] [--retries <count>]"
 			+ " [--report <file>] [--help]";
 
 	static final String HELP_FLAG = "--help";
@@ -131,6 +131,15 @@ public final class CliArguments {
 	 */
 	@Option(names = "--keep-workspace")
 	private boolean keepWorkspace;
+
+	/**
+	 * Reports whether each repository is still adopted and its guard still passes,
+	 * without adopting anything. The question a fleet asks between adoptions: a
+	 * CLAUDE.md a later commit deleted, or a guard someone removed from the build,
+	 * leaves a repository looking adopted and checking nothing.
+	 */
+	@Option(names = "--verify-only")
+	private boolean verifyOnly;
 
 	@Option(names = "--dry-run")
 	private boolean dryRun;
@@ -242,7 +251,7 @@ public final class CliArguments {
 	/** How this run is configured, as the pipeline and the command runner read it. */
 	public AdoptionOptions adoptionOptions() {
 		return new AdoptionOptions(pullRequestOptions(), assets, ruleVersion, dryRun, commandTimeout, retries,
-				guardRules(), sections);
+				guardRules(), sections, verifyOnly);
 	}
 
 	/**
@@ -256,7 +265,7 @@ public final class CliArguments {
 
 	/** What becomes of each repository's checkout once its adoption is over. */
 	public CheckoutRetention checkoutRetention() {
-		return CheckoutRetention.of(keepWorkspace, dryRun);
+		return CheckoutRetention.of(keepWorkspace, dryRun || verifyOnly);
 	}
 
 	public Optional<Path> reportFile() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -84,7 +84,7 @@ public class GitHubRepoAdopter {
 	 * with the tool that was probed.
 	 */
 	public static List<AdoptionStep> defaultSteps(AdoptionOptions options) {
-		List<BuildSystem> buildSystems = BuildSystems.defaults(options.pinnedRuleVersion());
+		List<BuildSystem> buildSystems = BuildSystems.defaults(options.guard());
 		return Stream.of(
 				adoptionSteps(buildSystems, options),
 				assetSteps(options),

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -101,7 +101,7 @@ public class GitHubRepoAdopter {
 				new BuildToolchainStep(buildSystems),
 				new BranchStep(),
 				new TrustStep(),
-				new ClaudeInitStep(),
+				ClaudeInitStep.retrying(options.retries()),
 				new ClaudeMdConformanceStep(buildSystems),
 				new CommitStep("Adopt Claude Code: add CLAUDE.md", "claude-md"),
 				new EnforcerStep(buildSystems),

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.command.CommandRunner;
+import io.github.adamw7.tools.adopt.step.AdoptionCheckStep;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
 import io.github.adamw7.tools.adopt.step.AssetsStep;
 import io.github.adamw7.tools.adopt.step.BranchStep;
@@ -83,6 +84,33 @@ public class GitHubRepoAdopter {
 	 * build-system list, so the guard that is wired in is the guard that is verified
 	 * with the tool that was probed.
 	 */
+	/**
+	 * The steps that answer "is this repository still adopted, and does its guard
+	 * still pass?" without adopting anything: check the tools, clone, check the
+	 * project's build tool, ask whether the document and the guard are there, and run
+	 * the guard. Nothing is branched, generated, committed, pushed, or opened.
+	 *
+	 * <p>It is a separate pipeline rather than an adoption with its writing steps
+	 * disabled, for the same reason a dry run is: the report then says what the run
+	 * really did, and a step that decided for itself to do nothing would still be
+	 * listed as having run.
+	 */
+	public static List<AdoptionStep> verificationSteps(AdoptionOptions options) {
+		List<BuildSystem> buildSystems = BuildSystems.defaults(options.guard());
+		return List.of(
+				ToolchainStep.forVerification(),
+				new CloneStep(),
+				new BuildToolchainStep(buildSystems),
+				new AdoptionCheckStep(buildSystems),
+				new VerifyStep(buildSystems));
+	}
+
+	/** The pipeline the options describe: a verification, or an adoption. */
+	public static GitHubRepoAdopter forRun(CommandRunner runner, AdoptionOptions options) {
+		return new GitHubRepoAdopter(runner,
+				options.verifyOnly() ? verificationSteps(options) : defaultSteps(options));
+	}
+
 	public static List<AdoptionStep> defaultSteps(AdoptionOptions options) {
 		List<BuildSystem> buildSystems = BuildSystems.defaults(options.guard());
 		return Stream.of(
@@ -151,6 +179,11 @@ public class GitHubRepoAdopter {
 	 *               failing step's exception propagates
 	 * @return the same report, once every step has completed
 	 */
+	/** The steps this adopter runs, so a test can assert which pipeline it was given. */
+	List<AdoptionStep> steps() {
+		return steps;
+	}
+
 	public AdoptionReport adopt(AdoptionContext context, AdoptionReport report) {
 		log.info("Adopting Claude Code into {} in {} steps", context.displayUrl(), steps.size());
 		Elapsed elapsed = Elapsed.started();

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -54,7 +54,8 @@ public class Main {
 	 *                           one and why it stopped
 	 */
 	static List<AdoptionRun> runAndReport(CliArguments cli, Checkouts checkouts, GitHubRepoAdopter adopter) {
-		List<AdoptionRun> runs = new BatchAdoption(adopter::adopt).adoptAll(cli.repositoryUrls(), checkouts);
+		List<AdoptionRun> runs = new BatchAdoption(adopter::adopt, cli.checkoutRetention())
+				.adoptAll(cli.repositoryUrls(), checkouts);
 		try {
 			requireEveryAdoptionSucceeded(runs);
 		} catch (RuntimeException e) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -53,7 +53,7 @@ public class Main {
 	 *                           one and why it stopped
 	 */
 	static List<AdoptionRun> runAndReport(CliArguments cli, Checkouts checkouts, GitHubRepoAdopter adopter) {
-		List<AdoptionRun> runs = new BatchAdoption(adopter::adopt, cli.checkoutRetention())
+		List<AdoptionRun> runs = new BatchAdoption(adopter::adopt, cli.checkoutRetention(), cli.parallelism())
 				.adoptAll(cli.repositoryUrls(), checkouts);
 		try {
 			requireEveryAdoptionSucceeded(runs);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/Main.java
@@ -40,8 +40,7 @@ public class Main {
 			return;
 		}
 		AdoptionOptions options = cli.adoptionOptions();
-		runAndReport(cli, checkouts(cli),
-				GitHubRepoAdopter.withDefaultPipeline(CommandRunners.forRun(options), options));
+		runAndReport(cli, checkouts(cli), GitHubRepoAdopter.forRun(CommandRunners.forRun(options), options));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/RateLimits.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/RateLimits.java
@@ -1,0 +1,96 @@
+package io.github.adamw7.tools.adopt.command;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Reads a rate limit out of what {@code git} or {@code gh} said, so a run stopped
+ * by one says when to try again.
+ *
+ * <p>A rate limit is deliberately not retried — {@link TransientFailures} leaves
+ * it out, because GitHub answers a secondary limit by asking for a wait measured
+ * in minutes and retrying it seconds later is what the limit exists to stop. The
+ * operator is told instead. What they were told, though, was the raw transcript:
+ * the wait GitHub named is in there, somewhere among the API's prose and a link to
+ * its documentation, and an operator re-running a fifty-repository batch had to
+ * find it.
+ *
+ * <p>So the wait is lifted out and put in the failure's first line. Nothing here
+ * changes what is retried; it changes only what the report says.
+ */
+public final class RateLimits {
+
+	/**
+	 * How GitHub's own wording names the wait. Minutes and seconds are both matched
+	 * because the API uses both — a secondary limit asks for minutes, a primary one
+	 * reports seconds — and either is an answer to the operator's question.
+	 */
+	private static final Pattern WAIT = Pattern.compile(
+			"(?:retry[- ]after|try again in|wait)\\D{0,20}?(\\d{1,5})\\s*(second|minute|hour)",
+			Pattern.CASE_INSENSITIVE);
+
+	/**
+	 * The wording that says a limit was hit at all. A transcript may name a limit
+	 * without naming a wait, and that is still worth reporting as a rate limit rather
+	 * than as an unexplained refusal.
+	 */
+	private static final Pattern LIMIT = Pattern.compile(
+			"rate limit|secondary rate|abuse detection|too many requests|\\b429\\b",
+			Pattern.CASE_INSENSITIVE);
+
+	private RateLimits() {
+	}
+
+	/** @return whether the transcript reports the run being rate limited */
+	public static boolean reported(String output) {
+		return LIMIT.matcher(output).find();
+	}
+
+	/**
+	 * @return how long the transcript asks the run to wait, or empty when it reports a
+	 *         limit without naming one — in which case the operator is told that much
+	 *         and no more, rather than being given a number nobody wrote
+	 */
+	public static Optional<Duration> waitFrom(String output) {
+		Matcher matcher = WAIT.matcher(output);
+		if (!matcher.find()) {
+			return Optional.empty();
+		}
+		return Optional.of(durationOf(Long.parseLong(matcher.group(1)), matcher.group(2)));
+	}
+
+	/**
+	 * The line a failed command's report opens with when a rate limit stopped it, or
+	 * empty when nothing did.
+	 *
+	 * @param output the command's transcript
+	 */
+	public static Optional<String> describe(String output) {
+		if (!reported(output)) {
+			return Optional.empty();
+		}
+		return Optional.of(waitFrom(output)
+				.map(wait -> "GitHub is rate limiting this run; try again in about " + humanized(wait) + ".")
+				.orElse("GitHub is rate limiting this run; try again later."));
+	}
+
+	private static Duration durationOf(long amount, String unit) {
+		return switch (unit.toLowerCase(Locale.ROOT)) {
+			case "hour" -> Duration.ofHours(amount);
+			case "minute" -> Duration.ofMinutes(amount);
+			default -> Duration.ofSeconds(amount);
+		};
+	}
+
+	/** Rounded up to the next minute past a minute, since a wait is acted on, not measured. */
+	private static String humanized(Duration wait) {
+		if (wait.toMinutes() < 1) {
+			return wait.toSeconds() + "s";
+		}
+		long minutes = wait.plusSeconds(59).toMinutes();
+		return minutes < 60 ? minutes + " minutes" : wait.toHours() + "h" + wait.toMinutesPart() + "m";
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/RetryingCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/RetryingCommandRunner.java
@@ -45,6 +45,17 @@ public class RetryingCommandRunner implements CommandRunner {
 	public interface Pause {
 
 		void of(Duration duration);
+
+		/**
+		 * The pause a real run serves. It lives here rather than beside each caller
+		 * because sleeping means touching {@link Thread}, and the architecture rules
+		 * keep concurrency inside this package: the adoption is a sequential pipeline,
+		 * and a step that reached for a thread would be doing something the pipeline
+		 * does not do.
+		 */
+		static Pause sleeping() {
+			return RetryingCommandRunner::sleep;
+		}
 	}
 
 	private static final Logger log = LogManager.getLogger(RetryingCommandRunner.class);

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -105,6 +105,11 @@ public class AdoptTool implements McpTool {
 							Map.entry("rule_version", Map.of("type", "string",
 									"description", "released claude-code-enforcer version to wire into an adopted "
 											+ "Maven project; defaults to the version of this build")),
+							Map.entry("parallel", Map.of("type", "integer",
+									"description", "how many repositories to adopt at once, between "
+											+ BatchAdoption.SEQUENTIAL + " and " + BatchAdoption.MAX_PARALLELISM
+											+ "; every log line carries the repository it belongs to, so a "
+											+ "parallel batch stays readable")),
 							Map.entry("verify_only", Map.of("type", "boolean",
 									"description", "report whether each repository is still adopted and its guard "
 											+ "still passes, without adopting anything: it clones and reads, and "
@@ -159,8 +164,19 @@ public class AdoptTool implements McpTool {
 	public ToolResult apply(Map<String, Object> arguments) {
 		log.info("Calling MCP adopt tool for {}", describe(arguments));
 		AdoptionOptions options = adoptionOptionsFrom(arguments);
-		BatchAdoption batch = new BatchAdoption(pipeline.create(options), checkoutRetention(arguments, options));
+		BatchAdoption batch = new BatchAdoption(pipeline.create(options), checkoutRetention(arguments, options),
+				parallelism(arguments));
 		return result(batch.adoptAll(repositoryUrls(arguments), checkoutsFrom(arguments)));
+	}
+
+	/**
+	 * Bounded here as well as in {@link BatchAdoption}, so a client asking for fifty
+	 * threads is refused with the argument's name rather than with the batch's
+	 * complaint about a field it never sent.
+	 */
+	private int parallelism(Map<String, Object> arguments) {
+		return ToolArguments.optionalBoundedInt(arguments, "parallel", BatchAdoption.SEQUENTIAL,
+				BatchAdoption.SEQUENTIAL, BatchAdoption.MAX_PARALLELISM);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -105,6 +105,10 @@ public class AdoptTool implements McpTool {
 							Map.entry("rule_version", Map.of("type", "string",
 									"description", "released claude-code-enforcer version to wire into an adopted "
 											+ "Maven project; defaults to the version of this build")),
+							Map.entry("verify_only", Map.of("type", "boolean",
+									"description", "report whether each repository is still adopted and its guard "
+											+ "still passes, without adopting anything: it clones and reads, and "
+											+ "writes nothing at all")),
 							Map.entry("keep_workspace", Map.of("type", "boolean",
 									"description", "keep every checkout after a successful adoption; by default "
 											+ "a checkout whose adoption landed is removed, since its product is "
@@ -143,7 +147,7 @@ public class AdoptTool implements McpTool {
 	 * {@code timeout_minutes} or a {@code retries} differently.
 	 */
 	private static BatchAdoption.Adoption runDefaultPipeline(AdoptionOptions options) {
-		return GitHubRepoAdopter.withDefaultPipeline(CommandRunners.forRun(options), options)::adopt;
+		return GitHubRepoAdopter.forRun(CommandRunners.forRun(options), options)::adopt;
 	}
 
 	@Override
@@ -166,7 +170,7 @@ public class AdoptTool implements McpTool {
 	 */
 	private CheckoutRetention checkoutRetention(Map<String, Object> arguments, AdoptionOptions options) {
 		return CheckoutRetention.of(ToolArguments.optionalBoolean(arguments, "keep_workspace", false),
-				options.dryRun());
+				options.dryRun() || options.verifyOnly());
 	}
 
 	/**
@@ -263,7 +267,8 @@ public class AdoptTool implements McpTool {
 		return new AdoptionOptions(pullRequestOptionsFrom(arguments),
 				ToolArguments.optionalBoolean(arguments, "assets", false), text(arguments, "rule_version"),
 				ToolArguments.optionalBoolean(arguments, "dry_run", false), commandTimeout(arguments),
-				retries(arguments), guardRules(arguments), textList(arguments, "claude_md_sections"));
+				retries(arguments), guardRules(arguments), textList(arguments, "claude_md_sections"),
+				ToolArguments.optionalBoolean(arguments, "verify_only", false));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -17,6 +17,7 @@ import io.github.adamw7.tools.adopt.AdoptionReport;
 import io.github.adamw7.tools.adopt.AdoptionReportWriter;
 import io.github.adamw7.tools.adopt.AdoptionRun;
 import io.github.adamw7.tools.adopt.BatchAdoption;
+import io.github.adamw7.tools.adopt.CheckoutRetention;
 import io.github.adamw7.tools.adopt.Checkouts;
 import io.github.adamw7.tools.adopt.GitHubRepoAdopter;
 import io.github.adamw7.tools.adopt.Redaction;
@@ -104,6 +105,10 @@ public class AdoptTool implements McpTool {
 							Map.entry("rule_version", Map.of("type", "string",
 									"description", "released claude-code-enforcer version to wire into an adopted "
 											+ "Maven project; defaults to the version of this build")),
+							Map.entry("keep_workspace", Map.of("type", "boolean",
+									"description", "keep every checkout after a successful adoption; by default "
+											+ "a checkout whose adoption landed is removed, since its product is "
+											+ "the pushed branch and the pull request")),
 							Map.entry("dry_run", Map.of("type", "boolean",
 									"description", "rehearse the adoption: clone, branch, and commit in the "
 											+ "workspace, but push nothing and open no pull request")),
@@ -149,8 +154,19 @@ public class AdoptTool implements McpTool {
 	@Override
 	public ToolResult apply(Map<String, Object> arguments) {
 		log.info("Calling MCP adopt tool for {}", describe(arguments));
-		BatchAdoption batch = new BatchAdoption(pipeline.create(adoptionOptionsFrom(arguments)));
+		AdoptionOptions options = adoptionOptionsFrom(arguments);
+		BatchAdoption batch = new BatchAdoption(pipeline.create(options), checkoutRetention(arguments, options));
 		return result(batch.adoptAll(repositoryUrls(arguments), checkoutsFrom(arguments)));
+	}
+
+	/**
+	 * What becomes of each repository's checkout, decided the same way the command
+	 * line decides it. A server serving many calls accumulates clones faster than an
+	 * operator does, so the default matters more here, not less.
+	 */
+	private CheckoutRetention checkoutRetention(Map<String, Object> arguments, AdoptionOptions options) {
+		return CheckoutRetention.of(ToolArguments.optionalBoolean(arguments, "keep_workspace", false),
+				options.dryRun());
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionOptions;
+import io.github.adamw7.tools.adopt.step.GuardRules;
 import io.github.adamw7.tools.adopt.AdoptionReport;
 import io.github.adamw7.tools.adopt.AdoptionReportWriter;
 import io.github.adamw7.tools.adopt.AdoptionRun;
@@ -112,7 +113,15 @@ public class AdoptTool implements McpTool {
 							Map.entry("retries", Map.of("type", "integer",
 									"description", "how many further attempts a git or gh command the network "
 											+ "refused earns, waiting longer before each; defaults to "
-											+ AdoptionOptions.DEFAULT_RETRIES + ", and 0 reports the first failure"))),
+											+ AdoptionOptions.DEFAULT_RETRIES + ", and 0 reports the first failure")),
+							Map.entry("rules", Map.of("type", "string",
+									"description", "how much of the adopted repository's Claude Code configuration "
+											+ "the wired guard checks: 'project' (default) for all of it, or "
+											+ "'minimal' for the CLAUDE.md format alone")),
+							Map.entry("claude_md_sections", Map.of("type", "string",
+									"description", "comma-separated CLAUDE.md headings the guard demands and the "
+											+ "reshape conforms to; an array is accepted too. Defaults to what the "
+											+ "detected build system asks for"))),
 					"required", List.of()));
 
 	public AdoptTool() {
@@ -238,7 +247,18 @@ public class AdoptTool implements McpTool {
 		return new AdoptionOptions(pullRequestOptionsFrom(arguments),
 				ToolArguments.optionalBoolean(arguments, "assets", false), text(arguments, "rule_version"),
 				ToolArguments.optionalBoolean(arguments, "dry_run", false), commandTimeout(arguments),
-				retries(arguments));
+				retries(arguments), guardRules(arguments), textList(arguments, "claude_md_sections"));
+	}
+
+	/**
+	 * Refused here rather than defaulted, the same as on the command line: a client
+	 * naming a rule set that does not exist has asked for something, and quietly
+	 * giving it the default would change what the adopted build enforces without
+	 * saying so.
+	 */
+	private GuardRules guardRules(Map<String, Object> arguments) {
+		String rules = text(arguments, "rules");
+		return rules == null || rules.isBlank() ? GuardRules.PROJECT : GuardRules.of(rules);
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractCommandStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AbstractCommandStep.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
+import io.github.adamw7.tools.adopt.command.RateLimits;
 
 /**
  * Base for steps that shell out through a {@link CommandRunner}, sharing the
@@ -61,7 +62,21 @@ public abstract class AbstractCommandStep implements AdoptionStep {
 	 * reported failure.
 	 */
 	private AdoptionException failure(CommandResult result) {
-		return new AdoptionException(name() + " failed (exit " + result.exitCode() + ") running: " + result.describe()
-				+ System.lineSeparator() + result.redactedOutput());
+		return new AdoptionException(rateLimitNotice(result) + name() + " failed (exit " + result.exitCode()
+				+ ") running: " + result.describe() + System.lineSeparator() + result.redactedOutput());
+	}
+
+	/**
+	 * Opens the report with the wait when a rate limit is what stopped the command.
+	 * The wait GitHub named is in the transcript either way, somewhere among the API's
+	 * prose and a link to its documentation, and an operator re-running a
+	 * fifty-repository batch had to find it. A rate limit is still not retried — see
+	 * {@link io.github.adamw7.tools.adopt.command.TransientFailures} — so what changes
+	 * is only what the report says.
+	 */
+	private String rateLimitNotice(CommandResult result) {
+		return RateLimits.describe(result.output())
+				.map(notice -> notice + System.lineSeparator())
+				.orElse("");
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionCheckStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionCheckStep.java
@@ -1,0 +1,74 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Reports whether a checkout is actually adopted: it carries a {@code CLAUDE.md},
+ * and its build wires in a guard that checks it.
+ *
+ * <p>This is the step a verification run has that an adoption does not, and it
+ * exists because the verification the adoption already had cannot answer the
+ * question. {@link VerifyStep} runs the guard, and a build with no guard wired in
+ * passes that command precisely because nothing ran — so a repository that had
+ * never been adopted, or one whose guard a later commit removed, verified exactly
+ * like one that was properly adopted. That is the drift a fleet-wide check exists
+ * to find.
+ *
+ * <p>Both halves are reported together rather than at the first missing one, so an
+ * operator re-adopting a repository knows whether they are restoring a document, a
+ * guard, or both.
+ */
+public class AdoptionCheckStep extends AbstractBuildSystemStep {
+
+	private static final Logger log = LogManager.getLogger(AdoptionCheckStep.class);
+
+	private static final String CLAUDE_MD = AdoptionAssets.CLAUDE_MD_FILE;
+
+	public AdoptionCheckStep() {
+	}
+
+	public AdoptionCheckStep(List<BuildSystem> buildSystems) {
+		super(buildSystems);
+	}
+
+	@Override
+	public String name() {
+		return "check-adopted";
+	}
+
+	@Override
+	protected void onDetected(BuildSystem buildSystem, AdoptionContext context, CommandRunner runner) {
+		Path checkout = context.repositoryDirectory();
+		List<String> missing = new ArrayList<>();
+		collectMissingDocument(checkout, missing);
+		collectMissingGuard(buildSystem, checkout, missing);
+		if (!missing.isEmpty()) {
+			throw new AdoptionException(context.displayUrl() + " is not adopted: " + String.join("; ", missing)
+					+ ". Adopt it to restore what is missing.");
+		}
+		log.info("{} carries {} and a {} guard that checks it", context.displayUrl(), CLAUDE_MD,
+				buildSystem.name());
+	}
+
+	private void collectMissingDocument(Path checkout, List<String> missing) {
+		if (!Files.isRegularFile(checkout.resolve(CLAUDE_MD))) {
+			missing.add("no " + CLAUDE_MD + " at its root");
+		}
+	}
+
+	private void collectMissingGuard(BuildSystem buildSystem, Path checkout, List<String> missing) {
+		if (!buildSystem.isGuardInstalled(checkout)) {
+			missing.add("its " + buildSystem.name() + " build wires in no CLAUDE.md guard");
+		}
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildMetadata.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildMetadata.java
@@ -1,0 +1,72 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+/**
+ * The versions this build pins, read from the metadata Maven filters into
+ * {@value #BUILD_PROPERTIES} at build time.
+ *
+ * <p>Both versions the adoption writes into somebody else's {@code pom.xml} come
+ * from here rather than from literals in the code: the {@code claude-code-enforcer}
+ * rule, pinned to the exact {@code tools} release running the adoption so it
+ * resolves from the repository that published it, and the
+ * {@code maven-enforcer-plugin}, pinned to the version this project builds
+ * against. A literal would drift, and the half that drifts is the one nobody
+ * builds — a stranger's repository, adopted with a version this project stopped
+ * using.
+ */
+final class BuildMetadata {
+
+	static final String BUILD_PROPERTIES = "/adopt-build.properties";
+
+	private BuildMetadata() {
+	}
+
+	/**
+	 * @param key         the property to read
+	 * @param description what the value is for, so a failure says what is missing
+	 *                    rather than only which key
+	 */
+	static String value(String key, String description) {
+		try (InputStream stream = BuildMetadata.class.getResourceAsStream(BUILD_PROPERTIES)) {
+			return read(stream, key, description);
+		} catch (IOException e) {
+			throw new AdoptionException("Could not read build metadata: " + BUILD_PROPERTIES, e);
+		}
+	}
+
+	/**
+	 * Refuses metadata that reached the classpath unfiltered as firmly as metadata
+	 * that is missing: an unsubstituted token would otherwise be wired into the
+	 * adopted POM as if it were a version. Both delimiters are rejected — the
+	 * resource is written with {@code @...@}, which is what this build filters, and
+	 * {@code ${...}} is what it would carry had that configuration changed.
+	 *
+	 * <p>Package-visible because the stream is the only seam these refusals have.
+	 * {@link #value} reads one resource off this class's own classpath, and that
+	 * resource is correct in every build that runs these tests — so a test driving a
+	 * version through it can only ever take the path that succeeds, leaving the
+	 * failures this method words for nobody to reach. They are the failures worth
+	 * reaching: each one is what stands between a broken build of {@code tools} and a
+	 * literal {@code @enforcer.rule.version@} wired into a stranger's {@code pom.xml}
+	 * by a pull request the adoption opened.
+	 */
+	static String read(InputStream stream, String key, String description) throws IOException {
+		if (stream == null) {
+			throw new AdoptionException("Build metadata not on the classpath: " + BUILD_PROPERTIES
+					+ " (build the module so its resources are filtered)");
+		}
+		Properties properties = new Properties();
+		properties.load(stream);
+		String value = properties.getProperty(key, "").strip();
+		if (value.isEmpty() || value.startsWith("@") || value.startsWith("${")) {
+			throw new AdoptionException("Build metadata " + BUILD_PROPERTIES + " carries no usable " + key
+					+ " (" + description + ") but '" + value + "'; the module's resources were not filtered.");
+		}
+		return value;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -62,6 +62,17 @@ public interface BuildSystem {
 	}
 
 	/**
+	 * Whether this checkout already carries the guard this build system installs.
+	 *
+	 * <p>It is the read-only half of {@link #install(Path)}, which answers the same
+	 * question but only by acting on it. A verification asks it of a repository it
+	 * must leave exactly as it cloned it, and the guard's own verification command
+	 * cannot answer it: a build with no guard wired in passes that command precisely
+	 * because nothing ran.
+	 */
+	boolean isGuardInstalled(Path repositoryDirectory);
+
+	/**
 	 * Command that runs the wired guard so a missing or malformed {@code CLAUDE.md}
 	 * fails the build. The checkout is a parameter because the command depends on
 	 * what the checkout itself ships: a project carrying a build wrapper is built

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystems.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystems.java
@@ -32,7 +32,17 @@ public final class BuildSystems {
 	 *                    running the adoption
 	 */
 	public static List<BuildSystem> defaults(Optional<String> ruleVersion) {
-		return List.of(new MavenBuildSystem(ruleVersion), new GradleBuildSystem(), new FallbackBuildSystem());
+		return defaults(GuardOptions.pinning(ruleVersion));
+	}
+
+	/**
+	 * @param guard what the wired guard is made of: its rule set, its pinned rule
+	 *              version, and the {@code CLAUDE.md} sections it demands. Only Maven
+	 *              wires a versioned artifact into the adopted project, so it is the
+	 *              only build system the guard options reach.
+	 */
+	public static List<BuildSystem> defaults(GuardOptions guard) {
+		return List.of(new MavenBuildSystem(guard), new GradleBuildSystem(), new FallbackBuildSystem());
 	}
 
 	public static Optional<BuildSystem> detect(List<BuildSystem> candidates, Path repositoryDirectory) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,6 +16,7 @@ import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.Failures;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
+import io.github.adamw7.tools.adopt.command.RetryingCommandRunner.Pause;
 
 /**
  * Runs the Claude Code CLI in headless mode against the checkout so it generates a
@@ -35,6 +37,16 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  * <p>The step is idempotent: a checkout that already carries a root
  * {@code CLAUDE.md} is left alone, because the CLI's output is not reproducible
  * and regenerating would discard whatever has been edited since.
+ *
+ * <p>A run that leaves no {@code CLAUDE.md} is tried again, a bounded number of
+ * times. This is the run's most expensive command and the only one with no other
+ * recovery: {@link io.github.adamw7.tools.adopt.command.TransientFailures} leaves
+ * {@code claude} out on purpose, because its transcript is a model's prose and may
+ * discuss a connection reset without one having happened. What is judged here is
+ * not the transcript but the <em>outcome</em> — whether the file exists — which
+ * that objection does not reach. A run that produced the file has succeeded
+ * whatever it exited with, and one that did not has produced nothing worth
+ * keeping, so there is no attempt to lose by trying again.
  */
 public class ClaudeInitStep extends AbstractCommandStep {
 
@@ -46,14 +58,51 @@ public class ClaudeInitStep extends AbstractCommandStep {
 	private static final String CLAUDE_MD = AdoptionAssets.CLAUDE_MD_FILE;
 	private static final String CLAUDE_DIR = ".claude";
 
+	/**
+	 * The wait before a second attempt, doubling before each one after it. Longer than
+	 * the transport backoff next door because what is being waited out is different:
+	 * a model that declined, timed out, or answered without writing anything, none of
+	 * which a two-second pause changes.
+	 */
+	static final Duration FIRST_BACKOFF = Duration.ofSeconds(5);
+
+	/** The wait the doubling stops at, so a generous retry count cannot idle a run for minutes. */
+	static final Duration MAX_BACKOFF = Duration.ofSeconds(30);
+
 	private final List<String> claudeCommand;
+	private final int retries;
+	private final Pause pause;
 
 	public ClaudeInitStep() {
 		this(DEFAULT_COMMAND);
 	}
 
+	/**
+	 * The default invocation, retried the number of times the run allows.
+	 *
+	 * @param retries how many further attempts a run that produced no {@code CLAUDE.md}
+	 *                earns
+	 */
+	public static ClaudeInitStep retrying(int retries) {
+		return new ClaudeInitStep(DEFAULT_COMMAND, retries);
+	}
+
 	public ClaudeInitStep(List<String> claudeCommand) {
+		this(claudeCommand, 0);
+	}
+
+	/**
+	 * @param retries how many further attempts a run that produced no {@code CLAUDE.md}
+	 *                earns; zero runs the CLI exactly once, as an undecorated step does
+	 */
+	public ClaudeInitStep(List<String> claudeCommand, int retries) {
+		this(claudeCommand, retries, Pause.sleeping());
+	}
+
+	ClaudeInitStep(List<String> claudeCommand, int retries, Pause pause) {
 		this.claudeCommand = List.copyOf(claudeCommand);
+		this.retries = retries;
+		this.pause = pause;
 	}
 
 	@Override
@@ -68,7 +117,27 @@ public class ClaudeInitStep extends AbstractCommandStep {
 			log.info("{} already carries {}; left unchanged", checkout, CLAUDE_MD);
 			return;
 		}
-		log.info("Running claude init in {}", checkout);
+		CommandResult result = attemptUntilGenerated(context, runner, checkout);
+		requireGenerated(context, result);
+	}
+
+	/**
+	 * Runs the CLI until it leaves a {@code CLAUDE.md} behind or the attempts run out,
+	 * answering the last attempt's result so the failure names what the CLI actually
+	 * said. The memory file is moved aside and restored around <em>each</em> attempt,
+	 * because a second attempt has to meet the same checkout the first one did.
+	 */
+	private CommandResult attemptUntilGenerated(AdoptionContext context, CommandRunner runner, Path checkout) {
+		CommandResult result = attempt(checkout, runner, 1);
+		for (int attempt = 1; attempt <= retries && !generated(context); attempt++) {
+			waitBefore(attempt, result);
+			result = attempt(checkout, runner, attempt + 1);
+		}
+		return result;
+	}
+
+	private CommandResult attempt(Path checkout, CommandRunner runner, int attempt) {
+		log.info("Running claude init in {} (attempt {} of {})", checkout, attempt, retries + 1);
 		Optional<Path> relocated = relocateExistingClaudeDirMemory(checkout);
 		CommandResult result;
 		try {
@@ -78,8 +147,31 @@ public class ClaudeInitStep extends AbstractCommandStep {
 			throw e;
 		}
 		restoreRelocated(relocated, checkout);
-		requireGenerated(context, result);
+		return result;
 	}
+
+	private boolean generated(AdoptionContext context) {
+		return Files.isRegularFile(context.repositoryDirectory().resolve(CLAUDE_MD));
+	}
+
+	/**
+	 * The attempt being replaced is logged here because nothing else will: an attempt a
+	 * later one succeeds after would otherwise leave no trace, and the transcript is
+	 * where a reader finds out that the CLI declined rather than failed.
+	 */
+	private void waitBefore(int attempt, CommandResult result) {
+		Duration backoff = backoff(attempt);
+		log.warn("claude init produced no {} (exit {}); retrying in {}s ({} of {}): {}", CLAUDE_MD,
+				result.exitCode(), backoff.toSeconds(), attempt, retries, result.redactedOutput().strip());
+		pause.of(backoff);
+	}
+
+	private Duration backoff(int attempt) {
+		Duration doubled = FIRST_BACKOFF.multipliedBy(1L << (attempt - 1));
+		return doubled.compareTo(MAX_BACKOFF) > 0 ? MAX_BACKOFF : doubled;
+	}
+
+
 
 	private void restoreRelocated(Optional<Path> relocated, Path checkout) {
 		relocated.ifPresent(backup -> restore(backup, claudeDirMemory(checkout)));

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformanceStep.java
@@ -11,6 +11,7 @@ import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.AdoptionFiles;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
+import io.github.adamw7.tools.markdown.LineTerminators;
 
 /**
  * Makes the adoption self-consistent: after {@link ClaudeInitStep} generates a

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeMdConformer.java
@@ -1,58 +1,44 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
-import io.github.adamw7.tools.markdown.MarkdownDocument;
-import io.github.adamw7.tools.markdown.MarkdownText;
+import io.github.adamw7.tools.markdown.MarkdownContract;
+import io.github.adamw7.tools.markdown.MarkdownConformer;
 
 /**
- * Reshapes the {@code CLAUDE.md} that {@link ClaudeInitStep} generated so it
- * satisfies the {@code claudeMdFormat} rule {@link EnforcerStep} wires into the
- * build. A generic {@code claude init} writes natural, project-specific headings
- * and no {@code AGENTS.md} reference, while the rule demands a fixed set of
- * whole-line headings plus that reference — so without this reshape the adoption
- * fails its own {@link VerifyStep}.
+ * The {@code CLAUDE.md} contract as the adoption states it, reshaped by the
+ * shared {@link MarkdownConformer}.
  *
- * <p>The reshape is deterministic and conservative: a near-miss heading is
- * <em>renamed</em> in place so its body survives, only a genuinely absent section
- * is appended, and a required section left empty gets a stub body because the rule
- * fails an empty section just as it fails a missing one. Code — fenced or indented
- * — and commented-out text are left alone, mirroring how the rule matches, and
- * reshaping an already-conforming document is a no-op. It is also repeated until the
- * document stops changing, because an edit changes how the lines below it are read
- * and so can undo a question the same pass had already answered — see
- * {@link #conform}.
+ * <p>A generic {@code claude init} writes natural, project-specific headings and
+ * no {@code AGENTS.md} reference, while the {@code claudeMdFormat} rule
+ * {@link EnforcerStep} wires in demands a fixed set of whole-line headings plus
+ * that reference — so without this reshape the adoption fails its own
+ * {@link VerifyStep}.
+ *
+ * <p>Only the contract lives here; the reshape itself is
+ * {@code markdown-common}'s, alongside the {@link io.github.adamw7.tools.markdown.MarkdownDocument}
+ * reader the rule judges the result with. It used to be a second implementation
+ * in this module, kept honest by a contract test running the real rule over its
+ * output — which caught the drift but only after it had been written twice.
  *
  * <p>Which sections it demands is the caller's to choose, because the guard being
  * wired in differs by build system — see
  * {@link BuildSystem#requiredClaudeMdSections()}. The title and the
  * {@code AGENTS.md} reference are settled either way, since the step writes a
  * companion {@code AGENTS.md} for every adopted repository.
- *
- * <p>How the document is <em>read</em> — which lines are code, which sit inside an
- * HTML comment, and what heading a line declares — is {@link MarkdownDocument}'s to
- * decide, the same reader the {@code claudeMdFormat} rule judges the result with.
- * Spelling those readings out here a second time made the two drift apart, and
- * every drift produced one shape of bug: this class acted on lines the rule holds
- * to be code, or appended a section the rule already reads as present, and the
- * adoption failed the very check it exists to satisfy — after pushing the file.
  */
 public class ClaudeMdConformer {
 
 	/*
 	 * These mirror io.github.adamw7.tools.enforcer.doc.ClaudeMdFormatRule in the
-	 * claude-code-enforcer module. They are duplicated rather than imported because
-	 * the adopt module does not depend on the enforcer module — a pipeline that
-	 * shipped an enforcer rule would force the maven-enforcer API on every consumer.
-	 * The copy is not trusted to stay in step: ClaudeMdConformerContractTest runs the
-	 * real rule over this class's output, so a rule that asks for one more section
-	 * fails this module's build rather than some adopted repository's.
+	 * claude-code-enforcer module. They are restated rather than imported because the
+	 * adopt module does not depend on the enforcer module — a pipeline that shipped an
+	 * enforcer rule would force the maven-enforcer API on every consumer. What is
+	 * restated is now only the contract's values; the reshape that satisfies them is
+	 * markdown-common's, which both modules do depend on. The copy is not trusted to
+	 * stay in step: ClaudeMdConformerContractTest runs the real rule over this class's
+	 * output, so a rule that asks for one more section fails this module's build
+	 * rather than some adopted repository's.
 	 */
 	static final String TITLE = "# CLAUDE.md";
 	static final String AGENTS_REFERENCE = "AGENTS.md";
@@ -74,34 +60,10 @@ public class ClaudeMdConformer {
 
 	static final String AGENTS_REFERENCE_LINE = "See [AGENTS.md](AGENTS.md) for the companion agent guide.";
 
-	/**
-	 * What a required section the project has nothing to say under is given, since the
-	 * rule fails an empty section as firmly as a missing one. It used to read "See
-	 * [AGENTS.md](AGENTS.md)." — which pointed at the companion file
-	 * {@link AdoptionAssets} installs beside it, and that file points back here and
-	 * calls {@code CLAUDE.md} the source of truth. Every adopted repository's pull
-	 * request therefore opened with six sections whose whole content was a reference to
-	 * a document that referred the reader straight back, and a maintainer reading it
-	 * had no way to tell an unanswered section from an answered one. Saying plainly
-	 * that nothing is recorded yet is both true and actionable.
-	 */
-	static final String STUB_BODY = "_Not documented yet — replace this line with the project's own guidance._";
+	/** @see MarkdownContract#DEFAULT_STUB_BODY */
+	static final String STUB_BODY = MarkdownContract.DEFAULT_STUB_BODY;
 
-	/** The blank lines the reshape may leave at the end, dropped so the document keeps a single one. */
-	private static final Pattern TRAILING_BLANK_LINES = Pattern.compile("\\n\\s*+\\z");
-
-	/**
-	 * How many times {@link #conform} may run the pass before it stops waiting for the
-	 * document to settle. Two is the ordinary cost — one pass that reshapes and one
-	 * that confirms the reshape left nothing behind — and a third is spent only where
-	 * a pass's own edit reclassified a line an earlier part of that same pass had read.
-	 * The bound is what stops a document nothing settles from looping; such a document
-	 * comes back as the last pass left it, and {@link VerifyStep} refuses it before
-	 * anything is pushed.
-	 */
-	private static final int MAX_PASSES = 4;
-
-	private final List<String> requiredSections;
+	private final MarkdownConformer conformer;
 
 	/** Conforms to the full {@code claudeMdFormat} contract. */
 	public ClaudeMdConformer() {
@@ -122,290 +84,25 @@ public class ClaudeMdConformer {
 	 *                         one would have had a second near-miss renamed to it.
 	 */
 	public ClaudeMdConformer(List<String> requiredSections) {
-		this.requiredSections = List.copyOf(new LinkedHashSet<>(requiredSections));
+		this.conformer = new MarkdownConformer(contractFor(requiredSections));
 	}
 
 	/**
-	 * Reshapes until the document stops changing, which is the only way one pass can
-	 * be trusted: an edit made part-way through a pass changes how the lines below it
-	 * are read, so a question the pass had already answered can stop being true before
-	 * the pass ends. Every edit here is one of those. Inserting the {@code AGENTS.md}
-	 * reference puts a blank line above what followed the title, and a blank line is
-	 * what lets the line below it open an indented code block, so a {@code ## Testing}
-	 * that had been a lazy continuation of a paragraph became code. Inserting a stub
-	 * puts a line at the margin, which ends an open list and lowers the column at
-	 * which the lines below quote code, so a fence delimiter indented inside that list
-	 * stopped being one — and the terminator already appended for it then
-	 * <em>opened</em> a block that swallowed everything after it. Renaming a near-miss
-	 * heading moves it to the margin and ends a list the same way. Each of those left
-	 * the reshape reporting work it had done on a document that no longer existed, and
-	 * {@link VerifyStep} failing on the file the adoption had just committed.
-	 *
-	 * <p>What makes repeating the pass an answer rather than a retry is that a pass
-	 * which changes nothing is exactly a document the rule accepts: the pass leaves a
-	 * title alone only where the rule finds one, leaves the reference alone only where
-	 * {@code containsInProse} finds one, and leaves a section alone only where the
-	 * rule's own lookup finds it carrying a body. So the loop ends on the very
-	 * condition the guard checks, and a document that already conforms settles on the
-	 * first pass — which is what keeps the reshape a no-op on re-adoption.
-	 *
 	 * @return {@code content} reshaped so the {@code claudeMdFormat} rule passes,
 	 *         with a single trailing newline
 	 */
 	public String conform(String content) {
-		String conformed = reshape(content);
-		for (int pass = 1; pass < MAX_PASSES; pass++) {
-			String settled = reshape(conformed);
-			if (settled.equals(conformed)) {
-				return conformed;
-			}
-			conformed = settled;
-		}
-		return conformed;
+		return conformer.conform(content);
 	}
 
 	/**
-	 * One pass, with the two insertions that go above the document's body — the title
-	 * and the reference — made before a section is looked for. The loop above is what
-	 * makes the result sound whatever this order is, but settling those first is what
-	 * lets the ordinary generated document reshape in one pass rather than two, and a
-	 * pass that finds work left over appends it at the end of the file.
+	 * The reference line is stated rather than derived, because it names the companion
+	 * guide the adoption installs and says what that guide is for. The rule only asks
+	 * that {@code AGENTS.md} be mentioned in prose.
 	 */
-	private String reshape(String content) {
-		List<String> lines = splitLines(content);
-		closeUnterminatedBlocks(lines);
-		ensureTitle(lines);
-		ensureAgentsReference(lines);
-		canonicalizeHeadings(lines);
-		ensureRequiredSections(lines);
-		return join(lines);
-	}
-
-	/**
-	 * The lines are split here rather than left to {@link MarkdownDocument#parse},
-	 * because {@link String#lines()} drops the empty line a document's trailing
-	 * newline leaves and this reshape appends to the list it splits.
-	 *
-	 * <p>A leading byte-order mark is dropped, the same reading the rule takes.
-	 * Keeping it left the mark in front of {@code # CLAUDE.md} — which
-	 * {@link String#strip()} does not shorten — so the reshape concluded the title was
-	 * missing and prepended a second one, which the rule accepted either way.
-	 */
-	private List<String> splitLines(String content) {
-		String normalized = LineTerminators.normalized(MarkdownText.stripByteOrderMark(content));
-		return new ArrayList<>(List.of(normalized.split("\n", -1)));
-	}
-
-	/**
-	 * Closes a fence and an HTML comment the document opened and never closed, so
-	 * everything appended below lands outside the block: a section appended inside an
-	 * open comment is inert text the rule does not see. A document whose fences and
-	 * comments balance is left untouched, keeping the reshape idempotent.
-	 *
-	 * <p>The fence is closed first, because a comment inside a fenced code block is
-	 * sample text rather than a comment — the same precedence the rule reads them
-	 * with — and the document is read afresh afterwards so the added line counts.
-	 */
-	private void closeUnterminatedBlocks(List<String> lines) {
-		MarkdownDocument.of(lines).openFenceTerminator().ifPresent(lines::add);
-		MarkdownDocument.of(lines).openCommentTerminator().ifPresent(lines::add);
-	}
-
-	/**
-	 * Puts the title on the document's first line, which is where the rule reads it.
-	 * A title the document already carries lower down is <em>moved</em> rather than
-	 * left where it is, since prepending a second one leaves two {@code # CLAUDE.md}
-	 * headings — which the rule accepts, so nothing downstream would report the
-	 * duplicate, and the reshape being idempotent means a re-adoption never clears it.
-	 *
-	 * <p>A document that already opens with the title is not left alone either: it
-	 * needs no title <em>added</em>, but a second one lower down is the same duplicate
-	 * by another route, and returning on the first line alone left it there for good —
-	 * the rule never looks past that line, so nothing downstream reported it, and the
-	 * reshape being idempotent meant no re-adoption cleared it.
-	 *
-	 * <p>The titles are removed latest first, so removing one cannot shift the index
-	 * of the next. Only structural lines are offered: a {@code # CLAUDE.md} inside a
-	 * code sample is the sample's, not the document's.
-	 */
-	private void ensureTitle(List<String> lines) {
-		MarkdownDocument document = MarkdownDocument.of(lines);
-		List<Integer> titles = document.headingIndices(TITLE).boxed().toList();
-		if (TITLE.equals(document.firstNonBlankLine())) {
-			removeHeadings(lines, allButTheFirst(titles));
-			return;
-		}
-		removeHeadings(lines, titles);
-		lines.addAll(0, List.of(TITLE, ""));
-	}
-
-	/**
-	 * The titles a document opening with one has to lose: every one but the title it
-	 * opens with, which is the one the rule reads. An empty list is the document whose
-	 * opening title is not a structural line at all — one indented into a code block,
-	 * which the rule accepts on the same reading and which is the sample's to keep.
-	 */
-	private static List<Integer> allButTheFirst(List<Integer> titles) {
-		return titles.isEmpty() ? titles : titles.subList(1, titles.size());
-	}
-
-	/** Removes the headings latest first, so removing one cannot shift the index of the next. */
-	private static void removeHeadings(List<String> lines, List<Integer> indices) {
-		indices.reversed().forEach(index -> removeHeading(lines, index));
-	}
-
-	/**
-	 * Removes the heading, and the blank line below it only when the line above was
-	 * blank too — otherwise the paragraph that followed the heading would be pulled up
-	 * against the one that preceded it and the two would read as a single paragraph.
-	 */
-	private static void removeHeading(List<String> lines, int index) {
-		lines.remove(index);
-		if (isBlankAt(lines, index) && precededByBlank(lines, index)) {
-			lines.remove(index);
-		}
-	}
-
-	private static boolean precededByBlank(List<String> lines, int index) {
-		return index == 0 || lines.get(index - 1).isBlank();
-	}
-
-	/**
-	 * Renaming a heading in place leaves the line count untouched and cannot turn a
-	 * structural line into code, so one reading of the document serves every required
-	 * section here — unlike {@link #ensureSection}, which inserts lines and has to
-	 * read the document afresh each time.
-	 */
-	private void canonicalizeHeadings(List<String> lines) {
-		MarkdownDocument document = MarkdownDocument.of(lines);
-		Set<Integer> claimed = reservedHeadings(document);
-		requiredSections.forEach(required -> canonicalize(lines, document, required, claimed));
-	}
-
-	/**
-	 * The indices of lines that already are a required heading exactly, reserved so
-	 * a near-match search never renames a heading that is already serving another
-	 * required section.
-	 */
-	private Set<Integer> reservedHeadings(MarkdownDocument document) {
-		return document
-				.structuralLines(line -> MarkdownDocument.headingOf(line).filter(requiredSections::contains).isPresent())
-				.boxed()
-				.collect(Collectors.toCollection(LinkedHashSet::new));
-	}
-
-	private void canonicalize(List<String> lines, MarkdownDocument document, String required, Set<Integer> claimed) {
-		if (document.headingIndex(required) >= 0) {
-			return;
-		}
-		int index = firstNearMatch(document, required, claimed);
-		if (index >= 0) {
-			lines.set(index, required);
-			claimed.add(index);
-		}
-	}
-
-	private int firstNearMatch(MarkdownDocument document, String required, Set<Integer> claimed) {
-		return document.structuralLines(line -> isNearMatch(line, required))
-				.filter(index -> !claimed.contains(index))
-				.findFirst()
-				.orElse(-1);
-	}
-
-	/**
-	 * A near-miss is the required heading in a different case, or followed by a
-	 * space and extra words — the two shapes {@code claude init} produces
-	 * ({@code ## Project purpose} for {@code ## Project}). The trailing space keeps
-	 * {@code ## Maven} from matching an unrelated {@code ## Mavenish} heading. The
-	 * line is compared as {@link MarkdownDocument#headingOf} writes it, so which
-	 * spelling a near-miss was typed in does not decide whether it is one.
-	 */
-	private static boolean isNearMatch(String line, String required) {
-		String wanted = required.toLowerCase(Locale.ROOT);
-		return MarkdownDocument.headingOf(line)
-				.map(heading -> heading.toLowerCase(Locale.ROOT))
-				.filter(actual -> actual.equals(wanted) || actual.startsWith(wanted + " "))
-				.isPresent();
-	}
-
-	/**
-	 * Gives every required section both a heading and a body: a heading the document
-	 * left bare — typically a near-miss renamed in place above — has a stub inserted
-	 * beneath it, and a section the document does not carry at all is appended with
-	 * one. The rule fails an empty section just as it fails a missing one, so both
-	 * are settled here.
-	 *
-	 * <p>The two are separate passes, with the document's blocks closed again between
-	 * them, because inserting a stub is a mid-document edit and a mid-document edit
-	 * can change what the lines below it are. A stub sits at the margin, which ends an
-	 * open list — and that lowers the column at which the lines below quote code, so a
-	 * fence delimiter indented inside that list stops being one. The terminator
-	 * {@link #closeUnterminatedBlocks} had already appended for it then <em>opened</em>
-	 * a block instead of closing one, and every section appended afterwards landed
-	 * inside it, where the rule reads it as code: the reshape handed
-	 * {@link VerifyStep} a document still missing the sections it had just written.
-	 * Interleaving the two passes has the same flaw one step further on, since a stub
-	 * inserted after a section was appended can bury that section the same way.
-	 * Appending, by contrast, only ever adds below every line that has been read, so
-	 * it can invalidate nothing.
-	 */
-	private void ensureRequiredSections(List<String> lines) {
-		requiredSections.forEach(required -> stubBareSection(lines, required));
-		closeUnterminatedBlocks(lines);
-		requiredSections.forEach(required -> appendAbsentSection(lines, required));
-	}
-
-	/**
-	 * The document is read afresh per section because inserting a stub shifts the
-	 * lines the next one is found at, and the sections are few enough for that to stay
-	 * cheap. Missing and empty are two answers to the one heading lookup, so it is
-	 * made once: a section the document does not declare is left to
-	 * {@link #appendAbsentSection}.
-	 */
-	private void stubBareSection(List<String> lines, String required) {
-		MarkdownDocument document = MarkdownDocument.of(lines);
-		int index = document.headingIndex(required);
-		if (index >= 0 && !document.hasBodyAt(index)) {
-			lines.addAll(index + 1, List.of("", STUB_BODY));
-		}
-	}
-
-	/** Appends the section and its stub when the document declares the heading nowhere. */
-	private void appendAbsentSection(List<String> lines, String required) {
-		if (MarkdownDocument.of(lines).headingIndex(required) < 0) {
-			lines.addAll(List.of("", required, "", STUB_BODY));
-		}
-	}
-
-	/**
-	 * The reference is separated from what follows it only when that line is not
-	 * already blank, since a document conformed to no required sections keeps the body
-	 * {@code claude init} wrote, blank line and all.
-	 *
-	 * <p>An existing mention only counts where the rule counts one: its
-	 * {@code containsInProse} reads the lines that carry document structure, so a
-	 * mention inside a code sample or an HTML comment satisfies it no more than a
-	 * commented-out heading satisfies a required section. Asking the looser question
-	 * let a document whose only {@code AGENTS.md} sat in a comment keep a reference it
-	 * never had. A document with no title line at all takes the reference at the top.
-	 */
-	private void ensureAgentsReference(List<String> lines) {
-		MarkdownDocument document = MarkdownDocument.of(lines);
-		if (document.containsInProse(AGENTS_REFERENCE)) {
-			return;
-		}
-		int index = Math.max(document.headingIndex(TITLE), 0) + 1;
-		lines.addAll(index, isBlankAt(lines, index)
-				? List.of("", AGENTS_REFERENCE_LINE)
-				: List.of("", AGENTS_REFERENCE_LINE, ""));
-	}
-
-	private static boolean isBlankAt(List<String> lines, int index) {
-		return index < lines.size() && lines.get(index).isBlank();
-	}
-
-	/** Joins the lines under a single trailing newline, dropping any blank lines the reshape left at the end. */
-	private String join(List<String> lines) {
-		return TRAILING_BLANK_LINES.matcher(String.join("\n", lines)).replaceAll("") + "\n";
+	private static MarkdownContract contractFor(List<String> requiredSections) {
+		return MarkdownContract.titled(TITLE)
+				.requiring(requiredSections)
+				.referencing(AGENTS_REFERENCE, AGENTS_REFERENCE_LINE);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersion.java
@@ -1,9 +1,5 @@
 package io.github.adamw7.tools.adopt.step;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-
 import io.github.adamw7.tools.adopt.AdoptionException;
 
 /**
@@ -17,7 +13,6 @@ import io.github.adamw7.tools.adopt.AdoptionException;
  */
 final class EnforcerRuleVersion {
 
-	static final String BUILD_PROPERTIES = "/adopt-build.properties";
 	static final String RULE_VERSION_KEY = "enforcer.rule.version";
 	private static final String SNAPSHOT_SUFFIX = "-SNAPSHOT";
 
@@ -60,46 +55,12 @@ final class EnforcerRuleVersion {
 
 	/**
 	 * Reads the rule version from the metadata Maven filters into
-	 * {@value #BUILD_PROPERTIES} at build time, so the dependency is pinned to the
-	 * exact {@code tools} release running the adoption — resolvable from the
-	 * repository that published it — rather than to a literal that silently drifts.
+	 * {@value BuildMetadata#BUILD_PROPERTIES} at build time, so the dependency is
+	 * pinned to the exact {@code tools} release running the adoption — resolvable from
+	 * the repository that published it — rather than to a literal that silently
+	 * drifts.
 	 */
 	static String fromBuildMetadata() {
-		try (InputStream stream = EnforcerRuleVersion.class.getResourceAsStream(BUILD_PROPERTIES)) {
-			return read(stream);
-		} catch (IOException e) {
-			throw new AdoptionException("Could not read build metadata: " + BUILD_PROPERTIES, e);
-		}
-	}
-
-	/**
-	 * Refuses metadata that reached the classpath unfiltered as firmly as metadata
-	 * that is missing: an unsubstituted token would otherwise be wired into the
-	 * adopted POM as if it were a version. Both delimiters are rejected — the
-	 * resource is written with {@code @...@}, which is what this build filters, and
-	 * {@code ${...}} is what it would carry had that configuration changed.
-	 *
-	 * <p>Package-visible because the stream is the only seam these refusals have.
-	 * {@link #fromBuildMetadata()} reads one resource off this class's own
-	 * classpath, and that resource is correct in every build that runs these tests —
-	 * so a test driving the version through it can only ever take the path that
-	 * succeeds, leaving the three failures this method words for nobody to reach.
-	 * They are the failures worth reaching: each one is what stands between a broken
-	 * build of {@code tools} and a literal {@code @enforcer.rule.version@} wired
-	 * into a stranger's {@code pom.xml} by a pull request the adoption opened.
-	 */
-	static String read(InputStream stream) throws IOException {
-		if (stream == null) {
-			throw new AdoptionException("Build metadata not on the classpath: " + BUILD_PROPERTIES
-					+ " (build the module so its resources are filtered)");
-		}
-		Properties properties = new Properties();
-		properties.load(stream);
-		String version = properties.getProperty(RULE_VERSION_KEY, "").strip();
-		if (version.isEmpty() || version.startsWith("@") || version.startsWith("${")) {
-			throw new AdoptionException(
-					RULE_VERSION_KEY + " was not filtered into " + BUILD_PROPERTIES + " (found: '" + version + "')");
-		}
-		return version;
+		return BuildMetadata.value(RULE_VERSION_KEY, "the claude-code-enforcer rule version to wire in");
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
@@ -54,6 +54,11 @@ public class FallbackBuildSystem implements BuildSystem {
 	}
 
 	@Override
+	public boolean isGuardInstalled(Path repositoryDirectory) {
+		return installer.isInstalled(repositoryDirectory);
+	}
+
+	@Override
 	public List<String> verifyCommand(Path repositoryDirectory) {
 		return VERIFY_COMMAND;
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleBuildSystem.java
@@ -61,6 +61,15 @@ public class GradleBuildSystem extends AbstractWrappedBuildSystem {
 	}
 
 	/**
+	 * A checkout with no Gradle build file at all carries no guard, rather than being
+	 * a failure: this is asked of a repository that may not be a Gradle project.
+	 */
+	@Override
+	public boolean isGuardInstalled(Path repositoryDirectory) {
+		return locate(repositoryDirectory).filter(installer::isInstalled).isPresent();
+	}
+
+	/**
 	 * Prefers the Groovy build file over the Kotlin one when a checkout carries
 	 * both, matching the order most Gradle projects resolve them in.
 	 */

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import io.github.adamw7.tools.adopt.AdoptionFiles;
+import io.github.adamw7.tools.markdown.LineTerminators;
 
 /**
  * Appends a {@code CLAUDE.md} guard task to a Gradle build script, so the adopted

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -1,5 +1,6 @@
 package io.github.adamw7.tools.adopt.step;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -130,6 +131,12 @@ public class GradleGuardInstaller {
 	 * or in a declaration someone commented out — is still given the task rather
 	 * than left without the one {@link GradleBuildSystem#verifyCommand(Path)} runs.
 	 */
+	/** Whether the script already declares the guard task; read-only, for a verification. */
+	public boolean isInstalled(Path buildFile) {
+		return Files.isRegularFile(buildFile)
+				&& declaresGuard(AdoptionFiles.read(buildFile, BUILD_FILE_DESCRIPTION));
+	}
+
 	private boolean declaresGuard(String script) {
 		return DECLARATION.matcher(withoutComments(script)).find();
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GuardOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GuardOptions.java
@@ -1,0 +1,60 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * What the guard wired into an adopted project is made of: which rule set it
+ * runs, which {@code claude-code-enforcer} version it pins, and which
+ * {@code CLAUDE.md} sections it demands.
+ *
+ * <p>The three travel together because the guard and the reshape that has to
+ * satisfy it are settled from the same answer. A section list that reached the
+ * conformer but not the POM — or the other way round — is the one shape of bug
+ * this whole area keeps producing: a document reshaped to a contract the guard
+ * beside it does not make, discovered on somebody else's repository after the
+ * branch is pushed.
+ *
+ * @param ruleVersion       the released rule version to pin, or {@code null} to
+ *                          resolve the version of the {@code tools} build running
+ *                          the adoption — read through {@link #pinnedRuleVersion()}
+ * @param rules             how much of the configuration the guard checks
+ * @param claudeMdSections  the headings to demand and to conform to, or empty to use
+ *                          the ones the detected build system asks for
+ */
+public record GuardOptions(String ruleVersion, GuardRules rules, List<String> claudeMdSections) {
+
+	public GuardOptions {
+		rules = rules == null ? GuardRules.PROJECT : rules;
+		claudeMdSections = claudeMdSections == null ? List.of() : List.copyOf(claudeMdSections);
+	}
+
+	/** The whole configuration checked, at the running build's rule version, with the build system's sections. */
+	public static GuardOptions defaults() {
+		return new GuardOptions(null, GuardRules.PROJECT, List.of());
+	}
+
+	/** The options a caller who cares only about the pinned version asks for. */
+	public static GuardOptions pinning(Optional<String> ruleVersion) {
+		return new GuardOptions(ruleVersion.orElse(null), GuardRules.PROJECT, List.of());
+	}
+
+	/**
+	 * @return the released rule version to pin, or empty to resolve the version of the
+	 *         {@code tools} build running the adoption. Preferred over the record's
+	 *         own {@link #ruleVersion()}, which answers {@code null} for the same case:
+	 *         a field holds the value, and the {@link Optional} is how it is read.
+	 */
+	public Optional<String> pinnedRuleVersion() {
+		return Optional.ofNullable(ruleVersion);
+	}
+
+	/**
+	 * @param fromBuildSystem what the detected build system's guard demands
+	 * @return the sections to demand: the ones the operator named, or the build
+	 *         system's when they named none
+	 */
+	public List<String> sectionsOr(List<String> fromBuildSystem) {
+		return claudeMdSections.isEmpty() ? fromBuildSystem : claudeMdSections;
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GuardRules.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GuardRules.java
@@ -1,0 +1,67 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.util.Locale;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * How much of the adopted repository's Claude Code configuration the guard checks.
+ *
+ * <p>The adoption used to wire one rule, {@code claudeMdFormat}, and the gap that
+ * left was not academic: the run installs a companion {@code AGENTS.md} and, with
+ * {@code --assets}, a {@code .claude} directory of settings and hooks — none of
+ * which anything then checked. A repository could carry a malformed
+ * {@code settings.json}, a skill with no definition, or a credential committed
+ * into a hook, and its build stayed green while advertising that it had adopted
+ * Claude Code.
+ */
+public enum GuardRules {
+
+	/**
+	 * Only the {@code CLAUDE.md} format rule. The narrowest guard that is still a
+	 * guard, for a repository whose maintainers want the document checked and nothing
+	 * else of theirs touched.
+	 */
+	MINIMAL("claudeMdFormat"),
+
+	/**
+	 * Every rule that has something to check, through the {@code claudeCodeProject}
+	 * composite: the documents, the definitions, the settings and hooks, and the
+	 * secret scan. It is the default because it is the one that covers what the
+	 * adoption itself installs, and because it costs the adopted POM three elements
+	 * rather than sixty.
+	 */
+	PROJECT("claudeCodeProject");
+
+	private final String ruleName;
+
+	GuardRules(String ruleName) {
+		this.ruleName = ruleName;
+	}
+
+	/** The {@code @Named} element the adopted POM configures. */
+	public String ruleName() {
+		return ruleName;
+	}
+
+	/**
+	 * @param name the value as an operator wrote it, in any case
+	 * @throws IllegalArgumentException naming what it accepts, since a misspelt rule
+	 *                                  set read as the default would quietly widen or
+	 *                                  narrow what somebody else's build enforces
+	 */
+	public static GuardRules of(String name) {
+		String normalized = name.strip().toUpperCase(Locale.ROOT);
+		return Arrays.stream(values())
+				.filter(candidate -> candidate.name().equals(normalized))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("Unknown rule set '" + name.strip()
+						+ "'. Use one of " + names()));
+	}
+
+	private static String names() {
+		return Arrays.stream(values())
+				.map(value -> value.name().toLowerCase(Locale.ROOT))
+				.collect(Collectors.joining(", "));
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -3,7 +3,6 @@ package io.github.adamw7.tools.adopt.step;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Maven support for the adoption: detects a {@code pom.xml}, wires the
@@ -26,27 +25,36 @@ public class MavenBuildSystem extends AbstractWrappedBuildSystem {
 	static final String POM = "pom.xml";
 
 	private final PomEnforcerInstaller installer;
+	private final GuardOptions guard;
 
 	public MavenBuildSystem() {
-		this(Optional.empty());
+		this(GuardOptions.defaults());
 	}
 
 	/**
-	 * @param ruleVersion the released {@code claude-code-enforcer} version to pin into
-	 *                    the adopted POM, or empty to resolve the version of the
-	 *                    {@code tools} build running the adoption
+	 * @param guard what the wired guard is made of: the rule set, the pinned rule
+	 *              version, and the {@code CLAUDE.md} sections it demands
 	 */
-	public MavenBuildSystem(Optional<String> ruleVersion) {
-		this(PomEnforcerInstaller.pinning(ruleVersion));
+	public MavenBuildSystem(GuardOptions guard) {
+		this(PomEnforcerInstaller.from(guard), guard, defaultWrapper());
 	}
 
 	public MavenBuildSystem(PomEnforcerInstaller installer) {
-		this(installer, new BuildWrapper("mvnw", "mvnw.cmd"));
+		this(installer, GuardOptions.defaults(), defaultWrapper());
 	}
 
 	MavenBuildSystem(PomEnforcerInstaller installer, BuildWrapper wrapper) {
+		this(installer, GuardOptions.defaults(), wrapper);
+	}
+
+	MavenBuildSystem(PomEnforcerInstaller installer, GuardOptions guard, BuildWrapper wrapper) {
 		super(NAME, MAVEN, VERIFY_ARGUMENTS, wrapper);
 		this.installer = installer;
+		this.guard = guard;
+	}
+
+	private static BuildWrapper defaultWrapper() {
+		return new BuildWrapper("mvnw", "mvnw.cmd");
 	}
 
 	@Override
@@ -59,20 +67,31 @@ public class MavenBuildSystem extends AbstractWrappedBuildSystem {
 		return List.of(POM);
 	}
 
+	/**
+	 * The sections the guard is given are the ones {@link #requiredClaudeMdSections()}
+	 * answers, which is what the conformer has just reshaped the document to. Reading
+	 * them from the one accessor is what keeps the document and the guard beside it
+	 * making the same demand.
+	 */
 	@Override
 	public boolean install(Path repositoryDirectory) {
-		return installer.install(repositoryDirectory.resolve(POM));
+		return installer.install(repositoryDirectory.resolve(POM), requiredClaudeMdSections());
 	}
 
 	/**
 	 * The only build system that demands sections, because it is the only one wiring
-	 * in the {@code claudeMdFormat} rule — the guard {@link #verifyCommand(Path)}
-	 * then runs, and the one that fails a {@code CLAUDE.md} for a missing section
-	 * rather than merely for being absent or blank. A Maven checkout is a JVM project,
-	 * so the rule's Java and Maven sections are ones it can answer.
+	 * in a rule that reads them — the guard {@link #verifyCommand(Path)} then runs,
+	 * and the one that fails a {@code CLAUDE.md} for a missing section rather than
+	 * merely for being absent or blank.
+	 *
+	 * <p>The default is this repository's own list, on the reasoning that a Maven
+	 * checkout is a JVM project and can answer Java and Maven questions. That is a
+	 * default and not a fact: a Maven build whose {@code CLAUDE.md} is about something
+	 * else names its own sections through {@link GuardOptions}, and they are written
+	 * into the guard as well as conformed to.
 	 */
 	@Override
 	public List<String> requiredClaudeMdSections() {
-		return ClaudeMdConformer.REQUIRED_SECTIONS;
+		return guard.sectionsOr(ClaudeMdConformer.REQUIRED_SECTIONS);
 	}
 }

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/MavenBuildSystem.java
@@ -67,6 +67,12 @@ public class MavenBuildSystem extends AbstractWrappedBuildSystem {
 		return List.of(POM);
 	}
 
+	@Override
+	public boolean isGuardInstalled(Path repositoryDirectory) {
+		Path pom = repositoryDirectory.resolve(POM);
+		return Files.isRegularFile(pom) && installer.isInstalled(pom);
+	}
+
 	/**
 	 * The sections the guard is given are the ones {@link #requiredClaudeMdSections()}
 	 * answers, which is what the conformer has just reshaped the document to. Reading

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomDocument.java
@@ -17,6 +17,7 @@ import org.jsoup.parser.Parser;
 
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.AdoptionFiles;
+import io.github.adamw7.tools.markdown.LineTerminators;
 
 /**
  * A {@code pom.xml} read for editing and written back without reformatting.

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jsoup.nodes.Element;
@@ -69,9 +70,15 @@ public class PomEnforcerInstaller {
 	private static final String IN_BUILD = "build/plugins";
 	private static final String IN_PLUGIN_MANAGEMENT = "build/pluginManagement";
 
+	/** The composite rule, which checks the whole configuration from the project directory. */
+	static final String PROJECT_RULE = GuardRules.PROJECT.ruleName();
+
+	/** The project directory the composite resolves every conventional path against. */
+	private static final String PROJECT_DIR = "${project.basedir}";
+
 	/**
-	 * The execution that runs the rule, bound to {@code validate} and not inherited
-	 * because {@code CLAUDE.md} lives only at the repository root.
+	 * The execution that runs the guard, bound to {@code validate} and not inherited
+	 * because the documents live only at the repository root.
 	 */
 	private static final String EXECUTION = """
 			<execution>
@@ -83,17 +90,16 @@ public class PomEnforcerInstaller {
 			  </goals>
 			  <configuration>
 			    <rules>
-			      <%1$s>
-			        <claudeMdFile>%2$s</claudeMdFile>
-			      </%1$s>
+			%s
 			    </rules>
 			  </configuration>
-			</execution>""".formatted(CLAUDE_MD_RULE, CLAUDE_MD_FILE);
+			</execution>""";
 
 	private final Supplier<String> ruleVersion;
+	private final GuardRules rules;
 
 	public PomEnforcerInstaller() {
-		this.ruleVersion = EnforcerRuleVersion::release;
+		this(EnforcerRuleVersion::release, GuardRules.PROJECT);
 	}
 
 	/**
@@ -103,18 +109,31 @@ public class PomEnforcerInstaller {
 	 * @param ruleVersion a released {@code claude-code-enforcer} version
 	 */
 	public PomEnforcerInstaller(String ruleVersion) {
+		this(released(ruleVersion), GuardRules.PROJECT);
+	}
+
+	private PomEnforcerInstaller(Supplier<String> ruleVersion, GuardRules rules) {
+		this.ruleVersion = ruleVersion;
+		this.rules = rules;
+	}
+
+	private static Supplier<String> released(String ruleVersion) {
 		String release = EnforcerRuleVersion.requireRelease(ruleVersion);
-		this.ruleVersion = () -> release;
+		return () -> release;
 	}
 
 	/**
-	 * The installer for an optionally supplied version: the one named, or the running
-	 * build's when none was. Naming the choice here keeps callers from spelling out
-	 * which of the two constructors an empty {@link Optional} means.
+	 * The installer the guard options describe: the version they pin, or the running
+	 * build's when they pin none, wiring the rule set they name. Naming the choice
+	 * here keeps callers from spelling out which of the constructors an empty
+	 * {@link Optional} means.
 	 */
-	static PomEnforcerInstaller pinning(Optional<String> ruleVersion) {
-		return ruleVersion.map(PomEnforcerInstaller::new).orElseGet(PomEnforcerInstaller::new);
+	static PomEnforcerInstaller from(GuardOptions guard) {
+		Supplier<String> version = guard.pinnedRuleVersion().map(PomEnforcerInstaller::released)
+				.orElse(EnforcerRuleVersion::release);
+		return new PomEnforcerInstaller(version, guard.rules());
 	}
+
 
 	/**
 	 * @return {@code true} when the rule was wired in, {@code false} when the POM
@@ -123,15 +142,74 @@ public class PomEnforcerInstaller {
 	 *         {@value #ENFORCER_ARTIFACT_ID} is pinned too far back to run the rule
 	 */
 	public boolean install(Path pomFile) {
+		return install(pomFile, List.of());
+	}
+
+	/**
+	 * @param requiredSections the {@code CLAUDE.md} headings the guard is to demand,
+	 *                         which are the headings the conformer has just reshaped
+	 *                         the document to. Written into the POM rather than left
+	 *                         to the rule's defaults, so a project whose document is
+	 *                         not a Java project's is held to its own headings instead
+	 *                         of to this repository's.
+	 * @return {@code true} when the guard was wired in, {@code false} when the POM
+	 *         already runs it and was left unchanged
+	 */
+	public boolean install(Path pomFile, List<String> requiredSections) {
 		PomDocument pom = PomDocument.read(pomFile);
 		if (alreadyRunsTheRule(pom)) {
 			return false;
 		}
+		String execution = EXECUTION.formatted(ruleConfiguration(requiredSections));
 		enforcerPluginOfTheBuild(pom).ifPresentOrElse(
-				plugin -> augment(pom, plugin),
-				() -> pom.insertUnder(pom.root(), BUILD_PLUGINS, plugin()));
+				plugin -> augment(pom, plugin, execution),
+				() -> pom.insertUnder(pom.root(), BUILD_PLUGINS, plugin(execution)));
 		pom.write();
 		return true;
+	}
+
+	/**
+	 * The rule element the execution configures, which is the whole difference between
+	 * the two rule sets: one document checked, or the whole configuration. Both are
+	 * given the section list, because both hold {@code CLAUDE.md} to it.
+	 */
+	private String ruleConfiguration(List<String> requiredSections) {
+		return rules == GuardRules.PROJECT
+				? projectRule(requiredSections)
+				: claudeMdRule(requiredSections);
+	}
+
+	private String claudeMdRule(List<String> requiredSections) {
+		return PomDocument.wrapped(CLAUDE_MD_RULE,
+				element("claudeMdFile", CLAUDE_MD_FILE) + sectionsElement(requiredSections));
+	}
+
+	private String projectRule(List<String> requiredSections) {
+		return PomDocument.wrapped(PROJECT_RULE,
+				element("projectDir", PROJECT_DIR) + claudeMdSectionsElement(requiredSections));
+	}
+
+	/**
+	 * Empty when the guard demands no particular section, which leaves the rule's own
+	 * defaults in place rather than writing an empty list that would demand nothing at
+	 * all. A build system whose guard asks only that the document exist is the case:
+	 * it has no sections to name, and it is not wiring this rule anyway.
+	 */
+	private String sectionsElement(List<String> requiredSections) {
+		return sections(requiredSections, "requiredSections", "requiredSection");
+	}
+
+	private String claudeMdSectionsElement(List<String> requiredSections) {
+		return sections(requiredSections, "claudeMdSections", "claudeMdSection");
+	}
+
+	private String sections(List<String> requiredSections, String wrapper, String item) {
+		if (requiredSections.isEmpty()) {
+			return "";
+		}
+		return PomDocument.wrapped(wrapper, requiredSections.stream()
+				.map(section -> element(item, section))
+				.collect(Collectors.joining("\n")));
 	}
 
 	/**
@@ -167,13 +245,22 @@ public class PomEnforcerInstaller {
 	 * name an element the same way elsewhere is not mistaken for one running it.
 	 */
 	private boolean runsClaudeMdRule(Element plugin) {
-		return PomDocument.selfAndDescendants(plugin).stream().anyMatch(this::isClaudeMdRule);
+		return PomDocument.selfAndDescendants(plugin).stream().anyMatch(this::isGuardRule);
 	}
 
-	private boolean isClaudeMdRule(Element element) {
+	/**
+	 * Either guard counts as one already wired. A repository adopted before the
+	 * composite existed runs {@code claudeMdFormat}, and re-adopting it must not
+	 * splice a second execution in beside the guard it already has — the run's job is
+	 * to leave a repository guarded, and it is.
+	 */
+	private boolean isGuardRule(Element element) {
 		Element parent = element.parent();
-		return CLAUDE_MD_RULE.equals(PomDocument.localName(element)) && parent != null
-				&& RULES.equals(PomDocument.localName(parent));
+		if (parent == null || !RULES.equals(PomDocument.localName(parent))) {
+			return false;
+		}
+		String name = PomDocument.localName(element);
+		return CLAUDE_MD_RULE.equals(name) || PROJECT_RULE.equals(name);
 	}
 
 	private boolean declaresRuleDependency(Element plugin) {
@@ -215,12 +302,12 @@ public class PomEnforcerInstaller {
 	 * execution is missing, and adding a second dependency on the same artifact would
 	 * leave the plugin's classpath deciding between two versions of it.
 	 */
-	private void augment(PomDocument pom, Element plugin) {
+	private void augment(PomDocument pom, Element plugin, String execution) {
 		requireRunnableEnforcer(pom, plugin);
 		if (!declaresRuleDependency(plugin)) {
 			pom.insertUnder(plugin, List.of("dependencies"), ruleDependency());
 		}
-		pom.insertUnder(plugin, List.of("executions"), EXECUTION);
+		pom.insertUnder(plugin, List.of("executions"), execution);
 	}
 
 	/**
@@ -277,7 +364,7 @@ public class PomEnforcerInstaller {
 	 */
 	private void requireRunnable(String version, String where) {
 		if (PluginVersion.isBelow(version, MINIMUM_ENFORCER_VERSION)) {
-			throw new AdoptionException("Cannot wire the " + CLAUDE_MD_RULE + " rule into the "
+			throw new AdoptionException("Cannot wire the " + rules.ruleName() + " rule into the "
 					+ ENFORCER_ARTIFACT_ID + " this project pins to " + version + " in " + where
 					+ ": the rule is looked up by name,"
 					+ " which the plugin only does from " + MINIMUM_ENFORCER_VERSION + ", so the guard would fail"
@@ -287,13 +374,13 @@ public class PomEnforcerInstaller {
 	}
 
 	/** A freshly declared enforcer plugin: pinned to a version, carrying the rule and its execution. */
-	private String plugin() {
+	private String plugin(String execution) {
 		return PomDocument.wrapped("plugin", String.join("\n",
 				element("groupId", ENFORCER_GROUP_ID),
 				element("artifactId", ENFORCER_ARTIFACT_ID),
 				element("version", ENFORCER_VERSION),
 				PomDocument.wrapped("dependencies", ruleDependency()),
-				PomDocument.wrapped("executions", EXECUTION)));
+				PomDocument.wrapped("executions", execution)));
 	}
 
 	private String ruleDependency() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -164,6 +164,15 @@ public class PomEnforcerInstaller {
 	}
 
 	/**
+	 * Answers the question a verification asks and an install answers only by doing
+	 * it: does this POM already run a guard? Read-only, so a run that is checking a
+	 * repository rather than adopting one leaves it exactly as it was cloned.
+	 */
+	public boolean isInstalled(Path pomFile) {
+		return alreadyRunsTheRule(PomDocument.read(pomFile));
+	}
+
+	/**
 	 * @param requiredSections the {@code CLAUDE.md} headings the guard is to demand,
 	 *                         which are the headings the conformer has just reshaped
 	 *                         the document to. Written into the POM rather than left

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -29,14 +29,32 @@ public class PomEnforcerInstaller {
 
 	private static final String ENFORCER_GROUP_ID = "org.apache.maven.plugins";
 	static final String ENFORCER_ARTIFACT_ID = "maven-enforcer-plugin";
-	static final String ENFORCER_VERSION = "3.6.3";
+
+	/** The property the build metadata carries the managed plugin version under. */
+	static final String ENFORCER_VERSION_KEY = "enforcer.plugin.version";
+
+	/**
+	 * The {@value #ENFORCER_ARTIFACT_ID} version a freshly declared plugin is pinned
+	 * to: the one the root pom manages, read through the build metadata rather than
+	 * written here as a literal. A literal is a number nobody builds — this project
+	 * would move on and go on asking strangers' repositories for the version it
+	 * stopped using, with nothing to notice by.
+	 *
+	 * <p>Resolved lazily, per POM, for the same reason the rule version is: merely
+	 * assembling {@link BuildSystems#DEFAULTS}, or adopting a repository that builds
+	 * with something other than Maven, must not depend on this build's metadata being
+	 * on the classpath.
+	 */
+	static String enforcerVersion() {
+		return BuildMetadata.value(ENFORCER_VERSION_KEY, "the maven-enforcer-plugin version to pin");
+	}
 
 	/**
 	 * The oldest {@value #ENFORCER_ARTIFACT_ID} that can run the rule wired in here.
 	 * {@value #CLAUDE_MD_RULE} is looked up by the component name it is published
 	 * under, which the plugin only does from this version; an older one fails the
 	 * build complaining it cannot find a rule the POM plainly declares. A declaration
-	 * this installer writes itself pins {@value #ENFORCER_VERSION}, so only a version
+	 * this installer writes itself pins {@link #enforcerVersion()}, so only a version
 	 * the project pinned — in its {@code build} or in the {@code pluginManagement}
 	 * that declaration resolves through — can be too old; see
 	 * {@link #requireRunnableEnforcer}.
@@ -330,7 +348,7 @@ public class PomEnforcerInstaller {
 	 * <p>Only a version literal is judged either way. One the POM leaves to a parent
 	 * or to a property cannot be read from here, and refusing on that would turn the
 	 * ordinary POM into an unadoptable one; see {@link PluginVersion}. A declaration
-	 * this installer writes itself always pins {@value #ENFORCER_VERSION}, which no
+	 * this installer writes itself always pins {@link #enforcerVersion()}, which no
 	 * {@code pluginManagement} entry overrides, so only a plugin the project already
 	 * had reaches this at all.
 	 */
@@ -378,7 +396,7 @@ public class PomEnforcerInstaller {
 		return PomDocument.wrapped("plugin", String.join("\n",
 				element("groupId", ENFORCER_GROUP_ID),
 				element("artifactId", ENFORCER_ARTIFACT_ID),
-				element("version", ENFORCER_VERSION),
+				element("version", enforcerVersion()),
 				PomDocument.wrapped("dependencies", ruleDependency()),
 				PomDocument.wrapped("executions", execution)));
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ToolchainStep.java
@@ -37,6 +37,9 @@ public class ToolchainStep implements AdoptionStep {
 	static final String GITHUB_CLI = "gh";
 	static final List<String> DEFAULT_TOOLS = List.of("git", "claude", GITHUB_CLI);
 
+	/** All a verification shells out to: it clones and runs a guard, and generates nothing. */
+	static final List<String> VERIFICATION_TOOLS = List.of("git");
+
 	/**
 	 * What a dry run actually shells out to. A dry run's pipeline is assembled
 	 * without {@link PushStep} and {@link PullRequestStep}, and {@code gh} is used
@@ -72,6 +75,17 @@ public class ToolchainStep implements AdoptionStep {
 	 */
 	public static ToolchainStep forDryRun() {
 		return new ToolchainStep(DRY_RUN_TOOLS);
+	}
+
+	/**
+	 * The check for a run that only reads a repository. A verification clones and
+	 * runs the guard already wired into the checkout; it generates nothing, so it
+	 * needs neither {@code claude} nor the {@code gh} a dry run has already dropped.
+	 * Requiring either would fail a fleet-wide check on a host that has no reason to
+	 * carry them.
+	 */
+	public static ToolchainStep forVerification() {
+		return new ToolchainStep(VERIFICATION_TOOLS);
 	}
 
 	@Override

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
@@ -63,6 +63,16 @@ public class WorkflowGuardInstaller {
 	 * @return {@code true} when either guard file was written, {@code false} when the
 	 *         checkout already carried both and was left unchanged.
 	 */
+	/**
+	 * Whether the checkout already carries this adoption's workflow and its script;
+	 * read-only, for a verification. Both are required, because the workflow runs the
+	 * script and either alone guards nothing.
+	 */
+	public boolean isInstalled(Path repositoryDirectory) {
+		return isAdoptionWorkflow(repositoryDirectory.resolve(WORKFLOW_FILE))
+				&& Files.isRegularFile(repositoryDirectory.resolve(SCRIPT_FILE));
+	}
+
 	public boolean install(Path repositoryDirectory) {
 		boolean workflowWritten = workflowInstaller.install(repositoryDirectory);
 		boolean scriptWritten = scriptInstaller.install(repositoryDirectory);

--- a/adopt/src/main/resources/log4j2.properties
+++ b/adopt/src/main/resources/log4j2.properties
@@ -12,7 +12,11 @@ appender.rolling.name = fileLogger
 appender.rolling.fileName= ${basePath}/adopt.log
 appender.rolling.filePattern= ${basePath}/adopt_%d{yyyyMMdd}.log.gz
 appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %level [%t] [%l] - %msg%n
+# %notEmpty around the repository context is what makes a parallel batch readable:
+# every line an adoption emits carries the repository it belongs to, and a run with
+# no repository in context (the batch's own summary lines) prints nothing extra.
+# See BatchAdoption.REPOSITORY_CONTEXT_KEY, which is the key put under.
+appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %level [%t] [%l]%notEmpty{ [%X{repository}]} - %msg%n
 appender.rolling.policies.type = Policies
 
 # RollingFileAppender rotation policy
@@ -39,7 +43,7 @@ appender.console.type = Console
 appender.console.name = consoleLogger
 appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %level - %msg%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %level%notEmpty{ [%X{repository}]} - %msg%n
 
 # The console shows the adoption's progress, never its command trace. An operator
 # watching a run wants the step it is on; the git/claude/gh invocations, their exit

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/BatchAdoptionParallelTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/BatchAdoptionParallelTest.java
@@ -1,0 +1,155 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Adopting several repositories at once. They are independent by construction —
+ * that is what {@link BatchAdoption} already promised — so what these cover is
+ * everything that independence relies on holding under contention.
+ */
+class BatchAdoptionParallelTest {
+
+	@TempDir
+	private Path workspace;
+
+	@Test
+	void answersInTheOrderTheRepositoriesWereGiven() {
+		List<String> urls = urls(6);
+
+		List<AdoptionRun> runs = new BatchAdoption((context, report) -> report.recordStep("done"),
+				CheckoutRetention.ALWAYS, 4).adoptAll(urls, checkouts());
+
+		assertEquals(urls, runs.stream().map(AdoptionRun::repositoryUrl).toList());
+	}
+
+	/** The point of the option: the adoptions really do overlap. */
+	@Test
+	void adoptsSeveralRepositoriesAtOnce() throws InterruptedException {
+		int parallelism = 4;
+		CountDownLatch allStarted = new CountDownLatch(parallelism);
+		BatchAdoption batch = new BatchAdoption((context, report) -> {
+			allStarted.countDown();
+			awaitQuietly(allStarted);
+			report.recordStep("done");
+		}, CheckoutRetention.ALWAYS, parallelism);
+
+		List<AdoptionRun> runs = batch.adoptAll(urls(parallelism), checkouts());
+
+		assertTrue(runs.stream().allMatch(AdoptionRun::succeeded), "every adoption should have landed");
+	}
+
+	/** Each adoption runs on its own thread, which is what the log context is put on. */
+	@Test
+	void putsTheRepositoryIntoTheLoggingContextOfItsOwnThread() {
+		Set<String> seen = ConcurrentHashMap.newKeySet();
+		BatchAdoption batch = new BatchAdoption((context, report) -> {
+			seen.add(ThreadContext.get(BatchAdoption.REPOSITORY_CONTEXT_KEY));
+			report.recordStep("done");
+		}, CheckoutRetention.ALWAYS, 3);
+
+		batch.adoptAll(urls(3), checkouts());
+
+		assertEquals(Set.copyOf(urls(3)), seen, "every adoption should log under its own repository");
+	}
+
+	/** The context must not outlive the adoption that set it. */
+	@Test
+	void clearsTheLoggingContextAfterwards() {
+		new BatchAdoption((context, report) -> report.recordStep("done"), CheckoutRetention.ALWAYS, 2)
+				.adoptAll(urls(2), checkouts());
+
+		assertEquals(null, ThreadContext.get(BatchAdoption.REPOSITORY_CONTEXT_KEY));
+	}
+
+	/** A failing adoption still does not stop the ones beside it. */
+	@Test
+	void oneFailureDoesNotStopTheOthers() {
+		BatchAdoption batch = new BatchAdoption((context, report) -> {
+			if (context.displayUrl().contains("repo3")) {
+				throw new AdoptionException("boom");
+			}
+			report.recordStep("done");
+		}, CheckoutRetention.ALWAYS, 4);
+
+		List<AdoptionRun> runs = batch.adoptAll(urls(5), checkouts());
+
+		assertEquals(4, runs.stream().filter(AdoptionRun::succeeded).count());
+		assertEquals(1, runs.stream().filter(run -> !run.succeeded()).count());
+	}
+
+	/**
+	 * Two repositories that would clone into one directory are refused, and the
+	 * refusal has to survive several threads racing for it: the claim must produce one
+	 * claim and one refusal, never two claims.
+	 */
+	@Test
+	void refusesASecondClaimOnOneCheckoutUnderContention() {
+		List<String> colliding = IntStream.range(0, 8)
+				.mapToObj(index -> "https://github.com/owner" + index + "/same.git")
+				.toList();
+
+		List<AdoptionRun> runs = new BatchAdoption((context, report) -> report.recordStep("done"),
+				CheckoutRetention.ALWAYS, 8).adoptAll(colliding, checkouts());
+
+		assertEquals(1, runs.stream().filter(AdoptionRun::succeeded).count(),
+				"exactly one repository may claim the checkout");
+	}
+
+	@Test
+	void refusesAParallelismOutsideItsBounds() {
+		assertThrows(IllegalArgumentException.class,
+				() -> new BatchAdoption(noop(), CheckoutRetention.ALWAYS, 0));
+		assertThrows(IllegalArgumentException.class, () -> new BatchAdoption(noop(), CheckoutRetention.ALWAYS,
+				BatchAdoption.MAX_PARALLELISM + 1));
+	}
+
+	/** A batch of one starts no pool at all: the ordinary run is the run it always was. */
+	@Test
+	void runsASingleRepositoryOnTheCallingThread() {
+		String callingThread = Thread.currentThread().getName();
+		StringBuilder ranOn = new StringBuilder();
+
+		new BatchAdoption((context, report) -> {
+			ranOn.append(Thread.currentThread().getName());
+			report.recordStep("done");
+		}, CheckoutRetention.ALWAYS, 4).adoptAll(urls(1), checkouts());
+
+		assertEquals(callingThread, ranOn.toString());
+	}
+
+	private BatchAdoption.Adoption noop() {
+		return (context, report) -> report.recordStep("done");
+	}
+
+	private Checkouts checkouts() {
+		return new Checkouts(workspace, "claude/adopt-claude-code");
+	}
+
+	private List<String> urls(int count) {
+		return IntStream.range(0, count)
+				.mapToObj(index -> "https://github.com/owner/repo" + index + ".git")
+				.toList();
+	}
+
+	private void awaitQuietly(CountDownLatch latch) {
+		try {
+			latch.await(2, TimeUnit.SECONDS);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CheckoutRetentionTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CheckoutRetentionTest.java
@@ -1,0 +1,108 @@
+package io.github.adamw7.tools.adopt;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * What becomes of a checkout once its adoption is over. A batch makes one full
+ * clone per repository, so the default matters: fifty repositories used to leave
+ * fifty clones behind, under a temporary directory nobody named.
+ */
+class CheckoutRetentionTest {
+
+	@TempDir
+	private Path workspace;
+
+	@Test
+	void removesTheCheckoutOfAnAdoptionThatLanded() throws IOException {
+		Path checkout = checkoutWithContent();
+
+		CheckoutRetention.ON_FAILURE.apply(checkout, true);
+
+		assertFalse(Files.exists(checkout), "a successful adoption's checkout is scaffolding");
+	}
+
+	/** The only record of how far a failed run got, and the first thing an operator reads. */
+	@Test
+	void keepsTheCheckoutOfAnAdoptionThatFailed() throws IOException {
+		Path checkout = checkoutWithContent();
+
+		CheckoutRetention.ON_FAILURE.apply(checkout, false);
+
+		assertTrue(Files.exists(checkout));
+	}
+
+	@Test
+	void keepsEveryCheckoutWhenAskedTo() throws IOException {
+		Path checkout = checkoutWithContent();
+
+		CheckoutRetention.ALWAYS.apply(checkout, true);
+
+		assertTrue(Files.exists(checkout));
+	}
+
+	/** A directory is only removable once it is empty, so the walk goes deepest first. */
+	@Test
+	void removesANestedCheckoutWhole() throws IOException {
+		Path checkout = checkoutWithContent();
+		Files.createDirectories(checkout.resolve(".git/refs/heads"));
+		Files.writeString(checkout.resolve(".git/refs/heads/main"), "ref");
+		Files.writeString(checkout.resolve(".git/config"), "[core]");
+
+		CheckoutRetention.ON_FAILURE.apply(checkout, true);
+
+		assertFalse(Files.exists(checkout));
+	}
+
+	/** A run that failed before its clone never made a checkout; that is nothing to remove. */
+	@Test
+	void toleratesACheckoutThatWasNeverMade() {
+		assertDoesNotThrow(() -> CheckoutRetention.ON_FAILURE.apply(workspace.resolve("absent"), true));
+	}
+
+	/**
+	 * An adoption that succeeded has succeeded. A checkout that could not be removed
+	 * is a warning, not a reason to report the repository as failed.
+	 */
+	@Test
+	void neverFailsTheRunOverACheckoutItCouldNotRemove() throws IOException {
+		Path checkout = checkoutWithContent();
+		Path unreadable = Files.createDirectory(checkout.resolve("locked"));
+		Files.writeString(unreadable.resolve("file"), "x");
+		unreadable.toFile().setReadable(false);
+
+		assertDoesNotThrow(() -> CheckoutRetention.ON_FAILURE.apply(checkout, true));
+
+		unreadable.toFile().setReadable(true);
+	}
+
+	@Test
+	void aDryRunKeepsItsCheckoutBecauseItIsAllTheRunProduced() {
+		assertEquals(CheckoutRetention.ALWAYS, CheckoutRetention.of(false, true));
+	}
+
+	@Test
+	void keepWorkspaceKeepsEveryCheckout() {
+		assertEquals(CheckoutRetention.ALWAYS, CheckoutRetention.of(true, false));
+	}
+
+	@Test
+	void anOrdinaryRunKeepsOnlyWhatFailed() {
+		assertEquals(CheckoutRetention.ON_FAILURE, CheckoutRetention.of(false, false));
+	}
+
+	private Path checkoutWithContent() throws IOException {
+		Path checkout = Files.createDirectories(workspace.resolve("repo"));
+		Files.writeString(checkout.resolve("CLAUDE.md"), "# CLAUDE.md");
+		return checkout;
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/ForeignRepositoryAdoptionIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/ForeignRepositoryAdoptionIT.java
@@ -420,10 +420,16 @@ class ForeignRepositoryAdoptionIT {
 		return Main.runAndReport(cli, Main.checkouts(cli), localAdopter());
 	}
 
+	/**
+	 * The checkouts are kept because every assertion below reads one: what the
+	 * adoption committed, what it left alone, what the guard it wired in looks like.
+	 * An ordinary run removes the checkout of an adoption that landed, its product
+	 * being the pushed branch and the pull request.
+	 */
 	private static String[] commandLine() {
 		return Stream.concat(
 				REPOSITORIES.stream().flatMap(repository -> Stream.of("--repo", repository.url())),
-				Stream.of("--workspace", workspace.toString(), "--branch", BRANCH))
+				Stream.of("--workspace", workspace.toString(), "--branch", BRANCH, "--keep-workspace"))
 				.toArray(String[]::new);
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
 import io.github.adamw7.tools.adopt.step.AdoptionStep;
+import io.github.adamw7.tools.adopt.step.GuardRules;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 
 class GitHubRepoAdopterTest {
@@ -229,5 +230,29 @@ class GitHubRepoAdopterTest {
 	private AdoptionOptions dryRun() {
 		return new AdoptionOptions(PullRequestOptions.defaults(), false, null, true, null,
 				AdoptionOptions.DEFAULT_RETRIES);
+	}
+
+	/**
+	 * A verification is a pipeline of its own rather than an adoption with its writing
+	 * steps disabled, for the same reason a dry run is: the report then says what the
+	 * run really did.
+	 */
+	@Test
+	void aVerificationRunNeitherGeneratesNorPublishes() {
+		List<String> steps = GitHubRepoAdopter.verificationSteps(verifyOnly()).stream()
+				.map(AdoptionStep::name).toList();
+
+		assertEquals(List.of("toolchain", "clone", "build-toolchain", "check-adopted", "verify"), steps);
+	}
+
+	@Test
+	void aVerificationRunIsTheOneTheOptionsAskFor() {
+		GitHubRepoAdopter adopter = GitHubRepoAdopter.forRun(new RecordingCommandRunner(), verifyOnly());
+
+		assertEquals(5, adopter.steps().size());
+	}
+
+	private AdoptionOptions verifyOnly() {
+		return new AdoptionOptions(null, false, "9.9.9", false, null, 0, GuardRules.PROJECT, List.of(), true);
 	}
 }

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/MultiRepoAdoptionIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/MultiRepoAdoptionIT.java
@@ -196,8 +196,15 @@ class MultiRepoAdoptionIT {
 		return new GitHubRepoAdopter(runner, steps);
 	}
 
+	/**
+	 * Every command line here keeps its checkouts, because inspecting them is what
+	 * these tests do: an ordinary run removes the checkout of an adoption that landed,
+	 * its product being the pushed branch and the pull request.
+	 */
 	private CliArguments parse(String... arguments) {
-		return CliArguments.parse(arguments);
+		String[] keepingCheckouts = Arrays.copyOf(arguments, arguments.length + 1);
+		keepingCheckouts[arguments.length] = "--keep-workspace";
+		return CliArguments.parse(keepingCheckouts);
 	}
 
 	/** A {@code --repos} file as an operator writes one: a comment, then the URLs. */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
@@ -240,12 +240,18 @@ public class AdoptArchitectureTest {
 					+ "exception is resolving an executable on PATH, which lives behind the command runner");
 
 	@ArchTest
-	static final ArchRule onlyTheCommandPackageNeedsConcurrency = noClasses()
+	static final ArchRule onlyTheCommandPackageAndTheBatchNeedConcurrency = noClasses()
 			.that().resideOutsideOfPackage(COMMAND_PACKAGE)
+			.and().doNotHaveFullyQualifiedName(ADOPT_PACKAGE + ".BatchAdoption")
+			.and().doNotHaveFullyQualifiedName(ADOPT_PACKAGE + ".Checkouts")
 			.should().dependOnClassesThat().resideInAPackage("java.util.concurrent..")
 			.orShould().dependOnClassesThat().haveFullyQualifiedName("java.lang.Thread")
-			.because("the adoption is a sequential pipeline whose steps depend on the one before; only "
-					+ "spawning a process needs threads, to pump its output while a timeout runs");
+			.because("one repository's adoption is a sequential pipeline whose steps depend on the one "
+					+ "before, and a step that reached for a thread would be doing something the pipeline "
+					+ "does not do. Two places legitimately do: spawning a process, which pumps its output "
+					+ "while a timeout runs, and the batch, whose repositories are independent of each "
+					+ "other by construction — Checkouts is named with it because the claim that keeps them "
+					+ "independent is what several threads contend on");
 
 	@ArchTest
 	static final ArchRule packagesAreFreeOfCycles = slices()

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/RateLimitsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/RateLimitsTest.java
@@ -1,0 +1,81 @@
+package io.github.adamw7.tools.adopt.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Lifting the wait out of what GitHub said. A rate limit is not retried — that is
+ * what the limit exists to stop — so the operator is told instead, and being told
+ * means being told when.
+ */
+class RateLimitsTest {
+
+	@Test
+	void recognisesTheWordingGitHubUsesForALimit() {
+		for (String transcript : List.of(
+				"You have exceeded a secondary rate limit",
+				"API rate limit exceeded for user ID 1",
+				"You have triggered an abuse detection mechanism",
+				"HTTP 429: Too Many Requests")) {
+			assertTrue(RateLimits.reported(transcript), transcript);
+		}
+	}
+
+	@Test
+	void doesNotReadAnOrdinaryRefusalAsALimit() {
+		for (String transcript : List.of(
+				"fatal: Authentication failed",
+				"The requested URL returned error: 403",
+				"remote: Permission to owner/repo.git denied")) {
+			assertFalse(RateLimits.reported(transcript), transcript);
+		}
+	}
+
+	@Test
+	void readsTheWaitInSecondsMinutesAndHours() {
+		assertEquals(Optional.of(Duration.ofSeconds(30)), RateLimits.waitFrom("Retry-After: 30 seconds"));
+		assertEquals(Optional.of(Duration.ofMinutes(6)), RateLimits.waitFrom("please try again in 6 minutes"));
+		assertEquals(Optional.of(Duration.ofHours(1)), RateLimits.waitFrom("wait 1 hour before trying again"));
+	}
+
+	@Test
+	void readsNoWaitFromATranscriptThatNamesNone() {
+		assertEquals(Optional.empty(), RateLimits.waitFrom("You have exceeded a secondary rate limit"));
+	}
+
+	/** A number nobody wrote is worse than no number, so the notice says only what it knows. */
+	@Test
+	void describesALimitThatNamedNoWaitWithoutInventingOne() {
+		String notice = RateLimits.describe("You have exceeded a secondary rate limit").orElseThrow();
+
+		assertTrue(notice.contains("rate limiting"), notice);
+		assertFalse(notice.contains("about"), notice);
+	}
+
+	@Test
+	void describesTheWaitWhereGitHubNamedOne() {
+		String notice = RateLimits.describe(
+				"You have exceeded a secondary rate limit. Please wait 6 minutes before trying again.")
+				.orElseThrow();
+
+		assertTrue(notice.contains("6 minutes"), notice);
+	}
+
+	/** A wait is acted on rather than measured, so a part-minute rounds up. */
+	@Test
+	void roundsAPartMinuteUp() {
+		assertTrue(RateLimits.describe("rate limit; retry-after 90 seconds").orElseThrow().contains("2 minutes"));
+	}
+
+	@Test
+	void describesNothingForATranscriptWithNoLimitInIt() {
+		assertEquals(Optional.empty(), RateLimits.describe("fatal: Authentication failed"));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AdoptionCheckStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AdoptionCheckStepTest.java
@@ -1,0 +1,121 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionContexts;
+import io.github.adamw7.tools.adopt.AdoptionException;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+/**
+ * The question a verification asks that the guard's own command cannot answer: is
+ * this repository actually adopted? A build with no guard wired in passes the
+ * verification command precisely because nothing ran.
+ */
+class AdoptionCheckStepTest {
+
+	@Test
+	void passesForARepositoryCarryingBothTheDocumentAndAGuard(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = adoptedRepository(workspace);
+
+		assertDoesNotThrow(() -> step().execute(context, new RecordingCommandRunner()));
+	}
+
+	/** The drift a fleet-wide check exists to find: a later commit deleted the document. */
+	@Test
+	void failsWhenTheDocumentIsGone(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = adoptedRepository(workspace);
+		Files.delete(context.repositoryDirectory().resolve("CLAUDE.md"));
+
+		assertFailure(AdoptionException.class, () -> step().execute(context, new RecordingCommandRunner()),
+				"no CLAUDE.md");
+	}
+
+	/** The other half of the drift: the document is there and nothing checks it. */
+	@Test
+	void failsWhenTheBuildWiresInNoGuard(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), "<project/>");
+		Files.writeString(context.repositoryDirectory().resolve("CLAUDE.md"), "# CLAUDE.md");
+
+		assertFailure(AdoptionException.class, () -> step().execute(context, new RecordingCommandRunner()),
+				"wires in no CLAUDE.md guard");
+	}
+
+	/** Both halves at once, so an operator knows whether to restore a document, a guard, or both. */
+	@Test
+	void reportsBothWhenBothAreMissing(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), "<project/>");
+
+		AdoptionException thrown = assertThrowsAdoption(context);
+
+		assertTrue(thrown.getMessage().contains("no CLAUDE.md"), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains("wires in no CLAUDE.md guard"), thrown.getMessage());
+	}
+
+	@Test
+	void namesTheRepositoryItCheckedWithoutItsCredentials(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = new AdoptionContext(
+				"https://x-access-token:secret@github.com/owner/repo.git", workspace);
+		Files.createDirectories(context.repositoryDirectory());
+		Files.writeString(context.repositoryDirectory().resolve("pom.xml"), "<project/>");
+
+		AdoptionException thrown = assertThrowsAdoption(context);
+
+		assertTrue(thrown.getMessage().contains("owner/repo"), thrown.getMessage());
+		assertFalse(thrown.getMessage().contains("secret"), thrown.getMessage());
+	}
+
+	private AdoptionException assertThrowsAdoption(AdoptionContext context) {
+		return assertThrows(AdoptionException.class,
+				() -> step().execute(context, new RecordingCommandRunner()));
+	}
+
+	private AdoptionCheckStep step() {
+		return new AdoptionCheckStep(List.of(new MavenBuildSystem(), new FallbackBuildSystem()));
+	}
+
+	/** A Maven checkout with the document and a POM whose build runs the composite guard. */
+	private AdoptionContext adoptedRepository(Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		Path checkout = context.repositoryDirectory();
+		Files.writeString(checkout.resolve("CLAUDE.md"), "# CLAUDE.md");
+		Files.writeString(checkout.resolve("pom.xml"), """
+				<project xmlns="http://maven.apache.org/POM/4.0.0">
+				  <artifactId>demo</artifactId>
+				  <build>
+				    <plugins>
+				      <plugin>
+				        <artifactId>maven-enforcer-plugin</artifactId>
+				        <executions>
+				          <execution>
+				            <configuration>
+				              <rules>
+				                <claudeCodeProject>
+				                  <projectDir>${project.basedir}</projectDir>
+				                </claudeCodeProject>
+				              </rules>
+				            </configuration>
+				          </execution>
+				        </executions>
+				      </plugin>
+				    </plugins>
+				  </build>
+				</project>
+				""");
+		return context;
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildMetadataTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildMetadataTest.java
@@ -1,0 +1,76 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.adamw7.tools.adopt.AdoptionException;
+
+/**
+ * The two versions the adoption writes into somebody else's POM, and the refusals
+ * that stand between a broken build of this project and a literal
+ * {@code @enforcer.rule.version@} wired into a stranger's build.
+ */
+class BuildMetadataTest {
+
+	/**
+	 * The defect this mechanism exists to prevent, now covering the plugin version
+	 * too: the version the adoption pins and the version this project builds against
+	 * must be one number, so that moving one moves the other.
+	 */
+	@Test
+	void thePluginVersionItPinsIsTheOneTheRootPomManages() throws IOException {
+		String managed = versionManagedByTheRootPom();
+
+		assertEquals(managed, PomEnforcerInstaller.enforcerVersion(),
+				"the maven-enforcer-plugin version wired into an adopted POM has drifted from the root pom's");
+	}
+
+	@Test
+	void readsThePluginVersion() {
+		assertTrue(PomEnforcerInstaller.enforcerVersion().matches("\\d+\\.\\d+\\.\\d+"),
+				PomEnforcerInstaller.enforcerVersion());
+	}
+
+	/** A failure has to say which key is missing and what the value was for. */
+	@Test
+	void failureNamesTheKeyAndWhatItIsFor() {
+		AdoptionException thrown = assertThrows(AdoptionException.class,
+				() -> BuildMetadata.read(properties("a.key="), "a.key", "the version to pin"));
+
+		assertTrue(thrown.getMessage().contains("a.key"), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains("the version to pin"), thrown.getMessage());
+	}
+
+	private InputStream properties(String content) {
+		return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+	}
+
+	/**
+	 * Read from the root pom itself rather than from a second copy of the number,
+	 * because a copy is exactly what this test exists to stop.
+	 */
+	private String versionManagedByTheRootPom() throws IOException {
+		String pom = Files.readString(rootPom());
+		String property = "<maven-enforcer-plugin.version>";
+		int start = pom.indexOf(property) + property.length();
+		return pom.substring(start, pom.indexOf('<', start));
+	}
+
+	/**
+	 * Surefire runs a module's tests with the module directory as the working
+	 * directory, so the reactor root is its parent.
+	 */
+	private Path rootPom() {
+		return Path.of("..", "pom.xml").toAbsolutePath().normalize();
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -260,6 +260,11 @@ class BuildSystemsTest {
 	private static final class NoVerifyCommandBuildSystem implements BuildSystem {
 
 		@Override
+		public boolean isGuardInstalled(Path repositoryDirectory) {
+			return false;
+		}
+
+		@Override
 		public String name() {
 			return "none";
 		}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeInitStepTest.java
@@ -1,6 +1,7 @@
 package io.github.adamw7.tools.adopt.step;
 
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -10,8 +11,11 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -161,6 +165,104 @@ class ClaudeInitStepTest {
 		RecordingCommandRunner runner = RecordingCommandRunner.answering("I did not create a CLAUDE.md");
 		assertFailure(AdoptionException.class, () -> new ClaudeInitStep().execute(context, runner),
 				"I did not create a CLAUDE.md");
+	}
+
+	/**
+	 * The run's most expensive command is the only one with no other recovery, because
+	 * TransientFailures leaves claude out: its transcript is a model's prose and may
+	 * discuss a connection reset without one having happened. What is judged here is
+	 * the outcome instead, which that objection does not reach.
+	 */
+	@Test
+	void runsTheCliAgainWhenItProducedNoClaudeMd(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AtomicInteger runs = new AtomicInteger();
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			if (runs.incrementAndGet() == 3) {
+				writeRootClaudeMd(context);
+			}
+			return new CommandResult(command, 0, "nothing written");
+		});
+
+		assertDoesNotThrow(() -> step(3).execute(context, runner));
+
+		assertEquals(3, runner.count(), "the CLI should have been run until it produced the file");
+	}
+
+	/** A run that produced the file has succeeded, whatever its exit code claimed. */
+	@Test
+	void stopsAsSoonAsTheFileExistsEvenWhenTheCliExitedNonZero(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			writeRootClaudeMd(context);
+			return new CommandResult(command, 0, "");
+		});
+
+		assertDoesNotThrow(() -> step(3).execute(context, runner));
+
+		assertEquals(1, runner.count(), "a run that produced the file must not be repeated");
+	}
+
+	@Test
+	void givesUpAfterTheAttemptsRunOutAndReportsWhatTheCliSaid(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		RecordingCommandRunner runner = RecordingCommandRunner.answering("I declined");
+
+		assertFailure(AdoptionException.class, () -> step(2).execute(context, runner), "I declined");
+		assertEquals(3, runner.count(), "one attempt plus the two retries");
+	}
+
+	/** Zero retries runs the CLI exactly once, as an undecorated step does. */
+	@Test
+	void runsOnceWhenNoRetriesAreAllowed(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		RecordingCommandRunner runner = RecordingCommandRunner.answering("nothing written");
+
+		assertThrows(AdoptionException.class, () -> step(0).execute(context, runner));
+		assertEquals(1, runner.count());
+	}
+
+	/** The wait doubles and is capped, so a generous retry count cannot idle a run for minutes. */
+	@Test
+	void waitsLongerBeforeEachAttemptUpToTheCap(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		List<Duration> waits = new ArrayList<>();
+		ClaudeInitStep step = new ClaudeInitStep(ClaudeInitStep.DEFAULT_COMMAND, 4, waits::add);
+
+		assertThrows(AdoptionException.class,
+				() -> step.execute(context, RecordingCommandRunner.answering("nothing")));
+
+		assertEquals(List.of(Duration.ofSeconds(5), Duration.ofSeconds(10), Duration.ofSeconds(20),
+				ClaudeInitStep.MAX_BACKOFF), waits);
+	}
+
+	/**
+	 * A second attempt has to meet the same checkout the first one did, so the memory
+	 * file is moved aside and restored around each attempt rather than around the run.
+	 */
+	@Test
+	void movesTheMemoryFileAsideForEveryAttempt(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		writeClaudeDirMemory(context);
+		AtomicInteger runs = new AtomicInteger();
+		RecordingCommandRunner runner = new RecordingCommandRunner(command -> {
+			assertFalse(Files.exists(claudeDirMemory(context)),
+					"the memory file must be aside while the CLI runs");
+			if (runs.incrementAndGet() == 2) {
+				writeRootClaudeMd(context);
+			}
+			return new CommandResult(command, 0, "");
+		});
+
+		assertDoesNotThrow(() -> step(2).execute(context, runner));
+
+		assertTrue(Files.exists(claudeDirMemory(context)), "the memory file must be restored afterwards");
+	}
+
+	/** Nothing is waited out where nothing is retried. */
+	private ClaudeInitStep step(int retries) {
+		return new ClaudeInitStep(ClaudeInitStep.DEFAULT_COMMAND, retries, duration -> {
+		});
 	}
 
 	/** The transcript is redacted like every other one, since it is the run's reported failure. */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersionTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/EnforcerRuleVersionTest.java
@@ -65,8 +65,8 @@ class EnforcerRuleVersionTest {
 	 */
 	@Test
 	void metadataMissingFromTheClasspathIsRefused() {
-		assertFailure(AdoptionException.class, () -> EnforcerRuleVersion.read(null),
-				EnforcerRuleVersion.BUILD_PROPERTIES);
+		assertFailure(AdoptionException.class, () -> BuildMetadata.read(null, EnforcerRuleVersion.RULE_VERSION_KEY, "the rule version"),
+				BuildMetadata.BUILD_PROPERTIES);
 	}
 
 	/**
@@ -94,7 +94,8 @@ class EnforcerRuleVersionTest {
 	/** A resource that was filtered but carries some other key answers no version either. */
 	@Test
 	void metadataWithoutTheVersionKeyIsRefused() throws IOException {
-		assertFailure(AdoptionException.class, () -> EnforcerRuleVersion.read(metadata("some.other.key=2.6.0")),
+		assertFailure(AdoptionException.class, () -> BuildMetadata.read(metadata("some.other.key=2.6.0"), EnforcerRuleVersion.RULE_VERSION_KEY,
+						"the rule version"),
 				EnforcerRuleVersion.RULE_VERSION_KEY);
 	}
 
@@ -105,13 +106,15 @@ class EnforcerRuleVersionTest {
 	 */
 	@Test
 	void aFilteredVersionIsReadWithoutItsSurroundingWhitespace() throws IOException {
-		assertEquals("2.6.0", EnforcerRuleVersion.read(metadata(EnforcerRuleVersion.RULE_VERSION_KEY + "=  2.6.0  ")));
+		assertEquals("2.6.0", BuildMetadata.read(metadata(EnforcerRuleVersion.RULE_VERSION_KEY + "=  2.6.0  "),
+				EnforcerRuleVersion.RULE_VERSION_KEY, "the rule version"));
 	}
 
 	private void assertUnfiltered(String version) {
 		assertFailure(AdoptionException.class,
-				() -> EnforcerRuleVersion.read(metadata(EnforcerRuleVersion.RULE_VERSION_KEY + "=" + version)),
-				EnforcerRuleVersion.BUILD_PROPERTIES);
+				() -> BuildMetadata.read(metadata(EnforcerRuleVersion.RULE_VERSION_KEY + "=" + version),
+						EnforcerRuleVersion.RULE_VERSION_KEY, "the rule version"),
+				BuildMetadata.BUILD_PROPERTIES);
 	}
 
 	private InputStream metadata(String content) {
@@ -127,8 +130,8 @@ class EnforcerRuleVersionTest {
 	}
 
 	private String filteredRuleVersion() throws IOException {
-		try (InputStream stream = getClass().getResourceAsStream(EnforcerRuleVersion.BUILD_PROPERTIES)) {
-			assertNotNull(stream, EnforcerRuleVersion.BUILD_PROPERTIES + " must be filtered onto the test classpath");
+		try (InputStream stream = getClass().getResourceAsStream(BuildMetadata.BUILD_PROPERTIES)) {
+			assertNotNull(stream, BuildMetadata.BUILD_PROPERTIES + " must be filtered onto the test classpath");
 			Properties properties = new Properties();
 			properties.load(stream);
 			String version = properties.getProperty(EnforcerRuleVersion.RULE_VERSION_KEY, "").strip();

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -346,7 +346,7 @@ class PomEnforcerInstallerTest {
 	@Test
 	void pinsEnforcerPluginVersionWhenCreatingIt(@TempDir Path dir) throws IOException {
 		String result = install(dir, POM_WITH_BUILD);
-		assertTrue(result.contains("<version>" + PomEnforcerInstaller.ENFORCER_VERSION + "</version>"),
+		assertTrue(result.contains("<version>" + PomEnforcerInstaller.enforcerVersion() + "</version>"),
 				"a freshly created maven-enforcer-plugin must declare a version so the adopted build validates");
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstallerTest.java
@@ -340,7 +340,7 @@ class PomEnforcerInstallerTest {
 		assertTrue(result.contains("maven-enforcer-plugin"));
 		assertTrue(result.contains("tools.claude-code-enforcer"));
 		assertTrue(result.contains("9.9.9"));
-		assertTrue(result.contains("claudeMdFormat"));
+		assertTrue(result.contains(PomEnforcerInstaller.PROJECT_RULE));
 	}
 
 	@Test
@@ -360,8 +360,8 @@ class PomEnforcerInstallerTest {
 	@Test
 	void configuresClaudeMdFileForTheRule(@TempDir Path dir) throws IOException {
 		String result = install(dir, POM_WITH_BUILD);
-		assertTrue(result.contains("<claudeMdFile>"));
-		assertTrue(result.contains("${project.basedir}/CLAUDE.md"));
+		assertTrue(result.contains("<projectDir>"));
+		assertTrue(result.contains("${project.basedir}"));
 	}
 
 	@Test
@@ -370,7 +370,7 @@ class PomEnforcerInstallerTest {
 		assertTrue(installer.install(pom));
 		String result = Files.readString(pom);
 		assertTrue(result.contains("tools.claude-code-enforcer"));
-		assertTrue(result.contains("claudeMdFormat"));
+		assertTrue(result.contains(PomEnforcerInstaller.PROJECT_RULE));
 		assertEquals(1, occurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"));
 	}
 
@@ -423,7 +423,98 @@ class PomEnforcerInstallerTest {
 		assertTrue(result.contains(CLAUDE_RULE_DECLARATION), "the profile's own declaration must be left verbatim");
 		assertEquals(2, occurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
 				"the build needs its own declaration alongside the profile's:\n" + result);
-		assertTrue(result.contains("<claudeMdFile>"), "the added rule must be the configured, always-on one");
+		assertTrue(result.contains("<projectDir>"), "the added rule must be the configured, always-on one");
+	}
+
+	/**
+	 * The default guard checks the whole configuration, not just the document. The
+	 * adoption installs an AGENTS.md and, with --assets, a .claude directory, so a
+	 * guard reading only CLAUDE.md left what the run itself wrote unchecked.
+	 */
+	@Test
+	void wiresTheWholeProjectGuardByDefault(@TempDir Path dir) throws IOException {
+		String result = install(dir, POM_WITH_BUILD);
+
+		assertTrue(result.contains("<" + PomEnforcerInstaller.PROJECT_RULE + ">"), result);
+		assertTrue(result.contains("<projectDir>${project.basedir}</projectDir>"), result);
+	}
+
+	/** A repository whose maintainers want only the document checked says so. */
+	@Test
+	void wiresTheDocumentGuardAloneWhenAskedFor(@TempDir Path dir) throws IOException {
+		PomEnforcerInstaller minimal = PomEnforcerInstaller
+				.from(new GuardOptions("9.9.9", GuardRules.MINIMAL, List.of()));
+		Path pom = write(dir, POM_WITH_BUILD);
+
+		assertTrue(minimal.install(pom));
+
+		String result = Files.readString(pom);
+		assertTrue(result.contains("<" + PomEnforcerInstaller.CLAUDE_MD_RULE + ">"), result);
+		assertFalse(result.contains(PomEnforcerInstaller.PROJECT_RULE), result);
+		assertTrue(result.contains("<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>"), result);
+	}
+
+	/**
+	 * The sections the conformer reshaped the document to are the sections the guard
+	 * demands. Leaving them to the rule's defaults held every adopted repository to
+	 * this repository's Java and Maven headings.
+	 */
+	@Test
+	void writesTheSectionsTheGuardIsToDemand(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, POM_WITH_BUILD);
+
+		assertTrue(installer.install(pom, List.of("## Overview", "## Running it")));
+
+		String result = Files.readString(pom);
+		assertTrue(result.contains("<claudeMdSection>## Overview</claudeMdSection>"), result);
+		assertTrue(result.contains("<claudeMdSection>## Running it</claudeMdSection>"), result);
+	}
+
+	@Test
+	void writesTheSectionsIntoTheDocumentGuardToo(@TempDir Path dir) throws IOException {
+		PomEnforcerInstaller minimal = PomEnforcerInstaller
+				.from(new GuardOptions("9.9.9", GuardRules.MINIMAL, List.of()));
+		Path pom = write(dir, POM_WITH_BUILD);
+
+		assertTrue(minimal.install(pom, List.of("## Overview")));
+
+		assertTrue(Files.readString(pom).contains("<requiredSection>## Overview</requiredSection>"),
+				Files.readString(pom));
+	}
+
+	/**
+	 * A guard demanding no particular section writes none, leaving the rule's own
+	 * defaults rather than an empty list that would demand nothing at all.
+	 */
+	@Test
+	void writesNoSectionsWhenTheGuardDemandsNone(@TempDir Path dir) throws IOException {
+		String result = install(dir, POM_WITH_BUILD);
+
+		assertFalse(result.contains("<claudeMdSections>"), result);
+	}
+
+	/**
+	 * A repository adopted before the composite existed runs claudeMdFormat. Re-adopting
+	 * it must leave that guard alone rather than splice a second execution in beside it:
+	 * the run's job is to leave the repository guarded, and it is.
+	 */
+	@Test
+	void leavesARepositoryGuardedByTheOlderRuleAlone(@TempDir Path dir) throws IOException {
+		Path pom = write(dir, """
+				<project xmlns="http://maven.apache.org/POM/4.0.0">
+				  <artifactId>demo</artifactId>
+				  <build>
+				    <plugins>
+				      <plugin>
+				        <artifactId>maven-enforcer-plugin</artifactId>
+				%s
+				      </plugin>
+				    </plugins>
+				  </build>
+				</project>
+				""".formatted(CLAUDE_RULE_DECLARATION));
+
+		assertFalse(installer.install(pom), "a POM that already runs a guard must be left untouched");
 	}
 
 	/**
@@ -440,7 +531,7 @@ class PomEnforcerInstallerTest {
 		Path pom = write(dir, POM_WITH_THE_ARTIFACT_FOR_ANOTHER_RULE);
 		assertTrue(installer.install(pom), "the artifact is present but no CLAUDE.md guard is");
 		String result = Files.readString(pom);
-		assertTrue(result.contains(PomEnforcerInstaller.CLAUDE_MD_RULE), "the rule must be wired in:\n" + result);
+		assertTrue(result.contains(PomEnforcerInstaller.PROJECT_RULE), "the rule must be wired in:\n" + result);
 		assertTrue(result.contains("noSecrets"), "the rule the project already ran must keep running");
 	}
 
@@ -471,7 +562,8 @@ class PomEnforcerInstallerTest {
 		Path pom = write(dir, POM_WITH_RULE_ONLY_MANAGED);
 		assertTrue(installer.install(pom), "a managed rule binds to no phase, so the build still needs one");
 		String result = Files.readString(pom);
-		assertTrue(result.contains("claudeMdFormat"), "the rule must be wired into the build that runs");
+		assertTrue(result.contains(PomEnforcerInstaller.PROJECT_RULE),
+				"the rule must be wired into the build that runs");
 		assertEquals(2, occurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
 				"the build needs its own enforcer declaration alongside the managed one");
 	}
@@ -505,7 +597,7 @@ class PomEnforcerInstallerTest {
 		assertTrue(result.contains(PROFILED_ENFORCER),
 				"the profile must be left verbatim; an execution there runs only when the profile is activated");
 		assertTrue(result.contains("<build>"), "the POM had no build of its own and needs one to run the rule from");
-		assertTrue(result.contains("claudeMdFormat"), "the rule must be wired into that build");
+		assertTrue(result.contains(PomEnforcerInstaller.PROJECT_RULE), "the rule must be wired into that build");
 	}
 
 	/**
@@ -522,7 +614,7 @@ class PomEnforcerInstallerTest {
 		assertTrue(result.contains(MANAGED_ENFORCER), "the managed declaration must be left verbatim");
 		assertEquals(3, occurrences(result, "<artifactId>maven-enforcer-plugin</artifactId>"),
 				"the build's existing declaration must be augmented, not joined by a fourth");
-		assertTrue(result.contains("claudeMdFormat"), "the rule must be wired in");
+		assertTrue(result.contains(PomEnforcerInstaller.PROJECT_RULE), "the rule must be wired in");
 	}
 
 	/**
@@ -538,13 +630,15 @@ class PomEnforcerInstallerTest {
 		AdoptionException failure = assertThrows(AdoptionException.class, () -> installer.install(pom));
 		assertTrue(failure.getMessage().contains(PomEnforcerInstaller.MINIMUM_ENFORCER_VERSION),
 				"the failure must name the version to raise the plugin to: " + failure.getMessage());
-		assertFalse(Files.readString(pom).contains("claudeMdFormat"), "nothing may be written to a refused POM");
+		assertFalse(Files.readString(pom).contains(PomEnforcerInstaller.PROJECT_RULE),
+				"nothing may be written to a refused POM");
 	}
 
 	@Test
 	void augmentsAnEnforcerPinnedToTheMinimumVersion(@TempDir Path dir) throws IOException {
 		String result = install(dir, pomPinningEnforcerTo(PomEnforcerInstaller.MINIMUM_ENFORCER_VERSION));
-		assertTrue(result.contains("claudeMdFormat"), "the minimum version runs the rule and must be augmented");
+		assertTrue(result.contains(PomEnforcerInstaller.PROJECT_RULE),
+				"the minimum version runs the rule and must be augmented");
 	}
 
 	/**
@@ -555,9 +649,10 @@ class PomEnforcerInstallerTest {
 	 */
 	@Test
 	void augmentsAnEnforcerWhoseVersionCannotBeReadFromThePom(@TempDir Path dir) throws IOException {
-		assertTrue(install(dir, pomPinningEnforcerTo("${enforcer.version}")).contains("claudeMdFormat"),
+		assertTrue(install(dir, pomPinningEnforcerTo("${enforcer.version}"))
+				.contains(PomEnforcerInstaller.PROJECT_RULE),
 				"a version given as a property must not be read as an old one");
-		assertTrue(install(dir, POM_WITH_ENFORCER).contains("claudeMdFormat"),
+		assertTrue(install(dir, POM_WITH_ENFORCER).contains(PomEnforcerInstaller.PROJECT_RULE),
 				"a plugin declaring no version at all must not be read as an old one");
 	}
 
@@ -576,13 +671,14 @@ class PomEnforcerInstallerTest {
 		AdoptionException failure = assertThrows(AdoptionException.class, () -> installer.install(pom));
 		assertTrue(failure.getMessage().contains("build/pluginManagement"),
 				"the failure must name the declaration to raise: " + failure.getMessage());
-		assertFalse(Files.readString(pom).contains("claudeMdFormat"), "nothing may be written to a refused POM");
+		assertFalse(Files.readString(pom).contains(PomEnforcerInstaller.PROJECT_RULE),
+				"nothing may be written to a refused POM");
 	}
 
 	/** The same shape managed at a version that runs the rule is augmented, not refused. */
 	@Test
 	void augmentsAnEnforcerTheProjectManagesAtARunnableVersion(@TempDir Path dir) throws IOException {
-		assertTrue(install(dir, pomManagingEnforcerAt("3.5.0")).contains("claudeMdFormat"),
+		assertTrue(install(dir, pomManagingEnforcerAt("3.5.0")).contains(PomEnforcerInstaller.PROJECT_RULE),
 				"a managed version new enough to run the rule must be wired into");
 	}
 
@@ -597,7 +693,7 @@ class PomEnforcerInstallerTest {
 		String declaredNewer = pomManagingEnforcerAt("3.0.0-M2")
 				.replace("<artifactId>maven-enforcer-plugin</artifactId>\n      </plugin>",
 						"<artifactId>maven-enforcer-plugin</artifactId>\n        <version>3.5.0</version>\n      </plugin>");
-		assertTrue(install(dir, declaredNewer).contains("claudeMdFormat"),
+		assertTrue(install(dir, declaredNewer).contains(PomEnforcerInstaller.PROJECT_RULE),
 				"the version the build declares must win over the one it merely manages");
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/VerifyStepTest.java
@@ -82,6 +82,11 @@ class VerifyStepTest {
 
 	private static final class FakeBuildSystem implements BuildSystem {
 
+		@Override
+		public boolean isGuardInstalled(Path repositoryDirectory) {
+			return false;
+		}
+
 		private final List<String> verifyCommand;
 
 		private FakeBuildSystem(List<String> verifyCommand) {

--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -17,6 +17,27 @@
 		     See the root pom's pitest.mutationThreshold. -->
 		<pitest.mutationThreshold>88</pitest.mutationThreshold>
 	</properties>
+	<build>
+		<plugins>
+			<!-- The rule jar is also the command line: `java -jar` runs the checks
+			     against a project directory with no Maven build around them, which
+			     is what a pre-commit hook, a Gradle project and anyone evaluating
+			     the rules before wiring them all need. Naming the class in the
+			     manifest costs the jar nothing when it is resolved as a
+			     maven-enforcer dependency instead. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifest>
+							<mainClass>io.github.adamw7.tools.enforcer.cli.Main</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<profile>
 			<id>integration-tests</id>

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/cli/CheckArguments.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/cli/CheckArguments.java
@@ -1,0 +1,190 @@
+package io.github.adamw7.tools.enforcer.cli;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.github.adamw7.tools.enforcer.project.ClaudeCodeProjectRule;
+
+/**
+ * The command line {@link Main} is driven by, parsed into the composite rule it
+ * describes.
+ *
+ * <p>Every option here corresponds to a parameter of {@code claudeCodeProject},
+ * because the command line exists to reach that rule from somewhere that is not a
+ * Maven build — a pre-commit hook, a project built with something else — and an
+ * option it did not have would be a second contract to keep in step.
+ *
+ * <p>An unrecognised option is refused rather than ignored. A hook invoking
+ * {@code --fix-all} and being quietly given a plain check is the failure this
+ * whole class exists to make impossible.
+ */
+final class CheckArguments {
+
+	static final String USAGE = """
+			Usage: claude-code-enforcer [<project-directory>] [options]
+
+			Checks a project's Claude Code configuration (CLAUDE.md, AGENTS.md, and the
+			.claude directory), reporting everything wrong with it at once. The project
+			directory defaults to the working directory.
+
+			Options:
+			  --skip <rule>[,<rule>...]  do not run these rules, by the name each is
+			                             reported under, e.g. okfBundleFormat
+			  --fix                      repair what can be repaired rather than only
+			                             reporting it: a missing title, a near-miss
+			                             heading, an empty or absent section
+			  --warn                     report violations without failing
+			  --budget <bytes>           the size CLAUDE.md is held to; 0 to not check
+			  --report <directory>       write an HTML report per rule, and an index
+			  --debug                    say what each rule was pointed at
+			  --help                     print this and check nothing""";
+
+	private final File projectDirectory;
+	private final List<String> skippedRules;
+	private final boolean fix;
+	private final boolean warn;
+	private final boolean debug;
+	private final boolean helpRequested;
+	private final Integer budget;
+	private final File reportDirectory;
+
+	private CheckArguments(Parsed parsed) {
+		this.projectDirectory = parsed.projectDirectory;
+		this.skippedRules = List.copyOf(parsed.skippedRules);
+		this.fix = parsed.fix;
+		this.warn = parsed.warn;
+		this.debug = parsed.debug;
+		this.helpRequested = parsed.helpRequested;
+		this.budget = parsed.budget;
+		this.reportDirectory = parsed.reportDirectory;
+	}
+
+	/**
+	 * @throws IllegalArgumentException when an option is unrecognised, missing its
+	 *                                  value, or a second project directory is named
+	 */
+	static CheckArguments parse(String... args) {
+		Parsed parsed = new Parsed();
+		for (int index = 0; index < args.length; index++) {
+			index = parsed.read(args, index);
+		}
+		return new CheckArguments(parsed);
+	}
+
+	boolean helpRequested() {
+		return helpRequested;
+	}
+
+	boolean debug() {
+		return debug;
+	}
+
+	/** @return where the reports go, or null when none were asked for */
+	File reportDirectory() {
+		return reportDirectory;
+	}
+
+	/** The rule this command line describes, configured and ready to run. */
+	ClaudeCodeProjectRule rule() {
+		ClaudeCodeProjectRule rule = new ClaudeCodeProjectRule();
+		rule.setProjectDir(projectDirectory == null ? new File(".") : projectDirectory);
+		rule.setSkippedRules(skippedRules);
+		rule.setAutoFix(fix);
+		if (warn) {
+			rule.setSeverity("warn");
+		}
+		if (budget != null) {
+			rule.setClaudeMdBudgetBytes(budget);
+		}
+		return rule;
+	}
+
+	/** The options as they accumulate, so the parse reads as one pass over the arguments. */
+	private static final class Parsed {
+
+		private File projectDirectory;
+		private final List<String> skippedRules = new ArrayList<>();
+		private boolean fix;
+		private boolean warn;
+		private boolean debug;
+		private boolean helpRequested;
+		private Integer budget;
+		private File reportDirectory;
+
+		/** @return the index of the last argument consumed, so the caller advances past a value */
+		private int read(String[] args, int index) {
+			String argument = args[index];
+			return switch (argument) {
+				case "--fix" -> flag(() -> fix = true, index);
+				case "--warn" -> flag(() -> warn = true, index);
+				case "--debug" -> flag(() -> debug = true, index);
+				case "--help", "-h" -> flag(() -> helpRequested = true, index);
+				case "--skip" -> readSkipped(value(args, index));
+				case "--budget" -> readBudget(value(args, index));
+				case "--report" -> readReport(value(args, index));
+				default -> readPositional(argument, index);
+			};
+		}
+
+		private int flag(Runnable set, int index) {
+			set.run();
+			return index;
+		}
+
+		private int readSkipped(Value value) {
+			for (String name : value.text.split(",")) {
+				addSkipped(name);
+			}
+			return value.index;
+		}
+
+		private void addSkipped(String name) {
+			if (!name.isBlank()) {
+				skippedRules.add(name.strip());
+			}
+		}
+
+		private int readBudget(Value value) {
+			try {
+				budget = Integer.valueOf(value.text.strip());
+			} catch (NumberFormatException e) {
+				throw new IllegalArgumentException("--budget takes a number of bytes, not '" + value.text + "'", e);
+			}
+			return value.index;
+		}
+
+		private int readReport(Value value) {
+			reportDirectory = new File(value.text);
+			return value.index;
+		}
+
+		/**
+		 * An argument that is not an option is the project directory. One that looks
+		 * like an option is refused, since a mistyped flag silently read as a directory
+		 * would run the check somewhere nobody meant.
+		 */
+		private int readPositional(String argument, int index) {
+			if (argument.startsWith("-")) {
+				throw new IllegalArgumentException("Unknown option: " + argument + System.lineSeparator() + USAGE);
+			}
+			if (projectDirectory != null) {
+				throw new IllegalArgumentException("Only one project directory can be checked, but both "
+						+ projectDirectory + " and " + argument + " were named");
+			}
+			projectDirectory = new File(argument);
+			return index;
+		}
+
+		private Value value(String[] args, int index) {
+			if (index + 1 >= args.length) {
+				throw new IllegalArgumentException(args[index] + " needs a value" + System.lineSeparator() + USAGE);
+			}
+			return new Value(args[index + 1], index + 1);
+		}
+	}
+
+	/** An option's value together with the index it was read from. */
+	private record Value(String text, int index) {
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/cli/Main.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/cli/Main.java
@@ -1,0 +1,104 @@
+package io.github.adamw7.tools.enforcer.cli;
+
+import java.io.File;
+import java.io.PrintStream;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.project.ClaudeCodeProjectRule;
+
+/**
+ * Command-line entry point: checks a project's Claude Code configuration without
+ * a Maven build around it.
+ *
+ * <p>A maven-enforcer rule has to be resolvable as a JAR before the build that
+ * uses it runs, which is why checking this repository's own documents takes two
+ * commands and why its CI needs a bootstrap step. That is the right cost for a
+ * check that gates a build; it is the wrong one for a pre-commit hook, for a
+ * project built with Gradle or with nothing, and for anyone who wants to know
+ * what the rules make of a repository before wiring anything at all. The rules
+ * never needed Maven — they read files and collect violations — so this runs them
+ * directly:
+ *
+ * <pre>{@code
+ * java -jar claude-code-enforcer.jar /path/to/project
+ * java -jar claude-code-enforcer.jar . --fix --skip okfBundleFormat
+ * }</pre>
+ *
+ * <p>Everything it can be asked is a parameter of {@link ClaudeCodeProjectRule},
+ * so the command line and a pom configure one thing rather than two that could
+ * come to disagree.
+ *
+ * <p>Failure is reported by throwing, as everywhere else in this repository, which
+ * leaves the process exiting non-zero without this class deciding to end a JVM it
+ * does not own. The violations are printed first, so what a hook shows its user is
+ * the report rather than the throw.
+ */
+public final class Main {
+
+	private Main() {
+	}
+
+	public static void main(String[] args) {
+		run(args, System.out, System.err);
+	}
+
+	/**
+	 * The run with its streams supplied, so a test reads what an operator would see.
+	 *
+	 * @throws EnforcerRuleException when the configuration is not valid, or the
+	 *                               command line could not be read
+	 */
+	static void run(String[] args, PrintStream out, PrintStream err) {
+		CheckArguments arguments = CheckArguments.parse(args);
+		if (arguments.helpRequested()) {
+			out.println(CheckArguments.USAGE);
+			return;
+		}
+		check(arguments, new PrintingEnforcerLogger(out, err, arguments.debug()), out);
+	}
+
+	private static void check(CheckArguments arguments, EnforcerLogger logger, PrintStream out) {
+		reportsGoTo(arguments.reportDirectory());
+		ClaudeCodeProjectRule rule = arguments.rule();
+		rule.setLog(logger);
+		try {
+			rule.execute();
+			out.println("Claude Code configuration is valid.");
+		} catch (EnforcerRuleException e) {
+			logger.error(e.getMessage());
+			throw new CheckFailedException();
+		}
+	}
+
+	/**
+	 * Points the rules at a report directory through the property they already read,
+	 * rather than through a parameter of its own. There is one way a build asks for
+	 * reports and this is it; a second would be a second thing to keep in step.
+	 */
+	private static void reportsGoTo(File reportDirectory) {
+		if (reportDirectory != null) {
+			System.setProperty("claude.enforcer.reportDir", reportDirectory.getPath());
+		}
+	}
+
+	/**
+	 * What a failed check throws, so the process exits non-zero without this class
+	 * ending a JVM it does not own.
+	 *
+	 * <p>It deliberately carries neither the rule's message nor the rule's exception
+	 * as its cause. Both would put the whole report into the stack trace a shell
+	 * prints after it, so an operator whose CLAUDE.md is missing six sections would
+	 * read those six twice — once as the report and once as a trace. The report has
+	 * already been printed; this only says that it was one.
+	 */
+	static final class CheckFailedException extends RuntimeException {
+
+		private static final long serialVersionUID = 1L;
+
+		CheckFailedException() {
+			super("The Claude Code configuration is not valid; see the violations above");
+		}
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/cli/PrintingEnforcerLogger.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/cli/PrintingEnforcerLogger.java
@@ -1,0 +1,112 @@
+package io.github.adamw7.tools.enforcer.cli;
+
+import java.io.PrintStream;
+import java.util.function.Supplier;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+
+/**
+ * The logger the command line runs a check with: maven-enforcer's own logger
+ * interface, writing to a stream instead of to a Maven session.
+ *
+ * <p>The rules already log everything they have to say through that interface —
+ * what each was pointed at, what it suppressed, what it repaired — and none of
+ * them knows or cares who is listening. So running them outside Maven needs no
+ * second reporting path, only somewhere for this one to go.
+ *
+ * <p>Debug is off unless asked for, because a rule's debug line says which inputs
+ * a verdict was reached on and that is a question an operator asks after a
+ * surprising answer, not before one.
+ */
+final class PrintingEnforcerLogger implements EnforcerLogger {
+
+	private final PrintStream out;
+	private final PrintStream err;
+	private final boolean debugEnabled;
+
+	PrintingEnforcerLogger(PrintStream out, PrintStream err, boolean debugEnabled) {
+		this.out = out;
+		this.err = err;
+		this.debugEnabled = debugEnabled;
+	}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return debugEnabled;
+	}
+
+	@Override
+	public void debug(CharSequence message) {
+		if (debugEnabled) {
+			out.println("[debug] " + message);
+		}
+	}
+
+	@Override
+	public void debug(Supplier<CharSequence> message) {
+		if (debugEnabled) {
+			debug(message.get());
+		}
+	}
+
+	@Override
+	public boolean isInfoEnabled() {
+		return true;
+	}
+
+	@Override
+	public void info(CharSequence message) {
+		out.println("[info] " + message);
+	}
+
+	@Override
+	public void info(Supplier<CharSequence> message) {
+		info(message.get());
+	}
+
+	@Override
+	public boolean isWarnEnabled() {
+		return true;
+	}
+
+	@Override
+	public void warn(CharSequence message) {
+		err.println("[warn] " + message);
+	}
+
+	@Override
+	public void warn(Supplier<CharSequence> message) {
+		warn(message.get());
+	}
+
+	/**
+	 * maven-enforcer calls this where a message's level depends on whether the rule
+	 * that produced it fails the build. Off the command line the answer is always the
+	 * same — the run reports what it found and the caller decides — so it reads as a
+	 * warning, which is the level that does not claim a verdict.
+	 */
+	@Override
+	public void warnOrError(CharSequence message) {
+		warn(message);
+	}
+
+	@Override
+	public void warnOrError(Supplier<CharSequence> message) {
+		warn(message);
+	}
+
+	@Override
+	public boolean isErrorEnabled() {
+		return true;
+	}
+
+	@Override
+	public void error(CharSequence message) {
+		err.println("[error] " + message);
+	}
+
+	@Override
+	public void error(Supplier<CharSequence> message) {
+		error(message.get());
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/CommandFormatRule.java
@@ -63,7 +63,7 @@ public class CommandFormatRule extends DefinitionFormatRule {
 		checks.checkModel(allowedModels);
 	}
 
-	void setCommandsDir(File commandsDir) {
+	public void setCommandsDir(File commandsDir) {
 		this.commandsDir = commandsDir;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/MultiDefinitionRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/MultiDefinitionRule.java
@@ -84,15 +84,15 @@ abstract class MultiDefinitionRule extends ClaudeCodeEnforcerRule {
 		}
 	}
 
-	void setCommandsDir(File commandsDir) {
+	public void setCommandsDir(File commandsDir) {
 		this.commandsDir = commandsDir;
 	}
 
-	void setAgentsDir(File agentsDir) {
+	public void setAgentsDir(File agentsDir) {
 		this.agentsDir = agentsDir;
 	}
 
-	void setSkillsDir(File skillsDir) {
+	public void setSkillsDir(File skillsDir) {
 		this.skillsDir = skillsDir;
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SkillFilesExistRule.java
@@ -80,7 +80,7 @@ public class SkillFilesExistRule extends DefinitionFormatRule {
 		checks.checkDescription(maxDescriptionLength);
 	}
 
-	void setSkillsDir(File skillsDir) {
+	public void setSkillsDir(File skillsDir) {
 		this.skillsDir = skillsDir;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/definition/SubAgentFormatRule.java
@@ -61,7 +61,7 @@ public class SubAgentFormatRule extends DefinitionFormatRule {
 		checks.checkModel(allowedModels);
 	}
 
-	void setAgentsDir(File agentsDir) {
+	public void setAgentsDir(File agentsDir) {
 		this.agentsDir = agentsDir;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/AgentsMdFormatRule.java
@@ -38,7 +38,7 @@ public class AgentsMdFormatRule extends MarkdownFormatRule {
 		return agentsMdFile;
 	}
 
-	void setAgentsMdFile(File agentsMdFile) {
+	public void setAgentsMdFile(File agentsMdFile) {
 		this.agentsMdFile = agentsMdFile;
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
@@ -89,8 +89,13 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 		}
 	}
 
-	/** @return the companion document to require, empty when the project keeps none */
-	final String requiredReference() {
+	/**
+	 * @return the companion document to require, empty when the project keeps none.
+	 *         The base class reads this too, so a repair inserts the reference this
+	 *         rule goes on to check for.
+	 */
+	@Override
+	protected String requiredReference() {
 		return requiredReference == null ? DEFAULT_REQUIRED_REFERENCE : requiredReference.strip();
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
@@ -13,11 +13,24 @@ import io.github.adamw7.tools.markdown.MarkdownDocument;
  * not follow the expected structure: it must start with the {@code # CLAUDE.md}
  * title, reference {@code AGENTS.md}, and contain every required section
  * heading.
+ *
+ * <p>Every one of those is a default, not a fixture. The title and the required
+ * sections are overridden through {@link MarkdownFormatRule}'s
+ * {@code titleHeading} and {@code requiredSections}, and the companion document
+ * this one must point at through {@link #setRequiredReference}. The defaults are
+ * this repository's — a Java project built with Maven, keeping its detail in an
+ * {@code AGENTS.md} — because a rule has to default to something; a project
+ * arranged differently configures the three and keeps the structural checking.
+ * Configuring {@code <requiredReference/>} empty is how a project that keeps no
+ * companion document says so, which is the one thing overriding the section list
+ * could not express.
  */
 @Named("claudeMdFormat")
 public class ClaudeMdFormatRule extends MarkdownFormatRule {
 
-	private static final String AGENTS_REFERENCE = "AGENTS.md";
+	/** The companion document a {@code CLAUDE.md} points at unless configured otherwise. */
+	static final String DEFAULT_REQUIRED_REFERENCE = "AGENTS.md";
+
 	private static final List<String> REQUIRED_SECTIONS = List.of(
 			"## Project",
 			"## Java version",
@@ -28,6 +41,13 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 
 	/** The {@code CLAUDE.md} file to validate. Injected from the rule configuration. */
 	private File claudeMdFile;
+
+	/**
+	 * Optional override for the companion document {@code CLAUDE.md} must reference.
+	 * Null falls back to {@value #DEFAULT_REQUIRED_REFERENCE}; configured empty, the
+	 * check is dropped, for a project that keeps no such document.
+	 */
+	private String requiredReference;
 
 	public ClaudeMdFormatRule() {
 		super("CLAUDE.md", REQUIRED_SECTIONS);
@@ -56,14 +76,29 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 		return claudeMdFile;
 	}
 
+	/**
+	 * The reference is looked for in prose, so a {@code CLAUDE.md} whose only mention
+	 * of the companion sits in a fenced sample or behind an HTML comment does not
+	 * satisfy it — the same reading every heading here gets.
+	 */
 	@Override
 	protected void collectAdditionalViolations(MarkdownDocument document, List<String> violations) {
-		if (!document.containsInProse(AGENTS_REFERENCE)) {
-			violations.add("CLAUDE.md must reference " + AGENTS_REFERENCE + " as the source of truth");
+		String reference = requiredReference();
+		if (!reference.isEmpty() && !document.containsInProse(reference)) {
+			violations.add("CLAUDE.md must reference " + reference + " as the source of truth");
 		}
+	}
+
+	/** @return the companion document to require, empty when the project keeps none */
+	final String requiredReference() {
+		return requiredReference == null ? DEFAULT_REQUIRED_REFERENCE : requiredReference.strip();
 	}
 
 	void setClaudeMdFile(File claudeMdFile) {
 		this.claudeMdFile = claudeMdFile;
+	}
+
+	public void setRequiredReference(String requiredReference) {
+		this.requiredReference = requiredReference;
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRule.java
@@ -99,7 +99,7 @@ public class ClaudeMdFormatRule extends MarkdownFormatRule {
 		return requiredReference == null ? DEFAULT_REQUIRED_REFERENCE : requiredReference.strip();
 	}
 
-	void setClaudeMdFile(File claudeMdFile) {
+	public void setClaudeMdFile(File claudeMdFile) {
 		this.claudeMdFile = claudeMdFile;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ContextBudgetRule.java
@@ -115,7 +115,7 @@ public class ContextBudgetRule extends ClaudeCodeEnforcerRule {
 		return (content.length() + CHARS_PER_TOKEN - 1) / CHARS_PER_TOKEN;
 	}
 
-	void setFiles(List<File> files) {
+	public void setFiles(List<File> files) {
 		this.files = files;
 	}
 
@@ -123,7 +123,7 @@ public class ContextBudgetRule extends ClaudeCodeEnforcerRule {
 		this.directories = directories;
 	}
 
-	void setMaxBytes(long maxBytes) {
+	public void setMaxBytes(long maxBytes) {
 		this.maxBytes = maxBytes;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/MemoryImportsRule.java
@@ -127,7 +127,7 @@ public class MemoryImportsRule extends ClaudeCodeEnforcerRule {
 		return Objects.requireNonNullElse(importExtensions, DEFAULT_IMPORT_EXTENSIONS);
 	}
 
-	void setClaudeMdFile(File claudeMdFile) {
+	public void setClaudeMdFile(File claudeMdFile) {
 		this.claudeMdFile = claudeMdFile;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ModuleMapConsistencyRule.java
@@ -124,11 +124,11 @@ public class ModuleMapConsistencyRule extends ClaudeCodeEnforcerRule {
 		return ignoredModules != null && ignoredModules.contains(name);
 	}
 
-	void setPomFile(File pomFile) {
+	public void setPomFile(File pomFile) {
 		this.pomFile = pomFile;
 	}
 
-	void setDocFiles(List<File> docFiles) {
+	public void setDocFiles(List<File> docFiles) {
 		this.docFiles = docFiles;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpConfigFormatRule.java
@@ -179,7 +179,7 @@ public class McpConfigFormatRule extends JsonFileRule {
 		}
 	}
 
-	void setMcpFile(File mcpFile) {
+	public void setMcpFile(File mcpFile) {
 		this.mcpFile = mcpFile;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/mcp/McpServersValidRule.java
@@ -147,7 +147,7 @@ public class McpServersValidRule extends JsonFileRule {
 		}
 	}
 
-	void setMcpFile(File mcpFile) {
+	public void setMcpFile(File mcpFile) {
 		this.mcpFile = mcpFile;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/okf/OkfBundleFormatRule.java
@@ -320,7 +320,7 @@ public class OkfBundleFormatRule extends ClaudeCodeEnforcerRule {
 		return relative.isEmpty() ? "The bundle root" : relative;
 	}
 
-	void setBundleDir(File bundleDir) {
+	public void setBundleDir(File bundleDir) {
 		this.bundleDir = bundleDir;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ClaudeCodeProjectRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ClaudeCodeProjectRule.java
@@ -1,0 +1,197 @@
+package io.github.adamw7.tools.enforcer.project;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+
+/**
+ * Checks a project's whole Claude Code configuration from its directory alone.
+ *
+ * <p>The shipped rules are deliberately separate — each names its own inputs and
+ * reaches its own verdict — and the cost of that lands on whoever wires them: a
+ * project adopting the catalogue writes around twenty elements and sixty paths,
+ * every one of them the conventional location the tool already uses. This rule
+ * spends that convention instead of restating it:
+ *
+ * <pre>{@code
+ * <claudeCodeProject>
+ *   <projectDir>${project.basedir}</projectDir>
+ * </claudeCodeProject>
+ * }</pre>
+ *
+ * <p>What it runs is decided by what the project has. A part whose input is absent
+ * is skipped rather than failed, because nothing named that path: a project with
+ * no {@code .claude/commands} has no slash commands, which is not a fault, and it
+ * starts being checked the day it grows one. {@link ProjectParts} says which parts
+ * there are and {@link ProjectLayout} where each one looks.
+ *
+ * <p>Each part still collects its own violations; this rule decides what they
+ * mean. So one severity, one baseline and one report cover the whole
+ * configuration, and each violation is prefixed with the name of the part that
+ * found it — the name to look up in the catalogue, and the name to put in
+ * {@code <skippedRules>} to switch that part off. Wiring a rule individually is
+ * still supported and still wins where a project needs to configure that rule's
+ * own parameters.
+ */
+@Named("claudeCodeProject")
+public class ClaudeCodeProjectRule extends ClaudeCodeEnforcerRule {
+
+	/**
+	 * 32 KB, which is a long summary and a short manual — comfortably more than a
+	 * {@code CLAUDE.md} that defers detail elsewhere needs, and well under the point
+	 * at which loading it into every session is the thing costing the context.
+	 */
+	static final int DEFAULT_CLAUDE_MD_BUDGET_BYTES = 32768;
+
+	/** The project root every conventional path is resolved against. */
+	private File projectDir;
+
+	/**
+	 * Names of parts not to run, as the catalogue spells them, e.g.
+	 * {@code okfBundleFormat}. Matched without regard to case, since the point of the
+	 * parameter is to switch a part off rather than to test the speller.
+	 */
+	private List<String> skippedRules;
+
+	/**
+	 * When true, the parts that can repair what they report do so. It is passed to
+	 * the document parts rather than set on this rule's own behalf, because a
+	 * composite has no document of its own to repair.
+	 */
+	private boolean autoFix;
+
+	/**
+	 * The size a {@code CLAUDE.md} is held to, since it is loaded into every session
+	 * and is meant to be a summary that defers to the fuller document rather than a
+	 * copy of it. Zero switches the check off. It is a parameter with a default rather
+	 * than a path this rule could look up, because it is the one part of the
+	 * convention that is a number instead of a location.
+	 */
+	private int claudeMdBudgetBytes = DEFAULT_CLAUDE_MD_BUDGET_BYTES;
+
+	@Override
+	public void execute() throws EnforcerRuleException {
+		requireConfigured(projectDir, "projectDir");
+		requireProjectDirectory();
+		List<String> violations = new ArrayList<>();
+		List<ClaudeCodeEnforcerRule> parts = runnableParts();
+		logWhatIsChecked(parts);
+		for (ClaudeCodeEnforcerRule part : parts) {
+			run(part, violations);
+		}
+		report("The Claude Code project configuration in " + projectDir + " is not valid:", violations);
+	}
+
+	/**
+	 * Runs one part, turning what it found into violations named after it. A part
+	 * that throws is reported as a violation of its own rather than allowed to end
+	 * the run: one part's build-setup problem must not cost the operator every other
+	 * part's verdict, which is the whole reason to check a project in one pass.
+	 */
+	private void run(ClaudeCodeEnforcerRule part, List<String> violations) {
+		part.setLog(log());
+		part.reportTo((ruleName, found) -> found.forEach(violation -> violations.add(named(ruleName, violation))));
+		try {
+			part.execute();
+		} catch (EnforcerRuleException | RuntimeException e) {
+			violations.add(named(nameOf(part), "could not be checked: " + e.getMessage()));
+		}
+	}
+
+	private String named(String ruleName, String violation) {
+		return "[" + ruleName + "] " + violation;
+	}
+
+	/**
+	 * The parts to run: those whose inputs are present, less those the project asked
+	 * to skip. Skipping is applied here rather than inside {@link ProjectParts} so
+	 * that what a part <em>is</em> and whether this project wants it stay separate
+	 * questions.
+	 */
+	private List<ClaudeCodeEnforcerRule> runnableParts() {
+		Set<String> skipped = skippedNames();
+		return new ProjectParts(new ProjectLayout(projectDir), autoFix, claudeMdBudgetBytes).present().stream()
+				.filter(part -> !skipped.contains(nameOf(part).toLowerCase(Locale.ROOT)))
+				.toList();
+	}
+
+	private Set<String> skippedNames() {
+		if (skippedRules == null) {
+			return Set.of();
+		}
+		return skippedRules.stream().map(name -> name.strip().toLowerCase(Locale.ROOT))
+				.collect(Collectors.toUnmodifiableSet());
+	}
+
+	/**
+	 * A project directory that is not there is a build-setup mistake, unlike any of
+	 * the paths inside it: those are conventions this rule looked for, while this one
+	 * was configured.
+	 */
+	private void requireProjectDirectory() throws EnforcerRuleException {
+		if (!projectDir.isDirectory()) {
+			throw new EnforcerRuleException("The projectDir does not exist at " + projectDir);
+		}
+	}
+
+	/**
+	 * Says which parts a run actually covered. Without it a project with no
+	 * {@code .claude} directory at all passes exactly like one whose configuration is
+	 * spotless, and nothing distinguishes the two.
+	 */
+	private void logWhatIsChecked(List<ClaudeCodeEnforcerRule> parts) {
+		log().debug(() -> "claudeCodeProject is checking " + projectDir + " with "
+				+ parts.stream().map(this::nameOf).collect(Collectors.joining(", ")));
+		if (parts.isEmpty()) {
+			log().warn("claudeCodeProject found no Claude Code configuration to check in " + projectDir);
+		}
+	}
+
+	/**
+	 * A part's catalogue name, derived the way every rule's is — the simple name
+	 * without its {@code Rule} suffix, decapitalised.
+	 *
+	 * @see ClaudeCodeEnforcerRule
+	 */
+	private String nameOf(ClaudeCodeEnforcerRule part) {
+		String simpleName = part.getClass().getSimpleName();
+		String withoutSuffix = simpleName.endsWith("Rule")
+				? simpleName.substring(0, simpleName.length() - "Rule".length())
+				: simpleName;
+		return withoutSuffix.substring(0, 1).toLowerCase(Locale.ROOT) + withoutSuffix.substring(1);
+	}
+
+	@Override
+	protected List<String> howToFix() {
+		return List.of(
+				"Each violation above is prefixed with the rule that found it; look that rule up in AGENTS.md.",
+				"Correct the file or directory each message names.",
+				"To stop running one of them, add its name to <skippedRules>.",
+				"Re-run the build to confirm the project's configuration is valid.");
+	}
+
+	public void setProjectDir(File projectDir) {
+		this.projectDir = projectDir;
+	}
+
+	public void setSkippedRules(List<String> skippedRules) {
+		this.skippedRules = skippedRules;
+	}
+
+	public void setAutoFix(boolean autoFix) {
+		this.autoFix = autoFix;
+	}
+
+	public void setClaudeMdBudgetBytes(int claudeMdBudgetBytes) {
+		this.claudeMdBudgetBytes = claudeMdBudgetBytes;
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ClaudeCodeProjectRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ClaudeCodeProjectRule.java
@@ -78,6 +78,22 @@ public class ClaudeCodeProjectRule extends ClaudeCodeEnforcerRule {
 	 */
 	private int claudeMdBudgetBytes = DEFAULT_CLAUDE_MD_BUDGET_BYTES;
 
+	/**
+	 * The section headings {@code CLAUDE.md} must carry, when the project's are not
+	 * the defaults {@code claudeMdFormat} ships. It is passed through rather than left
+	 * to that rule's own configuration because a project wiring this rule is a project
+	 * that wanted to configure one thing, and its headings are the part of the
+	 * convention no convention can supply: they are what the project's document is
+	 * about.
+	 */
+	private List<String> claudeMdSections;
+
+	/**
+	 * The companion document {@code CLAUDE.md} must reference, empty for a project
+	 * that keeps none. Passed through for the same reason as the sections.
+	 */
+	private String claudeMdReference;
+
 	@Override
 	public void execute() throws EnforcerRuleException {
 		requireConfigured(projectDir, "projectDir");
@@ -119,7 +135,7 @@ public class ClaudeCodeProjectRule extends ClaudeCodeEnforcerRule {
 	 */
 	private List<ClaudeCodeEnforcerRule> runnableParts() {
 		Set<String> skipped = skippedNames();
-		return new ProjectParts(new ProjectLayout(projectDir), autoFix, claudeMdBudgetBytes).present().stream()
+		return new ProjectParts(new ProjectLayout(projectDir), documentContract()).present().stream()
 				.filter(part -> !skipped.contains(nameOf(part).toLowerCase(Locale.ROOT)))
 				.toList();
 	}
@@ -193,5 +209,18 @@ public class ClaudeCodeProjectRule extends ClaudeCodeEnforcerRule {
 
 	public void setClaudeMdBudgetBytes(int claudeMdBudgetBytes) {
 		this.claudeMdBudgetBytes = claudeMdBudgetBytes;
+	}
+
+	public void setClaudeMdSections(List<String> claudeMdSections) {
+		this.claudeMdSections = claudeMdSections;
+	}
+
+	public void setClaudeMdReference(String claudeMdReference) {
+		this.claudeMdReference = claudeMdReference;
+	}
+
+	/** What the document parts are configured with, gathered so the parts take one argument. */
+	private DocumentContract documentContract() {
+		return new DocumentContract(autoFix, claudeMdBudgetBytes, claudeMdSections, claudeMdReference);
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/DocumentContract.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/DocumentContract.java
@@ -1,0 +1,23 @@
+package io.github.adamw7.tools.enforcer.project;
+
+import java.util.List;
+
+/**
+ * What {@link ClaudeCodeProjectRule} was told about the project's documents, as
+ * opposed to what {@link ProjectLayout} could work out for itself.
+ *
+ * <p>Everything else the composite runs is decided by convention — where a file
+ * lives, whether it is there. These four cannot be: what a project's {@code
+ * CLAUDE.md} is about, which companion document it points at, how big it may be,
+ * and whether the run may repair it. They travel together because they are settled
+ * in one place and read in another, and passing four arguments through would make
+ * the parts a list of parameters rather than a list of parts.
+ *
+ * @param autoFix        whether the document parts repair what they can
+ * @param budgetBytes    the size {@code CLAUDE.md} is held to; zero to not check
+ * @param claudeMdSections the headings it must carry, or null for the rule's defaults
+ * @param claudeMdReference the companion document it must mention, or null for the default
+ */
+record DocumentContract(boolean autoFix, int budgetBytes, List<String> claudeMdSections,
+		String claudeMdReference) {
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ProjectLayout.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ProjectLayout.java
@@ -1,0 +1,95 @@
+package io.github.adamw7.tools.enforcer.project;
+
+import java.io.File;
+
+import io.github.adamw7.tools.markdown.MarkdownText;
+
+/**
+ * Where Claude Code keeps a project's configuration, so a composite rule can find
+ * it from the project directory alone.
+ *
+ * <p>Every path here is the one Claude Code itself uses. That is what lets
+ * {@link ClaudeCodeProjectRule} be configured with a single {@code projectDir}
+ * instead of the sixty-odd elements naming each rule's inputs one at a time — and
+ * it is why the convention is stated once, here, rather than spelled into each
+ * part's configuration where two of them could come to disagree about where the
+ * skills live.
+ *
+ * @param projectDir the project's root, which every other path is resolved against
+ */
+public record ProjectLayout(File projectDir) {
+
+	private static final String CLAUDE_DIR = ".claude";
+
+	public File claudeMd() {
+		return new File(projectDir, "CLAUDE.md");
+	}
+
+	public File agentsMd() {
+		return new File(projectDir, "AGENTS.md");
+	}
+
+	public File readme() {
+		return new File(projectDir, "README.md");
+	}
+
+	public File pom() {
+		return new File(projectDir, "pom.xml");
+	}
+
+	public File gitignore() {
+		return new File(projectDir, ".gitignore");
+	}
+
+	public File mcpJson() {
+		return new File(projectDir, ".mcp.json");
+	}
+
+	public File settingsJson() {
+		return new File(claudeDir(), "settings.json");
+	}
+
+	public File skillsDir() {
+		return new File(claudeDir(), "skills");
+	}
+
+	public File agentsDir() {
+		return new File(claudeDir(), "agents");
+	}
+
+	public File commandsDir() {
+		return new File(claudeDir(), "commands");
+	}
+
+	public File hooksDir() {
+		return new File(claudeDir(), "hooks");
+	}
+
+	public File pluginJson() {
+		return new File(new File(projectDir, ".claude-plugin"), "plugin.json");
+	}
+
+	public File okfBundleDir() {
+		return new File(projectDir, "okf");
+	}
+
+	/**
+	 * Whether {@link #pom()} is an aggregator, and so whether there is a module map to
+	 * hold the documents to at all. A single-module project has a {@code pom.xml} and
+	 * no {@code <module>} in it, and the rule pointed at such a pom answers that it
+	 * was pointed at the wrong one — which is the right answer to a configured path
+	 * and the wrong one to a convention.
+	 *
+	 * <p>It is a text search rather than a parse because the question is only whether
+	 * the element occurs; which modules it names, and whether the documents agree, is
+	 * the rule's to answer. A pom that cannot be read is not an aggregator, and the
+	 * rule that reads it properly will say why.
+	 */
+	public boolean declaresModules() {
+		return MarkdownText.readIfText(pom()).filter(pom -> pom.contains("<module>")).isPresent();
+	}
+
+	private File claudeDir() {
+		return new File(projectDir, CLAUDE_DIR);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ProjectParts.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ProjectParts.java
@@ -1,0 +1,272 @@
+package io.github.adamw7.tools.enforcer.project;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.github.adamw7.tools.enforcer.definition.CommandFormatRule;
+import io.github.adamw7.tools.enforcer.definition.SkillFilesExistRule;
+import io.github.adamw7.tools.enforcer.definition.SubAgentFormatRule;
+import io.github.adamw7.tools.enforcer.definition.UniqueDescriptionsRule;
+import io.github.adamw7.tools.enforcer.definition.UniqueNamesRule;
+import io.github.adamw7.tools.enforcer.doc.AgentsMdFormatRule;
+import io.github.adamw7.tools.enforcer.doc.ClaudeMdFormatRule;
+import io.github.adamw7.tools.enforcer.doc.ContextBudgetRule;
+import io.github.adamw7.tools.enforcer.doc.MemoryImportsRule;
+import io.github.adamw7.tools.enforcer.doc.ModuleMapConsistencyRule;
+import io.github.adamw7.tools.enforcer.mcp.McpConfigFormatRule;
+import io.github.adamw7.tools.enforcer.mcp.McpServersValidRule;
+import io.github.adamw7.tools.enforcer.okf.OkfBundleFormatRule;
+import io.github.adamw7.tools.enforcer.rule.ClaudeCodeEnforcerRule;
+import io.github.adamw7.tools.enforcer.secret.NoSecretsRule;
+import io.github.adamw7.tools.enforcer.settings.HookCommandsValidRule;
+import io.github.adamw7.tools.enforcer.settings.HooksFormatRule;
+import io.github.adamw7.tools.enforcer.settings.LocalSettingsIgnoredRule;
+import io.github.adamw7.tools.enforcer.settings.PermissionsFormatRule;
+import io.github.adamw7.tools.enforcer.settings.SettingsJsonValidRule;
+
+/**
+ * Assembles the rules {@link ClaudeCodeProjectRule} runs, each pointed at the
+ * conventional path {@link ProjectLayout} gives it.
+ *
+ * <p>A part is included only when the input it reads is actually there. That is
+ * the difference between this and wiring the rules by hand: a rule configured
+ * with a directory treats an absent one as a build-setup mistake and fails,
+ * because somebody named a path that is not there — whereas nothing was named
+ * here, so an absent {@code .claude/commands} means a project with no slash
+ * commands, which is not a fault. A part therefore starts checking the day the
+ * project grows the thing it checks, with no configuration to remember.
+ *
+ * <p>The module map is checked only where there is one: a single-module project's
+ * {@code pom.xml} declares no {@code <module>}, and the rule pointed at it says so
+ * rather than comparing anything. Configured by hand that message is right — the
+ * operator named an aggregator that is not one — but here nothing named it, so the
+ * part is simply not applicable and is left out.
+ *
+ * <p>{@code contextBudget} is the one part the project's own files cannot size: it
+ * needs a limit, and there is no file to read one from. The composite supplies the
+ * convention instead — a {@code CLAUDE.md} is loaded into every session, so it is
+ * meant to be a summary — and a project that disagrees sets its own or turns the
+ * part off with a budget of zero.
+ *
+ * <p>Two shipped rules are deliberately absent: {@code crossDocConsistency} and
+ * {@code readmeConsistency} are configured with the patterns a particular project
+ * needs kept in step — a Java version, a protobuf major — and there is no
+ * convention to default those to. A project that wants them wires them beside
+ * this rule, which is why the composite is an addition to the catalogue rather
+ * than a replacement for it.
+ */
+final class ProjectParts {
+
+	private final ProjectLayout layout;
+	private final boolean autoFix;
+	private final int claudeMdBudgetBytes;
+
+	ProjectParts(ProjectLayout layout, boolean autoFix, int claudeMdBudgetBytes) {
+		this.layout = layout;
+		this.autoFix = autoFix;
+		this.claudeMdBudgetBytes = claudeMdBudgetBytes;
+	}
+
+	/**
+	 * @return every part whose input is present, in a fixed order so a run's report
+	 *         and a recorded baseline read the same way twice
+	 */
+	List<ClaudeCodeEnforcerRule> present() {
+		List<ClaudeCodeEnforcerRule> parts = new ArrayList<>();
+		addDocumentParts(parts);
+		addDefinitionParts(parts);
+		addSettingsParts(parts);
+		addFileParts(parts);
+		return parts;
+	}
+
+	private void addDocumentParts(List<ClaudeCodeEnforcerRule> parts) {
+		whenFile(parts, layout.claudeMd(), () -> {
+			ClaudeMdFormatRule rule = new ClaudeMdFormatRule();
+			rule.setClaudeMdFile(layout.claudeMd());
+			rule.setAutoFix(autoFix);
+			return rule;
+		});
+		whenFile(parts, layout.agentsMd(), () -> {
+			AgentsMdFormatRule rule = new AgentsMdFormatRule();
+			rule.setAgentsMdFile(layout.agentsMd());
+			rule.setAutoFix(autoFix);
+			return rule;
+		});
+		whenFile(parts, layout.claudeMd(), () -> {
+			MemoryImportsRule rule = new MemoryImportsRule();
+			rule.setClaudeMdFile(layout.claudeMd());
+			return rule;
+		});
+		if (claudeMdBudgetBytes > 0) {
+			whenFile(parts, layout.claudeMd(), () -> {
+				ContextBudgetRule rule = new ContextBudgetRule();
+				rule.setFiles(List.of(layout.claudeMd()));
+				rule.setMaxBytes(claudeMdBudgetBytes);
+				return rule;
+			});
+		}
+		if (layout.declaresModules()) {
+			whenFile(parts, layout.pom(), () -> {
+				ModuleMapConsistencyRule rule = new ModuleMapConsistencyRule();
+				rule.setPomFile(layout.pom());
+				rule.setDocFiles(presentOf(layout.claudeMd(), layout.agentsMd()));
+				return rule;
+			});
+		}
+	}
+
+	private void addDefinitionParts(List<ClaudeCodeEnforcerRule> parts) {
+		whenDirectory(parts, layout.skillsDir(), () -> {
+			SkillFilesExistRule rule = new SkillFilesExistRule();
+			rule.setSkillsDir(layout.skillsDir());
+			return rule;
+		});
+		whenDirectory(parts, layout.agentsDir(), () -> {
+			SubAgentFormatRule rule = new SubAgentFormatRule();
+			rule.setAgentsDir(layout.agentsDir());
+			return rule;
+		});
+		whenDirectory(parts, layout.commandsDir(), () -> {
+			CommandFormatRule rule = new CommandFormatRule();
+			rule.setCommandsDir(layout.commandsDir());
+			return rule;
+		});
+		addUniquenessParts(parts);
+	}
+
+	/**
+	 * Both uniqueness rules see all three kinds at once — a command sharing a name or
+	 * a description with a skill shadows it, and neither directory alone would show
+	 * that — so they are included when any one of the three directories exists, each
+	 * pointed only at the directories that do.
+	 */
+	private void addUniquenessParts(List<ClaudeCodeEnforcerRule> parts) {
+		if (!anyDefinitionDirectory()) {
+			return;
+		}
+		UniqueNamesRule names = new UniqueNamesRule();
+		pointAtDefinitions(names::setCommandsDir, names::setAgentsDir, names::setSkillsDir);
+		parts.add(names);
+		UniqueDescriptionsRule descriptions = new UniqueDescriptionsRule();
+		pointAtDefinitions(descriptions::setCommandsDir, descriptions::setAgentsDir, descriptions::setSkillsDir);
+		parts.add(descriptions);
+	}
+
+	private void pointAtDefinitions(DirectorySetter commands, DirectorySetter agents, DirectorySetter skills) {
+		ifDirectory(layout.commandsDir(), commands);
+		ifDirectory(layout.agentsDir(), agents);
+		ifDirectory(layout.skillsDir(), skills);
+	}
+
+	private void addSettingsParts(List<ClaudeCodeEnforcerRule> parts) {
+		whenFile(parts, layout.settingsJson(), () -> {
+			SettingsJsonValidRule rule = new SettingsJsonValidRule();
+			rule.setSettingsFile(layout.settingsJson());
+			return rule;
+		});
+		whenFile(parts, layout.settingsJson(), () -> {
+			PermissionsFormatRule rule = new PermissionsFormatRule();
+			rule.setSettingsFile(layout.settingsJson());
+			return rule;
+		});
+		whenFile(parts, layout.settingsJson(), () -> {
+			HookCommandsValidRule rule = new HookCommandsValidRule();
+			rule.setSettingsFile(layout.settingsJson());
+			rule.setProjectDir(layout.projectDir());
+			return rule;
+		});
+		whenDirectory(parts, layout.hooksDir(), () -> {
+			HooksFormatRule rule = new HooksFormatRule();
+			rule.setHooksDir(layout.hooksDir());
+			rule.setSettingsFile(layout.settingsJson());
+			rule.setProjectDir(layout.projectDir());
+			return rule;
+		});
+		whenFile(parts, layout.gitignore(), () -> {
+			LocalSettingsIgnoredRule rule = new LocalSettingsIgnoredRule();
+			rule.setGitignoreFile(layout.gitignore());
+			return rule;
+		});
+	}
+
+	private void addFileParts(List<ClaudeCodeEnforcerRule> parts) {
+		whenFile(parts, layout.mcpJson(), () -> {
+			McpServersValidRule rule = new McpServersValidRule();
+			rule.setMcpFile(layout.mcpJson());
+			return rule;
+		});
+		whenFile(parts, layout.mcpJson(), () -> {
+			McpConfigFormatRule rule = new McpConfigFormatRule();
+			rule.setMcpFile(layout.mcpJson());
+			return rule;
+		});
+		whenDirectory(parts, layout.okfBundleDir(), () -> {
+			OkfBundleFormatRule rule = new OkfBundleFormatRule();
+			rule.setBundleDir(layout.okfBundleDir());
+			return rule;
+		});
+		addSecretsPart(parts);
+	}
+
+	/**
+	 * The secret scan is pointed at every configuration file and directory the
+	 * project actually has, and included when it has any of them: a credential
+	 * committed into a hook is the finding that matters most, and a scan configured
+	 * with a directory that is not there would fail rather than scan the rest.
+	 */
+	private void addSecretsPart(List<ClaudeCodeEnforcerRule> parts) {
+		List<File> files = presentOf(layout.settingsJson(), layout.mcpJson());
+		List<File> directories = presentDirectoriesOf(layout.hooksDir(), layout.agentsDir(), layout.commandsDir(),
+				layout.skillsDir());
+		if (files.isEmpty() && directories.isEmpty()) {
+			return;
+		}
+		NoSecretsRule rule = new NoSecretsRule();
+		rule.setFiles(files);
+		rule.setDirectories(directories);
+		parts.add(rule);
+	}
+
+	private boolean anyDefinitionDirectory() {
+		return layout.commandsDir().isDirectory() || layout.agentsDir().isDirectory()
+				|| layout.skillsDir().isDirectory();
+	}
+
+	private void ifDirectory(File directory, DirectorySetter setter) {
+		if (directory.isDirectory()) {
+			setter.set(directory);
+		}
+	}
+
+	private void whenFile(List<ClaudeCodeEnforcerRule> parts, File file,
+			Supplier<ClaudeCodeEnforcerRule> part) {
+		if (file.isFile()) {
+			parts.add(part.get());
+		}
+	}
+
+	private void whenDirectory(List<ClaudeCodeEnforcerRule> parts, File directory,
+			Supplier<ClaudeCodeEnforcerRule> part) {
+		if (directory.isDirectory()) {
+			parts.add(part.get());
+		}
+	}
+
+	private List<File> presentOf(File... candidates) {
+		return Arrays.stream(candidates).filter(File::isFile).toList();
+	}
+
+	private List<File> presentDirectoriesOf(File... candidates) {
+		return Arrays.stream(candidates).filter(File::isDirectory).toList();
+	}
+
+	/** Named so the three uniqueness directories are pointed at through one shape. */
+	@FunctionalInterface
+	private interface DirectorySetter {
+		void set(File directory);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ProjectParts.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ProjectParts.java
@@ -61,13 +61,11 @@ import io.github.adamw7.tools.enforcer.settings.SettingsJsonValidRule;
 final class ProjectParts {
 
 	private final ProjectLayout layout;
-	private final boolean autoFix;
-	private final int claudeMdBudgetBytes;
+	private final DocumentContract contract;
 
-	ProjectParts(ProjectLayout layout, boolean autoFix, int claudeMdBudgetBytes) {
+	ProjectParts(ProjectLayout layout, DocumentContract contract) {
 		this.layout = layout;
-		this.autoFix = autoFix;
-		this.claudeMdBudgetBytes = claudeMdBudgetBytes;
+		this.contract = contract;
 	}
 
 	/**
@@ -87,13 +85,19 @@ final class ProjectParts {
 		whenFile(parts, layout.claudeMd(), () -> {
 			ClaudeMdFormatRule rule = new ClaudeMdFormatRule();
 			rule.setClaudeMdFile(layout.claudeMd());
-			rule.setAutoFix(autoFix);
+			rule.setAutoFix(contract.autoFix());
+			if (contract.claudeMdSections() != null) {
+				rule.setRequiredSections(contract.claudeMdSections());
+			}
+			if (contract.claudeMdReference() != null) {
+				rule.setRequiredReference(contract.claudeMdReference());
+			}
 			return rule;
 		});
 		whenFile(parts, layout.agentsMd(), () -> {
 			AgentsMdFormatRule rule = new AgentsMdFormatRule();
 			rule.setAgentsMdFile(layout.agentsMd());
-			rule.setAutoFix(autoFix);
+			rule.setAutoFix(contract.autoFix());
 			return rule;
 		});
 		whenFile(parts, layout.claudeMd(), () -> {
@@ -101,11 +105,11 @@ final class ProjectParts {
 			rule.setClaudeMdFile(layout.claudeMd());
 			return rule;
 		});
-		if (claudeMdBudgetBytes > 0) {
+		if (contract.budgetBytes() > 0) {
 			whenFile(parts, layout.claudeMd(), () -> {
 				ContextBudgetRule rule = new ContextBudgetRule();
 				rule.setFiles(List.of(layout.claudeMd()));
-				rule.setMaxBytes(claudeMdBudgetBytes);
+				rule.setMaxBytes(contract.budgetBytes());
 				return rule;
 			});
 		}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -1,13 +1,17 @@
 package io.github.adamw7.tools.enforcer.rule;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.StringJoiner;
+
+import javax.inject.Named;
 
 import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerLogger;
@@ -23,15 +27,24 @@ import io.github.adamw7.tools.markdown.MarkdownText;
  * The default severity is {@code error}. Setting
  * {@code <severity>warn</severity>} downgrades the same violations to a logged
  * warning, so a team can adopt a rule gradually before it is allowed to break the
- * build. Severity only governs collected structural violations; a misconfigured
- * rule (missing file or directory parameter) always fails, because that is a
- * build-setup mistake rather than a document-quality problem.
+ * build. Anything that is not one of those two is refused rather than read as the
+ * default; see {@link Severity}. Severity only governs collected structural
+ * violations; a misconfigured rule (missing file or directory parameter, an
+ * unreadable severity) always fails, because that is a build-setup mistake rather
+ * than a document-quality problem.
  * <p>
  * When {@code <reportFile>} is configured the same outcome is also written as a
  * self-contained HTML report — a single table pairing what failed and why with the
  * {@link #howToFix()} steps — so a build can surface the violations in a browser
  * or CI artifact. It is written whether the check passes or fails, so it always
  * reflects the latest run.
+ * <p>
+ * All three of those parameters are usually the same answer for every rule a
+ * project wires, so each also has a build-wide default — {@code
+ * -Dclaude.enforcer.severity}, {@code -Dclaude.enforcer.reportDir}, {@code
+ * -Dclaude.enforcer.baselineDir}. See {@link RuleDefaults}. A directory names each
+ * rule's file after the rule, and the reports written into one gain an
+ * {@link ReportIndex index page} linking them.
  * <p>
  * When {@code <baselineFile>} is configured, a violation already recorded in that
  * file is suppressed and only a <em>new</em> one drives the outcome. Record the
@@ -52,16 +65,27 @@ import io.github.adamw7.tools.markdown.MarkdownText;
  */
 public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 
-	private static final String WARN = "warn";
 	private static final String WRITE_BASELINE_PROPERTY = "claude.enforcer.writeBaseline";
 
-	/** Optional override: {@code error} (default) fails the build, {@code warn} only logs. */
+	/**
+	 * Optional override: {@code error} (default) fails the build, {@code warn} only
+	 * logs. Anything else is refused; see {@link Severity}. When unset the build's
+	 * {@link RuleDefaults#SEVERITY_PROPERTY} decides.
+	 */
 	private String severity;
 
-	/** Optional path for an HTML report of the outcome. When null, no report is written. */
+	/**
+	 * Optional path for an HTML report of the outcome. When unset the build's
+	 * {@link RuleDefaults#REPORT_DIR_PROPERTY} decides; when neither names one, no
+	 * report is written.
+	 */
 	private File reportFile;
 
-	/** Optional path of recorded violations to suppress. When null, nothing is suppressed. */
+	/**
+	 * Optional path of recorded violations to suppress. When unset the build's
+	 * {@link RuleDefaults#BASELINE_DIR_PROPERTY} decides; when neither names one,
+	 * nothing is suppressed.
+	 */
 	private File baselineFile;
 
 	/** When true (or the {@code claude.enforcer.writeBaseline} property is set), records the current violations. */
@@ -86,26 +110,76 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	 * does nothing when no new violation remains.
 	 */
 	protected final void report(String header, List<String> violations) throws EnforcerRuleException {
-		if (isWriteBaselineRequested()) {
-			recordBaseline(violations);
+		Severity configured = severity();
+		File baseline = baselineFile();
+		if (isWriteBaselineRequested(baseline)) {
+			recordBaseline(baseline, violations);
 			writeReport(header, List.of());
 			return;
 		}
-		Baseline baseline = Baseline.read(baselineFile, baseDir);
-		List<String> newViolations = baseline.newViolations(violations);
+		Baseline accepted = Baseline.read(baseline, baseDir);
+		List<String> newViolations = accepted.newViolations(violations);
 		writeReport(header, newViolations);
-		logSuppressed(violations.size() - newViolations.size());
-		logStaleEntries(baseline.staleEntries(violations));
+		logSuppressed(baseline, violations.size() - newViolations.size());
+		logStaleEntries(baseline, accepted.staleEntries(violations));
 		logOutcome(newViolations);
 		if (newViolations.isEmpty()) {
 			return;
 		}
 		String message = format(header, newViolations);
-		if (isWarn()) {
+		if (configured == Severity.WARN) {
 			log().warn(message + System.lineSeparator() + downgradeNotice());
 		} else {
 			throw new EnforcerRuleException(message);
 		}
+	}
+
+	/**
+	 * The severity this rule reports at: the one it was configured with, the one
+	 * {@link RuleDefaults#SEVERITY_PROPERTY} sets for the whole build, or
+	 * {@link Severity#DEFAULT}. It is read at the top of {@link #report} rather than
+	 * where the outcome is decided, so a value that is not a severity is refused
+	 * before the rule writes a report or a baseline off the back of it.
+	 */
+	private Severity severity() throws EnforcerRuleException {
+		Optional<Severity> onTheRule = Severity.parse(severity, toString());
+		if (onTheRule.isPresent()) {
+			return onTheRule.get();
+		}
+		return Severity.parse(RuleDefaults.severity(), RuleDefaults.SEVERITY_PROPERTY).orElse(Severity.DEFAULT);
+	}
+
+	/**
+	 * @return the baseline this rule reads and records, which is the one it was
+	 *         configured with or the one {@link RuleDefaults} derives from the
+	 *         build's baseline directory, and null when neither names one
+	 */
+	private File baselineFile() {
+		return baselineFile != null ? baselineFile : RuleDefaults.baselineFile(ruleName()).orElse(null);
+	}
+
+	/**
+	 * @return the report this rule writes, which is the one it was configured with or
+	 *         the one {@link RuleDefaults} derives from the build's report directory,
+	 *         and null when neither names one
+	 */
+	private File reportFile() {
+		return reportFile != null ? reportFile : RuleDefaults.reportFile(ruleName()).orElse(null);
+	}
+
+	/**
+	 * The name the pom configures this rule under, taken from the {@link Named}
+	 * annotation maven-enforcer already resolves it by, so a report and a baseline
+	 * derived from a directory are named the same thing the build's configuration
+	 * calls the rule. A rule without the annotation — only the test doubles here —
+	 * falls back to its class name, which is unique for the same reason.
+	 */
+	final String ruleName() {
+		Named named = getClass().getAnnotation(Named.class);
+		if (named == null || named.value().isBlank()) {
+			return getClass().getSimpleName();
+		}
+		return named.value();
 	}
 
 	/**
@@ -138,37 +212,80 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	 * reader to guess whether the build tolerated it deliberately.
 	 */
 	private String downgradeNotice() {
-		return "  (" + this + " has severity 'warn', so the build was not failed)";
+		return "  (" + this + " has severity '" + Severity.WARN.configuredName()
+				+ "', so the build was not failed)";
 	}
 
-	private boolean isWriteBaselineRequested() {
-		return baselineFile != null && (writeBaseline || Boolean.getBoolean(WRITE_BASELINE_PROPERTY));
+	/**
+	 * Whether this run is recording a baseline rather than checking against one.
+	 *
+	 * <p>Asking for one without a baseline to write it to is refused rather than
+	 * ignored. It used to be read as "no baseline, so check normally", which is the
+	 * answer to a question nobody asked: the operator who passed
+	 * {@code -Dclaude.enforcer.writeBaseline=true} was told the build failed on the
+	 * very violations they had just asked to accept, with nothing to say the request
+	 * had gone nowhere. Like every other build-setup mistake this fails whatever the
+	 * severity.
+	 */
+	private boolean isWriteBaselineRequested(File baseline) throws EnforcerRuleException {
+		boolean requested = writeBaseline || Boolean.getBoolean(WRITE_BASELINE_PROPERTY);
+		if (requested && baseline == null) {
+			throw new EnforcerRuleException("Recording a baseline was requested for " + this
+					+ ", which has no baselineFile to record it to. Configure <baselineFile> on the rule or set -D"
+					+ RuleDefaults.BASELINE_DIR_PROPERTY + " for the build, then re-run.");
+		}
+		return requested;
 	}
 
-	private void recordBaseline(List<String> violations) throws EnforcerRuleException {
-		Baseline.write(baselineFile, violations, baseDir);
-		log().info("Recorded " + violations.size() + " violation(s) to the baseline " + baselineFile);
+	private void recordBaseline(File baseline, List<String> violations) throws EnforcerRuleException {
+		Baseline.write(baseline, violations, baseDir);
+		log().info("Recorded " + violations.size() + " violation(s) to the baseline " + baseline);
 	}
 
-	private void logSuppressed(int suppressed) {
+	private void logSuppressed(File baseline, int suppressed) {
 		if (suppressed > 0) {
-			log().info(suppressed + " violation(s) suppressed by the baseline " + baselineFile);
+			log().info(suppressed + " violation(s) suppressed by the baseline " + baseline);
 		}
 	}
 
-	private void logStaleEntries(List<String> staleEntries) {
+	private void logStaleEntries(File baseline, List<String> staleEntries) {
 		if (!staleEntries.isEmpty()) {
 			log().info(staleEntries.size() + " baseline entry/entries no longer match and can be removed from "
-					+ baselineFile);
+					+ baseline);
 		}
 	}
 
 	private void writeReport(String header, List<String> violations) throws EnforcerRuleException {
-		if (reportFile == null) {
+		File report = reportFile();
+		if (report == null) {
 			return;
 		}
-		new HtmlReport(header, violations, howToFix()).writeTo(reportFile);
-		log().debug(() -> this + " wrote its report to " + reportFile);
+		new HtmlReport(header, violations, howToFix()).writeTo(report);
+		log().debug(() -> this + " wrote its report to " + report);
+		indexReport(violations.size());
+	}
+
+	/**
+	 * Adds this rule's outcome to the index beside the other rules' reports, when the
+	 * build collects them into one directory. A rule that was pointed at its own
+	 * {@code reportFile} is not indexed: nothing says that file sits with anyone
+	 * else's, and writing an index into a directory the build only asked for one
+	 * report in would be inventing an artifact.
+	 *
+	 * <p>A failure here is logged rather than thrown. The verdict is already decided
+	 * and the rule's own report already written; a build must not go red because the
+	 * page linking the reports could not be refreshed.
+	 */
+	private void indexReport(int violations) {
+		RuleDefaults.reportDirectory().ifPresent(directory -> index(directory, violations));
+	}
+
+	private void index(File directory, int violations) {
+		try {
+			ReportIndex.record(directory, ruleName(), violations);
+		} catch (IOException | RuntimeException e) {
+			log().warn("Could not update the report index in " + directory + ": " + e.getMessage());
+		}
 	}
 
 	/**
@@ -185,10 +302,6 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	private String format(String header, List<String> violations) {
 		String separator = System.lineSeparator() + "  - ";
 		return header + separator + String.join(separator, violations);
-	}
-
-	private boolean isWarn() {
-		return WARN.equalsIgnoreCase(severity);
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -102,6 +102,34 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	private File baseDir;
 
 	/**
+	 * Set when a composite rule runs this one as one of its parts, in which case the
+	 * violations are handed over instead of decided on here: the composite reports
+	 * every part's findings together, under its own severity, baseline and report.
+	 * Null for a rule a pom configured directly, which is every rule by default.
+	 */
+	private ViolationSink sink;
+
+	/**
+	 * Where a rule run as part of a composite sends what it found. It is given the
+	 * rule's name as well as its violations, because a composite's report has to say
+	 * which of its parts each violation came from — that name is what a reader takes
+	 * back to the catalogue, and what they would configure to switch the part off.
+	 */
+	@FunctionalInterface
+	public interface ViolationSink {
+		void accept(String ruleName, List<String> violations);
+	}
+
+	/**
+	 * Runs this rule as part of {@code sink}'s composite rather than on its own
+	 * account. A rule collects its violations the same way either way; what changes
+	 * is only who decides what they mean.
+	 */
+	public final void reportTo(ViolationSink sink) {
+		this.sink = sink;
+	}
+
+	/**
 	 * Reports the violations as a single grouped message. In write-baseline mode it
 	 * records every violation to {@link #baselineFile} and passes, writing the HTML
 	 * report as the pass it is — the report always shows the un-suppressed
@@ -112,6 +140,10 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	 * does nothing when no new violation remains.
 	 */
 	protected final void report(String header, List<String> violations) throws EnforcerRuleException {
+		if (sink != null) {
+			sink.accept(ruleName(), violations);
+			return;
+		}
 		Severity configured = severity();
 		File baseline = baselineFile();
 		if (isWriteBaselineRequested(baseline)) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -348,10 +348,14 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	 * as an internal error, which is the one outcome a rule must not have: a
 	 * {@code .gitignore} carrying a single Latin-1 byte took the build down with a
 	 * stack trace instead of the verdict the rule exists to give.
+	 * <p>
+	 * The read goes through {@link DocumentCache}, so the four rules that each check
+	 * a section of {@code settings.json} read it once between them.
 	 */
 	protected final String requireText(File file, String description) throws EnforcerRuleException {
-		return MarkdownText.readIfText(file).orElseThrow(() -> new EnforcerRuleException(
-				description + " cannot be read as UTF-8 text: " + file));
+		return DocumentCache.text(file, () -> MarkdownText.readIfText(file))
+				.orElseThrow(() -> new EnforcerRuleException(
+						description + " cannot be read as UTF-8 text: " + file));
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -7,11 +7,10 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
-
-import javax.inject.Named;
 
 import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerLogger;
@@ -66,6 +65,9 @@ import io.github.adamw7.tools.markdown.MarkdownText;
 public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 
 	private static final String WRITE_BASELINE_PROPERTY = "claude.enforcer.writeBaseline";
+
+	/** Stripped from a class name to derive the name a pom configures the rule under. */
+	private static final String RULE_SUFFIX = "Rule";
 
 	/**
 	 * Optional override: {@code error} (default) fails the build, {@code warn} only
@@ -168,18 +170,29 @@ public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 	}
 
 	/**
-	 * The name the pom configures this rule under, taken from the {@link Named}
-	 * annotation maven-enforcer already resolves it by, so a report and a baseline
-	 * derived from a directory are named the same thing the build's configuration
-	 * calls the rule. A rule without the annotation — only the test doubles here —
-	 * falls back to its class name, which is unique for the same reason.
+	 * The name the pom configures this rule under, so a report and a baseline derived
+	 * from a directory are named the same thing the build's configuration calls the
+	 * rule.
+	 *
+	 * <p>It is derived from the class name — the simple name without its {@code Rule}
+	 * suffix, decapitalised — rather than read back from the {@code @Named} annotation
+	 * that carries it. The two cannot disagree: {@code ruleNamesFollowTheClassName} in
+	 * the architecture tests is what holds every rule's annotation to this derivation,
+	 * for the separate reason that a pom, CLAUDE.md and AGENTS.md all name a rule and
+	 * a reader has to be able to predict it.
+	 *
+	 * <p>Deriving it also keeps {@code javax.inject} off the path a rule takes to
+	 * report. Reading the annotation put it there, and the adopt module — which runs
+	 * the real claudeMdFormat rule over its conformer's output, with no injection
+	 * framework anywhere — failed on a class it never uses.
 	 */
 	final String ruleName() {
-		Named named = getClass().getAnnotation(Named.class);
-		if (named == null || named.value().isBlank()) {
-			return getClass().getSimpleName();
-		}
-		return named.value();
+		String simpleName = getClass().getSimpleName();
+		String withoutSuffix = simpleName.endsWith(RULE_SUFFIX)
+				? simpleName.substring(0, simpleName.length() - RULE_SUFFIX.length())
+				: simpleName;
+		return withoutSuffix.isEmpty() ? simpleName
+				: withoutSuffix.substring(0, 1).toLowerCase(Locale.ROOT) + withoutSuffix.substring(1);
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/DocumentCache.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/DocumentCache.java
@@ -1,0 +1,141 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.github.adamw7.tools.markdown.MarkdownDocument;
+
+/**
+ * Reads and parses each input file once per build, however many rules ask for it.
+ *
+ * <p>The rules are deliberately independent — each names its own inputs and
+ * reaches a verdict on them alone — and the cost of that is that they overlap. A
+ * project wiring the catalogue has {@code CLAUDE.md} read and parsed by
+ * {@code claudeMdFormat}, {@code contextBudget}, {@code memoryImports},
+ * {@code crossDocConsistency} and {@code moduleMapConsistency}, and
+ * {@code settings.json} read and parsed by {@code settingsJsonValid},
+ * {@code hookCommandsValid}, {@code hooksFormat} and {@code permissionsFormat}.
+ * Sharing the result costs the rules none of their independence, because what is
+ * shared is the file's content and not any rule's reading of it.
+ *
+ * <p>An entry is keyed by what the file <em>is</em> rather than by where it is:
+ * the path together with its modification time and size. A file rewritten during
+ * the build — which {@code autoFix} does — therefore misses rather than serving
+ * the content it had before the fix, without anything having to remember to
+ * invalidate it. Only successful reads and parses are kept; a file that could not
+ * be read or did not parse is re-read, since the rule that asked is about to fail
+ * the build anyway and a cached failure would have to carry its diagnosis too.
+ *
+ * <p>The cache is static because a Maven session builds each rule afresh, so
+ * anything held per instance is held for exactly one rule. It is bounded and
+ * dropped wholesale when it fills: entries are worth keeping for one build, and a
+ * build reads a handful of files.
+ */
+final class DocumentCache {
+
+	/**
+	 * Roughly an order of magnitude more entries than a build touches, so the clear
+	 * below is a safety net against a long-lived JVM (an IDE, a daemon, the
+	 * integration tests' repeated runs) rather than something a build reaches.
+	 */
+	private static final int MAX_ENTRIES = 512;
+
+	private static final Map<Key, String> TEXT = new ConcurrentHashMap<>();
+	private static final Map<Key, MarkdownDocument> MARKDOWN = new ConcurrentHashMap<>();
+	private static final Map<Key, JsonNode> JSON = new ConcurrentHashMap<>();
+
+	private DocumentCache() {
+	}
+
+	/**
+	 * The file's text, read through {@code reader} on a miss.
+	 *
+	 * @param reader reads the file, answering empty when it is not readable as text
+	 */
+	static Optional<String> text(File file, Supplier<Optional<String>> reader) {
+		return cached(TEXT, file, reader);
+	}
+
+	/** The file's parsed Markdown, parsed from {@code content} on a miss. */
+	static MarkdownDocument markdown(File file, String content) {
+		return cached(MARKDOWN, file, () -> Optional.of(MarkdownDocument.parse(content)))
+				.orElseGet(() -> MarkdownDocument.parse(content));
+	}
+
+	/**
+	 * The file's parsed JSON, parsed through {@code parser} on a miss. A parse that
+	 * failed answers empty and is not kept, so the violation it collected is
+	 * collected again for the next rule that asks.
+	 */
+	static Optional<JsonNode> json(File file, Supplier<Optional<JsonNode>> parser) {
+		return cached(JSON, file, parser);
+	}
+
+	private static <T> Optional<T> cached(Map<Key, T> cache, File file, Supplier<Optional<T>> load) {
+		Optional<Key> key = Key.of(file);
+		if (key.isEmpty()) {
+			return load.get();
+		}
+		T hit = cache.get(key.get());
+		if (hit != null) {
+			return Optional.of(hit);
+		}
+		Optional<T> loaded = load.get();
+		loaded.ifPresent(value -> store(cache, key.get(), value));
+		return loaded;
+	}
+
+	private static <T> void store(Map<Key, T> cache, Key key, T value) {
+		if (cache.size() >= MAX_ENTRIES) {
+			cache.clear();
+		}
+		cache.put(key, value);
+	}
+
+	/** Drops everything held, so a test can prove a read happened rather than a hit. */
+	static void clear() {
+		TEXT.clear();
+		MARKDOWN.clear();
+		JSON.clear();
+	}
+
+	/**
+	 * What identifies a file's content for the length of a build: where it is, when
+	 * it was last written, and how big it is. A file whose stamp cannot be read —
+	 * because it is not there, or the filesystem refused — yields no key at all, and
+	 * the caller reads it directly: the rule's own missing-file diagnosis is a better
+	 * answer than anything this class could invent.
+	 */
+	private record Key(Path path, long lastModified, long size) {
+
+		static Optional<Key> of(File file) {
+			try {
+				Path path = file.toPath().toAbsolutePath().normalize();
+				BasicFileAttributes attributes = Files.readAttributes(path, BasicFileAttributes.class);
+				return Optional.of(new Key(path, nanoseconds(attributes), attributes.size()));
+			} catch (IOException | RuntimeException e) {
+				return Optional.empty();
+			}
+		}
+
+		/**
+		 * The finest modification time the filesystem records. Truncating to
+		 * milliseconds would leave a window in which two writes stamp identically, and
+		 * an equal-length rewrite inside it would be served from the cache — exactly the
+		 * stale read this key exists to prevent.
+		 */
+		private static long nanoseconds(BasicFileAttributes attributes) {
+			return attributes.lastModifiedTime().to(TimeUnit.NANOSECONDS);
+		}
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/DocumentCache.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/DocumentCache.java
@@ -11,8 +11,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import io.github.adamw7.tools.markdown.MarkdownDocument;
 
 /**
@@ -50,9 +48,15 @@ final class DocumentCache {
 	 */
 	private static final int MAX_ENTRIES = 512;
 
-	private static final Map<Key, String> TEXT = new ConcurrentHashMap<>();
-	private static final Map<Key, MarkdownDocument> MARKDOWN = new ConcurrentHashMap<>();
-	private static final Map<Key, JsonNode> JSON = new ConcurrentHashMap<>();
+	/**
+	 * One map for every kind of entry, keyed by the file and what was made of it.
+	 * Values are held as {@link Object} and cast back on the way out, so that nothing
+	 * here names the type of any particular parse — a cache that mentioned Jackson
+	 * dragged it onto the classpath of every caller that loads a rule, and the adopt
+	 * module's contract test, which runs the real claudeMdFormat rule with no JSON
+	 * parser anywhere, failed to load a class it never uses.
+	 */
+	private static final Map<Entry, Object> CACHE = new ConcurrentHashMap<>();
 
 	private DocumentCache() {
 	}
@@ -63,50 +67,59 @@ final class DocumentCache {
 	 * @param reader reads the file, answering empty when it is not readable as text
 	 */
 	static Optional<String> text(File file, Supplier<Optional<String>> reader) {
-		return cached(TEXT, file, reader);
+		return cached(Kind.TEXT, file, reader);
 	}
 
 	/** The file's parsed Markdown, parsed from {@code content} on a miss. */
 	static MarkdownDocument markdown(File file, String content) {
-		return cached(MARKDOWN, file, () -> Optional.of(MarkdownDocument.parse(content)))
+		return DocumentCache.<MarkdownDocument>cached(Kind.MARKDOWN, file,
+				() -> Optional.of(MarkdownDocument.parse(content)))
 				.orElseGet(() -> MarkdownDocument.parse(content));
 	}
 
 	/**
-	 * The file's parsed JSON, parsed through {@code parser} on a miss. A parse that
+	 * The file's parsed form, parsed through {@code parser} on a miss. A parse that
 	 * failed answers empty and is not kept, so the violation it collected is
 	 * collected again for the next rule that asks.
 	 */
-	static Optional<JsonNode> json(File file, Supplier<Optional<JsonNode>> parser) {
-		return cached(JSON, file, parser);
+	static <T> Optional<T> parsed(File file, Supplier<Optional<T>> parser) {
+		return cached(Kind.PARSED, file, parser);
 	}
 
-	private static <T> Optional<T> cached(Map<Key, T> cache, File file, Supplier<Optional<T>> load) {
+	@SuppressWarnings("unchecked")
+	private static <T> Optional<T> cached(Kind kind, File file, Supplier<Optional<T>> load) {
 		Optional<Key> key = Key.of(file);
 		if (key.isEmpty()) {
 			return load.get();
 		}
-		T hit = cache.get(key.get());
+		Entry entry = new Entry(key.get(), kind);
+		Object hit = CACHE.get(entry);
 		if (hit != null) {
-			return Optional.of(hit);
+			return Optional.of((T) hit);
 		}
 		Optional<T> loaded = load.get();
-		loaded.ifPresent(value -> store(cache, key.get(), value));
+		loaded.ifPresent(value -> store(entry, value));
 		return loaded;
 	}
 
-	private static <T> void store(Map<Key, T> cache, Key key, T value) {
-		if (cache.size() >= MAX_ENTRIES) {
-			cache.clear();
+	private static void store(Entry entry, Object value) {
+		if (CACHE.size() >= MAX_ENTRIES) {
+			CACHE.clear();
 		}
-		cache.put(key, value);
+		CACHE.put(entry, value);
 	}
 
 	/** Drops everything held, so a test can prove a read happened rather than a hit. */
 	static void clear() {
-		TEXT.clear();
-		MARKDOWN.clear();
-		JSON.clear();
+		CACHE.clear();
+	}
+
+	/** What was made of a file, so one file's text and its parse are two entries. */
+	private enum Kind {
+		TEXT, MARKDOWN, PARSED
+	}
+
+	private record Entry(Key key, Kind kind) {
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -88,7 +88,7 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 	 */
 	private Optional<JsonNode> parse(File file, List<String> violations) throws EnforcerRuleException {
 		String content = requireContent(file, description);
-		return DocumentCache.json(file,
+		return DocumentCache.parsed(file,
 				() -> Optional.ofNullable(JsonNodes.parseObject(content, description, violations)));
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/JsonFileRule.java
@@ -60,7 +60,7 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 			return;
 		}
 		List<String> violations = new ArrayList<>();
-		JsonNode root = JsonNodes.parseObject(requireContent(file, description), description, violations);
+		JsonNode root = parse(file, violations).orElse(null);
 		if (root != null) {
 			collectViolations(root, violations);
 		}
@@ -78,6 +78,18 @@ public abstract class JsonFileRule extends ClaudeCodeEnforcerRule {
 		}
 		log().debug(() -> description + " is absent at " + file + ", which this rule accepts; nothing to check");
 		report(header(), List.of());
+	}
+
+	/**
+	 * The parsed file, through {@link DocumentCache} so the four rules that each
+	 * check a section of {@code settings.json} parse it once between them. A parse
+	 * that fails is not cached: it collects the violation that says why, and the next
+	 * rule to ask needs that violation too.
+	 */
+	private Optional<JsonNode> parse(File file, List<String> violations) throws EnforcerRuleException {
+		String content = requireContent(file, description);
+		return DocumentCache.json(file,
+				() -> Optional.ofNullable(JsonNodes.parseObject(content, description, violations)));
 	}
 
 	/** The JSON file to validate. Injected from the rule configuration. */

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -163,10 +163,16 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 		this.referenceBaseDir = referenceBaseDir;
 	}
 
+	/**
+	 * Reading and parsing both go through {@link DocumentCache}, so the five rules
+	 * that each check something about {@code CLAUDE.md} parse it once between them.
+	 * They stay independent either way: what is shared is the document, not any
+	 * rule's reading of it.
+	 */
 	private MarkdownDocument readDocument() throws EnforcerRuleException {
 		File file = documentFile();
 		requireDocument(file, documentName());
-		return MarkdownDocument.parse(requireContent(file, documentName()));
+		return DocumentCache.markdown(file, requireContent(file, documentName()));
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/MarkdownFormatRule.java
@@ -12,6 +12,9 @@ import java.util.regex.Pattern;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
+import io.github.adamw7.tools.markdown.LineTerminators;
+import io.github.adamw7.tools.markdown.MarkdownConformer;
+import io.github.adamw7.tools.markdown.MarkdownContract;
 import io.github.adamw7.tools.markdown.MarkdownDocument;
 import io.github.adamw7.tools.markdown.MarkdownText;
 
@@ -36,6 +39,20 @@ import io.github.adamw7.tools.markdown.MarkdownText;
  * disk. The title and required sections default to the subclass-provided values
  * but can be overridden, so the rule is reusable across projects without a
  * recompile.
+ * <p>
+ * With {@code <autoFix>true</autoFix>} the structural part of that contract is
+ * <em>repaired</em> rather than merely reported: the document is reshaped by
+ * {@link MarkdownConformer} — the same reshape the adoption pipeline runs, against
+ * the same {@link MarkdownDocument} reader this rule judges the result with — and
+ * the checks then run over the repaired document. A missing title, a heading that
+ * is a near miss for a required one, an absent or empty section, and a missing
+ * companion-document reference are all mechanical edits with one correct answer,
+ * and reporting them left that answer to be typed out by hand on every project
+ * that adopts the rule.
+ * <p>
+ * Only that structural part is repaired. A forbidden token, an over-long line and
+ * a broken file reference are still reported, because each of those has no one
+ * correct repair — what a link ought to point at is the author's to say.
  */
 public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 
@@ -71,6 +88,9 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 
 	/** Base directory for resolving relative file references. Defaults to the document's directory. */
 	private File referenceBaseDir;
+
+	/** When true, the document's structure is repaired in place before it is checked. */
+	private boolean autoFix;
 
 	/**
 	 * @param documentName            human-readable file name used in messages, e.g.
@@ -163,6 +183,30 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 		this.referenceBaseDir = referenceBaseDir;
 	}
 
+	public void setAutoFix(boolean autoFix) {
+		this.autoFix = autoFix;
+	}
+
+	/**
+	 * The companion document the checked document must mention in prose, empty when
+	 * it must mention none. The base class asks so that a repair can insert a missing
+	 * reference; the check for it belongs to whichever subclass makes it.
+	 */
+	protected String requiredReference() {
+		return "";
+	}
+
+	/**
+	 * The shape a repair reshapes the document into: exactly what this rule goes on to
+	 * check it for, read from the same configured parameters. Deriving one from the
+	 * other is what stops a repair satisfying a contract the rule no longer makes.
+	 */
+	private MarkdownContract contract() {
+		return MarkdownContract.titled(titleHeading())
+				.requiring(requiredSections())
+				.referencing(requiredReference());
+	}
+
 	/**
 	 * Reading and parsing both go through {@link DocumentCache}, so the five rules
 	 * that each check something about {@code CLAUDE.md} parse it once between them.
@@ -172,7 +216,30 @@ public abstract class MarkdownFormatRule extends ClaudeCodeEnforcerRule {
 	private MarkdownDocument readDocument() throws EnforcerRuleException {
 		File file = documentFile();
 		requireDocument(file, documentName());
-		return DocumentCache.markdown(file, requireContent(file, documentName()));
+		String content = repaired(file, requireContent(file, documentName()));
+		return DocumentCache.markdown(file, content);
+	}
+
+	/**
+	 * Reshapes the document and writes it back when {@code autoFix} is on and the
+	 * reshape actually changed something, answering the content the checks then run
+	 * over. A reshape that changed nothing is not written, so a conforming document
+	 * keeps its modification time and a build that repairs nothing touches no file.
+	 *
+	 * <p>The line terminators the file already used are put back, so repairing a CRLF
+	 * document does not rewrite every line of it as a side effect.
+	 */
+	private String repaired(File file, String content) throws EnforcerRuleException {
+		if (!autoFix) {
+			return content;
+		}
+		String conformed = LineTerminators.matching(new MarkdownConformer(contract()).conform(content), content);
+		if (conformed.equals(content)) {
+			return content;
+		}
+		MarkdownText.write(file, conformed, documentName());
+		log().info("Auto-fixed the structure of " + documentName() + " in " + file);
+		return conformed;
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ReportIndex.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ReportIndex.java
@@ -1,0 +1,168 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+
+/**
+ * The one page a build's reports are read from: an {@code index.html} beside the
+ * per-rule reports, listing every rule that has reported into the directory and
+ * whether it passed.
+ *
+ * <p>Twenty rules writing twenty HTML files is twenty files nobody opens. Each
+ * rule still writes its own — that is where its violations and its remediation
+ * steps are — but the index says which of them are worth opening, which is the
+ * question a reader arrives with.
+ *
+ * <p>A rule reports as it runs and no rule knows what the others found, so the
+ * index is rebuilt from a sidecar of outcomes rather than assembled at the end:
+ * each rule records its own line, and the page is regenerated from every line
+ * recorded so far. A build that runs a subset of the rules therefore indexes that
+ * subset, and re-running one rule updates its row rather than duplicating it.
+ *
+ * <p>Failing to write the index never fails the build. The rule's own verdict has
+ * already been decided and its own report already written; losing the page that
+ * links them is not worth converting a passing build into a broken one, so it is
+ * reported as a warning and the run continues.
+ */
+final class ReportIndex {
+
+	static final String INDEX_FILE = "index.html";
+
+	/**
+	 * The recorded outcomes the page is rebuilt from. It is not itself HTML because
+	 * the page is regenerated whole on every write, and re-parsing markup to find out
+	 * what the previous rules found is a worse way to keep a list of pairs.
+	 */
+	static final String SIDECAR_FILE = ".claude-code-enforcer-index";
+
+	private static final String SEPARATOR = "\t";
+
+	private ReportIndex() {
+	}
+
+	/**
+	 * Records one rule's outcome and rebuilds the index around it.
+	 *
+	 * @param directory  the report directory the rule wrote its own report into
+	 * @param ruleName   the rule's configured name, which is also its report's file name
+	 * @param violations how many un-suppressed violations it reported
+	 * @throws IOException when the sidecar or the page cannot be written, which the
+	 *                     caller downgrades to a warning
+	 */
+	static synchronized void record(File directory, String ruleName, int violations) throws IOException {
+		Path path = directory.toPath().toAbsolutePath();
+		Files.createDirectories(path);
+		Map<String, Integer> outcomes = read(path.resolve(SIDECAR_FILE));
+		outcomes.put(ruleName, violations);
+		write(path.resolve(SIDECAR_FILE), outcomes);
+		Files.writeString(path.resolve(INDEX_FILE), render(outcomes), StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * The outcomes recorded so far, sorted by rule name so the page's order is the
+	 * build's to read rather than the order the reactor happened to run the rules in.
+	 * A sidecar line that is not a name and a count is dropped: the file lives in a
+	 * build directory anyone may write to, and a rule's verdict must not depend on
+	 * what it found there.
+	 */
+	private static Map<String, Integer> read(Path sidecar) throws IOException {
+		Map<String, Integer> outcomes = new TreeMap<>();
+		if (!Files.isRegularFile(sidecar)) {
+			return outcomes;
+		}
+		for (String line : Files.readAllLines(sidecar, StandardCharsets.UTF_8)) {
+			parse(line, outcomes);
+		}
+		return outcomes;
+	}
+
+	private static void parse(String line, Map<String, Integer> outcomes) {
+		String[] fields = line.split(SEPARATOR, 2);
+		if (fields.length == 2 && !fields[0].isBlank()) {
+			count(fields[1]).ifPresent(violations -> outcomes.put(fields[0], violations));
+		}
+	}
+
+	private static Optional<Integer> count(String field) {
+		try {
+			return Optional.of(Integer.valueOf(field.strip()));
+		} catch (NumberFormatException e) {
+			return Optional.empty();
+		}
+	}
+
+	private static void write(Path sidecar, Map<String, Integer> outcomes) throws IOException {
+		List<String> lines = outcomes.entrySet().stream()
+				.map(outcome -> outcome.getKey() + SEPARATOR + outcome.getValue())
+				.toList();
+		Files.write(sidecar, lines, StandardCharsets.UTF_8);
+	}
+
+	static String render(Map<String, Integer> outcomes) {
+		Map<String, Integer> ordered = new TreeMap<>(outcomes);
+		StringBuilder html = new StringBuilder();
+		html.append("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n");
+		html.append("<meta charset=\"utf-8\">\n");
+		html.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+		html.append("<title>Claude Code Enforcer reports</title>\n");
+		html.append("<style>").append(css()).append("</style>\n");
+		html.append("</head>\n<body>\n<main>\n");
+		html.append("<h1>Claude Code Enforcer reports</h1>\n");
+		appendSummary(html, ordered);
+		appendTable(html, ordered);
+		html.append("</main>\n</body>\n</html>\n");
+		return html.toString();
+	}
+
+	private static void appendSummary(StringBuilder html, Map<String, Integer> outcomes) {
+		long failed = outcomes.values().stream().filter(violations -> violations > 0).count();
+		String status = failed == 0 ? "passed" : "failed";
+		html.append("<p class=\"status ").append(status).append("\">")
+				.append(outcomes.size() - failed).append(" of ").append(outcomes.size())
+				.append(" rule(s) passed</p>\n");
+	}
+
+	private static void appendTable(StringBuilder html, Map<String, Integer> outcomes) {
+		html.append("<table>\n<thead>\n<tr><th>Rule</th><th>Violations</th></tr>\n</thead>\n<tbody>\n");
+		outcomes.forEach((rule, violations) -> appendRow(html, rule, violations));
+		html.append("</tbody>\n</table>\n");
+	}
+
+	private static void appendRow(StringBuilder html, String rule, int violations) {
+		String cell = violations == 0 ? "<td class=\"ok\">none</td>"
+				: "<td class=\"bad\">" + violations + "</td>";
+		html.append("<tr><td><a href=\"").append(escape(rule)).append(".html\">").append(escape(rule))
+				.append("</a></td>").append(cell).append("</tr>\n");
+	}
+
+	private static String css() {
+		return "body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;"
+				+ "line-height:1.5;color:#1a1a1a;background:#f6f7f9;margin:0;padding:2rem;}"
+				+ "main{max-width:52rem;margin:0 auto;background:#fff;padding:1.5rem 2rem;"
+				+ "border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,.1);}"
+				+ "h1{font-size:1.5rem;margin:0 0 .5rem;}"
+				+ ".status{display:inline-block;font-weight:600;padding:.25rem .75rem;border-radius:999px;}"
+				+ ".status.failed{background:#fdecea;color:#b3261e;}"
+				+ ".status.passed{background:#e6f4ea;color:#1e7e34;}"
+				+ "table{border-collapse:collapse;width:100%;margin:1rem 0;}"
+				+ "th,td{border:1px solid #e0e0e0;padding:.5rem .75rem;text-align:left;}"
+				+ "thead th{background:#f0f1f3;font-weight:600;}"
+				+ "td.ok{color:#1e7e34;}td.bad{color:#b3261e;font-weight:600;}";
+	}
+
+	/** Escapes the five characters that are significant in HTML text and attributes. */
+	private static String escape(String text) {
+		return text.replace("&", "&amp;")
+				.replace("<", "&lt;")
+				.replace(">", "&gt;")
+				.replace("\"", "&quot;")
+				.replace("'", "&#39;");
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/RuleDefaults.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/RuleDefaults.java
@@ -1,0 +1,66 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import java.io.File;
+import java.util.Optional;
+
+/**
+ * The reporting configuration a build sets once for every rule, read from system
+ * properties so a pom does not have to repeat it per rule.
+ *
+ * <p>A project wiring the full catalogue configures around twenty rules, and
+ * {@code severity}, {@code reportFile} and {@code baselineFile} are the three
+ * parameters that are the <em>same answer</em> for all of them: a team adopting
+ * the rules gradually wants every rule downgraded, not one, and a build
+ * publishing reports wants all of them under one directory. Spelled per rule that
+ * is sixty elements to keep in step, and a rule left out of the sweep is a rule
+ * whose severity silently differs from its neighbours'.
+ *
+ * <table>
+ * <caption>The properties and what they default</caption>
+ * <tr><th>Property</th><th>Defaults</th></tr>
+ * <tr><td>{@code claude.enforcer.severity}</td><td>every rule's {@code severity}</td></tr>
+ * <tr><td>{@code claude.enforcer.reportDir}</td><td>{@code reportFile} to {@code <dir>/<ruleName>.html}</td></tr>
+ * <tr><td>{@code claude.enforcer.baselineDir}</td><td>{@code baselineFile} to {@code <dir>/<ruleName>.txt}</td></tr>
+ * </table>
+ *
+ * <p>A parameter configured on the rule itself always wins: the property is a
+ * default, not an override, so a build can downgrade the catalogue and still
+ * insist on one rule. Naming the files after the rule is what makes the
+ * directories work at all — two rules sharing one report file would each
+ * overwrite the other's verdict, and one shared baseline would let a violation
+ * accepted for one rule suppress an identical message from another.
+ */
+final class RuleDefaults {
+
+	static final String SEVERITY_PROPERTY = "claude.enforcer.severity";
+	static final String REPORT_DIR_PROPERTY = "claude.enforcer.reportDir";
+	static final String BASELINE_DIR_PROPERTY = "claude.enforcer.baselineDir";
+
+	private RuleDefaults() {
+	}
+
+	/** The severity every rule falls back to, as configured text for {@link Severity#parse}. */
+	static String severity() {
+		return property(SEVERITY_PROPERTY).orElse(null);
+	}
+
+	/** @return {@code <reportDir>/<ruleName>.html}, or empty when no report directory is set */
+	static Optional<File> reportFile(String ruleName) {
+		return property(REPORT_DIR_PROPERTY).map(directory -> new File(directory, ruleName + ".html"));
+	}
+
+	/** @return {@code <baselineDir>/<ruleName>.txt}, or empty when no baseline directory is set */
+	static Optional<File> baselineFile(String ruleName) {
+		return property(BASELINE_DIR_PROPERTY).map(directory -> new File(directory, ruleName + ".txt"));
+	}
+
+	/** @return the directory reports are collected under, for the index that links them */
+	static Optional<File> reportDirectory() {
+		return property(REPORT_DIR_PROPERTY).map(File::new);
+	}
+
+	/** A property set to whitespace names no value, the same reading a blank pom element gets. */
+	private static Optional<String> property(String name) {
+		return Optional.ofNullable(System.getProperty(name)).map(String::strip).filter(value -> !value.isEmpty());
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Severity.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Severity.java
@@ -1,0 +1,69 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+/**
+ * What a rule does with the violations it collected: fail the build, or log them
+ * and let it through. Configured as {@code <severity>} on any rule, defaulting to
+ * {@link #ERROR}.
+ *
+ * <p>An unrecognised value is refused rather than read as the default. Deciding
+ * "not {@code warn}, therefore {@code error}" meant {@code <severity>warning</severity>}
+ * and {@code <severity>info</severity>} failed the build while the author who
+ * wrote them believed the rule had been downgraded — the one misconfiguration
+ * whose symptom is indistinguishable from the rule working. Every other
+ * build-setup mistake in {@link ClaudeCodeEnforcerRule} — an unconfigured
+ * parameter, a file that is not there — fails immediately and says what was
+ * wrong with the configuration, and this is one of those.
+ */
+public enum Severity {
+
+	/** Collected violations fail the build. The default. */
+	ERROR,
+
+	/** Collected violations are logged and the build continues. */
+	WARN;
+
+	/** The default when neither the rule nor {@link RuleDefaults} names one. */
+	static final Severity DEFAULT = ERROR;
+
+	/**
+	 * Reads a configured severity, tolerating case and surrounding whitespace: a
+	 * {@code <severity>} element indented across lines arrives padded, and a rule
+	 * refusing {@code "warn\n\t"} would be refusing what the author plainly wrote.
+	 *
+	 * @param configured the value as configured, which may be null or blank for none
+	 * @return the severity it names, or empty when it names none at all
+	 * @throws EnforcerRuleException when it names something that is not a severity
+	 */
+	static Optional<Severity> parse(String configured, String ruleLabel) throws EnforcerRuleException {
+		if (configured == null || configured.isBlank()) {
+			return Optional.empty();
+		}
+		String normalized = configured.strip().toUpperCase(Locale.ROOT);
+		return Optional.of(Arrays.stream(values())
+				.filter(severity -> severity.name().equals(normalized))
+				.findFirst()
+				.orElseThrow(() -> unrecognized(configured, ruleLabel)));
+	}
+
+	private static EnforcerRuleException unrecognized(String configured, String ruleLabel) {
+		return new EnforcerRuleException("The severity '" + configured.strip() + "' configured on " + ruleLabel
+				+ " is not a severity. Use one of " + names() + ". A value that is neither was previously read"
+				+ " as '" + DEFAULT.configuredName() + "', so a rule meant to be downgraded still failed the build.");
+	}
+
+	private static String names() {
+		return Arrays.stream(values()).map(Severity::configuredName).collect(Collectors.joining(", "));
+	}
+
+	/** The lower-case spelling a pom configures, which is how every message names one. */
+	String configuredName() {
+		return name().toLowerCase(Locale.ROOT);
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/secret/NoSecretsRule.java
@@ -121,11 +121,11 @@ public class NoSecretsRule extends ClaudeCodeEnforcerRule {
 		return patterns;
 	}
 
-	void setFiles(List<File> files) {
+	public void setFiles(List<File> files) {
 		this.files = files;
 	}
 
-	void setDirectories(List<File> directories) {
+	public void setDirectories(List<File> directories) {
 		this.directories = directories;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -164,11 +164,11 @@ public class HookCommandsValidRule extends JsonFileRule {
 		return new ClaudeProjectDir(projectDir, settingsFile).scriptsIn(command);
 	}
 
-	void setSettingsFile(File settingsFile) {
+	public void setSettingsFile(File settingsFile) {
 		this.settingsFile = settingsFile;
 	}
 
-	void setProjectDir(File projectDir) {
+	public void setProjectDir(File projectDir) {
 		this.projectDir = projectDir;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HooksFormatRule.java
@@ -160,15 +160,15 @@ public class HooksFormatRule extends ClaudeCodeEnforcerRule {
 				.collectViolations(scripts, violations);
 	}
 
-	void setHooksDir(File hooksDir) {
+	public void setHooksDir(File hooksDir) {
 		this.hooksDir = hooksDir;
 	}
 
-	void setSettingsFile(File settingsFile) {
+	public void setSettingsFile(File settingsFile) {
 		this.settingsFile = settingsFile;
 	}
 
-	void setProjectDir(File projectDir) {
+	public void setProjectDir(File projectDir) {
 		this.projectDir = projectDir;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/LocalSettingsIgnoredRule.java
@@ -71,7 +71,7 @@ public class LocalSettingsIgnoredRule extends ClaudeCodeEnforcerRule {
 		return withoutDot.startsWith("/") ? withoutDot.substring(1) : withoutDot;
 	}
 
-	void setGitignoreFile(File gitignoreFile) {
+	public void setGitignoreFile(File gitignoreFile) {
 		this.gitignoreFile = gitignoreFile;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
@@ -183,7 +183,7 @@ public class PermissionsFormatRule extends JsonFileRule {
 		return open < 0 ? value : value.substring(0, open);
 	}
 
-	void setSettingsFile(File settingsFile) {
+	public void setSettingsFile(File settingsFile) {
 		this.settingsFile = settingsFile;
 	}
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
@@ -63,7 +63,7 @@ public class SettingsJsonValidRule extends JsonFileRule {
 		return permissions != null ? Permissions.entriesIn(permissions, Permissions.ALLOW_KEY) : Set.of();
 	}
 
-	void setSettingsFile(File settingsFile) {
+	public void setSettingsFile(File settingsFile) {
 		this.settingsFile = settingsFile;
 	}
 

--- a/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/claude-code-enforcer/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -20,3 +20,4 @@ io.github.adamw7.tools.enforcer.settings.LocalSettingsIgnoredRule
 io.github.adamw7.tools.enforcer.doc.ModuleMapConsistencyRule
 io.github.adamw7.tools.enforcer.definition.PluginFormatRule
 io.github.adamw7.tools.enforcer.okf.OkfBundleFormatRule
+io.github.adamw7.tools.enforcer.project.ClaudeCodeProjectRule

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/CommandLineArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/CommandLineArchitectureTest.java
@@ -1,0 +1,106 @@
+package io.github.adamw7.tools.enforcer.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.GeneralCodingRules;
+
+import io.github.adamw7.tools.test.architecture.CommonNamingConventions;
+
+/**
+ * The command line's own rules. It is analysed apart from the rest of the module
+ * because one shared convention cannot hold here — {@code noAccessToStandardStreams}
+ * — and {@link io.github.adamw7.tools.test.architecture.CommonCodingConventions}
+ * is explicit that a rule which does not hold for every module must be exempted
+ * visibly rather than relaxed for everyone. This is that exemption, and it is
+ * narrow: the streams are an entry point's interface to whoever ran it, so exactly
+ * one class may reach them.
+ *
+ * <p>Everything else the shared conventions ask still applies and is restated
+ * here, so leaving the package out of the shared import costs it no checking:
+ * failure is still reported by throwing rather than by ending the JVM, a stack
+ * trace is still never printed raw, and logging still does not reach for another
+ * framework.
+ *
+ * @see EnforcerArchitectureTest.WithoutTheCommandLine
+ */
+@AnalyzeClasses(packages = CommandLineArchitectureTest.CLI_PACKAGE,
+		importOptions = ImportOption.DoNotIncludeTests.class)
+public class CommandLineArchitectureTest {
+
+	static final String CLI_PACKAGE = "io.github.adamw7.tools.enforcer.cli";
+
+	@ArchTest
+	static final ArchTests commonNamingConventions = ArchTests.in(CommonNamingConventions.class);
+
+	@ArchTest
+	static final ArchRule onlyTheEntryPointReachesTheStandardStreams = noClasses()
+			.that().haveSimpleNameNotEndingWith("Main")
+			.and().haveSimpleNameNotEndingWith("PrintingEnforcerLogger")
+			.should().accessField(System.class, "out")
+			.orShould().accessField(System.class, "err")
+			.because("the streams are how a command line answers whoever ran it, which is Main's job and "
+					+ "the logger's it hands them to; anywhere else they would be a check printing behind "
+					+ "the back of the logger every rule already reports through");
+
+	@ArchTest
+	static final ArchRule entryPointsAreNamedMain = methods()
+			.that().haveName("main").and().arePublic().and().areStatic()
+			.should().beDeclaredInClassesThat().haveSimpleName("Main")
+			.because("the module ships one entry point and the manifest names it by class, so a main method "
+					+ "anywhere else is unreachable in practice");
+
+	@ArchTest
+	static final ArchRule theCommandLineDoesNotHaltTheJvm = noClasses()
+			.should().callMethod(System.class, "exit", int.class)
+			.because("a failed check is reported by throwing, as everywhere else here: the process exits "
+					+ "non-zero either way, and a class that ends a JVM cannot be called by anything but a "
+					+ "shell");
+
+	@ArchTest
+	static final ArchRule noPrintStackTrace = noClasses()
+			.should().callMethod(Throwable.class, "printStackTrace")
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintStream.class)
+			.orShould().callMethod(Throwable.class, "printStackTrace", PrintWriter.class)
+			.because("a raw stack trace is not a report; the violations are printed and the failure thrown");
+
+	@ArchTest
+	static final ArchRule noJavaUtilLogging = noClasses()
+			.should().dependOnClassesThat().resideInAPackage("java.util.logging..")
+			.because("this module carries no logging framework at all, which is what keeps one off the "
+					+ "plugin class path of every build that wires a rule");
+
+	@ArchTest
+	static final ArchRule noGenericExceptionsAreThrown =
+			GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
+
+	/**
+	 * The command line reaches the rules only through the composite, which is the
+	 * layering {@link EnforcerArchitectureTest} pins for everything below it. Stated
+	 * here because the package is analysed apart from that test.
+	 */
+	@ArchTest
+	static final ArchRule theCommandLineReachesTheRulesThroughTheComposite = noClasses()
+			.that().resideInAPackage(CLI_PACKAGE)
+			.should().dependOnClassesThat().resideInAnyPackage("..enforcer.definition..", "..enforcer.doc..",
+					"..enforcer.mcp..", "..enforcer.okf..", "..enforcer.secret..", "..enforcer.settings..")
+			.because("what the command line runs is the composite's to decide, so a part named here would "
+					+ "be a second catalogue to keep in step with it");
+
+	@ArchTest
+	static final ArchRule theCommandLineIsSmall = classes()
+			.that().resideInAPackage(CLI_PACKAGE).and().areTopLevelClasses()
+			.should().bePackagePrivate()
+			.orShould().haveSimpleName("Main")
+			.because("the command line is a way to run the rules, not an API: only the entry point the "
+					+ "manifest names is visible outside it");
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
@@ -42,10 +42,31 @@ import io.github.adamw7.tools.test.architecture.CommonCodingConventions;
  * own rules there, because the {@code adopt} pipeline reads documents through the
  * same one and cannot depend on this module to get it.
  */
-@AnalyzeClasses(packages = EnforcerArchitectureTest.ENFORCER_PACKAGE, importOptions = ImportOption.DoNotIncludeTests.class)
+@AnalyzeClasses(packages = EnforcerArchitectureTest.ENFORCER_PACKAGE,
+		importOptions = { ImportOption.DoNotIncludeTests.class, EnforcerArchitectureTest.WithoutTheCommandLine.class })
 public class EnforcerArchitectureTest {
 
 	static final String ENFORCER_PACKAGE = "io.github.adamw7.tools.enforcer";
+
+	/**
+	 * Leaves the command line out of the shared conventions, which
+	 * {@link CommonCodingConventions} says must hold for every module and so must not
+	 * be quietly weakened for one package. The one convention the command line cannot
+	 * keep is the ban on standard streams: an entry point invoked as
+	 * {@code java -jar} has no host process to report through, and giving this module
+	 * a logging framework to satisfy the rule would put one on the plugin class path
+	 * of every build that wires a rule. {@link CommandLineArchitectureTest} states
+	 * what does apply there, including that only {@code Main} touches a stream.
+	 */
+	public static final class WithoutTheCommandLine implements ImportOption {
+
+		private static final String CLI_PACKAGE = "/io/github/adamw7/tools/enforcer/cli/";
+
+		@Override
+		public boolean includes(com.tngtech.archunit.core.importer.Location location) {
+			return !location.contains(CLI_PACKAGE);
+		}
+	}
 
 	private static final String RULE_SUFFIX = "Rule";
 	private static final String TEXT_PACKAGE = "..enforcer.text..";

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
@@ -72,6 +72,7 @@ public class EnforcerArchitectureTest {
 			.layer("Okf").definedBy("..enforcer.okf..")
 			.layer("Secret").definedBy("..enforcer.secret..")
 			.layer("Settings").definedBy("..enforcer.settings..")
+			.layer("Project").definedBy("..enforcer.project..")
 			.whereLayer("Text").mayNotAccessAnyLayer()
 			.whereLayer("Rule").mayOnlyAccessLayers("Text")
 			.whereLayer("Definition").mayOnlyAccessLayers("Rule", "Text")
@@ -80,8 +81,12 @@ public class EnforcerArchitectureTest {
 			.whereLayer("Okf").mayOnlyAccessLayers("Rule", "Text")
 			.whereLayer("Secret").mayOnlyAccessLayers("Rule", "Text")
 			.whereLayer("Settings").mayOnlyAccessLayers("Rule", "Text")
-			.as("text is the foundation, rule builds on it, and the feature packages "
-					+ "build on rule without depending on each other");
+			.whereLayer("Project").mayOnlyAccessLayers("Definition", "Doc", "Mcp", "Okf", "Secret", "Settings",
+					"Rule", "Text")
+			.as("text is the foundation, rule builds on it, the feature packages build on rule without "
+					+ "depending on each other, and project sits above them all: the composite rule is the "
+					+ "one place that may know every feature package, which is what stops any of them "
+					+ "reaching sideways to reach another");
 
 	@ArchTest
 	static final ArchRule packagesAreFreeOfCycles = slices()

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/architecture/EnforcerArchitectureTest.java
@@ -53,6 +53,7 @@ public class EnforcerArchitectureTest {
 	private static final String JSON_NODES = ENFORCER_PACKAGE + ".rule.JsonNodes";
 	private static final String BASELINE = ENFORCER_PACKAGE + ".rule.Baseline";
 	private static final String HTML_REPORT = ENFORCER_PACKAGE + ".rule.HtmlReport";
+	private static final String REPORT_INDEX = ENFORCER_PACKAGE + ".rule.ReportIndex";
 	private static final String FILE_MUTATIONS =
 			"write|writeString|newBufferedWriter|newOutputStream|createFile|createDirectory|createDirectories"
 					+ "|delete|deleteIfExists|move|copy";
@@ -172,10 +173,13 @@ public class EnforcerArchitectureTest {
 	static final ArchRule rulesDoNotWriteToTheProjectTheyCheck = noClasses()
 			.that().doNotHaveFullyQualifiedName(BASELINE)
 			.and().doNotHaveFullyQualifiedName(HTML_REPORT)
+			.and().doNotHaveFullyQualifiedName(REPORT_INDEX)
 			.should().callMethodWhere(target(owner(type(Files.class))).and(target(nameMatching(FILE_MUTATIONS))))
-			.because("a check reports what it found; the two places that write here are the ones a build "
-					+ "asked for — the HTML report and the recorded baseline. The front-matter fix writes "
-					+ "through markdown-common's MarkdownText, which its own module holds to the same rule")
+			.because("a check reports what it found; the three places that write here are the ones a build "
+					+ "asked for — the HTML report, the index linking the reports, and the recorded "
+					+ "baseline. Each writes only where a configured parameter or property pointed it, "
+					+ "never into the project under check. The front-matter fix writes through "
+					+ "markdown-common's MarkdownText, which its own module holds to the same rule")
 			.allowEmptyShould(true);
 
 	/**

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/cli/MainTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/cli/MainTest.java
@@ -1,0 +1,224 @@
+package io.github.adamw7.tools.enforcer.cli;
+
+import static io.github.adamw7.tools.test.TestFiles.createDirectory;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The command line as a pre-commit hook or a non-Maven project meets it: run it at
+ * a directory and read what it says.
+ */
+class MainTest {
+
+	private static final String VALID_CLAUDE_MD = """
+			# CLAUDE.md
+
+			See [AGENTS.md](AGENTS.md) for the full agent guide.
+
+			## Project
+			Java project built with Maven.
+
+			## Java version
+			Java 25.
+
+			## Maven
+			Versions live in the root pom.
+
+			## Principles for Java Development
+			Use SOLID Principles.
+
+			## Testing
+			Write unit tests for all new logic.
+
+			## Dependencies
+			Ask before adding a new one.
+			""";
+
+	@TempDir
+	private Path tempDir;
+
+	private ByteArrayOutputStream out;
+	private ByteArrayOutputStream err;
+
+	@BeforeEach
+	void captureTheStreams() {
+		out = new ByteArrayOutputStream();
+		err = new ByteArrayOutputStream();
+	}
+
+	@AfterEach
+	void clearTheReportDirectory() {
+		System.clearProperty("claude.enforcer.reportDir");
+	}
+
+	@Test
+	void reportsAValidConfigurationAndSaysSo() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD);
+
+		assertDoesNotThrow(() -> run(tempDir.toString()));
+
+		assertTrue(output().contains("Claude Code configuration is valid."), output());
+	}
+
+	/** The whole point: no Maven, no bootstrap, no pom edit. */
+	@Test
+	void printsTheViolationsAndThenFails() {
+		writeString(tempDir.resolve("CLAUDE.md"), "# CLAUDE.md\n\nNothing else.\n");
+
+		assertThrows(Main.CheckFailedException.class, () -> run(tempDir.toString()));
+
+		assertTrue(errors().contains("[claudeMdFormat]"), errors());
+	}
+
+	/** A hook shows its user the report, not the throw, so the report comes first. */
+	@Test
+	void failureNamesTheOutcomeRatherThanRepeatingTheReport() {
+		writeString(tempDir.resolve("CLAUDE.md"), "# CLAUDE.md\n\nNothing else.\n");
+
+		Main.CheckFailedException thrown = assertThrows(Main.CheckFailedException.class,
+				() -> run(tempDir.toString()));
+
+		assertTrue(thrown.getMessage().contains("not valid"), thrown.getMessage());
+		assertFalse(thrown.getMessage().contains("[claudeMdFormat]"), thrown.getMessage());
+	}
+
+	@Test
+	void repairsWhatItCanWhenAskedTo() {
+		Path claudeMd = writeString(tempDir.resolve("CLAUDE.md"), "## Project purpose\nA project.\n");
+
+		assertDoesNotThrow(() -> run(tempDir.toString(), "--fix"));
+
+		assertTrue(readString(claudeMd).startsWith("# CLAUDE.md"), readString(claudeMd));
+	}
+
+	@Test
+	void skipsTheRulesItIsToldTo() {
+		writeString(tempDir.resolve("CLAUDE.md"), "# CLAUDE.md\n\nNothing else.\n");
+
+		assertDoesNotThrow(() -> run(tempDir.toString(), "--skip",
+				"claudeMdFormat,memoryImports,contextBudget"));
+	}
+
+	@Test
+	void reportsWithoutFailingWhenAskedToWarn() {
+		writeString(tempDir.resolve("CLAUDE.md"), "# CLAUDE.md\n\nNothing else.\n");
+
+		assertDoesNotThrow(() -> run(tempDir.toString(), "--warn"));
+
+		assertTrue(errors().contains("[claudeMdFormat]"), errors());
+	}
+
+	@Test
+	void writesTheReportsWhereItIsToldTo() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD);
+		Path reports = createDirectory(tempDir.resolve("reports"));
+
+		assertDoesNotThrow(() -> run(tempDir.toString(), "--report", reports.toString()));
+
+		assertTrue(Files.exists(reports.resolve("index.html")));
+		assertTrue(Files.exists(reports.resolve("claudeCodeProject.html")));
+	}
+
+	/**
+	 * One verdict, one report. The parts hand their violations to the composite rather
+	 * than reporting themselves, so a run leaves the whole configuration's outcome in
+	 * one page instead of twenty pages that each answer for a fragment of it.
+	 */
+	@Test
+	void writesOneReportForTheWholeConfiguration() {
+		writeString(tempDir.resolve("CLAUDE.md"), "# CLAUDE.md\n\nNothing else.\n");
+		Path reports = createDirectory(tempDir.resolve("reports"));
+
+		assertThrows(Main.CheckFailedException.class,
+				() -> run(tempDir.toString(), "--report", reports.toString()));
+
+		assertFalse(Files.exists(reports.resolve("claudeMdFormat.html")));
+		assertTrue(readString(reports.resolve("claudeCodeProject.html")).contains("claudeMdFormat"));
+	}
+
+	@Test
+	void answersHelpAndChecksNothing() {
+		assertDoesNotThrow(() -> run("--help"));
+
+		assertTrue(output().contains("Usage: claude-code-enforcer"), output());
+	}
+
+	/** A hook invoking a flag that does not exist must not be quietly given a plain check. */
+	@Test
+	void refusesAnOptionItDoesNotKnow() {
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+				() -> run(tempDir.toString(), "--fix-everything"));
+
+		assertTrue(thrown.getMessage().contains("Unknown option: --fix-everything"), thrown.getMessage());
+	}
+
+	@Test
+	void refusesAnOptionMissingItsValue() {
+		assertThrows(IllegalArgumentException.class, () -> run(tempDir.toString(), "--skip"));
+	}
+
+	@Test
+	void refusesABudgetThatIsNotANumber() {
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+				() -> run(tempDir.toString(), "--budget", "large"));
+
+		assertTrue(thrown.getMessage().contains("--budget"), thrown.getMessage());
+	}
+
+	@Test
+	void refusesASecondProjectDirectory() {
+		assertThrows(IllegalArgumentException.class, () -> run(tempDir.toString(), tempDir.toString()));
+	}
+
+	@Test
+	void takesTheBudgetItIsGiven() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD);
+
+		assertThrows(Main.CheckFailedException.class, () -> run(tempDir.toString(), "--budget", "10"));
+		assertDoesNotThrow(() -> run(tempDir.toString(), "--budget", "0"));
+	}
+
+	/** Debug says what each rule was pointed at, which is a question asked after a surprise. */
+	@Test
+	void saysWhatItCheckedOnlyWhenAskedTo() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD);
+
+		assertDoesNotThrow(() -> run(tempDir.toString()));
+		assertFalse(output().contains("[debug]"), output());
+
+		captureTheStreams();
+		assertDoesNotThrow(() -> run(tempDir.toString(), "--debug"));
+		assertTrue(output().contains("[debug]"), output());
+	}
+
+	private void run(String... args) {
+		Main.run(args, new PrintStream(out, true, StandardCharsets.UTF_8),
+				new PrintStream(err, true, StandardCharsets.UTF_8));
+	}
+
+	private String output() {
+		return out.toString(StandardCharsets.UTF_8);
+	}
+
+	private String errors() {
+		return err.toString(StandardCharsets.UTF_8);
+	}
+
+	private String readString(Path path) {
+		return assertDoesNotThrow(() -> Files.readString(path));
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -8,7 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.List;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.Test;
@@ -96,6 +101,99 @@ class ClaudeMdFormatRuleTest {
 	@Test
 	void defaultsToRequiringAgentsMd() {
 		assertEquals("AGENTS.md", new ClaudeMdFormatRule().requiredReference());
+	}
+
+	/**
+	 * A missing title, a near-miss heading, an empty section and a missing companion
+	 * reference are mechanical edits with one correct answer, so autoFix makes them
+	 * rather than leaving each project to type them out.
+	 */
+	@Test
+	void autoFixRepairsTheStructureItWouldOtherwiseReport() {
+		ClaudeMdFormatRule rule = ruleFor("""
+				## Project purpose
+				A project.
+				""");
+		rule.setAutoFix(true);
+
+		assertDoesNotThrow(rule::execute);
+
+		String repaired = readClaudeMd();
+		assertTrue(repaired.startsWith("# CLAUDE.md"), repaired);
+		assertTrue(repaired.contains("## Project\n"), repaired);
+		assertTrue(repaired.contains("A project."), repaired);
+		assertTrue(repaired.contains("AGENTS.md"), repaired);
+		assertTrue(repaired.contains("## Dependencies"), repaired);
+	}
+
+	/** The repair has to satisfy the very checks that follow it, or it has repaired nothing. */
+	@Test
+	void autoFixLeavesADocumentTheRuleThenAccepts() {
+		ClaudeMdFormatRule rule = ruleFor("nothing structural at all\n");
+		rule.setAutoFix(true);
+		assertDoesNotThrow(rule::execute);
+
+		assertDoesNotThrow(ruleFor(readClaudeMd())::execute);
+	}
+
+	/** A conforming document is not rewritten, so a build that repairs nothing touches no file. */
+	@Test
+	void autoFixWritesNothingWhenTheDocumentAlreadyConforms() throws Exception {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
+		rule.setAutoFix(true);
+		Path file = tempDir.resolve("CLAUDE.md");
+		FileTime before = Files.getLastModifiedTime(file);
+
+		assertDoesNotThrow(rule::execute);
+
+		assertEquals(before, Files.getLastModifiedTime(file));
+		assertEquals(VALID_CONTENT, readClaudeMd());
+	}
+
+	/** Off by default: a check that rewrote the project without being asked is not a check. */
+	@Test
+	void repairsNothingUnlessAutoFixIsOn() {
+		String malformed = "## Project purpose\nA project.\n";
+		ClaudeMdFormatRule rule = ruleFor(malformed);
+
+		assertFailure(EnforcerRuleException.class, rule::execute, "CLAUDE.md");
+		assertEquals(malformed, readClaudeMd());
+	}
+
+	/** The repair reshapes to the configured contract, not to this repository's. */
+	@Test
+	void autoFixRepairsToTheConfiguredSectionsAndReference() {
+		ClaudeMdFormatRule rule = ruleFor("Some prose.\n");
+		rule.setRequiredSections(List.of("## Overview"));
+		rule.setRequiredReference("HANDBOOK.md");
+		rule.setAutoFix(true);
+
+		assertDoesNotThrow(rule::execute);
+
+		String repaired = readClaudeMd();
+		assertTrue(repaired.contains("## Overview"), repaired);
+		assertTrue(repaired.contains("HANDBOOK.md"), repaired);
+		assertFalse(repaired.contains("## Maven"), repaired);
+	}
+
+	/** Repairing a CRLF document must not rewrite every line of it as a side effect. */
+	@Test
+	void autoFixKeepsTheLineTerminatorsTheDocumentUsed() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("\n", "\r\n"));
+		rule.setAutoFix(true);
+
+		assertDoesNotThrow(rule::execute);
+
+		String repaired = readClaudeMd();
+		assertFalse(repaired.replace("\r\n", "").contains("\n"), "an LF crept into a CRLF document");
+	}
+
+	private String readClaudeMd() {
+		try {
+			return Files.readString(tempDir.resolve("CLAUDE.md"));
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
 	}
 
 	@Test
@@ -439,7 +537,7 @@ class ClaudeMdFormatRuleTest {
 	@Test
 	void doesNotReportOutOfOrderWhenARequiredSectionIsConfiguredTwice() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
-		rule.setRequiredSections(java.util.List.of("## Project", "## Testing", "## Project"));
+		rule.setRequiredSections(List.of("## Project", "## Testing", "## Project"));
 		rule.setEnforceSectionOrder(true);
 
 		assertDoesNotThrow(rule::execute);
@@ -453,7 +551,7 @@ class ClaudeMdFormatRuleTest {
 	@Test
 	void reportsOnlyTheMissingSectionWhenARequiredEntryIsNotAHeading() {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
-		rule.setRequiredSections(java.util.List.of("Testing"));
+		rule.setRequiredSections(List.of("Testing"));
 		rule.setEnforceSectionOrder(true);
 
 		EnforcerRuleException exception = assertFailure(EnforcerRuleException.class, rule::execute,

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ClaudeMdFormatRuleTest.java
@@ -4,6 +4,7 @@ import static io.github.adamw7.tools.test.TestFiles.writeBytes;
 import static io.github.adamw7.tools.test.TestFiles.writeString;
 import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -49,6 +50,52 @@ class ClaudeMdFormatRuleTest {
 		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
 
 		assertDoesNotThrow(rule::execute);
+	}
+
+	/**
+	 * The companion document is a default, not a fixture: a project that keeps its
+	 * detail somewhere other than an AGENTS.md says so rather than being told its
+	 * CLAUDE.md is malformed for pointing at the file it actually has.
+	 */
+	@Test
+	void requiresTheCompanionDocumentTheProjectNames() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("AGENTS.md", "CONTRIBUTING.md"));
+		rule.setRequiredReference("CONTRIBUTING.md");
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void failsWhenTheConfiguredCompanionDocumentIsNotReferenced() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT);
+		rule.setRequiredReference("CONTRIBUTING.md");
+
+		assertFailure(EnforcerRuleException.class, rule::execute, "must reference CONTRIBUTING.md");
+	}
+
+	/** An empty element is how a project with no companion document at all says so. */
+	@Test
+	void requiresNoCompanionDocumentWhenConfiguredEmpty() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("See [AGENTS.md](AGENTS.md) for the full agent guide.",
+				"A project that keeps everything here."));
+		rule.setRequiredReference("");
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/** Whitespace is not a document name, so an indented empty element still disables it. */
+	@Test
+	void requiresNoCompanionDocumentWhenConfiguredBlank() {
+		ClaudeMdFormatRule rule = ruleFor(VALID_CONTENT.replace("See [AGENTS.md](AGENTS.md) for the full agent guide.",
+				"A project that keeps everything here."));
+		rule.setRequiredReference("\n\t  ");
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void defaultsToRequiringAgentsMd() {
+		assertEquals("AGENTS.md", new ClaudeMdFormatRule().requiredReference());
 	}
 
 	@Test

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RepositoryEnforcementIT.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RepositoryEnforcementIT.java
@@ -52,14 +52,23 @@ class RepositoryEnforcementIT {
 			"pom.xml", "CLAUDE.md", "AGENTS.md", "README.md", ".gitignore", ".claude");
 
 	/**
-	 * The rules that ship unwired on purpose — none today. The two that were
-	 * exempted, {@code subAgentFormat} and {@code commandFormat}, take a definition
-	 * directory that must exist when configured, so they were wired the day
+	 * The rules that ship unwired on purpose. The two that were once exempted,
+	 * {@code subAgentFormat} and {@code commandFormat}, take a definition directory
+	 * that must exist when configured, so they were wired the day
 	 * {@code .claude/agents} and {@code .claude/commands} were added. A rule may be
-	 * listed here again only with a reason of that kind; the assertion below is what
-	 * stops the list growing quietly.
+	 * listed here only with a reason of that kind; the assertion below is what stops
+	 * the list growing quietly.
+	 * <p>
+	 * {@code claudeCodeProject} runs the other rules from the project directory
+	 * alone, so wiring it beside them would run every part twice. This repository
+	 * wires them individually because it is the enforcer's own: the profile is the
+	 * worked example of the whole configuration surface, and two of its rules —
+	 * {@code crossDocConsistency} and {@code readmeConsistency} — take the patterns
+	 * this project needs kept in step, which no convention could supply. A project
+	 * adopting the rules wires the composite instead, and
+	 * {@link EnforcerRuleBuildIT} is where that route is proved to bind.
 	 */
-	private static final Set<String> DELIBERATELY_UNWIRED = Set.of();
+	private static final Set<String> DELIBERATELY_UNWIRED = Set.of("claudeCodeProject");
 
 	private static BuildEnvironment environment;
 	private static MavenBuild maven;

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RepositoryPom.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RepositoryPom.java
@@ -41,10 +41,33 @@ final class RepositoryPom {
 	String pluginVersion(String artifactId) {
 		for (Element plugin : pom.select("pluginManagement > plugins > plugin")) {
 			if (artifactId.equals(textOf(plugin, "artifactId"))) {
-				return required(textOf(plugin, "version"), artifactId + " has no version in " + file);
+				return resolved(required(textOf(plugin, "version"), artifactId + " has no version in " + file));
 			}
 		}
 		throw new IllegalStateException(artifactId + " is not managed in " + file);
+	}
+
+	/**
+	 * A managed version given as {@code ${a.property}} resolved against the pom's own
+	 * {@code <properties>}, the way Maven resolves it. The harness poms these versions
+	 * are written into inherit nothing from this one, so a property reference copied
+	 * across verbatim reaches Maven as a literal and fails the harness build with
+	 * "must be a valid version".
+	 *
+	 * <p>The properties are walked rather than selected by name because a Maven
+	 * property name carries dots, which a CSS selector reads as class syntax.
+	 */
+	private String resolved(String version) {
+		if (!version.startsWith("${") || !version.endsWith("}")) {
+			return version;
+		}
+		String property = version.substring(2, version.length() - 1);
+		for (Element declared : pom.select("project > properties > *")) {
+			if (declared.tagName().equals(property)) {
+				return declared.text().strip();
+			}
+		}
+		throw new IllegalStateException(file + " declares no property " + property + " for " + version);
 	}
 
 	/**

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
@@ -272,6 +272,15 @@ final class RuleConfiguration {
 										<skippedRule>memoryImports</skippedRule>
 									</skippedRules>
 									<claudeMdBudgetBytes>32768</claudeMdBudgetBytes>
+									<claudeMdSections>
+										<claudeMdSection>## Project</claudeMdSection>
+										<claudeMdSection>## Java version</claudeMdSection>
+										<claudeMdSection>## Maven</claudeMdSection>
+										<claudeMdSection>## Principles for Java Development</claudeMdSection>
+										<claudeMdSection>## Testing</claudeMdSection>
+										<claudeMdSection>## Dependencies</claudeMdSection>
+									</claudeMdSections>
+									<claudeMdReference>AGENTS.md</claudeMdReference>
 									<autoFix>false</autoFix>
 								</claudeCodeProject>
 			""";

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
@@ -41,6 +41,7 @@ final class RuleConfiguration {
 									<maxLineLength>100</maxLineLength>
 									<validateFileReferences>true</validateFileReferences>
 									<referenceBaseDir>${project.basedir}</referenceBaseDir>
+									<autoFix>false</autoFix>
 								</claudeMdFormat>
 								<agentsMdFormat>
 									<agentsMdFile>${project.basedir}/AGENTS.md</agentsMdFile>
@@ -61,6 +62,7 @@ final class RuleConfiguration {
 									<maxLineLength>100</maxLineLength>
 									<validateFileReferences>true</validateFileReferences>
 									<referenceBaseDir>${project.basedir}</referenceBaseDir>
+									<autoFix>false</autoFix>
 								</agentsMdFormat>
 								<crossDocConsistency>
 									<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
@@ -252,6 +252,28 @@ final class RuleConfiguration {
 									</requiredKeys>
 									<requireIndex>true</requireIndex>
 								</okfBundleFormat>
+								<!-- The composite checks the same project from its directory
+								     alone. It is configured beside the rules it is made of so
+								     that a build proves both routes bind: the twenty elements
+								     a project may write out, and the one it may write
+								     instead. Its parts run twice here, which costs a
+								     fixture's build nothing and is not how a project would
+								     wire it. -->
+								<claudeCodeProject>
+									<projectDir>${project.basedir}</projectDir>
+									<!-- Both parts are configured above with something this
+									     rule cannot default: an OKF version, and the list of
+									     imports the fixture's CLAUDE.md deliberately names
+									     without providing. Unconfigured they are right to
+									     report what they find, which is not what this fixture
+									     is here to prove. -->
+									<skippedRules>
+										<skippedRule>okfBundleFormat</skippedRule>
+										<skippedRule>memoryImports</skippedRule>
+									</skippedRules>
+									<claudeMdBudgetBytes>32768</claudeMdBudgetBytes>
+									<autoFix>false</autoFix>
+								</claudeCodeProject>
 			""";
 
 	/** What {@link #COMPLETE} addresses its files through: the project being built. */

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/RuleConfiguration.java
@@ -25,6 +25,7 @@ final class RuleConfiguration {
 								<claudeMdFormat>
 									<claudeMdFile>${project.basedir}/CLAUDE.md</claudeMdFile>
 									<titleHeading># CLAUDE.md</titleHeading>
+									<requiredReference>AGENTS.md</requiredReference>
 									<requiredSections>
 										<requiredSection>## Project</requiredSection>
 										<requiredSection>## Java version</requiredSection>

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/project/ClaudeCodeProjectRuleTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/project/ClaudeCodeProjectRuleTest.java
@@ -1,0 +1,243 @@
+package io.github.adamw7.tools.enforcer.project;
+
+import static io.github.adamw7.tools.test.TestFiles.createDirectory;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.enforcer.rule.CapturingLogger;
+
+/**
+ * The composite as a project meets it: configured with a directory and nothing
+ * else, checking what the project has and staying quiet about what it does not.
+ */
+class ClaudeCodeProjectRuleTest {
+
+	private static final String VALID_CLAUDE_MD = """
+			# CLAUDE.md
+
+			See [AGENTS.md](AGENTS.md) for the full agent guide.
+
+			## Project
+			Java project built with Maven.
+
+			## Java version
+			Java 25.
+
+			## Maven
+			Versions live in the root pom.
+
+			## Principles for Java Development
+			Use SOLID Principles.
+
+			## Testing
+			Write unit tests for all new logic.
+
+			## Dependencies
+			Ask before adding a new one.
+			""";
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void passesForAProjectWhoseConfigurationIsWellFormed() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD);
+		writeString(tempDir.resolve(".gitignore"), ".claude/settings.local.json\n");
+		createDirectory(tempDir.resolve(".claude"));
+		writeString(tempDir.resolve(".claude/settings.json"), "{}");
+
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
+	/** One directory, not sixty paths: the whole point of the rule. */
+	@Test
+	void findsAViolationInAFileNobodyPointedItAt() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD);
+		createDirectory(tempDir.resolve(".claude"));
+		writeString(tempDir.resolve(".claude/settings.json"), "{ not json");
+
+		EnforcerRuleException thrown = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+
+		assertTrue(thrown.getMessage().contains("settings.json"), thrown.getMessage());
+	}
+
+	/** A violation has to say which part found it, since that is the name to look up. */
+	@Test
+	void namesThePartThatFoundEachViolation() {
+		writeString(tempDir.resolve("CLAUDE.md"), "# CLAUDE.md\n\nNothing else.\n");
+
+		EnforcerRuleException thrown = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+
+		assertTrue(thrown.getMessage().contains("[claudeMdFormat]"), thrown.getMessage());
+	}
+
+	/** Every part reports into one message, so one run says everything that is wrong. */
+	@Test
+	void reportsEveryPartsViolationsTogether() {
+		writeString(tempDir.resolve("CLAUDE.md"), "# CLAUDE.md\n\nNothing else.\n");
+		createDirectory(tempDir.resolve(".claude"));
+		writeString(tempDir.resolve(".claude/settings.json"), "{ not json");
+
+		EnforcerRuleException thrown = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+
+		assertTrue(thrown.getMessage().contains("[claudeMdFormat]"), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains("[settingsJsonValid]"), thrown.getMessage());
+	}
+
+	/**
+	 * The difference from wiring the rules by hand: nothing named these paths, so an
+	 * absent one is a project without that thing rather than a mistyped parameter.
+	 */
+	@Test
+	void skipsAPartWhoseInputTheProjectDoesNotHave() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD);
+
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+	}
+
+	/** A part starts checking the day the project grows the thing it checks. */
+	@Test
+	void checksADirectoryTheProjectAddsLater() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD);
+		assertDoesNotThrow(ruleFor(tempDir)::execute);
+
+		createDirectory(tempDir.resolve(".claude"));
+		createDirectory(tempDir.resolve(".claude/skills"));
+		createDirectory(tempDir.resolve(".claude/skills/broken"));
+
+		EnforcerRuleException thrown = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+		assertTrue(thrown.getMessage().contains("[skillFilesExist]"), thrown.getMessage());
+	}
+
+	@Test
+	void skipsThePartsTheProjectNames() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD);
+		createDirectory(tempDir.resolve(".claude"));
+		createDirectory(tempDir.resolve(".claude/skills"));
+		createDirectory(tempDir.resolve(".claude/skills/broken"));
+		ClaudeCodeProjectRule rule = ruleFor(tempDir);
+		rule.setSkippedRules(List.of("skillFilesExist", "uniqueNames", "uniqueDescriptions"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void skippingIsNotASpellingTest() {
+		writeString(tempDir.resolve("CLAUDE.md"), "# CLAUDE.md\n\nNothing else.\n");
+		ClaudeCodeProjectRule rule = ruleFor(tempDir);
+		rule.setSkippedRules(List.of("  ClaudeMdFormat  ", "memoryImports", "contextBudget"));
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	/** A project directory was configured, so one that is not there is a setup mistake. */
+	@Test
+	void failsWhenTheProjectDirectoryIsNotThere() {
+		ClaudeCodeProjectRule rule = ruleFor(tempDir.resolve("absent"));
+
+		EnforcerRuleException thrown = assertThrows(EnforcerRuleException.class, rule::execute);
+
+		assertTrue(thrown.getMessage().contains("projectDir does not exist"), thrown.getMessage());
+	}
+
+	@Test
+	void failsWhenTheProjectDirectoryIsNotConfigured() {
+		EnforcerRuleException thrown = assertThrows(EnforcerRuleException.class,
+				new ClaudeCodeProjectRule()::execute);
+
+		assertTrue(thrown.getMessage().contains("projectDir"), thrown.getMessage());
+	}
+
+	/**
+	 * A project with nothing to check passes exactly like one whose configuration is
+	 * spotless, so the run has to say which of the two it was.
+	 */
+	@Test
+	void warnsWhenItFoundNothingToCheckAtAll() {
+		ClaudeCodeProjectRule rule = ruleFor(tempDir);
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.warnings().stream().anyMatch(warning -> warning.contains("no Claude Code configuration")),
+				logger.warnings().toString());
+	}
+
+	@Test
+	void debugLogsWhichPartsItRan() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD);
+		ClaudeCodeProjectRule rule = ruleFor(tempDir);
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(logger.debugs().stream().anyMatch(debug -> debug.contains("claudeMdFormat")),
+				logger.debugs().toString());
+	}
+
+	/** One severity covers the whole configuration, which is why it is worth having. */
+	@Test
+	void oneSeverityCoversEveryPart() {
+		writeString(tempDir.resolve("CLAUDE.md"), "# CLAUDE.md\n\nNothing else.\n");
+		ClaudeCodeProjectRule rule = ruleFor(tempDir);
+		rule.setSeverity("warn");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertFalse(logger.warnings().isEmpty());
+	}
+
+	/** The one part of the convention that is a number: a CLAUDE.md is a summary. */
+	@Test
+	void holdsClaudeMdToTheContextBudgetByConvention() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD + "x".repeat(40000));
+
+		EnforcerRuleException thrown = assertThrows(EnforcerRuleException.class, ruleFor(tempDir)::execute);
+
+		assertTrue(thrown.getMessage().contains("[contextBudget]"), thrown.getMessage());
+	}
+
+	@Test
+	void takesTheContextBudgetTheProjectSets() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD + "x".repeat(40000));
+		ClaudeCodeProjectRule rule = ruleFor(tempDir);
+		rule.setClaudeMdBudgetBytes(100000);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void checksNoContextBudgetWhenSetToZero() {
+		writeString(tempDir.resolve("CLAUDE.md"), VALID_CLAUDE_MD + "x".repeat(40000));
+		ClaudeCodeProjectRule rule = ruleFor(tempDir);
+		rule.setClaudeMdBudgetBytes(0);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	@Test
+	void autoFixReachesTheDocumentParts() {
+		writeString(tempDir.resolve("CLAUDE.md"), "## Project purpose\nA project.\n");
+		ClaudeCodeProjectRule rule = ruleFor(tempDir);
+		rule.setAutoFix(true);
+
+		assertDoesNotThrow(rule::execute);
+	}
+
+	private ClaudeCodeProjectRule ruleFor(Path projectDir) {
+		ClaudeCodeProjectRule rule = new ClaudeCodeProjectRule();
+		rule.setProjectDir(projectDir.toFile());
+		return rule;
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/project/ProjectLayoutTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/project/ProjectLayoutTest.java
@@ -1,0 +1,62 @@
+package io.github.adamw7.tools.enforcer.project;
+
+import static io.github.adamw7.tools.test.TestFiles.writeBytes;
+import static io.github.adamw7.tools.test.TestFiles.writeString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Where the composite looks, and the one question it asks of a file's content. */
+class ProjectLayoutTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	void resolvesEveryPathAgainstTheProjectDirectory() {
+		ProjectLayout layout = new ProjectLayout(tempDir.toFile());
+
+		assertEquals(tempDir.resolve("CLAUDE.md").toFile(), layout.claudeMd());
+		assertEquals(tempDir.resolve("AGENTS.md").toFile(), layout.agentsMd());
+		assertEquals(tempDir.resolve(".mcp.json").toFile(), layout.mcpJson());
+		assertEquals(tempDir.resolve(".claude/settings.json").toFile(), layout.settingsJson());
+		assertEquals(tempDir.resolve(".claude/skills").toFile(), layout.skillsDir());
+		assertEquals(tempDir.resolve(".claude/agents").toFile(), layout.agentsDir());
+		assertEquals(tempDir.resolve(".claude/commands").toFile(), layout.commandsDir());
+		assertEquals(tempDir.resolve(".claude/hooks").toFile(), layout.hooksDir());
+		assertEquals(tempDir.resolve(".claude-plugin/plugin.json").toFile(), layout.pluginJson());
+	}
+
+	@Test
+	void readsAnAggregatorPomAsDeclaringModules() {
+		writeString(tempDir.resolve("pom.xml"), "<project><modules><module>data</module></modules></project>");
+
+		assertTrue(new ProjectLayout(tempDir.toFile()).declaresModules());
+	}
+
+	/** A single-module project has a pom and no module map, which is not a fault. */
+	@Test
+	void readsASingleModulePomAsDeclaringNone() {
+		writeString(tempDir.resolve("pom.xml"), "<project><artifactId>one</artifactId></project>");
+
+		assertFalse(new ProjectLayout(tempDir.toFile()).declaresModules());
+	}
+
+	@Test
+	void declaresNoModulesWhenThereIsNoPomAtAll() {
+		assertFalse(new ProjectLayout(tempDir.toFile()).declaresModules());
+	}
+
+	/** A pom that cannot be read is left to the rule that reads it properly to explain. */
+	@Test
+	void declaresNoModulesWhenThePomCannotBeRead() {
+		writeBytes(tempDir.resolve("pom.xml"), new byte[] { (byte) 0xC3, (byte) 0x28 });
+
+		assertFalse(new ProjectLayout(tempDir.toFile()).declaresModules());
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRuleConfigurationTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRuleConfigurationTest.java
@@ -13,8 +13,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.inject.Named;
-
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -134,7 +132,7 @@ class ClaudeCodeEnforcerRuleConfigurationTest {
 
 		assertThrows(EnforcerRuleException.class, rule::execute);
 
-		Path report = tempDir.resolve("configurableTestRule.html");
+		Path report = tempDir.resolve("configurableTest.html");
 		assertTrue(Files.exists(report), "no report named after the rule");
 		assertTrue(Files.readString(report, StandardCharsets.UTF_8).contains("something is wrong"));
 	}
@@ -149,8 +147,8 @@ class ClaudeCodeEnforcerRuleConfigurationTest {
 		assertDoesNotThrow(new OtherTestRule()::execute);
 
 		String index = Files.readString(tempDir.resolve(ReportIndex.INDEX_FILE), StandardCharsets.UTF_8);
-		assertTrue(index.contains("configurableTestRule.html"), index);
-		assertTrue(index.contains("otherTestRule.html"), index);
+		assertTrue(index.contains("configurableTest.html"), index);
+		assertTrue(index.contains("otherTest.html"), index);
 		assertTrue(index.contains("1 of 2 rule(s) passed"), index);
 	}
 
@@ -163,7 +161,7 @@ class ClaudeCodeEnforcerRuleConfigurationTest {
 
 		assertDoesNotThrow(rule::execute);
 		assertTrue(Files.exists(chosen));
-		assertFalse(Files.exists(tempDir.resolve("configurableTestRule.html")));
+		assertFalse(Files.exists(tempDir.resolve("configurableTest.html")));
 	}
 
 	/**
@@ -178,7 +176,7 @@ class ClaudeCodeEnforcerRuleConfigurationTest {
 		recording.setWriteBaseline(true);
 		assertDoesNotThrow(recording::execute);
 
-		assertTrue(Files.exists(tempDir.resolve("configurableTestRule.txt")));
+		assertTrue(Files.exists(tempDir.resolve("configurableTest.txt")));
 
 		ConfigurableTestRule rerun = new ConfigurableTestRule();
 		rerun.addViolation("known problem");
@@ -189,13 +187,15 @@ class ClaudeCodeEnforcerRuleConfigurationTest {
 		assertThrows(EnforcerRuleException.class, otherRule::execute);
 	}
 
-	/** The name a report and a baseline are filed under is the one the pom configures. */
+	/**
+	 * The name a report and a baseline are filed under is the one a pom configures the
+	 * rule by, which the architecture tests hold every rule's @Named value to.
+	 */
 	@Test
-	void ruleNameIsTheNamedAnnotationTheBuildConfiguresItBy() {
-		assertEquals("configurableTestRule", new ConfigurableTestRule().ruleName());
+	void ruleNameIsTheOneAPomConfiguresItBy() {
+		assertEquals("configurableTest", new ConfigurableTestRule().ruleName());
 	}
 
-	@Named("configurableTestRule")
 	private static class ConfigurableTestRule extends ClaudeCodeEnforcerRule {
 
 		private final List<String> violations = new ArrayList<>();
@@ -210,7 +210,6 @@ class ClaudeCodeEnforcerRuleConfigurationTest {
 		}
 	}
 
-	@Named("otherTestRule")
 	private static final class OtherTestRule extends ConfigurableTestRule {
 	}
 }

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRuleConfigurationTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRuleConfigurationTest.java
@@ -1,0 +1,216 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The shared configuration every rule inherits: what a severity that is not a
+ * severity does, what asking for a baseline with nowhere to write it does, and the
+ * build-wide defaults that save a project spelling the same three parameters out
+ * once per rule.
+ */
+class ClaudeCodeEnforcerRuleConfigurationTest {
+
+	@TempDir
+	private Path tempDir;
+
+	/** Each test sets at most the properties it needs; none may outlive it. */
+	@AfterEach
+	void clearBuildWideDefaults() {
+		System.clearProperty(RuleDefaults.SEVERITY_PROPERTY);
+		System.clearProperty(RuleDefaults.REPORT_DIR_PROPERTY);
+		System.clearProperty(RuleDefaults.BASELINE_DIR_PROPERTY);
+	}
+
+	/**
+	 * The regression: a misspelt severity was read as 'error', so a rule the author
+	 * believed downgraded failed the build in exactly the way a working rule does.
+	 */
+	@Test
+	void refusesASeverityThatIsNotASeverity() {
+		ConfigurableTestRule rule = new ConfigurableTestRule();
+		rule.addViolation("something is wrong");
+		rule.setSeverity("warning");
+
+		EnforcerRuleException thrown = assertThrows(EnforcerRuleException.class, rule::execute);
+
+		assertTrue(thrown.getMessage().contains("is not a severity"), thrown.getMessage());
+		assertFalse(thrown.getMessage().contains("something is wrong"), thrown.getMessage());
+	}
+
+	/** Refused even when the rule found nothing, since the configuration is wrong either way. */
+	@Test
+	void refusesASeverityThatIsNotASeverityEvenWithNoViolations() {
+		ConfigurableTestRule rule = new ConfigurableTestRule();
+		rule.setSeverity("ignore");
+
+		assertThrows(EnforcerRuleException.class, rule::execute);
+	}
+
+	/** A refused severity must not leave a report behind claiming a verdict was reached. */
+	@Test
+	void writesNoReportWhenTheSeverityIsRefused() {
+		ConfigurableTestRule rule = new ConfigurableTestRule();
+		rule.addViolation("something is wrong");
+		rule.setSeverity("warning");
+		Path report = tempDir.resolve("report.html");
+		rule.setReportFile(report.toFile());
+
+		assertThrows(EnforcerRuleException.class, rule::execute);
+		assertFalse(Files.exists(report), "a refused configuration reached a verdict it had no business reaching");
+	}
+
+	/**
+	 * The other silent no-op: asking to record a baseline with no baselineFile told
+	 * the operator the build failed on the very violations they had asked to accept.
+	 */
+	@Test
+	void refusesAWriteBaselineRequestWithNowhereToWriteIt() {
+		ConfigurableTestRule rule = new ConfigurableTestRule();
+		rule.addViolation("known problem");
+		rule.setWriteBaseline(true);
+
+		EnforcerRuleException thrown = assertThrows(EnforcerRuleException.class, rule::execute);
+
+		assertTrue(thrown.getMessage().contains("no baselineFile"), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains(RuleDefaults.BASELINE_DIR_PROPERTY), thrown.getMessage());
+	}
+
+	@Test
+	void buildWideSeverityDowngradesARuleThatConfiguresNone() {
+		System.setProperty(RuleDefaults.SEVERITY_PROPERTY, "warn");
+		ConfigurableTestRule rule = new ConfigurableTestRule();
+		rule.addViolation("something is wrong");
+		CapturingLogger logger = new CapturingLogger();
+		rule.setLog(logger);
+
+		assertDoesNotThrow(rule::execute);
+		assertEquals(1, logger.warnings().size());
+	}
+
+	/** The property is a default, not an override: one rule may still insist. */
+	@Test
+	void aRuleOwnSeverityWinsOverTheBuildWideOne() {
+		System.setProperty(RuleDefaults.SEVERITY_PROPERTY, "warn");
+		ConfigurableTestRule rule = new ConfigurableTestRule();
+		rule.addViolation("something is wrong");
+		rule.setSeverity("error");
+
+		assertThrows(EnforcerRuleException.class, rule::execute);
+	}
+
+	@Test
+	void refusesABuildWideSeverityThatIsNotASeverity() {
+		System.setProperty(RuleDefaults.SEVERITY_PROPERTY, "quiet");
+		ConfigurableTestRule rule = new ConfigurableTestRule();
+
+		EnforcerRuleException thrown = assertThrows(EnforcerRuleException.class, rule::execute);
+
+		assertTrue(thrown.getMessage().contains(RuleDefaults.SEVERITY_PROPERTY), thrown.getMessage());
+	}
+
+	@Test
+	void buildWideReportDirectoryNamesEachReportAfterItsRule() throws IOException {
+		System.setProperty(RuleDefaults.REPORT_DIR_PROPERTY, tempDir.toString());
+		ConfigurableTestRule rule = new ConfigurableTestRule();
+		rule.addViolation("something is wrong");
+
+		assertThrows(EnforcerRuleException.class, rule::execute);
+
+		Path report = tempDir.resolve("configurableTestRule.html");
+		assertTrue(Files.exists(report), "no report named after the rule");
+		assertTrue(Files.readString(report, StandardCharsets.UTF_8).contains("something is wrong"));
+	}
+
+	/** Twenty reports are twenty files nobody opens; the index says which are worth opening. */
+	@Test
+	void buildWideReportDirectoryGainsAnIndexOfEveryRuleThatReported() throws IOException {
+		System.setProperty(RuleDefaults.REPORT_DIR_PROPERTY, tempDir.toString());
+		ConfigurableTestRule failing = new ConfigurableTestRule();
+		failing.addViolation("something is wrong");
+		assertThrows(EnforcerRuleException.class, failing::execute);
+		assertDoesNotThrow(new OtherTestRule()::execute);
+
+		String index = Files.readString(tempDir.resolve(ReportIndex.INDEX_FILE), StandardCharsets.UTF_8);
+		assertTrue(index.contains("configurableTestRule.html"), index);
+		assertTrue(index.contains("otherTestRule.html"), index);
+		assertTrue(index.contains("1 of 2 rule(s) passed"), index);
+	}
+
+	@Test
+	void aRuleOwnReportFileWinsOverTheBuildWideDirectory() {
+		System.setProperty(RuleDefaults.REPORT_DIR_PROPERTY, tempDir.toString());
+		Path chosen = tempDir.resolve("chosen.html");
+		ConfigurableTestRule rule = new ConfigurableTestRule();
+		rule.setReportFile(chosen.toFile());
+
+		assertDoesNotThrow(rule::execute);
+		assertTrue(Files.exists(chosen));
+		assertFalse(Files.exists(tempDir.resolve("configurableTestRule.html")));
+	}
+
+	/**
+	 * Baselines are named after the rule for the same reason reports are: one shared
+	 * file would let a violation accepted for one rule suppress another's.
+	 */
+	@Test
+	void buildWideBaselineDirectoryNamesEachBaselineAfterItsRule() {
+		System.setProperty(RuleDefaults.BASELINE_DIR_PROPERTY, tempDir.toString());
+		ConfigurableTestRule recording = new ConfigurableTestRule();
+		recording.addViolation("known problem");
+		recording.setWriteBaseline(true);
+		assertDoesNotThrow(recording::execute);
+
+		assertTrue(Files.exists(tempDir.resolve("configurableTestRule.txt")));
+
+		ConfigurableTestRule rerun = new ConfigurableTestRule();
+		rerun.addViolation("known problem");
+		assertDoesNotThrow(rerun::execute);
+
+		OtherTestRule otherRule = new OtherTestRule();
+		otherRule.addViolation("known problem");
+		assertThrows(EnforcerRuleException.class, otherRule::execute);
+	}
+
+	/** The name a report and a baseline are filed under is the one the pom configures. */
+	@Test
+	void ruleNameIsTheNamedAnnotationTheBuildConfiguresItBy() {
+		assertEquals("configurableTestRule", new ConfigurableTestRule().ruleName());
+	}
+
+	@Named("configurableTestRule")
+	private static class ConfigurableTestRule extends ClaudeCodeEnforcerRule {
+
+		private final List<String> violations = new ArrayList<>();
+
+		void addViolation(String violation) {
+			violations.add(violation);
+		}
+
+		@Override
+		public void execute() throws EnforcerRuleException {
+			report("Test rule is not satisfied:", List.copyOf(violations));
+		}
+	}
+
+	@Named("otherTestRule")
+	private static final class OtherTestRule extends ConfigurableTestRule {
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/DocumentCacheTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/DocumentCacheTest.java
@@ -1,0 +1,173 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import static io.github.adamw7.tools.test.TestFiles.writeString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.markdown.MarkdownDocument;
+
+/**
+ * What the cache shares between rules, and — the part that would be a defect
+ * rather than a missed optimisation — what it refuses to share once the file
+ * behind it has changed.
+ */
+class DocumentCacheTest {
+
+	@TempDir
+	private Path tempDir;
+
+	@BeforeEach
+	void startEmpty() {
+		DocumentCache.clear();
+	}
+
+	@Test
+	void readsAFileOnceHoweverManyRulesAskForIt() {
+		File file = writeString(tempDir.resolve("CLAUDE.md"), "# CLAUDE.md\n").toFile();
+		AtomicInteger reads = new AtomicInteger();
+
+		for (int rule = 0; rule < 5; rule++) {
+			assertEquals(Optional.of("content"), DocumentCache.text(file, () -> {
+				reads.incrementAndGet();
+				return Optional.of("content");
+			}));
+		}
+
+		assertEquals(1, reads.get(), "the file was read once per rule that asked");
+	}
+
+	/** Sharing a parse is only sound because the parsed document is immutable. */
+	@Test
+	void handsEveryRuleTheSameParsedDocument() {
+		File file = writeString(tempDir.resolve("CLAUDE.md"), "# CLAUDE.md\n").toFile();
+
+		MarkdownDocument first = DocumentCache.markdown(file, "# CLAUDE.md\n");
+		MarkdownDocument second = DocumentCache.markdown(file, "# CLAUDE.md\n");
+
+		assertSame(first, second);
+	}
+
+	/**
+	 * The defect a cache invites: autoFix rewrites a definition mid-build, and a rule
+	 * running afterwards must validate what is on disk now, not what was there when
+	 * the first rule looked.
+	 */
+	@Test
+	void rereadsAFileThatWasRewrittenDuringTheBuild() throws IOException {
+		Path path = writeString(tempDir.resolve("SKILL.md"), "before");
+		File file = path.toFile();
+		assertEquals(Optional.of("before"), DocumentCache.text(file, () -> read(path)));
+
+		writeString(path, "after and appreciably longer");
+
+		assertEquals(Optional.of("after and appreciably longer"), DocumentCache.text(file, () -> read(path)));
+	}
+
+	/**
+	 * Size alone would not notice an edit that kept the length, so the stamp carries
+	 * the modification time too. Set explicitly rather than waited for, since a test
+	 * must not sleep and a filesystem's clock is not the test's to assume.
+	 */
+	@Test
+	void rereadsAFileEditedWithoutChangingItsLength() throws IOException {
+		Path path = writeString(tempDir.resolve("SKILL.md"), "aaaa");
+		File file = path.toFile();
+		assertEquals(Optional.of("aaaa"), DocumentCache.text(file, () -> read(path)));
+
+		writeString(path, "bbbb");
+		Files.setLastModifiedTime(path, FileTime.fromMillis(Files.getLastModifiedTime(path).toMillis() + 5000));
+
+		assertEquals(Optional.of("bbbb"), DocumentCache.text(file, () -> read(path)));
+	}
+
+	/**
+	 * A read that failed is not kept: the next rule to ask needs the same diagnosis,
+	 * and a cached empty would have to carry it.
+	 */
+	@Test
+	void doesNotCacheAReadThatFailed() {
+		File file = writeString(tempDir.resolve("CLAUDE.md"), "x").toFile();
+		AtomicInteger reads = new AtomicInteger();
+
+		for (int rule = 0; rule < 3; rule++) {
+			DocumentCache.text(file, () -> {
+				reads.incrementAndGet();
+				return Optional.empty();
+			});
+		}
+
+		assertEquals(3, reads.get());
+	}
+
+	/**
+	 * A file that is not there yields no key, so the caller reads it directly and the
+	 * rule's own missing-file diagnosis is what the operator sees.
+	 */
+	@Test
+	void readsDirectlyWhenTheFileCannotBeStamped() {
+		File absent = tempDir.resolve("absent.md").toFile();
+		AtomicInteger reads = new AtomicInteger();
+
+		for (int rule = 0; rule < 2; rule++) {
+			DocumentCache.text(absent, () -> {
+				reads.incrementAndGet();
+				return Optional.of("somehow");
+			});
+		}
+
+		assertEquals(2, reads.get());
+	}
+
+	/** Two files are two entries, however alike their content. */
+	@Test
+	void keysOnTheFileRatherThanItsContent() {
+		File first = writeString(tempDir.resolve("one.md"), "same").toFile();
+		File second = writeString(tempDir.resolve("two.md"), "same").toFile();
+
+		assertEquals(Optional.of("first"), DocumentCache.text(first, () -> Optional.of("first")));
+		assertEquals(Optional.of("second"), DocumentCache.text(second, () -> Optional.of("second")));
+	}
+
+	@Test
+	void clearingDropsWhatItHeld() {
+		File file = writeString(tempDir.resolve("CLAUDE.md"), "x").toFile();
+		DocumentCache.text(file, () -> Optional.of("first"));
+
+		DocumentCache.clear();
+
+		assertEquals(Optional.of("second"), DocumentCache.text(file, () -> Optional.of("second")));
+	}
+
+	/** The bound is a safety net for a long-lived JVM, not something a build reaches. */
+	@Test
+	void staysBoundedWhenAskedAboutManyFiles() {
+		for (int index = 0; index < 600; index++) {
+			File file = writeString(tempDir.resolve("file" + index + ".md"), "content " + index).toFile();
+			DocumentCache.text(file, () -> Optional.of("content"));
+		}
+
+		File extra = writeString(tempDir.resolve("extra.md"), "extra").toFile();
+		assertTrue(DocumentCache.text(extra, () -> Optional.of("extra")).isPresent());
+	}
+
+	private Optional<String> read(Path path) {
+		try {
+			return Optional.of(Files.readString(path));
+		} catch (IOException e) {
+			return Optional.empty();
+		}
+	}
+}

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/SeverityTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/SeverityTest.java
@@ -1,0 +1,82 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What a configured {@code <severity>} is read as, and — the point of the type —
+ * what it refuses.
+ */
+class SeverityTest {
+
+	@Test
+	void readsWarnWhateverItsCaseAndPadding() throws EnforcerRuleException {
+		for (String configured : List.of("warn", "WARN", "Warn", " warn ", "warn\n\t")) {
+			assertEquals(Optional.of(Severity.WARN), Severity.parse(configured, "aRule"), configured);
+		}
+	}
+
+	@Test
+	void readsErrorWhateverItsCaseAndPadding() throws EnforcerRuleException {
+		for (String configured : List.of("error", "ERROR", " Error ")) {
+			assertEquals(Optional.of(Severity.ERROR), Severity.parse(configured, "aRule"), configured);
+		}
+	}
+
+	/** An unset element names no severity, which lets the caller fall back rather than guess. */
+	@Test
+	void namesNoSeverityWhenBlank() throws EnforcerRuleException {
+		for (String configured : List.of("", "   ", "\n")) {
+			assertEquals(Optional.empty(), Severity.parse(configured, "aRule"), configured);
+		}
+	}
+
+	@Test
+	void namesNoSeverityWhenNull() throws EnforcerRuleException {
+		assertEquals(Optional.empty(), Severity.parse(null, "aRule"));
+	}
+
+	/**
+	 * The regression this type exists for: 'warning' and 'info' read as the default
+	 * and failed the build, which looks exactly like the rule doing its job.
+	 */
+	@Test
+	void refusesAValueThatIsNotASeverity() {
+		for (String configured : List.of("warning", "info", "ignore", "none", "off", "fail", "true")) {
+			EnforcerRuleException thrown = assertThrows(EnforcerRuleException.class,
+					() -> Severity.parse(configured, "aRule"), configured);
+
+			assertTrue(thrown.getMessage().contains("'" + configured + "'"), thrown.getMessage());
+		}
+	}
+
+	/** The refusal has to say which rule to correct and what it will accept. */
+	@Test
+	void refusalNamesTheRuleAndTheValuesItAccepts() {
+		EnforcerRuleException thrown = assertThrows(EnforcerRuleException.class,
+				() -> Severity.parse("warning", "ClaudeMdFormatRule[claudeMdFile=/tmp/CLAUDE.md]"));
+
+		String message = thrown.getMessage();
+		assertTrue(message.contains("ClaudeMdFormatRule[claudeMdFile=/tmp/CLAUDE.md]"), message);
+		assertTrue(message.contains("error"), message);
+		assertTrue(message.contains("warn"), message);
+	}
+
+	@Test
+	void configuredNameIsTheLowerCaseSpellingAPomWrites() {
+		assertEquals("warn", Severity.WARN.configuredName());
+		assertEquals("error", Severity.ERROR.configuredName());
+	}
+
+	@Test
+	void defaultsToError() {
+		assertEquals(Severity.ERROR, Severity.DEFAULT);
+	}
+}

--- a/markdown-common/src/main/java/io/github/adamw7/tools/markdown/LineTerminators.java
+++ b/markdown-common/src/main/java/io/github/adamw7/tools/markdown/LineTerminators.java
@@ -1,17 +1,20 @@
-package io.github.adamw7.tools.adopt.step;
+package io.github.adamw7.tools.markdown;
 
 /**
- * Keeps text the adoption writes into an existing file on the line terminator
- * that file already uses. Every place that edits a file in the checkout — the POM
- * rewrite in {@link PomEnforcerInstaller}, the block
- * {@link GradleGuardInstaller} appends, and the {@code CLAUDE.md}
- * {@link ClaudeMdConformanceStep} reshapes — produces LF text, so writing it into
- * a CRLF file would leave the new region with terminators mixed into an otherwise
- * CRLF file, or (for the POM and the {@code CLAUDE.md}, whose terminators the
- * reading has already normalised) flip every line of it to LF and reformat the
- * whole file.
+ * Keeps text written into an existing file on the line terminator that file
+ * already uses.
+ *
+ * <p>Text assembled in code is LF, so writing it into a CRLF file leaves the new
+ * region with terminators mixed into an otherwise CRLF file — or, where the
+ * reading normalised the file first, flips every line of it to LF and reformats
+ * the whole thing. Both show up as a diff nobody wrote.
+ *
+ * <p>It lives here rather than beside any one caller because the two that need it
+ * are on either side of this module: {@link MarkdownConformer} reshapes a
+ * document line by line and has to put the terminators back, and the adoption
+ * pipeline edits build files the same way.
  */
-final class LineTerminators {
+public final class LineTerminators {
 
 	private static final String CRLF = "\r\n";
 	private static final String LF = "\n";
@@ -26,7 +29,7 @@ final class LineTerminators {
 	 * to LF first, so one that already mixes terminators — assembled from a
 	 * converted body and a part carried over verbatim — is not double-converted.
 	 */
-	static String matching(String text, String sample) {
+	public static String matching(String text, String sample) {
 		String normalized = normalized(text);
 		return sample.contains(CRLF) ? normalized.replace(LF, CRLF) : normalized;
 	}
@@ -36,7 +39,7 @@ final class LineTerminators {
 	 * or read from a CRLF file and then reshaped line by line — is worked on in one
 	 * shape and converted back only when it is written.
 	 */
-	static String normalized(String text) {
+	public static String normalized(String text) {
 		return text.replace(CRLF, LF).replace(CR, LF);
 	}
 }

--- a/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownConformer.java
+++ b/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownConformer.java
@@ -1,0 +1,344 @@
+package io.github.adamw7.tools.markdown;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Reshapes a Markdown document until it satisfies a {@link MarkdownContract}: it
+ * opens with the required title, mentions the companion document the contract
+ * names, and carries every required section heading with a body under each.
+ *
+ * <p>It exists because the two things that produce such a document — a generator
+ * writing natural, project-specific headings, and an author editing by hand —
+ * both produce near misses, and a check that only reports them leaves the same
+ * mechanical edits to be made by hand every time. The reshape is deterministic and
+ * conservative: a near-miss heading is <em>renamed</em> in place so its body
+ * survives, only a genuinely absent section is appended, and a required section
+ * left empty gets a stub body because a check fails an empty section just as it
+ * fails a missing one. Code — fenced or indented — and commented-out text are left
+ * alone, mirroring how such a check matches, and reshaping an already-conforming
+ * document is a no-op.
+ *
+ * <p>How the document is <em>read</em> — which lines are code, which sit inside an
+ * HTML comment, and what heading a line declares — is {@link MarkdownDocument}'s
+ * to decide, the same reader the checks judge the result with. Spelling those
+ * readings out separately made the two drift apart, and every drift produced one
+ * shape of bug: the reshape acted on lines the check holds to be code, or appended
+ * a section the check already reads as present, and the document failed the very
+ * check the reshape exists to satisfy.
+ */
+public class MarkdownConformer {
+
+	/** The blank lines the reshape may leave at the end, dropped so the document keeps a single one. */
+	private static final Pattern TRAILING_BLANK_LINES = Pattern.compile("\\n\\s*+\\z");
+
+	/**
+	 * How many times {@link #conform} may run the pass before it stops waiting for the
+	 * document to settle. Two is the ordinary cost — one pass that reshapes and one
+	 * that confirms the reshape left nothing behind — and a third is spent only where
+	 * a pass's own edit reclassified a line an earlier part of that same pass had read.
+	 * The bound is what stops a document nothing settles from looping; such a document
+	 * comes back as the last pass left it, for the caller's own check to refuse.
+	 */
+	private static final int MAX_PASSES = 4;
+
+	private final MarkdownContract contract;
+
+	/**
+	 * @param contract the shape to reshape a document into — the same one the check
+	 *                 that judges the result is configured with
+	 */
+	public MarkdownConformer(MarkdownContract contract) {
+		this.contract = contract;
+	}
+
+	/**
+	 * Reshapes until the document stops changing, which is the only way one pass can
+	 * be trusted: an edit made part-way through a pass changes how the lines below it
+	 * are read, so a question the pass had already answered can stop being true before
+	 * the pass ends. Every edit here is one of those. Inserting the {@code AGENTS.md}
+	 * reference puts a blank line above what followed the title, and a blank line is
+	 * what lets the line below it open an indented code block, so a {@code ## Testing}
+	 * that had been a lazy continuation of a paragraph became code. Inserting a stub
+	 * puts a line at the margin, which ends an open list and lowers the column at
+	 * which the lines below quote code, so a fence delimiter indented inside that list
+	 * stopped being one — and the terminator already appended for it then
+	 * <em>opened</em> a block that swallowed everything after it. Renaming a near-miss
+	 * heading moves it to the margin and ends a list the same way. Each of those left
+	 * the reshape reporting work it had done on a document that no longer existed, and
+	 * the caller's own check failing on the document the reshape had just produced.
+	 *
+	 * <p>What makes repeating the pass an answer rather than a retry is that a pass
+	 * which changes nothing is exactly a document the check accepts: the pass leaves a
+	 * title alone only where the check finds one, leaves the reference alone only
+	 * where {@code containsInProse} finds one, and leaves a section alone only where
+	 * the check's own lookup finds it carrying a body. So the loop ends on the very
+	 * condition the check makes, and a document that already conforms settles on the
+	 * first pass — which is what keeps the reshape a no-op when it is run again.
+	 *
+	 * @return {@code content} reshaped to satisfy the contract, with a single
+	 *         trailing newline
+	 */
+	public String conform(String content) {
+		String conformed = reshape(content);
+		for (int pass = 1; pass < MAX_PASSES; pass++) {
+			String settled = reshape(conformed);
+			if (settled.equals(conformed)) {
+				return conformed;
+			}
+			conformed = settled;
+		}
+		return conformed;
+	}
+
+	/**
+	 * One pass, with the two insertions that go above the document's body — the title
+	 * and the reference — made before a section is looked for. The loop above is what
+	 * makes the result sound whatever this order is, but settling those first is what
+	 * lets the ordinary generated document reshape in one pass rather than two, and a
+	 * pass that finds work left over appends it at the end of the file.
+	 */
+	private String reshape(String content) {
+		List<String> lines = splitLines(content);
+		closeUnterminatedBlocks(lines);
+		ensureTitle(lines);
+		ensureReference(lines);
+		canonicalizeHeadings(lines);
+		ensureRequiredSections(lines);
+		return join(lines);
+	}
+
+	/**
+	 * The lines are split here rather than left to {@link MarkdownDocument#parse},
+	 * because {@link String#lines()} drops the empty line a document's trailing
+	 * newline leaves and this reshape appends to the list it splits.
+	 *
+	 * <p>A leading byte-order mark is dropped, the same reading a check takes. Keeping
+	 * it left the mark in front of the title — which {@link String#strip()} does not
+	 * shorten — so the reshape concluded the title was missing and prepended a second
+	 * one, which the check accepted either way.
+	 */
+	private List<String> splitLines(String content) {
+		String normalized = LineTerminators.normalized(MarkdownText.stripByteOrderMark(content));
+		return new ArrayList<>(List.of(normalized.split("\n", -1)));
+	}
+
+	/**
+	 * Closes a fence and an HTML comment the document opened and never closed, so
+	 * everything appended below lands outside the block: a section appended inside an
+	 * open comment is inert text the rule does not see. A document whose fences and
+	 * comments balance is left untouched, keeping the reshape idempotent.
+	 *
+	 * <p>The fence is closed first, because a comment inside a fenced code block is
+	 * sample text rather than a comment — the same precedence a check reads them
+	 * with — and the document is read afresh afterwards so the added line counts.
+	 */
+	private void closeUnterminatedBlocks(List<String> lines) {
+		MarkdownDocument.of(lines).openFenceTerminator().ifPresent(lines::add);
+		MarkdownDocument.of(lines).openCommentTerminator().ifPresent(lines::add);
+	}
+
+	/**
+	 * Puts the title on the document's first line, which is where the rule reads it.
+	 * A title the document already carries lower down is <em>moved</em> rather than
+	 * left where it is, since prepending a second one leaves two title headings —
+	 * which a check accepts, so nothing downstream would report the duplicate, and the
+	 * reshape being idempotent means running it again never clears it.
+	 *
+	 * <p>A document that already opens with the title is not left alone either: it
+	 * needs no title <em>added</em>, but a second one lower down is the same duplicate
+	 * by another route, and returning on the first line alone left it there for good —
+	 * a check never looks past that line, so nothing downstream reported it, and the
+	 * reshape being idempotent meant running it again never cleared it.
+	 *
+	 * <p>The titles are removed latest first, so removing one cannot shift the index
+	 * of the next. Only structural lines are offered: a {@code # CLAUDE.md} inside a
+	 * code sample is the sample's, not the document's.
+	 */
+	private void ensureTitle(List<String> lines) {
+		MarkdownDocument document = MarkdownDocument.of(lines);
+		List<Integer> titles = document.headingIndices(contract.title()).boxed().toList();
+		if (contract.title().equals(document.firstNonBlankLine())) {
+			removeHeadings(lines, allButTheFirst(titles));
+			return;
+		}
+		removeHeadings(lines, titles);
+		lines.addAll(0, List.of(contract.title(), ""));
+	}
+
+	/**
+	 * The titles a document opening with one has to lose: every one but the title it
+	 * opens with, which is the one a check reads. An empty list is the document whose
+	 * opening title is not a structural line at all — one indented into a code block,
+	 * which a check accepts on the same reading and which is the sample's to keep.
+	 */
+	private static List<Integer> allButTheFirst(List<Integer> titles) {
+		return titles.isEmpty() ? titles : titles.subList(1, titles.size());
+	}
+
+	/** Removes the headings latest first, so removing one cannot shift the index of the next. */
+	private static void removeHeadings(List<String> lines, List<Integer> indices) {
+		indices.reversed().forEach(index -> removeHeading(lines, index));
+	}
+
+	/**
+	 * Removes the heading, and the blank line below it only when the line above was
+	 * blank too — otherwise the paragraph that followed the heading would be pulled up
+	 * against the one that preceded it and the two would read as a single paragraph.
+	 */
+	private static void removeHeading(List<String> lines, int index) {
+		lines.remove(index);
+		if (isBlankAt(lines, index) && precededByBlank(lines, index)) {
+			lines.remove(index);
+		}
+	}
+
+	private static boolean precededByBlank(List<String> lines, int index) {
+		return index == 0 || lines.get(index - 1).isBlank();
+	}
+
+	/**
+	 * Renaming a heading in place leaves the line count untouched and cannot turn a
+	 * structural line into code, so one reading of the document serves every required
+	 * section here — unlike {@link #stubBareSection}, which inserts lines and has to
+	 * read the document afresh each time.
+	 */
+	private void canonicalizeHeadings(List<String> lines) {
+		MarkdownDocument document = MarkdownDocument.of(lines);
+		Set<Integer> claimed = reservedHeadings(document);
+		contract.requiredSections().forEach(required -> canonicalize(lines, document, required, claimed));
+	}
+
+	/**
+	 * The indices of lines that already are a required heading exactly, reserved so
+	 * a near-match search never renames a heading that is already serving another
+	 * required section.
+	 */
+	private Set<Integer> reservedHeadings(MarkdownDocument document) {
+		return document
+				.structuralLines(line -> MarkdownDocument.headingOf(line).filter(contract.requiredSections()::contains).isPresent())
+				.boxed()
+				.collect(Collectors.toCollection(LinkedHashSet::new));
+	}
+
+	private void canonicalize(List<String> lines, MarkdownDocument document, String required,
+			Set<Integer> claimed) {
+		if (document.headingIndex(required) >= 0) {
+			return;
+		}
+		int index = firstNearMatch(document, required, claimed);
+		if (index >= 0) {
+			lines.set(index, required);
+			claimed.add(index);
+		}
+	}
+
+	private int firstNearMatch(MarkdownDocument document, String required, Set<Integer> claimed) {
+		return document.structuralLines(line -> isNearMatch(line, required))
+				.filter(index -> !claimed.contains(index))
+				.findFirst()
+				.orElse(-1);
+	}
+
+	/**
+	 * A near-miss is the required heading in a different case, or followed by a space
+	 * and extra words — the two shapes a generator produces ({@code ## Project
+	 * purpose} for {@code ## Project}). The trailing space keeps
+	 * {@code ## Maven} from matching an unrelated {@code ## Mavenish} heading. The
+	 * line is compared as {@link MarkdownDocument#headingOf} writes it, so which
+	 * spelling a near-miss was typed in does not decide whether it is one.
+	 */
+	private static boolean isNearMatch(String line, String required) {
+		String wanted = required.toLowerCase(Locale.ROOT);
+		return MarkdownDocument.headingOf(line)
+				.map(heading -> heading.toLowerCase(Locale.ROOT))
+				.filter(actual -> actual.equals(wanted) || actual.startsWith(wanted + " "))
+				.isPresent();
+	}
+
+	/**
+	 * Gives every required section both a heading and a body: a heading the document
+	 * left bare — typically a near-miss renamed in place above — has a stub inserted
+	 * beneath it, and a section the document does not carry at all is appended with
+	 * one. A check fails an empty section just as it fails a missing one, so both are
+	 * settled here.
+	 *
+	 * <p>The two are separate passes, with the document's blocks closed again between
+	 * them, because inserting a stub is a mid-document edit and a mid-document edit
+	 * can change what the lines below it are. A stub sits at the margin, which ends an
+	 * open list — and that lowers the column at which the lines below quote code, so a
+	 * fence delimiter indented inside that list stops being one. The terminator
+	 * {@link #closeUnterminatedBlocks} had already appended for it then <em>opened</em>
+	 * a block instead of closing one, and every section appended afterwards landed
+	 * inside it, where a check reads it as code: the reshape answered with a document
+	 * still missing the sections it had just written.
+	 * Interleaving the two passes has the same flaw one step further on, since a stub
+	 * inserted after a section was appended can bury that section the same way.
+	 * Appending, by contrast, only ever adds below every line that has been read, so
+	 * it can invalidate nothing.
+	 */
+	private void ensureRequiredSections(List<String> lines) {
+		contract.requiredSections().forEach(required -> stubBareSection(lines, required));
+		closeUnterminatedBlocks(lines);
+		contract.requiredSections().forEach(required -> appendAbsentSection(lines, required));
+	}
+
+	/**
+	 * The document is read afresh per section because inserting a stub shifts the
+	 * lines the next one is found at, and the sections are few enough for that to stay
+	 * cheap. Missing and empty are two answers to the one heading lookup, so it is
+	 * made once: a section the document does not declare is left to
+	 * {@link #appendAbsentSection}.
+	 */
+	private void stubBareSection(List<String> lines, String required) {
+		MarkdownDocument document = MarkdownDocument.of(lines);
+		int index = document.headingIndex(required);
+		if (index >= 0 && !document.hasBodyAt(index)) {
+			lines.addAll(index + 1, List.of("", contract.stubBody()));
+		}
+	}
+
+	/** Appends the section and its stub when the document declares the heading nowhere. */
+	private void appendAbsentSection(List<String> lines, String required) {
+		if (MarkdownDocument.of(lines).headingIndex(required) < 0) {
+			lines.addAll(List.of("", required, "", contract.stubBody()));
+		}
+	}
+
+	/**
+	 * The reference is separated from what follows it only when that line is not
+	 * already blank, since a document conformed to no required sections keeps the body
+	 * {@code claude init} wrote, blank line and all.
+	 *
+	 * <p>An existing mention only counts where the rule counts one: its
+	 * {@code containsInProse} reads the lines that carry document structure, so a
+	 * mention inside a code sample or an HTML comment satisfies it no more than a
+	 * commented-out heading satisfies a required section. Asking the looser question
+	 * let a document whose only {@code AGENTS.md} sat in a comment keep a reference it
+	 * never had. A document with no title line at all takes the reference at the top.
+	 */
+	private void ensureReference(List<String> lines) {
+		MarkdownDocument document = MarkdownDocument.of(lines);
+		if (document.containsInProse(contract.requiredReference())) {
+			return;
+		}
+		int index = Math.max(document.headingIndex(contract.title()), 0) + 1;
+		lines.addAll(index, isBlankAt(lines, index)
+				? List.of("", contract.referenceLine())
+				: List.of("", contract.referenceLine(), ""));
+	}
+
+	private static boolean isBlankAt(List<String> lines, int index) {
+		return index < lines.size() && lines.get(index).isBlank();
+	}
+
+	/** Joins the lines under a single trailing newline, dropping any blank lines the reshape left at the end. */
+	private String join(List<String> lines) {
+		return TRAILING_BLANK_LINES.matcher(String.join("\n", lines)).replaceAll("") + "\n";
+	}
+}

--- a/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownContract.java
+++ b/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownContract.java
@@ -1,0 +1,91 @@
+package io.github.adamw7.tools.markdown;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The shape a Markdown document is required to have: the title it opens with, the
+ * section headings it must carry with a body under each, and optionally a
+ * companion document it must reference.
+ *
+ * <p>It is stated once and read by both sides of the same contract — the check
+ * that fails a document not shaped this way, and the {@link MarkdownConformer}
+ * that reshapes one into it. Two statements of it drifted, and every drift
+ * produced the same bug: a document reshaped to satisfy a check that had since
+ * come to ask for something else.
+ *
+ * @param title             the heading the document must open with, e.g. {@code # CLAUDE.md}
+ * @param requiredSections  the headings it must carry, in the order they are appended;
+ *                          a heading named twice counts once
+ * @param requiredReference a companion document the prose must mention, or empty for none
+ * @param referenceLine     the line inserted when {@code requiredReference} is missing
+ * @param stubBody          what a required section with nothing under it is given, since a
+ *                          check that fails an empty section fails it as firmly as a missing one
+ */
+public record MarkdownContract(String title, List<String> requiredSections, String requiredReference,
+		String referenceLine, String stubBody) {
+
+	/**
+	 * What a required section the project has nothing to say under is given. Saying
+	 * plainly that nothing is recorded yet is both true and actionable — a stub that
+	 * pointed at a companion document, which pointed back, left a reader unable to
+	 * tell an unanswered section from an answered one.
+	 */
+	public static final String DEFAULT_STUB_BODY =
+			"_Not documented yet — replace this line with the project's own guidance._";
+
+	public MarkdownContract {
+		Objects.requireNonNull(title, "title");
+		Objects.requireNonNull(requiredReference, "requiredReference");
+		Objects.requireNonNull(referenceLine, "referenceLine");
+		Objects.requireNonNull(stubBody, "stubBody");
+		requiredSections = List.copyOf(new LinkedHashSet<>(requiredSections));
+	}
+
+	/** A contract asking only that the document open with {@code title}. */
+	public static MarkdownContract titled(String title) {
+		return new MarkdownContract(title, List.of(), "", "", DEFAULT_STUB_BODY);
+	}
+
+	/**
+	 * @param sections the headings to require, empty for a check that demands none.
+	 *                 Stamping headings onto a document whose check does not ask for
+	 *                 them leaves sections carrying nothing but the stub, which
+	 *                 nothing then reads.
+	 */
+	public MarkdownContract requiring(List<String> sections) {
+		return new MarkdownContract(title, sections, requiredReference, referenceLine, stubBody);
+	}
+
+	/**
+	 * Requires the prose to mention {@code document}, inserting the conventional link
+	 * to it when it does not. A blank name requires no reference at all, for a project
+	 * that keeps no companion document.
+	 */
+	public MarkdownContract referencing(String document) {
+		String reference = document == null ? "" : document.strip();
+		return new MarkdownContract(title, requiredSections, reference, referenceLineFor(reference), stubBody);
+	}
+
+	/** Requires the reference and states verbatim the line to insert when it is absent. */
+	public MarkdownContract referencing(String document, String referenceLine) {
+		return new MarkdownContract(title, requiredSections, document.strip(), referenceLine, stubBody);
+	}
+
+	public MarkdownContract withStubBody(String stubBody) {
+		return new MarkdownContract(title, requiredSections, requiredReference, referenceLine, stubBody);
+	}
+
+	/** @return whether the document must mention a companion document at all */
+	public boolean requiresReference() {
+		return !requiredReference.isEmpty();
+	}
+
+	private static String referenceLineFor(String document) {
+		if (document.isEmpty()) {
+			return "";
+		}
+		return "See [" + document + "](" + document + ") for the companion agent guide.";
+	}
+}

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownConformerTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownConformerTest.java
@@ -1,0 +1,111 @@
+package io.github.adamw7.tools.markdown;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The reshape as anything but a CLAUDE.md asks for it. The CLAUDE.md contract has
+ * its own tests in the adopt module, which also runs the real enforcer rule over
+ * the output; these cover what generalising the contract added — another title,
+ * no companion document, and no required sections at all.
+ */
+class MarkdownConformerTest {
+
+	private static final MarkdownContract AGENTS = MarkdownContract.titled("# AGENTS.md")
+			.requiring(List.of("## Project overview", "## Module layout"));
+
+	@Test
+	void putsTheContractsOwnTitleOnTheFirstLine() {
+		String conformed = new MarkdownConformer(AGENTS).conform("Some prose.\n");
+
+		assertTrue(conformed.startsWith("# AGENTS.md\n"), conformed);
+	}
+
+	@Test
+	void appendsEveryRequiredSectionWithABody() {
+		String conformed = new MarkdownConformer(AGENTS).conform("# AGENTS.md\n");
+
+		assertTrue(conformed.contains("## Project overview"), conformed);
+		assertTrue(conformed.contains("## Module layout"), conformed);
+		assertTrue(conformed.contains(MarkdownContract.DEFAULT_STUB_BODY), conformed);
+	}
+
+	/** A near miss is renamed in place, so whatever the author wrote under it survives. */
+	@Test
+	void renamesANearMissAndKeepsItsBody()  {
+		String conformed = new MarkdownConformer(AGENTS)
+				.conform("# AGENTS.md\n\n## Project overview and goals\n\nWhat this is.\n");
+
+		assertTrue(conformed.contains("## Project overview\n"), conformed);
+		assertTrue(conformed.contains("What this is."), conformed);
+		assertFalse(conformed.contains("## Project overview and goals"), conformed);
+	}
+
+	/** A contract naming no companion document must not invent a reference to one. */
+	@Test
+	void insertsNoReferenceWhenTheContractNamesNoCompanionDocument() {
+		String conformed = new MarkdownConformer(AGENTS).conform("# AGENTS.md\n\nProse.\n");
+
+		assertFalse(conformed.contains("See ["), conformed);
+	}
+
+	@Test
+	void insertsTheReferenceTheContractNames() {
+		MarkdownContract contract = MarkdownContract.titled("# CLAUDE.md").referencing("HANDBOOK.md");
+
+		String conformed = new MarkdownConformer(contract).conform("# CLAUDE.md\n\nProse.\n");
+
+		assertTrue(conformed.contains("[HANDBOOK.md](HANDBOOK.md)"), conformed);
+	}
+
+	@Test
+	void leavesAReferenceTheDocumentAlreadyMakes() {
+		MarkdownContract contract = MarkdownContract.titled("# CLAUDE.md").referencing("HANDBOOK.md");
+
+		String conformed = new MarkdownConformer(contract).conform("# CLAUDE.md\n\nSee HANDBOOK.md for detail.\n");
+
+		assertEquals("# CLAUDE.md\n\nSee HANDBOOK.md for detail.\n", conformed);
+	}
+
+	/** A contract requiring nothing must not stamp headings onto a document nobody asked to shape. */
+	@Test
+	void addsNoSectionsWhenTheContractRequiresNone() {
+		MarkdownContract contract = MarkdownContract.titled("# NOTES.md");
+
+		String conformed = new MarkdownConformer(contract).conform("# NOTES.md\n\nJust prose.\n");
+
+		assertEquals("# NOTES.md\n\nJust prose.\n", conformed);
+	}
+
+	@Test
+	void reshapingAnAlreadyConformingDocumentChangesNothing() {
+		String once = new MarkdownConformer(AGENTS).conform("# AGENTS.md\n\nProse.\n");
+
+		assertEquals(once, new MarkdownConformer(AGENTS).conform(once));
+	}
+
+	/** A section named twice is one section, so a second near miss is not renamed to it. */
+	@Test
+	void countsARepeatedRequiredSectionOnce() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md")
+				.requiring(List.of("## Testing", "## Testing"));
+
+		String conformed = new MarkdownConformer(contract).conform("# X.md\n");
+
+		assertEquals(1, conformed.split("## Testing", -1).length - 1, conformed);
+	}
+
+	@Test
+	void stubBodyIsTheContractsToChoose() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md")
+				.requiring(List.of("## Testing"))
+				.withStubBody("TBD.");
+
+		assertTrue(new MarkdownConformer(contract).conform("# X.md\n").contains("TBD."));
+	}
+}

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownContractTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownContractTest.java
@@ -1,0 +1,47 @@
+package io.github.adamw7.tools.markdown;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class MarkdownContractTest {
+
+	@Test
+	void requiresNoReferenceByDefault() {
+		assertFalse(MarkdownContract.titled("# X.md").requiresReference());
+	}
+
+	@Test
+	void derivesTheConventionalLinkForAReferenceItIsGivenBare() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md").referencing("AGENTS.md");
+
+		assertTrue(contract.requiresReference());
+		assertTrue(contract.referenceLine().contains("[AGENTS.md](AGENTS.md)"), contract.referenceLine());
+	}
+
+	@Test
+	void keepsTheReferenceLineItIsGivenVerbatim() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md").referencing("AGENTS.md", "Read AGENTS.md.");
+
+		assertEquals("Read AGENTS.md.", contract.referenceLine());
+	}
+
+	/** A blank name is a project with no companion document, not a document called "". */
+	@Test
+	void requiresNoReferenceWhenNamedBlank() {
+		assertFalse(MarkdownContract.titled("# X.md").referencing("   ").requiresReference());
+		assertFalse(MarkdownContract.titled("# X.md").referencing(null).requiresReference());
+	}
+
+	@Test
+	void keepsARepeatedRequiredSectionOnceInTheOrderGiven() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md")
+				.requiring(List.of("## B", "## A", "## B"));
+
+		assertEquals(List.of("## B", "## A"), contract.requiredSections());
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,13 @@
 		     of the number is a copy that can drift. -->
 		<java.version>25</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<!-- Named rather than written twice: the adopt pipeline wires this same
+		     plugin into other people's poms, and it reads the number from this
+		     property through its filtered build metadata. A literal in both places
+		     is a literal that drifts, and the half that drifts is the one nobody
+		     builds — a stranger's repository, adopted with a version this project
+		     stopped using. -->
+		<maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
 		<!-- project.build.outputTimestamp — which makes the build reproducible by
 		     having every archive-producing plugin (jar, source, javadoc, assembly,
 		     plugin descriptor, Spring Boot repackage) stamp one fixed instant on
@@ -493,7 +500,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>
-					<version>3.6.3</version>
+					<version>${maven-enforcer-plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
A severity that was neither 'error' nor 'warn' was read as 'error', so
<severity>warning</severity> and <severity>info</severity> failed the build
while the author who wrote them believed the rule had been downgraded — the one
misconfiguration whose symptom is indistinguishable from the rule working.
Severity is now a type that refuses what it cannot read, naming the rule and the
values it accepts, and it is read before the rule writes a report or a baseline
off the back of it. Asking to record a baseline with no baselineFile to record
it to was the same shape of silence, answering a request that had gone nowhere
with the failure the operator had just asked to accept; it is now refused too.

severity, reportFile and baselineFile are the three parameters that are the same
answer for every rule a project wires, and a full catalogue is around twenty of
them. Each now has a build-wide default — -Dclaude.enforcer.severity,
-Dclaude.enforcer.reportDir, -Dclaude.enforcer.baselineDir — with a parameter
configured on the rule itself still winning, so a build can downgrade the
catalogue and insist on one rule. A directory names each rule's file after the
rule, since two rules sharing one report would overwrite each other's verdict
and one shared baseline would let a violation accepted for one suppress
another's. Reports collected into one directory gain an index page linking them,
because twenty HTML files are twenty files nobody opens.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NyZ2UTVLZxXfCnxEYRjWWq