### PR TITLE
fix(data): make getColumnNames() honour its never-null contract

### DIFF
--- a/.claude/skills/data-sources/SKILL.md
+++ b/.claude/skills/data-sources/SKILL.md
@@ -27,6 +27,13 @@ Every format ships in two variants:
   `ColumnarDataSource`, so a schema-less source can never be handed in and answer
   with `null`. Don't widen `IterableDataSource` to "fix" a compile error — reach
   for a columnar source instead.
+- `getColumnNames()` **never returns `null`**: a columnar source that cannot name
+  its columns throws `IllegalStateException` saying why. `IterableSQLDataSource`
+  does it for a source read before `open()`; `CSVDataSource` does it for one built
+  without a `columnsRow` (`new CSVDataSource(fileName)` defaults it to `-1`), which
+  otherwise surfaced two frames away as `execForAllColumns()` failing with
+  `Wrong input: null`. A CSV header survives `close()` and is only dropped —
+  and reloaded — by `reset()`.
 
 ## Source picker
 | Format | In-memory | Iterable | Notes |

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
@@ -53,9 +53,34 @@ public class CSVDataSource extends AbstractFileSource implements ColumnarDataSou
 		regex = Pattern.quote(delimiter) + REGEX_SUFFIX;
 	}
 
+	/**
+	 * The header row read by {@link #open()}. A source built without one &mdash;
+	 * {@code new CSVDataSource(fileName)} and the other constructors defaulting
+	 * {@code columnsRow} to {@code -1} &mdash; has no column names to report, so it says
+	 * that here rather than handing back a {@code null} array the caller only finds out
+	 * about further downstream: {@code execForAllColumns()} on such a source used to
+	 * fail with {@code Wrong input: null}, which names neither the source nor the
+	 * missing header.
+	 *
+	 * <p>The header outlives the read: a source closed after a full pass still names its
+	 * columns, since {@link #close()} ends the scan without unlearning the schema. Only
+	 * {@link #reset()} drops them, and it reloads them as it reopens.</p>
+	 */
 	@Override
 	public String[] getColumnNames() {
-		return columns;
+		if (!columnsExist()) {
+			throw new IllegalStateException(
+					"Source was created without a header row, so it has no column names; "
+							+ "pass the 1-based row the header sits on as columnsRow");
+		}
+		if (columnsAreLoaded()) {
+			return columns;
+		}
+		if (!opened) {
+			throw new IllegalStateException("DataSource is not open");
+		}
+		throw new IllegalStateException(
+				"Row " + columnsRow + " holds no header: the file ends before it, or it is a comment");
 	}
 
 	@Override

--- a/data/src/main/java/io/github/adamw7/tools/data/source/interfaces/ColumnarDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/interfaces/ColumnarDataSource.java
@@ -14,7 +14,13 @@ package io.github.adamw7.tools.data.source.interfaces;
 public interface ColumnarDataSource extends IterableDataSource {
 
 	/**
-	 * The names of the columns exposed by this source, never {@code null}.
+	 * The names of the columns exposed by this source, never {@code null}: a source
+	 * that cannot name them says why instead of answering with nothing, so a caller
+	 * reading the schema never has to tell a real column set from an absent one.
+	 *
+	 * @throws IllegalStateException when this source cannot name its columns &mdash;
+	 *         it has not been opened, or it was configured in a way that leaves it
+	 *         without a header row to read them from
 	 */
 	String[] getColumnNames();
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/CSVDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/CSVDataSourceTest.java
@@ -248,6 +248,40 @@ public class CSVDataSourceTest {
 	}
 
 	@Test
+	public void columnNamesWithoutAHeaderRowFailFast() {
+		CSVDataSource source = new CSVDataSource(streamOf("1,Adam\n"));
+		source.open();
+		// columnsRow defaults to -1, so there is no header to name the columns with.
+		// The source must say that instead of answering null, which reached callers
+		// as an unrelated "Wrong input: null" further downstream.
+		IllegalStateException thrown = assertThrows(IllegalStateException.class, source::getColumnNames);
+		Utils.close(source);
+		assertEquals("Source was created without a header row, so it has no column names; "
+				+ "pass the 1-based row the header sits on as columnsRow", thrown.getMessage());
+	}
+
+	@Test
+	public void columnNamesBeforeOpenFailFast() {
+		CSVDataSource source = new CSVDataSource(streamOf("id,name\n1,Adam\n"), ",", COLUMNS_ROW);
+		// The header is only read by open(), so before it the source has nothing to
+		// report and must not pass a null array off as the schema.
+		IllegalStateException thrown = assertThrows(IllegalStateException.class, source::getColumnNames);
+		Utils.close(source);
+		assertEquals("DataSource is not open", thrown.getMessage());
+	}
+
+	@Test
+	public void columnNamesFromAnUnreadableHeaderRowFailFast() {
+		CSVDataSource source = new CSVDataSource(streamOf("# only a comment\n"), ",", COLUMNS_ROW);
+		source.open();
+		// The configured row exists but is a comment, so nextRow() skipped it and left
+		// the columns unloaded; the message names the row rather than the open state.
+		IllegalStateException thrown = assertThrows(IllegalStateException.class, source::getColumnNames);
+		Utils.close(source);
+		assertEquals("Row 1 holds no header: the file ends before it, or it is a comment", thrown.getMessage());
+	}
+
+	@Test
 	public void inMemoryReadAll() {
 		String fileName = Utils.getHouseholdFile();
 		InMemoryCSVDataSource inMemoryDataSource = Utils.createInMemoryDataSource(fileName, 1);

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/UniquenessCheckTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/UniquenessCheckTest.java
@@ -210,4 +210,18 @@ public class UniquenessCheckTest extends DBTest {
 		
 	}
 
+	@Test
+	public void allColumnsOnAHeaderlessSourceNamesTheCause() {
+		NoMemoryUniquenessCheck uniqueness = new NoMemoryUniquenessCheck(
+				Utils.createDataSource(Utils.getHouseholdFile()));
+
+		// The source was built without a columnsRow, so it has no columns to check.
+		// The failure used to reach the caller as "Wrong input: null", which named
+		// neither the source nor the header it was created without.
+		IllegalStateException thrown = assertThrows(IllegalStateException.class, uniqueness::execForAllColumns);
+
+		assertEquals("Source was created without a header row, so it has no column names; "
+				+ "pass the 1-based row the header sits on as columnsRow", thrown.getMessage());
+	}
+
 }


### PR DESCRIPTION
ColumnarDataSource documented getColumnNames() as never null, but
CSVDataSource returned the columns field, which stays null whenever
columnsRow is -1 — the default for new CSVDataSource(fileName) and
new InMemoryCSVDataSource(fileName). The disagreement was load-bearing:
execForAllColumns() on such a source failed with "Wrong input: null",
naming neither the source nor the header it was created without.

Keep the contract and make the source honour it, the way
IterableSQLDataSource already does for a source read before open():
getColumnNames() now throws IllegalStateException naming the actual
cause — no header row configured, the source not open, or a configured
header row the file ends before or comments out. The header still
outlives close(), so a source read to exhaustion can name its columns
afterwards; only reset() drops them, and it reloads them as it reopens.

Documents the same on the interface and in the data-sources skill.

Refs #639