### PR TITLE
build(data): clear the SQL-injection detector on the two JDBC sources

### DIFF
--- a/.claude/skills/data-sources/SKILL.md
+++ b/.claude/skills/data-sources/SKILL.md
@@ -49,6 +49,10 @@ Every format ships in two variants:
   transparently **decompress `.gz`** with no extra config.
 - JSON/YAML flatten nested objects to dotted keys, e.g.
   `people[0].address.city`.
+- The **JDBC sources run the query verbatim** through a plain `Statement`: they
+  bind nothing, so a query built from untrusted input is an injection at the
+  caller's keyboard. Their javadoc says so, and `data/spotbugs-exclude.xml`
+  accepts `SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE` for those two methods only.
 - A **read that breaks part-way through fails**, rather than reading as a short
   file. The `Scanner`-backed sources (`CSVDataSource` and the map-backed
   in-memory JSON/YAML/TOON ones) go through `AbstractFileSource.hasNextLine()`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -781,6 +781,14 @@ module's `*IT`s stay unrun until it gets its own copy. Run them with
   meant to be triaged. The same two generated-code modules opt out with
   `spotbugs.skip`, for the same reason they set `jacoco.skip` and `pitest.skip`.
 
+  A finding that has been decided about rather than fixed is excluded in the
+  module's own filter file, wired in from the module pom — today only
+  `data/spotbugs-exclude.xml`, which accepts
+  `SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE` on the two JDBC sources that run the
+  caller's query by contract. Every `Match` there names a class, a method and a
+  pattern, so the detector still fires anywhere else in the module;
+  `SpotBugsExcludeFilterTest` fails the build if one grows broader than that.
+
   Run it through `verify` rather than the bare `spotbugs:spotbugs` goal: on its
   own the goal cannot resolve the sibling `-SNAPSHOT` test-jars, which only a
   reactor run supplies.

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -44,6 +44,15 @@
 					<useModulePath>false</useModulePath>
 				</configuration>
 			</plugin>
+			<!-- Narrows the SpotBugs run configured in the root pom's `spotbugs` profile; the
+			     plugin runs only when that profile is active, this just supplies the filter. -->
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<configuration>
+					<excludeFilterFile>${project.basedir}/spotbugs-exclude.xml</excludeFilterFile>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/data/spotbugs-exclude.xml
+++ b/data/spotbugs-exclude.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SpotBugs findings this module has decided about, scoped to the exact method each one
+  was accepted for. Nothing here disables a detector: every Match names a class, a
+  method and a bug pattern, so the same pattern anywhere else in the module still
+  fails. Wired in from data/pom.xml; SpotBugsExcludeFilterTest pins the scoping.
+-->
+<FindBugsFilter>
+	<!--
+	  Both sources run the SQL the caller handed them, verbatim and unparameterised.
+	  That is the published contract of these classes rather than a concatenation bug —
+	  the module runs a query you give it, it never builds one from fragments — and the
+	  javadoc on both says so and tells the caller what they own as a result.
+	-->
+	<Match>
+		<Class name="io.github.adamw7.tools.data.source.db.IterableSQLDataSource" />
+		<Method name="executeQuery" />
+		<Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE" />
+	</Match>
+	<Match>
+		<Class name="io.github.adamw7.tools.data.source.db.InMemorySQLDataSource" />
+		<Method name="readAll" />
+		<Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE" />
+	</Match>
+</FindBugsFilter>

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/InMemorySQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/InMemorySQLDataSource.java
@@ -14,15 +14,30 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
 
+/**
+ * An {@link IterableSQLDataSource} that reads the whole result set into memory in one
+ * call. The query is executed verbatim and unparameterised, on the same terms as the
+ * superclass: see {@link IterableSQLDataSource} for what the caller must guarantee
+ * about the SQL it hands over.
+ */
 public class InMemorySQLDataSource extends IterableSQLDataSource implements InMemoryDataSource {
 	
 	private static final Logger log = LogManager.getLogger(InMemorySQLDataSource.class.getName());
 
 	
+	/**
+	 * @param connection the JDBC connection to run the query on
+	 * @param query the SQL to execute, run verbatim &mdash; see {@link IterableSQLDataSource}
+	 *        for what the caller must guarantee about how it was built
+	 */
 	public InMemorySQLDataSource(Connection connection, String query) {
 		super(connection, query);
 	}
 	
+	/**
+	 * Executes the query given to the constructor, verbatim and unparameterised, and
+	 * returns every row it produced.
+	 */
 	@Override
 	public List<String[]> readAll() {
 		try (Statement statement = connection.createStatement()) {

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -12,6 +12,21 @@ import org.apache.logging.log4j.Logger;
 
 import io.github.adamw7.tools.data.source.interfaces.ColumnarDataSource;
 
+/**
+ * A {@link ColumnarDataSource} over a JDBC query, read a row at a time.
+ *
+ * <p><strong>The query is executed verbatim.</strong> This source hands the SQL it was
+ * given to a plain {@link Statement}, binding nothing and rewriting nothing, so the
+ * caller owns the statement's safety: assemble it from constants and values you
+ * control, and never from input that arrived from outside the program. A query built
+ * by concatenating untrusted text is a SQL injection here, exactly as it would be at
+ * the {@code Statement} call this class makes on the caller's behalf.</p>
+ *
+ * <p>Running caller-supplied SQL is the contract, not an oversight, so SpotBugs'
+ * {@code SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE} is excluded for the two methods
+ * that execute it &mdash; see {@code data/spotbugs-exclude.xml}, which names those
+ * methods alone so a genuine concatenation elsewhere in this package still fails.</p>
+ */
 public class IterableSQLDataSource implements ColumnarDataSource {
 
 	private static final Logger log = LogManager.getLogger(IterableSQLDataSource.class.getName());
@@ -22,6 +37,11 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 	protected final String query;
 	protected final Connection connection;
 
+	/**
+	 * @param connection the JDBC connection to run the query on
+	 * @param query the SQL to execute, run verbatim &mdash; see the class javadoc for what
+	 *        the caller must guarantee about how it was built
+	 */
 	public IterableSQLDataSource(Connection connection, String query) {
 		this.connection = connection;
 		this.query = query;
@@ -62,6 +82,10 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 		}
 	}
 
+	/**
+	 * Executes the query given to the constructor, verbatim and unparameterised, and
+	 * positions this source before its first row.
+	 */
 	@Override
 	public void open() {
 		closeQueryResources();

--- a/data/src/test/java/io/github/adamw7/tools/data/source/db/SpotBugsExcludeFilterTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/db/SpotBugsExcludeFilterTest.java
@@ -1,0 +1,89 @@
+package io.github.adamw7.tools.data.source.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * Pins the scope of the module's SpotBugs exclude filter. The two JDBC sources run the
+ * caller's query on purpose, so {@code SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE} is
+ * accepted there — but only there. A filter that grew a Match without a class, a method
+ * or a pattern would silently stop the detector reporting a genuine concatenation
+ * elsewhere in the module, which is what these assertions exist to catch.
+ */
+public class SpotBugsExcludeFilterTest {
+
+	private static final Path FILTER = Path.of("spotbugs-exclude.xml");
+	private static final String SQL_INJECTION = "SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE";
+
+	private static List<Element> matches;
+
+	@BeforeAll
+	static void readFilter() throws IOException, ParserConfigurationException, SAXException {
+		Document document = parse(Files.readString(FILTER));
+		assertEquals("FindBugsFilter", document.getDocumentElement().getNodeName());
+		matches = elementsOf(document.getElementsByTagName("Match"));
+	}
+
+	private static Document parse(String xml) throws ParserConfigurationException, IOException, SAXException {
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+		return factory.newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+	}
+
+	private static List<Element> elementsOf(NodeList nodes) {
+		List<Element> elements = new ArrayList<>();
+		for (int i = 0; i < nodes.getLength(); ++i) {
+			elements.add((Element) nodes.item(i));
+		}
+		return elements;
+	}
+
+	@Test
+	public void everyExclusionNamesAClassAMethodAndAPattern() {
+		assertFalse(matches.isEmpty(), "the filter is wired into the build, so it must exclude something");
+		for (Element match : matches) {
+			assertEquals(1, match.getElementsByTagName("Class").getLength(), "one Class per Match: " + describe(match));
+			assertEquals(1, match.getElementsByTagName("Method").getLength(), "one Method per Match: " + describe(match));
+			assertEquals(1, match.getElementsByTagName("Bug").getLength(), "one Bug per Match: " + describe(match));
+		}
+	}
+
+	@Test
+	public void onlyTheTwoJdbcQueryExecutionsAreExcluded() {
+		List<String> excluded = matches.stream().map(SpotBugsExcludeFilterTest::describe).toList();
+		assertEquals(List.of(
+				IterableSQLDataSource.class.getName() + "#executeQuery:" + SQL_INJECTION,
+				InMemorySQLDataSource.class.getName() + "#readAll:" + SQL_INJECTION),
+				excluded);
+	}
+
+	private static String describe(Element match) {
+		return attribute(match, "Class", "name") + "#" + attribute(match, "Method", "name") + ":"
+				+ attribute(match, "Bug", "pattern");
+	}
+
+	private static String attribute(Element match, String tag, String name) {
+		NodeList tagged = match.getElementsByTagName(tag);
+		return tagged.getLength() == 0 ? "" : ((Element) tagged.item(0)).getAttribute(name);
+	}
+}


### PR DESCRIPTION
SpotBugs reports SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE (SECURITY,
priority 3) on IterableSQLDataSource.executeQuery and
InMemorySQLDataSource.readAll. Both hand the caller's query to a plain
Statement, which is what these classes are for — the module runs a query you
give it, it never builds one from fragments — so the finding describes the
published contract rather than a concatenation bug. Left red it would keep
firing, and clearing the existing findings is what gates promoting SpotBugs
into the default build.

Say what the contract is where a caller reads it: javadoc on both classes and
on the constructors, open() and readAll() now states that the query runs
verbatim and unparameterised, so building it from untrusted input is an
injection the source cannot see coming.

Accept the two findings in data/spotbugs-exclude.xml, wired in from the module
pom so the root profile stays untouched. Each Match names a class, a method
and the pattern, so a genuine concatenation anywhere else in source.db still
reports; SpotBugsExcludeFilterTest parses the filter and fails the build if a
Match loses one of the three or names a site other than those two.

Closes #659

Claude-Session: https://claude.ai/code/session_01SNRuqprNfFnYqcXHBqjaDo

Co-authored-by: Claude <noreply@anthropic.com>