### PR TITLE
test(adopt, claude-code-enforcer): meet five repositories neither had met

### DIFF
--- a/.claude/commands/new-enforcer-rule.md
+++ b/.claude/commands/new-enforcer-rule.md
@@ -35,9 +35,10 @@ outside the class. Work through every step:
    with **every** parameter it accepts; `EnforcerRuleBuildIT` checks that block
    against the compiled classes and fails if a rule or parameter is missing.
 7. **Survive a repository nobody prepared** — `ForeignRepositoryEnforcementIT`
-   points the same configuration at five real clones. The rule must reach a
+   points the same configuration at eight real clones. The rule must reach a
    verdict on a file it did not expect and a directory that is not there, and
-   report both rather than throwing.
+   report both rather than throwing; where one of the eight really ships the file
+   your rule reads, pin that it read it rather than reported it absent.
 8. **Wire it** into the root pom's `claude-md-enforce` profile, one child element
    per parameter. A rule taking a definition directory can only be wired once that
    directory exists — add the directory and the wiring in the same change.

--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -134,18 +134,21 @@ clone URL's credentials come back in the tool's own error text.
 - `MultiRepoAdoptionIT` clones real sample repositories to prove each gets its
   own checkout, and **stops at the branch step** — the `*IT`s never push and
   never open a pull request. Keep that invariant when extending them.
-- `ForeignRepositoryAdoptionIT` adopts five real repositories nobody prepared —
+- `ForeignRepositoryAdoptionIT` adopts seven real repositories nobody prepared —
   `google/gson` (multi-module Maven), `square/okhttp` (Gradle, Kotlin DSL),
+  `JakeWharton/timber` (Gradle, Groovy DSL, developed on `trunk`),
   `anthropics/anthropic-quickstarts` (a real `CLAUDE.md`),
-  `anthropics/claude-code` (a real `.claude`) and `github/gitignore` (a very
+  `anthropics/claude-code` (a real `.claude`), `modelcontextprotocol/servers`
+  (its own files where two starter assets go) and `github/gitignore` (a very
   large flat tree). A step that reads or writes the checkout has to survive them:
-  the guard is only ever an *addition* to a build file somebody else wrote, the
-  commits carry only `AdoptionAssets.WRITTEN_PATHS`, the working tree is left
-  clean, the default branch and the remote are untouched, and a second adoption
-  changes nothing. It installs the starter assets too, so `AssetInstaller`'s
-  "the project's own version wins" is checked against a file somebody else wrote
-  — `claude-code`'s own `.github/workflows/claude.yml`, which no fixture can
-  imitate. Its Maven guard is pinned to a released `--rule-version`,
+  the guard is only ever an *addition* to a build file somebody else wrote and is
+  written in that script's own DSL, the commits carry only
+  `AdoptionAssets.WRITTEN_PATHS`, the working tree is left clean, the default
+  branch — read from the remote, never guessed — and the remote are untouched,
+  and a second adoption changes nothing. It installs the starter assets too, so
+  `AssetInstaller`'s "the project's own version wins" is checked against files
+  somebody else wrote — `claude-code`'s own `.github/workflows/claude.yml` and
+  `servers`' own `.mcp.json`, which no fixture can imitate. Its Maven guard is pinned to a released `--rule-version`,
   because the installer refuses to wire a `-SNAPSHOT` into another project's POM.
 - Run them with `mvn -P integration-tests verify` (the profile is declared in
   `adopt`'s own pom).
@@ -154,6 +157,6 @@ clone URL's credentials come back in the tool's own error text.
 - `CLAUDE.md` / `AGENTS.md` — *Claude Code adoption* (source of truth)
 - `adopt/.../GitHubRepoAdopter.java` — the assembled pipeline
 - `adopt/.../architecture/AdoptArchitectureTest.java` — the rules above, as tests
-- `adopt/.../ForeignRepositoryAdoptionIT.java` — the pipeline against five real
+- `adopt/.../ForeignRepositoryAdoptionIT.java` — the pipeline against seven real
   repositories that never adopted it
 - `adopt/.../mcp/MCP_USAGE.md` — the `adopt_repo` tool

--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -144,8 +144,10 @@ clone URL's credentials come back in the tool's own error text.
   the guard is only ever an *addition* to a build file somebody else wrote and is
   written in that script's own DSL, the commits carry only
   `AdoptionAssets.WRITTEN_PATHS`, the working tree is left clean, the default
-  branch — read from the remote, never guessed — and the remote are untouched,
-  and a second adoption changes nothing. It installs the starter assets too, so
+  branch — read from the remote, never guessed — is untouched, and the repository
+  on GitHub is asked with `ls-remote` whether the adoption branch reached it (a
+  local tracking ref is evidence about the clone; the claim is about somebody
+  else's repository). A second adoption changes nothing. It installs the starter assets too, so
   `AssetInstaller`'s "the project's own version wins" is checked against files
   somebody else wrote — `claude-code`'s own `.github/workflows/claude.yml` and
   `servers`' own `.mcp.json`, which no fixture can imitate. Its Maven guard is pinned to a released `--rule-version`,

--- a/.claude/skills/enforcer-rules/SKILL.md
+++ b/.claude/skills/enforcer-rules/SKILL.md
@@ -127,15 +127,21 @@ parameter left out fails `EnforcerRuleBuildIT`), and `RepositoryEnforcementIT`
 compares the shipped catalogue against the root pom's profile. Run them with
 `mvn -pl claude-code-enforcer -am -P integration-tests verify`.
 
-**A new rule also meets five real repositories.**
+**A new rule also meets eight real repositories.**
 `ForeignRepositoryEnforcementIT` points the same complete configuration at
 shallow clones of `octocat/Hello-World`, `octocat/Spoon-Knife`,
-`github/gitignore`, `anthropics/claude-code` and
-`anthropics/anthropic-quickstarts` — projects nobody prepared for these rules.
-It does not expect them to pass; it expects every rule to *reach a verdict* on
-each of them, to say why when it fails, and never to break the build on the
-rule's own account. So a new rule must survive a file it did not expect and a
-directory that is not there, and report both as violations rather than throwing.
+`github/gitignore`, `anthropics/claude-code`,
+`anthropics/anthropic-quickstarts`, `github/spec-kit`,
+`modelcontextprotocol/servers` and `anthropics/claude-code-action` — projects
+nobody prepared for these rules. It does not expect them to pass; it expects
+every rule to *reach a verdict* on each of them, to say why when it fails, and
+never to break the build on the rule's own account. So a new rule must survive a
+file it did not expect and a directory that is not there, and report both as
+violations rather than throwing. Between them the eight carry a real `CLAUDE.md`,
+a real `AGENTS.md`, a real `.mcp.json`, and a real `.claude` directory with
+commands, sub-agents and a `settings.json` — so a rule reading one of those is
+pinned to *read* it rather than report it absent. If your rule reads a file none
+of the eight ships, say so in its test rather than leaving the claim untested.
 
 **Naming trap for a `List<String>` parameter.** Plexus infers a configured
 list's element type from the *child element name*, trying the rule's own package
@@ -179,5 +185,5 @@ fails a real build with "Failed to create enforcer rules with name: …". The
 - `claude-code-enforcer/.../architecture/EnforcerArchitectureTest.java` — layering
 - `claude-code-enforcer/.../e2e/EnforcerRuleBuildIT.java` — the pom-to-rule seam
 - `claude-code-enforcer/.../e2e/ForeignRepositoryEnforcementIT.java` — the rules
-  against five real repositories that never adopted them
+  against eight real repositories that never adopted them
 - Root `pom.xml` — the `claude-md-enforce` profile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -588,7 +588,10 @@ module's `*IT`s stay unrun until it gets its own copy. Run them with
   only paths `AdoptionAssets.WRITTEN_PATHS` names and the working tree is left
   clean, the guard commit's diff *removes* nothing the build file already
   declared, the default branch and the remote are untouched, and a second
-  adoption of the same batch commits nothing. The default branch is read from the
+  adoption of the same batch commits nothing. That nothing was published is asked
+  of GitHub itself with `ls-remote`, not only of the clone's tracking refs: a ref
+  in the checkout is evidence about the checkout, and the promise is about seven
+  repositories belonging to other people. The default branch is read from the
   remote rather than guessed, which only a repository like `timber` — developed
   on `trunk` — can show: its adoption branch is asserted to have been cut from
   that branch. The
@@ -647,11 +650,15 @@ module's `*IT`s stay unrun until it gets its own copy. Run them with
   question the other way round, since for them an absent file *is* a pass:
   `servers` ships an `.mcp.json` declaring none of the servers the
   configuration requires, so a rule that read it has something to say and a
-  rule that passed it over has not. A further test adopts the contract into a
-  fresh clone and enforces it green, so the rules are shown satisfiable
-  outside the repository that wrote them. The last takes the adopter's other
-  route — record the backlog, gate what is added to it — and pins the half a
-  fixture cannot reach: `commandFormat`'s real backlog in
+  rule that passed it over has not. One more asks git what the eight checkouts
+  hold after all the builds — modified, staged, untracked and ignored alike —
+  because they are somebody else's projects and the enforcing build is given
+  only their path: an auto-fix rewriting a document it was asked to check, or a
+  report landing beside the file it read, would show up there and nowhere else.
+  A further test adopts the contract into a fresh clone and enforces it green,
+  so the rules are shown satisfiable outside the repository that wrote them. The
+  last takes the adopter's other route — record the backlog, gate what is added
+  to it — and pins the half a fixture cannot reach: `commandFormat`'s real backlog in
   `anthropics/claude-code` (the `allowed-tools` key its commands declare,
   which the configuration does not allow) is recorded against the shared
   checkout and replayed against a *second* clone of it, at a path the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -566,29 +566,40 @@ module's `*IT`s stay unrun until it gets its own copy. Run them with
   `claude`, never pushes, never opens a pull request and needs no `gh` login.
   Because it clones over the network, it identifies each checkout by the
   `owner/repository` its `origin` names rather than by the URL it was given.
-- `adopt`'s `ForeignRepositoryAdoptionIT` adopts five **real** repositories in
+- `adopt`'s `ForeignRepositoryAdoptionIT` adopts seven **real** repositories in
   one batch — `google/gson`, `square/okhttp`,
-  `anthropics/anthropic-quickstarts`, `anthropics/claude-code` and
-  `github/gitignore` — chosen for the shapes they put in front of the steps that
-  read a checkout: a multi-module Maven build, a Gradle build on the Kotlin DSL,
-  a real `CLAUDE.md`, a real `.claude` directory, and a very large flat tree with
-  no build file. Every step test drives its step over a directory this repository
-  laid out, so between them these five are the only place all three
-  `BuildSystem`s meet build files nobody wrote for them. What is asserted is that
+  `anthropics/anthropic-quickstarts`, `anthropics/claude-code`,
+  `github/gitignore`, `JakeWharton/timber` and `modelcontextprotocol/servers` —
+  chosen for the shapes they put in front of the steps that read a checkout: a
+  multi-module Maven build, a Gradle build on the Kotlin DSL and another on the
+  Groovy one, a real `CLAUDE.md`, a real `.claude` directory, a project whose own
+  files already sit where two of the starter assets go, a default branch called
+  neither `main` nor `master`, and a very large flat tree with no build file.
+  Every step test drives its step over a directory this repository laid out, so
+  between them these seven are the only place all three `BuildSystem`s — and both
+  Gradle DSLs — meet build files nobody wrote for them. What is asserted is that
   the adoption's work is *its own and nothing else*: the pipeline runs to its end
   on each, the guard that lands is the one the checkout's build files ask for
   (the enforcer execution spliced into gson's `pom.xml`, the guard task appended
-  to okhttp's `build.gradle.kts`, the workflow and script for the rest), the two
-  commits carry only paths `AdoptionAssets.WRITTEN_PATHS` names and the working
-  tree is left clean, the guard commit's diff *removes* nothing the build file
-  already declared, the default branch and the remote are untouched, and a second
-  adoption of the same batch commits nothing. The run installs the starter assets
-  too, because `AssetInstaller`'s promise that the project's own version always
-  wins is about a file somebody else keeps at one of their paths, and only a real
-  repository brings one: `claude-code` ships a `claude.yml` workflow of its own,
-  so the batch asserts each repository was given exactly the assets it lacked and
-  that workflow came through byte-identical to the blob that was cloned. A last
-  test reads the one document the pipeline reshapes rather than adds beside:
+  to okhttp's `build.gradle.kts` and to timber's `build.gradle`, the workflow and
+  script for the rest) and is written in that script's own DSL — a Kotlin block
+  appended to a Groovy script would register the task the verification looks for
+  and leave the project a build that no longer compiles — the two commits carry
+  only paths `AdoptionAssets.WRITTEN_PATHS` names and the working tree is left
+  clean, the guard commit's diff *removes* nothing the build file already
+  declared, the default branch and the remote are untouched, and a second
+  adoption of the same batch commits nothing. The default branch is read from the
+  remote rather than guessed, which only a repository like `timber` — developed
+  on `trunk` — can show: its adoption branch is asserted to have been cut from
+  that branch. The
+  run installs the starter assets too, because `AssetInstaller`'s promise that
+  the project's own version always wins is about a file somebody else keeps at
+  one of their paths, and only a real repository brings one: `claude-code` ships
+  a `claude.yml` workflow of its own and `servers` an `.mcp.json` of its own, so
+  the batch asserts each repository was given exactly the assets it lacked and
+  that both of those files came through byte-identical to the blobs that were
+  cloned. A last test reads the one document the pipeline reshapes rather than
+  adds beside:
   `anthropic-quickstarts`' real `CLAUDE.md` is conformed and the real
   `claudeMdFormat` rule then accepts it, the foreign document having been
   asserted to fail it first.
@@ -616,37 +627,46 @@ module's `*IT`s stay unrun until it gets its own copy. Run them with
   and then breaks a *copy* — a skill losing its `SKILL.md`, the two agent
   documents disagreeing about the Java version — to prove the wiring bites.
   `ForeignRepositoryEnforcementIT` points the same complete configuration at
-  five **real** repositories shallow-cloned from GitHub — `octocat/Hello-World`,
-  `octocat/Spoon-Knife`, `github/gitignore`, `anthropics/claude-code` and
-  `anthropics/anthropic-quickstarts` — because both tests above read files
-  written to be read by these rules, and an adopter's project was not. None of
-  the five passes and none should; what is asserted is that every rule *reaches a
-  verdict* on every one of them (`EnforcerVerdicts` reads maven-enforcer's
-  per-rule `passed`/`failed with message:` lines back out of the log, since an
-  exit code cannot tell a rule that examined a project from one that never ran),
-  that no build goes red on the rules' own account — an unbindable parameter, an
-  exception escaping a rule — that every failure says why, that the four
-  optional-file rules pass where the file really is absent, and that
-  `commandFormat` reads `anthropics/claude-code`'s real `.claude/commands`
-  instead of reporting it absent. A sixth test adopts the contract into a fresh
-  clone and enforces it green, so the rules are shown satisfiable outside the
-  repository that wrote them. A seventh takes the adopter's other route — record
-  the backlog, gate what is added to it — and pins the half a fixture cannot
-  reach: `commandFormat`'s real backlog in `anthropics/claude-code` (the
-  `allowed-tools` key its commands declare, which the configuration does not
-  allow) is recorded against the shared checkout and replayed against a *second*
-  clone of it, at a path the recording never saw. A baseline is a file a project
-  commits, so a signature naming the clone it was recorded under would suppress
-  nothing anywhere else — the fixture's three baseline builds share one directory
-  and cannot show it. Only a command added to the second clone fails that build,
-  and everything the baseline accepted stays unreported. The build runs in a
+  eight **real** repositories shallow-cloned from GitHub — `octocat/Hello-World`,
+  `octocat/Spoon-Knife`, `github/gitignore`, `anthropics/claude-code`,
+  `anthropics/anthropic-quickstarts`, `github/spec-kit`,
+  `modelcontextprotocol/servers` and `anthropics/claude-code-action` — because
+  both tests above read files written to be read by these rules, and an adopter's
+  project was not. None of the eight passes and none should; what is asserted is
+  that every rule *reaches a verdict* on every one of them (`EnforcerVerdicts`
+  reads maven-enforcer's per-rule `passed`/`failed with message:` lines back
+  out of the log, since an exit code cannot tell a rule that examined a
+  project from one that never ran), that no build goes red on the rules' own
+  account — an unbindable parameter, an exception escaping a rule — that every
+  failure says why, that the four optional-file rules pass where the file
+  really is absent, and that a rule reads a real file rather than reporting it
+  absent: `commandFormat` over `anthropics/claude-code`'s `.claude/commands`,
+  `subAgentFormat` and `settingsJsonValid` over `claude-code-action`'s
+  `.claude/agents` and `.claude/settings.json`, and `agentsMdFormat` over
+  `spec-kit`'s `AGENTS.md`. The two optional MCP rules are asked the same
+  question the other way round, since for them an absent file *is* a pass:
+  `servers` ships an `.mcp.json` declaring none of the servers the
+  configuration requires, so a rule that read it has something to say and a
+  rule that passed it over has not. A further test adopts the contract into a
+  fresh clone and enforces it green, so the rules are shown satisfiable
+  outside the repository that wrote them. The last takes the adopter's other
+  route — record the backlog, gate what is added to it — and pins the half a
+  fixture cannot reach: `commandFormat`'s real backlog in
+  `anthropics/claude-code` (the `allowed-tools` key its commands declare,
+  which the configuration does not allow) is recorded against the shared
+  checkout and replayed against a *second* clone of it, at a path the
+  recording never saw. A baseline is a file a project commits, so a signature
+  naming the clone it was recorded under would suppress nothing anywhere else
+  — the fixture's three baseline builds share one directory and cannot show
+  it. Only a command added to the second clone fails that build, and
+  everything the baseline accepted stays unreported. The build runs in a
   directory of its own and only the rule parameters point at a checkout
-  (`RuleConfiguration.against`), so no shared clone is written to; the shared pom
-  both fixtures build lives in `EnforcerPom`.
-  Two mechanics: the `*IT`s run at `integration-test`, *before* this module is
-  installed, so they publish the freshly packaged jar themselves (`install-file`,
-  with the flattened pom); and a forked test JVM cannot work out where Maven, the
-  local repository or that jar are, so the profile passes each in as an
+  (`RuleConfiguration.against`), so no shared clone is written to; the shared
+  pom both fixtures build lives in `EnforcerPom`. Two mechanics: the `*IT`s
+  run at `integration-test`, *before* this module is installed, so they
+  publish the freshly packaged jar themselves (`install-file`, with the
+  flattened pom); and a forked test JVM cannot work out where Maven, the local
+  repository or that jar are, so the profile passes each in as an
   `enforcer.it.*` system property that `BuildEnvironment` reads.
 
 ### Coverage and mutation testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,13 +195,14 @@ Skill: `testing-conventions`.
   step, so it never pushes or opens a pull request), and `claude-code-enforcer`'s
   real Maven builds, which exercise the pom-to-rule seam a unit test skips. The
   profile is declared per module — `data`, `code/context`, `adopt`,
-  `claude-code-enforcer` — not in the root pom. Both modules also meet five real
-  repositories cloned from GitHub: the enforcer points every shipped rule at
-  them, to prove a project nobody prepared for the rules gets an actionable
-  verdict rather than a build broken on the rules' own account, and `adopt`
-  adopts them, to prove the guard it wires into a build file somebody else wrote
-  is an addition to it and nothing more, and that a file the project already
-  keeps where a starter asset goes is left exactly as it was cloned.
+  `claude-code-enforcer` — not in the root pom. Both modules also meet real
+  repositories cloned from GitHub — eight for the enforcer, seven for `adopt`:
+  the enforcer points every shipped rule at them, to prove a project nobody
+  prepared for the rules gets an actionable verdict rather than a build broken on
+  the rules' own account, and `adopt` adopts them, to prove the guard it wires
+  into a build file somebody else wrote is an addition to it and nothing more,
+  and that a file the project already keeps where a starter asset goes is left
+  exactly as it was cloned.
 
 ## Continuous integration and commits
 

--- a/README.md
+++ b/README.md
@@ -1312,8 +1312,11 @@ runs real Maven builds:
   cannot ship unwired unnoticed, and then breaks a **copy** of the checkout to
   prove the wiring bites.
 - **[`ForeignRepositoryEnforcementIT`](claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/ForeignRepositoryEnforcementIT.java)**
-  points that complete configuration at five **real** repositories shallow-cloned
-  from GitHub, none of which has ever heard of this enforcer. None of them passes
+  points that complete configuration at eight **real** repositories shallow-cloned
+  from GitHub, none of which has ever heard of this enforcer — among them a real
+  `AGENTS.md`, a real `.mcp.json` and a real `.claude/agents` directory beside a
+  real `.claude/settings.json`, so the rules that read those meet a file somebody
+  else wrote rather than only its absence. None of them passes
   and none should; what is asserted is that every rule **reaches a verdict** on
   every one of them — a pass, or a failure naming what is wrong — rather than
   going red on the rules' own account with an unbindable parameter or an
@@ -1336,20 +1339,24 @@ clone from GitHub with the real `git` and answer that:
   stub and synthetic URLs prove the wiring; only a `git clone` that really ran
   twice into one workspace proves the checkouts.
 - **[`ForeignRepositoryAdoptionIT`](adopt/src/test/java/io/github/adamw7/tools/adopt/ForeignRepositoryAdoptionIT.java)**
-  adopts five real repositories — `google/gson`, `square/okhttp`,
-  `anthropics/anthropic-quickstarts`, `anthropics/claude-code` and
-  `github/gitignore` — chosen for the shapes they put in front of the steps that
-  read a checkout: a multi-module Maven build, a Gradle build on the Kotlin DSL,
-  a real `CLAUDE.md`, a real `.claude` directory, and a very large flat tree with
-  no build file at all. Between them they are the only place all three build
-  systems meet build files this repository did not write. What is asserted is
+  adopts seven real repositories — `google/gson`, `square/okhttp`,
+  `anthropics/anthropic-quickstarts`, `anthropics/claude-code`,
+  `github/gitignore`, `JakeWharton/timber` and `modelcontextprotocol/servers` —
+  chosen for the shapes they put in front of the steps that read a checkout: a
+  multi-module Maven build, a Gradle build on the Kotlin DSL and another on the
+  Groovy one, a real `CLAUDE.md`, a real `.claude` directory, a project whose own
+  files already sit where two of the starter assets go, a default branch called
+  neither `main` nor `master`, and a very large flat tree with no build file at
+  all. Between them they are the only place all three build systems — and both
+  Gradle DSLs — meet build files this repository did not write. What is asserted is
   that the adoption's work is **its own and nothing else**: the guard that lands
-  is the one the checkout's build files ask for, the commits carry only the paths
-  the pipeline claims to write, the guard commit removes nothing the build file
-  already declared, a starter asset the project already keeps at that path comes
-  through byte-identical to the blob that was cloned, the default branch and the
-  remote are left as cloned, and adopting the same batch a second time commits
-  nothing.
+  is the one the checkout's build files ask for and is written in that build
+  script's own DSL, the commits carry only the paths the pipeline claims to write,
+  the guard commit removes nothing the build file already declared, the starter
+  assets the project already keeps at those paths come through byte-identical to
+  the blobs that were cloned, the default branch — read from the remote rather
+  than guessed — and the remote are left as cloned, and adopting the same batch a
+  second time commits nothing.
 
 Both adoption `*IT`s stop short of the push and the pull request, so the runs stay
 **read-only towards GitHub**, need no logged-in `gh`, and may be repeated as often

--- a/README.md
+++ b/README.md
@@ -1322,6 +1322,9 @@ runs real Maven builds:
   going red on the rules' own account with an unbindable parameter or an
   exception escaping a file it did not expect. Only the log tells those apart, so
   the per-rule `passed` / `failed with message:` lines are read back out of it.
+  The checkouts are also asked, after all eight builds, to be exactly as `git`
+  produced them — these are somebody else's projects, and a rule that wrote into
+  one would have edited a project that asked it for a verdict.
 
 ### The adoption against real repositories
 
@@ -1355,8 +1358,9 @@ clone from GitHub with the real `git` and answer that:
   the guard commit removes nothing the build file already declared, the starter
   assets the project already keeps at those paths come through byte-identical to
   the blobs that were cloned, the default branch — read from the remote rather
-  than guessed — and the remote are left as cloned, and adopting the same batch a
-  second time commits nothing.
+  than guessed — is left as cloned, GitHub itself is asked with `ls-remote` and
+  has no branch of the adoption's, and adopting the same batch a second time
+  commits nothing.
 
 Both adoption `*IT`s stop short of the push and the pull request, so the runs stay
 **read-only towards GitHub**, need no logged-in `gh`, and may be repeated as often

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/ForeignRepositoryAdoptionIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/ForeignRepositoryAdoptionIT.java
@@ -68,8 +68,9 @@ import io.github.adamw7.tools.enforcer.doc.ClaudeMdFormatRule;
  * nothing the project already declared is removed to make room for it, the starter
  * assets installed are the ones the repository was missing and the files it already
  * keeps at their paths are left exactly as they were cloned, the default branch — read
- * from the remote rather than assumed — and the remote itself are left exactly as they
- * were cloned, and adopting the same repository a second time changes nothing.
+ * from the remote rather than assumed — is where the clone left it, the repository on
+ * GitHub is asked directly and has no branch of the adoption's, and adopting the same
+ * repository a second time changes nothing.
  *
  * <p>The starter assets are installed here — {@code --include-assets} adds them to a
  * real run — because the promise {@link AssetInstaller} makes is about a file the
@@ -338,9 +339,16 @@ class ForeignRepositoryAdoptionIT {
 	/**
 	 * The promise the adoption makes to a repository it is pointed at: the default
 	 * branch is never written to, and nothing leaves the machine until an operator
-	 * pushes. Both are asserted against the refs {@code git clone} produced, so a step
-	 * that committed on the wrong branch — or a pipeline that grew a push — is caught
-	 * here rather than on somebody's repository.
+	 * pushes. The first is asserted against the refs {@code git clone} produced, so a
+	 * step that committed on the wrong branch is caught here rather than on somebody's
+	 * repository.
+	 *
+	 * <p>The second is asked of GitHub itself. A pipeline that grew a push would leave a
+	 * remote-tracking ref behind, which is checked too because it costs nothing — but a
+	 * ref in this checkout is evidence about this checkout, and the claim is about seven
+	 * repositories that belong to other people. Only {@code ls-remote} answers that, and
+	 * it answers it for a push this class knew nothing about as readily as for one of
+	 * its own.
 	 */
 	@Test
 	void neitherTheDefaultBranchNorTheRemoteIsWrittenTo() {
@@ -351,9 +359,11 @@ class ForeignRepositoryAdoptionIT {
 			assertEquals(git(checkout, "rev-parse", AdoptionContext.REMOTE + "/" + defaultBranch),
 					git(checkout, "rev-parse", defaultBranch),
 					() -> "adopting " + repository + " moved " + defaultBranch + " away from the remote's");
-			List<String> published = List.of("git", "rev-parse", "--verify", AdoptionContext.REMOTE + "/" + BRANCH);
-			assertFalse(RUNNER.run(checkout, published).succeeded(),
-					() -> "adopting " + repository + " published " + BRANCH + " to the remote");
+			List<String> tracked = List.of("git", "rev-parse", "--verify", AdoptionContext.REMOTE + "/" + BRANCH);
+			assertFalse(RUNNER.run(checkout, tracked).succeeded(),
+					() -> "adopting " + repository + " left a remote-tracking ref for " + BRANCH);
+			assertEquals("", git(checkout, "ls-remote", "--heads", AdoptionContext.REMOTE, "refs/heads/" + BRANCH),
+					() -> "adopting " + repository + " published " + BRANCH + " to the repository itself");
 		}
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/ForeignRepositoryAdoptionIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/ForeignRepositoryAdoptionIT.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -42,7 +43,7 @@ import io.github.adamw7.tools.adopt.step.ToolchainStep;
 import io.github.adamw7.tools.enforcer.doc.ClaudeMdFormatRule;
 
 /**
- * Adopts five <em>real</em> repositories, cloned from GitHub over the network, none
+ * Adopts seven <em>real</em> repositories, cloned from GitHub over the network, none
  * of which has ever heard of this pipeline.
  *
  * <p>{@link MultiRepoAdoptionIT} proves a batch gives each repository its own
@@ -53,20 +54,22 @@ import io.github.adamw7.tools.enforcer.doc.ClaudeMdFormatRule;
  * to a project nobody prepared for it — which is every project it will ever be
  * pointed at.
  *
- * <p>The five are chosen for the shapes they put in front of the steps that read the
- * checkout: a real multi-module Maven build, a real Gradle build on the Kotlin DSL, a
- * real {@code CLAUDE.md}, a real {@code .claude} directory, and a very large flat tree
- * with no build file at all. Between them they exercise all three
- * {@link BuildSystem}s on build files this repository did not write.
+ * <p>The seven are chosen for the shapes they put in front of the steps that read the
+ * checkout: a real multi-module Maven build, a real Gradle build on the Kotlin DSL and
+ * another on the Groovy one, a real {@code CLAUDE.md}, a real {@code .claude} directory,
+ * a project whose own files already sit where two of the starter assets go, a default
+ * branch called neither {@code main} nor {@code master}, and a very large flat tree with
+ * no build file at all. Between them they exercise all three {@link BuildSystem}s — and
+ * both Gradle DSLs — on build files this repository did not write.
  *
  * <p>What is asserted is that the adoption's work on each of them is <em>its own and
  * nothing else</em>: the guard that lands is the one the checkout's build files ask
  * for, the commits carry only paths {@link AdoptionAssets#WRITTEN_PATHS} names,
  * nothing the project already declared is removed to make room for it, the starter
- * assets installed are the ones the repository was missing and a file it already
- * keeps at one of their paths is left exactly as it was cloned, the default branch
- * and the remote are left exactly as they were cloned, and adopting the same
- * repository a second time changes nothing.
+ * assets installed are the ones the repository was missing and the files it already
+ * keeps at their paths are left exactly as they were cloned, the default branch — read
+ * from the remote rather than assumed — and the remote itself are left exactly as they
+ * were cloned, and adopting the same repository a second time changes nothing.
  *
  * <p>The starter assets are installed here — {@code --include-assets} adds them to a
  * real run — because the promise {@link AssetInstaller} makes is about a file the
@@ -106,6 +109,15 @@ class ForeignRepositoryAdoptionIT {
 		}
 	}
 
+	/** A file a repository already keeps at one of {@link #ASSET_PATHS}, which is not the adoption's. */
+	private record OwnAsset(RealRepository repository, String path) {
+
+		@Override
+		public String toString() {
+			return path + " in " + repository;
+		}
+	}
+
 	private static final String WORKFLOW_GUARD = ".github/workflows/claude-md-guard.yml";
 	private static final String GUARD_SCRIPT = ".github/claude-md-guard.sh";
 
@@ -113,6 +125,20 @@ class ForeignRepositoryAdoptionIT {
 	private static final List<String> WORKFLOW_GUARD_PATHS = List.of(GUARD_SCRIPT, WORKFLOW_GUARD);
 
 	private static final String GITHUB_ACTIONS = "github-actions";
+	private static final String GRADLE = "gradle";
+
+	private static final String GROOVY_BUILD_FILE = "build.gradle";
+	private static final String KOTLIN_BUILD_FILE = "build.gradle.kts";
+
+	/**
+	 * How each Gradle DSL spells the registration of the guard task. The two build
+	 * scripts here are real ones in different languages, and a block in the other DSL
+	 * would still register a task by the name {@link BuildSystem#isGuardInstalled} looks
+	 * for while failing to compile in the project it was appended to.
+	 */
+	private static final Map<String, String> GRADLE_REGISTRATIONS = Map.of(
+			GROOVY_BUILD_FILE, "tasks.register('enforceClaudeMd')",
+			KOTLIN_BUILD_FILE, "tasks.register(\"enforceClaudeMd\")");
 
 	private static final List<RealRepository> REPOSITORIES = List.of(
 			new RealRepository("https://github.com/google/gson.git",
@@ -131,16 +157,37 @@ class ForeignRepositoryAdoptionIT {
 					GITHUB_ACTIONS, WORKFLOW_GUARD_PATHS),
 			new RealRepository("https://github.com/github/gitignore.git",
 					"thousands of small files in one flat tree, and no build file",
+					GITHUB_ACTIONS, WORKFLOW_GUARD_PATHS),
+			new RealRepository("https://github.com/JakeWharton/timber.git",
+					"a real Gradle build on the Groovy DSL, developed on a default branch called neither"
+							+ " main nor master",
+					GRADLE, List.of(GROOVY_BUILD_FILE)),
+			new RealRepository("https://github.com/modelcontextprotocol/servers.git",
+					"a project already keeping files of its own where two of the starter assets go",
 					GITHUB_ACTIONS, WORKFLOW_GUARD_PATHS));
 
 	/** The repository whose {@code CLAUDE.md} somebody else wrote. */
 	private static final RealRepository WITH_CLAUDE_MD = named("anthropic-quickstarts");
 
-	/** The repository already shipping a file at one of {@link #ASSET_PATHS}. */
-	private static final RealRepository WITH_OWN_ASSET = named("claude-code");
-
-	/** The path {@link #WITH_OWN_ASSET} carries a version of that is not the adoption's. */
 	private static final String CLAUDE_WORKFLOW = ".github/workflows/claude.yml";
+	private static final String MCP_CONFIG = ".mcp.json";
+
+	/**
+	 * The files these repositories were cloned already carrying where a starter asset
+	 * goes: a {@code claude.yml} workflow doing a different job from the adoption's
+	 * starter one, and an {@code .mcp.json} declaring a server of the project's own. Two
+	 * of them, and at different paths, because one asset left alone is as easily an
+	 * installer that skips that one path as one that honours what it finds.
+	 */
+	private static final List<OwnAsset> OWN_ASSETS = List.of(
+			new OwnAsset(named("claude-code"), CLAUDE_WORKFLOW),
+			new OwnAsset(named("servers"), MCP_CONFIG));
+
+	/** The repository developed on a branch neither {@link #CONVENTIONAL_BRANCHES} names. */
+	private static final RealRepository WITH_OWN_DEFAULT_BRANCH = named("timber");
+
+	/** The two names a pipeline that guessed the default branch instead of reading it would guess. */
+	private static final List<String> CONVENTIONAL_BRANCHES = List.of("main", "master");
 
 	private static final String CLAUDE_MD = "CLAUDE.md";
 
@@ -175,7 +222,7 @@ class ForeignRepositoryAdoptionIT {
 	 * enough that a stalled network fails the class in minutes. The pipeline's own
 	 * default is sized for a {@code claude init}, which is not among the steps here.
 	 *
-	 * <p>Wrapped as a real run wraps it, so a GitHub that refused one of the five
+	 * <p>Wrapped as a real run wraps it, so a GitHub that refused one of the seven
 	 * clones does not report this class's subject — the guard the adoption writes into
 	 * somebody else's build file — as broken.
 	 */
@@ -183,7 +230,7 @@ class ForeignRepositoryAdoptionIT {
 			new ProcessCommandRunner(Duration.ofMinutes(5)), AdoptionOptions.DEFAULT_RETRIES);
 
 	/**
-	 * Class-scoped, because the five clones are what this class costs and every test
+	 * Class-scoped, because the seven clones are what this class costs and every test
 	 * below reads the same checkouts.
 	 */
 	@TempDir
@@ -314,7 +361,7 @@ class ForeignRepositoryAdoptionIT {
 	 * The starter assets arrive in a repository that already has files of its own, and
 	 * {@link AssetsStep} installs exactly the ones it is missing. Asserting the commit's
 	 * paths against the difference — rather than against a list written out here — is
-	 * what makes the claim hold for whatever these five repositories ship next: an
+	 * what makes the claim hold for whatever these seven repositories ship next: an
 	 * installer that started overwriting would commit a path the project already
 	 * tracked, and one that stopped installing would leave a missing path out.
 	 */
@@ -330,23 +377,69 @@ class ForeignRepositoryAdoptionIT {
 	}
 
 	/**
-	 * The one repository here that already ships a file at an asset's path — a
+	 * The two repositories here that already ship a file at an asset's path — a
 	 * {@code claude.yml} workflow of its own, doing a different job from the adoption's
-	 * starter one. {@link AssetInstaller} promises the project's version always wins,
-	 * and every fixture that promise is checked against holds a file this repository
-	 * wrote to be overwritten. Comparing against the blob on the cloned default branch
-	 * is what makes it somebody else's file: nothing here says what it should contain.
+	 * starter one, and an {@code .mcp.json} declaring a server of the project's own.
+	 * {@link AssetInstaller} promises the project's version always wins, and every
+	 * fixture that promise is checked against holds a file this repository wrote to be
+	 * overwritten. Comparing against the blob on the cloned default branch is what makes
+	 * it somebody else's file: nothing here says what either should contain.
 	 */
 	@Test
-	void theProjectsOwnFileAtAnAssetsPathIsLeftExactlyAsItWasCloned() {
-		Path checkout = checkoutOf(WITH_OWN_ASSET);
-		assertTrue(Files.isRegularFile(checkout.resolve(CLAUDE_WORKFLOW)),
-				() -> WITH_OWN_ASSET + " no longer ships " + CLAUDE_WORKFLOW + ", so this test needs a repository"
-						+ " that carries a file at one of " + ASSET_PATHS);
-		assertTrue(assetsAlreadyIn(WITH_OWN_ASSET).contains(CLAUDE_WORKFLOW),
-				() -> CLAUDE_WORKFLOW + " must be the project's own, or overwriting it would prove nothing");
-		assertEquals("", git(checkout, "diff", defaultBranchOf(checkout), "HEAD", "--", CLAUDE_WORKFLOW),
-				() -> "adopting " + WITH_OWN_ASSET + " changed the project's own " + CLAUDE_WORKFLOW);
+	void theProjectsOwnFilesAtAnAssetsPathAreLeftExactlyAsTheyWereCloned() {
+		for (OwnAsset own : OWN_ASSETS) {
+			Path checkout = checkoutOf(own.repository());
+			assertTrue(Files.isRegularFile(checkout.resolve(own.path())),
+					() -> own.repository() + " no longer ships " + own.path() + ", so this test needs a repository"
+							+ " that carries a file at one of " + ASSET_PATHS);
+			assertTrue(assetsAlreadyIn(own.repository()).contains(own.path()),
+					() -> own + " must be the project's own, or overwriting it would prove nothing");
+			assertEquals("", git(checkout, "diff", defaultBranchOf(checkout), "HEAD", "--", own.path()),
+					() -> "adopting " + own.repository() + " changed the project's own " + own.path());
+		}
+	}
+
+	/**
+	 * Which Gradle DSL the guard is written in is read from the build script's own
+	 * extension, and only a repository of each kind puts that decision in front of a
+	 * real script. Both blocks register a task by the same name, so an installer that
+	 * appended the Kotlin one to a Groovy script would pass every other assertion here
+	 * — the guard commit carries the right path, removes nothing, and declares the task
+	 * — and leave the adopted project a build script that no longer compiles.
+	 */
+	@Test
+	void eachGradleScriptIsGivenTheGuardWrittenInItsOwnDsl() {
+		for (RealRepository repository : gradleRepositories()) {
+			String buildFile = repository.guardPaths().getFirst();
+			String added = addedBy(repository, GitHubRepoAdopter.GUARD_COMMIT_MESSAGE);
+			assertTrue(added.contains(GRADLE_REGISTRATIONS.get(buildFile)),
+					() -> "the guard appended to " + buildFile + " in " + repository + " is not the one the "
+							+ buildFile + " DSL registers a task with: " + added);
+			assertFalse(added.contains(otherDslRegistration(buildFile)),
+					() -> "the guard appended to " + buildFile + " in " + repository + " is written in the other"
+							+ " Gradle DSL: " + added);
+		}
+	}
+
+	/**
+	 * The default branch is read from the remote rather than assumed, and one repository
+	 * here is what makes the reading matter: {@code timber} develops on {@code trunk}. A
+	 * pipeline that took {@code main} for the default would clone this repository, cut
+	 * its branch from the wrong ref or from none, and pass every other assertion in this
+	 * class on the six that are conventionally named.
+	 */
+	@Test
+	void aRepositoryDevelopedOnItsOwnDefaultBranchIsAdoptedFromThatBranch() {
+		Path checkout = checkoutOf(WITH_OWN_DEFAULT_BRANCH);
+		String defaultBranch = defaultBranchOf(checkout);
+
+		assertFalse(CONVENTIONAL_BRANCHES.contains(defaultBranch),
+				() -> WITH_OWN_DEFAULT_BRANCH + " now develops on " + defaultBranch + ", so this test needs a"
+						+ " repository whose default branch is none of " + CONVENTIONAL_BRANCHES);
+		assertEquals(git(checkout, "rev-parse", defaultBranch),
+				git(checkout, "merge-base", defaultBranch, BRANCH),
+				() -> "adopting " + WITH_OWN_DEFAULT_BRANCH + " cut " + BRANCH + " from something other than "
+						+ defaultBranch);
 	}
 
 	/**
@@ -411,8 +504,8 @@ class ForeignRepositoryAdoptionIT {
 	}
 
 	/**
-	 * The run goes through the command line an operator would type, so the five
-	 * repositories are one batch into one workspace rather than five runs assembled from
+	 * The run goes through the command line an operator would type, so the seven
+	 * repositories are one batch into one workspace rather than seven runs assembled from
 	 * {@link BatchAdoption} inwards.
 	 */
 	private static List<AdoptionRun> adoptAll() {
@@ -480,6 +573,31 @@ class ForeignRepositoryAdoptionIT {
 				defaultBranchOf(checkout) + ".." + BRANCH);
 		assertFalse(commit.isBlank(), () -> "adopting " + repository + " left no commit saying " + message);
 		return commit;
+	}
+
+	/** The listed repositories the adoption wires a Gradle guard into, one per DSL. */
+	private static List<RealRepository> gradleRepositories() {
+		List<RealRepository> gradle = REPOSITORIES.stream()
+				.filter(repository -> GRADLE.equals(repository.buildSystem()))
+				.toList();
+		assertEquals(GRADLE_REGISTRATIONS.keySet(),
+				gradle.stream().map(repository -> repository.guardPaths().getFirst())
+						.collect(Collectors.toSet()),
+				() -> "this test needs one real repository per Gradle DSL, and has " + gradle);
+		return gradle;
+	}
+
+	/** The registration belonging to the DSL the build file is not written in. */
+	private static String otherDslRegistration(String buildFile) {
+		return GRADLE_REGISTRATIONS.get(GROOVY_BUILD_FILE.equals(buildFile) ? KOTLIN_BUILD_FILE : GROOVY_BUILD_FILE);
+	}
+
+	/** The lines that commit added, which is where a guard block written for it appears. */
+	private static String addedBy(RealRepository repository, String message) {
+		return git(checkoutOf(repository), "show", "--unified=0", "--pretty=format:",
+				commitOf(repository, message)).lines()
+				.filter(line -> line.startsWith("+") && !line.startsWith("+++ "))
+				.collect(Collectors.joining("\n"));
 	}
 
 	/** The paths that commit carries, sorted so the expectation reads as a set. */

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/ForeignRepositoryEnforcementIT.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/ForeignRepositoryEnforcementIT.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Points every shipped rule at five <em>real</em> repositories, cloned from GitHub
+ * Points every shipped rule at eight <em>real</em> repositories, cloned from GitHub
  * over the network, none of which has ever heard of this enforcer.
  *
  * <p>{@link EnforcerRuleBuildIT} proves the rules bind and fire, and
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.io.TempDir;
  * they meet a project nobody prepared for them.
  *
  * <p>What is asserted is therefore not that a foreign repository passes: none of
- * these five does, and none should. It is that every rule <em>reaches a verdict</em>
+ * these eight does, and none should. It is that every rule <em>reaches a verdict</em>
  * on every one of them — a pass, or a failure with a message that names what is
  * wrong — rather than failing the build on the rules' own account with an
  * unbindable parameter, an internal error, or an exception escaping from a file it
@@ -39,10 +39,12 @@ import org.junit.jupiter.api.io.TempDir;
  * both leave a red build; only the log tells them apart, which is what
  * {@link EnforcerVerdicts} reads.
  *
- * <p>The five are chosen for the shapes they put in front of the rules — an almost
+ * <p>The eight are chosen for the shapes they put in front of the rules — an almost
  * empty repository, a small one, a very large flat one, a real {@code .claude}
- * directory somebody else wrote, and a real {@code CLAUDE.md} somebody else wrote —
- * and every clone is shallow, so the whole class costs about as much as one of the
+ * directory somebody else wrote, a real {@code CLAUDE.md} somebody else wrote, a real
+ * {@code AGENTS.md} somebody else wrote, a real {@code .mcp.json}, and a real
+ * {@code .claude/agents} directory beside a real {@code .claude/settings.json} — and
+ * every clone is shallow, so the whole class costs about as much as one of the
  * builds it runs. Nothing is written to any of them: the enforcing build runs in a
  * directory of its own and only the rule parameters point at a checkout.
  */
@@ -75,11 +77,18 @@ class ForeignRepositoryEnforcementIT {
 					"a real .claude/commands directory, and a .claude-plugin holding a "
 							+ "marketplace.json rather than the plugin.json a rule looks for"),
 			new RealRepository("https://github.com/anthropics/anthropic-quickstarts.git",
-					"a real CLAUDE.md, written by someone who never heard of these rules"));
+					"a real CLAUDE.md, written by someone who never heard of these rules"),
+			new RealRepository("https://github.com/github/spec-kit.git",
+					"a real AGENTS.md, written by someone who never heard of these rules"),
+			new RealRepository("https://github.com/modelcontextprotocol/servers.git",
+					"a real .mcp.json, so the two optional MCP rules meet a file rather than its absence"),
+			new RealRepository("https://github.com/anthropics/claude-code-action.git",
+					"a real .claude/agents directory and a real .claude/settings.json, neither of them "
+							+ "written for these rules"));
 
 	/**
 	 * The property the harness pom addresses the checkout through. One pom serves all
-	 * five repositories because only this changes between them.
+	 * eight repositories because only this changes between them.
 	 */
 	private static final String REPOSITORY_PROPERTY = "claude.repository";
 
@@ -89,6 +98,13 @@ class ForeignRepositoryEnforcementIT {
 	private static final String HARNESS_ARTIFACT_ID = "foreign-repository-harness";
 	private static final String BASELINE_HARNESS_ARTIFACT_ID = "foreign-repository-baseline-harness";
 
+	private static final String MCP_FILE = ".mcp.json";
+	private static final String SETTINGS_FILE = ".claude/settings.json";
+	private static final String AGENTS_DIRECTORY = ".claude/agents";
+
+	private static final String MCP_SERVERS_VALID = "mcpServersValid";
+	private static final String MCP_CONFIG_FORMAT = "mcpConfigFormat";
+
 	/**
 	 * The rules whose file is optional, which must pass when a project does not ship
 	 * it. Each is paired with the path {@link RuleConfiguration#COMPLETE} points it at,
@@ -97,8 +113,8 @@ class ForeignRepositoryEnforcementIT {
 	 */
 	private static final Map<String, String> OPTIONAL_RULE_TARGETS = Map.of(
 			"pluginFormat", ".claude-plugin/plugin.json",
-			"mcpServersValid", ".mcp.json",
-			"mcpConfigFormat", ".mcp.json",
+			MCP_SERVERS_VALID, MCP_FILE,
+			MCP_CONFIG_FORMAT, MCP_FILE,
 			"okfBundleFormat", "okf");
 
 	/**
@@ -118,6 +134,15 @@ class ForeignRepositoryEnforcementIT {
 
 	private static final String CLAUDE_MD_FORMAT = "claudeMdFormat";
 	private static final String CLAUDE_MD = "CLAUDE.md";
+
+	private static final String AGENTS_MD_FORMAT = "agentsMdFormat";
+	private static final String AGENTS_MD = "AGENTS.md";
+
+	private static final String SUB_AGENT_FORMAT = "subAgentFormat";
+	private static final String ABSENT_AGENTS = "Agents directory does not exist";
+
+	private static final String SETTINGS_JSON_VALID = "settingsJsonValid";
+	private static final String ABSENT_SETTINGS = "settings.json does not exist";
 
 	private static final String COMMAND_FORMAT = "commandFormat";
 	private static final String COMMANDS_DIRECTORY = ".claude/commands";
@@ -166,6 +191,15 @@ class ForeignRepositoryEnforcementIT {
 	/** The repository whose {@code .claude} directory somebody else wrote. */
 	private static final RealRepository WITH_AGENT_CONFIGURATION = named("claude-code");
 
+	/** The repository whose sub-agents and {@code settings.json} somebody else wrote. */
+	private static final RealRepository WITH_FOREIGN_SUB_AGENTS = named("claude-code-action");
+
+	/** The repository whose {@code AGENTS.md} somebody else wrote. */
+	private static final RealRepository WITH_AGENTS_MD = named("spec-kit");
+
+	/** The repository shipping an {@code .mcp.json} the two optional MCP rules can read. */
+	private static final RealRepository WITH_MCP_CONFIGURATION = named("servers");
+
 	/**
 	 * A repository with no agent configuration at all, which is the state a project is
 	 * in on the day it adopts one.
@@ -178,7 +212,7 @@ class ForeignRepositoryEnforcementIT {
 	private static List<Enforcement> enforcements;
 
 	/**
-	 * Class-scoped, because the clones and the five builds over them are what this
+	 * Class-scoped, because the clones and the eight builds over them are what this
 	 * class costs and every test below reads the same results. The two tests that
 	 * change a checkout take a fresh clone of their own, into {@link #adoption} and
 	 * {@link #replay}.
@@ -209,7 +243,7 @@ class ForeignRepositoryEnforcementIT {
 
 	/**
 	 * The claim this class exists for. Every rule the module ships is asked about every
-	 * one of the five, and every one of them has to answer: a rule that reached no
+	 * one of the eight, and every one of them has to answer: a rule that reached no
 	 * verdict either never ran — a misspelled {@code @Named} name, an execution that
 	 * did not fire — or stopped the build before the ones after it could run, and in
 	 * both cases a project that trusted it is guarded by nothing.
@@ -262,7 +296,7 @@ class ForeignRepositoryEnforcementIT {
 
 	/**
 	 * "Says why" is only worth something if the message is about the reader's project,
-	 * so one rule is followed all the way through: none of these five ships a document
+	 * so one rule is followed all the way through: none of these eight ships a document
 	 * titled {@code # CLAUDE.md} carrying the six required sections, so
 	 * {@code claudeMdFormat} fails every one of them, and whether the document is
 	 * absent or merely someone else's, what it failed with has to name it.
@@ -283,7 +317,7 @@ class ForeignRepositoryEnforcementIT {
 	/**
 	 * Four rules target files a project need not have, and the documented behaviour is
 	 * that an absent one is a pass rather than a failure. That is exactly the promise a
-	 * repository adopting the rules one at a time depends on, and these five are where
+	 * repository adopting the rules one at a time depends on, and these eight are where
 	 * it is really tested: the fixture ships all four files, so it can only show what
 	 * happens when they are there.
 	 *
@@ -326,6 +360,115 @@ class ForeignRepositoryEnforcementIT {
 	}
 
 	/**
+	 * The sub-agent rule's counterpart to the command one, on the other repository here
+	 * that ships an agent configuration nobody wrote for these rules. Its five
+	 * definitions declare a {@code tools} key this repository never invented and a
+	 * {@code model} of {@code inherit} that the configuration's {@code allowedModels}
+	 * does not list, which is real foreign front matter of a kind no fixture supplies.
+	 *
+	 * <p>What is pinned is that the rule read those definitions rather than reporting the
+	 * directory absent. Whether it then approves of them is the repository's business and
+	 * may change with any commit; that it looked is the rule's.
+	 */
+	@Test
+	void theRulesReadForeignSubAgentDefinitionsRatherThanReportingThemAbsent() {
+		Enforcement enforcement = enforcementOf(WITH_FOREIGN_SUB_AGENTS);
+		List<Path> agents = markdownIn(enforcement.checkout().resolve(AGENTS_DIRECTORY));
+
+		assertFalse(agents.isEmpty(),
+				() -> WITH_FOREIGN_SUB_AGENTS + " no longer ships sub-agent definitions under " + AGENTS_DIRECTORY
+						+ ", so this test needs a repository that does");
+		assertTrue(enforcement.verdicts().reached(SUB_AGENT_FORMAT),
+				() -> SUB_AGENT_FORMAT + " reached no verdict: " + enforcement.outcome().describe());
+		assertFalse(enforcement.verdicts().messageOf(SUB_AGENT_FORMAT).contains(ABSENT_AGENTS),
+				() -> SUB_AGENT_FORMAT + " reported " + agents.size() + " real sub-agent definition(s) absent: "
+						+ enforcement.outcome().describe());
+	}
+
+	/**
+	 * The same claim for the settings file, which is the one input here a rule reads as
+	 * JSON somebody else wrote rather than as markdown or a directory listing. Four rules
+	 * are pointed at it, and every fixture they are otherwise proved against holds a
+	 * {@code settings.json} written to be read by them.
+	 *
+	 * <p>A rule that fell over on a foreign key would be caught by
+	 * {@link #noRuleFailsARealRepositoryOnItsOwnAccount}; what is pinned here is the
+	 * quieter failure — a rule that reported the file absent while it was sitting in the
+	 * checkout, which reads as a pass on a project that has nothing and tells a project
+	 * that has something nothing at all.
+	 */
+	@Test
+	void aRuleReadsAForeignSettingsFileRatherThanReportingItAbsent() {
+		Enforcement enforcement = enforcementOf(WITH_FOREIGN_SUB_AGENTS);
+
+		assertTrue(Files.isRegularFile(enforcement.checkout().resolve(SETTINGS_FILE)),
+				() -> WITH_FOREIGN_SUB_AGENTS + " no longer ships a " + SETTINGS_FILE
+						+ ", so this test needs a repository that does");
+		assertTrue(enforcement.verdicts().reached(SETTINGS_JSON_VALID),
+				() -> SETTINGS_JSON_VALID + " reached no verdict: " + enforcement.outcome().describe());
+		assertFalse(enforcement.verdicts().passed(SETTINGS_JSON_VALID),
+				() -> SETTINGS_JSON_VALID + " passed a real " + SETTINGS_FILE + " that grants none of the"
+						+ " permissions it requires, so this test needs a repository whose settings the"
+						+ " configuration is not already satisfied by: " + enforcement.outcome().describe());
+		assertFalse(enforcement.verdicts().messageOf(SETTINGS_JSON_VALID).contains(ABSENT_SETTINGS),
+				() -> SETTINGS_JSON_VALID + " reported a real " + SETTINGS_FILE + " absent: "
+						+ enforcement.outcome().describe());
+	}
+
+	/**
+	 * The two MCP rules are optional, and
+	 * {@link #theOptionalRulesPassOnARepositoryThatShipsNoneOfTheirFiles} only ever sees
+	 * them pass over a file that is not there. That pass is indistinguishable, from the
+	 * verdict alone, from a rule that skipped a file it should have read — so one
+	 * repository here ships a real {@code .mcp.json}, and what is pinned is that the
+	 * rules do not pass it over.
+	 *
+	 * <p>The declared server is not the one the configuration requires, so a rule that
+	 * read the file has something to say about it and a rule that skipped it has not.
+	 * That is the only observable difference between the two, which is why the
+	 * repository has to be one whose {@code .mcp.json} the configuration is not already
+	 * satisfied by.
+	 */
+	@Test
+	void theOptionalMcpRulesReadAForeignConfigurationRatherThanPassingItOver() {
+		Enforcement enforcement = enforcementOf(WITH_MCP_CONFIGURATION);
+
+		assertTrue(Files.isRegularFile(enforcement.checkout().resolve(MCP_FILE)),
+				() -> WITH_MCP_CONFIGURATION + " no longer ships an " + MCP_FILE
+						+ ", so this test needs a repository that does");
+		assertTrue(enforcement.verdicts().reached(MCP_CONFIG_FORMAT),
+				() -> MCP_CONFIG_FORMAT + " reached no verdict: " + enforcement.outcome().describe());
+		assertFalse(enforcement.verdicts().passed(MCP_SERVERS_VALID),
+				() -> MCP_SERVERS_VALID + " passed a real " + MCP_FILE + " that declares none of the servers it"
+						+ " requires, so it cannot have read it: " + enforcement.outcome().describe());
+		assertFalse(enforcement.verdicts().messageOf(MCP_SERVERS_VALID).isBlank(),
+				() -> MCP_SERVERS_VALID + " failed without saying why: " + enforcement.outcome().describe());
+	}
+
+	/**
+	 * {@code AGENTS.md} is the companion document, and until now no repository here
+	 * shipped one: the rule met its absence five times over and reported it five times,
+	 * which proves only the build-setup check. One repository now carries a real one —
+	 * sixty sections written for a Python CLI — so the rule reads a foreign document and
+	 * fails it on what it found rather than on what was not there.
+	 */
+	@Test
+	void aForeignAgentsMdIsReadRatherThanReportedAbsent() {
+		Enforcement enforcement = enforcementOf(WITH_AGENTS_MD);
+		String message = enforcement.verdicts().messageOf(AGENTS_MD_FORMAT);
+
+		assertTrue(Files.isRegularFile(enforcement.checkout().resolve(AGENTS_MD)),
+				() -> WITH_AGENTS_MD + " no longer ships an " + AGENTS_MD
+						+ ", so this test needs a repository that does");
+		assertTrue(message.contains(AGENTS_MD),
+				() -> AGENTS_MD_FORMAT + " did not fail " + WITH_AGENTS_MD + " with a message naming " + AGENTS_MD
+						+ ": " + enforcement.outcome().describe());
+		assertFalse(message.contains(AGENTS_MD + " does not exist"),
+				() -> AGENTS_MD_FORMAT + " reported a real " + AGENTS_MD + " absent: "
+						+ enforcement.outcome().describe());
+	}
+
+	/**
 	 * The other half of the claim: the rules are not only survivable but satisfiable
 	 * outside the repository that wrote them. A real checkout is adopted the way a
 	 * project would be — the contract's documents and {@code .claude} configuration
@@ -334,7 +477,7 @@ class ForeignRepositoryEnforcementIT {
 	 * them.
 	 *
 	 * <p>It takes a clone of its own because it is the one test here that writes into a
-	 * checkout, and the five the other tests share are read as {@code git} produced
+	 * checkout, and the eight the other tests share are read as {@code git} produced
 	 * them.
 	 */
 	@Test
@@ -419,9 +562,9 @@ class ForeignRepositoryEnforcementIT {
 	}
 
 	/**
-	 * The listed repository of that name. Two tests are about one repository each and
-	 * say which by name rather than by position, so reordering the list cannot quietly
-	 * point them at a different one.
+	 * The listed repository of that name. The tests about one repository each say which
+	 * by name rather than by position, so reordering the list cannot quietly point them
+	 * at a different one.
 	 */
 	private static RealRepository named(String name) {
 		return REPOSITORIES.stream()

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/ForeignRepositoryEnforcementIT.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/ForeignRepositoryEnforcementIT.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.enforcer.e2e;
 
 import static io.github.adamw7.tools.test.TestFiles.readString;
 import static io.github.adamw7.tools.test.TestFiles.writeString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,8 +46,10 @@ import org.junit.jupiter.api.io.TempDir;
  * {@code AGENTS.md} somebody else wrote, a real {@code .mcp.json}, and a real
  * {@code .claude/agents} directory beside a real {@code .claude/settings.json} — and
  * every clone is shallow, so the whole class costs about as much as one of the
- * builds it runs. Nothing is written to any of them: the enforcing build runs in a
- * directory of its own and only the rule parameters point at a checkout.
+ * builds it runs. Nothing is written to any of them — the enforcing build runs in a
+ * directory of its own and only the rule parameters point at a checkout — and
+ * {@link #everyCheckoutIsLeftExactlyAsGitProducedIt} holds the builds to it rather
+ * than leaving it a claim in this comment.
  */
 class ForeignRepositoryEnforcementIT {
 
@@ -357,6 +360,29 @@ class ForeignRepositoryEnforcementIT {
 		assertFalse(enforcement.verdicts().messageOf(COMMAND_FORMAT).contains(ABSENT_COMMANDS),
 				() -> COMMAND_FORMAT + " reported " + commands.size() + " real command definition(s) absent: "
 						+ enforcement.outcome().describe());
+	}
+
+	/**
+	 * The other promise this class makes to the repositories it is pointed at: it reads
+	 * them and writes nothing back. They are somebody else's projects, and the enforcing
+	 * build is given only their path — so an auto-fix rewriting a document it was asked
+	 * to check, a report landing beside the file it read, or a later test laying a
+	 * fixture out in a shared checkout instead of a clone of its own would all be a rule
+	 * editing a project that asked it for a verdict.
+	 *
+	 * <p>Everything git can see is asked for — modified, staged, untracked and ignored
+	 * alike — because a rule writing a <em>new</em> file beside the one it read is the
+	 * shape this is likeliest to take, and a check of tracked files alone would not see
+	 * it. The two tests here that do write take clones of their own, so this holds
+	 * whichever order the class runs in.
+	 */
+	@Test
+	void everyCheckoutIsLeftExactlyAsGitProducedIt() {
+		for (Enforcement enforcement : enforcements) {
+			assertEquals("", GitClone.changesIn(enforcement.checkout()),
+					() -> "enforcing " + enforcement.repository() + " wrote into the checkout, which is somebody"
+							+ " else's project: " + enforcement.outcome().describe());
+		}
 	}
 
 	/**

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/GitClone.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/e2e/GitClone.java
@@ -50,6 +50,30 @@ final class GitClone {
 	}
 
 	/**
+	 * Everything {@code git} reports as changed in a checkout — modified, staged,
+	 * untracked and ignored alike — which for a clone nothing has written to is nothing
+	 * at all.
+	 * <p>
+	 * This is how a test asks whether the enforcing builds kept the promise this class
+	 * makes: a rule writing a report or an auto-fix beside the file it read, or a
+	 * fixture laid out in a shared checkout rather than a clone of its own, shows up
+	 * here and nowhere else.
+	 * <p>
+	 * Ignored files are asked for too, and cost nothing: a clone materialises only
+	 * tracked files, so a fresh one has none, while a report written to a path the
+	 * project happens to ignore — a {@code target} directory, an {@code *.html} — is
+	 * exactly the write that would otherwise go unseen.
+	 */
+	static String changesIn(Path checkout) {
+		BuildOutcome outcome = GIT.run(checkout,
+				List.of("git", "status", "--porcelain", "--untracked-files=all", "--ignored"));
+		if (!outcome.succeeded()) {
+			throw new IllegalStateException("Could not read the status of " + checkout + ": " + outcome.output());
+		}
+		return outcome.output().strip();
+	}
+
+	/**
 	 * The repository's own name, which is what {@code git clone} would have called the
 	 * directory anyway. It is spelled out here rather than left to git so a caller can
 	 * name the checkout before the clone has run.


### PR DESCRIPTION
Both foreign-repository ITs read projects nobody prepared for this code, so
what they cover is decided by which projects they clone. Five more are added,
each for a shape the existing clones could not put in front of the code.

adopt (five to seven):
- JakeWharton/timber — a real Gradle build on the Groovy DSL, developed on
  `trunk`. Only the Kotlin DSL had ever met a real build script, and the
  default branch was only ever read on repositories where guessing `main`
  would have worked. Two new tests: the guard appended to each Gradle script
  is written in that script's own DSL (a Kotlin block in a Groovy script
  registers the task the verification looks for and leaves the project a build
  that no longer compiles), and the adoption branch is cut from the default
  branch the remote names.
- modelcontextprotocol/servers — its own `.mcp.json` and `.github/workflows/
  claude.yml`, so `AssetInstaller`'s "the project's version wins" is checked
  over two files at two paths rather than one.

claude-code-enforcer (five to eight):
- github/spec-kit — a real `AGENTS.md`, which `agentsMdFormat` had only ever
  met the absence of.
- modelcontextprotocol/servers — a real `.mcp.json`. The two MCP rules are
  optional, so an absent file passes; the only observable difference between
  reading one and skipping it is that this file declares none of the servers
  the configuration requires.
- anthropics/claude-code-action — real `.claude/agents` definitions and a real
  `.claude/settings.json`, so `subAgentFormat` and `settingsJsonValid` are
  pinned to read them rather than report them absent.

All eight enforcer builds stay red for the project's reasons and none for the
rules' own; all seven adoptions run to the end of the pipeline.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KS7TauzmyDB9R5Jo8hs4qg