### PR TITLE
fix(context): correct four defects in the context-engineering module

### DIFF
--- a/.claude/skills/context-finder/SKILL.md
+++ b/.claude/skills/context-finder/SKILL.md
@@ -66,7 +66,9 @@ new OkfBundleWriter().write(bundle, Path.of("target/okf"));
 ```
 
 - Every directory → the reserved `index.md` (no frontmatter; only a bundle-root
-  index may carry `okf_version`). Every file → a concept document.
+  index may carry `okf_version`). Every file → a concept document at its name plus
+  `.md`; a file whose name would claim a reserved document (`index`, `log`) gets
+  `.concept.md` instead, so no two documents share a path.
 - `type` is the **one** mandatory frontmatter field; `title`, `description`,
   `resource`, `tags` are recommended; v0.2 records production as
   `generated: { by, at }` using the `<producer>/<version>` actor convention.
@@ -89,9 +91,12 @@ green:
 
 ## MCP tools
 `project_tree`, `find_context`, `estimate_tokens` and `okf_bundle` are the
-adapter over the above, in `…context.mcp`. `PathPolicy` confines them to allowed
-directories, and the server is **read-only** — `okf_bundle` returns the bundle as
-JSON rather than writing it, so keep writing on the caller's side.
+adapter over the above, in `…context.mcp`. All four resolve with
+`PackageAwareFinder` — the whole-project tools pass it to `ProjectTreeBuilder` as a
+`ContextFactory` rather than taking the builder's name-based default, so one server
+answers one question one way. `depth` runs from 1 to 10. `PathPolicy` confines them
+to allowed directories, and the server is **read-only** — `okf_bundle` returns the
+bundle as JSON rather than writing it, so keep writing on the caller's side.
 **The core must never depend on the `mcp` package** — ArchUnit pins it. See the
 `mcp-server` skill before changing a tool, and update
 `code/context/.../mcp/MCP_USAGE.md` in the same change.

--- a/code/context/src/main/java/io/github/adamw7/context/AbstractFinder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/AbstractFinder.java
@@ -106,7 +106,31 @@ public abstract class AbstractFinder implements Context {
 		dependencies.add(container);
 	}
 
+	/**
+	 * Blanks out every comment and string or character literal, leaving the code's
+	 * line structure intact: each stripped character becomes a space and each line
+	 * terminator stays where it was. Replacing a whole match with a single space
+	 * instead pulled what followed a multi-line comment onto the comment's first
+	 * line, and a {@code package} or {@code import} declaration that landed there was
+	 * no longer at the start of a line for {@link PackageAwareFinder} to read.
+	 */
 	protected String stripCommentsAndLiterals(String code) {
-		return COMMENTS_AND_LITERALS.matcher(code).replaceAll(" ");
+		return COMMENTS_AND_LITERALS.matcher(code).replaceAll(match -> blankOut(match.group()));
+	}
+
+	private String blankOut(String stripped) {
+		StringBuilder blanked = new StringBuilder(stripped.length());
+		for (int index = 0; index < stripped.length(); index++) {
+			blanked.append(blank(stripped.charAt(index)));
+		}
+		return blanked.toString();
+	}
+
+	private char blank(char character) {
+		return isLineTerminator(character) ? character : ' ';
+	}
+
+	private boolean isLineTerminator(char character) {
+		return character == '\n' || character == '\r';
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractContextTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractContextTool.java
@@ -17,12 +17,18 @@ import io.github.adamw7.tools.mcp.ToolResult;
  * and bounding the depth happens once here, next to the {@link ContextToolSchema}
  * that advertises them. What a tool does with the {@link Scan} is its own, supplied
  * through {@link #answer}.
+ *
+ * <p>The depth is bounded below at {@value #MIN_DEPTH} as well as above. A depth of
+ * zero resolves nothing and every finder rejects it, so accepting it here only moved
+ * the refusal to a message that named no bound; refusing it while the arguments are
+ * read tells the caller the range the tools actually take.
  */
 abstract class AbstractContextTool implements ContextTool {
 
 	private static final Logger log = LogManager.getLogger(AbstractContextTool.class);
 
 	private static final int DEFAULT_DEPTH = 1;
+	private static final int MIN_DEPTH = 1;
 	private static final int MAX_DEPTH = 10;
 
 	protected final PathPolicy pathPolicy;
@@ -40,7 +46,7 @@ abstract class AbstractContextTool implements ContextTool {
 		log.info("Calling MCP {} tool for {}", getToolDefinition().name(), arguments);
 		Scan scan = new Scan(pathPolicy.resolve(ToolArguments.requiredString(arguments, "path")),
 				LanguageArguments.optionalLanguage(arguments, "language", Language.JAVA),
-				ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, 0, MAX_DEPTH));
+				ToolArguments.optionalBoundedInt(arguments, "depth", DEFAULT_DEPTH, MIN_DEPTH, MAX_DEPTH));
 		return answer(scan, arguments);
 	}
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractProjectScanTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/AbstractProjectScanTool.java
@@ -2,7 +2,9 @@ package io.github.adamw7.context.mcp;
 
 import java.util.Map;
 
+import io.github.adamw7.context.ContextFactory;
 import io.github.adamw7.context.Language;
+import io.github.adamw7.context.PackageAwareFinder;
 import io.github.adamw7.context.tree.ProjectTreeBuilder;
 import io.github.adamw7.context.tree.ProjectTreeNode;
 import io.github.adamw7.tools.mcp.ToolResult;
@@ -14,6 +16,12 @@ import io.github.adamw7.tools.mcp.ToolResult;
  * which subclasses supply through {@link #render}. Keeping that step here removes
  * the duplication between {@link ProjectTreeTool} and {@link OkfBundleTool} — the
  * whole-project counterpart of {@link AbstractClassContextTool}.
+ *
+ * <p>The tree is resolved with the same package-aware finder {@link ContextFinderTool}
+ * uses, so this server answers one question one way: the name-based finder the tree
+ * builder defaults to cannot tell two classes sharing a simple name apart, which had
+ * the whole-project tools drawing an edge to the wrong file — and, where the wrong
+ * file was the one being scanned, a self-edge no class actually has.
  */
 abstract class AbstractProjectScanTool extends AbstractContextTool {
 
@@ -23,7 +31,8 @@ abstract class AbstractProjectScanTool extends AbstractContextTool {
 
 	@Override
 	protected final ToolResult answer(Scan scan, Map<String, Object> arguments) {
-		ProjectTreeNode tree = new ProjectTreeBuilder(scan.language(), scan.depth()).build(scan.root());
+		ProjectTreeNode tree = new ProjectTreeBuilder(packageAwareFinder(scan.language()), scan.language(),
+				scan.depth()).build(scan.root());
 		return ToolResult.success(render(tree, scan.language(), arguments));
 	}
 
@@ -33,4 +42,8 @@ abstract class AbstractProjectScanTool extends AbstractContextTool {
 	 * depth every scan takes.
 	 */
 	protected abstract String render(ProjectTreeNode tree, Language language, Map<String, Object> arguments);
+
+	private ContextFactory packageAwareFinder(Language language) {
+		return containers -> new PackageAwareFinder(containers, language);
+	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ContextToolSchema.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ContextToolSchema.java
@@ -18,7 +18,7 @@ final class ContextToolSchema {
 	private static final Map<String, Object> LANGUAGE = property("string",
 			"source language: java (default), kotlin or scala");
 	private static final Map<String, Object> DEPTH = property("integer",
-			"how many levels of transitive dependencies to resolve (default 1)");
+			"how many levels of transitive dependencies to resolve, from 1 to 10 (default 1)");
 	private static final Map<String, Object> CLASS_NAME = property("string",
 			"simple name of the class to inspect, e.g. Foo or Foo.java");
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -22,6 +22,11 @@ The server exposes four tools:
   (OKF) v0.2: a directory of markdown concept documents with YAML frontmatter,
   portable to any consumer that speaks OKF.
 
+All four resolve dependencies with the package-aware finder, which reads each
+source's `package` declaration and `import` statements, so two classes sharing a
+simple name in different packages are told apart rather than resolved to whichever
+was scanned first.
+
 ## Architecture
 
 The implementation lives in a package separate from the core finders:
@@ -65,7 +70,7 @@ Scans a project into a tree of folders, files and class dependencies.
 
 - `path` (string, required): absolute path to the project root directory
 - `language` (string, optional): `java` (default), `kotlin` or `scala`
-- `depth` (integer, optional): levels of transitive dependencies to resolve (default `1`)
+- `depth` (integer, optional): levels of transitive dependencies to resolve, from `1` to `10` (default `1`)
 - `format` (string, optional): `json` (default), `markdown`, `text`, `dot` or `mermaid`
 
 **Example:**
@@ -88,7 +93,7 @@ Finds the classes a given class depends on, within a project.
 - `path` (string, required): absolute path to the project root directory
 - `class_name` (string, required): simple name of the class to inspect, e.g. `Foo` or `Foo.java`
 - `language` (string, optional): `java` (default), `kotlin` or `scala`
-- `depth` (integer, optional): levels of transitive dependencies to resolve (default `1`)
+- `depth` (integer, optional): levels of transitive dependencies to resolve, from `1` to `10` (default `1`)
 
 **Returns:** a JSON array of dependency class names, e.g. `["A.java","B.java"]`.
 An unknown class is reported as an error result.
@@ -113,7 +118,7 @@ dependencies, to a bounded depth.
 - `path` (string, required): absolute path to the project root directory
 - `class_name` (string, required): simple name of the class to inspect, e.g. `Foo` or `Foo.java`
 - `language` (string, optional): `java` (default), `kotlin` or `scala`
-- `depth` (integer, optional): levels of transitive dependencies to resolve (default `1`)
+- `depth` (integer, optional): levels of transitive dependencies to resolve, from `1` to `10` (default `1`)
 
 **Returns:** a JSON object with the `total` token estimate and a `classes` array of
 `{ "class": ..., "tokens": ... }` entries, the target class first. An unknown
@@ -137,13 +142,15 @@ Scans a project into a bundle in Google's Open Knowledge Format (OKF) v0.2.
 
 - `path` (string, required): absolute path to the project root directory
 - `language` (string, optional): `java` (default), `kotlin` or `scala`
-- `depth` (integer, optional): levels of transitive dependencies to resolve (default `1`)
+- `depth` (integer, optional): levels of transitive dependencies to resolve, from `1` to `10` (default `1`)
 
 **Returns:** a JSON object with the targeted `okf_version` and a `documents` map
 from each bundle-relative path to that document's markdown. Every directory
 becomes a reserved `index.md` listing what it holds, and every file becomes a
-concept document — YAML frontmatter naming it, then a `# Dependencies` section
-linking to the concepts it relies on. The bundle is **returned, never written**:
+concept document at its own name plus `.md` — or, where that would claim a name
+OKF reserves (a file called `index` or `log`), at that name plus `.concept.md`.
+A concept document is YAML frontmatter naming the file, then a `# Dependencies`
+section linking to the concepts it relies on. The bundle is **returned, never written**:
 the server stays read-only, so a client cannot use it to create files on the
 host. Write it out with `OkfBundleWriter` on the consumer's side.
 
@@ -254,8 +261,9 @@ constrained by design:
   **no authentication**, so it must not be exposed on a routable interface.
   Change `server.address` only after putting authentication in front of it.
 
-- **Bounded depth.** The `depth` argument is capped at `10` to bound the cost of
-  transitive dependency resolution.
+- **Bounded depth.** The `depth` argument runs from `1` to `10`: the cap bounds
+  the cost of transitive dependency resolution, and the floor refuses a depth of
+  zero, which resolves nothing.
 
 ## Configuring MCP Clients
 

--- a/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundle.java
+++ b/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundle.java
@@ -21,6 +21,9 @@ public class OkfBundle {
 	/** The reserved name of a directory listing, which carries no concept of its own. */
 	public static final String INDEX = "index.md";
 
+	/** The reserved name of a bundle's change log, which is likewise no concept of its own. */
+	public static final String LOG = "log.md";
+
 	private final List<OkfDocument> documents;
 
 	public OkfBundle(List<OkfDocument> documents) {

--- a/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundler.java
+++ b/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundler.java
@@ -35,6 +35,8 @@ public class OkfBundler {
 
 	private static final String SEPARATOR = "/";
 	private static final String DOCUMENT_SUFFIX = ".md";
+	private static final String CONCEPT_SUFFIX = ".concept";
+	private static final Set<String> RESERVED_NAMES = Set.of(OkfBundle.INDEX, OkfBundle.LOG);
 	private static final String DELIMITER = "---";
 	private static final String BULLET = "* ";
 	private static final String DIRECTORIES_HEADING = "# Directories";
@@ -232,7 +234,28 @@ public class OkfBundler {
 		return name.charAt(0) + name.substring(1).toLowerCase(Locale.ROOT);
 	}
 
+	/**
+	 * The bundle document a file's concept is written to. A file's own name plus
+	 * {@value #DOCUMENT_SUFFIX} would let a file called {@code index} or {@code log}
+	 * claim one of the names the specification reserves for a directory's listing and
+	 * a bundle's log — two documents at one path, of which only the last written
+	 * survives. Such a name is escaped instead, and so is a name that already carries
+	 * the escape, which keeps the mapping one-to-one: no two files can be given the
+	 * same concept document.
+	 */
 	private String conceptName(ProjectTreeNode node) {
-		return node.name() + DOCUMENT_SUFFIX;
+		return escapeReserved(node.name()) + DOCUMENT_SUFFIX;
+	}
+
+	private String escapeReserved(String fileName) {
+		return claimsAReservedName(fileName) ? fileName + CONCEPT_SUFFIX : fileName;
+	}
+
+	/** True for a reserved name and for anything the escaping above maps onto one. */
+	private boolean claimsAReservedName(String fileName) {
+		if (fileName.endsWith(CONCEPT_SUFFIX)) {
+			return claimsAReservedName(fileName.substring(0, fileName.length() - CONCEPT_SUFFIX.length()));
+		}
+		return RESERVED_NAMES.contains(fileName + DOCUMENT_SUFFIX);
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/PackageAwareFinderTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/PackageAwareFinderTest.java
@@ -230,6 +230,41 @@ public class PackageAwareFinderTest {
 		assertEquals(List.of("Mid.java", "Leaf.java"), order);
 	}
 
+	@Test
+	void readsAnImportThatFollowsAMultiLineBlockCommentOnTheSameLine() {
+		// Stripping the comment must not pull the import onto the comment's first line:
+		// the import is what tells the two Foo apart, so losing it loses the dependency.
+		ClassContainer user = new ClassContainer("User.java",
+				"package x; /* a comment\n*/ import a.Foo;\npublic class User { Foo foo; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(fooInA, fooInB, user)).find(user, 1);
+
+		assertEquals(Set.of(fooInA), dependencies);
+	}
+
+	@Test
+	void readsAPackageDeclarationThatFollowsAMultiLineBlockCommentOnTheSameLine() {
+		ClassContainer user = new ClassContainer("User.java",
+				"/* a licence\n   header */ package a;\npublic class User { Foo foo; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(fooInA, fooInB, user)).find(user, 1);
+
+		assertEquals(Set.of(fooInA), dependencies);
+	}
+
+	@Test
+	void aStrippedCommentStillSeparatesTheNamesAroundIt() {
+		// Blanking a comment must leave something between its neighbours, or the two
+		// names on either side would read as the single name of a class that is there.
+		ClassContainer fooBar = new ClassContainer("FooBar.java", "package a;\npublic class FooBar {}");
+		ClassContainer user = new ClassContainer("User.java",
+				"package a;\npublic class User { Foo/* not a join */Bar bar; }");
+
+		Set<ClassContainer> dependencies = new PackageAwareFinder(containers(fooInA, fooBar, user)).find(user, 1);
+
+		assertEquals(Set.of(fooInA), dependencies);
+	}
+
 	private Set<ClassContainer> containers(ClassContainer... containers) {
 		return new HashSet<>(Set.of(containers));
 	}

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/AbstractContextToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/AbstractContextToolTest.java
@@ -68,6 +68,19 @@ abstract class AbstractContextToolTest {
 		assertThrows(IllegalArgumentException.class, () -> tool().apply(arguments));
 	}
 
+	@Test
+	void zeroDepthIsRejectedWithTheAcceptedRange() {
+		// A depth of zero resolves nothing and every finder refuses it, so it is
+		// refused here, where the message can name the range the tools do take.
+		Map<String, Object> arguments = pathArgument(projectRoot);
+		arguments.put("depth", 0);
+
+		IllegalArgumentException rejected =
+				assertThrows(IllegalArgumentException.class, () -> tool().apply(arguments));
+
+		assertTrue(rejected.getMessage().contains("between 1 and 10"), rejected.getMessage());
+	}
+
 	/** The arguments naming a root, as the map a test then adds its own entries to. */
 	protected Map<String, Object> pathArgument(Path root) {
 		Map<String, Object> arguments = new HashMap<>();

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/ProjectTreeToolTest.java
@@ -5,6 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -88,6 +92,35 @@ public class ProjectTreeToolTest extends AbstractContextToolTest {
 		writeJava("A", "public class A {}");
 
 		assertFalse(tool.apply(arguments()).isError());
+	}
+
+	@Test
+	void twoClassesSharingASimpleNameAreToldApartByTheirPackage() throws IOException {
+		// The name-based finder resolved either Dup to whichever was indexed first, so
+		// the one that lost drew an edge to the other — a self-edge, by the only name
+		// the tree carries. The package-aware finder resolves each within its own
+		// package, where neither depends on anything.
+		Path one = Files.createDirectory(projectRoot.resolve("one"));
+		Path two = Files.createDirectory(projectRoot.resolve("two"));
+		Files.writeString(one.resolve("Dup.java"), "package one;\npublic class Dup {}");
+		Files.writeString(two.resolve("Dup.java"), "package two;\npublic class Dup {}");
+		Files.writeString(one.resolve("User.java"), "package one;\npublic class User { Dup dup; }");
+
+		JsonNode tree = MAPPER.readTree(tool.apply(arguments()).text());
+
+		List<JsonNode> duplicates = nodesNamed(tree, "Dup.java");
+		assertEquals(2, duplicates.size());
+		duplicates.forEach(node -> assertTrue(node.get("dependencies").isEmpty(),
+				"a class must not depend on a class of its own name: " + node));
+	}
+
+	private List<JsonNode> nodesNamed(JsonNode node, String name) {
+		List<JsonNode> found = new ArrayList<>();
+		if (name.equals(node.get("name").asText())) {
+			found.add(node);
+		}
+		node.get("children").forEach(child -> found.addAll(nodesNamed(child, name)));
+		return found;
 	}
 
 	private Map<String, Object> arguments() {

--- a/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundleConformanceTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundleConformanceTest.java
@@ -199,6 +199,10 @@ public class OkfBundleConformanceTest {
 		root.addChild(pkg);
 		root.addChild(new ProjectTreeNode("pom.xml", ProjectTreeNode.Type.FILE));
 		root.addChild(new ProjectTreeNode(INDEX, ProjectTreeNode.Type.FILE));
+		// Files whose own names are what the reserved document names are built from,
+		// which is where a concept last took a path a directory listing already had.
+		root.addChild(new ProjectTreeNode("index", ProjectTreeNode.Type.FILE));
+		root.addChild(new ProjectTreeNode("log", ProjectTreeNode.Type.FILE));
 		return root;
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundlerTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/okf/OkfBundlerTest.java
@@ -167,6 +167,45 @@ public class OkfBundlerTest {
 	}
 
 	@Test
+	void aFileNamedAfterAReservedDocumentDoesNotClaimIt() {
+		ProjectTreeNode root = directory("project");
+		root.addChild(file("index"));
+		root.addChild(file("log"));
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertEquals(List.of("index.md", "index.concept.md", "log.concept.md"),
+				bundle.documents().stream().map(OkfDocument::path).toList());
+		assertTrue(document(bundle, "index.md").contains("* [index](index.concept.md)"));
+		assertTrue(document(bundle, "index.md").contains("* [log](log.concept.md)"));
+	}
+
+	@Test
+	void aFileNamedAfterAnEscapedReservedDocumentDoesNotClaimItEither() {
+		ProjectTreeNode root = directory("project");
+		root.addChild(file("index"));
+		root.addChild(file("index.concept"));
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertEquals(List.of("index.md", "index.concept.md", "index.concept.concept.md"),
+				bundle.documents().stream().map(OkfDocument::path).toList());
+	}
+
+	@Test
+	void aDependencyOnAFileNamedAfterAReservedDocumentLinksToItsEscapedConcept() {
+		ProjectTreeNode root = directory("project");
+		root.addChild(file("index"));
+		ProjectTreeNode dependent = file("B.java");
+		dependent.addDependency("index");
+		root.addChild(dependent);
+
+		OkfBundle bundle = bundler.bundle(root);
+
+		assertTrue(document(bundle, "B.java.md").contains("* [`index`](/index.concept.md)"));
+	}
+
+	@Test
 	void aFileThatIsNotASourceFileIsTypedAsAProjectFile() {
 		ProjectTreeNode root = directory("project");
 		root.addChild(file("pom.xml"));


### PR DESCRIPTION
A file named `index` or `log` took the OKF document name the specification
reserves for a directory's listing and a bundle's log, so two documents
claimed one bundle path: the writer kept whichever it wrote last and the
`okf_bundle` JSON dropped the other. Such a name is escaped to
`.concept.md` now, and so is a name that already carries the escape, which
keeps the file-to-document mapping one-to-one. The conformance test's
sample tree grew the two names, so the conditions it already stated —
no concept on a reserved name, every document path unique — now run on
the input that broke them.

The MCP tools accepted a `depth` of 0 and then failed on it, since every
finder refuses a non-positive depth. The bound is 1 to 10 now, so the
refusal names the range the tools take rather than arriving later from
the finder.

Stripping comments and literals replaced a whole match with one space,
which pulled everything after a multi-line comment onto that comment's
first line. A `package` or `import` declaration that landed there was no
longer at the start of a line, so the package-aware finder lost the import
that told two same-named classes apart. Each stripped character becomes a
space now and line terminators stay where they were.

`project_tree` and `okf_bundle` scanned with the tree builder's name-based
default while `find_context` used the package-aware finder, so one server
answered one question two ways — and where the name-based finder resolved
a reference to the wrong file of that name, the wrong file was sometimes
the one being scanned, drawing a self-edge no class has. Both now pass
the package-aware finder to the builder as a `ContextFactory`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U2ZXoVQemonh3PBcYtwMnx