### PR TITLE
test(adopt): give the adoption MCP server transport integration tests

### DIFF
--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -153,6 +153,13 @@ clone URL's credentials come back in the tool's own error text.
   somebody else wrote — `claude-code`'s own `.github/workflows/claude.yml` and
   `servers`' own `.mcp.json`, which no fixture can imitate. Its Maven guard is pinned to a released `--rule-version`,
   because the installer refuses to wire a `-SNAPSHOT` into another project's POM.
+- `McpStreamableHttpIT` and `McpStatelessHttpIT` (over `AbstractAdoptMcpIT`) boot
+  the adoption MCP server on each HTTP transport and drive `adopt_repo` across it
+  with a real client. The payload is a `verify_only` call — it clones
+  `octocat/Hello-World`, finds it was never adopted, and answers with the failed
+  run's JSON report — because a `dry_run` would reach `claude init` and a
+  verification shells out to `git` alone, writing nothing anywhere. Keep any new
+  transport test to that: no test may need a logged-in `claude` or `gh`.
 - Run them with `mvn -P integration-tests verify` (the profile is declared in
   `adopt`'s own pom).
 

--- a/.claude/skills/mcp-server/SKILL.md
+++ b/.claude/skills/mcp-server/SKILL.md
@@ -94,6 +94,12 @@ A `Main.java` Spring Boot entry point sits next to the configuration
   declared **per module** (`data`, `code/context`, `adopt`,
   `claude-code-enforcer`) — a new module's `*IT`s do not run until that module
   gets its own copy.
+- Each server's transport tests follow one shape: an abstract fixture holding the
+  client, the helpers and whatever both transports must assert, plus a
+  `McpStreamableHttpIT` and a `McpStatelessHttpIT` that supply only the transport
+  and the client name. Copy it for a new server, and pick a payload the
+  integration runner can actually serve — `adopt`'s pair *verifies* a repository
+  rather than adopting one, because no runner has a logged-in `claude`.
 - Unit-test the tool directly as a function: build the argument map, assert on
   the `ToolResult` text and `isError`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -596,7 +596,20 @@ module in `data`, `code/context`, `adopt` and `claude-code-enforcer`, so a new
 module's `*IT`s stay unrun until it gets its own copy. Run them with
 `mvn -P integration-tests verify`. They cover what needs something real:
 
-- `data` and `code/context` exercise their MCP servers over streamable HTTP.
+- All three MCP servers are exercised over streamable HTTP and stateless HTTP:
+  each boots on a random port and a real MCP client lists its tools and calls
+  one, so the definitions and the results are met as a client meets them.
+  `adopt`'s pair — `McpStreamableHttpIT` and `McpStatelessHttpIT` over
+  `AbstractAdoptMcpIT` — calls `adopt_repo` with `verify_only`, which clones
+  `octocat/Hello-World`, finds it was never adopted and answers with the failed
+  run's JSON report. That is the heaviest payload the server can be asked for
+  without credentials: a `dry_run` would reach `claude init`, and a verification
+  shells out to `git` alone and writes nothing, to GitHub or to the checkout.
+  The checkout is asserted on disk under the test's own workspace, so the clone
+  is known to have run on the server rather than the arguments having been
+  echoed back. The streamable test also pins the whole argument set of the
+  schema as it arrives on the wire, an argument lost in translation being
+  invisible from inside the pipeline.
 - `adopt`'s `MultiRepoAdoptionIT` clones GitHub's `octocat/Hello-World` and
   `octocat/Spoon-Knife` with the real `git`, proving a batch gives each
   repository its own checkout, that an uncloneable repository costs only itself,

--- a/README.md
+++ b/README.md
@@ -1273,14 +1273,28 @@ PR build is therefore not proof that this suite passes.
 
 ### MCP servers over a real transport
 
-`data` and `code/context` start their MCP servers as Spring Boot applications on a
-random port and talk to them through a real MCP client, so the tool listing, the
-argument schemas and the results are exercised as a client meets them rather than
-through a direct method call. Both cover **streamable HTTP and stateless HTTP**;
-only the transport differs between the subclasses, so the fixture and the helpers
-live in an abstract parent and each subclass supplies the transport and the calls
-it is there to assert. `code/context` adds an **HTTPS** run against a throwaway
-self-signed keystore, which is where
+All three servers — `data`, `code/context` and `adopt` — start as Spring Boot
+applications on a random port and are talked to through a real MCP client, so the
+tool listing, the argument schemas and the results are exercised as a client meets
+them rather than through a direct method call. Each covers **streamable HTTP and
+stateless HTTP**; only the transport differs between the subclasses, so the
+fixture and the helpers live in an abstract parent and each subclass supplies the
+transport and the calls it is there to assert.
+
+[`adopt`'s pair](adopt/src/test/java/io/github/adamw7/tools/adopt/mcp) is the one
+whose tool does real work over the wire: `adopt_repo` is called with
+`verify_only`, so the server clones `octocat/Hello-World`, finds it was never
+adopted, and answers with the failed run's whole JSON report — the steps that
+completed, the verdict that stopped it, and the checkout it really made under the
+test's own workspace, which is then asserted on disk. A verification shells out to
+`git` alone and writes nothing, to GitHub or to the checkout, so it is the
+heaviest payload these transports can carry without a logged-in `claude` or `gh`;
+a `dry_run` would reach `claude init`. The streamable test also pins the tool's
+**whole argument set as it arrives on the wire**, an argument lost between the
+tool definition and the client being invisible from inside the pipeline.
+
+`code/context` adds an **HTTPS** run against a throwaway self-signed keystore,
+which is where
 [`McpStreamableHttpsIT`](code/context/src/test/java/io/github/adamw7/context/mcp/McpStreamableHttpsIT.java)
 asserts the server's TLS hardening end to end: a tool call succeeds over the secure channel,
 the negotiated protocol is TLS 1.3, a client offering only TLS 1.2 is refused,

--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -66,7 +66,9 @@
 	<profiles>
 		<!-- Gates the *IT tests, which need real network: MultiRepoAdoptionIT
 		     clones real GitHub repositories to prove a batch gives each one its
-		     own checkout. Mirrors the data and code/context modules. -->
+		     own checkout, and the two MCP *IT tests boot the adoption server on
+		     each HTTP transport and drive adopt_repo across it. Mirrors the data
+		     and code/context modules. -->
 		<profile>
 			<id>integration-tests</id>
 			<build>
@@ -146,6 +148,15 @@
 		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
+		</dependency>
+		<!-- Boots the adoption MCP server on a random port for the transport
+		     integration tests (@SpringBootTest, @LocalServerPort), as the data and
+		     code/context modules do for theirs. The MCP client those tests reach it
+		     with travels with mcp-json-jackson2 above. -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AbstractAdoptMcpIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/AbstractAdoptMcpIT.java
@@ -1,0 +1,201 @@
+package io.github.adamw7.tools.adopt.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * What every adoption MCP integration test asserts, whichever HTTP transport the
+ * subclass's {@code @SpringBootTest} started the server with: a synchronous client
+ * reaches the {@code /mcp} endpoint, {@code adopt_repo} is discoverable there, and one
+ * real call runs the pipeline end to end and answers with the run's JSON report. Only
+ * the transport and the client name differ between the streamable-HTTP and the
+ * stateless server, so that is all a subclass supplies — along with the calls it is
+ * there to assert on its own.
+ *
+ * <p>The module's other integration tests drive the pipeline from Java. Neither of them
+ * boots the server, so nothing here used to prove that the tool an agent actually calls
+ * is reachable over a transport at all: that its definition survives the wire, that its
+ * arguments arrive as the pipeline's options, and that a whole report — not a truncated
+ * or protocol-level failure — comes back with the success flag the run earned.
+ *
+ * <p>The payload is a {@code verify_only} call rather than the {@code dry_run} an
+ * operator rehearses with. A dry run reaches {@code claude init}, which needs a
+ * logged-in {@code claude} the integration runner has not got — the same reason
+ * {@code ForeignRepositoryAdoptionIT} leaves that step out. A verification shells out to
+ * {@code git} alone: it clones and reads, and writes nothing at all, neither to GitHub
+ * nor to the checkout. It is therefore the heaviest payload this server can be asked for
+ * without credentials, and it exercises the argument mapping, the batch, and the report
+ * exactly as an adoption would.
+ *
+ * <p>The repository is GitHub's own long-lived sample, a few hundred kilobytes, and it
+ * has never been adopted — so the verification's verdict is a failure, and that verdict
+ * is what proves the call was real: the report crosses the transport carrying the steps
+ * that completed, the step that did not, and the checkout the run really made under this
+ * test's own workspace.
+ */
+abstract class AbstractAdoptMcpIT {
+
+	protected static final String ADOPT_REPO = "adopt_repo";
+
+	/** A real repository, cloned over HTTPS so no key is needed, that nobody has adopted. */
+	protected static final String HELLO_WORLD = "https://github.com/octocat/Hello-World.git";
+
+	/** The directory {@code Hello-World} is cloned into, named after the repository. */
+	private static final String CHECKOUT = "Hello-World";
+
+	private static final String BRANCH = "claude/adopt-mcp-it";
+
+	/**
+	 * Well under the runner's ten-minute default, which is sized for a
+	 * {@code claude init} rather than for cloning a sample repository, so a stalled
+	 * network fails the test in minutes instead of hanging the build.
+	 */
+	private static final int TIMEOUT_MINUTES = 2;
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	@LocalServerPort
+	protected int port;
+
+	/**
+	 * The workspace the call is told to clone into, so the checkout the report names can
+	 * be found and read — and so the clone is removed with the temporary directory
+	 * rather than left under one nobody named. A verification keeps its checkout, that
+	 * being the whole product of a run that pushes nothing.
+	 */
+	@TempDir
+	protected Path workspace;
+
+	protected McpSyncClient client;
+
+	@BeforeEach
+	void startClient() {
+		client = McpClient.sync(transport())
+				.clientInfo(McpSchema.Implementation.builder(clientName(), "1.0").build())
+				.build();
+		client.initialize();
+	}
+
+	@AfterEach
+	void closeClient() {
+		client.close();
+	}
+
+	/** The transport reaching the server this test started, built once {@link #port} is known. */
+	protected abstract HttpClientStreamableHttpTransport transport();
+
+	/** The name this test's client identifies itself to the server with. */
+	protected abstract String clientName();
+
+	@Test
+	void listsTheAdoptionTool() {
+		McpSchema.ListToolsResult tools = client.listTools();
+
+		Set<String> names = tools.tools().stream().map(McpSchema.Tool::name).collect(Collectors.toSet());
+		assertEquals(Set.of(ADOPT_REPO), names);
+	}
+
+	/**
+	 * The call that proves the transport carries a real run: a repository is cloned from
+	 * GitHub, read, and reported on, over the wire and back. The verdict is the failure
+	 * the sample repository earns — it carries no {@code CLAUDE.md} and its build wires
+	 * in no guard — which is asserted rather than avoided, because a report that names
+	 * the step that stopped and the checkout it stopped in is the one an agent has to be
+	 * able to read.
+	 */
+	@Test
+	void verifiesARealRepositoryOverTheWire() {
+		McpSchema.CallToolResult result = call(ADOPT_REPO, Map.of(
+				"repository_url", HELLO_WORLD,
+				"workspace", workspace.toString(),
+				"branch", BRANCH,
+				"verify_only", true,
+				"timeout_minutes", TIMEOUT_MINUTES));
+
+		assertTrue(result.isError(), "a repository that was never adopted must not verify");
+		JsonNode report = parse(singleText(result));
+		assertEquals(HELLO_WORLD, report.get("repositoryUrl").asText());
+		assertEquals(BRANCH, report.get("branch").asText());
+		assertFalse(report.get("succeeded").asBoolean());
+		assertEquals(List.of("toolchain", "clone", "build-toolchain"), textValues(report.get("completedSteps")));
+		assertVerdict(report.get("failure").asText());
+		assertClonedIntoTheWorkspace(report);
+	}
+
+	/**
+	 * The verdict names the step that reached it and both halves of what is missing, so
+	 * an operator re-adopting the repository knows whether they are restoring a document,
+	 * a guard, or both.
+	 */
+	private void assertVerdict(String failure) {
+		assertTrue(failure.startsWith("check-adopted: "), failure);
+		assertTrue(failure.contains("is not adopted"), failure);
+		assertTrue(failure.contains("no CLAUDE.md at its root"), failure);
+		assertTrue(failure.contains("wires in no CLAUDE.md guard"), failure);
+	}
+
+	/**
+	 * The checkout is asserted on disk as well as in the report, since the report would
+	 * name it either way: a {@code .git} directory under the workspace this call named is
+	 * what says the clone really ran on the server rather than the arguments merely
+	 * having been echoed back. A verification publishes nothing, so the pull request URL
+	 * must be absent.
+	 */
+	private void assertClonedIntoTheWorkspace(JsonNode report) {
+		Path checkout = Path.of(report.get("checkout").asText());
+		assertEquals(CHECKOUT, checkout.getFileName().toString());
+		assertTrue(Files.isDirectory(checkout.resolve(".git")), () -> checkout + " is not a git checkout");
+		assertTrue(Files.isDirectory(workspace.resolve(CHECKOUT)), () -> "nothing was cloned into " + workspace);
+		assertTrue(report.get("pullRequestUrl").isNull(), "a verification opens no pull request");
+	}
+
+	protected McpSchema.CallToolResult call(String tool, Map<String, Object> arguments) {
+		return client.callTool(McpSchema.CallToolRequest.builder(tool).arguments(arguments).build());
+	}
+
+	/** @return the one text element of a result, whether it is a success or an error */
+	protected String singleText(McpSchema.CallToolResult result) {
+		assertEquals(1, result.content().size(), "expected exactly one content element");
+		McpSchema.Content content = result.content().getFirst();
+		assertInstanceOf(McpSchema.TextContent.class, content);
+		return ((McpSchema.TextContent) content).text();
+	}
+
+	protected List<String> textValues(JsonNode array) {
+		List<String> values = new ArrayList<>();
+		array.forEach(node -> values.add(node.asText()));
+		return values;
+	}
+
+	protected JsonNode parse(String json) {
+		try {
+			return MAPPER.readTree(json);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Invalid JSON: " + json, e);
+		}
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/McpStatelessHttpIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/McpStatelessHttpIT.java
@@ -1,0 +1,35 @@
+package io.github.adamw7.tools.adopt.mcp;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+
+/**
+ * Integration test that serves the adoption MCP server over the stateless HTTP
+ * transport. The server keeps no session between requests, yet the standard
+ * streamable-HTTP client speaks the same wire protocol, so tool discovery and a real
+ * adoption call must still succeed end-to-end over the {@code /mcp} endpoint.
+ *
+ * <p>It inherits both, and adds nothing: what differs from the streamable server is the
+ * transport under the same tool, and a run that clones a repository and reports on it is
+ * the strongest statement that the difference does not show. The stateless path is the
+ * one where a long call could plausibly lose the client between request and response.
+ */
+@SpringBootTest(
+		classes = Main.class,
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = {
+				"transport.mode=stateless-http",
+				"spring.main.banner-mode=off" })
+public class McpStatelessHttpIT extends AbstractAdoptMcpIT {
+
+	@Override
+	protected HttpClientStreamableHttpTransport transport() {
+		return HttpClientStreamableHttpTransport.builder("http://localhost:" + port).build();
+	}
+
+	@Override
+	protected String clientName() {
+		return "integration-test-stateless-client";
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/McpStreamableHttpIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/McpStreamableHttpIT.java
@@ -1,0 +1,101 @@
+package io.github.adamw7.tools.adopt.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Integration test that serves the adoption MCP server over the streamable HTTP
+ * transport, on a random port, and drives {@code adopt_repo} across it with a real
+ * client.
+ *
+ * <p>Beyond the discovery and the real run every transport is held to, this one asserts
+ * what only a client can see: the tool's schema as it arrives on the wire, and the two
+ * refusals an agent is most likely to earn — a call naming no repository, and one asking
+ * for more parallelism than a batch will take. Both are answered as error results
+ * carrying the argument's own name, rather than as protocol-level failures, which is
+ * what lets a client correct the call instead of only reporting that something threw.
+ */
+@SpringBootTest(
+		classes = Main.class,
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = {
+				"transport.mode=streamable-http",
+				"spring.main.banner-mode=off" })
+public class McpStreamableHttpIT extends AbstractAdoptMcpIT {
+
+	/**
+	 * Every argument the tool takes, as a client reads them off the wire. Pinned whole
+	 * rather than sampled: an argument dropped in the translation from the SPI's
+	 * transport-neutral definition to the SDK's tool is invisible from inside the
+	 * pipeline — the server keeps answering, and the call silently runs with the default
+	 * of whatever the client thought it had asked for.
+	 */
+	private static final Set<String> ARGUMENTS = Set.of("repository_url", "repository_urls", "workspace",
+			"branch", "title", "body", "reviewers", "labels", "assignees", "draft", "assets", "rule_version",
+			"parallel", "verify_only", "keep_workspace", "dry_run", "timeout_minutes", "retries", "rules",
+			"claude_md_sections");
+
+	@Override
+	protected HttpClientStreamableHttpTransport transport() {
+		return HttpClientStreamableHttpTransport.builder("http://localhost:" + port).build();
+	}
+
+	@Override
+	protected String clientName() {
+		return "integration-test-client";
+	}
+
+	@Test
+	void describesEveryArgumentTheToolTakes() {
+		McpSchema.Tool tool = client.listTools().tools().getFirst();
+
+		assertEquals(ADOPT_REPO, tool.name());
+		assertTrue(tool.description().contains("Adopt Claude Code into one or more GitHub repositories"),
+				tool.description());
+		Object properties = tool.inputSchema().get("properties");
+		assertInstanceOf(Map.class, properties);
+		assertEquals(ARGUMENTS, ((Map<?, ?>) properties).keySet());
+	}
+
+	/**
+	 * The one requirement the schema cannot express as a required field — a call must
+	 * name a repository through one argument or the other — so it is the one an agent
+	 * reaches by sending a well-formed call the pipeline cannot run.
+	 */
+	@Test
+	void refusesACallNamingNoRepository() {
+		McpSchema.CallToolResult result = call(ADOPT_REPO, Map.of("verify_only", true));
+
+		assertTrue(result.isError());
+		String message = singleText(result);
+		assertTrue(message.contains(ADOPT_REPO + " failed"), message);
+		assertTrue(message.contains("repository_url or repository_urls"), message);
+	}
+
+	/**
+	 * A bound the client is answered with by name. The batch enforces it too, but its
+	 * complaint is about a field the client never sent; refusing here says which
+	 * argument to change.
+	 */
+	@Test
+	void refusesMoreParallelismThanABatchWillTake() {
+		McpSchema.CallToolResult result = call(ADOPT_REPO, Map.of(
+				"repository_url", HELLO_WORLD,
+				"verify_only", true,
+				"parallel", 50));
+
+		assertTrue(result.isError());
+		String message = singleText(result);
+		assertTrue(message.contains("parallel"), message);
+	}
+}


### PR DESCRIPTION
data and code/context each cover their MCP server over the wire; adopt ships one
too and nothing ever booted it. Its *ITs drive the pipeline from Java, so the
tool an agent actually calls was never proven reachable on a transport at all --
that its definition survives the translation to the SDK's tool, that its
arguments arrive as the pipeline's options, and that a whole report comes back
carrying the success flag the run earned rather than a protocol-level failure.

McpStreamableHttpIT and McpStatelessHttpIT, sharing AbstractAdoptMcpIT, boot the
server on a random port and talk to it with a real MCP client, in the shape the
other two modules' pairs already have. The payload is a verify_only call: it
clones octocat/Hello-World, finds it was never adopted, and answers with the
failed run's JSON report, whose checkout is then asserted on disk under the
test's own workspace -- a .git directory there is what says the clone really ran
on the server rather than the arguments having been echoed back. A dry_run would
reach claude init, which no integration runner has a login for, while a
verification shells out to git alone and writes nothing, to GitHub or to the
checkout; it is the heaviest payload these transports can carry unattended.

The streamable test also pins what only a client can see: the tool's whole
argument set as the schema arrives on the wire, an argument lost in that
translation being invisible from inside the pipeline, and the two refusals a
client is likeliest to earn -- a call naming no repository, and one asking for
more parallelism than a batch will take -- each answered as an error result
carrying the argument's own name.

adopt's pom gains spring-boot-starter-test at test scope, as data and
code/context already carry for theirs; the MCP client travels with
mcp-json-jackson2 the module already had.

Refs #630

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ETdiJgszZaDJ4J7rWSRZ3S