### PR TITLE
fix(adopt): bind the adoption MCP server to loopback

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
@@ -132,6 +132,29 @@ and a `repositories` array of exactly the documents above:
 }
 ```
 
+## Security
+
+The pipeline writes to real repositories with the host's own credentials, so the
+endpoint in front of it is part of the security boundary:
+
+- **Loopback binding.** The HTTP transports (streamable HTTP and stateless HTTP)
+  bind to `127.0.0.1` by default (`server.address` in
+  `adopt/src/main/resources/application.properties`, which also gives the server
+  port `8083` of its own so all three MCP servers here can run side by side). The
+  `/mcp` endpoint has **no authentication**, and `adopt_repo` clones
+  repositories, runs `claude`, pushes branches and opens pull requests on the
+  `git` and `gh` logins of the machine serving it — so an endpoint on a routable
+  interface hands that reach to whoever can reach the host. Change
+  `server.address` only after putting authentication in front of it.
+
+- **The default branch is never written to.** Every adoption works on the feature
+  branch it names, so the worst a call can do to a repository it was pointed at
+  is push a branch and open a pull request.
+
+- **Credentials are masked.** A clone URL carrying a token is masked in
+  everything the run reports and is never left behind in the checkout's
+  `.git/config`.
+
 ## Configuring MCP Clients
 
 For any MCP client that supports stdio transport:

--- a/adopt/src/main/resources/application.properties
+++ b/adopt/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+spring.application.name=adopt-server
+# 8081 is the uniqueness server's and 8082 the context server's, so all three can
+# run side by side on one host.
+server.port=8083
+# Bind the streamable HTTP transport to the loopback interface only. The MCP
+# endpoint has no authentication, so it must not be reachable from the network.
+# Override deliberately (and add authentication) before exposing it more widely.
+server.address=127.0.0.1

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/ApplicationPropertiesTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/mcp/ApplicationPropertiesTest.java
@@ -1,0 +1,52 @@
+package io.github.adamw7.tools.adopt.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The configuration the server jar ships, read off the classpath rather than out of a
+ * booted context: the file is what an operator gets by default, and asserting it costs
+ * neither a web server nor a port.
+ *
+ * <p>The binding is the reason this test exists. {@code adopt_repo} clones repositories,
+ * runs {@code claude}, wires a guard into a build file, pushes a branch and opens a pull
+ * request — all on the host's own {@code git} and {@code gh} credentials — and the
+ * {@code /mcp} endpoint has no authentication in front of it. Left unset,
+ * {@code server.address} has Spring Boot bind the HTTP transports to every interface,
+ * which offers that reach to anything that can route to the host.
+ */
+class ApplicationPropertiesTest {
+
+	private static final String RESOURCE = "/application.properties";
+
+	@Test
+	void bindsTheHttpTransportsToLoopbackOnly() {
+		assertEquals("127.0.0.1", shippedProperties().getProperty("server.address"));
+	}
+
+	/**
+	 * A port of its own, so the three MCP servers this repository ships run side by side
+	 * on one host: the uniqueness server takes 8081 and the context server 8082.
+	 */
+	@Test
+	void servesOnItsOwnPort() {
+		assertEquals("8083", shippedProperties().getProperty("server.port"));
+	}
+
+	private Properties shippedProperties() {
+		Properties properties = new Properties();
+		try (InputStream shipped = Main.class.getResourceAsStream(RESOURCE)) {
+			assertNotNull(shipped, RESOURCE + " is missing from the server jar");
+			properties.load(shipped);
+		} catch (IOException e) {
+			throw new IllegalStateException("Could not read " + RESOURCE, e);
+		}
+		return properties;
+	}
+}


### PR DESCRIPTION
The `data` and `code/context` servers each ship an `application.properties`
pinning `server.address=127.0.0.1`, because the `/mcp` endpoint carries no
authentication. `adopt` shipped no such file, so
`--transport.mode=streamable-http` (or `stateless-http`) started Spring Boot
on the default `0.0.0.0:8080` — offering the server with the most reach of the
three to every interface. `adopt_repo` clones repositories, runs `claude`,
wires a guard into a build file, pushes a branch and opens a pull request, all
on the host's own `git` and `gh` credentials.

Add the missing `application.properties`, mirroring the other two: the loopback
binding with the same reasoning spelled out, and port 8083 of its own, 8081 and
8082 being taken, so the three servers run side by side.

`ApplicationPropertiesTest` reads the shipped resource off the classpath and
pins both, so a server jar that would bind wide fails the build instead. The
module's `MCP_USAGE.md` gains a Security section documenting the binding
alongside the two guarantees the pipeline already made.

Closes #617

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TBR52D5E36VSzeqf5mYWHb