### PR TITLE
ci: state permissions, add concurrency and pin actions by SHA

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:recommended",
     ":semanticCommits",
-    ":dependencyDashboard"
+    ":dependencyDashboard",
+    "helpers:pinGitHubActionDigests"
   ],
   "timezone": "UTC",
   "schedule": [
@@ -17,6 +18,21 @@
   },
   "osvVulnerabilityAlerts": false,
   "packageRules": [
+    {
+      "description": "The workflows pin every action to a commit SHA, so a floating tag cannot change what CI runs; keep those digests fresh in one PR.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github actions",
+      "pinDigests": true
+    },
+    {
+      "description": "assembly/Dockerfile pins its base images by digest for the same reason, and a Temurin rebuild is what carries the base OS's security fixes in.",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "pinDigests": true
+    },
     {
       "description": "This project's own modules resolve inside the reactor at ${revision}; there is no released version for Renovate to raise.",
       "matchPackageNames": [

--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -29,6 +29,12 @@ on:
         required: false
         default: ""
 
+# A publish is never cancelled half-way: an interrupted deploy can leave a
+# partial bundle staged in the Central Portal.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   central:
     runs-on: ubuntu-latest
@@ -56,7 +62,7 @@ jobs:
           fi
           echo "All required Maven Central secrets are present."
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Derive the reproducible-build timestamp
         # The pom declares no project.build.outputTimestamp on purpose, so that no
@@ -74,7 +80,7 @@ jobs:
           echo "BUILD_OUTPUT_TIMESTAMP=${timestamp}" >> "$GITHUB_ENV"
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: '25'
           distribution: 'temurin'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,12 @@ on:
     # Run only on Saturday (day-of-week 6)
     - cron: '23 21 * * 6'
 
+# One run of this weekly job at a time. Unlike a pull-request build it is never
+# superseded by a newer commit, so an in-flight run is left to finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   analyze:
     name: Analyze
@@ -36,17 +42,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       
     - name: Setup java
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: 25
         distribution: 'temurin'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@988661ebb5e81487b3fb31b2185d2856c0a10679 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +66,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@988661ebb5e81487b3fb31b2185d2856c0a10679 # v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -74,6 +80,6 @@ jobs:
     
     
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@988661ebb5e81487b3fb31b2185d2856c0a10679 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,15 +4,26 @@ on:
   schedule:
     - cron: '0 0 * * 6'
 
+# Least privilege: this build only reads the repository. Nothing here writes to
+# it, comments on a pull request, or publishes anything.
+permissions:
+  contents: read
+
+# One run of this weekly job at a time. Unlike a pull-request build it is never
+# superseded by a newer commit, so an in-flight run is left to finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   coverage:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - name: Set up JDK 25
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '25'
         distribution: 'temurin'
@@ -20,7 +31,7 @@ jobs:
     - name: Run tests with JaCoCo
       run: mvn -B -ntp verify -Pcoverage --file pom.xml
     - name: Upload coverage reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: jacoco-reports
         path: '**/target/site/jacoco/'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -78,17 +78,17 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # A single-arch build first, loaded into the local daemon, so the image is
       # actually executed before anything is published. Buildx cannot --load a
       # multi-platform image, hence the two builds; the GHA layer cache makes the
       # later multi-arch build reuse this work for linux/amd64.
       - name: Build the image (linux/amd64)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: assembly/Dockerfile
@@ -122,7 +122,7 @@ jobs:
       # caught before the push rather than after — and, on the weekly run, while
       # there is still time to fix it rather than at the release.
       - name: Scan the image for vulnerabilities
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: tools:ci
           format: table
@@ -132,7 +132,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'release'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -143,7 +143,7 @@ jobs:
       # architectures the trimmed DuckDB driver still carries natives for.
       - name: Push the image to GHCR
         if: github.event_name == 'release'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: assembly/Dockerfile

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,15 +4,26 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+# Least privilege: this build only reads the repository. Nothing here writes to
+# it, comments on a pull request, or publishes anything.
+permissions:
+  contents: read
+
+# One run of this nightly job at a time. Unlike a pull-request build it is never
+# superseded by a newer commit, so an in-flight run is left to finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   integration-tests:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - name: Set up JDK 25
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '25'
         distribution: 'temurin'

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -11,6 +11,12 @@ on:
   release:
     types: [created]
 
+# A publish is never cancelled half-way: an interrupted deploy can leave the
+# remote repository holding part of a release.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   github-packages:
     runs-on: ubuntu-latest
@@ -19,7 +25,7 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
     - name: Derive the reproducible-build timestamp
       # The pom declares no project.build.outputTimestamp on purpose, so that no
@@ -37,7 +43,7 @@ jobs:
         echo "BUILD_OUTPUT_TIMESTAMP=${timestamp}" >> "$GITHUB_ENV"
 
     - name: Set up JDK 25
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '25'
         distribution: 'temurin'

--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -9,15 +9,26 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+# Least privilege: this build only reads the repository. Nothing here writes to
+# it, comments on a pull request, or publishes anything.
+permissions:
+  contents: read
+
+# One run of this weekly job at a time. Unlike a pull-request build it is never
+# superseded by a newer commit, so an in-flight run is left to finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
 
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - name: Set up JDK 25
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '25'
         distribution: 'temurin'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,15 +17,27 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# Least privilege: this build only reads the repository. Nothing here writes to
+# it, comments on a pull request, or publishes anything.
+permissions:
+  contents: read
+
+# A second push to a pull request supersedes the first. This build caps itself at
+# 120 seconds to keep the feedback loop tight; letting a superseded run finish
+# anyway spends a runner on an answer nobody is waiting for.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - name: Set up JDK 25
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '25'
         distribution: 'temurin'

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -6,15 +6,26 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+# Least privilege: this build only reads the repository. Nothing here writes to
+# it, comments on a pull request, or publishes anything.
+permissions:
+  contents: read
+
+# One run of this weekly job at a time. Unlike a pull-request build it is never
+# superseded by a newer commit, so an in-flight run is left to finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   pitest:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - name: Set up JDK 25
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: '25'
         distribution: 'temurin'
@@ -29,7 +40,7 @@ jobs:
       # bound to the `test` phase, so it still runs on every module.
       run: mvn -B -ntp install -Ppitest --file pom.xml
     - name: Upload mutation testing reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: pitest-reports
         path: '**/target/pit-reports/'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -781,7 +781,26 @@ not proof the whole matrix passes.
 | `maven-publish.yml` | on release | Deploys to **GitHub Packages** (`-P github-packages`). |
 | `central-publish.yml` | on release; manual | Deploys to **Maven Central** (`-P release`), or a staged-only dry run on manual dispatch. |
 
-Every workflow builds on JDK 25 (Temurin) and passes `-ntp`.
+Every workflow builds on JDK 25 (Temurin) and passes `-ntp`. Three things hold
+across all nine, and a new workflow is expected to keep them:
+
+- **A stated `permissions:` scope.** No workflow inherits the repository's
+  default `GITHUB_TOKEN` scope. Seven need nothing but `contents: read`;
+  `docker.yml` and `maven-publish.yml` add `packages: write` for the registry
+  push, and `codeql.yml` adds `actions: read` and `security-events: write` to
+  upload its results.
+- **A `concurrency:` group.** `maven.yml` alone sets `cancel-in-progress: true`:
+  a second push to a pull request supersedes the first, and a build that caps
+  itself at 120 s has no business finishing an answer nobody is waiting for.
+  Everywhere else it is `false` — a scheduled run is not superseded by a newer
+  commit, and a publish interrupted half-way can leave a partial release behind.
+- **Actions pinned to a commit SHA**, with the tag kept in a trailing comment
+  (`uses: actions/checkout@d23441a… # v6`). A tag is mutable, so an unpinned
+  action is a third party's ability to change what CI runs without a commit
+  here — and CI is what produces the released artifacts the supply-chain posture
+  of [ADR 0002](docs/adr/0002-security-policy-and-supply-chain-posture.md) rests
+  on. `assembly/Dockerfile` pins its `eclipse-temurin` base images by digest for
+  the same reason. Renovate refreshes both.
 
 ### Dependency updates
 
@@ -804,6 +823,9 @@ configuration is `.github/renovate.json`:
   once already.
 - This project's own `io.github.adamw7:**` modules are **disabled**: they resolve
   inside the reactor at `${revision}`.
+- `pinDigests` is on for the **github-actions** and **dockerfile** managers, so
+  the SHA pins above are refreshed rather than left to rot; the action bumps
+  arrive as one grouped PR.
 - A **major** bump of the Maven API artifacts or of Spring Boot needs dependency
   dashboard approval — a Maven 4 API is wired in on purpose while the build is
   pinned to 3.9.x, and the framework the MCP servers boot on deserves a review.

--- a/assembly/Dockerfile
+++ b/assembly/Dockerfile
@@ -16,7 +16,12 @@
 # Pinned to BUILDPLATFORM: repacking a jar produces the same bytes on any
 # architecture, so there is no reason to run this stage under QEMU emulation
 # during the multi-arch build.
-FROM --platform=$BUILDPLATFORM eclipse-temurin:25-jdk AS trim
+#
+# Base images are pinned by digest, with the tag kept alongside so it stays
+# readable: a tag is mutable, and ADR 0002 commits this project to a build
+# anyone can reproduce byte for byte from a commit. Renovate refreshes both the
+# digest and the tag.
+FROM --platform=$BUILDPLATFORM eclipse-temurin:25-jdk@sha256:32861ec22e54af9597a3875c69001f57c0954648f5e3fcb6be601b4e35290ab5 AS trim
 WORKDIR /work
 COPY assembly/target/tools.assembly-*-dist/ ./dist/
 RUN set -eux; \
@@ -29,7 +34,7 @@ RUN set -eux; \
     jar cfm "${driver}" MANIFEST.MF -C unpacked .
 
 # Use the slimmer JRE variant since we only need to run the app, not compile.
-FROM eclipse-temurin:25-jre
+FROM eclipse-temurin:25-jre@sha256:7c1c6297dc3a3ff947922f3ab14ecd326e29083b9edaa8dbff3b94fef1688311
 
 # Build metadata, supplied by docker.yml; the defaults keep a local
 # `docker build` working without --build-arg.


### PR DESCRIPTION
The nine workflows were relying on three defaults that a hardened
supply chain should not leave to chance.

Five of them (maven, coverage, integration-tests, maven-windows,
pitest) declared no `permissions:` block at all, inheriting whatever
the repository's default GITHUB_TOKEN scope happens to be. None needs
more than `contents: read`, so that is what they now ask for; the
publishing and CodeQL workflows already stated their own narrower
scopes and keep them.

None declared `concurrency:`, so pushing twice to a pull request ran
both builds to completion. Only `maven.yml` cancels a superseded run:
it caps itself at 120 seconds precisely to keep the feedback loop
tight, and an outdated answer is not worth a runner. Everywhere else
the group serialises runs with `cancel-in-progress: false` — a
scheduled run is not superseded by a newer commit, and a publish
interrupted half-way can leave a partial release behind.

Every action was referenced by a floating tag, which is a third
party's ability to change what CI runs without a commit here. Each is
now pinned to the commit SHA the tag resolves to today, with the tag
kept in a trailing comment, and `assembly/Dockerfile` pins its two
eclipse-temurin base images by digest for the same reason. Renovate
keeps both current: `helpers:pinGitHubActionDigests` plus `pinDigests`
for the github-actions and dockerfile managers, with the action bumps
grouped into one pull request.

Closes #634

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PXSCCFk1LMyg4j7yARL54B