### PR TITLE
Refactor formatter interface and remove bean-definition-overriding

### DIFF
--- a/code/context/src/main/resources/application.properties
+++ b/code/context/src/main/resources/application.properties
@@ -4,7 +4,6 @@ server.port=8082
 # endpoint has no authentication, so it must not be reachable from the network.
 # Override deliberately (and add authentication) before exposing it more widely.
 server.address=127.0.0.1
-spring.main.allow-bean-definition-overriding=true
 
 # Confine the project scanners to these directories (File.pathSeparator-separated
 # list of absolute paths). Any requested path is resolved to its real location

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/EclipseFormatter.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/EclipseFormatter.java
@@ -1,0 +1,14 @@
+package io.github.adamw7.tools.code.format;
+
+import org.eclipse.jdt.core.ToolFactory;
+import org.eclipse.jdt.core.formatter.CodeFormatter;
+
+public class EclipseFormatter implements Formatter {
+
+	@Override
+	public String format(String code) {
+		CodeFormatter codeFormatter = ToolFactory.createCodeFormatter(null);
+		return Documents.edited(code,
+				document -> codeFormatter.format(CodeFormatter.K_COMPILATION_UNIT, code, 0, code.length(), 0, null));
+	}
+}

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/Formatter.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/Formatter.java
@@ -1,14 +1,6 @@
 package io.github.adamw7.tools.code.format;
 
-import org.eclipse.jdt.core.ToolFactory;
-import org.eclipse.jdt.core.formatter.CodeFormatter;
+public interface Formatter {
 
-public class Formatter implements FormatterIfc {
-
-	@Override
-	public String format(String code) {
-		CodeFormatter codeFormatter = ToolFactory.createCodeFormatter(null);
-		return Documents.edited(code,
-				document -> codeFormatter.format(CodeFormatter.K_COMPILATION_UNIT, code, 0, code.length(), 0, null));
-	}
+	String format(String code);
 }

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/FormatterIfc.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/FormatterIfc.java
@@ -1,6 +1,0 @@
-package io.github.adamw7.tools.code.format;
-
-public interface FormatterIfc {
-
-	String format(String code);
-}

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/ImportRemover.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/ImportRemover.java
@@ -1,6 +1,6 @@
 package io.github.adamw7.tools.code.format;
 
-public interface ImportRemoverIfc {
+public interface ImportRemover {
 
 	String removeUnused(String code);
 }

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/UnusedImportsRemover.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/format/UnusedImportsRemover.java
@@ -13,7 +13,7 @@ import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
-public class UnusedImportsRemover implements ImportRemoverIfc {
+public class UnusedImportsRemover implements ImportRemover {
 
 	@Override
 	public String removeUnused(String code) {

--- a/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/ClassContainer.java
+++ b/code/protogen-maven-plugin/src/main/java/io/github/adamw7/tools/code/gen/ClassContainer.java
@@ -1,13 +1,13 @@
 package io.github.adamw7.tools.code.gen;
 
-import io.github.adamw7.tools.code.format.Formatter;
+import io.github.adamw7.tools.code.format.EclipseFormatter;
 import io.github.adamw7.tools.code.format.UnusedImportsRemover;
 
 public record ClassContainer(String name, CharSequence code) {
 
 	public ClassContainer format() {
 		String withoutUnusedImports = new UnusedImportsRemover().removeUnused(codeAsString());
-		return new ClassContainer(name, new Formatter().format(withoutUnusedImports));
+		return new ClassContainer(name, new EclipseFormatter().format(withoutUnusedImports));
 	}
 
 	String codeAsString() {

--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/format/UnusedImportsRemoverTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/format/UnusedImportsRemoverTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 public class UnusedImportsRemoverTest {
 
-	private final ImportRemoverIfc remover = new UnusedImportsRemover();
+	private final ImportRemover remover = new UnusedImportsRemover();
 
 	@Test
 	public void removesSingleUnusedImport() {

--- a/data/src/main/resources/application.properties
+++ b/data/src/main/resources/application.properties
@@ -4,7 +4,6 @@ server.port=8081
 # endpoint has no authentication, so it must not be reachable from the network.
 # Override deliberately (and add authentication) before exposing it more widely.
 server.address=127.0.0.1
-spring.main.allow-bean-definition-overriding=true
 
 logging.level.root=INFO
 logging.level.org.springframework.boot.autoconfigure=ERROR

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -375,7 +375,7 @@ flowchart TB
         end
 
         subgraph fmt ["Formatting"]
-            formatter["<b>Formatter /<br/>UnusedImportsRemover</b>"]
+            formatter["<b>EclipseFormatter /<br/>UnusedImportsRemover</b>"]
         end
     end
 

--- a/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
+++ b/mcp-common/src/main/java/io/github/adamw7/tools/mcp/AbstractMcpConfiguration.java
@@ -106,6 +106,16 @@ public abstract class AbstractMcpConfiguration {
 		return registration;
 	}
 
+	/**
+	 * Built for the session-based transports, which is stdio here. Its condition and
+	 * {@link #mcpSyncServerStreamable(McpStreamableServerTransportProvider)}'s are
+	 * mutually exclusive — {@link McpStreamableServerTransportProvider} extends
+	 * {@code McpServerTransportProviderBase}, not {@link McpServerTransportProvider},
+	 * so this one cannot match in {@code streamable-http} mode — and the two carry
+	 * different bean names regardless. Exactly one {@link McpSyncServer} is therefore
+	 * ever defined, and no server needs
+	 * {@code spring.main.allow-bean-definition-overriding}.
+	 */
 	@Bean(destroyMethod = "close")
 	@ConditionalOnBean(McpServerTransportProvider.class)
 	public McpSyncServer mcpSyncServer(McpServerTransportProvider transport) {

--- a/mcp-common/src/test/java/io/github/adamw7/tools/mcp/AbstractMcpConfigurationTest.java
+++ b/mcp-common/src/test/java/io/github/adamw7/tools/mcp/AbstractMcpConfigurationTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -21,6 +22,7 @@ import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport;
 import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
 
 public class AbstractMcpConfigurationTest {
 
@@ -147,6 +149,24 @@ public class AbstractMcpConfigurationTest {
 		McpStatelessSyncServer server = config.mcpStatelessSyncServer(transport);
 		assertTrue(server.listTools().stream().anyMatch(tool -> "test_tool".equals(tool.name())));
 		server.close();
+	}
+
+	/**
+	 * {@link AbstractMcpConfiguration#mcpSyncServer(McpServerTransportProvider)} is
+	 * conditional on an {@link McpServerTransportProvider} bean, so it can only match
+	 * where the transport implements that interface. The streamable provider does not
+	 * — it extends {@code McpServerTransportProviderBase} directly — which is why
+	 * exactly one {@link McpSyncServer} is defined in every mode and no server sets
+	 * {@code spring.main.allow-bean-definition-overriding}. Pinned here because the
+	 * hierarchy belongs to the MCP SDK: an SDK release that widened it would silently
+	 * give {@code streamable-http} two sync servers to choose between.
+	 */
+	@Test
+	public void onlyTheStdioTransportSatisfiesTheSessionBasedServerCondition() {
+		TestMcpConfiguration config = new TestMcpConfiguration();
+
+		assertInstanceOf(McpServerTransportProvider.class, config.stdioServerTransport());
+		assertFalse(config.streamableServerTransport() instanceof McpServerTransportProvider);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

This change refactors the code formatter to use a proper interface hierarchy, eliminates the need for Spring's `allow-bean-definition-overriding` setting, and adds documentation explaining the mutual exclusivity of transport-based bean conditions.

## Key Changes

- **Formatter interface refactoring**: Renamed `FormatterIfc` to `Formatter` (the interface) and extracted the Eclipse-specific implementation into a new `EclipseFormatter` class, following the Interface Segregation Principle
- **Import remover interface**: Renamed `ImportRemoverIfc` to `ImportRemover` for consistency
- **Bean definition cleanup**: Removed `spring.main.allow-bean-definition-overriding=true` from both `code/context` and `data` application properties, as the MCP sync server bean conditions are now properly mutually exclusive
- **Documentation**: Added comprehensive JavaDoc to `AbstractMcpConfiguration.mcpSyncServer()` explaining why exactly one `McpSyncServer` is ever defined (stdio transport implements `McpServerTransportProvider`, but streamable HTTP transport does not)
- **Test coverage**: Added `onlyTheStdioTransportSatisfiesTheSessionBasedServerCondition()` test to pin the transport interface hierarchy and prevent silent regressions if the MCP SDK widens it in a future release
- **Documentation update**: Updated C4 architecture diagram to reference `EclipseFormatter` instead of generic `Formatter`

## Implementation Details

The refactoring ensures that:
- The formatter interface is decoupled from its Eclipse implementation, allowing for alternative implementations
- Spring bean conditions are properly exclusive: `@ConditionalOnBean(McpServerTransportProvider.class)` for stdio vs. a separate method for streamable HTTP
- No bean definition overriding is needed because the two sync server beans have different names and mutually exclusive conditions
- The test documents the SDK contract that must be maintained to avoid silent bean conflicts

https://claude.ai/code/session_01X3tG6pkhi4ZDJ4ZAzu2Fia