### PR TITLE
fix(data): reject key candidates that differ only in case

### DIFF
--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -73,8 +73,9 @@ pull request's URL.
   `--no-write-fetch-head`. Do not reach for `-c remote.origin.url` or a
   positional URL — git treats the first as another value of a multi-valued key
   and resolves the configured one instead, and writes the second into the reflog
-  of every ref the fetch updates. `Redaction` masks credentials in every log,
-  message and report — keep it that way.
+  of every ref the fetch updates. `Redaction` (in `mcp-common`, package
+  `io.github.adamw7.tools.secret`, so the MCP failure path masks with the same
+  rule) masks credentials in every log, message and report — keep it that way.
 - Register the step in `GitHubRepoAdopter.defaultSteps` (or the optional list it
   belongs to), and unit-test it with a fake `CommandRunner`.
 

--- a/.claude/skills/mcp-server/SKILL.md
+++ b/.claude/skills/mcp-server/SKILL.md
@@ -41,6 +41,11 @@ public class MyTool implements McpTool {   // Function<Map<String,Object>, ToolR
   turns any thrown `RuntimeException` into an error `ToolResult` naming the
   tool, so a bad argument reaches the client as an actionable tool error. Throw
   a clear exception; return `ToolResult.error` when the failure is expected.
+- **The failure path masks both channels** (`FailureMessage`): the arguments it
+  logs lose their credentials, and the message the client reads loses both those
+  and any absolute path, keeping only the file's name. Write exception messages
+  that stay useful under that — name what was wrong with the argument, not where
+  on the server's disk it resolved to.
 
 ## The server
 ```java
@@ -58,6 +63,12 @@ with `--transport.mode`:
 | stdio (default) | `stdio` | — |
 | streamable HTTP | `streamable-http` | `/mcp` |
 | stateless HTTP | `stateless-http` | `/mcp`, no session kept |
+
+`TransportConfigurer.configure(args)` reads the argument through `TransportMode`,
+so anything but those three values is refused at startup with a message naming
+them. Write the conditions with `TransportMode.Value.*` rather than a literal:
+an unmatched `havingValue` registers no transport, and outside stdio it also
+leaves the web server on — a server that binds its port and serves no `/mcp`.
 
 A `Main.java` Spring Boot entry point sits next to the configuration
 (`entryPointsAreNamedMain` is an ArchUnit rule in `adopt`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,9 @@ What is worth knowing before changing any of it:
   run therefore needs no GitHub credentials at all, and `completedSteps` ends at
   `verify`.
 - **Credentials never outlive the run.** Every log line, failure message and
-  report field goes through `Redaction`, which masks the user information of a
+  report field goes through `Redaction` — which lives in `mcp-common`
+  (`io.github.adamw7.tools.secret`), the lowest module this pipeline and the
+  shared MCP failure path both build on — and it masks the user information of a
   URL carrying a scheme, so a CI runner's
   `https://x-access-token:TOKEN@github.com/...` never reaches disk or an MCP
   client. `git` is still handed the URL as given, but only per invocation: the
@@ -277,7 +279,8 @@ tools (root pom, packaging=pom)
 ├── claude-code-enforcer        # custom maven-enforcer rules validating CLAUDE.md,
 │                               #   AGENTS.md, README.md and the .claude config
 ├── test-common                 # shared ArchUnit rule libraries and assertions (test-jar)
-├── mcp-common                  # shared MCP server scaffolding (transport wiring, tool SPI)
+├── mcp-common                  # shared MCP server scaffolding (transport wiring, tool SPI,
+│                               #   credential masking shared with adopt)
 ├── data                        # data sources, uniqueness checks, structures, MCP server
 ├── code
 │   ├── protogen-maven-plugin       # the builder-generating Maven plugin
@@ -312,7 +315,9 @@ module, `io.github.adamw7.tools.*` elsewhere).
 Three MCP servers ship here, each a Spring Boot app whose entry point is
 `Main.java` and which supports stdio (default), streamable HTTP
 (`--transport.mode=streamable-http`, served at `/mcp`) or stateless HTTP
-(`--transport.mode=stateless-http`, session-less, also `/mcp`). Each has an
+(`--transport.mode=stateless-http`, session-less, also `/mcp`). Any other value
+is refused at startup, naming the three, since a mode no transport matches used
+to leave a server bound to its port with no `/mcp` endpoint at all. Each has an
 `MCP_USAGE.md` next to its `mcp` package:
 
 | Server | Package | Tools |

--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ It contains:
     - `stdio` (default) — JSON-RPC over stdin/stdout (Spring Boot, no HTTP server started)
     - `streamable-http` — the modern HTTP transport served at `/mcp`
     - `stateless-http` — the same HTTP transport served at `/mcp`, but session-less: each JSON-RPC request is answered in isolation, which suits load-balanced or serverless deployments
+    - any other value is refused at startup with a message naming the three
   - Build: `mvn clean install` produces `data/target/tools.data-<version>.jar`
   - Run: `java -jar data/target/tools.data-<version>.jar --transport.mode=stdio`
   - See [MCP Usage Documentation](data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md) for client configuration (Claude Desktop, Cline) and usage examples

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/BatchAdoption.java
@@ -11,6 +11,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 
+import io.github.adamw7.tools.secret.Redaction;
+
 /**
  * Adopts a list of repositories one after another, with a fresh
  * {@link AdoptionReport} for each.

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/CliArguments.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 
 import io.github.adamw7.tools.adopt.step.GuardRules;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
+import io.github.adamw7.tools.secret.Redaction;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/RepositoryUrl.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import io.github.adamw7.tools.secret.Redaction;
+
 /**
  * A repository clone URL, parsed once into the two facts the adoption needs from
  * it: the repository name the checkout directory is created under, and the

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/BoundedTranscript.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/BoundedTranscript.java
@@ -14,7 +14,7 @@ package io.github.adamw7.tools.adopt.command;
  * unbounded transcript is an unbounded response.
  *
  * <p>A transcript that fits is answered verbatim. Only one that overflowed is cut,
- * and then <em>only at line boundaries</em>: {@link io.github.adamw7.tools.adopt.Redaction}
+ * and then <em>only at line boundaries</em>: {@link io.github.adamw7.tools.secret.Redaction}
  * masks a clone URL's credentials by matching the user information after a
  * {@code ://}, so a cut through the middle of one would leave the token with nothing
  * to recognise it by. A region carrying no line feed is dropped whole.

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandResult.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/CommandResult.java
@@ -2,7 +2,7 @@ package io.github.adamw7.tools.adopt.command;
 
 import java.util.List;
 
-import io.github.adamw7.tools.adopt.Redaction;
+import io.github.adamw7.tools.secret.Redaction;
 
 /**
  * Outcome of running an external command: the exit code and the combined

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ProcessCommandRunner.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.Elapsed;
-import io.github.adamw7.tools.adopt.Redaction;
+import io.github.adamw7.tools.secret.Redaction;
 
 /**
  * {@link CommandRunner} backed by {@link ProcessBuilder}. Standard error is

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -20,7 +20,7 @@ import io.github.adamw7.tools.adopt.BatchAdoption;
 import io.github.adamw7.tools.adopt.CheckoutRetention;
 import io.github.adamw7.tools.adopt.Checkouts;
 import io.github.adamw7.tools.adopt.GitHubRepoAdopter;
-import io.github.adamw7.tools.adopt.Redaction;
+import io.github.adamw7.tools.secret.Redaction;
 import io.github.adamw7.tools.adopt.RepositoryUrls;
 import io.github.adamw7.tools.adopt.Workspaces;
 import io.github.adamw7.tools.adopt.command.CommandRunners;

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
@@ -39,6 +39,7 @@ be installed and authenticated on the machine running the MCP server.
 The server supports the same transports as the repository's other MCP servers:
 stdio (default), streamable HTTP (`--transport.mode=streamable-http`, served at
 `/mcp`), and stateless HTTP (`--transport.mode=stateless-http`, also at `/mcp`).
+Any other value is refused at startup with a message naming the three.
 
 ## Building the Server
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.Logger;
 import io.github.adamw7.tools.adopt.AdoptionContext;
 import io.github.adamw7.tools.adopt.AdoptionException;
 import io.github.adamw7.tools.adopt.AdoptionReport;
-import io.github.adamw7.tools.adopt.Redaction;
+import io.github.adamw7.tools.secret.Redaction;
 import io.github.adamw7.tools.adopt.command.CommandResult;
 import io.github.adamw7.tools.adopt.command.CommandRunner;
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
+import io.github.adamw7.tools.secret.Redaction;
 
 class CliArgumentsTest {
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/RepositoryUrlTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import io.github.adamw7.tools.secret.Redaction;
+
 class RepositoryUrlTest {
 
 	/**

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/architecture/AdoptArchitectureTest.java
@@ -75,7 +75,10 @@ public class AdoptArchitectureTest {
 	static final ArchRule onlyTheMcpAdapterKnowsTheScaffolding = noClasses()
 			.that().resideOutsideOfPackage(MCP_PACKAGE)
 			.should().dependOnClassesThat().resideInAPackage(MCP_COMMON_PACKAGE)
-			.because("only the mcp delivery package builds on the shared MCP scaffolding");
+			.because("only the mcp delivery package builds on the shared MCP scaffolding. The masking the "
+					+ "pipeline shares with it ships in the same module but outside that package — "
+					+ "io.github.adamw7.tools.secret — precisely so one rule can mask a credential for both "
+					+ "without the pipeline taking on the scaffolding");
 
 	@ArchTest
 	static final ArchRule onlyTheMcpAdapterKnowsSpring = noClasses()

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/BoundedTranscriptTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/BoundedTranscriptTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import io.github.adamw7.tools.adopt.Redaction;
+import io.github.adamw7.tools.secret.Redaction;
 
 class BoundedTranscriptTest {
 

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/MCP_USAGE.md
@@ -45,7 +45,8 @@ The server uses:
 - **Transport**: stdio (default), streamable HTTP
   (`--transport.mode=streamable-http`), which serves the MCP endpoint at `/mcp`,
   or stateless HTTP (`--transport.mode=stateless-http`), which serves the same
-  `/mcp` endpoint without keeping a session.
+  `/mcp` endpoint without keeping a session. Any other value is refused at
+  startup with a message naming the three.
 - **MCP SDK**: `io.modelcontextprotocol.sdk` v2.0.0
 - **Framework**: Spring Boot
 - **Protocol**: Model Context Protocol (MCP)

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/AbstractUniqueness.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.data.uniqueness;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
@@ -37,21 +38,37 @@ public abstract class AbstractUniqueness<T extends ColumnarDataSource> implement
 		checkIfCandidatesExistIn(keyCandidates, allColumns);
 		return IntStream.range(0, allColumns.length)
 				.flatMap(index -> Arrays.stream(keyCandidates)
-						.filter(candidate -> allColumns[index].equalsIgnoreCase(candidate))
+						.filter(candidate -> Objects.equals(normalized(allColumns[index]), normalized(candidate)))
 						.mapToInt(candidate -> index))
 				.toArray();
 	}
 
 	private void checkIfCandidatesExistIn(String[] keyCandidates, String[] allColumns) {
 		Set<String> all = Arrays.stream(allColumns)
-				.map(column -> column == null ? null : column.toLowerCase())
+				.map(AbstractUniqueness::normalized)
 				.collect(Collectors.toCollection(HashSet::new));
 
 		for (String candidate : keyCandidates) {
-			if (!all.contains(candidate.toLowerCase())) {
+			if (!all.contains(normalized(candidate))) {
 				throw new ColumnNotFoundException(candidate + " cannot be found in " + Arrays.toString(allColumns));
 			}
 		}
+	}
+
+	/**
+	 * The one rule every question about a column name is answered by: a fold to
+	 * {@link Locale#ROOT} lower case. Does the source declare this name, which position
+	 * does it sit at, was it asked for twice — all three must read a name the same way.
+	 * When they did not, {@code exec("id", "ID")} passed the duplicate check and then
+	 * collapsed to a single index in {@link #indicesOf}, so the check ran against a
+	 * narrower key than the caller named and could only report more duplicates than the
+	 * real one has. The fold is anchored to {@code Locale.ROOT} because the default one
+	 * is not a property of the data: in a Turkish locale {@code "ID".toLowerCase()} is
+	 * {@code "\u0131d"}, which matches no column on that machine and every column on the
+	 * next.
+	 */
+	private static String normalized(String column) {
+		return column == null ? null : column.toLowerCase(Locale.ROOT);
 	}
 
 
@@ -72,7 +89,7 @@ public abstract class AbstractUniqueness<T extends ColumnarDataSource> implement
 	private void handleDuplicates(String[] keyCandidates) {
 		Set<String> set = new HashSet<>();
 		for (String candidate : keyCandidates) {
-			if (!set.add(candidate)) {
+			if (!set.add(normalized(candidate))) {
 				throw new IllegalArgumentException("Duplicate in input: " + candidate);
 			}
 		}

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
@@ -15,7 +15,7 @@ The implementation consists of three main components:
 3. **UniquenessTool.java** - Implements the uniqueness checking tool
 
 The server uses:
-- **Transport**: stdio (default), streamable-http (`--transport.mode=streamable-http`, served at `/mcp`), or stateless-http (`--transport.mode=stateless-http`, session-less, also served at `/mcp`)
+- **Transport**: stdio (default), streamable-http (`--transport.mode=streamable-http`, served at `/mcp`), or stateless-http (`--transport.mode=stateless-http`, session-less, also served at `/mcp`). Any other value is refused at startup, naming the three
 - **MCP SDK**: io.modelcontextprotocol.sdk v2.0.0
 - **Framework**: Spring Boot
 - **Protocol**: Model Context Protocol (MCP)

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/UniquenessCheckTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/UniquenessCheckTest.java
@@ -109,6 +109,31 @@ public class UniquenessCheckTest extends DBTest {
 		assertEquals("Duplicate in input: year1", thrown.getMessage());
 	}
 
+	/**
+	 * A column is matched by name case-insensitively, so ("year1", "YEAR1") names one
+	 * column twice. Folded case-sensitively the pair passed this check and then
+	 * collapsed to a single index, so the run checked a one-column key the caller never
+	 * asked for — and a narrower key can only report duplicates the named one has not.
+	 */
+	@ParameterizedTest
+	@MethodSource("happyPath")
+	void negativeDuplicatesDifferingOnlyInCase(Uniqueness uniqueness) throws Exception {
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+				() -> uniqueness.exec("year1", "YEAR1"), "Expected exec method to throw, but it didn't");
+
+		assertEquals("Duplicate in input: YEAR1", thrown.getMessage());
+	}
+
+	/**
+	 * The counterpart of the rejection above: two genuinely different columns named in
+	 * a case the source does not use are still the key the caller asked for.
+	 */
+	@ParameterizedTest
+	@MethodSource("happyPath")
+	void uniqueKeyNamedInADifferentCase(Uniqueness uniqueness) throws Exception {
+		assertTrue(uniqueness.exec("YEAR1", "HLPI_NAME").isUnique());
+	}
+
 	@Test
 	public void notUniquePathClosesDataSource() throws Exception {
 		ClosingSpyDataSource source = new ClosingSpyDataSource(

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -100,7 +100,7 @@ flowchart TB
             enforcer["<b>claude-code-enforcer</b><br/><i>maven-enforcer rules</i><br/>Fails the build on malformed<br/>CLAUDE.md / AGENTS.md / README /<br/>skills / settings / .mcp.json"]
             markdownCommon["<b>markdown-common</b><br/><i>Shared library</i><br/>MarkdownDocument · MarkdownText:<br/>lines plus the code and comment masks"]
             testCommon["<b>test-common</b><br/><i>test-jar</i><br/>Shared ArchUnit rule libraries:<br/>coding · naming · test conventions"]
-            mcpCommon["<b>mcp-common</b><br/><i>Shared library</i><br/>MCP scaffolding: AbstractMcpConfiguration ·<br/>McpTool · ToolDefinition · TransportConfigurer"]
+            mcpCommon["<b>mcp-common</b><br/><i>Shared library</i><br/>MCP scaffolding: AbstractMcpConfiguration ·<br/>McpTool · ToolDefinition · TransportConfigurer ·<br/>TransportMode · FailureMessage · Redaction"]
         end
 
         subgraph codegen ["Code generation"]
@@ -435,7 +435,7 @@ flowchart TB
             adopter["<b>GitHubRepoAdopter</b><br/><i>runs the ordered pipeline</i>"]
             ctx["<b>AdoptionContext / Checkouts /<br/>Workspaces / RepositoryUrl</b>"]
             report["<b>AdoptionReport /<br/>AdoptionReportWriter</b><br/><i>steps completed + PR URL → JSON</i>"]
-            redaction["<b>Redaction</b><br/><i>masks clone-URL credentials<br/>in every log &amp; report</i>"]
+            redaction["<b>Redaction</b><br/><i>from mcp-common: masks URL credentials<br/>in every log &amp; report</i>"]
         end
 
         subgraph steps ["Pipeline steps"]
@@ -775,8 +775,12 @@ flowchart TB
   Spring Boot apps whose entry point is `Main.java` and which support stdio
   (default), streamable HTTP, or stateless HTTP. All three build on the shared
   **`mcp-common`** module (`AbstractMcpConfiguration`, `McpTool`,
-  `ToolDefinition`, `ToolArguments`, `ToolResult`, `TransportConfigurer`), and
-  each ships an `MCP_USAGE.md` next to its `mcp` package.
+  `ToolDefinition`, `ToolArguments`, `ToolResult`, `TransportConfigurer`,
+  `TransportMode`), and each ships an `MCP_USAGE.md` next to its `mcp` package.
+  A mode `TransportMode` does not know is refused before Spring starts, and
+  every tool's failure is masked on both channels by `FailureMessage` —
+  credentials out of the logged arguments through `Redaction`, credentials and
+  filesystem locations out of the message the client reads.
 - **Build:** Java 25 + Maven 3.9.x; `mvn clean install` from the root. CI runs
   `mvn -B package -DenforceClaudeMd`, which also runs the `claude-code-enforcer`
   rules — those need a two-phase build, since a maven-enforcer rule must be

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
@@ -55,14 +55,15 @@ public abstract class AbstractMcpConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stdio", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = TransportMode.Value.STDIO,
+			matchIfMissing = true)
 	public StdioServerTransportProvider stdioServerTransport() {
 		log.info("Creating StdioServerTransport");
 		return new StdioServerTransportProvider(new JacksonMcpJsonMapper(objectMapper()));
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = TransportMode.Value.STREAMABLE_HTTP)
 	public HttpServletStreamableServerTransportProvider streamableServerTransport() {
 		log.info("Creating HttpServletStreamableServerTransport");
 		return HttpServletStreamableServerTransportProvider.builder()
@@ -72,14 +73,14 @@ public abstract class AbstractMcpConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = TransportMode.Value.STREAMABLE_HTTP)
 	public ServletRegistrationBean<HttpServletStreamableServerTransportProvider> streamableServletRegistration(
 			HttpServletStreamableServerTransportProvider transport) {
 		return asyncRegistration(transport, MCP_ENDPOINT);
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stateless-http")
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = TransportMode.Value.STATELESS_HTTP)
 	public HttpServletStatelessServerTransport statelessServerTransport() {
 		log.info("Creating HttpServletStatelessServerTransport");
 		return HttpServletStatelessServerTransport.builder()
@@ -89,7 +90,7 @@ public abstract class AbstractMcpConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stateless-http")
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = TransportMode.Value.STATELESS_HTTP)
 	public ServletRegistrationBean<HttpServletStatelessServerTransport> statelessServletRegistration(
 			HttpServletStatelessServerTransport transport) {
 		return asyncRegistration(transport, MCP_ENDPOINT);
@@ -113,14 +114,14 @@ public abstract class AbstractMcpConfiguration {
 	}
 
 	@Bean(destroyMethod = "close")
-	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "streamable-http")
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = TransportMode.Value.STREAMABLE_HTTP)
 	public McpSyncServer mcpSyncServerStreamable(McpStreamableServerTransportProvider transport) {
 		log.info("Initializing McpSyncServer with streamable transport: {}", transport);
 		return buildServer(McpServer.sync(transport));
 	}
 
 	@Bean(destroyMethod = "close")
-	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stateless-http")
+	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = TransportMode.Value.STATELESS_HTTP)
 	public McpStatelessSyncServer mcpStatelessSyncServer(HttpServletStatelessServerTransport transport) {
 		log.info("Initializing McpStatelessSyncServer with stateless transport: {}", transport);
 		McpStatelessSyncServer statelessServer = McpServer.sync(transport)
@@ -162,17 +163,20 @@ public abstract class AbstractMcpConfiguration {
 	/**
 	 * Invokes a tool and turns any thrown exception into an error {@link ToolResult}
 	 * rather than letting it surface as a protocol-level failure, so a bad argument or a
-	 * denied path reaches the client as a clear, actionable tool error. Package-private so
-	 * the behaviour can be exercised directly in tests.
+	 * denied path reaches the client as a clear, actionable tool error. Both what is
+	 * logged and what is answered go through {@link FailureMessage}, since this one
+	 * handler carries every tool's failure on every transport: the arguments a call
+	 * failed on can name a clone URL or a JDBC URL, and the exception behind it can name
+	 * where on disk the server keeps its files. Package-private so the behaviour can be
+	 * exercised directly in tests.
 	 */
 	ToolResult safeApply(McpTool tool, Map<String, Object> arguments) {
 		String name = tool.getToolDefinition().name();
 		try {
 			return tool.apply(arguments);
 		} catch (RuntimeException e) {
-			log.warn("MCP tool {} failed for {}", name, arguments, e);
-			String message = e.getMessage() == null ? e.toString() : e.getMessage();
-			return ToolResult.error(name + " failed: " + message);
+			log.warn("MCP tool {} failed for {}", name, FailureMessage.forLog(arguments), e);
+			return ToolResult.error(name + " failed: " + FailureMessage.forClient(e));
 		}
 	}
 

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/FailureMessage.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/FailureMessage.java
@@ -1,0 +1,78 @@
+package io.github.adamw7.tools.mcp;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.github.adamw7.tools.secret.Redaction;
+
+/**
+ * What a failed tool call is allowed to say, on each of the two channels a failure
+ * reaches: the server's log, and the error result the client reads. Every tool of
+ * every server funnels through {@link AbstractMcpConfiguration#safeApply}, so this is
+ * the one place either can leak.
+ *
+ * <p>The log keeps the call's arguments, because a failure nobody can reproduce is
+ * not much of a log line, but a credential in them is masked: an MCP server is
+ * long-lived, and a token written to its log outlives every session that could have
+ * used it. The client's message is masked further — the filesystem locations a
+ * failure names are the server's, not the caller's, and a denied path answering with
+ * where the server keeps its files hands back exactly what the path confinement is
+ * there to withhold.
+ */
+final class FailureMessage {
+
+	/**
+	 * An absolute POSIX path. The leading separator must not follow a word character,
+	 * a colon or another separator, so the {@code /owner/repo.git} of a URL — whose
+	 * host is already the word before it — is left as the URL it is part of rather
+	 * than mistaken for a directory. Quotes and whitespace end the path, since a
+	 * message quotes the paths it names.
+	 */
+	private static final Pattern POSIX_PATH = Pattern.compile("(?<![\\w:/])/(?:[^/\\s'\"]+/)+[^/\\s'\",;)\\]]*");
+
+	/** The same for a Windows path, which names its drive and separates with backslashes. */
+	private static final Pattern WINDOWS_PATH =
+			Pattern.compile("(?<![\\w])[A-Za-z]:\\\\(?:[^\\\\\\s'\"]+\\\\)*[^\\\\\\s'\",;)\\]]*");
+
+	private static final String ELLIPSIS = "...";
+
+	private FailureMessage() {
+	}
+
+	/**
+	 * @return the call's arguments as the log may carry them
+	 */
+	static String forLog(Map<String, Object> arguments) {
+		return Redaction.of(String.valueOf(arguments));
+	}
+
+	/**
+	 * @return what the failure may tell the client: its message — or the exception's
+	 *         own {@code toString()} when it carries none, so a
+	 *         {@link NullPointerException} still names something — with credentials
+	 *         and filesystem locations taken out of it
+	 */
+	static String forClient(RuntimeException e) {
+		String message = e.getMessage() == null ? e.toString() : e.getMessage();
+		return withoutLocations(Redaction.of(message));
+	}
+
+	/**
+	 * Keeps the last segment of every absolute path, which is the part the caller
+	 * named and the part that says what went wrong, and replaces the directories
+	 * leading to it with {@value #ELLIPSIS}.
+	 */
+	private static String withoutLocations(String message) {
+		return abbreviate(abbreviate(message, POSIX_PATH, '/'), WINDOWS_PATH, '\\');
+	}
+
+	private static String abbreviate(String message, Pattern path, char separator) {
+		return path.matcher(message)
+				.replaceAll(match -> Matcher.quoteReplacement(ELLIPSIS + separator + lastSegment(match.group(), separator)));
+	}
+
+	private static String lastSegment(String path, char separator) {
+		return path.substring(path.lastIndexOf(separator) + 1);
+	}
+}

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/TransportConfigurer.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/TransportConfigurer.java
@@ -3,37 +3,46 @@ package io.github.adamw7.tools.mcp;
 /**
  * Selects the MCP transport from the command line and primes the Spring runtime
  * before the application context starts. The transport is read from
- * {@code --transport.mode} (defaulting to stdio). In stdio mode the web server is
- * disabled so nothing but JSON-RPC reaches the channel; every HTTP transport
- * ({@code streamable-http} and {@code stateless-http}) keeps the web server so its
- * servlet can be exposed. The banner is always suppressed because it
- * would otherwise corrupt the stdio stream. Both MCP servers share this so their
+ * {@code --transport.mode} (defaulting to stdio) and must name one of the
+ * {@link TransportMode known modes}; anything else is refused here, at the argument
+ * that carries the typo, rather than starting a server no request can reach. In stdio
+ * mode the web server is disabled so nothing but JSON-RPC reaches the channel; every
+ * HTTP transport ({@code streamable-http} and {@code stateless-http}) keeps the web
+ * server so its servlet can be exposed. The banner is always suppressed because it
+ * would otherwise corrupt the stdio stream. The MCP servers share this so their
  * {@code Main} entry points stay trivial.
  */
 public final class TransportConfigurer {
 
 	private static final String TRANSPORT_MODE_PREFIX = "--transport.mode=";
 
-	private static final String STDIO = "stdio";
-
 	private TransportConfigurer() {
 	}
 
+	/**
+	 * @throws IllegalArgumentException when {@code --transport.mode} names no known
+	 *         transport, before any Spring runtime property is set
+	 */
 	public static void configure(String[] args) {
-		String transportMode = resolveTransportMode(args);
-		System.setProperty("transport.mode", transportMode);
-		if (STDIO.equals(transportMode)) {
+		TransportMode transportMode = resolveTransportMode(args);
+		System.setProperty("transport.mode", transportMode.value());
+		if (transportMode == TransportMode.STDIO) {
 			System.setProperty("spring.main.web-application-type", "none");
 		}
 		System.setProperty("spring.main.banner-mode", "off");
 	}
 
-	public static String resolveTransportMode(String[] args) {
+	/**
+	 * @return the transport the arguments name, or {@link TransportMode#STDIO} when
+	 *         they name none
+	 * @throws IllegalArgumentException when they name one that does not exist
+	 */
+	public static TransportMode resolveTransportMode(String[] args) {
 		for (String arg : args) {
 			if (arg.startsWith(TRANSPORT_MODE_PREFIX)) {
-				return arg.substring(TRANSPORT_MODE_PREFIX.length());
+				return TransportMode.of(arg.substring(TRANSPORT_MODE_PREFIX.length()));
 			}
 		}
-		return STDIO;
+		return TransportMode.STDIO;
 	}
 }

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/TransportMode.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/TransportMode.java
@@ -1,0 +1,73 @@
+package io.github.adamw7.tools.mcp;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * The transports an MCP server can be started on, and the only values
+ * {@code --transport.mode} accepts. Naming them once, as a type, is what lets an
+ * unrecognised mode be refused at the command line instead of reaching Spring: every
+ * transport's beans in {@link AbstractMcpConfiguration} are gated on the property
+ * matching one of these spellings exactly, so {@code streamablehttp} matched no
+ * transport at all — and, not being stdio, left the web server enabled. The server
+ * then started, bound its port, logged nothing unusual, and served no {@code /mcp}
+ * endpoint, with a single character in a launch argument the only thing to point at.
+ */
+public enum TransportMode {
+
+	STDIO(Value.STDIO),
+	STREAMABLE_HTTP(Value.STREAMABLE_HTTP),
+	STATELESS_HTTP(Value.STATELESS_HTTP);
+
+	/**
+	 * The spellings as compile-time constants, so the {@code @ConditionalOnProperty}
+	 * conditions and this enum cannot drift apart: an annotation takes only a constant
+	 * expression, which an enum constant is not, and an enum's own constants must be
+	 * declared before any field of it, so the list above cannot refer to fields
+	 * declared below it either. A nested class is what both can name.
+	 */
+	public static final class Value {
+
+		public static final String STDIO = "stdio";
+
+		public static final String STREAMABLE_HTTP = "streamable-http";
+
+		public static final String STATELESS_HTTP = "stateless-http";
+
+		private Value() {
+		}
+	}
+
+	private final String value;
+
+	TransportMode(String value) {
+		this.value = value;
+	}
+
+	/**
+	 * @return the spelling this mode is named by on the command line and in the
+	 *         {@code transport.mode} property the transports are gated on
+	 */
+	public String value() {
+		return value;
+	}
+
+	/**
+	 * @param value the spelling given on the command line
+	 * @return the mode it names
+	 * @throws IllegalArgumentException naming every known mode when it names none of
+	 *         them, so a typo is reported where it was made rather than becoming a
+	 *         server that answers nothing
+	 */
+	public static TransportMode of(String value) {
+		return Arrays.stream(values())
+				.filter(mode -> mode.value.equals(value))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("Unknown transport mode: '" + value
+						+ "'. Known modes are: " + known()));
+	}
+
+	private static String known() {
+		return Arrays.stream(values()).map(TransportMode::value).collect(Collectors.joining(", "));
+	}
+}

--- a/mcp-common/src/main/java/io/github/adamw7/tools/secret/Redaction.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/secret/Redaction.java
@@ -1,13 +1,23 @@
-package io.github.adamw7.tools.adopt;
+package io.github.adamw7.tools.secret;
 
 import java.util.regex.Pattern;
 
 /**
- * Masks the credentials a clone URL can carry before the text reaches somewhere it
- * outlives the run. An adoption driven by CI is handed
- * {@code https://x-access-token:TOKEN@github.com/owner/repo.git}, and puts that URL
- * in three places a secret must not reach: the log, a failing command's
- * {@link AdoptionException}, and the JSON report's {@code failure} field.
+ * Masks the credentials a URL can carry before the text reaches somewhere it outlives
+ * the request that carried it. An adoption driven by CI is handed
+ * {@code https://x-access-token:TOKEN@github.com/owner/repo.git}, and puts that URL in
+ * three places a secret must not reach: the log, a failing command's
+ * {@code AdoptionException}, and the JSON report's {@code failure} field. The MCP
+ * servers are handed the same URL as a tool argument, and a JDBC URL carries a
+ * password the same way.
+ *
+ * <p>It lives in {@code mcp-common} because that is the lowest module both users
+ * share — the adoption pipeline and the shared MCP failure path — and one masking
+ * rule is the point: a second implementation is a second reading of where a
+ * credential ends, and the half that reads it differently is the half that logs the
+ * token. It is deliberately outside {@code io.github.adamw7.tools.mcp}, since masking
+ * a secret is not MCP scaffolding and the adoption's own layering rule keeps that
+ * scaffolding to its delivery package.
  *
  * <p>Only the user information of a URL with a scheme is masked, so the scp-like
  * {@code git@host:owner/repo} — whose {@code git@} is a well-known user, not a

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/AbstractMcpConfigurationTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/AbstractMcpConfigurationTest.java
@@ -163,6 +163,39 @@ public class AbstractMcpConfigurationTest {
 		assertEquals("boom failed: bad argument", result.text());
 	}
 
+	/**
+	 * Every tool of every server fails through this one handler, so it is where a
+	 * credential-bearing argument reaches the client if anywhere does: a failing clone
+	 * quotes the URL it was handed back in its own message.
+	 */
+	@Test
+	public void safeApplyAnswersWithoutTheCredentialsTheCallCarried() {
+		ToolResult result = new TestMcpConfiguration().safeApply(new CredentialQuotingTool(),
+				Map.of("repository_url", "https://x-access-token:s3cr3t@github.com/owner/repo.git"));
+
+		assertTrue(result.isError());
+		assertFalse(result.text().contains("s3cr3t"), result.text());
+		assertEquals("clone failed: fatal: could not read Username for 'https://***@github.com/owner/repo.git'",
+				result.text());
+	}
+
+	private static final class CredentialQuotingTool implements McpTool {
+
+		private final ToolDefinition toolDefinition = new ToolDefinition("clone", "Quotes what it was given",
+				Map.of("type", "object", "properties", Map.of()));
+
+		@Override
+		public ToolDefinition getToolDefinition() {
+			return toolDefinition;
+		}
+
+		@Override
+		public ToolResult apply(Map<String, Object> arguments) {
+			throw new IllegalStateException("fatal: could not read Username for "
+					+ "'https://x-access-token:s3cr3t@github.com/owner/repo.git'");
+		}
+	}
+
 	private static final class ThrowingTool implements McpTool {
 
 		private final ToolDefinition toolDefinition = new ToolDefinition("boom", "Always fails",

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/FailureMessageTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/FailureMessageTest.java
@@ -1,0 +1,106 @@
+package io.github.adamw7.tools.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class FailureMessageTest {
+
+	private static final String TOKEN = "ghp-a-real-looking-token";
+
+	/**
+	 * The argument an {@code adopt_repo} call carries is the clone URL, credentials and
+	 * all. The log line is the likeliest place for a token to reach disk, and this
+	 * server outlives the call by days.
+	 */
+	@Test
+	public void logKeepsTheArgumentsWithoutTheirCredentials() {
+		String logged = FailureMessage.forLog(
+				Map.of("repository_url", "https://x-access-token:" + TOKEN + "@github.com/owner/repo.git"));
+
+		assertFalse(logged.contains(TOKEN), logged);
+		assertTrue(logged.contains("repository_url"), logged);
+		assertTrue(logged.contains("github.com/owner/repo.git"), logged);
+	}
+
+	@Test
+	public void logDescribesACallWithNoArguments() {
+		assertEquals("{}", FailureMessage.forLog(Map.of()));
+	}
+
+	/**
+	 * A failing command quotes the URL it was given back in its own message, so the
+	 * answer has to be masked as well as the log.
+	 */
+	@Test
+	public void clientMessageCarriesNoCredentials() {
+		String message = FailureMessage.forClient(new IllegalStateException(
+				"clone failed for https://" + TOKEN + "@github.com/owner/repo.git"));
+
+		assertEquals("clone failed for https://***@github.com/owner/repo.git", message);
+	}
+
+	/**
+	 * The path a denied call resolved to is the server's, not the caller's: answering
+	 * with it hands back the very layout the path confinement exists to withhold. The
+	 * leaf is kept, because that is what the caller named and what says what went wrong.
+	 */
+	@Test
+	public void clientMessageKeepsTheFileButNotWhereItLives() {
+		String message = FailureMessage.forClient(new SecurityException(
+				"Access denied: path '/srv/secrets/project/report.csv' is outside the allowed base directory "
+						+ "'/srv/mcp/allowed'"));
+
+		assertEquals("Access denied: path '.../report.csv' is outside the allowed base directory '.../allowed'",
+				message);
+	}
+
+	@Test
+	public void clientMessageAbbreviatesAWindowsPath() {
+		String message = FailureMessage.forClient(
+				new IllegalArgumentException("Invalid file path: C:\\Users\\operator\\data\\report.csv"));
+
+		assertEquals("Invalid file path: ...\\report.csv", message);
+	}
+
+	/**
+	 * A URL's path is part of the URL, not a directory on this machine, so masking it
+	 * would only make the failure harder to read.
+	 */
+	@Test
+	public void clientMessageLeavesAUrlPathAlone() {
+		String message = FailureMessage.forClient(
+				new IllegalStateException("gh: no commits between main and https://github.com/owner/repo/pull/7"));
+
+		assertEquals("gh: no commits between main and https://github.com/owner/repo/pull/7", message);
+	}
+
+	@Test
+	public void clientMessageLeavesAPlainFailureAlone() {
+		assertEquals("Missing required argument: file",
+				FailureMessage.forClient(new IllegalArgumentException("Missing required argument: file")));
+	}
+
+	/**
+	 * A relative path names nothing about the server's layout, and is what the caller
+	 * asked with, so it is answered as it was given.
+	 */
+	@Test
+	public void clientMessageLeavesARelativePathAlone() {
+		assertEquals("Class not found in src/main/java: Missing",
+				FailureMessage.forClient(new IllegalArgumentException("Class not found in src/main/java: Missing")));
+	}
+
+	/**
+	 * An exception thrown with no message of its own still has to name something, or
+	 * the client is told only that the call failed.
+	 */
+	@Test
+	public void clientMessageNamesTheExceptionWhenItCarriesNoMessage() {
+		assertEquals("java.lang.NullPointerException", FailureMessage.forClient(new NullPointerException()));
+	}
+}

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/TransportConfigurerTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/TransportConfigurerTest.java
@@ -2,6 +2,9 @@ package io.github.adamw7.tools.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,29 +35,60 @@ public class TransportConfigurerTest {
 
 	@Test
 	public void defaultsToStdioWhenNoArguments() {
-		assertEquals("stdio", TransportConfigurer.resolveTransportMode(new String[] {}));
+		assertSame(TransportMode.STDIO, TransportConfigurer.resolveTransportMode(new String[] {}));
 	}
 
 	@Test
 	public void defaultsToStdioWhenPrefixAbsent() {
-		assertEquals("stdio", TransportConfigurer.resolveTransportMode(new String[] { "--server.port=8080", "--other" }));
+		assertSame(TransportMode.STDIO,
+				TransportConfigurer.resolveTransportMode(new String[] { "--server.port=8080", "--other" }));
 	}
 
 	@Test
 	public void readsExplicitTransportMode() {
-		assertEquals("stateless-http",
+		assertSame(TransportMode.STATELESS_HTTP,
 				TransportConfigurer.resolveTransportMode(new String[] { "--transport.mode=stateless-http" }));
 	}
 
 	@Test
 	public void findsTransportModeAmongOtherArguments() {
 		String[] args = { "--server.port=8080", "--transport.mode=streamable-http" };
-		assertEquals("streamable-http", TransportConfigurer.resolveTransportMode(args));
+		assertSame(TransportMode.STREAMABLE_HTTP, TransportConfigurer.resolveTransportMode(args));
+	}
+
+	/**
+	 * A mode nothing recognises is the argument that used to start a healthy-looking
+	 * server serving no endpoint: it is not stdio, so the web server stayed on, and it
+	 * matched no transport condition, so nothing was ever registered at /mcp. It is
+	 * refused at the argument instead, and the message names what may be written there.
+	 */
+	@Test
+	public void refusesAnUnknownTransportMode() {
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+				() -> TransportConfigurer.resolveTransportMode(new String[] { "--transport.mode=streamablehttp" }));
+
+		assertTrue(thrown.getMessage().contains("streamablehttp"), thrown.getMessage());
+		assertTrue(thrown.getMessage().contains("stdio, streamable-http, stateless-http"), thrown.getMessage());
 	}
 
 	@Test
-	public void supportsEmptyTransportModeValue() {
-		assertEquals("", TransportConfigurer.resolveTransportMode(new String[] { "--transport.mode=" }));
+	public void refusesAnEmptyTransportModeValue() {
+		assertThrows(IllegalArgumentException.class,
+				() -> TransportConfigurer.resolveTransportMode(new String[] { "--transport.mode=" }));
+	}
+
+	/**
+	 * Nothing is primed for a run that cannot start, so a refused mode leaves the JVM
+	 * exactly as it found it rather than half-configured for a server that never runs.
+	 */
+	@Test
+	public void refusedModeSetsNoRuntimeProperty() {
+		assertThrows(IllegalArgumentException.class,
+				() -> TransportConfigurer.configure(new String[] { "--transport.mode=streamable_http" }));
+
+		assertNull(System.getProperty(TRANSPORT_MODE));
+		assertNull(System.getProperty(WEB_APPLICATION_TYPE));
+		assertNull(System.getProperty(BANNER_MODE));
 	}
 
 	@Test

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/TransportModeTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/TransportModeTest.java
@@ -1,0 +1,59 @@
+package io.github.adamw7.tools.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class TransportModeTest {
+
+	@Test
+	public void readsEveryKnownMode() {
+		assertSame(TransportMode.STDIO, TransportMode.of("stdio"));
+		assertSame(TransportMode.STREAMABLE_HTTP, TransportMode.of("streamable-http"));
+		assertSame(TransportMode.STATELESS_HTTP, TransportMode.of("stateless-http"));
+	}
+
+	/**
+	 * The spellings the {@code @ConditionalOnProperty} conditions in
+	 * {@link AbstractMcpConfiguration} are written with are the same constants, so a
+	 * mode this enum accepts always matches the transport it names.
+	 */
+	@Test
+	public void namesTheSpellingsTheTransportsAreGatedOn() {
+		assertEquals(TransportMode.Value.STDIO, TransportMode.STDIO.value());
+		assertEquals(TransportMode.Value.STREAMABLE_HTTP, TransportMode.STREAMABLE_HTTP.value());
+		assertEquals(TransportMode.Value.STATELESS_HTTP, TransportMode.STATELESS_HTTP.value());
+	}
+
+	@Test
+	public void everyModeIsReadBackFromItsOwnValue() {
+		for (TransportMode mode : TransportMode.values()) {
+			assertSame(mode, TransportMode.of(mode.value()));
+		}
+	}
+
+	/**
+	 * The enum's own constant names are not what a launch argument is written with, so
+	 * accepting them would let a mode through that no transport condition matches.
+	 */
+	@Test
+	public void refusesTheEnumConstantName() {
+		assertThrows(IllegalArgumentException.class, () -> TransportMode.of("STREAMABLE_HTTP"));
+	}
+
+	@Test
+	public void refusesAnUnknownModeNamingTheKnownOnes() {
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+				() -> TransportMode.of("streamablehttp"));
+
+		assertTrue(thrown.getMessage().contains("stdio, streamable-http, stateless-http"), thrown.getMessage());
+	}
+
+	@Test
+	public void refusesNull() {
+		assertThrows(IllegalArgumentException.class, () -> TransportMode.of(null));
+	}
+}

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/McpCommonArchitectureTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/McpCommonArchitectureTest.java
@@ -20,10 +20,19 @@ import io.github.adamw7.tools.test.architecture.CommonNamingConventions;
  * production classes are analysed; test classes are excluded via
  * {@link ImportOption}.
  */
-@AnalyzeClasses(packages = McpCommonArchitectureTest.MCP_PACKAGE, importOptions = ImportOption.DoNotIncludeTests.class)
+@AnalyzeClasses(packages = { McpCommonArchitectureTest.MCP_PACKAGE, McpCommonArchitectureTest.SECRET_PACKAGE },
+		importOptions = ImportOption.DoNotIncludeTests.class)
 public class McpCommonArchitectureTest {
 
 	static final String MCP_PACKAGE = "io.github.adamw7.tools.mcp";
+
+	/**
+	 * The masking this module shares with the adoption pipeline. It ships here but
+	 * deliberately outside {@link #MCP_PACKAGE}, so the pipeline can depend on it
+	 * without depending on the MCP scaffolding its own layering rule keeps to its
+	 * delivery package.
+	 */
+	static final String SECRET_PACKAGE = "io.github.adamw7.tools.secret";
 
 	@ArchTest
 	static final ArchTests commonCodingConventions = ArchTests.in(CommonCodingConventions.class);

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/TestConventionsArchitectureTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/architecture/TestConventionsArchitectureTest.java
@@ -14,10 +14,14 @@ import io.github.adamw7.tools.test.architecture.CommonTestConventions;
  * rules, this class analyses only the test classes via
  * {@link ImportOption.OnlyIncludeTests}.
  */
-@AnalyzeClasses(packages = TestConventionsArchitectureTest.TEST_PACKAGE, importOptions = ImportOption.OnlyIncludeTests.class)
+@AnalyzeClasses(
+		packages = { TestConventionsArchitectureTest.TEST_PACKAGE, TestConventionsArchitectureTest.SECRET_TEST_PACKAGE },
+		importOptions = ImportOption.OnlyIncludeTests.class)
 public class TestConventionsArchitectureTest {
 
 	static final String TEST_PACKAGE = "io.github.adamw7.tools.mcp";
+
+	static final String SECRET_TEST_PACKAGE = "io.github.adamw7.tools.secret";
 
 	@ArchTest
 	static final ArchTests commonTestConventions = ArchTests.in(CommonTestConventions.class);

--- a/mcp-common/src/test/java/io/github/adamw7/tools/secret/RedactionTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/secret/RedactionTest.java
@@ -1,4 +1,4 @@
-package io.github.adamw7.tools.adopt;
+package io.github.adamw7.tools.secret;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;


### PR DESCRIPTION
handleDuplicates folded the candidates case-sensitively while indicesOf and
checkIfCandidatesExistIn matched them case-insensitively, so exec("id", "ID")
passed the duplicate check and then resolved to the same physical column twice.
The run then checked a one-column key the caller never named, and a narrower key
can only report duplicates the named one has not — with nothing in the output to
say why.

Every question about a column name now reads it through one normalisation,
anchored to Locale.ROOT so a Turkish default locale cannot make "ID" and "id"
different columns; that also settles the two default-locale folds this class did.

Closes #619
Refs #618

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TocQ4dYVixx59XacdnwKfH