### PR TITLE
build(pom, code, data-test): upgrade to Spring Boot 4.1.1

### DIFF
--- a/.claude/skills/java-code-review/SKILL.md
+++ b/.claude/skills/java-code-review/SKILL.md
@@ -65,7 +65,7 @@ Production code is `io.github.adamw7.*` (Java 25). Flag any violation as
 | **`java.time` only** | Any use of legacy `java.util.Date` / `Calendar`. |
 | **Abstract types prefixed `Abstract`, public fields `final`** | Except `claude-code-enforcer`, whose rule bases are named for the poms. |
 | **No package cycles / layering breaks** | Data-source contracts depending on their impls, uniqueness core depending on its MCP adapter, JDBC outside `source.db`, a step spawning a process outside `command`. |
-| **Test conventions** | Tests only in `*Test`/`*IT`; JUnit 5 only; no `@Disabled`; no `Thread.sleep`; no `System.out`/`err`. See `testing-conventions`. |
+| **Test conventions** | Tests only in `*Test`/`*IT`; JUnit Jupiter only; no `@Disabled`; no `Thread.sleep`; no `System.out`/`err`. See `testing-conventions`. |
 | **Surefire 5 s/unit test** | A unit test doing real work without a justified `@Timeout`. |
 
 ---

--- a/.claude/skills/maven-conventions/SKILL.md
+++ b/.claude/skills/maven-conventions/SKILL.md
@@ -28,6 +28,13 @@ profile, is the most common source of avoidable build friction here.
   are Spring Boot's own property names, so overriding them also moves the
   siblings the `spring-boot-dependencies` BOM manages (derbyshared, the other
   log4j2 artifacts) instead of leaving them on Boot's older version.
+- **The Spring Boot parent manages plugins too.** It binds a `generate`
+  execution on `protobuf-maven-plugin` and adds `protoc-gen-grpc-java` to it for
+  its gRPC starter; the root pom unbinds that execution (`<phase>none</phase>`)
+  and clears the generator list (`<plugins combine.self="override"/>`), because
+  the modules here declare the protobuf executions they want. Leave both in
+  place — without them `protogen-maven-plugin` fails at `generate-sources`
+  looking for a `src/main/proto` it does not have.
 
 ### Ask before adding a dependency
 - Use the existing Maven dependencies. **Always ask the user before adding a new

--- a/.claude/skills/testing-conventions/README.md
+++ b/.claude/skills/testing-conventions/README.md
@@ -8,7 +8,7 @@
 
 Helps Claude write tests that satisfy the `tools` repo's enforced testing rules:
 the 5 s Surefire per-test timeout, network-off unit tests, ArchUnit test
-conventions, and JUnit 5 only.
+conventions, and JUnit Jupiter only.
 
 ---
 

--- a/.claude/skills/testing-conventions/SKILL.md
+++ b/.claude/skills/testing-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-conventions
-description: Write tests that pass this repo's enforced testing rules (Surefire 5s timeout, network-off unit tests, ArchUnit conventions, JUnit 5 only). Use when adding or changing tests, when a test times out or opens a network connection, or when the user says "write a test", "add tests", or "fix the failing test".
+description: Write tests that pass this repo's enforced testing rules (Surefire 5s timeout, network-off unit tests, ArchUnit conventions, JUnit Jupiter only). Use when adding or changing tests, when a test times out or opens a network connection, or when the user says "write a test", "add tests", or "fix the failing test".
 ---
 
 # Testing Conventions Skill
@@ -48,7 +48,7 @@ fails the build, not just review.
 
 ### Test conventions pinned by `TestConventionsArchitectureTest`
 - Test methods live only in `*Test` / `*IT` classes.
-- **JUnit 5 only** (`org.junit.jupiter`). No JUnit 4.
+- **JUnit Jupiter only** (`org.junit.jupiter`). No JUnit 4.
 - No `@Disabled`.
 - No `System.out` / `System.err` in tests.
 - No `Thread.sleep` in tests.
@@ -81,7 +81,7 @@ fails the build, not just review.
 | Per-unit-test time | 5 s (opt out with commented `@Timeout`) |
 | `@BeforeAll` etc. | 10 s (15 s under coverage) |
 | Network in unit test | Blocked by `NetworkOffExtension` — use `*IT` |
-| Test framework | JUnit 5 only |
+| Test framework | JUnit Jupiter only |
 | Disabled tests | Not allowed (`@Disabled` banned) |
 | `Thread.sleep` in test | Banned |
 | `System.out`/`err` in test | Banned |

--- a/.claude/skills/text-parsers/SKILL.md
+++ b/.claude/skills/text-parsers/SKILL.md
@@ -208,7 +208,7 @@ in its column before calling it done.
   `claude-code-enforcer` holds an 88% threshold:
   `mvn -Ppitest install -pl claude-code-enforcer -am`. A surviving mutant on a
   boundary condition in a mask is very often a real gap.
-- Standard rules still apply — 5 s per unit test, JUnit 5, no `Thread.sleep`.
+- Standard rules still apply — 5 s per unit test, Jupiter, no `Thread.sleep`.
   See `testing-conventions`.
 
 ## Common mistakes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -534,9 +534,10 @@ Repo-wide rules (declared once in `test-common` and imported with
   separate because `claude-code-enforcer` is exempt: its abstract rule bases are
   public API that poms configure by name.
 - `CommonTestConventions` — every `@Testable` method lives in a `*Test`/`*IT`
-  class; no `@Disabled`; JUnit 5 only; no `System.out`/`err`; no `Thread.sleep`;
-  a `*Test` that writes a system property is `@Isolated`, since the unit run is
-  class-parallel (the `*IT`s failsafe runs one after another are exempt).
+  class; no `@Disabled`; JUnit Jupiter only; no `System.out`/`err`; no
+  `Thread.sleep`; a `*Test` that writes a system property is `@Isolated`, since
+  the unit run is class-parallel (the `*IT`s failsafe runs one after another are
+  exempt).
 
 Adding a repository-wide convention means editing one library, not six tests; an
 exemption means a module not importing a library, which stays visible.
@@ -744,7 +745,7 @@ module's `*IT`s stay unrun until it gets its own copy. Run them with
   `**/target/site/jacoco/` and **fails** if a bundle's instruction **or** branch
   coverage drops below **80%**. The profile also raises the per-test timeout to
   8 s, because instrumentation slows first-use class-loading.
-- **Mutation testing** — `mvn -Ppitest install` (PIT + JUnit 5) writes reports to
+- **Mutation testing** — `mvn -Ppitest install` (PIT + Jupiter) writes reports to
   `**/target/pit-reports/` and **fails** when a module's mutation score drops
   below its `pitest.mutationThreshold`:
 
@@ -889,7 +890,7 @@ which is why they, not `CLAUDE.md`, are where detail belongs.
 | `enforcer-rules` | writing, testing and wiring a `claude-code-enforcer` rule, including `severity`/`reportFile`/`baselineFile` |
 | `doc-contract` | keeping `CLAUDE.md`, `AGENTS.md` and `README.md` inside the enforced documentation contract |
 | `maven-conventions` | versions only in the root pom, version-free module poms, the profiles, clean-after-codegen |
-| `testing-conventions` | the surefire timeouts, network-off unit tests, the ArchUnit conventions, JUnit 5 only |
+| `testing-conventions` | the surefire timeouts, network-off unit tests, the ArchUnit conventions, JUnit Jupiter only |
 | `java-code-review` | review led by the rules the build fails on, then the defect shapes this repository ships fixes for |
 | `text-parsers` | the invariants of the readers — `MarkdownDocument`, `MarkdownText`, `ImportGraph`, `CommandTokens`, the `ClaudeMdConformer` copy, the SnakeYAML-backed `FrontMatter` — and the input that has broken each |
 | `solid-principles` | the per-principle detection heuristics and the refactorings that fix them |
@@ -1232,6 +1233,16 @@ Skill: `maven-conventions`.
   `derby.version` and `log4j2.version` are Spring Boot's own property names on
   purpose — the BOM manages the rest of each family from them, so pinning only
   the artifacts declared here would leave the siblings on Boot's older version.
+- The root pom's parent is `spring-boot-starter-parent`, so its
+  `<dependencyManagement>` and `<pluginManagement>` reach every module. Two of
+  its entries are deliberately neutralised in the root pom rather than lived
+  with: the `generate` execution it binds on `protobuf-maven-plugin` (for its
+  gRPC starter) would look for a `src/main/proto` the plugin module has none of,
+  and the `protoc-gen-grpc-java` it adds to that plugin's `<plugins>` would reach
+  the modules that generate plain protobuf. `grpc-example` names the gRPC
+  generator in its own execution instead. The parent also decides which JUnit
+  generation the tests run on — Boot 4 brings **JUnit 6** (Jupiter), which is why
+  `data-test` needs a slightly larger heap than it did under Boot 3.
 - A module that is an example, a test harness or a distribution opts out of
   publication with `maven.deploy.skip` (GitHub Packages) and
   `central.skipPublishing` (Maven Central) — not by redeclaring the `release`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ Skill: `testing-conventions`.
   package, every enforcer rule is a public `@Named` type that neither spawns a
   process nor reaches the network). A companion `TestConventionsArchitectureTest`
   pins the tests themselves: methods only in `*Test`/`*IT` classes, no
-  `@Disabled`, JUnit 5 only, no `System.out`/`err`, no `Thread.sleep`. The
+  `@Disabled`, JUnit Jupiter only, no `System.out`/`err`, no `Thread.sleep`. The
   repo-wide rules live once in `test-common` and are imported with
   `ArchTests.in(...)`.
 - **Integration tests** (`*IT`) are gated behind the `integration-tests` profile

--- a/README.md
+++ b/README.md
@@ -1165,7 +1165,7 @@ transcript.
 ## Architecture tests (ArchUnit)
 
 Every production module guards its own package structure with
-[ArchUnit](https://www.archunit.org/) rules that run as ordinary JUnit 5 tests,
+[ArchUnit](https://www.archunit.org/) rules that run as ordinary JUnit tests,
 so an accidental dependency or a broken naming convention **fails the build**
 instead of quietly eroding the design. Each module keeps its rules in a single
 `*ArchitectureTest` under an `architecture` package, annotated with
@@ -1249,12 +1249,12 @@ Alongside the production rules, each module carries a companion
 `TestConventionsArchitectureTest` that analyses only the *test* classes (via
 `ImportOption.OnlyIncludeTests`) and pins conventions on the tests themselves:
 every `@Testable` method must live in a `*Test` or `*IT` class so surefire or
-failsafe actually runs it, no test is `@Disabled`, tests use JUnit 5 only (no
+failsafe actually runs it, no test is `@Disabled`, tests use JUnit Jupiter only (no
 JUnit 4 `org.junit` API), and no test calls `Thread.sleep` or `TimeUnit.sleep`
 (sleeping is slow and flaky — wait on a condition instead). A few rules guard
 against tests that silently never run: a `@Testable` method must not be
-`private` or `static` (JUnit 5 quietly ignores both), and a `@BeforeAll`/
-`@AfterAll` method must be `static` (JUnit 5 requires it unless the class opts
+`private` or `static` (Jupiter quietly ignores both), and a `@BeforeAll`/
+`@AfterAll` method must be `static` (Jupiter requires it unless the class opts
 into the `PER_CLASS` lifecycle).
 
 Run them for a single module with, for example:

--- a/code/context/src/main/java/io/github/adamw7/context/mcp/TlsConfiguration.java
+++ b/code/context/src/main/java/io/github/adamw7/context/mcp/TlsConfiguration.java
@@ -2,9 +2,9 @@ package io.github.adamw7.context.mcp;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.Ssl;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/code/context/src/test/java/io/github/adamw7/context/mcp/TlsConfigurationTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/mcp/TlsConfigurationTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.boot.web.server.Ssl;
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
 
 /**
  * Runs alone under the class-parallel unit-test run: every case here clears or

--- a/data-test/pom.xml
+++ b/data-test/pom.xml
@@ -18,8 +18,9 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<!-- The tight heap is the point of this module: it proves the iterative sources
-					     stream rather than buffer. @{argLine} keeps the JaCoCo agent composed in. -->
-					<argLine>@{argLine} -Xmx16m</argLine>
+					     stream rather than buffer, and an in-memory read of this document still runs
+					     out of memory at 24m. @{argLine} keeps the JaCoCo agent composed in. -->
+					<argLine>@{argLine} -Xmx24m</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/data-test/src/test/java/io/github/adamw7/tools/data/test/MemoryLeakTest.java
+++ b/data-test/src/test/java/io/github/adamw7/tools/data/test/MemoryLeakTest.java
@@ -49,7 +49,7 @@ public class MemoryLeakTest {
 	/**
 	 * The iterable JSON, YAML and TOON sources emit one row at a time without holding the
 	 * document in memory. To prove that, each generated document has far more fields than
-	 * could be buffered under the tight surefire heap (-Xmx16m): a non-iterable reader
+	 * could be buffered under the tight surefire heap (-Xmx24m): a non-iterable reader
 	 * would run out of memory, while a single pass stays flat.
 	 */
 	private static final int ITERABLE_FIELDS = 100_000;

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.16</version>
+		<version>4.1.1</version>
 		<relativePath/>
 	</parent>
 	
@@ -331,7 +331,17 @@
 					<version>5.1.8</version>
 					<configuration>
 						<protoc>${protobuf.version}</protoc>
+						<!-- Boot's parent adds protoc-gen-grpc-java here; grpc-example names it in
+						     its own execution instead. -->
+						<plugins combine.self="override"/>
 					</configuration>
+					<executions>
+						<!-- Boot's parent binds this over src/main/proto, which no module here has. -->
+						<execution>
+							<id>generate</id>
+							<phase>none</phase>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/test-common/src/test/java/io/github/adamw7/tools/test/architecture/CommonTestConventions.java
+++ b/test-common/src/test/java/io/github/adamw7/tools/test/architecture/CommonTestConventions.java
@@ -52,7 +52,7 @@ public class CommonTestConventions {
 	@ArchTest
 	static final ArchRule testsUseJunit5 = noClasses()
 			.should().dependOnClassesThat().resideInAPackage("org.junit")
-			.because("tests use JUnit 5 (org.junit.jupiter); the JUnit 4 API must not creep back in");
+			.because("tests use JUnit Jupiter (org.junit.jupiter); the JUnit 4 API must not creep back in");
 
 	@ArchTest
 	static final ArchRule testsDoNotSleep = noClasses()
@@ -73,7 +73,7 @@ public class CommonTestConventions {
 			.that().areAnnotatedWith(BeforeAll.class)
 			.or().areAnnotatedWith(AfterAll.class)
 			.should().beStatic()
-			.because("JUnit 5 runs @BeforeAll/@AfterAll once per class only when they are static; "
+			.because("Jupiter runs @BeforeAll/@AfterAll once per class only when they are static; "
 					+ "a non-static one fails at runtime unless the class opts into the PER_CLASS lifecycle")
 			.allowEmptyShould(true);
 
@@ -95,5 +95,5 @@ public class CommonTestConventions {
 			.that().areMetaAnnotatedWith(TESTABLE_ANNOTATION)
 			.should().notBePrivate()
 			.andShould().notBeStatic()
-			.because("JUnit 5 silently ignores a private or static test method, so it never runs");
+			.because("Jupiter silently ignores a private or static test method, so it never runs");
 }


### PR DESCRIPTION
Move the root parent from spring-boot-starter-parent 3.5.16 to 4.1.1, the
latest 4.x release, which brings Spring Framework 7 and JUnit 6 with it.

Three things the new parent changed had to be answered:

- It manages io.github.ascopes:protobuf-maven-plugin for its gRPC starter,
  binding a `generate` execution over src/main/proto and adding
  protoc-gen-grpc-java to the plugin's generator list. Both reach every
  module that declares the plugin, so protogen-maven-plugin — which has
  only src/test/proto — failed at generate-sources with "No protobuf
  sources found". The root pom's pluginManagement now unbinds that
  execution and clears the inherited generator list; grpc-example keeps
  naming the gRPC generator in its own execution.
- TomcatServletWebServerFactory moved to org.springframework.boot.tomcat.servlet
  (the new spring-boot-tomcat module). Ssl, WebServerFactoryCustomizer,
  ServletRegistrationBean and LocalServerPort stayed where they were.
- JUnit 6, which the new BOM manages, costs a couple of megabytes more
  baseline heap than JUnit 5 did, so data-test's deliberately tight
  surefire heap goes from 16m to 24m. The test keeps its meaning: the
  iterable sources still stream the 100k-field document through, and an
  in-memory source reading the same document still runs out of memory at
  24m.

Docs say "JUnit Jupiter" rather than "JUnit 5" where they name the
framework the tests run on, so the statement survives the next bump, and
AGENTS.md and the maven-conventions skill record what the Boot parent
manages on this build's behalf.

Verified: full build, the integration-tests profile (all three MCP servers
over both HTTP transports plus the HTTPS/TLS 1.3 case), the two-phase doc
check, data-test, a stdio JSON-RPC handshake against the context server
jar, and the SampleApp distribution.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ATm3orPhYYWtiHk6MPc3x