### PR TITLE
docs(build): trim pom comments to one-line rationale

### DIFF
--- a/adopt/pom.xml
+++ b/adopt/pom.xml
@@ -12,35 +12,26 @@
 	<name>Claude Code repository adoption</name>
 	<description>Adopts Claude Code into a GitHub repository: clones it, runs claude init to generate CLAUDE.md, commits and pushes, then wires the claude-code-enforcer into the project build.</description>
 	<properties>
-		<!-- Mutation-score floor for this module, a few points under the 91% it
-		     measures today so an equivalent refactor cannot turn the build red.
-		     See the root pom's pitest.mutationThreshold. -->
+		<!-- Mutation-score floor, a few points under what this module measures today. See the root
+		     pom's pitest.mutationThreshold. -->
 		<pitest.mutationThreshold>88</pitest.mutationThreshold>
 	</properties>
 	<build>
 		<resources>
-			<!-- Default resources copied verbatim: log4j2.properties carries ${...}
-			     tokens that are log4j's own and must survive unfiltered. -->
+			<!-- Unfiltered: log4j2.properties carries ${...} tokens that are log4j's own. -->
 			<resource>
 				<directory>src/main/resources</directory>
 			</resource>
-			<!-- A dedicated directory that IS filtered, so the project version is
-			     baked into adopt-build.properties (see PomEnforcerInstaller). The
-			     spring-boot-starter parent filters with the @...@ delimiter, which
-			     that file uses. Kept separate from src/main/resources because
-			     overlapping filtered and unfiltered entries on one directory are
-			     unreliable, and because log4j2.properties must stay unfiltered. -->
+			<!-- Filtered separately, so the version reaches adopt-build.properties (the @...@
+			     delimiter the parent configures) while log4j2.properties stays unfiltered. -->
 			<resource>
 				<directory>src/main/filtered-resources</directory>
 				<filtering>true</filtering>
 			</resource>
 		</resources>
 		<plugins>
-			<!-- No module-info.java here, so the JPMS name was being derived from
-			     the jar filename, which changes with the artifactId or the version
-			     scheme and takes a consumer's `requires` clause down with it.
-			     Pinning the name the filename already produced makes it part of the
-			     artifact. See mcp-common, which does the same. -->
+			<!-- No module-info.java here, so pin the JPMS name the jar filename already produced
+			     rather than let it change with the artifactId. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
@@ -52,11 +43,8 @@
 					</archive>
 				</configuration>
 			</plugin>
-			<!-- Lets the pipeline be launched with `mvn -pl adopt exec:java`, which
-			     resolves the full runtime classpath (log4j2 and the rest) from the
-			     module's dependencies. Running the Main class with a bare
-			     `java -cp adopt/target/classes` omits those jars and fails at
-			     start-up with NoClassDefFoundError for the log4j LogManager. -->
+			<!-- Runs the pipeline CLI with the module's full runtime classpath: mvn -pl adopt
+			     exec:java. -->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
@@ -64,10 +52,8 @@
 					<mainClass>io.github.adamw7.tools.adopt.Main</mainClass>
 				</configuration>
 			</plugin>
-			<!-- Repackages the module jar as the executable adoption MCP server,
-			     mirroring the data and context modules; the release profile skips
-			     the repackaging so Maven Central still gets a plain library jar.
-			     The pipeline CLI stays reachable through exec:java above. -->
+			<!-- Executable jar for the adoption MCP server; the release profile skips the
+			     repackaging. -->
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -80,11 +66,7 @@
 		</plugins>
 	</build>
 	<profiles>
-		<!-- Gates the *IT tests, which need real network: MultiRepoAdoptionIT
-		     clones real GitHub repositories to prove a batch gives each one its
-		     own checkout, and the two MCP *IT tests boot the adoption server on
-		     each HTTP transport and drive adopt_repo across it. Mirrors the data
-		     and code/context modules. -->
+		<!-- Gates the *IT tests, which need real network: real clones and the MCP server over HTTP. -->
 		<profile>
 			<id>integration-tests</id>
 			<build>
@@ -107,12 +89,7 @@
 	</profiles>
 
 	<dependencies>
-		<!-- Reads the generated CLAUDE.md for ClaudeMdConformer. It is the same
-		     reader the claudeMdFormat rule judges the reshaped file with, which is
-		     the point: the conformer used to carry a copy of it, and every way the
-		     two drifted apart let the adoption commit and push a file that then
-		     failed its own VerifyStep. The module is dependency-free, so sharing it
-		     costs the pipeline nothing it did not already carry. -->
+		<!-- The same Markdown reader the claudeMdFormat rule judges ClaudeMdConformer's output with. -->
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.markdown-common</artifactId>
@@ -143,32 +120,16 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
-		<!-- Matches the adoption command line. CliArguments used to walk the
-		     argument array itself, which meant hand-writing what every parser
-		     already knows: which flags take a value, which repeat, where the
-		     positionals are, and what to say when a value is missing. picocli
-		     declares all of that, and it has no transitive dependencies, so the
-		     pipeline stays a plain library. -->
 		<dependency>
 			<groupId>info.picocli</groupId>
 			<artifactId>picocli</artifactId>
 		</dependency>
-		<!-- Reads the pom.xml the enforcer is wired into. PomDocument used to pair a
-		     JAXP parse with a lexical scan of its own, because a DOM records nothing
-		     about where its elements were read from and the edit has to be spliced
-		     into the bytes the file already holds. jsoup's XML parser reports the
-		     source range of every start and end tag, so the scan is gone and the two
-		     readings can no longer disagree. It resolves no DTDs or external
-		     entities, and like picocli it has no transitive dependencies, so the
-		     pipeline stays a plain library. -->
+		<!-- Reads the pom.xml the enforcer is wired into, reporting the source ranges the edit is
+		     spliced into. -->
 		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
 		</dependency>
-		<!-- Boots the adoption MCP server on a random port for the transport
-		     integration tests (@SpringBootTest, @LocalServerPort), as the data and
-		     code/context modules do for theirs. The MCP client those tests reach it
-		     with travels with mcp-json-jackson2 above. -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -191,23 +152,16 @@
 			<artifactId>archunit-junit5</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<!-- Test scope only, so the pipeline stays a plain library that ships no
-		     enforcer rule: ClaudeMdConformerContractTest runs the real
-		     claudeMdFormat rule over the conformer's output, which is the only way
-		     the two can be held to the one contract they both spell out. A compile
-		     dependency would drag the maven-enforcer API into every consumer of
-		     adopt for a check that belongs to this module's tests. -->
+		<!-- Test scope only, so the pipeline ships no enforcer rule: ClaudeMdConformerContractTest
+		     runs the real claudeMdFormat rule over the conformer's output. -->
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.claude-code-enforcer</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<!-- The rule's execute() declares EnforcerRuleException, so the test that
-		     calls it needs the API on its classpath. It is managed as `provided`
-		     for the enforcer module, which maven-enforcer supplies at build time
-		     and which therefore does not travel with the rule jar; narrowed to
-		     `test` here so it stays off adopt's own compile classpath. -->
+		<!-- The rule's execute() declares EnforcerRuleException; test scope keeps the API off
+		     adopt's compile classpath. -->
 		<dependency>
 			<groupId>org.apache.maven.enforcer</groupId>
 			<artifactId>enforcer-api</artifactId>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -12,21 +12,16 @@
 	<name>assembly</name>
 	<description>Builds a runnable SampleApp distribution: a launcher jar plus a lib/ of dependency jars (mainClass: io.github.adamw7.tools.data.SampleApp).</description>
 	<properties>
-		<!-- This module only assembles a runnable SampleApp distribution (a
-		     launcher jar plus its lib/ of dependencies), not a reusable library,
-		     so keep it out of both publications: the GitHub Packages deployment
-		     maven-deploy-plugin performs on `mvn deploy`, and the Maven Central
-		     bundle the root pom's release profile publishes. -->
+		<!-- A runnable distribution, not a reusable library: keep it out of the GitHub Packages
+		     deploy and the Maven Central bundle. -->
 		<maven.deploy.skip>true</maven.deploy.skip>
 		<central.skipPublishing>true</central.skipPublishing>
 	</properties>
 	<build>
 		<plugins>
 			<plugin>
-				<!-- The module has no sources of its own; its jar exists to be the
-				     distribution's launcher. Main-Class plus a lib/-prefixed Class-Path
-				     make `java -jar tools.assembly-<version>.jar` work straight out of
-				     the assembled directory, in the container images and outside them. -->
+				<!-- The module has no sources of its own; its jar launches the distribution, so
+				     Main-Class plus a lib/-prefixed Class-Path make java -jar work. -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>

--- a/claude-code-enforcer/pom.xml
+++ b/claude-code-enforcer/pom.xml
@@ -12,19 +12,14 @@
 	<name>CLAUDE.md enforcer rule</name>
 	<description>Custom maven-enforcer rule that validates CLAUDE.md documents for structure and naming conventions during the build.</description>
 	<properties>
-		<!-- Mutation-score floor for this module, a few points under the 91% it
-		     measures today so an equivalent refactor cannot turn the build red.
-		     See the root pom's pitest.mutationThreshold. -->
+		<!-- Mutation-score floor, a few points under what this module measures today. See the root
+		     pom's pitest.mutationThreshold. -->
 		<pitest.mutationThreshold>88</pitest.mutationThreshold>
 	</properties>
 	<build>
 		<plugins>
-			<!-- The rule jar is also the command line: `java -jar` runs the checks
-			     against a project directory with no Maven build around them, which
-			     is what a pre-commit hook, a Gradle project and anyone evaluating
-			     the rules before wiring them all need. Naming the class in the
-			     manifest costs the jar nothing when it is resolved as a
-			     maven-enforcer dependency instead. -->
+			<!-- The rule jar is also the command line: java -jar runs the checks against a project
+			     directory with no Maven build around them. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
@@ -33,11 +28,8 @@
 						<manifest>
 							<mainClass>io.github.adamw7.tools.enforcer.cli.Main</mainClass>
 						</manifest>
-						<!-- No module-info.java here, so without this the JPMS name would
-						     be derived from the jar filename and would change with the
-						     artifactId or the version scheme. Pinning the name the
-						     filename already produced keeps it stable for a consumer that
-						     puts the rule jar on the module path. See mcp-common. -->
+						<!-- No module-info.java here, so pin the JPMS name the jar filename already
+						     produced rather than let it change with the artifactId. -->
 						<manifestEntries>
 							<Automatic-Module-Name>tools.claude.code.enforcer</Automatic-Module-Name>
 						</manifestEntries>
@@ -63,13 +55,8 @@
 							</execution>
 						</executions>
 						<configuration>
-							<!-- The *IT tests run real Maven builds against the rule jar
-							     this module has just packaged, which a forked test JVM
-							     cannot locate on its own: the local repository may have
-							     been relocated with -Dmaven.repo.local, and the jar's
-							     name comes from the build's finalName. Only the build
-							     knows all of that, so it hands each fact over rather
-							     than letting a test guess. -->
+							<!-- The *IT tests run real Maven builds against the jar just packaged,
+							     which only the build can locate. -->
 							<systemPropertyVariables>
 								<enforcer.it.mavenHome>${maven.home}</enforcer.it.mavenHome>
 								<enforcer.it.localRepository>${settings.localRepository}</enforcer.it.localRepository>
@@ -84,18 +71,11 @@
 			</build>
 		</profile>
 	</profiles>
-	<!-- flatten-maven-plugin is inherited from the root pom, which flattens the
-	     CI-friendly ${revision} out of every module's pom. This module needs it
-	     because it is consumed as a maven-enforcer-plugin dependency resolved
-	     from a repository outside the reactor. -->
+	<!-- Needed here because this module is consumed as a maven-enforcer-plugin dependency resolved
+	     from outside the reactor. -->
 	<dependencies>
-		<!-- Reads a Markdown document into its lines plus the code and HTML-comment
-		     masks every structural check is made against. It is a module of its own
-		     because the adopt pipeline's ClaudeMdConformer reshapes a CLAUDE.md so
-		     the claudeMdFormat rule below passes, and the two have to read the
-		     document identically; adopt cannot depend on this module to get that,
-		     since it would put the maven-enforcer API and a shipped rule on every
-		     consumer's classpath. -->
+		<!-- The Markdown reader adopt's ClaudeMdConformer shares, so the checker and the rewriter
+		     cannot disagree about a document. -->
 		<dependency>
 			<groupId>io.github.adamw7</groupId>
 			<artifactId>tools.markdown-common</artifactId>
@@ -113,13 +93,8 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
-		<!-- Reads the YAML front matter of a skill, sub-agent, command or OKF
-		     concept document. The rules used to scan those lines by hand, which
-		     meant re-deriving where a quoted scalar ends, where a trailing comment
-		     begins, and how a block scalar folds — every one of them a place the
-		     check could disagree with the loader Claude Code itself reads the
-		     document with. FrontMatter now composes the block with SnakeYAML
-		     instead, so the rules validate what the tool acts on. -->
+		<!-- Reads YAML front matter through SnakeYAML, so the rules validate what Claude Code's own
+		     loader acts on. -->
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>

--- a/code/context/pom.xml
+++ b/code/context/pom.xml
@@ -12,18 +12,14 @@
 	<name>Context engineering</name>
 	<description>Fast, regex-based finder that builds the tree of classes used by a given class and assembles context for gen-AI agents, exposed over an MCP server.</description>
 	<properties>
-		<!-- Mutation-score floor for this module, a few points under the 95% it
-		     measures today so an equivalent refactor cannot turn the build red.
-		     See the root pom's pitest.mutationThreshold. -->
+		<!-- Mutation-score floor, a few points under what this module measures today. See the root
+		     pom's pitest.mutationThreshold. -->
 		<pitest.mutationThreshold>92</pitest.mutationThreshold>
 	</properties>
 	<build>
 		<plugins>
-			<!-- No module-info.java here, so the JPMS name was being derived from
-			     the jar filename, which changes with the artifactId or the version
-			     scheme and takes a consumer's `requires` clause down with it.
-			     Pinning the name the filename already produced makes it part of the
-			     artifact. See mcp-common, which does the same. -->
+			<!-- No module-info.java here, so pin the JPMS name the jar filename already produced
+			     rather than let it change with the artifactId. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
@@ -84,9 +80,7 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
-		<!-- Emits the YAML frontmatter of every OKF concept document. Quoting and
-		     escaping are the emitter's job: hand-writing them wrote a raw newline
-		     or control character straight into a double-quoted scalar. -->
+		<!-- Quotes and escapes the YAML front matter of every OKF concept document. -->
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>

--- a/code/protogen-maven-plugin-test/pom.xml
+++ b/code/protogen-maven-plugin-test/pom.xml
@@ -12,21 +12,13 @@
 	<name>protogen-maven-plugin-test</name>
 	<description>Integration test module that exercises the protogen-maven-plugin by generating and compiling protobuf builders end to end.</description>
 	<properties>
-		<!-- This module only exercises generated protobuf classes, so the
-		     instruction-coverage gate is not meaningful here. The mutation gate is
-		     not meaningful for the same reason, and for a sharper one: every class
-		     here was written by protoc and the plugin, so PIT scored the module at
-		     10% — 3406 of its 4122 mutants uncovered — measuring a generator's
-		     output rather than anybody's tests. The generator itself is mutated in
-		     protogen-maven-plugin. -->
+		<!-- Only generated protobuf classes here, so the coverage and mutation gates would measure a
+		     generator rather than anybody's tests. The generator itself is mutated in protogen-
+		     maven-plugin. -->
 		<jacoco.skip>true</jacoco.skip>
 		<pitest.skip>true</pitest.skip>
-		<!-- An integration-test harness for the protogen-maven-plugin, not a
-		     reusable library: it has no main Java sources (only src/main/proto),
-		     so its -sources.jar is empty and Central validation rejects it. Keep
-		     it out of both publications: the GitHub Packages deployment
-		     maven-deploy-plugin performs on `mvn deploy`, and the Maven Central
-		     bundle the root pom's release profile publishes. -->
+		<!-- A test harness with no main Java sources, so its -sources.jar is empty and Central
+		     rejects it: keep it out of both publications. -->
 		<maven.deploy.skip>true</maven.deploy.skip>
 		<central.skipPublishing>true</central.skipPublishing>
 	</properties>

--- a/code/protogen-maven-plugin/pom.xml
+++ b/code/protogen-maven-plugin/pom.xml
@@ -12,20 +12,14 @@
 	<name>protogen-maven-plugin</name>
 	<description>Maven plugin that generates fluent, type-safe builders for protobuf-generated message classes during the generate-sources phase.</description>
 	<properties>
-		<!-- Mutation-score floor for this module, a few points under the 87% it
-		     measures today so an equivalent refactor cannot turn the build red.
-		     See the root pom's pitest.mutationThreshold. -->
+		<!-- Mutation-score floor, a few points under what this module measures today. See the root
+		     pom's pitest.mutationThreshold. -->
 		<pitest.mutationThreshold>84</pitest.mutationThreshold>
 	</properties>
 	<build>
 		<plugins>
-			<!-- No module-info.java here, so the JPMS name was being derived from
-			     the jar filename, which changes with the artifactId or the version
-			     scheme. Unlike the library modules this artifactId carries no
-			     `tools.` prefix, so the name is spelled out rather than left to the
-			     filename: a Maven plugin is resolved by coordinates and loaded by
-			     Maven's own classloader, never named in a `requires`, so nothing
-			     depends on the previous filename-derived spelling. See mcp-common. -->
+			<!-- No module-info.java here. A plugin is loaded by coordinates and never named in a
+			     requires, so the JPMS name is spelled out rather than derived from the filename. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
@@ -37,8 +31,7 @@
 					</archive>
 				</configuration>
 			</plugin>
-			<!-- Expose the mockito-core jar path so it can be pre-loaded as a Java
-			     agent below, avoiding Mockito's slow runtime self-attach. -->
+			<!-- Path for the Mockito agent below. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
@@ -51,13 +44,8 @@
 					</execution>
 				</executions>
 			</plugin>
-			<!-- Pre-load Mockito as a Java agent at JVM startup. This module is the
-			     only one that uses Mockito; loading the agent up front (instead of
-			     letting Mockito self-attach on first mock creation) both silences the
-			     "Mockito is currently self-attaching" deprecation warning and moves
-			     the ~0.8s byte-buddy attach cost out of the timed test method, so the
-			     surefire per-test timeout can stay tight. @{argLine} keeps the JaCoCo
-			     agent (coverage profile) composed in. -->
+			<!-- Pre-loads Mockito as an agent instead of its slow runtime self-attach, keeping that
+			     cost out of the timed test method. @{argLine} keeps the JaCoCo agent composed in. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
@@ -91,8 +79,7 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<!-- The plugin itself logs through the Mojo log, so log4j2 is narrowed to
-		     the scope the tests need it in and stays out of the plugin's own jar. -->
+		<!-- The plugin logs through the Mojo log, so log4j2 stays out of its jar. -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>

--- a/data-test/pom.xml
+++ b/data-test/pom.xml
@@ -17,10 +17,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<!-- The tight heap is the point of this module: it proves the
-					     iterative sources stream rather than buffer. @{argLine} keeps
-					     whatever the build already put there (the JaCoCo agent under
-					     the coverage profile) instead of dropping it. -->
+					<!-- The tight heap is the point of this module: it proves the iterative sources
+					     stream rather than buffer. @{argLine} keeps the JaCoCo agent composed in. -->
 					<argLine>@{argLine} -Xmx16m</argLine>
 				</configuration>
 			</plugin>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -12,16 +12,13 @@
 	<name>Tooling for data</name>
 	<description>Data sources (CSV, GZip, JDBC, Parquet; in-memory and iterative), a uniqueness-checking tool, data structures, and an MCP server exposing the uniqueness checker.</description>
 	<properties>
-		<!-- Mutation-score floor for this module, a few points under the 86% it
-		     measures today so an equivalent refactor cannot turn the build red.
-		     See the root pom's pitest.mutationThreshold. -->
+		<!-- Mutation-score floor, a few points under what this module measures today. See the root
+		     pom's pitest.mutationThreshold. -->
 		<pitest.mutationThreshold>82</pitest.mutationThreshold>
 	</properties>
 	<build>
 		<plugins>
-			<!-- Expose the mockito-core jar path (it arrives transitively through
-			     spring-boot-starter-test) so it can be pre-loaded as a Java agent
-			     below. -->
+			<!-- Path for the Mockito agent below; it arrives through spring-boot-starter-test. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
@@ -38,23 +35,11 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<!-- Run unit tests from the classpath, not the module path, so the
-					     NetworkOffExtension registered through META-INF/services is
-					     discovered by JUnit's extension auto-detection. ServiceLoader
-					     ignores META-INF/services for a named module, and surefire
-					     otherwise patches the test classes into the
-					     io.github.adamw7.tools.data module. Running from the classpath
-					     also lets the tests reach the MCP client/SDK types (which live in
-					     the unnamed module) without patching the module open. -->
-					<!-- The enable-native-access flag grants the native access the DuckDB
-					     JDBC driver needs for its System::load call. Without it the JVM
-					     warns on every Parquet test and, as that warning says, will block
-					     the call outright in a future release.
-
-					     Pre-loading Mockito as a Java agent (the Spring Boot test context
-					     mocks beans) replaces its runtime self-attach, which warns today
-					     and stops working once the JDK disallows dynamic agent loading.
-					     @{argLine} keeps the JaCoCo agent (coverage profile) composed in. -->
+					<!-- Classpath, not module path: ServiceLoader ignores META-INF/services in a
+					     named module, so NetworkOffExtension would never be found. -->
+					<!-- enable-native-access covers the DuckDB driver's System::load call, and the
+					     Mockito agent replaces its runtime self-attach. @{argLine} keeps the JaCoCo
+					     agent composed in. -->
 					<argLine>@{argLine} --enable-native-access=ALL-UNNAMED -javaagent:${org.mockito:mockito-core:jar}</argLine>
 					<useModulePath>false</useModulePath>
 				</configuration>
@@ -67,14 +52,9 @@
 					<executable>true</executable>
 					<layout>JAR</layout>
 					<jvmArguments>-Djdk.tls.client.protocols=TLSv1.3</jvmArguments>
-					<!-- Attach the executable MCP-server jar under a classifier instead of
-					     letting it replace the main artifact. Repackaging in place gives
-					     tools.data a nested BOOT-INF/ layout, which every consumer inherits:
-					     the assembly's jar-with-dependencies then carries SampleApp under
-					     BOOT-INF/classes while its manifest Main-Class points at the flat
-					     name, so `java -jar` fails with ClassNotFoundException. With the
-					     classifier the main artifact stays an ordinary library jar and the
-					     runnable server is tools.data-{version}-boot.jar. -->
+					<!-- Attach the executable server jar under a classifier, so the main artifact
+					     stays an ordinary library jar rather than a nested BOOT-INF layout every
+					     consumer inherits. -->
 					<classifier>boot</classifier>
 				</configuration>
 			</plugin>
@@ -97,10 +77,8 @@
 							</execution>
 						</executions>
 						<configuration>
-							<!-- Run the *IT tests from the classpath, so their MCP
-							     client/SDK types (in the unnamed module) resolve without
-							     patching the module open, and the server runs exactly as it
-							     does in production (a classpath Spring Boot app). -->
+							<!-- Classpath again, so the *IT tests reach the MCP client types and run
+							     the server as production does. -->
 							<useModulePath>false</useModulePath>
 						</configuration>
 					</plugin>

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -12,22 +12,16 @@
 	<name>grpc-example</name>
 	<description>End-to-end gRPC example demonstrating the protogen-generated, compile-time-safe protobuf builders in a working service.</description>
 	<properties>
-		<!-- This module only exercises generated protobuf/gRPC classes, so the
-		     instruction-coverage gate is not meaningful here. The mutation gate is
-		     not meaningful for the same reason: with no hand-written production
-		     Java at all, PIT scored the module at 14% — 615 of its 776 mutants
-		     uncovered — measuring protoc's output rather than anybody's tests. -->
+		<!-- Only generated protobuf and gRPC classes here, so the coverage and mutation gates would
+		     measure protoc's output rather than anybody's tests. -->
 		<jacoco.skip>true</jacoco.skip>
 		<pitest.skip>true</pitest.skip>
-		<!-- An example, not a reusable library, so keep it out of both
-		     publications: the GitHub Packages deployment maven-deploy-plugin
-		     performs on `mvn deploy`, and the Maven Central bundle the root pom's
-		     release profile publishes. -->
+		<!-- An example, not a reusable library: keep it out of the GitHub Packages deploy and the
+		     Maven Central bundle. -->
 		<maven.deploy.skip>true</maven.deploy.skip>
 		<central.skipPublishing>true</central.skipPublishing>
-		<!-- Default main class for exec:java. Declared as a property (rather than
-		     hard-coded in the plugin <configuration>) so that -Dexec.mainClass on
-		     the command line can override it to run GreeterClient. -->
+		<!-- A property rather than a literal in the plugin configuration, so -Dexec.mainClass can
+		     override it to run GreeterClient. -->
 		<exec.mainClass>io.github.adamw7.tools.grpc.GreeterServer</exec.mainClass>
 	</properties>
 	<build>
@@ -134,12 +128,8 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<!--
-			This module's src/main carries only .proto: the sole Java that logs is the
-			GreeterClient/GreeterServer pair under src/test, so both artifacts are test
-			scope. At compile scope they were published as dependencies of a jar that
-			cannot use them.
-		-->
+		<!-- src/main carries only .proto; the Java that logs is the test-scoped
+		     GreeterClient/GreeterServer pair. -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>

--- a/markdown-common/pom.xml
+++ b/markdown-common/pom.xml
@@ -12,20 +12,14 @@
 	<name>Shared Markdown reader</name>
 	<description>Reads a Markdown document into its lines plus the masks marking which of them are code and which sit inside an HTML comment, so a checker and a rewriter agree on what the document says.</description>
 	<properties>
-		<!-- Mutation-score floor for this module, a few points under what it
-		     measures today so an equivalent refactor cannot turn the build red.
-		     See the root pom's pitest.mutationThreshold. -->
+		<!-- Mutation-score floor, a few points under what this module measures today. See the root
+		     pom's pitest.mutationThreshold. -->
 		<pitest.mutationThreshold>91</pitest.mutationThreshold>
 	</properties>
 	<build>
 		<plugins>
-			<!-- This module has no module-info.java, so the JPMS name a consumer's
-			     `requires` resolves against was being derived from the jar filename.
-			     javac warns about publishing such a filename-based automodule,
-			     because renaming the artifact silently renames the module. Pinning
-			     the manifest entry to the name the filename already produced keeps
-			     existing consumers working and makes the name part of the artifact
-			     instead of an accident. See mcp-common, which does the same. -->
+			<!-- No module-info.java here, so pin the JPMS name the jar filename already produced
+			     rather than let it change with the artifactId. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
@@ -39,15 +33,9 @@
 			</plugin>
 		</plugins>
 	</build>
-	<!-- Deliberately dependency-free beyond the JDK. Two modules read Markdown the
-	     same way and must keep agreeing about it: claude-code-enforcer's
-	     claudeMdFormat rule judges a CLAUDE.md, and adopt's ClaudeMdConformer
-	     reshapes one so that rule passes. They used to carry a copy of this reader
-	     each, because adopt cannot depend on claude-code-enforcer without putting
-	     the maven-enforcer API and a shipped rule on every consumer's classpath.
-	     Carving the reader out is what lets both depend on the same one instead —
-	     which only works while it stays free of either module's dependencies, so
-	     add nothing here without a very good reason. -->
+	<!-- Deliberately dependency-free beyond the JDK: claude-code-enforcer's claudeMdFormat rule and
+	     adopt's ClaudeMdConformer both read Markdown through this module, and adopt cannot take on
+	     the enforcer's dependencies. Add nothing here. -->
 	<dependencies>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/mcp-common/pom.xml
+++ b/mcp-common/pom.xml
@@ -16,26 +16,16 @@
 			<resource>
 				<directory>src/main/resources</directory>
 			</resource>
-			<!-- A dedicated directory that IS filtered, so the project version is
-			     baked into mcp-common-build.properties and advertised in every MCP
-			     handshake (see ServerVersion). The spring-boot-starter parent filters
-			     with the @...@ delimiter, which that file uses. Kept separate from
-			     src/main/resources because overlapping filtered and unfiltered
-			     entries on one directory are unreliable, and because a future
-			     log4j2.properties here must stay unfiltered. -->
+			<!-- Filtered separately, so the version reaches mcp-common-build.properties (the @...@
+			     delimiter the parent configures) and every MCP handshake. See ServerVersion. -->
 			<resource>
 				<directory>src/main/filtered-resources</directory>
 				<filtering>true</filtering>
 			</resource>
 		</resources>
 		<plugins>
-			<!-- This module has no module-info.java, so the JPMS name that
-			     `requires tools.mcp.common` in tools.data resolves against was being
-			     derived from the jar filename. javac warns about publishing such a
-			     filename-based automodule, because renaming the artifact silently
-			     renames the module. Pinning the manifest entry to the name the
-			     filename already produced keeps existing consumers working and makes
-			     the name part of the artifact instead of an accident. -->
+			<!-- No module-info.java here, so pin the JPMS name the jar filename already produced
+			     rather than let it change with the artifactId. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,123 +19,39 @@
 	<url>https://github.com/adamw7/tools</url>
 	<properties>
 		<revision>2.6.0-SNAPSHOT</revision>
-		<!-- The Spring Boot parent derives maven.compiler.release from this, so
-		     javac both targets and validates against the Java 25 API. Setting
-		     maven.compiler.source/target as well would be dead weight: the
-		     compiler plugin ignores them once release is set, and a second copy
-		     of the number is a copy that can drift. -->
 		<java.version>25</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<!-- Named rather than written twice: the adopt pipeline wires this same
-		     plugin into other people's poms, and it reads the number from this
-		     property through its filtered build metadata. A literal in both places
-		     is a literal that drifts, and the half that drifts is the one nobody
-		     builds — a stranger's repository, adopted with a version this project
-		     stopped using. -->
+		<!-- Read back by the adopt pipeline, which wires this same plugin into other poms. -->
 		<maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
-		<!-- project.build.outputTimestamp — which makes the build reproducible by
-		     having every archive-producing plugin (jar, source, javadoc, assembly,
-		     plugin descriptor, Spring Boot repackage) stamp one fixed instant on
-		     its entries and write them in a stable order — is deliberately *not*
-		     declared here. A literal in the pom is a date somebody has to remember
-		     to bump, and releases here are a `revision` edit rather than a
-		     maven-release-plugin run, so nothing would bump it automatically.
-
-		     The publishing workflows pass it instead, deriving it from the released
-		     commit's own timestamp (`git log -1` with an ISO date format) and
-		     handing it to Maven as a user property, which overrides the pom
-		     cleanly. Pinning it to the commit rather than to the clock is what lets
-		     anyone check out the tag, rebuild, and get artifacts byte-identical to
-		     the published ones — the supply-chain posture in docs/adr/0002. See
-		     "Releasing" in AGENTS.md for the exact command and its local
-		     equivalent. -->
-		<!-- One version for the whole protobuf toolchain: the protobuf-java
-		     runtime below and the protoc that protobuf-maven-plugin runs. Keeping
-		     them apart let the generated code and the runtime it compiles against
-		     drift by two minor versions. -->
+		<!-- One version for the whole toolchain: the protobuf-java runtime and protoc. -->
 		<protobuf.version>4.35.1</protobuf.version>
 		<grpc.version>1.83.1</grpc.version>
 		<derby.version>10.17.1.0</derby.version>
 		<log4j2.version>2.26.1</log4j2.version>
-		<!-- Named maven.api.version, not maven.version: Maven itself exposes
-		     ${maven.version} as the running Maven's own version. -->
+		<!-- Not maven.version: Maven exposes that as the running Maven's own version. -->
 		<maven.api.version>4.0.0-rc-5</maven.api.version>
 		<argLine/>
-		<!-- Per-test timeout for unit tests (see the surefire plugin config). The
-		     build runs the reactor in parallel (-T1C in .mvn/maven.config), so
-		     several modules' test forks run at once and contend for CPU. That
-		     stretches the one-time cold-JVM/class-loading warmup the first test in
-		     each fork pays: on a dedicated core it is ~0.7s, but under 4-way fork
-		     contention the heaviest first-in-fork test (an MCP server boot in the
-		     small mcp-common module, which amortizes the warmup over nothing) was
-		     measured at up to ~3.9s. The limit is sized above that worst case with
-		     margin yet still low enough to catch a test doing real work. The
-		     coverage profile overrides it to a larger value because the JaCoCo
-		     agent's bytecode instrumentation roughly doubles first-use
-		     class-loading time on top of the contention. -->
+		<!-- Per-test timeout for unit tests, sized above the cold-fork warmup a parallel build pays. -->
 		<unit.test.method.timeout>5 s</unit.test.method.timeout>
-		<!-- Companion limit for lifecycle methods (@BeforeAll/@BeforeEach/@AfterEach/
-		     @AfterAll). Deliberately far looser than the per-test method timeout:
-		     lifecycle methods legitimately do shared, one-time setup that a test
-		     method must not (e.g. DBTest boots an embedded Derby database and loads
-		     fixtures, ~2s on a cold fork). This still fails a fixture that is truly
-		     stuck (deadlock, infinite retry) rather than merely heavy; a total hang
-		     that never returns is caught by forkedProcessTimeoutInSeconds. The
-		     coverage profile raises it because JaCoCo instrumentation slows setup. -->
+		<!-- Lifecycle methods (@BeforeAll and friends) do shared setup a test method must not, so
+		     they get a looser limit. -->
 		<unit.test.lifecycle.timeout>10 s</unit.test.lifecycle.timeout>
-		<!-- Minimum mutation score (percent of mutants killed) the pitest profile
-		     enforces, so the weekly run fails on a regression instead of merely
-		     recording one in an artifact nobody opens. This is the floor, sized on
-		     the weakest module at the time it was introduced (mcp-common, 84%); a
-		     module scoring comfortably above it raises the bar in its own
-		     <properties>, which is what makes the gate mean something module by
-		     module. Each number sits a few points under the measured score, so an
-		     equivalent refactor — or a timed-out mutant, which PIT counts as
-		     killed — cannot turn a green build red on its own. Ratchet a number up
-		     once a module's score has settled above it; never down to make a red
-		     build pass. PIT skips a module with no production code or no tests
-		     entirely, so the threshold never applies to one. -->
+		<!-- Mutation-score floor for the pitest profile; a module scoring higher raises it in its
+		     own <properties>. Ratchet up, never down. -->
 		<pitest.mutationThreshold>80</pitest.mutationThreshold>
-		<!-- Whether the pitest profile skips this module. Mutating code nobody
-		     wrote says nothing about the tests: the two modules that opt out hold
-		     no hand-written production Java at all, only protobuf and gRPC classes
-		     generated from their .proto files, and PIT scored them at 10% and 14%
-		     purely because a generator's output has no unit tests aimed at it. The
-		     plugin that generates those builders is itself mutated, in
-		     protogen-maven-plugin, which is where the logic under test lives. A
-		     module that grows hand-written production code should clear this flag
-		     and take a threshold instead. -->
+		<!-- Set true by the modules holding only generated code, where a mutation score measures a
+		     generator rather than tests. -->
 		<pitest.skip>false</pitest.skip>
-		<!-- Whole-fork wall-clock cap (seconds). JUnit's per-method timeout only
-		     reports after a method returns; it cannot unwedge a thread that never
-		     yields (deadlock, non-daemon thread that never dies). Surefire kills the
-		     forked JVM after this many seconds, so a genuinely hung test still fails
-		     the build. Sized far above a full module's fast unit run. -->
+		<!-- Whole-fork wall-clock cap. The per-method timeout only reports after a method returns,
+		     so a wedged thread needs this. -->
 		<unit.test.fork.timeout>300</unit.test.fork.timeout>
-		<!-- How many test classes one module runs at a time. Unit tests are
-		     class-parallel (see the surefire configurationParameters): the reactor's
-		     -T1C already builds several modules at once, but the dependency graph
-		     starves it whenever a module everything waits on is the only one left,
-		     and that module then ran its whole suite one class after another. This
-		     fills those gaps. It is a small fixed number rather than a per-core one
-		     precisely because -T1C is already per-core: on a 4-core machine the two
-		     multiply out to 4 module threads x this, so a per-core value here would
-		     oversubscribe by the square of the core count and push the slowest
-		     methods into the ${unit.test.method.timeout} limit. Lower it to 1 to
-		     turn class-parallelism off for a run: -Dunit.test.parallelism=1. -->
+		<!-- Test classes one module runs at a time. -T1C already parallelises modules, so keep this
+		     a small fixed number; -Dunit.test.parallelism=1 turns it off. -->
 		<unit.test.parallelism>3</unit.test.parallelism>
-		<!-- Maven Central publishing behavior for the release profile. Defaults
-		     publish on release; overridable so the maven-publish.yml
-		     workflow_dispatch dry run can upload and validate without
-		     publishing: -Dcentral.autoPublish=false -Dcentral.waitUntil=validated. -->
+		<!-- Overridable so maven-publish.yml's dry run can upload and validate without publishing. -->
 		<central.autoPublish>true</central.autoPublish>
 		<central.waitUntil>published</central.waitUntil>
-		<!-- Whether the release profile keeps this module out of the Maven Central
-		     bundle. Modules that are examples, test harnesses or distributions
-		     rather than reusable libraries set it to true in their own
-		     <properties>, which is one line instead of a copy of the
-		     central-publishing plugin declaration inside a copy of the release
-		     profile. -->
+		<!-- Set true by modules that are examples, harnesses or distributions rather than libraries. -->
 		<central.skipPublishing>false</central.skipPublishing>
 	</properties>
 	<licenses>
@@ -201,22 +117,15 @@
 				<version>1.4.2</version>
 				<scope>test</scope>
 			</dependency>
-			<!-- No managed scope, because the two modules that read markup with jsoup
-			     want different ones: adopt parses every pom.xml it edits, so it needs
-			     the parser at runtime, while claude-code-enforcer only reads HTML back
-			     in its own tests. The narrower of the two is declared on the module
-			     that wants it rather than imposed on both from here. -->
+			<!-- No managed scope: adopt parses poms at runtime, claude-code-enforcer only reads HTML
+			     in its tests. -->
 			<dependency>
 				<groupId>org.jsoup</groupId>
 				<artifactId>jsoup</artifactId>
 				<version>1.23.1</version>
 			</dependency>
-			<!-- log4j2.version and derby.version are Spring Boot's own property
-			     names. Setting them (rather than only pinning the artifacts we
-			     declare) is what keeps the rest of each family in step: the
-			     spring-boot-dependencies BOM manages derbyshared and derbynet from
-			     derby.version, so leaving it at Boot's value resolved derbyshared
-			     10.16.1.1 underneath derby 10.17.1.0. -->
+			<!-- Spring Boot's own property names, so the BOM keeps the rest of each family
+			     (derbyshared, derbynet) in step. -->
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-api</artifactId>
@@ -284,12 +193,6 @@
 				<artifactId>reflections</artifactId>
 				<version>0.10.2</version>
 			</dependency>
-			<!-- The adoption command-line parser. Declared here rather than left to
-			     the Spring Boot parent, which does not manage it: the BOM covers the
-			     web and JSON stack the MCP servers are built on, not a CLI library.
-			     snakeyaml, which claude-code-enforcer reads front matter with, needs
-			     no entry for the opposite reason — Boot already pins it, and pinning
-			     it a second time here is a copy that can fall behind the parent. -->
 			<dependency>
 				<groupId>info.picocli</groupId>
 				<artifactId>picocli</artifactId>
@@ -300,9 +203,7 @@
 				<artifactId>grpc-protobuf</artifactId>
 				<version>${grpc.version}</version>
 			</dependency>
-			<!-- The gRPC tree requests error_prone_annotations at two versions
-			     (grpc directly vs. gson transitively). Pin the highest so the
-			     dependencyConvergence enforcer rule is satisfied. -->
+			<!-- Requested at two versions; pin the highest so dependencyConvergence is satisfied. -->
 			<dependency>
 				<groupId>com.google.errorprone</groupId>
 				<artifactId>error_prone_annotations</artifactId>
@@ -336,10 +237,8 @@
 				<artifactId>org.eclipse.jdt.core</artifactId>
 				<version>3.46.0</version>
 			</dependency>
-			<!-- org.eclipse.jdt.core drags in the Eclipse platform tree, whose
-			     internal artifacts resolve to several different versions along
-			     different paths. Pin the highest requested version of each so the
-			     dependencyConvergence enforcer rule is satisfied. -->
+			<!-- The Eclipse platform tree resolves at several versions along different paths; pin
+			     the highest so dependencyConvergence is satisfied. -->
 			<dependency>
 				<groupId>org.eclipse.platform</groupId>
 				<artifactId>org.eclipse.osgi</artifactId>
@@ -369,9 +268,7 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
-			<!-- Managed only to attach the exclusion; the version stays the one the
-			     spring-boot-dependencies BOM already supplies, so it cannot fall
-			     behind the parent on the next Spring Boot bump. -->
+			<!-- Managed only to attach the exclusion; the version stays the parent's. -->
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter</artifactId>
@@ -392,46 +289,15 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>3.5.6</version>
 					<configuration>
-						<!-- Fail any unit test whose testable method runs
-						     ${unit.test.method.timeout} or longer, so a test doing
-						     real work (rather than the unavoidable one-time
-						     JVM/class-loading warmup a cold fork pays, ~0.7s at most)
-						     is caught. Applies to @Test, @ParameterizedTest,
-						     @RepeatedTest, @TestFactory and @TestTemplate methods (not
-						     lifecycle setup/teardown). Only surefire (unit tests)
-						     inherits this; failsafe integration tests are unaffected.
-						     A genuinely heavier test opts out with an explicit
-						     @Timeout. The one module using Mockito pre-loads it as a
-						     -javaagent (see protogen-maven-plugin/pom.xml) so its
-						     byte-buddy self-attach is not billed to the first timed
-						     method. The coverage profile raises the limit because
-						     JaCoCo instrumentation slows the timed methods. -->
 						<forkedProcessTimeoutInSeconds>${unit.test.fork.timeout}</forkedProcessTimeoutInSeconds>
-						<!-- Engage the network kill-switch for every unit test: the
-						     data module registers a NetworkOffExtension via
-						     META-INF/services that turns the network off before any
-						     test runs, so a unit test can never open an outbound
-						     connection. Auto-detection and the guard property are set
-						     only here on surefire, so failsafe integration tests (*IT),
-						     which need real network, keep it. -->
+						<!-- The guard the data module's NetworkOffExtension reads. Set on surefire only,
+						     so failsafe *IT tests keep the network. -->
 						<systemPropertyVariables>
 							<tools.test.network.off>true</tools.test.network.off>
 						</systemPropertyVariables>
-						<!-- Run each module's unit tests a class at a time in parallel
-						     (${unit.test.parallelism} of them at once), but every method
-						     of one class on a single thread. Concurrency between classes
-						     is the mode this suite can actually take: a class already
-						     owns its fixture (79 of them take a @TempDir, which JUnit
-						     makes unique per class), whereas concurrency *within* a class
-						     would interleave methods sharing one @BeforeEach-built
-						     instance, which nothing here was written for. State a class
-						     cannot own alone is guarded at the class that touches it:
-						     @Isolated where a test writes something JVM-wide that others
-						     read (a system property, the allowed base directory), and
-						     @ResourceLock where test classes share one database. Each
-						     module's TestConventionsArchitectureTest holds that line for
-						     new tests, so the next such test fails the build rather than
-						     the suite beside it. -->
+						<!-- Classes in parallel, every method of one class on a single thread. State
+						     a class cannot own alone is guarded at the test with @Isolated or
+						     @ResourceLock. -->
 						<properties>
 							<configurationParameters>
 								junit.jupiter.execution.timeout.testable.method.default = ${unit.test.method.timeout}
@@ -580,16 +446,9 @@
 		</pluginManagement>
 		<plugins>
 			<plugin>
-				<!-- Lint scripts/**/*.sh and .claude/hooks/**/*.sh with shellcheck.
-				     binaryResolutionMethod
-				     "embedded" runs the shellcheck binary bundled inside the plugin
-				     jar (pulled from Maven Central like any other artifact), so the
-				     build needs no shellcheck on the PATH and downloads nothing at
-				     execution time. The previous default fetched the binary from
-				     GitHub releases on first use, which fails in networks that
-				     cannot reach that host (offline builds, Claude Code web/remote
-				     sessions whose proxy scopes GitHub to this repo only), breaking
-				     the root pom with "Input is not in the XZ format". -->
+				<!-- Lints scripts/**/*.sh and .claude/hooks/**/*.sh. The embedded binary ships
+				     inside the plugin jar, so the lint needs no shellcheck on the PATH and no
+				     network. -->
 				<groupId>dev.dimlight</groupId>
 				<artifactId>shellcheck-maven-plugin</artifactId>
 				<inherited>false</inherited>
@@ -601,12 +460,7 @@
 						</goals>
 						<configuration>
 							<binaryResolutionMethod>embedded</binaryResolutionMethod>
-							<!-- The plugin defaults to reporting shellcheck's findings as
-							     build warnings and passing anyway, so the lint ran for a
-							     log nobody reads: a probe script with an unquoted
-							     expansion and an unassigned variable was reported in full
-							     and the build still succeeded. Both source directories are
-							     clean today, so the lint gates from here on. -->
+							<!-- The plugin otherwise reports findings as warnings and passes anyway. -->
 							<failBuildIfWarnings>true</failBuildIfWarnings>
 							<sourceDirs>
 								<sourceDir>
@@ -615,13 +469,6 @@
 										<include>**/*.sh</include>
 									</includes>
 								</sourceDir>
-								<!-- The session-start hook is a shell script the runtime
-								     executes before any tool call, so a mistake in it fails
-								     a session rather than a build and is found by whoever
-								     opened that session. hooksFormat checks the shebang and
-								     the executable bit; only shellcheck reads what the
-								     script does, which is why the hook is linted with the
-								     same binary as scripts/ rather than trusted. -->
 								<sourceDir>
 									<directory>${project.basedir}/.claude/hooks</directory>
 									<includes>
@@ -660,24 +507,16 @@
 								</requirePluginVersions>
 								<dependencyConvergence />
 								<requireNoRepositories />
-								<!-- A profile named on the command line that no pom declares
-								     is silently ignored by Maven, so a typo in -Pcoverage or
-								     -Pintegration-tests looks like a clean run that quietly
-								     skipped the very thing it was asked for. -->
+								<!-- Maven ignores an unknown -P id silently, so a typo looks like a
+								     clean run that skipped the work. -->
 								<requireProfileIdsExist />
 							</rules>
 						</configuration>
 					</execution>
 				</executions>
 			</plugin>
-			<!-- The root pom uses a CI-friendly ${revision} version, so the
-			     installed/deployed pom of every module would otherwise still
-			     contain the literal ${revision} in its <parent> and in
-			     inter-module dependency versions. Flatten every module (this
-			     execution is inherited by all reactor modules and their
-			     submodules) into a self-contained pom whose versions are
-			     resolved, which is required for Maven Central and for the
-			     claude-code-enforcer module consumed as a plugin dependency. -->
+			<!-- Resolves ${revision} out of every module's installed pom, which Maven Central and
+			     the enforcer-as-plugin-dependency both need. -->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>flatten-maven-plugin</artifactId>
@@ -707,27 +546,11 @@
 
 	<profiles>
 		<profile>
-			<!-- Validates that the repository CLAUDE.md exists and is well formed,
-			     using the custom rule from the tools.claude-code-enforcer module.
-			     Opt-in via -DenforceClaudeMd so that only the dedicated CI build
-			     (.github/workflows/maven.yml) runs it; every other Maven build
-			     (other workflows, local) is unaffected and needs no bootstrap.
-			     The rule must be installed into the local repo first (see
-			     AGENTS.md "CLAUDE.md enforcement"). -->
+			<!-- Opt-in documentation checks (-DenforceClaudeMd), run only by
+			     .github/workflows/maven.yml. The rule must be installed first; see AGENTS.md. -->
 			<id>claude-md-enforce</id>
-			<!-- Both conditions must hold, so this activates in the root project
-			     alone: it is the only one with a CLAUDE.md beside its pom. A profile
-			     declared in a parent is inherited, so every module would otherwise
-			     evaluate this one and take on the plugin below — and with it a reactor
-			     edge to claude-code-enforcer, because Maven orders a project after
-			     every plugin dependency it declares. Maven tolerates a cycle whose
-			     closing edge comes from a plugin, which is why an inherited profile
-			     went unnoticed while no reactor module was a real dependency of the
-			     enforcer. markdown-common is one, so the cycle closed through a
-			     dependency edge instead and `mvn -B package -DenforceClaudeMd` could
-			     not sort the reactor at all. Scoping the profile to the project that
-			     owns the documents keeps a module's build order independent of a
-			     profile it never uses. -->
+			<!-- Both conditions hold in the root project alone. Inherited into a module, this would
+			     add a reactor edge to claude-code-enforcer and the reactor could not be sorted. -->
 			<activation>
 				<property>
 					<name>enforceClaudeMd</name>
@@ -741,9 +564,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-enforcer-plugin</artifactId>
-						<!-- Belt and braces beside the profile's file activation: even
-						     were this plugin to reach a child module, it would carry no
-						     execution there. -->
 						<inherited>false</inherited>
 						<dependencies>
 							<dependency>
@@ -766,13 +586,9 @@
 										<agentsMdFormat>
 											<agentsMdFile>${project.basedir}/AGENTS.md</agentsMdFile>
 										</agentsMdFormat>
-										<!-- allowedFrontMatterKeys lists the keys Claude Code
-										     accepts in a SKILL.md, not the two this repository
-										     currently uses, so a skill may grow an
-										     `allowed-tools` without touching this pom while a
-										     mistyped `descripton` is still reported. Skills
-										     route by description, so a key that silently does
-										     nothing costs a skill its loading. -->
+										<!-- Every key Claude Code accepts, not only the two used
+										     here, so a skill may grow one without touching this pom
+										     while a typo is still reported. -->
 										<skillFilesExist>
 											<skillsDir>${project.basedir}/.claude/skills</skillsDir>
 											<allowedFrontMatterKeys>
@@ -783,10 +599,6 @@
 												<allowedFrontMatterKey>license</allowedFrontMatterKey>
 											</allowedFrontMatterKeys>
 										</skillFilesExist>
-										<!-- A configured definition directory must exist, so
-										     these two could only be wired once .claude/agents
-										     and .claude/commands did — which is why the
-										     directories and this wiring arrived together. -->
 										<subAgentFormat>
 											<agentsDir>${project.basedir}/.claude/agents</agentsDir>
 											<allowedModels>
@@ -812,10 +624,8 @@
 												<allowedModel>inherit</allowedModel>
 											</allowedModels>
 										</commandFormat>
-										<!-- Both uniqueness rules see all three kinds at once:
-										     a command sharing a name or a description with a
-										     skill shadows it, and neither directory alone would
-										     show that. -->
+										<!-- All three kinds at once: a command sharing a name or
+										     description with a skill shadows it. -->
 										<uniqueNames>
 											<commandsDir>${project.basedir}/.claude/commands</commandsDir>
 											<agentsDir>${project.basedir}/.claude/agents</agentsDir>
@@ -833,13 +643,8 @@
 											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
 											<projectDir>${project.basedir}</projectDir>
 										</hookCommandsValid>
-										<!-- reportUnreferencedScripts is the half of the
-										     wiring cross-check that catches the silent
-										     direction: a script no hook names never runs, and
-										     nothing about it looks wrong — it has its shebang,
-										     its executable bit and its shellcheck pass. The
-										     other direction (a hook naming a missing script)
-										     is on by default. -->
+										<!-- Also reports a script no hook names; the opposite
+										     direction is on by default. -->
 										<hooksFormat>
 											<hooksDir>${project.basedir}/.claude/hooks</hooksDir>
 											<settingsFile>${project.basedir}/.claude/settings.json</settingsFile>
@@ -852,10 +657,8 @@
 										<mcpConfigFormat>
 											<mcpFile>${project.basedir}/.mcp.json</mcpFile>
 										</mcpConfigFormat>
-										<!-- This repository emits OKF bundles rather than
-										     shipping one, so the bundle root is absent and the
-										     rule passes; it starts enforcing the day a bundle
-										     is committed here. -->
+										<!-- No bundle is committed here, so the rule passes until
+										     one is. -->
 										<okfBundleFormat>
 											<bundleDir>${project.basedir}/okf</bundleDir>
 											<okfVersion>0.2</okfVersion>
@@ -896,7 +699,7 @@
 												<file>${project.basedir}/CLAUDE.md</file>
 											</files>
 											<!-- CLAUDE.md is loaded into every session; keep it a
-											     summary that defers to AGENTS.md rather than a copy. -->
+											     summary that defers to AGENTS.md. -->
 											<maxBytes>32768</maxBytes>
 										</contextBudget>
 										<localSettingsIgnored>
@@ -923,11 +726,7 @@
 		<profile>
 			<id>coverage</id>
 			<properties>
-				<!-- JaCoCo's bytecode instrumentation roughly doubles the time a
-				     timed test method spends loading classes on first use, so give
-				     the per-test timeouts extra headroom under coverage. This stacks
-				     on top of the parallel-reactor (-T1C) fork contention the base
-				     limit already absorbs, so it is set well above the base 5 s. -->
+				<!-- JaCoCo instrumentation slows timed methods, so the limits get extra headroom. -->
 				<unit.test.method.timeout>8 s</unit.test.method.timeout>
 				<unit.test.lifecycle.timeout>15 s</unit.test.lifecycle.timeout>
 			</properties>
@@ -1015,13 +814,8 @@
 			</build>
 		</profile>
 		<profile>
-			<!-- Attaches the javadoc jar to the GitHub Packages deployment that
-			     maven-publish.yml performs on release. The default `mvn deploy`
-			     (maven-deploy-plugin) only publishes the main jar, so without
-			     this the GitHub Packages coordinates would ship no javadoc.
-			     Opt-in via -Pgithub-packages so ordinary `mvn install` builds
-			     stay fast and never generate javadoc. (The Maven Central bundle
-			     gets its javadoc from the separate `release` profile instead.) -->
+			<!-- Attaches the javadoc jar to the GitHub Packages deploy. Opt-in, so ordinary builds
+			     never generate javadoc. -->
 			<id>github-packages</id>
 			<build>
 				<plugins>
@@ -1045,24 +839,12 @@
 			</build>
 		</profile>
 		<profile>
-			<!-- Publishes signed artifacts (sources, javadoc, GPG signatures)
-			     to Maven Central via the Sonatype Central Portal. Opt-in with
-			     -Prelease so ordinary and CI builds never need GPG keys or
-			     Central credentials. The central-publishing-maven-plugin runs
-			     with extensions enabled, so it takes over the deploy phase in
-			     place of the default maven-deploy-plugin (GitHub Packages). -->
+			<!-- Publishes signed artifacts to Maven Central. Opt-in, so ordinary builds need no GPG
+			     keys or Central credentials. -->
 			<id>release</id>
 			<properties>
-				<!-- The data and context modules apply spring-boot:repackage,
-				     which by default replaces the main jar with an executable
-				     Spring Boot bundle (nested BOOT-INF dependencies plus a
-				     launch script from <executable>true</executable>). Maven
-				     Central rejects executable bundles ("Executable bundles are
-				     not supported"), and such a fat jar is not a usable library
-				     dependency anyway. Skip repackaging for the release so the
-				     plain, reusable library jar is what gets published. The
-				     executable jar remains available from ordinary local builds
-				     for running the MCP servers. -->
+				<!-- Central rejects the executable bundle spring-boot:repackage produces, so publish
+				     the plain library jar instead. -->
 				<spring-boot.repackage.skip>true</spring-boot.repackage.skip>
 			</properties>
 			<build>
@@ -1100,13 +882,9 @@
 						<artifactId>central-publishing-maven-plugin</artifactId>
 						<extensions>true</extensions>
 						<configuration>
-							<!-- Server credentials live under this id in settings.xml. -->
 							<publishingServerId>central</publishingServerId>
 							<autoPublish>${central.autoPublish}</autoPublish>
 							<waitUntil>${central.waitUntil}</waitUntil>
-							<!-- Honoured per module, so a module stays out of the bundle by
-							     setting the property rather than redeclaring this plugin
-							     inside a copy of this profile. -->
 							<skipPublishing>${central.skipPublishing}</skipPublishing>
 						</configuration>
 					</plugin>

--- a/test-common/pom.xml
+++ b/test-common/pom.xml
@@ -12,21 +12,15 @@
 	<name>Shared test scaffolding</name>
 	<description>Shared ArchUnit rule libraries and test assertions reused by every module's tests.</description>
 	<properties>
-		<!-- This module carries no production code, only the rule libraries and
-		     assertions the other modules' tests import, so keep it out of both
-		     publications: the GitHub Packages deployment maven-deploy-plugin
-		     performs on `mvn deploy`, and the Maven Central bundle the root pom's
-		     release profile publishes. -->
+		<!-- Test rule libraries and assertions only, no production code: keep it out of the GitHub
+		     Packages deploy and the Maven Central bundle. -->
 		<maven.deploy.skip>true</maven.deploy.skip>
 		<central.skipPublishing>true</central.skipPublishing>
 	</properties>
 	<build>
 		<plugins>
-			<!-- The rules live in src/test/java so archunit-junit5 can stay
-			     test-scoped as the root pom declares it. Attaching a test-jar is
-			     what makes them reachable from the other modules' test
-			     classpaths. The main jar this module also produces is empty by
-			     design; nothing depends on it and it is never published. -->
+			<!-- The rules live in src/test/java so archunit-junit5 stays test-scoped; the test-jar
+			     is what the other modules' tests import. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
Every pom carried multi-paragraph rationale beside its properties,
plugins and dependencies, much of it restating what the XML says or
repeating what AGENTS.md already documents. Condense each surviving
comment to the fact a reader cannot get from the element itself (why a
version is pinned, why a scope is narrowed, why a directory is filtered)
and drop the eleven that only paraphrased their element — including the
project.build.outputTimestamp essay, whose subject is documented under
"Releasing" in AGENTS.md.

No build behaviour changes: 538 lines removed, 151 added, all comments.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WDhhFNmHY6tZAMRVTvoxGT