### PR TITLE
fix(data, adopt, claude-code-enforcer, code): check the 14 Path and File lookups before dereferencing them (#658)

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionFiles.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/AdoptionFiles.java
@@ -34,8 +34,10 @@ public final class AdoptionFiles {
 	}
 
 	/**
-	 * The path is absolutised first so a relative file name — which has no parent
-	 * of its own — still resolves to the directory it will be written into.
+	 * The path is absolutised first so a relative file name — which {@link Path#getParent}
+	 * answers {@code null} for, having no parent of its own — still resolves to the
+	 * directory it will be written into, and a path that has no parent even then is left
+	 * alone rather than dereferenced.
 	 */
 	private static void createParentDirectories(Path file) throws IOException {
 		Path parent = file.toAbsolutePath().getParent();

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/command/ExecutableResolver.java
@@ -79,7 +79,7 @@ final class ExecutableResolver {
 	 * for {@link ProcessBuilder} to start as it was given.
 	 */
 	private Optional<Path> given(String program) {
-		return toPath(program).filter(Files::isRegularFile).filter(this::isBatchScript);
+		return toPath(program).filter(Files::isRegularFile).filter(ExecutableResolver::isBatchScript);
 	}
 
 	private Optional<Path> locate(String program) {
@@ -107,8 +107,16 @@ final class ExecutableResolver {
 				.toList();
 	}
 
-	private boolean isBatchScript(Path executable) {
-		String name = executable.getFileName().toString().toLowerCase(Locale.ROOT);
+	/**
+	 * A path naming no file — a filesystem root, which {@link Path#getFileName} answers
+	 * {@code null} for — is not a batch script, so it is answered rather than dereferenced.
+	 */
+	static boolean isBatchScript(Path executable) {
+		Path fileName = executable.getFileName();
+		if (fileName == null) {
+			return false;
+		}
+		String name = fileName.toString().toLowerCase(Locale.ROOT);
 		return BATCH_EXTENSIONS.stream().anyMatch(name::endsWith);
 	}
 

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeInitStep.java
@@ -204,9 +204,17 @@ public class ClaudeInitStep extends AbstractCommandStep {
 		}
 	}
 
+	/**
+	 * The path is absolutised before its parent is taken, so a memory file named relative
+	 * to the working directory — which {@link Path#getParent} answers {@code null} for —
+	 * still names the directory the move will land in instead of being dereferenced.
+	 */
 	private void restore(Path backup, Path memory) {
 		try {
-			Files.createDirectories(memory.getParent());
+			Path directory = memory.toAbsolutePath().getParent();
+			if (directory != null) {
+				Files.createDirectories(directory);
+			}
 			Files.move(backup, memory, StandardCopyOption.REPLACE_EXISTING);
 			log.info("Restored existing {}", memory);
 		} catch (IOException e) {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStore.java
@@ -80,6 +80,21 @@ public class ClaudeTrustStore {
 		this.configFile = configFile.toAbsolutePath();
 	}
 
+	/**
+	 * The directory holding the configuration, the lock file beside it and the temporary
+	 * file the write moves from. A filesystem root names no configuration file and has no
+	 * directory to hold one, so it is refused in those terms — the update having touched
+	 * nothing yet — rather than as an NPE from the first write to dereference the
+	 * {@code null} {@link Path#getParent} answers for it.
+	 */
+	private Path configDirectory() {
+		Path directory = configFile.getParent();
+		if (directory == null) {
+			throw new AdoptionException("The Claude config path names no file: " + configFile);
+		}
+		return directory;
+	}
+
 	private static Path defaultConfigFile() {
 		return Path.of(System.getProperty("user.home"), ".claude.json");
 	}
@@ -237,7 +252,7 @@ public class ClaudeTrustStore {
 
 	/** Created before the lock file is opened beside it, and so before anything is read. */
 	private void createConfigDirectory() {
-		Path directory = configFile.getParent();
+		Path directory = configDirectory();
 		try {
 			Files.createDirectories(directory);
 		} catch (IOException e) {
@@ -247,7 +262,7 @@ public class ClaudeTrustStore {
 
 	/** A sibling, so the move stays within one filesystem and can be atomic. */
 	private Path temporaryBeside() throws IOException {
-		return Files.createTempFile(configFile.getParent(), ".claude-adopt-", ".json");
+		return Files.createTempFile(configDirectory(), ".claude-adopt-", ".json");
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -189,8 +189,14 @@ public class GradleGuardInstaller {
 		return character == SINGLE_QUOTE || character == DOUBLE_QUOTE ? character : 0;
 	}
 
-	private String blockFor(Path buildFile) {
-		return buildFile.getFileName().toString().endsWith(KOTLIN_SUFFIX) ? KOTLIN_BLOCK : GROOVY_BLOCK;
+	/**
+	 * Groovy is the block a path naming no file gets, since only a name ending in
+	 * {@value #KOTLIN_SUFFIX} selects the Kotlin one and a filesystem root has no name
+	 * for {@link Path#getFileName} to answer with.
+	 */
+	static String blockFor(Path buildFile) {
+		Path fileName = buildFile.getFileName();
+		return fileName != null && fileName.toString().endsWith(KOTLIN_SUFFIX) ? KOTLIN_BLOCK : GROOVY_BLOCK;
 	}
 
 	/** The block's LF terminators are rewritten to the script's own, so a CRLF file stays CRLF throughout. */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ExecutableResolverTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/command/ExecutableResolverTest.java
@@ -1,7 +1,9 @@
 package io.github.adamw7.tools.adopt.command;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,6 +17,27 @@ import org.junit.jupiter.api.io.TempDir;
 class ExecutableResolverTest {
 
 	private static final List<String> EXTENSIONS = List.of(".com", ".exe", ".bat", ".cmd");
+
+	@Test
+	void aScriptIsRecognisedByItsExtensionWhateverItsCase() {
+		assertTrue(ExecutableResolver.isBatchScript(Path.of("mvn.cmd")));
+		assertTrue(ExecutableResolver.isBatchScript(Path.of("GRADLEW.BAT")));
+	}
+
+	@Test
+	void aRealExecutableIsNotAScript() {
+		assertFalse(ExecutableResolver.isBatchScript(Path.of("git.exe")));
+	}
+
+	/**
+	 * A path naming no file — a filesystem root, which {@link Path#getFileName} answers
+	 * {@code null} for — is not a script, and answering so is what keeps the question
+	 * from being an NPE for whoever named a program by a path of their own.
+	 */
+	@Test
+	void aPathThatNamesNoFileIsNotAScript() {
+		assertFalse(ExecutableResolver.isBatchScript(Path.of(File.separator)));
+	}
 
 	@Test
 	void posixReturnsTheCommandUnchanged(@TempDir Path dir) throws IOException {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStoreTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/ClaudeTrustStoreTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,6 +38,21 @@ class ClaudeTrustStoreTest {
 	@BeforeAll
 	static void warmUpJackson(@TempDir Path dir) {
 		new ClaudeTrustStore(dir.resolve(".claude.json")).trust(dir.resolve("repo"));
+	}
+
+	/**
+	 * The store resolves its lock file, its temporary file and its move against the
+	 * configuration's directory, and a filesystem root has none — {@link Path#getParent}
+	 * answers {@code null} for it. Refusing it in those terms, before the update has
+	 * touched anything, beats an NPE from the first write to dereference that {@code null}.
+	 */
+	@Test
+	void aConfigPathThatNamesNoFileIsRefusedRatherThanDereferenced(@TempDir Path dir) {
+		ClaudeTrustStore store = new ClaudeTrustStore(Path.of(File.separator));
+
+		AdoptionException thrown = assertThrows(AdoptionException.class, () -> store.trust(dir));
+
+		assertTrue(thrown.getMessage().contains("names no file"), thrown.getMessage());
 	}
 
 	private JsonNode read(Path config) throws IOException {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GradleGuardInstallerTest.java
@@ -2,9 +2,11 @@ package io.github.adamw7.tools.adopt.step;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -17,6 +19,25 @@ import io.github.adamw7.tools.adopt.AdoptionException;
 class GradleGuardInstallerTest {
 
 	private final GradleGuardInstaller installer = new GradleGuardInstaller();
+
+	@Test
+	void theKotlinBlockIsChosenByTheScriptsExtension() {
+		assertEquals(GradleGuardInstaller.blockFor(Path.of("build.gradle.kts")),
+				GradleGuardInstaller.blockFor(Path.of("nested", "build.gradle.kts")));
+		assertNotEquals(GradleGuardInstaller.blockFor(Path.of("build.gradle")),
+				GradleGuardInstaller.blockFor(Path.of("build.gradle.kts")));
+	}
+
+	/**
+	 * Only a name ending in {@code .kts} selects the Kotlin block, and a filesystem root
+	 * has no name for {@link Path#getFileName} to answer with, so it takes the Groovy one
+	 * rather than throwing NPE on the way to the question.
+	 */
+	@Test
+	void aPathThatNamesNoFileTakesTheGroovyBlock() {
+		assertEquals(GradleGuardInstaller.blockFor(Path.of("build.gradle")),
+				GradleGuardInstaller.blockFor(Path.of(File.separator)));
+	}
 
 	/**
 	 * Gradle's configuration cache — on by default from Gradle 9 — rejects a task

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/doc/ImportGraph.java
@@ -191,7 +191,7 @@ final class ImportGraph {
 
 	private File resolve(File file, String imported) {
 		if (imported.startsWith("/")) {
-			return rootedAt(file, imported);
+			return rootedAt(ProjectFiles.normalized(file), imported);
 		}
 		return new File(file.getParentFile(), imported);
 	}
@@ -200,10 +200,18 @@ final class ImportGraph {
 	 * A leading slash starts the path at a file system root. Which root comes from
 	 * the importing file, so a document resolves the same way wherever the build was
 	 * launched from — on Windows {@code new File("/docs.md")} would otherwise pick
-	 * whichever drive the build started on.
+	 * whichever drive the build started on. An importing path that names no root —
+	 * which {@link Path#getRoot} reports as {@code null} — has no drive to lend, so the
+	 * import is left to be read as the platform reads it.
+	 *
+	 * @param importingFile the normalised path of the document the import was read from
 	 */
-	private File rootedAt(File file, String imported) {
-		return ProjectFiles.normalized(file).getRoot().resolve(imported.substring(1)).toFile();
+	static File rootedAt(Path importingFile, String imported) {
+		Path root = importingFile.getRoot();
+		if (root == null) {
+			return new File(imported);
+		}
+		return root.resolve(imported.substring(1)).toFile();
 	}
 
 	/**

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Baseline.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/Baseline.java
@@ -93,12 +93,17 @@ final class Baseline {
 	/**
 	 * Writes {@code violations} as a fresh baseline, replacing any previous content.
 	 * Signatures are normalised against {@code baseDir}, de-duplicated and sorted so
-	 * the file stays diffable. Missing parent directories are created first.
+	 * the file stays diffable. Missing parent directories are created first, unless the
+	 * absolutised path has no parent to create — which {@link Path#getParent} answers
+	 * {@code null} for at a filesystem root — leaving nothing to make before the write.
 	 */
 	static void write(File file, List<String> violations, File baseDir) throws EnforcerRuleException {
 		try {
 			Path path = file.toPath().toAbsolutePath();
-			Files.createDirectories(path.getParent());
+			Path parent = path.getParent();
+			if (parent != null) {
+				Files.createDirectories(parent);
+			}
 			Files.writeString(path, render(violations, Signatures.rootedAt(baseDir)), StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new EnforcerRuleException("Could not write baseline file " + file, e);

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/HtmlReport.java
@@ -47,12 +47,17 @@ final class HtmlReport {
 	/**
 	 * Writes the rendered report to {@code file}, failing the build if it cannot be
 	 * written. Missing parent directories are created first: a report under
-	 * {@code target/} is written at {@code validate}, before any plugin created it.
+	 * {@code target/} is written at {@code validate}, before any plugin created it. A
+	 * path with no parent to create — which {@link Path#getParent} answers {@code null}
+	 * for at a filesystem root — simply has nothing to make before the write.
 	 */
 	void writeTo(File file) throws EnforcerRuleException {
 		try {
 			Path path = file.toPath().toAbsolutePath();
-			Files.createDirectories(path.getParent());
+			Path parent = path.getParent();
+			if (parent != null) {
+				Files.createDirectories(parent);
+			}
 			Files.writeString(path, render(), StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new EnforcerRuleException("Could not write HTML report to " + file, e);

--- a/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ProjectFiles.java
+++ b/claude-code-enforcer/src/main/java/io/github/adamw7/tools/enforcer/rule/ProjectFiles.java
@@ -62,7 +62,8 @@ public final class ProjectFiles {
 	 * that budget or scan a tree of documents select theirs.
 	 */
 	public static boolean isMarkdown(Path path) {
-		return path.getFileName().toString().endsWith(MARKDOWN_SUFFIX);
+		Path fileName = path.getFileName();
+		return fileName != null && fileName.toString().endsWith(MARKDOWN_SUFFIX);
 	}
 
 	/** The file name with the {@code .md} suffix stripped. */

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/doc/ImportGraphTest.java
@@ -27,6 +27,31 @@ import io.github.adamw7.tools.enforcer.rule.ProjectFiles;
 class ImportGraphTest {
 
 	private static final Predicate<String> NOTHING_IGNORED = imported -> false;
+
+	/**
+	 * The root comes from the importing document, so an absolute import resolves the
+	 * same way wherever the build was launched from — on Windows {@code new File("/x.md")}
+	 * would otherwise pick whichever drive that happened to be.
+	 */
+	@Test
+	void anAbsoluteImportStartsAtTheImportingDocumentsRoot() {
+		Path importing = ProjectFiles.normalized(tempDir.resolve("CLAUDE.md"));
+
+		File resolved = ImportGraph.rootedAt(importing, "/docs/shared.md");
+
+		assertEquals(importing.getRoot().resolve(Path.of("docs", "shared.md")).toFile(), resolved);
+	}
+
+	/**
+	 * An importing path that names no root has no drive to lend — {@link Path#getRoot}
+	 * answers {@code null} for it — so the import is left to be read as the platform
+	 * reads it, rather than dereferenced into an NPE.
+	 */
+	@Test
+	void anImportingPathWithNoRootLeavesTheImportAsThePlatformReadsIt() {
+		assertEquals(new File("/docs/shared.md"), ImportGraph.rootedAt(Path.of("CLAUDE.md"), "/docs/shared.md"));
+	}
+
 	private static final List<String> EXTENSIONS = List.of("md", "markdown", "txt");
 
 	@TempDir

--- a/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ProjectFilesTest.java
+++ b/claude-code-enforcer/src/test/java/io/github/adamw7/tools/enforcer/rule/ProjectFilesTest.java
@@ -144,6 +144,16 @@ class ProjectFilesTest {
 		assertFalse(ProjectFiles.isMarkdown(tempDir.resolve("settings.json")));
 	}
 
+	/**
+	 * A path with no name element — a filesystem root, which {@link Path#getFileName}
+	 * answers {@code null} for — is no Markdown document, and saying so is what keeps a
+	 * rule scanning a tree that reaches one from failing on an NPE instead of a verdict.
+	 */
+	@Test
+	void isMarkdownRejectsAPathThatNamesNoFile() {
+		assertFalse(ProjectFiles.isMarkdown(Path.of(File.separator)));
+	}
+
 	@Test
 	void markdownBaseNameStripsTheMarkdownSuffix() {
 		assertEquals("git-commit", ProjectFiles.markdownBaseName(tempDir.resolve("git-commit.md").toFile()));

--- a/code/context/src/main/java/io/github/adamw7/context/PathNames.java
+++ b/code/context/src/main/java/io/github/adamw7/context/PathNames.java
@@ -1,0 +1,22 @@
+package io.github.adamw7.context;
+
+import java.nio.file.Path;
+
+/**
+ * The name a path is recognised, loaded and ordered by. {@link Path#getFileName}
+ * answers {@code null} for a path with no name element — a filesystem root such as
+ * {@code /} or {@code C:\} — so a project walked from one, or a listing that reaches
+ * one, would otherwise fail on it with a {@link NullPointerException} rather than
+ * simply finding no sources there.
+ */
+public final class PathNames {
+
+	private PathNames() {
+	}
+
+	/** The path's last element, or the whole path when it has no name of its own. */
+	public static String of(Path path) {
+		Path name = path.getFileName();
+		return name != null ? name.toString() : path.toString();
+	}
+}

--- a/code/context/src/main/java/io/github/adamw7/context/ProjectSources.java
+++ b/code/context/src/main/java/io/github/adamw7/context/ProjectSources.java
@@ -34,10 +34,10 @@ public class ProjectSources {
 	}
 
 	private boolean isSourceFile(Path path) {
-		return Files.isRegularFile(path) && path.getFileName().toString().endsWith(language.extension());
+		return Files.isRegularFile(path) && PathNames.of(path).endsWith(language.extension());
 	}
 
 	private ClassContainer toContainer(Path path) {
-		return ClassContainer.load(path, path.getFileName().toString());
+		return ClassContainer.load(path, PathNames.of(path));
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundleWriter.java
+++ b/code/context/src/main/java/io/github/adamw7/context/okf/OkfBundleWriter.java
@@ -33,13 +33,26 @@ public class OkfBundleWriter {
 		return target;
 	}
 
+	/**
+	 * The path is absolutised before its parent is taken, so a document written under an
+	 * empty target — which {@link Path#getParent} answers {@code null} for, the resolved
+	 * path being a bare file name — still names the directory it lands in instead of
+	 * being dereferenced as {@code null}.
+	 */
 	private void writeDocument(OkfDocument document, Path target) {
 		Path file = target.resolve(document.path());
 		try {
-			Files.createDirectories(file.getParent());
+			createParentDirectories(file);
 			Files.writeString(file, document.content(), StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Failed to write the OKF document " + file, e);
+		}
+	}
+
+	private static void createParentDirectories(Path file) throws IOException {
+		Path directory = file.toAbsolutePath().getParent();
+		if (directory != null) {
+			Files.createDirectories(directory);
 		}
 	}
 }

--- a/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeBuilder.java
+++ b/code/context/src/main/java/io/github/adamw7/context/tree/ProjectTreeBuilder.java
@@ -5,6 +5,7 @@ import io.github.adamw7.context.Context;
 import io.github.adamw7.context.ContextFactory;
 import io.github.adamw7.context.Finder;
 import io.github.adamw7.context.Language;
+import io.github.adamw7.context.PathNames;
 import io.github.adamw7.context.ProjectSources;
 
 import java.io.IOException;
@@ -98,8 +99,12 @@ public class ProjectTreeBuilder {
 		}
 	}
 
+	/**
+	 * Directories first, then by name — {@link PathNames} being what keeps that second
+	 * key total, so a child with no name of its own cannot fail the ordering.
+	 */
 	private Comparator<Path> childOrdering() {
 		return Comparator.comparing((Path path) -> Files.isDirectory(path) ? 0 : 1)
-				.thenComparing(path -> path.getFileName().toString());
+				.thenComparing(PathNames::of);
 	}
 }

--- a/code/context/src/test/java/io/github/adamw7/context/PathNamesTest.java
+++ b/code/context/src/test/java/io/github/adamw7/context/PathNamesTest.java
@@ -1,0 +1,34 @@
+package io.github.adamw7.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The name a path is recognised, loaded and ordered by. A project walked from a
+ * filesystem root, or a listing that reaches one, meets a path {@link Path#getFileName}
+ * answers {@code null} for — so the lookup every such walk goes through has to be total,
+ * or the walk fails on an NPE rather than simply finding no sources there.
+ */
+class PathNamesTest {
+
+	@Test
+	void aPathIsNamedByItsLastElement() {
+		assertEquals("Finder.java", PathNames.of(Path.of("src", "main", "java", "Finder.java")));
+	}
+
+	@Test
+	void aBareNameIsItsOwnName() {
+		assertEquals("Finder.java", PathNames.of(Path.of("Finder.java")));
+	}
+
+	@Test
+	void aPathThatNamesNoFileIsNamedByThePathItself() {
+		Path root = Path.of(File.separator);
+
+		assertEquals(root.toString(), PathNames.of(root));
+	}
+}

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractFileSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractFileSource.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -129,11 +130,22 @@ public abstract class AbstractFileSource implements IterableDataSource {
 		}
 	}
 	
+	/**
+	 * The last element of the path this source reads, which a caller naming its columns
+	 * after the file it came from asks for. A path that names no file — a filesystem root
+	 * such as {@code /} or {@code C:\} — is refused in the same terms as a raw stream,
+	 * rather than dereferencing the {@code null} {@link Path#getFileName}
+	 * answers for it.
+	 */
 	public String getFileName() {
 		if (fileName == null) {
 			throw new IllegalStateException("Source is backed by a raw input stream, not a file");
 		}
-		return Paths.get(fileName).getFileName().toString();
+		Path name = Paths.get(fileName).getFileName();
+		if (name == null) {
+			throw new IllegalStateException("Source path names no file: " + fileName);
+		}
+		return name.toString();
 	}
 	
 	protected List<String[]> readAll() {

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/AbstractFileSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/AbstractFileSourceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -30,7 +31,8 @@ import io.github.adamw7.tools.data.uniqueness.NoMemoryUniquenessCheck;
  * without the check in {@link AbstractFileSource#hasNextLine()} a truncated transfer,
  * a corrupt GZip member or a disk error reads as a short but successful file. The same
  * corrupt GZip member is what leaks a descriptor when the wrapping fails before any
- * Scanner owns the opened file, which the last test pins.
+ * Scanner owns the opened file, which one test pins. The name a source answers for the
+ * file it reads is pinned here too, that being the other thing every one of them shares.
  */
 public class AbstractFileSourceTest {
 
@@ -101,6 +103,34 @@ public class AbstractFileSourceTest {
 		// No Scanner was built, so nothing else owns the descriptor: createScanner had to
 		// close it itself. A closed FileInputStream refuses to read.
 		assertThrows(IOException.class, () -> source.openedStream.read());
+	}
+
+	@Test
+	public void theFileNameIsTheLastElementOfThePath() {
+		RecordingSource source = new RecordingSource(Path.of("data", "rows.csv").toString());
+
+		assertEquals("rows.csv", source.getFileName());
+	}
+
+	@Test
+	public void aPathThatNamesNoFileIsRefusedRatherThanDereferenced() {
+		// A filesystem root has no last element, so getFileName() answers null and the
+		// lookup would throw NPE two lines after the method took care to say what was
+		// wrong. File.separator is that root on both POSIX and Windows.
+		RecordingSource source = new RecordingSource(File.separator);
+
+		IllegalStateException thrown = assertThrows(IllegalStateException.class, source::getFileName);
+
+		assertTrue(thrown.getMessage().contains("names no file"), thrown.getMessage());
+	}
+
+	@Test
+	public void aSourceBackedByARawStreamStillSaysSoRatherThanNamingAFile() {
+		CSVDataSource source = new CSVDataSource(stream(HEADER), ",", 1);
+
+		IllegalStateException thrown = assertThrows(IllegalStateException.class, source::getFileName);
+
+		assertTrue(thrown.getMessage().contains("raw input stream"), thrown.getMessage());
 	}
 
 	private static int readAll(CSVDataSource source) {


### PR DESCRIPTION
SpotBugs' NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE found fourteen call sites
dereferencing a method documented to return null — almost all of them
Path.getParent() or Path.getFileName(). Each is an NPE on an input that is
legal but unusual: a root path has no parent and no file name, and a bare
relative name has no parent either. The adopt and claude-code-enforcer sites
are the ones that matter in practice, both walking directories supplied by
whoever invoked them.

Every site now either guards and produces the module's own error, or answers
the question totally:

- AbstractFileSource.getFileName() refuses a path naming no file in the same
  terms it already refuses a raw stream, rather than throwing NPE two lines
  after taking care to say what was wrong.
- ClaudeTrustStore resolves its lock file, its temporary file and its move
  against one configDirectory(), which refuses a root before the update has
  touched anything.
- ClaudeInitStep.restore and OkfBundleWriter absolutise before taking the
  parent, the idiom AdoptionFiles already documents, so a relative name still
  names the directory it lands in.
- ExecutableResolver.isBatchScript, GradleGuardInstaller.blockFor and
  ProjectFiles.isMarkdown answer false-or-default for a path with no name;
  ImportGraph.rootedAt leaves an import the platform's to read when the
  importing path lends no root. The three that are pure are static and
  package-private, so a test drives the guard directly rather than through a
  seam that cannot reach it.
- PathNames says the context module's name lookup once, for the walk, the
  load and the child ordering that each had their own copy of it.

Baseline and HtmlReport guard at their own writes rather than through a
shared helper: the enforcer's layering confines Files.createDirectories to
the three classes a build asked to write, and centralising it there broke
that rule.

The detector now reports zero instances across the reactor, down from 14,
with no new SpotBugs finding introduced (104 -> 90 overall). Full build,
the doc check and the integration tests of all four modules pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EwbWjeLHa16y2ByuDWRxcR