### PR TITLE
fix(data): fail a Scanner read that breaks instead of calling it EOF

### DIFF
--- a/.claude/skills/data-sources/SKILL.md
+++ b/.claude/skills/data-sources/SKILL.md
@@ -49,6 +49,15 @@ Every format ships in two variants:
   transparently **decompress `.gz`** with no extra config.
 - JSON/YAML flatten nested objects to dotted keys, e.g.
   `people[0].address.city`.
+- A **read that breaks part-way through fails**, rather than reading as a short
+  file. The `Scanner`-backed sources (`CSVDataSource` and the map-backed
+  in-memory JSON/YAML/TOON ones) go through `AbstractFileSource.hasNextLine()`,
+  which raises `UncheckedIOException` when `Scanner.ioException()` is set —
+  `Scanner` swallows the failure by design and just stops producing tokens, so a
+  truncated transfer, a corrupt GZip member or a disk error would otherwise look
+  like the end of the data and let the uniqueness check call a column unique on
+  half a file. The forward-only sources on `AbstractIterableFileSource` already
+  propagate. A new source must do one or the other.
 
 ### Confining a source to a directory
 Every path a source is given is canonicalised and refused if it climbs out with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,11 +36,15 @@ skill carries the reasoning and the worked example.
   JDBC-backed source. Sources that know their columns up front implement
   `ColumnarDataSource`, a narrower contract than `IterableDataSource`, so a
   caller that needs the schema — such as the uniqueness check — cannot be handed
-  a forward-only source (JSON/YAML/TOON) that would only answer `null`. Also a
-  uniqueness checker (does a subset of columns form a key, and is there a smaller
-  one), open-addressing collections (`OpenAddressingMap`, `OpenAddressingSet`,
-  the primitive `IntKeyOpenAddressingMap`), and an **MCP server** exposing the
-  uniqueness checker. Skill: `data-sources`.
+  a forward-only source (JSON/YAML/TOON) that would only answer `null`. A read
+  that breaks part-way through fails instead of reading as a short file: the
+  `Scanner`-backed sources check `Scanner.ioException()` before reporting the end
+  of the data, so a truncated transfer or a corrupt GZip member cannot pass for a
+  clean end and leave the uniqueness check calling a column unique on half a
+  file. Also a uniqueness checker (does a subset of columns form a key, and is
+  there a smaller one), open-addressing collections (`OpenAddressingMap`,
+  `OpenAddressingSet`, the primitive `IntKeyOpenAddressingMap`), and an **MCP
+  server** exposing the uniqueness checker. Skill: `data-sources`.
 - **Claude Code adoption** (`adopt`) — an ordered pipeline that adopts Claude
   Code into a GitHub repository. Skill: `adopt-pipeline`. Summarised below.
 

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractFileSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractFileSource.java
@@ -75,6 +75,31 @@ public abstract class AbstractFileSource implements IterableDataSource {
 		return createScanner(new FileInputStream(fileName));
 	}
 	
+	/**
+	 * Answers whether the scan has another line, failing rather than reporting a clean end
+	 * of data when the read behind it broke. {@link Scanner} never throws
+	 * {@link IOException}: it swallows a read failure, stops producing tokens, and keeps
+	 * the cause in {@link Scanner#ioException()}. Left unread, that turns a truncated
+	 * transfer, a corrupt GZip member or a disk error into an ordinary end of file, and a
+	 * caller such as the uniqueness check then answers "this column is unique" having seen
+	 * only the rows that arrived.
+	 */
+	protected boolean hasNextLine() {
+		if (scanner.hasNextLine()) {
+			return true;
+		}
+		IOException failure = scanner.ioException();
+		if (failure != null) {
+			throw new UncheckedIOException("Reading " + describeSource() + " failed before the end of the data",
+					failure);
+		}
+		return false;
+	}
+
+	private String describeSource() {
+		return fileName != null ? fileName : "the input stream";
+	}
+
 	protected void checkIfOpen() {
 		if (!opened) {
 			throw new IllegalStateException("DataSource is not open");

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryJacksonDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryJacksonDataSource.java
@@ -42,7 +42,7 @@ public abstract class AbstractInMemoryJacksonDataSource extends AbstractInMemory
 	@Override
 	protected void parse() {
 		StringBuilder content = new StringBuilder();
-		while (scanner.hasNextLine()) {
+		while (hasNextLine()) {
 			content.append(scanner.nextLine()).append('\n');
 		}
 		flatten("", read(content.toString()));

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
@@ -128,7 +128,7 @@ public class CSVDataSource extends AbstractFileSource implements ColumnarDataSou
 
 	@Override
 	public String[] nextRow() {
-		if (scanner.hasNextLine()) {
+		if (hasNextLine()) {
 			String line = scanner.nextLine();
 			if (line.trim().startsWith("#")) {
 				return null;

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryTOONDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryTOONDataSource.java
@@ -33,7 +33,7 @@ public class InMemoryTOONDataSource extends AbstractInMemoryMapDataSource {
 	@Override
 	protected void parse() {
 		ToonFlattener flattener = new ToonFlattener(fieldsMap::put);
-		while (scanner.hasNextLine()) {
+		while (hasNextLine()) {
 			flattener.accept(scanner.nextLine());
 		}
 		flattener.finish();

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/AbstractFileSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/AbstractFileSourceTest.java
@@ -1,0 +1,142 @@
+package io.github.adamw7.tools.data.source.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.zip.GZIPOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.data.uniqueness.NoMemoryUniquenessCheck;
+
+/**
+ * Covers the one thing every {@link java.util.Scanner}-backed source shares: a read
+ * that fails part-way through must be reported, not mistaken for the end of the data.
+ * Scanner swallows the {@link IOException} and simply stops producing tokens, so
+ * without the check in {@link AbstractFileSource#hasNextLine()} a truncated transfer,
+ * a corrupt GZip member or a disk error reads as a short but successful file.
+ */
+public class AbstractFileSourceTest {
+
+	private static final String HEADER = "id,name\n";
+
+	@Test
+	public void csvSourceFailsWhenTheReadBreaksMidFile() {
+		CSVDataSource source = new CSVDataSource(failingAfter(HEADER + "1,Adam\n"), ",", 1);
+		source.open();
+
+		UncheckedIOException thrown = assertThrows(UncheckedIOException.class, () -> readAll(source));
+
+		assertEquals("disk went away", thrown.getCause().getMessage());
+		assertTrue(thrown.getMessage().contains("the input stream"), thrown.getMessage());
+	}
+
+	@Test
+	public void csvSourceNamesTheFileItFailedToRead(@TempDir Path directory) throws IOException {
+		Path file = truncatedGzip(directory);
+		CSVDataSource source = new CSVDataSource(file.toString(), ",", 1, AllowedPaths.under(directory));
+		source.open();
+
+		UncheckedIOException thrown = assertThrows(UncheckedIOException.class, () -> readAll(source));
+
+		// A GZip member cut short ends with an unexpected EOF rather than a clean end of
+		// data; the message must name the file so the failure can be traced to it.
+		assertInstanceOf(EOFException.class, thrown.getCause());
+		assertTrue(thrown.getMessage().contains(file.toString()), thrown.getMessage());
+	}
+
+	@Test
+	public void uniquenessCheckFailsRatherThanCallingAHalfReadColumnUnique() {
+		// The duplicate sits in the part of the file the read never reaches, so a
+		// swallowed failure would answer "unique" — wrong in the dangerous direction.
+		CSVDataSource source = new CSVDataSource(failingAfter(HEADER + "1,Adam\n"), ",", 1);
+
+		assertThrows(UncheckedIOException.class, () -> new NoMemoryUniquenessCheck(source).exec("id"));
+	}
+
+	@Test
+	public void jacksonSourceFailsWhenTheReadBreaksMidDocument() {
+		// The map sources parse in their constructor, so the failure surfaces there.
+		assertThrows(UncheckedIOException.class,
+				() -> new InMemoryJSONDataSource(failingAfter("{\"id\": \"1\",\n")));
+	}
+
+	@Test
+	public void toonSourceFailsWhenTheReadBreaksMidDocument() {
+		assertThrows(UncheckedIOException.class, () -> new InMemoryTOONDataSource(failingAfter("id: 1\n")));
+	}
+
+	@Test
+	public void cleanEndOfFileIsStillAnEndOfFile() {
+		CSVDataSource source = new CSVDataSource(stream(HEADER + "1,Adam\n2,Adam\n"), ",", 1);
+		source.open();
+
+		// Nothing failed, so ioException() is null and the read ends normally.
+		assertEquals(2, readAll(source));
+	}
+
+	private static int readAll(CSVDataSource source) {
+		int rows = 0;
+		while (source.hasMoreData()) {
+			String[] row = source.nextRow();
+			if (row != null) {
+				++rows;
+			}
+		}
+		return rows;
+	}
+
+	private static Path truncatedGzip(Path directory) throws IOException {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		try (GZIPOutputStream gzip = new GZIPOutputStream(bytes)) {
+			gzip.write((HEADER + "1,Adam\n2,Adam\n").getBytes(StandardCharsets.UTF_8));
+		}
+		byte[] complete = bytes.toByteArray();
+		Path file = directory.resolve("truncated.csv.gz");
+		// Everything but the trailer: the magic number still says GZip, so the source
+		// starts reading and only discovers the member is cut short part-way through.
+		Files.write(file, Arrays.copyOf(complete, complete.length - 8));
+		return file;
+	}
+
+	private static InputStream stream(String content) {
+		return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+	}
+
+	/** A stream that hands over {@code prefix} and then fails the way a dying disk does. */
+	private static InputStream failingAfter(String prefix) {
+		InputStream readable = stream(prefix);
+		return new InputStream() {
+			@Override
+			public int read() throws IOException {
+				int next = readable.read();
+				if (next == -1) {
+					throw new IOException("disk went away");
+				}
+				return next;
+			}
+
+			@Override
+			public int read(byte[] buffer, int offset, int length) throws IOException {
+				int read = readable.read(buffer, offset, length);
+				if (read == -1) {
+					throw new IOException("disk went away");
+				}
+				return read;
+			}
+		};
+	}
+}


### PR DESCRIPTION
Scanner never throws IOException: it catches a read failure, stops
producing tokens and keeps the cause in ioException(), which nothing in
the module read. A truncated transfer, a corrupt GZip member or a disk
error was therefore indistinguishable from a clean end of file, so a
partial read reported success and the uniqueness check could answer
"this column is unique" having seen only the rows that arrived — wrong
in the dangerous direction.

AbstractFileSource.hasNextLine() now checks ioException() once the scan
stops and raises UncheckedIOException naming the file (or the input
stream) it failed to read. CSVDataSource and the map-backed in-memory
JSON/YAML/TOON parsers drive their loops through it; the forward-only
sources on AbstractIterableFileSource already propagate.

Closes #626