### PR TITLE
refactor(enforcer, markdown-common, adopt, code): cut duplicated code and Javadoc

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionOptions.java
@@ -30,7 +30,7 @@ import io.github.adamw7.tools.adopt.step.PullRequestOptions;
  * @param ruleVersion     the released {@code claude-code-enforcer} version to pin
  *                        into an adopted Maven project, or {@code null} to resolve
  *                        the running build's — read through
- *                        {@link #pinnedRuleVersion()}, which says so in its type
+ *                        {@link #pinnedRuleVersion()}
  * @param dryRun          whether the run stops after the verification, committing
  *                        the adoption locally but pushing nothing and opening no
  *                        pull request
@@ -128,12 +128,7 @@ public record AdoptionOptions(PullRequestOptions pullRequest, boolean includeAss
 		return new GuardOptions(ruleVersion, guardRules, claudeMdSections);
 	}
 
-	/**
-	 * @return the released rule version to pin, or empty to resolve the version of
-	 *         the {@code tools} build running the adoption. Preferred over the
-	 *         record's own {@link #ruleVersion()}, which answers {@code null} for
-	 *         the same case.
-	 */
+	/** As {@link GuardOptions#pinnedRuleVersion()}, and preferred over {@link #ruleVersion()} for the same reason. */
 	public Optional<String> pinnedRuleVersion() {
 		return Optional.ofNullable(ruleVersion);
 	}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/CloneStep.java
@@ -33,17 +33,11 @@ import io.github.adamw7.tools.adopt.command.CommandRunner;
  *
  * <p>A reused checkout must also be free of uncommitted work that is not the
  * adoption's own, since {@link CommitStep} stages the whole tree and would push a
- * contributor's work in progress as part of the adoption.
- *
- * <p>The checkout is then refreshed with {@code git fetch}, because every later
- * decision about the feature branch is taken against the remote-tracking refs a
- * stale checkout has out of date. That fetch carries the credentials the run was
- * given rather than the credential-free {@code origin} left behind for it — see
- * {@link #fetchCommand}.
- *
- * <p>A freshly cloned checkout records the credential-free form of the URL as its
- * {@code origin}, so the token an adoption is driven with does not outlive the run
- * in {@code .git/config} — see {@link #forgetCredentials}.
+ * contributor's work in progress as part of the adoption. It is then refreshed
+ * with {@code git fetch}, because every later decision about the feature branch is
+ * taken against remote-tracking refs a stale checkout has out of date — see
+ * {@link #fetchCommand} for the credentials that fetch carries, and
+ * {@link #forgetCredentials} for why a fresh clone's {@code origin} carries none.
  */
 public class CloneStep extends AbstractCommandStep {
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GuardOptions.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GuardOptions.java
@@ -41,8 +41,7 @@ public record GuardOptions(String ruleVersion, GuardRules rules, List<String> cl
 	/**
 	 * @return the released rule version to pin, or empty to resolve the version of the
 	 *         {@code tools} build running the adoption. Preferred over the record's
-	 *         own {@link #ruleVersion()}, which answers {@code null} for the same case:
-	 *         a field holds the value, and the {@link Optional} is how it is read.
+	 *         own {@link #ruleVersion()}, which answers {@code null} for the same case.
 	 */
 	public Optional<String> pinnedRuleVersion() {
 		return Optional.ofNullable(ruleVersion);

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ProjectLayout.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ProjectLayout.java
@@ -26,10 +26,6 @@ public record ProjectLayout(File projectDir) {
 		return new File(projectDir, "AGENTS.md");
 	}
 
-	public File readme() {
-		return new File(projectDir, "README.md");
-	}
-
 	public File pom() {
 		return new File(projectDir, "pom.xml");
 	}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ProjectParts.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/project/ProjectParts.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import io.github.adamw7.tools.enforcer.definition.CommandFormatRule;
@@ -199,30 +200,33 @@ final class ProjectParts {
 	/** Adds the part, configured, when the file it reads is there. */
 	private <R extends ClaudeCodeEnforcerRule> void ifFile(List<ClaudeCodeEnforcerRule> parts, File file,
 			Supplier<R> part, Consumer<R> configure) {
-		if (file.isFile()) {
-			parts.add(configured(part, configure));
-		}
+		ifPresent(parts, file, File::isFile, part, configure);
 	}
 
 	/** Adds the part, configured, when the directory it scans is there. */
 	private <R extends ClaudeCodeEnforcerRule> void ifDirectory(List<ClaudeCodeEnforcerRule> parts, File directory,
 			Supplier<R> part, Consumer<R> configure) {
-		if (directory.isDirectory()) {
-			parts.add(configured(part, configure));
+		ifPresent(parts, directory, File::isDirectory, part, configure);
+	}
+
+	private <R extends ClaudeCodeEnforcerRule> void ifPresent(List<ClaudeCodeEnforcerRule> parts, File input,
+			Predicate<File> present, Supplier<R> part, Consumer<R> configure) {
+		if (present.test(input)) {
+			R rule = part.get();
+			configure.accept(rule);
+			parts.add(rule);
 		}
 	}
 
-	private <R extends ClaudeCodeEnforcerRule> R configured(Supplier<R> part, Consumer<R> configure) {
-		R rule = part.get();
-		configure.accept(rule);
-		return rule;
-	}
-
 	private List<File> presentOf(File... candidates) {
-		return Arrays.stream(candidates).filter(File::isFile).toList();
+		return presentOf(File::isFile, candidates);
 	}
 
 	private List<File> presentDirectoriesOf(File... candidates) {
-		return Arrays.stream(candidates).filter(File::isDirectory).toList();
+		return presentOf(File::isDirectory, candidates);
+	}
+
+	private List<File> presentOf(Predicate<File> present, File... candidates) {
+		return Arrays.stream(candidates).filter(present).toList();
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ClaudeCodeEnforcerRule.java
@@ -44,13 +44,16 @@ import io.github.adamw7.tools.markdown.MarkdownText;
  * <p>
  * A rule's configuration parameters are its <em>fields</em>: Plexus binds a
  * {@code <claudeMdFile>} element to a field of that name and never sees the
- * package-private setters here, because it looks only at public methods. So every
- * concrete rule declares a field named exactly as its pom element, and a base that
- * needs it reads it back through an abstract accessor —
- * {@link MarkdownFormatRule#documentFile()}, {@link JsonFileRule#jsonFile()}.
- * Hoisting those fields into a base under one shared name compiles, unit-tests
- * green, then fails every real build with "Cannot find 'claudeMdFile' in class";
- * the {@code *IT}s are what catch it.
+ * package-private setters here, because it looks only at public methods. So the
+ * field is declared under exactly the name its pom element uses — on the concrete
+ * rule, or on a base only rules that spell it identically share, as the three
+ * {@code settings.json} rules share {@link
+ * io.github.adamw7.tools.enforcer.settings.SettingsJsonRule}'s {@code settingsFile}
+ * — and a base that needs a differently-named one reads it back through an
+ * abstract accessor: {@link MarkdownFormatRule#documentFile()},
+ * {@link JsonFileRule#jsonFile()}. Hoisting those fields into a base under one
+ * <em>shared</em> name compiles, unit-tests green, then fails every real build with
+ * "Cannot find 'claudeMdFile' in class"; the {@code *IT}s are what catch it.
  */
 public abstract class ClaudeCodeEnforcerRule extends AbstractEnforcerRule {
 

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlPage.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlPage.java
@@ -1,0 +1,58 @@
+package io.github.adamw7.tools.enforcer.rule;
+
+/**
+ * The document both report pages are written into: the head, the styling and the
+ * escaping they share. A page contributes its own title and body; the frame around
+ * it is written once, so a per-rule report and the index that links to it cannot
+ * come to look like pages from different tools.
+ */
+final class HtmlPage {
+
+	/**
+	 * The rules the pages share. Each adds what only it uses — the index its
+	 * pass/fail cells, a report its numbered columns — through {@link #style}.
+	 */
+	private static final String COMMON_CSS =
+			"body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;"
+			+ "line-height:1.5;color:#1a1a1a;background:#f6f7f9;margin:0;padding:2rem;}"
+			+ "main{max-width:52rem;margin:0 auto;background:#fff;padding:1.5rem 2rem;"
+			+ "border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,.1);}"
+			+ "h1{font-size:1.5rem;margin:0 0 .5rem;}"
+			+ ".status{display:inline-block;font-weight:600;padding:.25rem .75rem;border-radius:999px;}"
+			+ ".status.failed{background:#fdecea;color:#b3261e;}"
+			+ ".status.passed{background:#e6f4ea;color:#1e7e34;}"
+			+ "table{border-collapse:collapse;width:100%;}"
+			+ "th,td{border:1px solid #e0e0e0;padding:.5rem .75rem;text-align:left;}"
+			+ "thead th{background:#f0f1f3;font-weight:600;}";
+
+	private final StringBuilder html = new StringBuilder();
+
+	HtmlPage(String title, String style) {
+		html.append("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n");
+		html.append("<meta charset=\"utf-8\">\n");
+		html.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+		html.append("<title>").append(escape(title)).append("</title>\n");
+		html.append("<style>").append(COMMON_CSS).append(style).append("</style>\n");
+		html.append("</head>\n<body>\n<main>\n");
+		html.append("<h1>").append(escape(title)).append("</h1>\n");
+	}
+
+	/** The body so far, for a page still adding to it. */
+	StringBuilder body() {
+		return html;
+	}
+
+	/** The finished document, closed off after the body. */
+	String render() {
+		return html + "</main>\n</body>\n</html>\n";
+	}
+
+	/** Escapes the five characters that are significant in HTML text and attributes. */
+	static String escape(String text) {
+		return text.replace("&", "&amp;")
+				.replace("<", "&lt;")
+				.replace(">", "&gt;")
+				.replace("\"", "&quot;")
+				.replace("'", "&#39;");
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
@@ -1,5 +1,7 @@
 package io.github.adamw7.tools.enforcer.rule;
 
+import static io.github.adamw7.tools.enforcer.rule.HtmlPage.escape;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -18,11 +20,19 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
  * renders a short "passed" page, so a configured report file never leaves a stale
  * failure behind.
  * <p>
- * The document is inlined (styles included, no external assets) so it opens
- * anywhere, and every piece of rule-supplied text is HTML-escaped so a violation
- * message containing {@code <} or {@code &} cannot break or inject markup.
+ * The frame, the styling and the escaping that keeps a violation message
+ * containing {@code <} or {@code &} from breaking or injecting markup are
+ * {@link HtmlPage}'s.
  */
 final class HtmlReport {
+
+	private static final String TITLE = "Claude Code Enforcer report";
+
+	private static final String CSS = "h2{font-size:1.15rem;margin:1.5rem 0 .5rem;}"
+			+ "table{margin:.25rem 0;}th,td{vertical-align:top;}"
+			+ "td.num,th.num{width:3rem;text-align:right;color:#666;white-space:nowrap;}"
+			+ ".report td.failure{color:#b3261e;}"
+			+ ".report td.fix{color:#1a1a1a;}";
 
 	private final String header;
 	private final List<String> violations;
@@ -50,33 +60,20 @@ final class HtmlReport {
 	}
 
 	String render() {
-		StringBuilder html = new StringBuilder();
-		html.append("<!DOCTYPE html>\n");
-		html.append("<html lang=\"en\">\n<head>\n");
-		html.append("<meta charset=\"utf-8\">\n");
-		html.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
-		html.append("<title>Claude Code Enforcer report</title>\n");
-		html.append("<style>").append(css()).append("</style>\n");
-		html.append("</head>\n<body>\n");
-		html.append("<main>\n");
-		appendHeading(html);
+		HtmlPage page = new HtmlPage(TITLE, CSS);
+		StringBuilder html = page.body();
+		appendStatus(html);
 		if (violations.isEmpty()) {
-			appendPassed(html);
+			html.append("<p>No violations were found.</p>\n");
 		} else {
 			appendFailures(html);
 		}
-		html.append("</main>\n</body>\n</html>\n");
-		return html.toString();
+		return page.render();
 	}
 
-	private void appendHeading(StringBuilder html) {
+	private void appendStatus(StringBuilder html) {
 		String status = violations.isEmpty() ? "passed" : "failed";
-		html.append("<h1>Claude Code Enforcer report</h1>\n");
 		html.append("<p class=\"status ").append(status).append("\">Check ").append(status).append("</p>\n");
-	}
-
-	private void appendPassed(StringBuilder html) {
-		html.append("<p>No violations were found.</p>\n");
 	}
 
 	private void appendFailures(StringBuilder html) {
@@ -101,31 +98,5 @@ final class HtmlReport {
 
 	private String cell(List<String> cells, int index) {
 		return index < cells.size() ? escape(cells.get(index)) : "";
-	}
-
-	private String css() {
-		return "body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;"
-				+ "line-height:1.5;color:#1a1a1a;background:#f6f7f9;margin:0;padding:2rem;}"
-				+ "main{max-width:52rem;margin:0 auto;background:#fff;padding:1.5rem 2rem;"
-				+ "border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,.1);}"
-				+ "h1{font-size:1.5rem;margin:0 0 .5rem;}h2{font-size:1.15rem;margin:1.5rem 0 .5rem;}"
-				+ ".status{display:inline-block;font-weight:600;padding:.25rem .75rem;border-radius:999px;}"
-				+ ".status.failed{background:#fdecea;color:#b3261e;}"
-				+ ".status.passed{background:#e6f4ea;color:#1e7e34;}"
-				+ "table{border-collapse:collapse;width:100%;margin:.25rem 0;}"
-				+ "th,td{border:1px solid #e0e0e0;padding:.5rem .75rem;text-align:left;vertical-align:top;}"
-				+ "thead th{background:#f0f1f3;font-weight:600;}"
-				+ "td.num,th.num{width:3rem;text-align:right;color:#666;white-space:nowrap;}"
-				+ ".report td.failure{color:#b3261e;}"
-				+ ".report td.fix{color:#1a1a1a;}";
-	}
-
-	/** Escapes the five characters that are significant in HTML text and attributes. */
-	private String escape(String text) {
-		return text.replace("&", "&amp;")
-				.replace("<", "&lt;")
-				.replace(">", "&gt;")
-				.replace("\"", "&quot;")
-				.replace("'", "&#39;");
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ReportIndex.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ReportIndex.java
@@ -1,5 +1,7 @@
 package io.github.adamw7.tools.enforcer.rule;
 
+import static io.github.adamw7.tools.enforcer.rule.HtmlPage.escape;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -40,6 +42,11 @@ final class ReportIndex {
 	static final String SIDECAR_FILE = ".claude-code-enforcer-index";
 
 	private static final String SEPARATOR = "\t";
+
+	private static final String TITLE = "Claude Code Enforcer reports";
+
+	private static final String CSS = "table{margin:1rem 0;}"
+			+ "td.ok{color:#1e7e34;}td.bad{color:#b3261e;font-weight:600;}";
 
 	private ReportIndex() {
 	}
@@ -104,18 +111,10 @@ final class ReportIndex {
 
 	static String render(Map<String, Integer> outcomes) {
 		Map<String, Integer> ordered = new TreeMap<>(outcomes);
-		StringBuilder html = new StringBuilder();
-		html.append("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n");
-		html.append("<meta charset=\"utf-8\">\n");
-		html.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
-		html.append("<title>Claude Code Enforcer reports</title>\n");
-		html.append("<style>").append(css()).append("</style>\n");
-		html.append("</head>\n<body>\n<main>\n");
-		html.append("<h1>Claude Code Enforcer reports</h1>\n");
-		appendSummary(html, ordered);
-		appendTable(html, ordered);
-		html.append("</main>\n</body>\n</html>\n");
-		return html.toString();
+		HtmlPage page = new HtmlPage(TITLE, CSS);
+		appendSummary(page.body(), ordered);
+		appendTable(page.body(), ordered);
+		return page.render();
 	}
 
 	private static void appendSummary(StringBuilder html, Map<String, Integer> outcomes) {
@@ -137,29 +136,5 @@ final class ReportIndex {
 				: "<td class=\"bad\">" + violations + "</td>";
 		html.append("<tr><td><a href=\"").append(escape(rule)).append(".html\">").append(escape(rule))
 				.append("</a></td>").append(cell).append("</tr>\n");
-	}
-
-	private static String css() {
-		return "body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;"
-				+ "line-height:1.5;color:#1a1a1a;background:#f6f7f9;margin:0;padding:2rem;}"
-				+ "main{max-width:52rem;margin:0 auto;background:#fff;padding:1.5rem 2rem;"
-				+ "border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,.1);}"
-				+ "h1{font-size:1.5rem;margin:0 0 .5rem;}"
-				+ ".status{display:inline-block;font-weight:600;padding:.25rem .75rem;border-radius:999px;}"
-				+ ".status.failed{background:#fdecea;color:#b3261e;}"
-				+ ".status.passed{background:#e6f4ea;color:#1e7e34;}"
-				+ "table{border-collapse:collapse;width:100%;margin:1rem 0;}"
-				+ "th,td{border:1px solid #e0e0e0;padding:.5rem .75rem;text-align:left;}"
-				+ "thead th{background:#f0f1f3;font-weight:600;}"
-				+ "td.ok{color:#1e7e34;}td.bad{color:#b3261e;font-weight:600;}";
-	}
-
-	/** Escapes the five characters that are significant in HTML text and attributes. */
-	private static String escape(String text) {
-		return text.replace("&", "&amp;")
-				.replace("<", "&lt;")
-				.replace(">", "&gt;")
-				.replace("\"", "&quot;")
-				.replace("'", "&#39;");
 	}
 }

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/HookCommandsValidRule.java
@@ -7,7 +7,6 @@ import javax.inject.Named;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
 import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 
 /**
@@ -29,16 +28,13 @@ import io.github.adamw7.tools.enforcer.rule.JsonNodes;
  * that is present and is not an object is reported rather than skipped.
  */
 @Named("hookCommandsValid")
-public class HookCommandsValidRule extends JsonFileRule {
+public class HookCommandsValidRule extends SettingsJsonRule {
 
 	/** The keys of the hooks section, named once in {@link HookCommands} and read the same way here. */
 	private static final String HOOKS_KEY = HookCommands.HOOKS_KEY;
 	private static final String TYPE_KEY = HookCommands.TYPE_KEY;
 	private static final String COMMAND_KEY = HookCommands.COMMAND_KEY;
 	private static final String COMMAND_TYPE = HookCommands.COMMAND_TYPE;
-
-	/** The {@code .claude/settings.json} file to validate. Injected from the rule configuration. */
-	private File settingsFile;
 
 	/** Base directory that {@code $CLAUDE_PROJECT_DIR} resolves to. Defaults to the settings file's grandparent. */
 	private File projectDir;
@@ -48,15 +44,6 @@ public class HookCommandsValidRule extends JsonFileRule {
 
 	/** When true (default), a {@code $CLAUDE_PROJECT_DIR} script reference must resolve to an existing file. */
 	private boolean validateScriptReferences = true;
-
-	public HookCommandsValidRule() {
-		super("settingsFile", "settings.json");
-	}
-
-	@Override
-	protected File jsonFile() {
-		return settingsFile;
-	}
 
 	@Override
 	protected String header() {
@@ -157,11 +144,7 @@ public class HookCommandsValidRule extends JsonFileRule {
 		if (!validateScriptReferences) {
 			return List.of();
 		}
-		return new ClaudeProjectDir(projectDir, settingsFile).scriptsIn(command);
-	}
-
-	public void setSettingsFile(File settingsFile) {
-		this.settingsFile = settingsFile;
+		return new ClaudeProjectDir(projectDir, jsonFile()).scriptsIn(command);
 	}
 
 	public void setProjectDir(File projectDir) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/PermissionsFormatRule.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.enforcer.settings;
 
-import java.io.File;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -12,7 +11,6 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
 import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 import io.github.adamw7.tools.enforcer.rule.Patterns;
 
@@ -34,7 +32,7 @@ import io.github.adamw7.tools.enforcer.rule.Patterns;
  * by shape rather than spelling. A file without a {@code permissions} section passes.
  */
 @Named("permissionsFormat")
-public class PermissionsFormatRule extends JsonFileRule {
+public class PermissionsFormatRule extends SettingsJsonRule {
 
 	/** The keys of the permissions section, named once in {@link Permissions} and read the same way here. */
 	private static final String PERMISSIONS_KEY = Permissions.SECTION_KEY;
@@ -52,23 +50,11 @@ public class PermissionsFormatRule extends JsonFileRule {
 	private static final String MCP_TOOL_PREFIX = "mcp__";
 	private static final String FORBIDDEN_PATTERN_PARAMETER = "forbiddenEntryPattern";
 
-	/** The {@code .claude/settings.json} file to validate. Injected from the rule configuration. */
-	private File settingsFile;
-
 	/** Optional whitelist of tool names an entry may reference. When set, unknown tools are reported. */
 	private List<String> allowedTools;
 
 	/** Optional regular expressions no {@code allow} entry may match, e.g. {@code Bash\(\*\)}. */
 	private List<String> forbiddenEntryPatterns;
-
-	public PermissionsFormatRule() {
-		super("settingsFile", "settings.json");
-	}
-
-	@Override
-	protected File jsonFile() {
-		return settingsFile;
-	}
 
 	@Override
 	protected String header() {
@@ -179,10 +165,6 @@ public class PermissionsFormatRule extends JsonFileRule {
 	private String toolNameOf(String value) {
 		int open = value.indexOf('(');
 		return open < 0 ? value : value.substring(0, open);
-	}
-
-	public void setSettingsFile(File settingsFile) {
-		this.settingsFile = settingsFile;
 	}
 
 	void setAllowedTools(List<String> allowedTools) {

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonRule.java
@@ -1,0 +1,30 @@
+package io.github.adamw7.tools.enforcer.settings;
+
+import java.io.File;
+
+import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
+
+/**
+ * Base for the rules that each check a section of {@code .claude/settings.json}:
+ * the file parameter they all take, named once so the three cannot come to spell
+ * it differently in a pom. Each subclass contributes only the section it reads and
+ * the header it reports under.
+ */
+public abstract class SettingsJsonRule extends JsonFileRule {
+
+	/** The {@code .claude/settings.json} file to validate. Injected from the rule configuration. */
+	private File settingsFile;
+
+	protected SettingsJsonRule() {
+		super("settingsFile", "settings.json");
+	}
+
+	@Override
+	protected final File jsonFile() {
+		return settingsFile;
+	}
+
+	public void setSettingsFile(File settingsFile) {
+		this.settingsFile = settingsFile;
+	}
+}

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/settings/SettingsJsonValidRule.java
@@ -1,6 +1,5 @@
 package io.github.adamw7.tools.enforcer.settings;
 
-import java.io.File;
 import java.util.List;
 import java.util.Set;
 
@@ -8,7 +7,6 @@ import javax.inject.Named;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import io.github.adamw7.tools.enforcer.rule.JsonFileRule;
 import io.github.adamw7.tools.enforcer.rule.JsonNodes;
 import io.github.adamw7.tools.enforcer.rule.Violations;
 
@@ -25,25 +23,13 @@ import io.github.adamw7.tools.enforcer.rule.Violations;
  * reported together.
  */
 @Named("settingsJsonValid")
-public class SettingsJsonValidRule extends JsonFileRule {
-
-	/** The {@code .claude/settings.json} file to validate. Injected from the rule configuration. */
-	private File settingsFile;
+public class SettingsJsonValidRule extends SettingsJsonRule {
 
 	/** Permission entries that must appear in {@code permissions.allow}. */
 	private List<String> requiredPermissions;
 
 	/** Permission entries that must not appear in {@code permissions.allow}. */
 	private List<String> forbiddenPermissions;
-
-	public SettingsJsonValidRule() {
-		super("settingsFile", "settings.json");
-	}
-
-	@Override
-	protected File jsonFile() {
-		return settingsFile;
-	}
 
 	@Override
 	protected void collectViolations(JsonNode settings, List<String> violations) {
@@ -61,10 +47,6 @@ public class SettingsJsonValidRule extends JsonFileRule {
 	private Set<String> allowList(JsonNode settings) {
 		JsonNode permissions = JsonNodes.objectAt(settings, Permissions.SECTION_KEY);
 		return permissions != null ? Permissions.entriesIn(permissions, Permissions.ALLOW_KEY) : Set.of();
-	}
-
-	public void setSettingsFile(File settingsFile) {
-		this.settingsFile = settingsFile;
 	}
 
 	void setRequiredPermissions(List<String> requiredPermissions) {

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/ContextFinderTool.java
@@ -1,7 +1,6 @@
 package io.github.adamw7.context.mcp;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/EstimateTokensTool.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/EstimateTokensTool.java
@@ -2,7 +2,6 @@ package io.github.adamw7.context.mcp;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownConformer.java
+++ b/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownConformer.java
@@ -26,11 +26,8 @@ import java.util.stream.Collectors;
  *
  * <p>How the document is <em>read</em> — which lines are code, which sit inside an
  * HTML comment, and what heading a line declares — is {@link MarkdownDocument}'s
- * to decide, the same reader the checks judge the result with. Spelling those
- * readings out separately made the two drift apart, and every drift produced one
- * shape of bug: the reshape acted on lines the check holds to be code, or appended
- * a section the check already reads as present, and the document failed the very
- * check the reshape exists to satisfy.
+ * to decide, the same reader the checks judge the result with, for the reasons
+ * that class gives.
  */
 public class MarkdownConformer {
 
@@ -61,17 +58,12 @@ public class MarkdownConformer {
 	 * Reshapes until the document stops changing, which is the only way one pass can
 	 * be trusted: an edit made part-way through a pass changes how the lines below it
 	 * are read, so a question the pass had already answered can stop being true before
-	 * the pass ends. Every edit here is one of those. Inserting the {@code AGENTS.md}
-	 * reference puts a blank line above what followed the title, and a blank line is
-	 * what lets the line below it open an indented code block, so a {@code ## Testing}
-	 * that had been a lazy continuation of a paragraph became code. Inserting a stub
-	 * puts a line at the margin, which ends an open list and lowers the column at
-	 * which the lines below quote code, so a fence delimiter indented inside that list
-	 * stopped being one — and the terminator already appended for it then
-	 * <em>opened</em> a block that swallowed everything after it. Renaming a near-miss
-	 * heading moves it to the margin and ends a list the same way. Each of those left
-	 * the reshape reporting work it had done on a document that no longer existed, and
-	 * the caller's own check failing on the document the reshape had just produced.
+	 * the pass ends. Every edit here is one of those — an inserted reference or stub
+	 * puts a blank line or a margin line where the reading of the lines below turns on
+	 * one, and a renamed heading moves to the margin the same way. Each left the
+	 * reshape reporting work it had done on a document that no longer existed, and the
+	 * caller's own check failing on the document the reshape had just produced;
+	 * {@link #ensureRequiredSections} works one such case through.
 	 *
 	 * <p>What makes repeating the pass an answer rather than a retry is that a pass
 	 * which changes nothing is exactly a document the check accepts: the pass leaves a
@@ -151,14 +143,12 @@ public class MarkdownConformer {
 	 * reshape being idempotent means running it again never clears it.
 	 *
 	 * <p>A document that already opens with the title is not left alone either: it
-	 * needs no title <em>added</em>, but a second one lower down is the same duplicate
-	 * by another route, and returning on the first line alone left it there for good —
-	 * a check never looks past that line, so nothing downstream reported it, and the
-	 * reshape being idempotent meant running it again never cleared it.
+	 * needs no title <em>added</em>, but a second one lower down is that same
+	 * duplicate by another route, and returning on the first line alone left it there
+	 * for good.
 	 *
-	 * <p>The titles are removed latest first, so removing one cannot shift the index
-	 * of the next. Only structural lines are offered: a {@code # CLAUDE.md} inside a
-	 * code sample is the sample's, not the document's.
+	 * <p>Only structural lines are offered: a {@code # CLAUDE.md} inside a code sample
+	 * is the sample's, not the document's.
 	 */
 	private void ensureTitle(List<String> lines) {
 		MarkdownDocument document = MarkdownDocument.of(lines);
@@ -275,12 +265,10 @@ public class MarkdownConformer {
 	 * fence delimiter indented inside that list stops being one. The terminator
 	 * {@link #closeUnterminatedBlocks} had already appended for it then <em>opened</em>
 	 * a block instead of closing one, and every section appended afterwards landed
-	 * inside it, where a check reads it as code: the reshape answered with a document
-	 * still missing the sections it had just written.
-	 * Interleaving the two passes has the same flaw one step further on, since a stub
-	 * inserted after a section was appended can bury that section the same way.
-	 * Appending, by contrast, only ever adds below every line that has been read, so
-	 * it can invalidate nothing.
+	 * inside it, where a check reads it as code. Interleaving the two passes has the
+	 * same flaw one step further on, since a stub inserted after a section was
+	 * appended can bury that section the same way. Appending, by contrast, only ever
+	 * adds below every line that has been read, so it can invalidate nothing.
 	 */
 	private void ensureRequiredSections(List<String> lines) {
 		contract.requiredSections().forEach(required -> stubBareSection(lines, required));
@@ -317,10 +305,10 @@ public class MarkdownConformer {
 	 *
 	 * <p>An existing mention only counts where the rule counts one: its
 	 * {@code containsInProse} reads the lines that carry document structure, so a
-	 * mention inside a code sample or an HTML comment satisfies it no more than a
-	 * commented-out heading satisfies a required section. Asking the looser question
-	 * let a document whose only {@code AGENTS.md} sat in a comment keep a reference it
-	 * never had. A document with no title line at all takes the reference at the top.
+	 * mention inside a code sample or an HTML comment does not satisfy it. Asking the
+	 * looser question let a document whose only {@code AGENTS.md} sat in a comment
+	 * keep a reference it never had. A document with no title line at all takes the
+	 * reference at the top.
 	 */
 	private void ensureReference(List<String> lines) {
 		MarkdownDocument document = MarkdownDocument.of(lines);

--- a/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownDocument.java
+++ b/markdown-common/src/main/java/io/github/adamw7/tools/markdown/MarkdownDocument.java
@@ -17,69 +17,32 @@ import java.util.stream.Stream;
  * construction, lets the structural checks share them instead of each rebuilding
  * them.
  * <p>
- * Two kinds of caller read a document through this class, and they must agree
- * about it: one that <em>judges</em> a document — the {@code claudeMdFormat}
- * enforcer rule asking whether a {@code CLAUDE.md} carries a required section —
- * and one that <em>reshapes</em> a document so that judgement passes, which is
- * what the adoption pipeline's {@code ClaudeMdConformer} does before it commits a
- * generated {@code CLAUDE.md}. Every reading below was at some point spelled out
- * twice, once for each, and every way the two spellings drifted apart produced the
- * same shape of bug: the rewriter acted on lines the rule holds to be code, or
- * concluded a section was missing that the rule reads as present, and the adoption
- * then failed the very check it exists to satisfy — after committing and pushing
- * the file. That is why the reader is one class in a module of its own rather than
- * a copy on each side.
+ * Two kinds of caller read a document through this class and must agree about it:
+ * one that <em>judges</em> a document — the {@code claudeMdFormat} enforcer rule
+ * asking whether a {@code CLAUDE.md} carries a required section — and one that
+ * <em>reshapes</em> a document so that judgement passes, which is what the
+ * adoption pipeline's {@code ClaudeMdConformer} does before it commits a generated
+ * {@code CLAUDE.md}. Two spellings of these readings drifted apart in every way
+ * they could, each time producing the same bug: the rewriter acted on lines the
+ * rule holds to be code, or concluded a section was missing that the rule reads as
+ * present, and the adoption then failed the very check it exists to satisfy —
+ * after committing and pushing the file. That is why the reader is one class in a
+ * module of its own rather than a copy on each side.
  * <p>
- * Headings are recognised on whole lines outside code, so a heading mentioned in a
- * sample or in prose is not treated as document structure. The mask includes a
- * fence's opening and closing delimiters themselves, so heading and body detection
- * agree on what is code. A heading is an ATX one — one to six {@code #}
- * characters followed by whitespace or nothing else — so a line that merely starts
- * with a hash, such as {@code #1 rule: run mvn install}, stays prose. Counting it
- * as a heading would end the section it sits in and report that section as empty.
+ * Structure — a heading — is only ever recognised outside code and outside an HTML
+ * comment, so a heading shown in a sample or commented out is not structure. Code
+ * is quoted both ways Markdown allows, and the two are read in a single pass
+ * because each decides what the other may read: a fence shown inside an indented
+ * block is the delimiter that block illustrates rather than one this document
+ * opens. A fence closes only on a run of the same character, at least as long, and
+ * carrying no info string, so the nested fences documentation about Markdown
+ * writes stay content. An indented block opens only where one may, after a blank
+ * line, and its four columns are measured from the enclosing list item rather than
+ * from the margin, so a paragraph continuing a list item is prose however deep the
+ * item is nested.
  * <p>
- * A heading is also recognised only outside an HTML comment block. A section
- * commented out with {@code <!-- ... -->} is inert text, not structure, so counting
- * it would let a document satisfy a required-section check with the very heading its
- * author had removed. The delimiters that open and close such a block are read only
- * where a document writes one rather than illustrates one — see {@link #asRead}.
- * <p>
- * A fence is closed only by a run of the <em>same</em> character, at least as long
- * as the one that opened it, carrying no info string. All three conditions matter,
- * because documentation about Markdown nests one fence inside another: a
- * {@code ~~~} line inside a {@code ```} block, the {@code ```java} line of an
- * example inside a {@code ````} wrapper, and a {@code ```} example inside a
- * {@code ````} wrapper all stay content. Closing on the first character alone would
- * end the block early and then treat the real closing delimiter as a fresh opening
- * one, silently masking the rest of the document as code.
- * <p>
- * Code is also quoted the other way Markdown allows — by indenting it four columns,
- * a tab counting on to the next four-column stop — and those lines are masked
- * alike. Such a block opens only where one may, after a blank line, because an
- * indented line below a paragraph is a lazy continuation of that paragraph rather
- * than code; it then runs on through indented and blank lines until the next line
- * that is neither. Reading an indented sample as prose let a {@code ## Testing}
- * shown as an example satisfy the very check that demands that section, and
- * reported the sample's own {@code TODO} and its {@code [link](sample.md)} as the
- * document's own — while the identical text inside a fence was correctly ignored.
- * <p>
- * Where that indent is measured from is the enclosing list item, not the margin. A
- * list item indents its own continuation paragraphs to the column its content
- * starts at, so the four columns that quote code are four columns past
- * <em>that</em> — a paragraph continuing a {@code -} item is prose however deep the
- * item is nested. Measuring from the margin read every such paragraph as code: a
- * module named only in one went unmentioned as far as
- * {@link #containsInProse} was concerned, and a token a document forbids could be
- * written there without the check that forbids it ever seeing it.
- * <p>
- * The two ways are read in a single pass, because each decides what the other may
- * read. A fence inside an indented block is the delimiter that block illustrates,
- * not one this document opens: a lone {@code ```} shown four columns in is exactly
- * how a document explains what a fence looks like. Marking the fences first and the
- * indents afterwards left that lone delimiter opening a block nothing closed, and
- * so masked every line below it — the document's remaining headings included — as
- * code. The indent speaks for the line wherever it sits, whether a code block may
- * open at it or it merely continues the paragraph above.
+ * Each of those readings is stated where it is implemented, together with what
+ * misreading it silently reclassified.
  */
 public final class MarkdownDocument {
 
@@ -245,14 +208,7 @@ public final class MarkdownDocument {
 		return headingTexts().collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
-	/**
-	 * The heading each structural line declares, in document order, canonical rather
-	 * than verbatim. A heading is matched by the text it carries, so the closing
-	 * {@code #} run Markdown lets an author balance a heading with — {@code ## Testing
-	 * ##} — and the tab a heading may be separated by are not part of it. Comparing
-	 * the raw line reported a document that has {@code ## Testing} written that way as
-	 * missing the section, and attributed the section's content to the one above it.
-	 */
+	/** The heading each structural line declares, canonicalised by {@link #headingOf}. */
 	private Stream<String> headingTexts() {
 		return structuralLines()
 				.mapToObj(index -> lines.get(index))
@@ -268,11 +224,9 @@ public final class MarkdownDocument {
 	 * spurious out-of-order failure.
 	 * <p>
 	 * Only a heading answers, which is what keeps this in step with
-	 * {@link #headings()}. Reading every structural line let an entry of
-	 * {@code wanted} that is not a heading at all — a section configured as
-	 * {@code Testing} rather than {@code ## Testing} — be answered by a line of prose,
-	 * so the same document was reported both as missing that section and as having it
-	 * out of order.
+	 * {@link #headings()}: reading every structural line let an entry of
+	 * {@code wanted} that is no heading — {@code Testing} rather than
+	 * {@code ## Testing} — be answered by a line of prose.
 	 */
 	public List<String> headingsInOrder(List<String> wanted) {
 		Set<String> required = new LinkedHashSet<>(wanted);
@@ -282,10 +236,8 @@ public final class MarkdownDocument {
 	/**
 	 * @return the index of the first line declaring {@code section}, outside code and
 	 *         comments, or {@code -1} when the document declares it nowhere. The
-	 *         <em>first</em> is what answers, because that is the one every other
-	 *         reading here takes when a document carries the section twice — a
-	 *         rewriter that stubbed a later copy would be editing a section no check
-	 *         is judging.
+	 *         <em>first</em> answers, because that is the copy every other reading
+	 *         here takes when a document carries the section twice.
 	 */
 	public int headingIndex(String section) {
 		return headingIndices(section).findFirst().orElse(-1);
@@ -346,21 +298,16 @@ public final class MarkdownDocument {
 	/**
 	 * The heading {@code line} declares, written canonically — its {@code #} run,
 	 * then a single space and the text it carries, or the run alone when it carries
-	 * none — or empty when the line declares no heading at all.
-	 * <p>
-	 * A heading is the text it names, not the line it was typed on, so the
-	 * surrounding whitespace, the separator between the run and the text (a tab
-	 * counts), and the closing {@code #} run Markdown lets an author balance a
-	 * heading with are spelling rather than content. Comparing raw lines instead
-	 * made a checker and a rewriter disagree about which lines are the required
-	 * sections: a {@code ##  Testing} this reads as {@code ## Testing} was reported
-	 * as no section at all, so a second, stubbed copy of it was appended to a file
-	 * the adoption went on to commit and push.
+	 * none — or empty when the line declares no heading at all. A heading is the text
+	 * it names, not the line it was typed on, so the surrounding whitespace, the
+	 * separator (a tab counts) and the closing {@code #} run an author may balance a
+	 * heading with are spelling rather than content; comparing raw lines instead made
+	 * a checker and a rewriter disagree about which lines are the required sections.
 	 * <p>
 	 * Whether the line is <em>structure</em> is a separate question this does not
 	 * answer — a {@code ## Testing} inside a code sample still reads as a heading
-	 * here. Callers pair this with {@link #structuralLines} rather than asking it of
-	 * an arbitrary line, which is what {@link #headingIndices} does.
+	 * here. Callers pair this with {@link #structuralLines}, as {@link #headingIndices}
+	 * does.
 	 */
 	public static Optional<String> headingOf(String line) {
 		String stripped = line.strip();
@@ -459,10 +406,8 @@ public final class MarkdownDocument {
 	/**
 	 * Marks the lines an HTML comment spans, so a commented-out section is not read
 	 * as document structure. A comment that opens and closes on one line masks
-	 * nothing — {@code <!-- ## Testing -->} is not a heading to begin with — while a
-	 * block comment hid a required section from the check that exists to demand it
-	 * and satisfied it at the same time. A comment inside code is sample text, so
-	 * the code wins.
+	 * nothing — {@code <!-- ## Testing -->} is not a heading to begin with. A comment
+	 * inside code is sample text, so the code wins.
 	 */
 	private static CommentScan commentScan(List<String> lines, boolean[] insideCode) {
 		boolean[] mask = new boolean[lines.size()];
@@ -497,10 +442,8 @@ public final class MarkdownDocument {
 	 * {@link #containsUnquoted} takes, and the reading a fence already gets from
 	 * being matched on whole lines. Documentation about Markdown writes
 	 * {@code `<!--`} in prose precisely because it is an example, and taking it for a
-	 * real delimiter opened a comment nothing closed: every line below it was masked
-	 * as inert, so {@link #headingIndex} reported sections the document plainly carries
-	 * as missing and every check that reads the document's own text stopped seeing
-	 * it — the same silent reclassification a mis-read fence produces.
+	 * real delimiter opened a comment nothing closed, masking the rest of the
+	 * document as inert.
 	 * <p>
 	 * Inside a comment there are no code spans to honour: the text is already inert,
 	 * so its backticks are ordinary characters and a {@code -->} among them closes
@@ -521,13 +464,11 @@ public final class MarkdownDocument {
 	 * a closed one for the next {@code <!--}.
 	 * <p>
 	 * The delimiters are followed in a loop rather than by recursing on the rest of
-	 * the line, because the line is content this reader does not control: a document
-	 * carrying a few thousand delimiters on one line — a generated or minified line
-	 * is all it takes — recursed once per delimiter and overflowed the stack. A
-	 * {@link StackOverflowError} is no kind of verdict: it aborts the Maven build as
-	 * an internal error rather than as the violation a rule exists to report, and it
-	 * is not a {@code RuntimeException}, so the adoption's batch loop — which keeps
-	 * one repository's failure from stopping the rest — does not catch it either.
+	 * the line, because the line is content this reader does not control: a generated
+	 * or minified line carrying a few thousand delimiters recursed once per delimiter
+	 * and overflowed the stack. A {@link StackOverflowError} is no kind of verdict —
+	 * it aborts the Maven build as an internal error, and being no
+	 * {@code RuntimeException} it escapes the adoption's batch loop as well.
 	 */
 	private static boolean remainsOpen(String line, boolean open) {
 		boolean inside = open;
@@ -590,12 +531,8 @@ public final class MarkdownDocument {
 		 * That it is not a fence delimiter is the point. A fence opener may be indented
 		 * at most three columns past its container, so a {@code ```} shown four columns
 		 * in below a paragraph opens nothing. Falling through to {@link #atDelimiter}
-		 * read one as a fence the document opened and never closed, and every line
-		 * below it — the document's remaining headings included — was masked as code:
-		 * {@link #headingIndex} then reported sections the document plainly carries as
-		 * missing, and every check that reads the document's own text stopped seeing it.
-		 * The blank-line case was already answered here; only a paragraph directly
-		 * above the indent reached the delimiter reading.
+		 * read one as a fence the document opened and never closed, masking the rest of
+		 * the document — its remaining headings included — as code.
 		 */
 		private Scan atIndent(boolean[] mask, int index) {
 			mask[index] = mayIndent;


### PR DESCRIPTION
Removes code that was written twice and Javadoc that said the same thing
twice, leaving each fact stated where it is implemented.

Code:
- Add HtmlPage, the frame, styling and escaping HtmlReport and ReportIndex
  each carried a copy of; both now contribute only their own body and CSS.
- Add SettingsJsonRule, the settingsFile parameter settingsJsonValid,
  permissionsFormat and hookCommandsValid each declared. The field keeps the
  name its pom element uses, which is what the real-Maven EnforcerRuleBuildIT
  confirms; ClaudeCodeEnforcerRule's warning about hoisting is refined rather
  than dropped.
- Collapse ProjectParts' ifFile/ifDirectory and presentOf/presentDirectoriesOf
  onto one predicate-taking helper each.
- Drop ProjectLayout.readme(), which nothing reads: readmeConsistency is
  deliberately not one of the composite's parts.
- Drop two unused java.util.Map imports in the context MCP tools.

Javadoc:
- MarkdownDocument, MarkdownConformer, CloneStep: the class comment no longer
  restates what each member's comment then explains in full, and a rationale
  spelled out at two or three members is now spelled out at one.
- AdoptionOptions.pinnedRuleVersion() points at GuardOptions' identical
  contract instead of repeating it.

Full build, the two-phase doc check and the enforcer's real-Maven
integration test are green.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BpLQyDRNeAGZxh96MApxtH