### PR TITLE
build(pom, test-common, data): run unit tests a class at a time in parallel

### DIFF
--- a/.claude/skills/testing-conventions/SKILL.md
+++ b/.claude/skills/testing-conventions/SKILL.md
@@ -23,6 +23,21 @@ fails the build, not just review.
   under coverage). A fork that hangs outright is killed at 300 s
   (`forkedProcessTimeoutInSeconds`).
 
+### Unit tests run class-parallel
+- Surefire runs `unit.test.parallelism` (default **3**) test classes at once per
+  module; the methods **within** one class still run on a single thread, so a
+  `@BeforeEach`-built fixture is never shared across threads.
+- A `@TempDir` is unique per class, so an ordinary test needs nothing extra.
+- **Writing process-global state needs a guard**, or the test corrupts whatever
+  runs beside it:
+  - a system property, or `PathValidator.setAllowedBaseDir` → annotate the class
+    `@Isolated` (`org.junit.jupiter.api.parallel.Isolated`); it then runs alone.
+    ArchUnit fails the build if you forget.
+  - a fixture genuinely shared between classes (the embedded Derby database) →
+    `@ResourceLock("<name>")`, which serialises just those classes. Put it on the
+    shared base class; subclasses inherit it.
+- Debug a suspected ordering problem with `-Dunit.test.parallelism=1`.
+
 ### Network is off for unit tests
 - The `data` module's `NetworkOffExtension` engages the `Switch` kill-switch
   before any test runs, so a unit test **cannot** open an outbound connection.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -462,6 +462,34 @@ apply to. The one module using Mockito (`protogen-maven-plugin`) pre-loads it as
 a surefire `-javaagent`, so the byte-buddy self-attach happens at JVM startup
 rather than inside the first timed test.
 
+**Unit tests run a class at a time in parallel.** Surefire turns JUnit's parallel
+execution on with `mode.classes.default = concurrent` but `mode.default =
+same_thread`: `unit.test.parallelism` (default **3**) test classes run at once in
+a module, while the methods of one class stay on a single thread. A class already
+owns its fixture — 79 of them take a `@TempDir`, which JUnit makes unique per
+class — so concurrency *between* classes is the mode this suite can take;
+concurrency *within* one would interleave methods sharing a `@BeforeEach`-built
+instance, which nothing here was written for. The number is deliberately a small
+constant, not per-core: the reactor's `-T1C` is already per-core, and a per-core
+value here would multiply out to the square of the core count and push the
+slowest methods into the 5 s limit. `-Dunit.test.parallelism=1` turns it off for
+a run.
+
+Process-global state is guarded at the class that writes it, because a class
+cannot own it alone:
+
+| State | Guard | Where |
+| --- | --- | --- |
+| a system property the whole JVM reads | `@Isolated` | `TransportConfigurerTest`, `TlsConfigurationTest`, `MainTest`, `ClaudeCodeEnforcerRuleConfigurationTest` |
+| `PathValidator`'s allowed base directory | `@Isolated` | `PathValidatorTest`, `McpConfigurationTest` |
+| the one embedded Derby database | `@ResourceLock("derby-testDB")` on `DBTest` | inherited by `UniquenessCheckTest`, `SQLDataSourceTest` |
+
+The Derby lock is what the suite most depends on: its subclasses share a static
+`Connection` and one `jdbc:derby:memory:testDB`, so without the lock two of them
+racing create the same tables, overwrite each other's connection, and drop the
+database mid-test — reproducibly, every run. `Switch` needs no guard: it is
+one-way and every class engages it before its own first test.
+
 **Unit tests run with the network off.** The `data` module registers a
 `NetworkOffExtension` — a JUnit `BeforeAllCallback` discovered through
 `META-INF/services` — that calls `Switch.off()` before any test runs. Both the
@@ -492,7 +520,9 @@ Repo-wide rules (declared once in `test-common` and imported with
   separate because `claude-code-enforcer` is exempt: its abstract rule bases are
   public API that poms configure by name.
 - `CommonTestConventions` — every `@Testable` method lives in a `*Test`/`*IT`
-  class; no `@Disabled`; JUnit 5 only; no `System.out`/`err`; no `Thread.sleep`.
+  class; no `@Disabled`; JUnit 5 only; no `System.out`/`err`; no `Thread.sleep`;
+  a `*Test` that writes a system property is `@Isolated`, since the unit run is
+  class-parallel (the `*IT`s failsafe runs one after another are exempt).
 
 Adding a repository-wide convention means editing one library, not six tests; an
 exemption means a module not importing a library, which stays visible.
@@ -502,7 +532,11 @@ Per-module rules:
 - **`data`** — data-source contracts in `source.interfaces` must not depend on
   their `source.db`/`source.file` implementations; the uniqueness core must not
   depend on its MCP adapter; the `structure` collections stay decoupled from data
-  sources; JDBC (`java.sql`) stays confined to `source.db`.
+  sources; JDBC (`java.sql`) stays confined to `source.db`. Its
+  `TestConventionsArchitectureTest` adds the module's counterpart to the shared
+  system-property rule: a `*Test` that sets or clears `PathValidator`'s allowed
+  base directory is `@Isolated`, that field being the other JVM-wide state a test
+  here can write.
 - **`adopt`** (`AdoptArchitectureTest`) — the `command` package is the only place
   a process is spawned, and a step knows only the `CommandRunner` contract, never
   `ProcessCommandRunner`; a step never reaches back to `GitHubRepoAdopter`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,15 @@ Skill: `testing-conventions`.
   lifecycle-method timeout (15 s under coverage) covers shared setup like
   `@BeforeAll`, and surefire's **300-second** `forkedProcessTimeoutInSeconds`
   kills a fork that hangs outright.
+- **Unit tests run a class at a time in parallel**, `unit.test.parallelism`
+  (default **3**) classes at once per module, with the methods of one class still
+  on a single thread. Set `-Dunit.test.parallelism=1` to turn it off for a run.
+  A test that writes something the whole JVM reads — a system property, or
+  `PathValidator`'s allowed base directory — carries `@Isolated` so it runs
+  alone; test classes sharing the embedded Derby database carry `@ResourceLock`.
+  Each module's `TestConventionsArchitectureTest` fails the build on a new test
+  that writes such state without isolating, so it cannot break the suite beside
+  it instead.
 - **Unit tests run with the network off.** The `data` module's
   `NetworkOffExtension` engages the `Switch` kill-switch before any test runs, so
   a unit test can never open an outbound connection; the failsafe `*IT`s are

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/cli/MainTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/cli/MainTest.java
@@ -17,11 +17,19 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * The command line as a pre-commit hook or a non-Maven project meets it: run it at
  * a directory and read what it says.
  */
+/**
+ * Runs alone under the class-parallel unit-test run: it clears
+ * {@code claude.enforcer.reportDir}, a JVM-wide default every rule reads, so a
+ * rule test running beside it would be handed a report directory this test
+ * removed.
+ */
+@Isolated
 class MainTest {
 
 	private static final String VALID_CLAUDE_MD = """

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRuleConfigurationTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRuleConfigurationTest.java
@@ -17,6 +17,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * The shared configuration every rule inherits: what a severity that is not a
@@ -24,6 +25,13 @@ import org.junit.jupiter.api.io.TempDir;
  * build-wide defaults that save a project spelling the same three parameters out
  * once per rule.
  */
+/**
+ * Runs alone under the class-parallel unit-test run: the build-wide defaults it
+ * sets are system properties {@link RuleDefaults} reads for every rule, so a
+ * concurrent rule test would inherit the severity or the directories this one is
+ * part-way through configuring.
+ */
+@Isolated
 class ClaudeCodeEnforcerRuleConfigurationTest {
 
 	@TempDir

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/TlsConfigurationTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/TlsConfigurationTest.java
@@ -8,9 +8,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.boot.web.server.Ssl;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 
+/**
+ * Runs alone under the class-parallel unit-test run: every case here clears or
+ * restores {@code jdk.tls.namedGroups}, a JVM-wide system property that any
+ * concurrently running test reading TLS configuration would see change under it.
+ */
+@Isolated
 public class TlsConfigurationTest {
 
 	private final TlsConfiguration config = new TlsConfiguration();

--- a/data/src/test/java/io/github/adamw7/tools/data/DBTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/DBTest.java
@@ -8,9 +8,24 @@ import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.github.adamw7.tools.data.source.file.InMemoryCSVDataSource;
 
+/**
+ * The shared embedded-Derby fixture: one in-memory database, created with its
+ * tables by {@link #setup()} and dropped again by {@link #tearDown()}.
+ *
+ * <p>The lock is what lets the suite run class-parallel. Every subclass boots the
+ * same {@code jdbc:derby:memory:testDB} and shares this class's static
+ * {@link #connection}, so two of them running at once would race three ways: both
+ * would create the same tables and one would fail on the duplicate, the second to
+ * connect would overwrite the connection the first is still issuing statements on,
+ * and the first to finish would close that connection and drop the database out
+ * from under the other. Holding one named lock for the whole class serialises the
+ * subclasses against each other while leaving them parallel with everything else.
+ */
+@ResourceLock("derby-testDB")
 public abstract class DBTest {
 	protected static Connection connection;
 	protected static String query;

--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/TestConventionsArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/TestConventionsArchitectureTest.java
@@ -1,10 +1,18 @@
 package io.github.adamw7.tools.data.architecture;
 
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.parallel.Isolated;
+
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchTests;
+import com.tngtech.archunit.lang.ArchRule;
 
+import io.github.adamw7.tools.data.source.file.PathValidator;
 import io.github.adamw7.tools.test.architecture.CommonTestConventions;
 
 /**
@@ -21,4 +29,22 @@ public class TestConventionsArchitectureTest {
 
 	@ArchTest
 	static final ArchTests commonTestConventions = ArchTests.in(CommonTestConventions.class);
+
+	/**
+	 * The module's own answer to the shared rule on system properties. The allowed
+	 * base directory is the other piece of JVM-wide state a test here can write, and
+	 * it fails the same way: while one class points it at a {@code @TempDir}, every
+	 * concurrently running test that opens a file source is refused the resource it
+	 * reads, with a {@link SecurityException} that names a directory it never chose.
+	 */
+	@ArchTest
+	static final ArchRule testsConfiningFileAccessAreIsolated = noClasses()
+			.that().haveSimpleNameEndingWith("Test")
+			.and().areNotAnnotatedWith(Isolated.class)
+			.should().callMethod(PathValidator.class, "setAllowedBaseDir", Path.class)
+			.orShould().callMethod(PathValidator.class, "clearAllowedBaseDir")
+			.because("the allowed base directory is one field for the whole JVM, so a test that "
+					+ "writes it must run alone; only the surefire unit run is class-parallel, "
+					+ "so the *IT classes failsafe runs one after another are exempt")
+			.allowEmptyShould(true);
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/PathValidatorTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/PathValidatorTest.java
@@ -12,7 +12,16 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Isolated;
 
+/**
+ * Runs alone under the class-parallel unit-test run: the allowed base directory
+ * is one {@code volatile} field for the whole JVM, so while this class points it
+ * at a {@code @TempDir}, every other test constructing a file source would be
+ * refused the test resource it reads. Clearing it afterwards is not enough when
+ * something else runs *during*.
+ */
+@Isolated
 public class PathValidatorTest {
 
 	@AfterEach

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.adamw7.tools.data.source.file.PathValidator;
@@ -22,6 +23,12 @@ import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 
+/**
+ * Runs alone under the class-parallel unit-test run: {@code tools()} confines file
+ * access by setting the JVM-wide {@link PathValidator} base directory, which would
+ * otherwise deny a concurrently running test the file it reads.
+ */
+@Isolated
 public class McpConfigurationTest {
 
 	private final McpConfiguration config = new McpConfiguration();

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/TransportConfigurerTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/TransportConfigurerTest.java
@@ -6,7 +6,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
+/**
+ * Runs alone under the class-parallel unit-test run: it clears the transport,
+ * web-application-type and banner system properties that
+ * {@link TransportConfigurer} sets process-wide, which a concurrently running
+ * server test would otherwise find missing.
+ */
+@Isolated
 public class TransportConfigurerTest {
 
 	private static final String TRANSPORT_MODE = "transport.mode";

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,18 @@
 		     forked JVM after this many seconds, so a genuinely hung test still fails
 		     the build. Sized far above a full module's fast unit run. -->
 		<unit.test.fork.timeout>300</unit.test.fork.timeout>
+		<!-- How many test classes one module runs at a time. Unit tests are
+		     class-parallel (see the surefire configurationParameters): the reactor's
+		     -T1C already builds several modules at once, but the dependency graph
+		     starves it whenever a module everything waits on is the only one left,
+		     and that module then ran its whole suite one class after another. This
+		     fills those gaps. It is a small fixed number rather than a per-core one
+		     precisely because -T1C is already per-core: on a 4-core machine the two
+		     multiply out to 4 module threads x this, so a per-core value here would
+		     oversubscribe by the square of the core count and push the slowest
+		     methods into the ${unit.test.method.timeout} limit. Lower it to 1 to
+		     turn class-parallelism off for a run: -Dunit.test.parallelism=1. -->
+		<unit.test.parallelism>3</unit.test.parallelism>
 		<!-- Maven Central publishing behavior for the release profile. Defaults
 		     publish on release; overridable so the maven-publish.yml
 		     workflow_dispatch dry run can upload and validate without
@@ -405,11 +417,31 @@
 						<systemPropertyVariables>
 							<tools.test.network.off>true</tools.test.network.off>
 						</systemPropertyVariables>
+						<!-- Run each module's unit tests a class at a time in parallel
+						     (${unit.test.parallelism} of them at once), but every method
+						     of one class on a single thread. Concurrency between classes
+						     is the mode this suite can actually take: a class already
+						     owns its fixture (79 of them take a @TempDir, which JUnit
+						     makes unique per class), whereas concurrency *within* a class
+						     would interleave methods sharing one @BeforeEach-built
+						     instance, which nothing here was written for. State a class
+						     cannot own alone is guarded at the class that touches it:
+						     @Isolated where a test writes something JVM-wide that others
+						     read (a system property, the allowed base directory), and
+						     @ResourceLock where test classes share one database. Each
+						     module's TestConventionsArchitectureTest holds that line for
+						     new tests, so the next such test fails the build rather than
+						     the suite beside it. -->
 						<properties>
 							<configurationParameters>
 								junit.jupiter.execution.timeout.testable.method.default = ${unit.test.method.timeout}
 								junit.jupiter.execution.timeout.lifecycle.method.default = ${unit.test.lifecycle.timeout}
 								junit.jupiter.extensions.autodetection.enabled = true
+								junit.jupiter.execution.parallel.enabled = true
+								junit.jupiter.execution.parallel.mode.default = same_thread
+								junit.jupiter.execution.parallel.mode.classes.default = concurrent
+								junit.jupiter.execution.parallel.config.strategy = fixed
+								junit.jupiter.execution.parallel.config.fixed.parallelism = ${unit.test.parallelism}
 							</configurationParameters>
 						</properties>
 					</configuration>

--- a/test-common/src/test/java/io/github/adamw7/tools/test/architecture/CommonTestConventions.java
+++ b/test-common/src/test/java/io/github/adamw7/tools/test/architecture/CommonTestConventions.java
@@ -4,11 +4,13 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
 
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.ArchTest;
@@ -73,6 +75,19 @@ public class CommonTestConventions {
 			.should().beStatic()
 			.because("JUnit 5 runs @BeforeAll/@AfterAll once per class only when they are static; "
 					+ "a non-static one fails at runtime unless the class opts into the PER_CLASS lifecycle")
+			.allowEmptyShould(true);
+
+	@ArchTest
+	static final ArchRule testsWritingSystemPropertiesAreIsolated = noClasses()
+			.that().haveSimpleNameEndingWith("Test")
+			.and().areNotAnnotatedWith(Isolated.class)
+			.should().callMethod(System.class, "setProperty", String.class, String.class)
+			.orShould().callMethod(System.class, "clearProperty", String.class)
+			.orShould().callMethod(System.class, "setProperties", Properties.class)
+			.because("unit tests run a class at a time in parallel and a system property is JVM-wide: "
+					+ "a class that writes one changes what every concurrently running test reads, "
+					+ "so it must carry @Isolated and run alone. Only the surefire unit run is "
+					+ "class-parallel, so the *IT classes failsafe runs one after another are exempt")
 			.allowEmptyShould(true);
 
 	@ArchTest


### PR DESCRIPTION
Surefire now enables JUnit's parallel execution with classes concurrent and
methods same_thread, so each module runs unit.test.parallelism (default 3)
test classes at once instead of its whole suite one after another. Measured
over three alternating clean builds, the median wall clock drops from 49.9s
to 46.4s; the gain is modest because the reactor's -T1C already saturates a
four-core machine, and it is a small constant rather than a per-core value
so the two do not multiply out to the square of the core count.

Class-parallelism exposed three pieces of process-global state that a test
class cannot own alone, each guarded where it is written: DBTest's
subclasses share one static Connection and one in-memory Derby database, so
they take a @ResourceLock -- without it the data suite failed every run;
PathValidator's allowed base directory and the system properties four tests
write are JVM-wide reads for everything else, so those classes take
@Isolated.

Two ArchUnit rules keep the line for new tests: a *Test writing a system
property (CommonTestConventions, repo-wide) or PathValidator's base
directory (data) must be @Isolated, so the next such test fails the build
rather than the suite running beside it. Both were verified to fail when
the annotation is removed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G7uKSU3PPPRJMWcAV54oic