### PR TITLE
build: pin Automatic-Module-Name on every published jar

### DIFF
--- a/.claude/skills/maven-conventions/SKILL.md
+++ b/.claude/skills/maven-conventions/SKILL.md
@@ -34,6 +34,28 @@ profile, is the most common source of avoidable build friction here.
   one.** If approved, declare it (with version) in root `<dependencyManagement>`,
   then reference it version-free in the module.
 
+### Name the module of every published jar
+- A published jar states its JPMS module name instead of letting the JVM derive
+  one from the filename, which changes with the artifactId or the version scheme
+  and breaks a consumer's `requires`.
+- `data` and `data-test` state it in `module-info.java`. Every other published
+  module states it in the jar manifest, via `maven-jar-plugin`:
+  ```xml
+  <archive>
+  	<manifestEntries>
+  		<Automatic-Module-Name>tools.markdown.common</Automatic-Module-Name>
+  	</manifestEntries>
+  </archive>
+  ```
+- The name is the artifactId with every non-alphanumeric run collapsed to a dot
+  (`tools.markdown-common` → `tools.markdown.common`), so pinning it changes
+  nothing for a consumer already reading the derived name.
+  `protogen-maven-plugin` is the exception: no `tools.` prefix in its artifactId,
+  and nothing `requires` a Maven plugin, so it takes `tools.protogen.maven.plugin`.
+- **A new published module needs this too.** The unpublished ones
+  (`grpc-example`, `assembly`, `*-test`, anything with
+  `central.skipPublishing`) need nothing.
+
 ### Clean after removing a code-generation source
 - Run `clean` after deleting a codegen input, so stale generated builders in
   `target/` cannot mask the change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1215,6 +1215,56 @@ Skill: `maven-conventions`.
   satisfied when *any* project in the reactor declares the id, which is what lets
   the per-module `integration-tests` profile be requested from the root.
 
+#### Java module names
+
+Every **published** jar states its JPMS module name, so a consumer on the module
+path gets a name that belongs to the artifact rather than one the JVM guessed
+from the filename — a guess that changes with the artifactId or the version
+scheme and takes the consumer's `requires` clause down with it.
+
+Two ways to state it, and the module descriptor wins where a module has one:
+
+| Module | Name | Stated in |
+|---|---|---|
+| `data` | `io.github.adamw7.tools.data` | `module-info.java` |
+| `data-test` | `io.github.adamw7.tools.data.test` | `module-info.java` |
+| `markdown-common` | `tools.markdown.common` | jar manifest |
+| `claude-code-enforcer` | `tools.claude.code.enforcer` | jar manifest |
+| `mcp-common` | `tools.mcp.common` | jar manifest |
+| `code/context` | `tools.code.context` | jar manifest |
+| `code/protogen-maven-plugin` | `tools.protogen.maven.plugin` | jar manifest |
+| `adopt` | `tools.adopt` | jar manifest |
+
+A module without a `module-info.java` configures `maven-jar-plugin` with an
+`Automatic-Module-Name` manifest entry — three lines, and it locks the name in
+without the far larger change a full descriptor is:
+
+```xml
+<plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-jar-plugin</artifactId>
+	<configuration>
+		<archive>
+			<manifestEntries>
+				<Automatic-Module-Name>tools.markdown.common</Automatic-Module-Name>
+			</manifestEntries>
+		</archive>
+	</configuration>
+</plugin>
+```
+
+The name is the one the filename already produced — the artifactId with every
+non-alphanumeric run collapsed to a dot — so pinning it breaks no consumer who
+was already reading the guess. `protogen-maven-plugin` is the one exception: its
+artifactId carries no `tools.` prefix, and a Maven plugin is resolved by
+coordinates and loaded by Maven's own classloader, never named in a `requires`,
+so it takes the `tools.` name the rest of the repository uses.
+
+**A new published module picks this up too.** `grpc-example`, `assembly` and the
+`*-test` harnesses are not published (`central.skipPublishing`) and need nothing.
+Spring Boot's `repackage` preserves the entry, so `code/context` and `adopt` keep
+their name in the executable jar as well as the plain one.
+
 #### Reproducible builds
 
 Setting `project.build.outputTimestamp` makes every archive-producing plugin

--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -36,6 +36,22 @@
 			</resource>
 		</resources>
 		<plugins>
+			<!-- No module-info.java here, so the JPMS name was being derived from
+			     the jar filename, which changes with the artifactId or the version
+			     scheme and takes a consumer's `requires` clause down with it.
+			     Pinning the name the filename already produced makes it part of the
+			     artifact. See mcp-common, which does the same. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>tools.adopt</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
 			<!-- Lets the pipeline be launched with `mvn -pl adopt exec:java`, which
 			     resolves the full runtime classpath (log4j2 and the rest) from the
 			     module's dependencies. Running the Main class with a bare

--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -33,6 +33,14 @@
 						<manifest>
 							<mainClass>io.github.adamw7.tools.enforcer.cli.Main</mainClass>
 						</manifest>
+						<!-- No module-info.java here, so without this the JPMS name would
+						     be derived from the jar filename and would change with the
+						     artifactId or the version scheme. Pinning the name the
+						     filename already produced keeps it stable for a consumer that
+						     puts the rule jar on the module path. See mcp-common. -->
+						<manifestEntries>
+							<Automatic-Module-Name>tools.claude.code.enforcer</Automatic-Module-Name>
+						</manifestEntries>
 					</archive>
 				</configuration>
 			</plugin>

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -19,6 +19,22 @@
 	</properties>
 	<build>
 		<plugins>
+			<!-- No module-info.java here, so the JPMS name was being derived from
+			     the jar filename, which changes with the artifactId or the version
+			     scheme and takes a consumer's `requires` clause down with it.
+			     Pinning the name the filename already produced makes it part of the
+			     artifact. See mcp-common, which does the same. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>tools.code.context</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/code/protogen-maven-plugin/pom.xml
+++ b/code/protogen-maven-plugin/pom.xml
@@ -19,6 +19,24 @@
 	</properties>
 	<build>
 		<plugins>
+			<!-- No module-info.java here, so the JPMS name was being derived from
+			     the jar filename, which changes with the artifactId or the version
+			     scheme. Unlike the library modules this artifactId carries no
+			     `tools.` prefix, so the name is spelled out rather than left to the
+			     filename: a Maven plugin is resolved by coordinates and loaded by
+			     Maven's own classloader, never named in a `requires`, so nothing
+			     depends on the previous filename-derived spelling. See mcp-common. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>tools.protogen.maven.plugin</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
 			<!-- Expose the mockito-core jar path so it can be pre-loaded as a Java
 			     agent below, avoiding Mockito's slow runtime self-attach. -->
 			<plugin>

--- a/markdown-common/pom.xml
+++ b/markdown-common/pom.xml
@@ -17,6 +17,28 @@
 		     See the root pom's pitest.mutationThreshold. -->
 		<pitest.mutationThreshold>91</pitest.mutationThreshold>
 	</properties>
+	<build>
+		<plugins>
+			<!-- This module has no module-info.java, so the JPMS name a consumer's
+			     `requires` resolves against was being derived from the jar filename.
+			     javac warns about publishing such a filename-based automodule,
+			     because renaming the artifact silently renames the module. Pinning
+			     the manifest entry to the name the filename already produced keeps
+			     existing consumers working and makes the name part of the artifact
+			     instead of an accident. See mcp-common, which does the same. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>tools.markdown.common</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<!-- Deliberately dependency-free beyond the JDK. Two modules read Markdown the
 	     same way and must keep agreeing about it: claude-code-enforcer's
 	     claudeMdFormat rule judges a CLAUDE.md, and adopt's ClaudeMdConformer


### PR DESCRIPTION
JPMS support was half applied: `data` and `data-test` name themselves in a
`module-info.java` and `mcp-common` pins an `Automatic-Module-Name`, while
`markdown-common`, `claude-code-enforcer`, `code/context`,
`protogen-maven-plugin` and `adopt` named themselves nowhere. A jar with
neither gets an automatic module name derived from its filename, which
changes with the artifactId or the version scheme and takes a consumer's
`requires` clause with it — and these are published to Maven Central.

Each of the five now configures maven-jar-plugin with the manifest entry, on
the mcp-common pattern. The name is the one the filename already produced —
the artifactId with each non-alphanumeric run collapsed to a dot — so no
consumer reading the old derived name breaks. `protogen-maven-plugin` is the
exception: its artifactId carries no `tools.` prefix, and a Maven plugin is
resolved by coordinates and loaded by Maven's own classloader rather than
named in a `requires`, so it takes `tools.protogen.maven.plugin` in line with
the rest of the repository.

Spring Boot's `repackage` preserves the entry, so `code/context` and `adopt`
keep the name in the executable jar too. The unpublished modules
(`grpc-example`, `assembly`, the `*-test` harnesses) are left alone.

Documents the convention in AGENTS.md and the `maven-conventions` skill so a
new published module picks it up.

Closes #637

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QhN41EtwXa76yS2xZ2K9TM