### PR TITLE
refactor(data): confine file access per source, not per JVM

### DIFF
--- a/.claude/skills/data-sources/SKILL.md
+++ b/.claude/skills/data-sources/SKILL.md
@@ -50,6 +50,25 @@ Every format ships in two variants:
 - JSON/YAML flatten nested objects to dotted keys, e.g.
   `people[0].address.city`.
 
+### Confining a source to a directory
+Every path a source is given is canonicalised and refused if it climbs out with
+`..`. To also **hold one source inside one directory** — always do this when the
+path comes from outside the process, as an MCP tool's does — pass it an
+`AllowedPaths`:
+
+```java
+AllowedPaths uploads = AllowedPaths.under(Path.of("/data/uploads"));   // throws if absent
+new InMemoryCSVDataSource(fileName, 1, uploads);                       // SecurityException outside it
+new InMemoryCSVDataSource(fileName, 1, AllowedPaths.anywhere());       // unrestricted
+```
+
+The boundary belongs to the source it was handed to, so two sources can hold two
+different roots, and symlinks are followed before the check so one inside the
+root cannot point out of it. Every file source has a constructor taking one; the
+constructors without it fall back to the process-wide base directory of
+`PathValidator`, deprecated for removal because it is one boundary for the whole
+JVM that any caller can move or clear.
+
 ## Uniqueness check
 ```java
 AbstractUniqueness check = new InMemoryUniquenessCheck();   // or NoMemoryUniquenessCheck

--- a/.claude/skills/mcp-server/SKILL.md
+++ b/.claude/skills/mcp-server/SKILL.md
@@ -76,8 +76,11 @@ A `Main.java` Spring Boot entry point sits next to the configuration
 ## Rules that bite
 - **Confine file access.** A server that reads paths from a client must clamp
   them to a configured base directory before returning any tool — the uniqueness
-  server does this in `tools()` via `PathValidator.setAllowedBaseDir`, defaulting
-  to the working directory, so a client cannot steer it at `/etc/passwd`.
+  server builds an `AllowedPaths.under(baseDir)` in `tools()` and hands it to the
+  tool, defaulting to the working directory, so a client cannot steer it at
+  `/etc/passwd`. Give the boundary to the thing being confined, never to the JVM:
+  a process-wide setter confines every other source in the host too, and the
+  second server to start silently moves the first one's boundary.
 - **The core must not depend on its MCP adapter.** ArchUnit pins this in every
   module: the uniqueness/context/adoption logic knows nothing about `mcp`, and
   only the `mcp` package may see Spring or the scaffolding. Put the adapter in

--- a/.claude/skills/testing-conventions/SKILL.md
+++ b/.claude/skills/testing-conventions/SKILL.md
@@ -30,9 +30,11 @@ fails the build, not just review.
 - A `@TempDir` is unique per class, so an ordinary test needs nothing extra.
 - **Writing process-global state needs a guard**, or the test corrupts whatever
   runs beside it:
-  - a system property, or `PathValidator.setAllowedBaseDir` → annotate the class
-    `@Isolated` (`org.junit.jupiter.api.parallel.Isolated`); it then runs alone.
-    ArchUnit fails the build if you forget.
+  - a system property, or the deprecated `PathValidator.setAllowedBaseDir` →
+    annotate the class `@Isolated` (`org.junit.jupiter.api.parallel.Isolated`); it
+    then runs alone. ArchUnit fails the build if you forget. Confining a source
+    with an `AllowedPaths` of its own writes nothing shared, and needs no
+    annotation.
   - a fixture genuinely shared between classes (the embedded Derby database) →
     `@ResourceLock("<name>")`, which serialises just those classes. Put it on the
     shared base class; subclasses inherit it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,7 +265,8 @@ unwrapped.
   standing choices (the foundational record, the security and supply-chain
   posture, TLS 1.3 and hybrid post-quantum key exchange, CodeQL, the two
   dependency-update bots, DuckDB as the Parquet engine, log4j2, MCP on Spring
-  Boot, documentation as an enforced contract). A record is immutable once
+  Boot, documentation as an enforced contract, path confinement scoped per data
+  source). A record is immutable once
   accepted: revisiting a decision means a new ADR that supersedes it, never an
   edit to the old one. [docs/adr/README.md](docs/adr/README.md) has the
   numbering, template and status vocabulary.
@@ -486,7 +487,7 @@ cannot own it alone:
 | State | Guard | Where |
 | --- | --- | --- |
 | a system property the whole JVM reads | `@Isolated` | `TransportConfigurerTest`, `TlsConfigurationTest`, `MainTest`, `ClaudeCodeEnforcerRuleConfigurationTest` |
-| `PathValidator`'s allowed base directory | `@Isolated` | `PathValidatorTest`, `McpConfigurationTest` |
+| `PathValidator`'s deprecated process-wide base directory | `@Isolated` | `PathValidatorTest` |
 | the one embedded Derby database | `@ResourceLock("derby-testDB")` on `DBTest` | inherited by `UniquenessCheckTest`, `SQLDataSourceTest` |
 
 The Derby lock is what the suite most depends on: its subclasses share a static
@@ -539,9 +540,10 @@ Per-module rules:
   depend on its MCP adapter; the `structure` collections stay decoupled from data
   sources; JDBC (`java.sql`) stays confined to `source.db`. Its
   `TestConventionsArchitectureTest` adds the module's counterpart to the shared
-  system-property rule: a `*Test` that sets or clears `PathValidator`'s allowed
-  base directory is `@Isolated`, that field being the other JVM-wide state a test
-  here can write.
+  system-property rule: a `*Test` that sets or clears `PathValidator`'s deprecated
+  process-wide base directory is `@Isolated`, that field being the other JVM-wide
+  state a test here can write. It retires with those two methods — a test confining
+  a source through its own `AllowedPaths` writes nothing the JVM shares.
 - **`adopt`** (`AdoptArchitectureTest`) — the `command` package is the only place
   a process is spawned, and a step knows only the `CommandRunner` contract, never
   `ProcessCommandRunner`; a step never reaches back to `GitHubRepoAdopter`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,9 +172,11 @@ Skill: `testing-conventions`.
 - **Unit tests run a class at a time in parallel**, `unit.test.parallelism`
   (default **3**) classes at once per module, with the methods of one class still
   on a single thread. Set `-Dunit.test.parallelism=1` to turn it off for a run.
-  A test that writes something the whole JVM reads — a system property, or
-  `PathValidator`'s allowed base directory — carries `@Isolated` so it runs
-  alone; test classes sharing the embedded Derby database carry `@ResourceLock`.
+  A test that writes something the whole JVM reads — a system property, or the
+  deprecated process-wide base directory of `PathValidator` — carries `@Isolated`
+  so it runs alone; test classes sharing the embedded Derby database carry
+  `@ResourceLock`. A source confined through an `AllowedPaths` of its own needs
+  neither.
   Each module's `TestConventionsArchitectureTest` fails the build on a new test
   that writes such state without isolating, so it cannot break the suite beside
   it instead.

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractFileSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractFileSource.java
@@ -31,8 +31,21 @@ public abstract class AbstractFileSource implements IterableDataSource {
 		opened = false;
 	}
 	
+	/**
+	 * Reads {@code fileName} under the process-wide base directory, if one was set through
+	 * the deprecated {@code PathValidator} entry points, and unrestricted otherwise. Prefer
+	 * {@link #AbstractFileSource(String, AllowedPaths)}, which confines this source alone.
+	 */
 	protected AbstractFileSource(String fileName) {
-		this.fileName = PathValidator.validate(fileName);
+		this(fileName, PathValidator.shared());
+	}
+
+	/**
+	 * Reads {@code fileName} after checking it against {@code allowedPaths}, the boundary
+	 * this source is confined to.
+	 */
+	protected AbstractFileSource(String fileName, AllowedPaths allowedPaths) {
+		this.fileName = allowedPaths.validate(fileName);
 		try {
 			scanner = createScanner();
 		} catch (FileNotFoundException e) {

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryJacksonDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryJacksonDataSource.java
@@ -28,6 +28,10 @@ public abstract class AbstractInMemoryJacksonDataSource extends AbstractInMemory
 		super(filePath);
 	}
 
+	protected AbstractInMemoryJacksonDataSource(String filePath, AllowedPaths allowedPaths) {
+		super(filePath, allowedPaths);
+	}
+
 	/**
 	 * The mapper for this source's syntax. It is asked for while the base constructor
 	 * parses, so it must answer from a constant rather than from instance state the

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryMapDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryMapDataSource.java
@@ -32,6 +32,11 @@ public abstract class AbstractInMemoryMapDataSource extends AbstractFileSource i
 		parse();
 	}
 
+	protected AbstractInMemoryMapDataSource(String filePath, AllowedPaths allowedPaths) {
+		super(filePath, allowedPaths);
+		parse();
+	}
+
 	/** Parses the open {@link #scanner} into {@link #fieldsMap}. */
 	protected abstract void parse();
 

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractIterableFileSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractIterableFileSource.java
@@ -21,8 +21,22 @@ public abstract class AbstractIterableFileSource implements IterableDataSource {
 	protected boolean opened = false;
 	private String[] lookahead;
 
+	/**
+	 * Reads {@code fileName} under the process-wide base directory, if one was set through
+	 * the deprecated {@code PathValidator} entry points, and unrestricted otherwise. Prefer
+	 * {@link #AbstractIterableFileSource(String, AllowedPaths)}, which confines this source
+	 * alone.
+	 */
 	protected AbstractIterableFileSource(String fileName) {
-		this.fileName = PathValidator.validate(fileName);
+		this(fileName, PathValidator.shared());
+	}
+
+	/**
+	 * Reads {@code fileName} after checking it against {@code allowedPaths}, the boundary
+	 * this source is confined to.
+	 */
+	protected AbstractIterableFileSource(String fileName, AllowedPaths allowedPaths) {
+		this.fileName = allowedPaths.validate(fileName);
 		this.providedStream = null;
 	}
 

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractIterableJacksonDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractIterableJacksonDataSource.java
@@ -28,6 +28,10 @@ public abstract class AbstractIterableJacksonDataSource extends AbstractIterable
 		super(fileName);
 	}
 
+	protected AbstractIterableJacksonDataSource(String fileName, AllowedPaths allowedPaths) {
+		super(fileName, allowedPaths);
+	}
+
 	protected AbstractIterableJacksonDataSource(InputStream inputStream) {
 		super(inputStream);
 	}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AllowedPaths.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AllowedPaths.java
@@ -1,0 +1,147 @@
+package io.github.adamw7.tools.data.source.file;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * The directory a file source may read from, and the check that holds it there
+ * (path traversal, CWE-22).
+ *
+ * <p>An instance is immutable and is handed to the source it confines, so a host
+ * embedding this library can point two sources at two different roots, and no
+ * unrelated code can widen or narrow a boundary somebody else set. Paths are
+ * canonicalized either way, so a malformed path is rejected even by an
+ * {@link #anywhere() unconfined} instance.</p>
+ *
+ * <h3>Usage:</h3>
+ * <pre>{@code
+ * // Restrict this source to one directory
+ * AllowedPaths uploads = AllowedPaths.under(Path.of("/data/uploads"));
+ *
+ * // Throws SecurityException if the resolved path escapes /data/uploads
+ * InMemoryDataSource source = new InMemoryCSVDataSource("report.csv", 1, uploads);
+ *
+ * // Or leave a source unrestricted
+ * new InMemoryCSVDataSource("report.csv", 1, AllowedPaths.anywhere());
+ * }</pre>
+ */
+public final class AllowedPaths {
+
+	private static final Logger log = LogManager.getLogger(AllowedPaths.class.getName());
+
+	private static final AllowedPaths ANYWHERE = new AllowedPaths(null);
+
+	/** The root every validated path must sit under, or {@code null} when unconfined. */
+	private final Path baseDir;
+
+	private AllowedPaths(Path baseDir) {
+		this.baseDir = baseDir;
+	}
+
+	/**
+	 * Paths are canonicalized and checked for traversal sequences, but not restricted
+	 * to any directory. This is what a source built without a boundary uses.
+	 *
+	 * @return the shared unconfined instance
+	 */
+	public static AllowedPaths anywhere() {
+		return ANYWHERE;
+	}
+
+	/**
+	 * Confines validated paths to {@code baseDir} and its subdirectories.
+	 *
+	 * @param baseDir the allowed base directory (must exist)
+	 * @return a validator confined to that directory
+	 * @throws IllegalArgumentException if baseDir is null
+	 * @throws IOException if the base directory path cannot be resolved
+	 */
+	public static AllowedPaths under(Path baseDir) throws IOException {
+		if (baseDir == null) {
+			throw new IllegalArgumentException("Base directory must not be null");
+		}
+		Path resolvedBase = baseDir.toRealPath();
+		log.info("Confining file access to base directory: {}", resolvedBase);
+		return new AllowedPaths(resolvedBase);
+	}
+
+	/**
+	 * Validates and canonicalizes a file path.
+	 *
+	 * @param filePath the raw file path to validate
+	 * @return the canonicalized absolute path string
+	 * @throws SecurityException if the path contains traversal sequences or escapes the allowed base directory
+	 * @throws IllegalArgumentException if the path is null, empty, or syntactically invalid
+	 */
+	public String validate(String filePath) {
+		if (filePath == null || filePath.trim().isEmpty()) {
+			throw new IllegalArgumentException("File path must not be null or empty");
+		}
+
+		if (containsTraversalSequences(filePath)) {
+			throw new SecurityException("Path traversal detected in file path: " + filePath);
+		}
+
+		try {
+			Path resolved = Path.of(filePath).toAbsolutePath().normalize();
+			if (baseDir != null) {
+				checkInsideBaseDir(resolved);
+			}
+
+			log.debug("Path validated: {} -> {}", filePath, resolved);
+			return resolved.toString();
+		} catch (InvalidPathException e) {
+			throw new IllegalArgumentException("Invalid file path: " + filePath, e);
+		}
+	}
+
+	private void checkInsideBaseDir(Path resolved) {
+		Path realResolved = toRealPathAllowingMissing(resolved);
+		if (!realResolved.startsWith(baseDir)) {
+			throw new SecurityException(
+					"Access denied: path '" + realResolved + "' is outside the allowed base directory '" + baseDir + "'");
+		}
+	}
+
+	/**
+	 * Resolves {@code path} to its real, symlink-followed location so the containment
+	 * check cannot be bypassed by a symlink that lives inside the base directory but
+	 * points outside it. A purely textual {@code normalize()} would collapse {@code ..}
+	 * without ever following the link, letting {@code <base>/link/secret} slip past when
+	 * {@code link} targets {@code /etc}. The nearest existing ancestor is canonicalised
+	 * with {@link Path#toRealPath()} and the not-yet-created remainder re-appended, so the
+	 * check works whether or not the leaf file exists yet.
+	 */
+	private static Path toRealPathAllowingMissing(Path path) {
+		Path existing = path;
+		while (existing != null && !Files.exists(existing)) {
+			existing = existing.getParent();
+		}
+		if (existing == null) {
+			return path;
+		}
+		try {
+			Path realExisting = existing.toRealPath();
+			return realExisting.resolve(existing.relativize(path)).normalize();
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not resolve real path for: " + path, e);
+		}
+	}
+
+	/**
+	 * Looks for a {@code ..} that is a path element of its own, rather than for the
+	 * substring: a file legitimately named {@code ..name} contains {@code /..} without
+	 * ever climbing out of its directory, and used to be refused for it.
+	 */
+	private static boolean containsTraversalSequences(String path) {
+		String normalized = path.replace('\\', '/');
+		return Arrays.stream(normalized.split("/", -1)).anyMatch(".."::equals);
+	}
+}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
@@ -53,6 +53,26 @@ public class CSVDataSource extends AbstractFileSource implements ColumnarDataSou
 		regex = Pattern.quote(delimiter) + REGEX_SUFFIX;
 	}
 
+	public CSVDataSource(String fileName, AllowedPaths allowedPaths) throws FileNotFoundException {
+		this(fileName, DEFAULT_DELIMITER, -1, allowedPaths);
+	}
+
+	public CSVDataSource(String fileName, int columnsRow, AllowedPaths allowedPaths) throws FileNotFoundException {
+		this(fileName, DEFAULT_DELIMITER, columnsRow, allowedPaths);
+	}
+
+	/**
+	 * Reads {@code fileName} confined to {@code allowedPaths}, rather than to whatever
+	 * base directory the process happens to have set.
+	 */
+	public CSVDataSource(String fileName, String delimiter, int columnsRow, AllowedPaths allowedPaths)
+			throws FileNotFoundException {
+		super(fileName, allowedPaths);
+		this.delimiter = delimiter;
+		this.columnsRow = columnsRow;
+		regex = Pattern.quote(delimiter) + REGEX_SUFFIX;
+	}
+
 	/**
 	 * The header row read by {@link #open()}. A source built without one &mdash;
 	 * {@code new CSVDataSource(fileName)} and the other constructors defaulting

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryCSVDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryCSVDataSource.java
@@ -19,6 +19,20 @@ public class InMemoryCSVDataSource extends CSVDataSource implements InMemoryData
 		super(fileName, DEFAULT_DELIMITER, -1);
 	}
 
+	public InMemoryCSVDataSource(String fileName, AllowedPaths allowedPaths) throws FileNotFoundException {
+		super(fileName, DEFAULT_DELIMITER, -1, allowedPaths);
+	}
+
+	public InMemoryCSVDataSource(String fileName, int columnsRow, AllowedPaths allowedPaths)
+			throws FileNotFoundException {
+		super(fileName, DEFAULT_DELIMITER, columnsRow, allowedPaths);
+	}
+
+	public InMemoryCSVDataSource(String fileName, String delimiter, int columnsRow, AllowedPaths allowedPaths)
+			throws FileNotFoundException {
+		super(fileName, delimiter, columnsRow, allowedPaths);
+	}
+
 	@Override
 	public List<String[]> readAll() {
 		return super.readAll();

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryJSONDataSource.java
@@ -23,6 +23,10 @@ public class InMemoryJSONDataSource extends AbstractInMemoryJacksonDataSource {
 		super(filePath);
 	}
 
+	public InMemoryJSONDataSource(String filePath, AllowedPaths allowedPaths) {
+		super(filePath, allowedPaths);
+	}
+
 	@Override
 	protected ObjectMapper mapper() {
 		return MAPPER;

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryTOONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryTOONDataSource.java
@@ -26,6 +26,10 @@ public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 		super(filePath);
 	}
 
+	public InMemoryTOONDataSource(String filePath, AllowedPaths allowedPaths) {
+		super(filePath, allowedPaths);
+	}
+
 	@Override
 	protected void parse() {
 		ToonFlattener flattener = new ToonFlattener(fieldsMap::put);

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryYAMLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryYAMLDataSource.java
@@ -24,6 +24,10 @@ public class InMemoryYAMLDataSource extends AbstractInMemoryJacksonDataSource {
 		super(filePath);
 	}
 
+	public InMemoryYAMLDataSource(String filePath, AllowedPaths allowedPaths) {
+		super(filePath, allowedPaths);
+	}
+
 	@Override
 	protected ObjectMapper mapper() {
 		return MAPPER;

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/IterableJSONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/IterableJSONDataSource.java
@@ -15,6 +15,10 @@ public class IterableJSONDataSource extends AbstractIterableJacksonDataSource {
 		super(fileName);
 	}
 
+	public IterableJSONDataSource(String fileName, AllowedPaths allowedPaths) {
+		super(fileName, allowedPaths);
+	}
+
 	public IterableJSONDataSource(InputStream inputStream) {
 		super(inputStream);
 	}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/IterableTOONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/IterableTOONDataSource.java
@@ -25,6 +25,10 @@ public class IterableTOONDataSource extends AbstractIterableFileSource {
 		super(fileName);
 	}
 
+	public IterableTOONDataSource(String fileName, AllowedPaths allowedPaths) {
+		super(fileName, allowedPaths);
+	}
+
 	public IterableTOONDataSource(InputStream inputStream) {
 		super(inputStream);
 	}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/IterableYAMLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/IterableYAMLDataSource.java
@@ -20,6 +20,10 @@ public class IterableYAMLDataSource extends AbstractIterableJacksonDataSource {
 		super(fileName);
 	}
 
+	public IterableYAMLDataSource(String fileName, AllowedPaths allowedPaths) {
+		super(fileName, allowedPaths);
+	}
+
 	public IterableYAMLDataSource(InputStream inputStream) {
 		super(inputStream);
 	}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/PathValidator.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/PathValidator.java
@@ -1,131 +1,78 @@
 package io.github.adamw7.tools.data.source.file;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 /**
- * Utility class for validating file paths to prevent path traversal attacks (CWE-22).
- * 
- * <p>Canonicalizes paths to resolve {@code ..}, {@code .}, and symlinks, then optionally
- * verifies the resolved path resides within an allowed base directory.</p>
- * 
- * <p>When no base directory is configured (the default), paths are still canonicalized
- * to reject obviously malformed inputs, but access is not restricted to any directory.</p>
- * 
- * <h3>Usage:</h3>
+ * Process-wide path validation, superseded by {@link AllowedPaths}.
+ *
+ * <p>Every entry point here reads or writes one boundary shared by the whole JVM: two
+ * sources cannot be confined to two directories, and any code can lift the restriction
+ * for everything else in the process by calling {@link #clearAllowedBaseDir()}. Hand an
+ * {@link AllowedPaths} to the source it confines instead:</p>
+ *
  * <pre>{@code
- * // Opt-in: restrict all file access to a specific directory
- * PathValidator.setAllowedBaseDir(Path.of("/data/uploads"));
- * 
- * // Will throw SecurityException if resolved path escapes /data/uploads
- * String safe = PathValidator.validate("report.csv");
- * 
- * // Reset when done
- * PathValidator.clearAllowedBaseDir();
+ * new InMemoryCSVDataSource(fileName, 1, AllowedPaths.under(Path.of("/data/uploads")));
  * }</pre>
+ *
+ * <p>The methods below remain for one release so callers can migrate, and are the only
+ * thing this class exists for; it goes away with them. The class itself carries no
+ * {@code @Deprecated} annotation, so that the data sources reading {@link #shared()}
+ * internally do not report a deprecation they cannot avoid while these methods stand.</p>
  */
 public final class PathValidator {
 
-	private static final Logger log = LogManager.getLogger(PathValidator.class.getName());
-
-	private static volatile Path allowedBaseDir = null;
+	private static volatile AllowedPaths shared = AllowedPaths.anywhere();
 
 	private PathValidator() {}
 
 	/**
-	 * Validates and canonicalizes a file path.
+	 * The boundary the {@code String}-taking data-source constructors validate against
+	 * when the caller supplies none. Not deprecated, because it is how those constructors
+	 * keep honouring a base directory set through this class; once the methods below are
+	 * gone it becomes {@link AllowedPaths#anywhere()}.
+	 */
+	static AllowedPaths shared() {
+		return shared;
+	}
+
+	/**
+	 * Validates and canonicalizes a file path against the process-wide base directory.
 	 *
 	 * @param filePath the raw file path to validate
 	 * @return the canonicalized absolute path string
 	 * @throws SecurityException if the path contains traversal sequences or escapes the allowed base directory
 	 * @throws IllegalArgumentException if the path is null, empty, or syntactically invalid
+	 * @deprecated call {@link AllowedPaths#validate(String)} on the instance confining the caller
 	 */
+	@Deprecated(since = "2.6.0", forRemoval = true)
 	public static String validate(String filePath) {
-		if (filePath == null || filePath.trim().isEmpty()) {
-			throw new IllegalArgumentException("File path must not be null or empty");
-		}
-
-		if (containsTraversalSequences(filePath)) {
-			throw new SecurityException("Path traversal detected in file path: " + filePath);
-		}
-
-		try {
-			Path resolved = Path.of(filePath).toAbsolutePath().normalize();
-			Path baseDir = allowedBaseDir;
-			if (baseDir != null) {
-				Path realResolved = toRealPathAllowingMissing(resolved);
-				if (!realResolved.startsWith(baseDir)) {
-					throw new SecurityException(
-							"Access denied: path '" + realResolved + "' is outside the allowed base directory '" + baseDir + "'");
-				}
-			}
-
-			log.debug("Path validated: {} -> {}", filePath, resolved);
-			return resolved.toString();
-		} catch (InvalidPathException e) {
-			throw new IllegalArgumentException("Invalid file path: " + filePath, e);
-		}
+		return shared.validate(filePath);
 	}
 
 	/**
-	 * Resolves {@code path} to its real, symlink-followed location so the containment
-	 * check cannot be bypassed by a symlink that lives inside the base directory but
-	 * points outside it. A purely textual {@code normalize()} would collapse {@code ..}
-	 * without ever following the link, letting {@code <base>/link/secret} slip past when
-	 * {@code link} targets {@code /etc}. The nearest existing ancestor is canonicalised
-	 * with {@link Path#toRealPath()} and the not-yet-created remainder re-appended, so the
-	 * check works whether or not the leaf file exists yet.
-	 */
-	private static Path toRealPathAllowingMissing(Path path) {
-		Path existing = path;
-		while (existing != null && !Files.exists(existing)) {
-			existing = existing.getParent();
-		}
-		if (existing == null) {
-			return path;
-		}
-		try {
-			Path realExisting = existing.toRealPath();
-			return realExisting.resolve(existing.relativize(path)).normalize();
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not resolve real path for: " + path, e);
-		}
-	}
-
-	private static boolean containsTraversalSequences(String path) {
-		String normalized = path.replace('\\', '/');
-		return normalized.contains("../") || normalized.contains("/..") || normalized.equals("..");
-	}
-
-	/**
-	 * Sets the allowed base directory. When set, all validated paths must reside
-	 * within this directory (or its subdirectories).
+	 * Sets the allowed base directory for the whole JVM. When set, all validated paths
+	 * must reside within this directory (or its subdirectories).
 	 *
 	 * @param baseDir the allowed base directory (must exist)
 	 * @throws IllegalArgumentException if baseDir is null
 	 * @throws IOException if the base directory path cannot be resolved
+	 * @deprecated build an {@link AllowedPaths#under(Path)} and pass it to the source it confines
 	 */
+	@Deprecated(since = "2.6.0", forRemoval = true)
 	public static void setAllowedBaseDir(Path baseDir) throws IOException {
-		if (baseDir == null) {
-			throw new IllegalArgumentException("Base directory must not be null");
-		}
-		allowedBaseDir = baseDir.toRealPath();
-		log.info("Allowed base directory set to: {}", allowedBaseDir);
+		shared = AllowedPaths.under(baseDir);
 	}
 
 	/**
-	 * Clears the allowed base directory restriction.
-	 * After calling this method, path validation will only canonicalize and
-	 * check for traversal sequences, but not restrict to a specific directory.
+	 * Clears the process-wide base directory restriction. After calling this method,
+	 * path validation will only canonicalize and check for traversal sequences, but not
+	 * restrict to a specific directory.
+	 *
+	 * @deprecated pass {@link AllowedPaths#anywhere()} to the source that should be unrestricted
 	 */
+	@Deprecated(since = "2.6.0", forRemoval = true)
 	public static void clearAllowedBaseDir() {
-		allowedBaseDir = null;
-		log.info("Allowed base directory cleared");
+		shared = AllowedPaths.anywhere();
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/MCP_USAGE.md
@@ -290,10 +290,15 @@ Then register it in `McpConfiguration`:
 ```java
 @Override
 protected List<McpTool> tools() {
-    confineFileAccess();
-    return List.of(new UniquenessTool(), new MyNewTool());
+    AllowedPaths allowedPaths = confinement();
+    return List.of(new UniquenessTool(allowedPaths), new MyNewTool(allowedPaths));
 }
 ```
+
+A tool that opens files takes the `AllowedPaths` and hands it to every data source
+it builds, so the boundary confines this server's tools and nothing else in the
+JVM. `PathValidator.setAllowedBaseDir`, which set one boundary for the whole
+process, is deprecated for removal.
 
 A `RuntimeException` thrown out of `apply` already becomes an error result, so
 there is no need to catch one just to report it over the protocol.

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfiguration.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfiguration.java
@@ -5,13 +5,10 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.List;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
-import io.github.adamw7.tools.data.source.file.PathValidator;
+import io.github.adamw7.tools.data.source.file.AllowedPaths;
 import io.github.adamw7.tools.mcp.AbstractMcpConfiguration;
 import io.github.adamw7.tools.mcp.McpTool;
 
@@ -19,13 +16,13 @@ import io.github.adamw7.tools.mcp.McpTool;
  * Wires the uniqueness MCP server. It exposes a single uniqueness-check tool,
  * confined to the configured {@code data.allowed-base-dir} (defaulting to the
  * server's working directory) so a client cannot steer the tool at arbitrary
- * files such as {@code /etc/passwd}; all transport wiring is inherited from
+ * files such as {@code /etc/passwd}. The boundary is handed to the tool as an
+ * {@link AllowedPaths} rather than set process-wide, so it confines this server's
+ * tools and nothing else; all transport wiring is inherited from
  * {@link AbstractMcpConfiguration}.
  */
 @Configuration
 public class McpConfiguration extends AbstractMcpConfiguration {
-
-	private static final Logger log = LogManager.getLogger(McpConfiguration.class);
 
 	@Value("${data.allowed-base-dir:}")
 	String allowedBaseDir;
@@ -37,18 +34,21 @@ public class McpConfiguration extends AbstractMcpConfiguration {
 
 	@Override
 	protected List<McpTool> tools() {
-		confineFileAccess();
-		return List.of(new UniquenessTool());
+		return List.of(new UniquenessTool(confinement()));
 	}
 
-	private void confineFileAccess() {
+	/**
+	 * The boundary this server's tools read within. It belongs to the tools built here
+	 * and to nothing else in the JVM, so a host running a second server &mdash; or a test
+	 * running beside this one &mdash; keeps its own.
+	 */
+	AllowedPaths confinement() {
 		Path baseDir = resolveBaseDir();
 		try {
-			PathValidator.setAllowedBaseDir(baseDir);
+			return AllowedPaths.under(baseDir);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Could not confine MCP file access to " + baseDir, e);
 		}
-		log.info("Confining MCP file access to base directory: {}", baseDir);
 	}
 
 	private Path resolveBaseDir() {

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessTool.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import io.github.adamw7.tools.data.source.file.AllowedPaths;
 import io.github.adamw7.tools.data.source.file.InMemoryCSVDataSource;
 import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
 import io.github.adamw7.tools.data.uniqueness.InMemoryUniquenessCheck;
@@ -22,6 +23,8 @@ public class UniquenessTool implements McpTool {
 
 	private static final Logger log = LogManager.getLogger(UniquenessTool.class.getName());
 
+	private final AllowedPaths allowedPaths;
+
     private final ToolDefinition toolDefinition = new ToolDefinition("uniqueness_check",
             "Check if a given set of columns is unique in a given data set",
                     Map.of(
@@ -34,8 +37,15 @@ public class UniquenessTool implements McpTool {
                         "required", List.of("file", "columns_row", "columns_name")
                     ));
 
-	public UniquenessTool() {
-    }
+	/**
+	 * Reads only files under {@code allowedPaths}, the boundary the server wiring this
+	 * tool confined it to. A client naming anything outside it &mdash; {@code /etc/passwd},
+	 * or a symlink in the base directory pointing there &mdash; is refused when the source
+	 * is built.
+	 */
+	public UniquenessTool(AllowedPaths allowedPaths) {
+		this.allowedPaths = allowedPaths;
+	}
 
 	public ToolDefinition getToolDefinition() {
 		return toolDefinition;
@@ -53,7 +63,7 @@ public class UniquenessTool implements McpTool {
 		String fileName = ToolArguments.requiredString(arguments, "file");
 		String columnName = ToolArguments.requiredString(arguments, "columns_name");
 		int columnsRow = ToolArguments.requiredInt(arguments, "columns_row");
-		try (InMemoryDataSource source = new InMemoryCSVDataSource(fileName, columnsRow)) {
+		try (InMemoryDataSource source = new InMemoryCSVDataSource(fileName, columnsRow, allowedPaths)) {
 			Uniqueness check = new InMemoryUniquenessCheck(source);
 			Result result = check.exec(columnName);
 			logResult(result, columnName);

--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/TestConventionsArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/TestConventionsArchitectureTest.java
@@ -31,11 +31,15 @@ public class TestConventionsArchitectureTest {
 	static final ArchTests commonTestConventions = ArchTests.in(CommonTestConventions.class);
 
 	/**
-	 * The module's own answer to the shared rule on system properties. The allowed
-	 * base directory is the other piece of JVM-wide state a test here can write, and
-	 * it fails the same way: while one class points it at a {@code @TempDir}, every
-	 * concurrently running test that opens a file source is refused the resource it
+	 * The module's own answer to the shared rule on system properties. The deprecated
+	 * process-wide base directory is the other piece of JVM-wide state a test here can
+	 * write, and it fails the same way: while one class points it at a {@code @TempDir},
+	 * every concurrently running test that opens a file source is refused the resource it
 	 * reads, with a {@link SecurityException} that names a directory it never chose.
+	 *
+	 * <p>A test confining a source through an {@link io.github.adamw7.tools.data.source.file.AllowedPaths}
+	 * of its own needs none of this, which is why only the class covering those two
+	 * methods still carries {@code @Isolated}; the rule retires with them.</p>
 	 */
 	@ArchTest
 	static final ArchRule testsConfiningFileAccessAreIsolated = noClasses()

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/AllowedPathsTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/AllowedPathsTest.java
@@ -1,0 +1,160 @@
+package io.github.adamw7.tools.data.source.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Runs in the class-parallel unit suite without {@code @Isolated}: each test builds the
+ * boundary it needs and nothing else in the JVM can see it, which is the point of the
+ * type.
+ */
+public class AllowedPathsTest {
+
+	private final AllowedPaths anywhere = AllowedPaths.anywhere();
+
+	@Test
+	public void rejectsNullPath() {
+		assertThrows(IllegalArgumentException.class, () -> anywhere.validate(null));
+	}
+
+	@Test
+	public void rejectsEmptyPath() {
+		assertThrows(IllegalArgumentException.class, () -> anywhere.validate(""));
+	}
+
+	@Test
+	public void rejectsBlankPath() {
+		assertThrows(IllegalArgumentException.class, () -> anywhere.validate("   "));
+	}
+
+	@Test
+	public void rejectsLeadingTraversal() {
+		assertThrows(SecurityException.class, () -> anywhere.validate("../etc/passwd"));
+	}
+
+	@Test
+	public void rejectsEmbeddedTraversal() {
+		assertThrows(SecurityException.class, () -> anywhere.validate("/data/uploads/../secret"));
+	}
+
+	@Test
+	public void rejectsTrailingTraversal() {
+		assertThrows(SecurityException.class, () -> anywhere.validate("/data/uploads/.."));
+	}
+
+	@Test
+	public void rejectsBareDotDot() {
+		assertThrows(SecurityException.class, () -> anywhere.validate(".."));
+	}
+
+	@Test
+	public void rejectsBackslashTraversal() {
+		assertThrows(SecurityException.class, () -> anywhere.validate("..\\windows\\system32"));
+	}
+
+	/**
+	 * A file whose name merely starts with two dots climbs out of nothing: the check
+	 * looks for a {@code ..} that is a path element of its own, not for the substring.
+	 */
+	@Test
+	public void acceptsFileNameStartingWithTwoDots(@TempDir Path baseDir) throws IOException {
+		Path dotted = Files.createFile(baseDir.resolve("..name.csv"));
+
+		String validated = AllowedPaths.under(baseDir).validate(dotted.toString());
+
+		assertEquals(dotted.toRealPath().toString(), validated);
+	}
+
+	@Test
+	public void returnsCanonicalisedAbsolutePathWhenUnconfined() {
+		String validated = anywhere.validate("report.csv");
+
+		assertEquals(Path.of("report.csv").toAbsolutePath().normalize().toString(), validated);
+	}
+
+	@Test
+	public void unconfinedAllowsAnyDirectory(@TempDir Path tempDir) {
+		String validated = anywhere.validate(tempDir.resolve("outside.csv").toString());
+
+		assertTrue(validated.endsWith("outside.csv"));
+	}
+
+	@Test
+	public void underRejectsNull() {
+		assertThrows(IllegalArgumentException.class, () -> AllowedPaths.under(null));
+	}
+
+	@Test
+	public void underRejectsMissingDirectory(@TempDir Path tempDir) {
+		assertThrows(IOException.class, () -> AllowedPaths.under(tempDir.resolve("absent")));
+	}
+
+	@Test
+	public void allowsPathInsideBaseDir(@TempDir Path baseDir) throws IOException {
+		Path inside = baseDir.toRealPath().resolve("report.csv");
+
+		String validated = AllowedPaths.under(baseDir).validate(inside.toString());
+
+		assertEquals(inside.toAbsolutePath().normalize().toString(), validated);
+	}
+
+	@Test
+	public void deniesPathOutsideBaseDir(@TempDir Path tempDir) throws IOException {
+		Path baseDir = Files.createDirectory(tempDir.resolve("base"));
+		AllowedPaths paths = AllowedPaths.under(baseDir);
+
+		Path outside = tempDir.resolve("outside.csv");
+		assertThrows(SecurityException.class, () -> paths.validate(outside.toString()));
+	}
+
+	@Test
+	public void deniesSymlinkInsideBaseDirPointingOutside(@TempDir Path tempDir) throws IOException {
+		Path baseDir = Files.createDirectory(tempDir.resolve("base"));
+		Path secret = Files.writeString(tempDir.resolve("secret.csv"), "top,secret");
+		Path link = baseDir.resolve("link.csv");
+		assumeTrue(canCreateSymbolicLink(link, secret),
+				"platform does not support creating symbolic links");
+		AllowedPaths paths = AllowedPaths.under(baseDir);
+
+		assertThrows(SecurityException.class, () -> paths.validate(link.toString()));
+	}
+
+	/**
+	 * The boundary is per instance, which the static it replaced could not express: one
+	 * validator confines to one directory while another confines to a second, and neither
+	 * moves the other.
+	 */
+	@Test
+	public void twoValidatorsHoldTwoSeparateBoundaries(@TempDir Path tempDir) throws IOException {
+		Path first = Files.createDirectory(tempDir.resolve("first"));
+		Path second = Files.createDirectory(tempDir.resolve("second"));
+		AllowedPaths firstPaths = AllowedPaths.under(first);
+		AllowedPaths secondPaths = AllowedPaths.under(second);
+
+		String inFirst = first.toRealPath().resolve("data.csv").toString();
+		String inSecond = second.toRealPath().resolve("data.csv").toString();
+
+		assertEquals(inFirst, firstPaths.validate(inFirst));
+		assertEquals(inSecond, secondPaths.validate(inSecond));
+		assertThrows(SecurityException.class, () -> firstPaths.validate(inSecond));
+		assertThrows(SecurityException.class, () -> secondPaths.validate(inFirst));
+	}
+
+	private static boolean canCreateSymbolicLink(Path link, Path target) {
+		try {
+			Files.createSymbolicLink(link, target);
+			return true;
+		} catch (UnsupportedOperationException | IOException e) {
+			return false;
+		}
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/PathValidatorTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/PathValidatorTest.java
@@ -3,8 +3,8 @@ package io.github.adamw7.tools.data.source.file;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -15,13 +15,19 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Isolated;
 
 /**
- * Runs alone under the class-parallel unit-test run: the allowed base directory
- * is one {@code volatile} field for the whole JVM, so while this class points it
- * at a {@code @TempDir}, every other test constructing a file source would be
- * refused the test resource it reads. Clearing it afterwards is not enough when
- * something else runs *during*.
+ * Covers what is left of the deprecated process-wide entry points: that they still
+ * delegate to an {@link AllowedPaths}, and that a source built without one of its own
+ * still honours a base directory set through them. The path checks themselves are
+ * {@code AllowedPathsTest}'s.
+ *
+ * <p>Still runs alone under the class-parallel unit run, and is the only class here that
+ * has to: these methods write one field for the whole JVM, so while this class points it
+ * at a {@code @TempDir}, every other test constructing a file source would be refused the
+ * test resource it reads. Clearing it afterwards is not enough when something else runs
+ * <em>during</em>. The class goes when the methods do.</p>
  */
 @Isolated
+@SuppressWarnings("removal")
 public class PathValidatorTest {
 
 	@AfterEach
@@ -30,60 +36,20 @@ public class PathValidatorTest {
 	}
 
 	@Test
-	public void rejectsNullPath() {
-		assertThrows(IllegalArgumentException.class, () -> PathValidator.validate(null));
-	}
-
-	@Test
-	public void rejectsEmptyPath() {
-		assertThrows(IllegalArgumentException.class, () -> PathValidator.validate(""));
-	}
-
-	@Test
-	public void rejectsBlankPath() {
-		assertThrows(IllegalArgumentException.class, () -> PathValidator.validate("   "));
-	}
-
-	@Test
-	public void rejectsLeadingTraversal() {
-		assertThrows(SecurityException.class, () -> PathValidator.validate("../etc/passwd"));
-	}
-
-	@Test
-	public void rejectsEmbeddedTraversal() {
-		assertThrows(SecurityException.class, () -> PathValidator.validate("/data/uploads/../secret"));
-	}
-
-	@Test
-	public void rejectsBareDotDot() {
-		assertThrows(SecurityException.class, () -> PathValidator.validate(".."));
-	}
-
-	@Test
-	public void rejectsBackslashTraversal() {
-		assertThrows(SecurityException.class, () -> PathValidator.validate("..\\windows\\system32"));
-	}
-
-	@Test
-	public void returnsCanonicalisedAbsolutePathWhenNoBaseDir() {
+	public void validatesThroughTheProcessWideBoundary() {
 		String validated = PathValidator.validate("report.csv");
-		Path expected = Path.of("report.csv").toAbsolutePath().normalize();
-		assertEquals(expected.toString(), validated);
+
+		assertEquals(Path.of("report.csv").toAbsolutePath().normalize().toString(), validated);
+	}
+
+	@Test
+	public void rejectsTraversal() {
+		assertThrows(SecurityException.class, () -> PathValidator.validate("../etc/passwd"));
 	}
 
 	@Test
 	public void setBaseDirRejectsNull() {
 		assertThrows(IllegalArgumentException.class, () -> PathValidator.setAllowedBaseDir(null));
-	}
-
-	@Test
-	public void allowsPathInsideBaseDir(@TempDir Path baseDir) throws IOException {
-		PathValidator.setAllowedBaseDir(baseDir);
-
-		Path inside = baseDir.toRealPath().resolve("report.csv");
-		String validated = PathValidator.validate(inside.toString());
-
-		assertEquals(inside.toAbsolutePath().normalize().toString(), validated);
 	}
 
 	@Test
@@ -96,27 +62,6 @@ public class PathValidatorTest {
 	}
 
 	@Test
-	public void deniesSymlinkInsideBaseDirPointingOutside(@TempDir Path tempDir) throws IOException {
-		Path baseDir = Files.createDirectory(tempDir.resolve("base"));
-		Path secret = Files.writeString(tempDir.resolve("secret.csv"), "top,secret");
-		Path link = baseDir.resolve("link.csv");
-		assumeTrue(canCreateSymbolicLink(link, secret),
-				"platform does not support creating symbolic links");
-		PathValidator.setAllowedBaseDir(baseDir);
-
-		assertThrows(SecurityException.class, () -> PathValidator.validate(link.toString()));
-	}
-
-	private static boolean canCreateSymbolicLink(Path link, Path target) {
-		try {
-			Files.createSymbolicLink(link, target);
-			return true;
-		} catch (UnsupportedOperationException | IOException e) {
-			return false;
-		}
-	}
-
-	@Test
 	public void clearingBaseDirLiftsRestriction(@TempDir Path tempDir) throws IOException {
 		Path baseDir = Files.createDirectory(tempDir.resolve("base"));
 		PathValidator.setAllowedBaseDir(baseDir);
@@ -124,6 +69,43 @@ public class PathValidatorTest {
 
 		Path outside = tempDir.resolve("outside.csv");
 		String validated = PathValidator.validate(outside.toString());
+
 		assertTrue(validated.endsWith("outside.csv"));
+	}
+
+	/**
+	 * A source built through a constructor taking no {@link AllowedPaths} keeps reading
+	 * within a base directory set here, so migrating to the instance boundary does not
+	 * silently unconfine a host that has not migrated yet.
+	 */
+	@Test
+	public void sourceWithoutItsOwnBoundaryHonoursTheProcessWideOne(@TempDir Path tempDir) throws IOException {
+		Path baseDir = Files.createDirectory(tempDir.resolve("base"));
+		Path outside = Files.writeString(tempDir.resolve("outside.csv"), "id\n1\n");
+		PathValidator.setAllowedBaseDir(baseDir);
+
+		assertThrows(SecurityException.class, () -> new InMemoryCSVDataSource(outside.toString(), 1));
+	}
+
+	/**
+	 * The other half of that promise: a source handed its own boundary reads within it,
+	 * whatever the process-wide one says.
+	 */
+	@Test
+	public void sourceWithItsOwnBoundaryIgnoresTheProcessWideOne(@TempDir Path tempDir)
+			throws IOException {
+		Path baseDir = Files.createDirectory(tempDir.resolve("base"));
+		Path elsewhere = Files.createDirectory(tempDir.resolve("elsewhere"));
+		Path data = Files.writeString(elsewhere.resolve("data.csv"), "id\n1\n");
+		PathValidator.setAllowedBaseDir(baseDir);
+
+		assertOpens(data, AllowedPaths.under(elsewhere));
+	}
+
+	private void assertOpens(Path data, AllowedPaths allowedPaths) throws FileNotFoundException, IOException {
+		try (InMemoryCSVDataSource source = new InMemoryCSVDataSource(data.toString(), 1, allowedPaths)) {
+			source.open();
+			assertEquals("id", source.getColumnNames()[0]);
+		}
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/McpConfigurationTest.java
@@ -10,45 +10,37 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.parallel.Isolated;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.adamw7.tools.data.source.file.PathValidator;
+import io.github.adamw7.tools.data.source.file.AllowedPaths;
+import io.github.adamw7.tools.mcp.McpTool;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 
 /**
- * Runs alone under the class-parallel unit-test run: {@code tools()} confines file
- * access by setting the JVM-wide {@link PathValidator} base directory, which would
- * otherwise deny a concurrently running test the file it reads.
+ * Runs in the class-parallel unit suite: the base directory {@code tools()} confines its
+ * tools to is theirs alone, so pointing it at a {@code @TempDir} here denies a
+ * concurrently running test nothing.
  */
-@Isolated
 public class McpConfigurationTest {
 
 	private final McpConfiguration config = new McpConfiguration();
-
-	@AfterEach
-	public void clearBaseDir() {
-		// tools() confines file access through global PathValidator state; reset it
-		// so the restriction does not leak into other tests.
-		PathValidator.clearAllowedBaseDir();
-	}
 
 	@Test
 	public void confinesFileAccessToConfiguredBaseDir(@TempDir Path baseDir) throws IOException {
 		Path insideFile = Files.createFile(baseDir.resolve("data.csv"));
 		config.allowedBaseDir = baseDir.toString();
 
-		config.tools();
+		AllowedPaths confinement = config.confinement();
 
-		assertThrows(SecurityException.class, () -> PathValidator.validate(outsideBase(baseDir)));
-		assertDoesNotThrow(() -> PathValidator.validate(insideFile.toRealPath().toString()));
+		assertThrows(SecurityException.class, () -> confinement.validate(outsideBase(baseDir)));
+		assertDoesNotThrow(() -> confinement.validate(insideFile.toRealPath().toString()));
 	}
 
 	@Test
@@ -56,11 +48,28 @@ public class McpConfigurationTest {
 		Path outsideFile = Files.createFile(outsideDir.resolve("data.csv"));
 		config.allowedBaseDir = "   ";
 
-		config.tools();
+		AllowedPaths confinement = config.confinement();
 
 		// The JUnit temp dir lives outside the module's working directory, so a file
 		// there must be rejected once access is confined to the default base.
-		assertThrows(SecurityException.class, () -> PathValidator.validate(outsideFile.toRealPath().toString()));
+		assertThrows(SecurityException.class, () -> confinement.validate(outsideFile.toRealPath().toString()));
+	}
+
+	/**
+	 * The tools the server registers are the ones carrying that boundary: a client
+	 * naming a file outside it is refused rather than served.
+	 */
+	@Test
+	public void toolsAreBuiltConfinedToThatBaseDir(@TempDir Path baseDir, @TempDir Path outsideDir) throws IOException {
+		Path outsideFile = Files.writeString(outsideDir.resolve("outside.csv"), "id\n1\n");
+		config.allowedBaseDir = baseDir.toString();
+
+		McpTool tool = config.tools().get(0);
+
+		assertThrows(SecurityException.class, () -> tool.apply(Map.of(
+				"file", outsideFile.toRealPath().toString(),
+				"columns_row", "1",
+				"columns_name", "id")));
 	}
 
 	@Test

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessToolTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/mcp/UniquenessToolTest.java
@@ -17,8 +17,10 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.data.Utils;
+import io.github.adamw7.tools.data.source.file.AllowedPaths;
 import io.github.adamw7.tools.data.uniqueness.ColumnNotFoundException;
 import io.github.adamw7.tools.mcp.ToolResult;
 
@@ -26,7 +28,7 @@ public class UniquenessToolTest {
 
 	@Test
 	public void happyPath() {
-		UniquenessTool tool = new UniquenessTool();
+		UniquenessTool tool = new UniquenessTool(AllowedPaths.anywhere());
 		assertNotNull(tool.getToolDefinition());
 		Map<String, Object> input = new HashMap<>();
 		input.put("file", Utils.getHouseholdFile());
@@ -39,7 +41,7 @@ public class UniquenessToolTest {
 
 	@Test
 	public void uniqueColumn() {
-		UniquenessTool tool = new UniquenessTool();
+		UniquenessTool tool = new UniquenessTool(AllowedPaths.anywhere());
 		Map<String, Object> input = new HashMap<>();
 		input.put("file", Utils.getHouseholdFile());
 		input.put("columns_row", "1");
@@ -50,8 +52,22 @@ public class UniquenessToolTest {
 	}
 
 	@Test
+	public void refusesFileOutsideItsOwnBoundary(@TempDir Path baseDir) throws IOException {
+		UniquenessTool tool = new UniquenessTool(AllowedPaths.under(baseDir));
+		Map<String, Object> input = new HashMap<>();
+		input.put("file", Utils.getHouseholdFile());
+		input.put("columns_row", "1");
+		input.put("columns_name", "income");
+
+		// The boundary belongs to this tool, so an unconfined tool built beside it still
+		// reads the same file.
+		assertThrows(SecurityException.class, () -> tool.apply(input));
+		assertFalse(new UniquenessTool(AllowedPaths.anywhere()).apply(input).isError());
+	}
+
+	@Test
 	public void missingFile() {
-		UniquenessTool tool = new UniquenessTool();
+		UniquenessTool tool = new UniquenessTool(AllowedPaths.anywhere());
 		Map<String, Object> input = new HashMap<>();
 		input.put("file", "nonExistentFile.csv");
 		input.put("columns_row", "1");
@@ -61,7 +77,7 @@ public class UniquenessToolTest {
 
 	@Test
 	public void invalidColumn() {
-		UniquenessTool tool = new UniquenessTool();
+		UniquenessTool tool = new UniquenessTool(AllowedPaths.anywhere());
 		Map<String, Object> input = new HashMap<>();
 		input.put("file", Utils.getHouseholdFile());
 		input.put("columns_row", "1");
@@ -71,14 +87,14 @@ public class UniquenessToolTest {
 
 	@Test
 	public void toolDefinitionName() {
-		UniquenessTool tool = new UniquenessTool();
+		UniquenessTool tool = new UniquenessTool(AllowedPaths.anywhere());
 		assertTrue("uniqueness_check".equals(tool.getToolDefinition().name()));
 	}
 
 	@Test
 	@SuppressWarnings("unchecked")
 	public void toolDefinitionRequiredFields() {
-		UniquenessTool tool = new UniquenessTool();
+		UniquenessTool tool = new UniquenessTool(AllowedPaths.anywhere());
 		List<String> required = (List<String>) tool.getToolDefinition().inputSchema().get("required");
 		assertTrue(required.contains("file"));
 		assertTrue(required.contains("columns_row"));
@@ -90,7 +106,7 @@ public class UniquenessToolTest {
 		Path fdDir = Paths.get("/proc/self/fd");
 		assumeTrue(Files.isDirectory(fdDir), "file-descriptor probing is only available on Linux");
 
-		UniquenessTool tool = new UniquenessTool();
+		UniquenessTool tool = new UniquenessTool(AllowedPaths.anywhere());
 		warmUp(tool);
 
 		long before = openFileDescriptors(fdDir);

--- a/docs/adr/0012-per-source-path-confinement.md
+++ b/docs/adr/0012-per-source-path-confinement.md
@@ -1,0 +1,65 @@
+# 12. Path confinement scoped to the data source, not the JVM
+
+- **Status:** Accepted
+- **Date:** 2026-08-20
+- **Deciders:** Project maintainers
+- **Tags:** data, security, api
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context
+
+Every file-backed data source in the `data` module canonicalises the path it is
+given and refuses one that climbs out of its directory with `..` (CWE-22). It
+could additionally be held inside a base directory, and the uniqueness MCP
+server relies on that: a client names the file to check, so without a boundary
+it could name `/etc/passwd`.
+
+That boundary was one `static volatile Path` on `PathValidator`, written by
+`setAllowedBaseDir` and wiped by `clearAllowedBaseDir`. One field for the whole
+JVM has three consequences:
+
+- **One boundary per process.** A host embedding the library cannot confine two
+  sources to two roots — the second `setAllowedBaseDir` moves the first one's
+  boundary without saying so.
+- **Order-dependent security.** Any code in the process can call
+  `clearAllowedBaseDir()` and lift the restriction for everything else.
+- **It reached into the test suite.** It was one of the two reasons `@Isolated`
+  exists here: a test pointing the boundary at a `@TempDir` denied every
+  concurrently running test the resource it read, so the classes touching it
+  could not join the class-parallel run.
+
+The `code/context` module had already solved the same problem the other way,
+with per-server `context.allowed-roots` configuration rather than a static.
+
+## Decision
+
+Make the boundary a value, held by the thing it confines.
+
+`AllowedPaths` is immutable, built either as `AllowedPaths.under(baseDir)` or
+`AllowedPaths.anywhere()`, and carries the path check itself. Every file source
+gains a constructor taking one, and passes it nothing else; the uniqueness MCP
+server builds one from `data.allowed-base-dir` and hands it to the tool it
+registers, so the confinement travels with the tool instead of with the process.
+
+`PathValidator`'s three static entry points remain for one release as
+`@Deprecated(forRemoval = true)` delegates over a shared `AllowedPaths`, and the
+source constructors that take no boundary keep validating against it. A host
+that has not migrated therefore stays exactly as confined as it was — the
+alternative, defaulting those constructors to unconfined, would have quietly
+removed a restriction somebody was relying on.
+
+## Consequences
+
+- Two sources can be confined to two directories in one JVM, and no unrelated
+  code can widen or clear a boundary it did not set.
+- `AllowedPathsTest` and `McpConfigurationTest` run in the class-parallel unit
+  suite. Only the class covering the deprecated statics still carries
+  `@Isolated`, and the ArchUnit rule requiring it retires with them.
+- The public API grows one constructor per file source, and `UniquenessTool`'s
+  constructor now takes its boundary — a breaking change for anyone who
+  constructed that tool directly, which only the server wiring does.
+- Symlink resolution, the traversal check and the messages are unchanged, so
+  what was refused before is still refused — with one deliberate exception: a
+  path element is now compared to `..` rather than searched for as a substring,
+  so a legitimate file named `..name` is no longer mistaken for an escape.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,6 +62,7 @@ decision, add a new ADR that supersedes it and set both records' `Supersedes` /
 | [0009](0009-mcp-servers-on-spring-boot.md) | MCP servers built on Spring Boot | Accepted | 2026-07-16 |
 | [0010](0010-documentation-as-enforced-contract.md) | Documentation as a build-enforced contract | Accepted | 2026-07-16 |
 | [0011](0011-hybrid-post-quantum-key-exchange.md) | Prefer the X25519MLKEM768 hybrid key exchange for TLS 1.3 | Accepted | 2026-07-19 |
+| [0012](0012-per-source-path-confinement.md) | Path confinement scoped to the data source, not the JVM | Accepted | 2026-08-20 |
 
 ## Related documents
 

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -218,7 +218,7 @@ flowchart TB
             parquetSrc["<b>Parquet sources</b><br/><i>DuckDbParquet — in-process DuckDB</i>"]
             jacksonMem["<b>In-memory JSON · YAML · TOON</b><br/><i>map-backed</i>"]
             jacksonIter["<b>Iterative JSON · YAML · TOON</b><br/><i>forward-only, no schema</i>"]
-            paths["<b>PathValidator</b><br/><i>path checks</i>"]
+            paths["<b>AllowedPaths</b><br/><i>path checks, confined<br/>per source</i>"]
             compression["<b>ZipUtils</b><br/><i>GZip</i>"]
         end
 


### PR DESCRIPTION
The path-confinement boundary was one `static volatile Path` on
`PathValidator`: a host could hold only one directory at a time, any
caller could clear it for everything else in the process, and a test
touching it had to run alone, which is one of the two reasons `@Isolated`
exists here.

`AllowedPaths` replaces it with an immutable value — `AllowedPaths.under(baseDir)`
or `AllowedPaths.anywhere()` — carrying the check itself. Every file source
gains a constructor taking one, and the uniqueness MCP server builds one from
`data.allowed-base-dir` and hands it to the tool it registers, so the
confinement travels with the tool rather than with the process. Two sources can
now hold two roots, and nothing can widen a boundary it did not set.

`PathValidator`'s three static entry points stay for one release as
`@Deprecated(forRemoval = true)` delegates over a shared `AllowedPaths`, and the
constructors taking no boundary keep validating against it — a host that has not
migrated stays exactly as confined as it was, rather than being silently
unrestricted.

Also fixes a false positive in the traversal check while in the file: a path
element is now compared to `..` rather than searched for as a substring, so a
legitimate file named `..name` is no longer refused.

`AllowedPathsTest` and `McpConfigurationTest` drop `@Isolated` and join the
class-parallel run; only the class covering the deprecated statics still needs
it, and the ArchUnit rule requiring it retires with them. Decision recorded in
ADR 0012.

Closes #638

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E5WkDv2Yymnta8bWxA19py