### PR TITLE
fix(data): lock a private monitor in the network kill-switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,9 +832,12 @@ any subsequent attempt to open an outbound connection fails fast. The method is:
 
 - **One-way** — there is no `on()`; once off, the JVM stays offline. Apply it
   early, only when you really mean to seal the process.
-- **Idempotent and thread-safe** — it is `synchronized` and guarded by a
-  `volatile` flag; calling it again is a no-op that logs a warning and returns
-  `false`.
+- **Idempotent and thread-safe** — the one-shot installation is serialized on a
+  private monitor and the state is guarded by a `volatile` flag; calling it again
+  is a no-op that logs a warning and returns `false`. The monitor is deliberately
+  not `Switch.class`: that object is reachable from anything on the classpath, so
+  a `static synchronized` method would let unrelated code contend with — and
+  delay — the kill-switch.
   
 The switch is wired into the `data` module's unit-test run for exactly this
 reason: a `NetworkOffExtension` (a JUnit `BeforeAllCallback` discovered through
@@ -1215,8 +1218,11 @@ design:
   structures honest about their documented lack of thread-safety: no method in
   `structure` may be `synchronized`, and `structure` may not depend on
   `java.util.concurrent`, so neither can silently suggest the collections are safe
-  to share. Two more pin the `network` kill-switch to its documented shape:
-  `Switch.off()` must be `synchronized` and its `isOff` flag must be `volatile`.
+  to share. Three more pin the `network` kill-switch to its documented shape: no
+  method there may be `synchronized`, since a `static synchronized` method would
+  lock the publicly reachable `Switch.class`; the `LOCK` it synchronizes on
+  instead must be `private static final`; and its `isOff` flag must be
+  `volatile`.
 - **[`code/context`](code/context/src/test/java/io/github/adamw7/context/architecture/ContextArchitectureTest.java)** — the finder/tree core must not depend on the `mcp`
   delivery package, and only that `mcp` package may build on the shared MCP
   scaffolding; every concrete `*Serializer` must honour the

--- a/data/src/main/java/io/github/adamw7/tools/data/network/Switch.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/network/Switch.java
@@ -24,10 +24,17 @@ import org.apache.logging.log4j.Logger;
  * {@code SelectorProvider} are the one remaining gap: the provider cannot be
  * replaced once the JVM has loaded it, so a library that opens raw channels is
  * not blocked by this switch.
+ * <p>
+ * Callers race only over the one-shot installation, which is serialized on a
+ * private monitor rather than on {@code Switch.class}: the class object is
+ * reachable from anything on the classpath, so locking it would let unrelated
+ * code contend with — and delay — the kill-switch.
  */
 public class Switch {
 
 	private static final Logger log = LogManager.getLogger(Switch.class.getName());
+
+	private static final Object LOCK = new Object();
 
 	private static volatile boolean isOff = false;
 
@@ -56,16 +63,18 @@ public class Switch {
 	 *
 	 * @return true if this execution has turned off the network
 	 */
-	public static synchronized boolean off() {
-		if (isOff) {
-			log.warn("Network is already off. Nothing changed");
-			return false;
+	public static boolean off() {
+		synchronized (LOCK) {
+			if (isOff) {
+				log.warn("Network is already off. Nothing changed");
+				return false;
+			}
+			ProxySelector.setDefault(new BlockingProxySelector());
+			blockClientSockets();
+			isOff = true;
+			log.info("Network is off now");
+			return true;
 		}
-		ProxySelector.setDefault(new BlockingProxySelector());
-		blockClientSockets();
-		isOff = true;
-		log.info("Network is off now");
-		return true;
 	}
 
 	/**

--- a/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/architecture/DataArchitectureTest.java
@@ -3,7 +3,6 @@ package io.github.adamw7.tools.data.architecture;
 import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
@@ -102,12 +101,22 @@ public class DataArchitectureTest {
 					+ "dependency would misleadingly suggest they are safe to share across threads");
 
 	@ArchTest
-	static final ArchRule networkSwitchGuardsWithSynchronization = methods()
-			.that().haveName("off")
-			.and().areDeclaredInClassesThat().resideInAPackage(NETWORK_PACKAGE)
+	static final ArchRule networkSwitchDeclaresNoSynchronizedMethods = noMethods()
+			.that().areDeclaredInClassesThat().resideInAPackage(NETWORK_PACKAGE)
 			.should().haveModifier(JavaModifier.SYNCHRONIZED)
-			.because("Switch.off() is documented as synchronized so concurrent callers cannot race "
-					+ "while installing the blocking proxy selector");
+			.because("a static synchronized method would lock Switch.class, a monitor anything on the "
+					+ "classpath can take, letting unrelated code contend with the kill-switch; the "
+					+ "one-shot installation is serialized on a private monitor instead");
+
+	@ArchTest
+	static final ArchRule networkSwitchLocksAPrivateMonitor = fields()
+			.that().haveName("LOCK")
+			.and().areDeclaredInClassesThat().resideInAPackage(NETWORK_PACKAGE)
+			.should().haveModifier(JavaModifier.PRIVATE)
+			.andShould().haveModifier(JavaModifier.STATIC)
+			.andShould().haveModifier(JavaModifier.FINAL)
+			.because("the monitor Switch.off() locks must be unreachable and unswappable from outside "
+					+ "the class, so no caller can contend for it or replace it");
 
 	@ArchTest
 	static final ArchRule networkSwitchFlagIsVolatile = fields()

--- a/data/src/test/java/io/github/adamw7/tools/data/network/SwitchThreadSafetyTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/network/SwitchThreadSafetyTest.java
@@ -3,18 +3,22 @@ package io.github.adamw7.tools.data.network;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.ProxySelector;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -27,11 +31,23 @@ import org.junit.jupiter.api.Timeout;
  * one-time {@code true} return. Instead it engages the switch itself and then
  * hammers {@code off()} from many threads released together, proving that every
  * concurrent call is a consistent, exception-free no-op that returns {@code false}
- * and leaves the network sealed.
+ * and leaves the network sealed. It also pins the monitor the switch locks: the
+ * private one, not {@code Switch.class}, which anything on the classpath could
+ * take and hold.
  */
 public class SwitchThreadSafetyTest {
 
 	private static final int THREADS = 16;
+
+	private static final int WAIT_SECONDS = 5;
+
+	/**
+	 * The neighbouring thread must still hold {@code Switch.class} when the
+	 * assertion window closes, so that a blocked {@code off()} fails the test
+	 * rather than being let through by the holder timing out. The test releases it
+	 * in a {@code finally}, so this ceiling is only reached if that never runs.
+	 */
+	private static final int HOLD_SECONDS = 60;
 
 	/**
 	 * Opts out of the 900 ms per-test timeout: spinning up and joining a pool of
@@ -74,6 +90,65 @@ public class SwitchThreadSafetyTest {
 			throws InterruptedException, ExecutionException {
 		for (Future<Boolean> result : results) {
 			assertFalse(result.get(), "off() must be a no-op once the switch is already engaged");
+		}
+	}
+
+	/**
+	 * Pins the monitor {@link Switch#off()} locks. A {@code static synchronized}
+	 * method would lock {@code Switch.class}, so any classpath neighbour holding
+	 * that monitor could stall the kill-switch; here a thread takes it and keeps
+	 * it, and {@code off()} must still complete. Opts out of the per-test timeout
+	 * for the same reason as the test above.
+	 */
+	@Test
+	@Timeout(value = 10, unit = TimeUnit.SECONDS)
+	public void offDoesNotWaitOnThePubliclyLockableClassMonitor() throws InterruptedException, ExecutionException {
+		Switch.off(); // engage the one-way switch, so the call under test is a no-op
+
+		CountDownLatch monitorHeld = new CountDownLatch(1);
+		CountDownLatch releaseMonitor = new CountDownLatch(1);
+		ExecutorService pool = Executors.newFixedThreadPool(2);
+		try {
+			pool.submit(holdClassMonitorUntilReleased(monitorHeld, releaseMonitor));
+			assertTrue(monitorHeld.await(WAIT_SECONDS, TimeUnit.SECONDS),
+					"the neighbouring thread never took the Switch.class monitor");
+			assertOffCompletesWhileClassMonitorIsHeld(pool);
+		} finally {
+			releaseMonitor.countDown();
+			pool.shutdownNow();
+		}
+	}
+
+	private Runnable holdClassMonitorUntilReleased(CountDownLatch held, CountDownLatch release) {
+		return () -> {
+			synchronized (Switch.class) {
+				held.countDown();
+				awaitRelease(release);
+			}
+		};
+	}
+
+	private void awaitRelease(CountDownLatch release) {
+		try {
+			release.await(HOLD_SECONDS, TimeUnit.SECONDS);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	private void assertOffCompletesWhileClassMonitorIsHeld(ExecutorService pool)
+			throws InterruptedException, ExecutionException {
+		Callable<Boolean> off = Switch::off;
+		Future<Boolean> result = pool.submit(off);
+		assertFalse(offResultWithinWaitWindow(result), "off() must be a no-op once the switch is already engaged");
+	}
+
+	private Boolean offResultWithinWaitWindow(Future<Boolean> result) throws InterruptedException, ExecutionException {
+		try {
+			return result.get(WAIT_SECONDS, TimeUnit.SECONDS);
+		} catch (TimeoutException e) {
+			return fail("off() blocked while another thread held the Switch.class monitor, "
+					+ "so it is locking a monitor code outside Switch can take", e);
 		}
 	}
 


### PR DESCRIPTION
Switch.off() was static synchronized, so it locked the intrinsic monitor of
Switch.class — an object anything on the classpath can name. Unrelated code
running synchronized (Switch.class) could therefore contend with, and delay,
the switch that guarantees a unit test cannot open a socket. SpotBugs reports
this as USO_UNSAFE_STATIC_METHOD_SYNCHRONIZATION (SECURITY, priority 2).

Serialize the one-shot installation on a private static final LOCK instead.
The guarded region is unchanged, so the idempotence and publication guarantees
hold; isOff stays volatile and is still read only under the lock — it has no
getter and nothing outside the class reads it.

The ArchUnit rule that pinned the old shape is replaced by two that pin the new
one: no method in the network package may be synchronized, and the LOCK it
synchronizes on must be private static final. SwitchThreadSafetyTest gains a
test that holds the Switch.class monitor in a neighbouring thread and requires
off() to complete anyway — it fails on the previous shape.

Closes #657

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XkF1HPEoYN6B4fcUqLc42b