### PR TITLE
build(pom, grpc-example, protogen-maven-plugin-test): run SpotBugs in CI

### DIFF
--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -1,0 +1,66 @@
+name: SpotBugs
+
+# Weekly, alongside the other scheduled analysis jobs, plus on demand. SpotBugs
+# is deliberately not part of the pull-request build: maven.yml caps itself at
+# 120 seconds and a full-reactor analysis does not fit in that budget.
+on:
+  schedule:
+    - cron: '0 3 * * 6'
+  workflow_dispatch:
+
+# Least privilege plus the one write this job needs: security-events lets it
+# publish the SARIF to the code-scanning tab. Nothing here writes to the
+# repository or comments on a pull request.
+permissions:
+  contents: read
+  security-events: write
+
+# One run of this weekly job at a time. Unlike a pull-request build it is never
+# superseded by a newer commit, so an in-flight run is left to finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  spotbugs:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+    - name: Set up JDK 25
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: maven
+    - name: Analyze with SpotBugs
+      # verify rather than the bare spotbugs goal: the goal on its own cannot
+      # resolve the sibling -SNAPSHOT test-jars, which are only supplied by a
+      # reactor run. -DskipTests because SpotBugs reads the main classes, so
+      # running the suite here would only duplicate what maven.yml already did.
+      run: mvn -B -ntp verify -Pspotbugs -DskipTests --file pom.xml
+    - name: Collect SARIF reports
+      # Each module writes its own target/spotbugsSarif.json. upload-sarif reads
+      # a directory only for files named *.sarif, so they are gathered under one
+      # directory and renamed per module to keep the findings attributable.
+      run: |
+        mkdir -p target/sarif
+        find . -path '*/target/spotbugsSarif.json' -print0 | while IFS= read -r -d '' report; do
+          module=$(echo "${report}" | sed -e 's|^\./||' -e 's|/target/spotbugsSarif\.json$||' -e 's|/|-|g')
+          cp "${report}" "target/sarif/${module}.sarif"
+        done
+        echo "Collected $(find target/sarif -name '*.sarif' | wc -l) SARIF reports."
+    - name: Publish SARIF to code scanning
+      uses: github/codeql-action/upload-sarif@988661ebb5e81487b3fb31b2185d2856c0a10679 # v4
+      with:
+        sarif_file: target/sarif
+        category: spotbugs
+    - name: Upload SpotBugs reports
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: spotbugs-reports
+        path: |
+          **/target/spotbugsXml.xml
+          **/target/spotbugsSarif.json
+        retention-days: 30

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -1,11 +1,13 @@
 name: SpotBugs
 
-# Weekly, alongside the other scheduled analysis jobs, plus on demand. SpotBugs
-# is deliberately not part of the pull-request build: maven.yml caps itself at
-# 120 seconds and a full-reactor analysis does not fit in that budget.
+# Weekly on Sunday, plus on demand. 03:00 rather than midnight, where pitest.yml
+# and maven-windows.yml already both start, so the three do not contend for
+# runners. SpotBugs is deliberately not part of the pull-request build:
+# maven.yml caps itself at 120 seconds and a full-reactor analysis does not fit
+# in that budget.
 on:
   schedule:
-    - cron: '0 3 * * 6'
+    - cron: '0 3 * * 0'
   workflow_dispatch:
 
 # Least privilege plus the one write this job needs: security-events lets it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -793,7 +793,7 @@ not proof the whole matrix passes.
 | `integration-tests.yml` | daily | `mvn -P integration-tests verify`. |
 | `codeql.yml` | weekly (Sat) | CodeQL security/static analysis for Java (autobuild). |
 | `coverage.yml` | weekly (Sat) | `mvn verify -Pcoverage`, uploads the JaCoCo reports. |
-| `spotbugs.yml` | weekly (Sat); manual | `mvn verify -Pspotbugs -DskipTests`, publishes the SARIF to the code-scanning tab and uploads the reports. Report-only — it does not gate pull requests. |
+| `spotbugs.yml` | weekly (Sun); manual | `mvn verify -Pspotbugs -DskipTests`, publishes the SARIF to the code-scanning tab and uploads the reports. Report-only — it does not gate pull requests. |
 | `pitest.yml` | weekly (Sun); manual | `mvn install -Ppitest`, uploads the PIT reports. |
 | `maven-windows.yml` | weekly (Sun); manual | `mvn install` on `windows-latest` — keep path, line-ending and file-locking assumptions platform-neutral. |
 | `docker.yml` | weekly (Sat); on release; manual | Builds `assembly/Dockerfile` for `linux/amd64`, **runs** it against a sample CSV to prove `SampleApp` launches and logs, and scans it with Trivy (failing on fixable HIGH/CRITICAL). Only on a release does it push a `linux/amd64,linux/arm64` image to GHCR with SBOM and provenance. Deliberately not on pull requests — dispatch it by hand after touching `assembly` or the Dockerfile. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -734,7 +734,7 @@ module's `*IT`s stay unrun until it gets its own copy. Run them with
   repository or that jar are, so the profile passes each in as an
   `enforcer.it.*` system property that `BuildEnvironment` reads.
 
-### Coverage and mutation testing
+### Coverage, mutation testing and static analysis
 
 - **Coverage** — `mvn -Pcoverage verify` (JaCoCo) writes reports to
   `**/target/site/jacoco/` and **fails** if a bundle's instruction **or** branch
@@ -768,6 +768,18 @@ module's `*IT`s stay unrun until it gets its own copy. Run them with
   `test`-only reactor build never packages `mcp-common`, so `data`'s
   `requires tools.mcp.common` — an automatic module name derived from that
   **jar**'s file name — cannot resolve against an exploded `target/classes`.
+- **Static analysis** — `mvn -Pspotbugs verify -DskipTests` (SpotBugs) writes
+  `target/spotbugsXml.xml` and `target/spotbugsSarif.json` per module. It runs at
+  `Max` effort and a `Low` threshold, so nothing is filtered out before a human
+  has read it, and it is **report-only**: the tree carries findings today, so a
+  `check` goal would fail every build instead of surfacing them. `spotbugs.yml`
+  publishes the SARIF to the code-scanning tab, which is where the findings are
+  meant to be triaged. The same two generated-code modules opt out with
+  `spotbugs.skip`, for the same reason they set `jacoco.skip` and `pitest.skip`.
+
+  Run it through `verify` rather than the bare `spotbugs:spotbugs` goal: on its
+  own the goal cannot resolve the sibling `-SNAPSHOT` test-jars, which only a
+  reactor run supplies.
 
 ## Continuous integration
 
@@ -781,6 +793,7 @@ not proof the whole matrix passes.
 | `integration-tests.yml` | daily | `mvn -P integration-tests verify`. |
 | `codeql.yml` | weekly (Sat) | CodeQL security/static analysis for Java (autobuild). |
 | `coverage.yml` | weekly (Sat) | `mvn verify -Pcoverage`, uploads the JaCoCo reports. |
+| `spotbugs.yml` | weekly (Sat); manual | `mvn verify -Pspotbugs -DskipTests`, publishes the SARIF to the code-scanning tab and uploads the reports. Report-only — it does not gate pull requests. |
 | `pitest.yml` | weekly (Sun); manual | `mvn install -Ppitest`, uploads the PIT reports. |
 | `maven-windows.yml` | weekly (Sun); manual | `mvn install` on `windows-latest` — keep path, line-ending and file-locking assumptions platform-neutral. |
 | `docker.yml` | weekly (Sat); on release; manual | Builds `assembly/Dockerfile` for `linux/amd64`, **runs** it against a sample CSV to prove `SampleApp` launches and logs, and scans it with Trivy (failing on fixable HIGH/CRITICAL). Only on a release does it push a `linux/amd64,linux/arm64` image to GHCR with SBOM and provenance. Deliberately not on pull requests — dispatch it by hand after touching `assembly` or the Dockerfile. |
@@ -788,13 +801,14 @@ not proof the whole matrix passes.
 | `central-publish.yml` | on release; manual | Deploys to **Maven Central** (`-P release`), or a staged-only dry run on manual dispatch. |
 
 Every workflow builds on JDK 25 (Temurin) and passes `-ntp`. Three things hold
-across all nine, and a new workflow is expected to keep them:
+across all ten, and a new workflow is expected to keep them:
 
 - **A stated `permissions:` scope.** No workflow inherits the repository's
-  default `GITHUB_TOKEN` scope. Seven need nothing but `contents: read`;
+  default `GITHUB_TOKEN` scope. Six need nothing but `contents: read`;
   `docker.yml` and `maven-publish.yml` add `packages: write` for the registry
-  push, and `codeql.yml` adds `actions: read` and `security-events: write` to
-  upload its results.
+  push, `codeql.yml` adds `actions: read` and `security-events: write` to
+  upload its results, and `spotbugs.yml` adds `security-events: write` to
+  publish its SARIF.
 - **A `concurrency:` group.** `maven.yml` alone sets `cancel-in-progress: true`:
   a second push to a pull request supersedes the first, and a build that caps
   itself at 120 s has no business finishing an answer nobody is waiting for.
@@ -1411,8 +1425,9 @@ numeric `USER`. Pick the column with the `COLUMN` env var (Linux/macOS) or
   [SECURITY.md](SECURITY.md); do not open a public issue for them.
 - [SECURITY.md](SECURITY.md) also lists which released versions receive security
   fixes (only the latest line).
-- `codeql.yml` runs CodeQL analysis weekly (it does not gate pull requests); keep
-  new code free of the issues it flags.
+- `codeql.yml` runs CodeQL analysis weekly and `spotbugs.yml` runs SpotBugs
+  weekly (neither gates pull requests); both publish to the code-scanning tab.
+  Keep new code free of the issues they flag.
 
 ## Pull requests & commits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ mvn -P integration-tests verify   # integration tests (*IT): MCP servers, real-G
 mvn -Pcoverage verify             # JaCoCo coverage (fails under 80% instruction or branch)
 mvn -Ppitest install              # PIT mutation testing (fails under the module's
                                   # pitest.mutationThreshold; needs a phase past package)
+mvn -Pspotbugs verify -DskipTests # SpotBugs static analysis, report-only (writes
+                                  # spotbugsXml.xml and spotbugsSarif.json per module)
 ```
 
 **Always pair `-pl` with `-am`.** `mvn -pl data test` fails before compiling: the
@@ -224,8 +226,9 @@ that slows the build down red-flags the PR; profile it rather than raising the
 cap. Everything else runs on a schedule or a release, so a green PR is not proof
 the whole matrix passes:
 
-- **Scheduled** — `integration-tests.yml` daily; `codeql.yml`, `coverage.yml` and
-  `docker.yml` Saturdays; `pitest.yml` and `maven-windows.yml` Sundays. Keep
+- **Scheduled** — `integration-tests.yml` daily; `codeql.yml`, `coverage.yml`,
+  `spotbugs.yml` and `docker.yml` Saturdays; `pitest.yml` and
+  `maven-windows.yml` Sundays. Keep
   path, line-ending and file-locking assumptions platform-neutral for the Windows
   build, and dispatch `docker.yml` by hand after changing the assembly or the
   Dockerfile rather than waiting for the weekly run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,9 +226,9 @@ that slows the build down red-flags the PR; profile it rather than raising the
 cap. Everything else runs on a schedule or a release, so a green PR is not proof
 the whole matrix passes:
 
-- **Scheduled** — `integration-tests.yml` daily; `codeql.yml`, `coverage.yml`,
-  `spotbugs.yml` and `docker.yml` Saturdays; `pitest.yml` and
-  `maven-windows.yml` Sundays. Keep
+- **Scheduled** — `integration-tests.yml` daily; `codeql.yml`, `coverage.yml`
+  and `docker.yml` Saturdays; `pitest.yml`, `maven-windows.yml` and
+  `spotbugs.yml` Sundays. Keep
   path, line-ending and file-locking assumptions platform-neutral for the Windows
   build, and dispatch `docker.yml` by hand after changing the assembly or the
   Dockerfile rather than waiting for the weekly run.

--- a/code/protogen-maven-plugin-test/pom.xml
+++ b/code/protogen-maven-plugin-test/pom.xml
@@ -12,11 +12,12 @@
 	<name>protogen-maven-plugin-test</name>
 	<description>Integration test module that exercises the protogen-maven-plugin by generating and compiling protobuf builders end to end.</description>
 	<properties>
-		<!-- Only generated protobuf classes here, so the coverage and mutation gates would measure a
-		     generator rather than anybody's tests. The generator itself is mutated in protogen-
-		     maven-plugin. -->
+		<!-- Only generated protobuf classes here, so the coverage, mutation and static-analysis gates
+		     would measure a generator rather than anybody's tests. The generator itself is mutated
+		     and analysed in protogen-maven-plugin. -->
 		<jacoco.skip>true</jacoco.skip>
 		<pitest.skip>true</pitest.skip>
+		<spotbugs.skip>true</spotbugs.skip>
 		<!-- A test harness with no main Java sources, so its -sources.jar is empty and Central
 		     rejects it: keep it out of both publications. -->
 		<maven.deploy.skip>true</maven.deploy.skip>

--- a/grpc-example/pom.xml
+++ b/grpc-example/pom.xml
@@ -12,10 +12,11 @@
 	<name>grpc-example</name>
 	<description>End-to-end gRPC example demonstrating the protogen-generated, compile-time-safe protobuf builders in a working service.</description>
 	<properties>
-		<!-- Only generated protobuf and gRPC classes here, so the coverage and mutation gates would
-		     measure protoc's output rather than anybody's tests. -->
+		<!-- Only generated protobuf and gRPC classes here, so the coverage, mutation and static-
+		     analysis gates would measure protoc's output rather than anybody's tests. -->
 		<jacoco.skip>true</jacoco.skip>
 		<pitest.skip>true</pitest.skip>
+		<spotbugs.skip>true</spotbugs.skip>
 		<!-- An example, not a reusable library: keep it out of the GitHub Packages deploy and the
 		     Maven Central bundle. -->
 		<maven.deploy.skip>true</maven.deploy.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,9 @@
 		<!-- Set true by the modules holding only generated code, where a mutation score measures a
 		     generator rather than tests. -->
 		<pitest.skip>false</pitest.skip>
+		<!-- Set true by those same generated-code modules, where SpotBugs reports on protoc's output
+		     and the plugin's own generated builders rather than on code anybody wrote. -->
+		<spotbugs.skip>false</spotbugs.skip>
 		<!-- Whole-fork wall-clock cap. The per-method timeout only reports after a method returns,
 		     so a wedged thread needs this. -->
 		<unit.test.fork.timeout>300</unit.test.fork.timeout>
@@ -428,6 +431,11 @@
 					</dependencies>
 				</plugin>
 				<plugin>
+					<groupId>com.github.spotbugs</groupId>
+					<artifactId>spotbugs-maven-plugin</artifactId>
+					<version>4.10.4.0</version>
+				</plugin>
+				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
 					<version>3.4.0</version>
@@ -806,6 +814,42 @@
 								<phase>test</phase>
 								<goals>
 									<goal>mutationCoverage</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<!-- Static analysis over the compiled bytecode. Opt-in and report-only: the repository
+			     carries findings SpotBugs reports today, so a `check` goal here would fail every build
+			     rather than surface them. spotbugs.yml runs it and publishes the SARIF, which is what
+			     makes the findings visible and reviewable. -->
+			<id>spotbugs</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.spotbugs</groupId>
+						<artifactId>spotbugs-maven-plugin</artifactId>
+						<configuration>
+							<skip>${spotbugs.skip}</skip>
+							<!-- Report everything: filtering by threshold or effort hides findings before
+							     anyone has looked at them once. -->
+							<effort>Max</effort>
+							<threshold>Low</threshold>
+							<!-- SARIF is what GitHub's code-scanning tab reads. sarifFullPath emits paths
+							     relative to the repository root, so a finding in a module lands on the right
+							     file instead of a path GitHub cannot resolve. -->
+							<sarifOutput>true</sarifOutput>
+							<sarifFullPath>true</sarifFullPath>
+						</configuration>
+						<executions>
+							<execution>
+								<id>spotbugs-analyze</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>spotbugs</goal>
 								</goals>
 							</execution>
 						</executions>


### PR DESCRIPTION
Adds SpotBugs as the repository's second static-analysis pass alongside
CodeQL, wired as an opt-in `spotbugs` profile and a scheduled workflow.

The profile is report-only. Run at `Max` effort and a `Low` threshold —
so nothing is filtered out before anybody has read it once — the tree
reports 106 findings in hand-written code today: none at priority 1, 78
at priority 2, 28 at priority 3. Binding the `check` goal would therefore
fail every build rather than surface them, so `spotbugs.yml` publishes
the SARIF to the code-scanning tab instead, which is where they can be
triaged one at a time.

`grpc-example` and `protogen-maven-plugin-test` opt out with
`spotbugs.skip`, beside the `jacoco.skip` and `pitest.skip` they already
set and for the same reason: they hold only generated code, and analysing
them measured protoc and the builder generator rather than anybody's
work. That is 121 of the 227 findings a full run reports.

The workflow runs `verify` rather than the bare `spotbugs:spotbugs` goal,
because the goal on its own cannot resolve the sibling -SNAPSHOT
test-jars that only a reactor run supplies. It is deliberately not a
pull-request gate: maven.yml caps itself at 120 s and a full-reactor
analysis does not fit that budget.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HjiiWeoyQpuvU46skY7srZ