### PR TITLE
fix(adopt): fill the guard templates in without a format string (#660)

### DIFF
--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/GradleGuardInstaller.java
@@ -71,10 +71,23 @@ public class GradleGuardInstaller {
 	/** The lifecycle task the guard is hung from, and the one created when the project has none. */
 	static final String LIFECYCLE_TASK = "check";
 
+	/**
+	 * The two task names the blocks below are stamped with. They are substituted rather
+	 * than formatted in, so the templates stay LF wherever the adoption runs — the
+	 * shape {@link #append} re-terminates from when it matches the script's own
+	 * endings. A {@code %n} would make the constant CRLF on a Windows run without
+	 * changing a byte of the appended block, so the platform's separator has nothing to
+	 * offer here.
+	 */
+	private static final String GUARD_TASK_TOKEN = "@guardTask@";
+
+	private static final String LIFECYCLE_TASK_TOKEN = "@lifecycleTask@";
+
+	/** The Groovy guard, its {@value #GUARD_TASK_TOKEN} and {@value #LIFECYCLE_TASK_TOKEN} filled in. */
 	private static final String GROOVY_BLOCK = """
 
 			// Added by claude-code-adopt: fail the build when CLAUDE.md is missing or empty.
-			tasks.register('%1$s') {
+			tasks.register('@guardTask@') {
 			    def claudeMd = project.file('CLAUDE.md')
 			    doLast {
 			        if (!claudeMd.isFile() || claudeMd.text.trim().isEmpty()) {
@@ -82,18 +95,19 @@ public class GradleGuardInstaller {
 			        }
 			    }
 			}
-			tasks.matching { it.name == '%2$s' }.configureEach { it.dependsOn('%1$s') }
+			tasks.matching { it.name == '@lifecycleTask@' }.configureEach { it.dependsOn('@guardTask@') }
 			project.afterEvaluate {
-			    if (!tasks.names.contains('%2$s')) {
-			        tasks.register('%2$s') { it.dependsOn('%1$s') }
+			    if (!tasks.names.contains('@lifecycleTask@')) {
+			        tasks.register('@lifecycleTask@') { it.dependsOn('@guardTask@') }
 			    }
 			}
-			""".formatted(GUARD_TASK, LIFECYCLE_TASK);
+			""".replace(GUARD_TASK_TOKEN, GUARD_TASK).replace(LIFECYCLE_TASK_TOKEN, LIFECYCLE_TASK);
 
+	/** The Kotlin guard, filled in and terminated exactly as {@link #GROOVY_BLOCK} is. */
 	private static final String KOTLIN_BLOCK = """
 
 			// Added by claude-code-adopt: fail the build when CLAUDE.md is missing or empty.
-			tasks.register("%1$s") {
+			tasks.register("@guardTask@") {
 			    val claudeMd = project.file("CLAUDE.md")
 			    doLast {
 			        if (!claudeMd.isFile || claudeMd.readText().trim().isEmpty()) {
@@ -101,13 +115,13 @@ public class GradleGuardInstaller {
 			        }
 			    }
 			}
-			tasks.matching { it.name == "%2$s" }.configureEach { dependsOn("%1$s") }
+			tasks.matching { it.name == "@lifecycleTask@" }.configureEach { dependsOn("@guardTask@") }
 			project.afterEvaluate {
-			    if (!tasks.names.contains("%2$s")) {
-			        tasks.register("%2$s") { dependsOn("%1$s") }
+			    if (!tasks.names.contains("@lifecycleTask@")) {
+			        tasks.register("@lifecycleTask@") { dependsOn("@guardTask@") }
 			    }
 			}
-			""".formatted(GUARD_TASK, LIFECYCLE_TASK);
+			""".replace(GUARD_TASK_TOKEN, GUARD_TASK).replace(LIFECYCLE_TASK_TOKEN, LIFECYCLE_TASK);
 
 	/**
 	 * @return {@code true} when the guard was appended, {@code false} when the

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/PomEnforcerInstaller.java
@@ -87,6 +87,15 @@ public class PomEnforcerInstaller {
 	private static final String PROJECT_DIR = "${project.basedir}";
 
 	/**
+	 * Where the rule element is substituted into {@link #EXECUTION}. Substituted rather
+	 * than formatted in, so the execution reaches {@link PomDocument} in LF, the shape
+	 * it documents its fragments in and re-indents from. A {@code %n} would make the
+	 * same template CRLF on a Windows run for nothing: the POM's own terminator is what
+	 * the written block ends up on either way.
+	 */
+	private static final String RULES_TOKEN = "@rules@";
+
+	/**
 	 * The execution that runs the guard, bound to {@code validate} and not inherited
 	 * because the documents live only at the repository root.
 	 */
@@ -100,7 +109,7 @@ public class PomEnforcerInstaller {
 			  </goals>
 			  <configuration>
 			    <rules>
-			%s
+			@rules@
 			    </rules>
 			  </configuration>
 			</execution>""";
@@ -174,7 +183,7 @@ public class PomEnforcerInstaller {
 		if (alreadyRunsTheRule(pom)) {
 			return false;
 		}
-		String execution = EXECUTION.formatted(ruleConfiguration(requiredSections));
+		String execution = EXECUTION.replace(RULES_TOKEN, ruleConfiguration(requiredSections));
 		enforcerPluginOfTheBuild(pom).ifPresentOrElse(
 				plugin -> augment(pom, plugin, execution),
 				() -> pom.insertUnder(pom.root(), BUILD_PLUGINS, plugin(execution)));

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstaller.java
@@ -33,8 +33,20 @@ public class WorkflowGuardInstaller {
 
 	private static final String MARKER = "Added by claude-code-adopt";
 
+	/**
+	 * The marker and the script's path, substituted into the two templates rather than
+	 * formatted in so both files are written with LF on every platform. The script is
+	 * run by {@code sh}, which reads a CRLF shebang line as an interpreter named
+	 * {@code /bin/sh\r} and refuses to run it, so LF here is the guard working rather
+	 * than a line-ending preference; the workflow beside it is written the same way, so
+	 * the pair a run adds is identical wherever the run happened.
+	 */
+	private static final String MARKER_TOKEN = "@marker@";
+
+	private static final String SCRIPT_FILE_TOKEN = "@scriptFile@";
+
 	private static final String WORKFLOW = """
-			# %s: fail CI when CLAUDE.md is missing or empty.
+			# @marker@: fail CI when CLAUDE.md is missing or empty.
 			name: CLAUDE.md guard
 			on: [push, pull_request]
 			jobs:
@@ -43,17 +55,17 @@ public class WorkflowGuardInstaller {
 			    steps:
 			      - uses: actions/checkout@v4
 			      - name: Enforce CLAUDE.md
-			        run: sh %s
-			""".formatted(MARKER, SCRIPT_FILE);
+			        run: sh @scriptFile@
+			""".replace(MARKER_TOKEN, MARKER).replace(SCRIPT_FILE_TOKEN, SCRIPT_FILE);
 
 	private static final String SCRIPT = """
 			#!/bin/sh
-			# %s: fail when CLAUDE.md is missing or empty.
+			# @marker@: fail when CLAUDE.md is missing or empty.
 			if [ ! -f CLAUDE.md ] || ! grep -q '[^[:space:]]' CLAUDE.md; then
 			  echo "CLAUDE.md is missing or empty" >&2
 			  exit 1
 			fi
-			""".formatted(MARKER);
+			""".replace(MARKER_TOKEN, MARKER);
 
 	private final AssetInstaller workflowInstaller = new AssetInstaller(WORKFLOW_FILE, WORKFLOW);
 	private final AssetInstaller scriptInstaller = new AssetInstaller(SCRIPT_FILE, SCRIPT);

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstallerTest.java
@@ -36,6 +36,24 @@ class WorkflowGuardInstallerTest {
 	}
 
 	/**
+	 * Both files are written verbatim, so their terminators are whatever the templates
+	 * carry — nothing re-terminates them against a file already in the checkout. LF is
+	 * the answer on every platform: {@code sh} reads a CRLF shebang as an interpreter
+	 * named {@code /bin/sh\r} and refuses the script, which would fail the guard the
+	 * adoption just installed on the run's own machine.
+	 */
+	@Test
+	void writesBothGuardFilesWithLfEndingsAndTheAdoptionMarker(@TempDir Path directory) throws IOException {
+		assertTrue(installer.install(directory));
+		String workflow = Files.readString(directory.resolve(WorkflowGuardInstaller.WORKFLOW_FILE));
+		String script = Files.readString(directory.resolve(WorkflowGuardInstaller.SCRIPT_FILE));
+		assertFalse(workflow.contains("\r"), "the workflow must be LF, whatever platform the adoption ran on");
+		assertFalse(script.contains("\r"), "the script must be LF; sh refuses a CRLF shebang line");
+		assertTrue(workflow.contains("# Added by claude-code-adopt:"), "the workflow must name its author");
+		assertTrue(script.contains("# Added by claude-code-adopt:"), "the script must name its author");
+	}
+
+	/**
 	 * The fallback guard is the only thing standing between a build-less repository
 	 * and an unchecked CLAUDE.md, so a checkout it cannot be written into must fail
 	 * the adoption rather than pass silently guarded by nothing.


### PR DESCRIPTION
The five templates the adoption writes into somebody else's repository —
the two Gradle guard blocks, the workflow and its shell script, and the
enforcer execution — were text blocks passed through String.formatted,
so SpotBugs read their LF terminators as VA_FORMAT_STRING_USES_NEWLINE.

LF is the right answer at every one of the five, not the platform's
separator: the workflow and the script are written verbatim, and sh reads
a CRLF shebang as an interpreter named /bin/sh\r and refuses the script
the adoption just installed; the Gradle block and the POM execution are
re-terminated against the file they are written into, which expects them
in LF. So the placeholders are substituted with String.replace rather
than formatted in, leaving the detector nothing to report and each site
documented with why it stays LF.

Pins the guard files' terminators and their marker with a test, since
they are the pair nothing re-terminates.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NnX6S2ybBRQNfZRLudyrVV