### PR TITLE
fix(data): close the statement when closing the result set throws (#621)

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/InMemorySQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/InMemorySQLDataSource.java
@@ -42,9 +42,10 @@ public class InMemorySQLDataSource extends IterableSQLDataSource implements InMe
 	public List<String[]> readAll() {
 		try (Statement statement = connection.createStatement()) {
 			ResultSet resultSet = statement.executeQuery(query);
+			int columnCount = columnCountOf(resultSet);
 			List<String[]> allData = new ArrayList<>();
 			while (resultSet.next()) {
-				allData.add(getNextFrom(resultSet));
+				allData.add(getNextFrom(resultSet, columnCount));
 			}
 			log.info("Loaded {} rows into memory", allData::size);
 			return allData;

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -33,6 +33,7 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 
 	private ResultSet resultSet;
 	private Statement statement;
+	private int columnCount;
 	protected boolean hasMoreData = true;
 	protected final String query;
 	protected final Connection connection;
@@ -58,16 +59,57 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 		} finally {
 			resultSet = null;
 			statement = null;
+			columnCount = 0;
 		}
 	}
 
+	/**
+	 * Closes both resources whichever of them fails. A {@link ResultSet#close()} that
+	 * throws must not skip the statement: {@link #closeQueryResources()} nulls both
+	 * fields either way, so a statement left open here — and the server-side cursor it
+	 * holds on a connection the caller keeps using — is unreachable and can never be
+	 * closed. Both failures are reported as one, the statement's suppressed by the
+	 * result set's.
+	 */
 	private void closeOpenResources() throws SQLException {
-		if (resultSet != null) {
-			resultSet.close();
+		SQLException resultSetFailure = closeResultSet();
+		SQLException statementFailure = closeStatement();
+		SQLException failure = firstOf(resultSetFailure, statementFailure);
+		if (failure != null) {
+			throw failure;
 		}
-		if (statement != null) {
-			statement.close();
+	}
+
+	private SQLException closeResultSet() {
+		return resultSet == null ? null : failureFrom(resultSet::close);
+	}
+
+	private SQLException closeStatement() {
+		return statement == null ? null : failureFrom(statement::close);
+	}
+
+	/** @return what {@code call} failed with, or {@code null} if it succeeded */
+	private static SQLException failureFrom(Sql.Call call) {
+		try {
+			call.run();
+			return null;
+		} catch (SQLException e) {
+			return e;
 		}
+	}
+
+	/**
+	 * @return {@code first}, carrying {@code second} as a suppressed exception, or
+	 *         whichever of the two is not {@code null}
+	 */
+	private static SQLException firstOf(SQLException first, SQLException second) {
+		if (first == null) {
+			return second;
+		}
+		if (second != null) {
+			first.addSuppressed(second);
+		}
+		return first;
 	}
 
 	@Override
@@ -96,6 +138,7 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 		statement = connection.createStatement();
 		log.info("Executing query: {}", query);
 		resultSet = statement.executeQuery(query);
+		columnCount = columnCountOf(resultSet);
 	}
 
 	@Override
@@ -106,7 +149,7 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 
 	private String[] readRow() throws SQLException {
 		hasMoreData = resultSet.next();
-		return hasMoreData ? getNextFrom(resultSet) : null;
+		return hasMoreData ? getNextFrom(resultSet, columnCount) : null;
 	}
 
 	@Override
@@ -141,8 +184,17 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 		open();
 	}
 
-	protected static String[] getNextFrom(ResultSet resultSet) throws SQLException {
-		return byColumn(resultSet.getMetaData().getColumnCount(), resultSet::getString);
+	/**
+	 * Reads one row, taking the column count the caller read once at the start of the
+	 * result set rather than asking for the metadata again — a round trip to the server
+	 * on some drivers, and the row count is what it would be multiplied by.
+	 */
+	protected static String[] getNextFrom(ResultSet resultSet, int columnCount) throws SQLException {
+		return byColumn(columnCount, resultSet::getString);
+	}
+
+	protected static int columnCountOf(ResultSet resultSet) throws SQLException {
+		return resultSet.getMetaData().getColumnCount();
 	}
 
 	protected static String[] getColumnsFrom(ResultSet resultSet) throws SQLException {

--- a/data/src/test/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSourceCloseTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSourceCloseTest.java
@@ -1,0 +1,118 @@
+package io.github.adamw7.tools.data.source.db;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.UncheckedIOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * What {@link IterableSQLDataSource} does when JDBC fails on the way out, which the
+ * embedded-Derby tests cannot reach: the driver has to refuse to close. The source
+ * forgets both resources once it has closed them, so a statement it skipped is
+ * unreachable — and on a connection the caller keeps using, leaked.
+ */
+public class IterableSQLDataSourceCloseTest {
+
+	private static final String QUERY = "SELECT * FROM PEOPLE";
+
+	private final Connection connection = mock(Connection.class);
+	private final Statement statement = mock(Statement.class);
+	private final ResultSet resultSet = mock(ResultSet.class);
+
+	private IterableSQLDataSource openedSource() throws SQLException {
+		ResultSetMetaData meta = mock(ResultSetMetaData.class);
+		when(meta.getColumnCount()).thenReturn(2);
+		when(resultSet.getMetaData()).thenReturn(meta);
+		when(statement.executeQuery(QUERY)).thenReturn(resultSet);
+		when(connection.createStatement()).thenReturn(statement);
+		IterableSQLDataSource source = new IterableSQLDataSource(connection, QUERY);
+		source.open();
+		return source;
+	}
+
+	@Test
+	public void statementIsClosedWhenTheResultSetRefusesTo() throws SQLException {
+		IterableSQLDataSource source = openedSource();
+		doThrow(new SQLException("connection dropped")).when(resultSet).close();
+
+		assertThrows(UncheckedIOException.class, source::close);
+
+		verify(statement).close();
+	}
+
+	@Test
+	public void resettingClosesTheStatementWhenTheResultSetRefusesTo() throws SQLException {
+		IterableSQLDataSource source = openedSource();
+		doThrow(new SQLException("connection dropped")).when(resultSet).close();
+
+		assertThrows(UncheckedIOException.class, source::reset);
+
+		verify(statement).close();
+	}
+
+	@Test
+	public void bothCloseFailuresAreReportedAsOne() throws SQLException {
+		IterableSQLDataSource source = openedSource();
+		SQLException resultSetFailure = new SQLException("result set");
+		SQLException statementFailure = new SQLException("statement");
+		doThrow(resultSetFailure).when(resultSet).close();
+		doThrow(statementFailure).when(statement).close();
+
+		UncheckedIOException thrown = assertThrows(UncheckedIOException.class, source::close);
+
+		Throwable reported = thrown.getCause().getCause();
+		assertSame(resultSetFailure, reported);
+		assertArrayEquals(new Throwable[] { statementFailure }, reported.getSuppressed());
+	}
+
+	@Test
+	public void aStatementThatRefusesToCloseIsReportedOnItsOwn() throws SQLException {
+		IterableSQLDataSource source = openedSource();
+		SQLException statementFailure = new SQLException("statement");
+		doThrow(statementFailure).when(statement).close();
+
+		UncheckedIOException thrown = assertThrows(UncheckedIOException.class, source::close);
+
+		assertSame(statementFailure, thrown.getCause().getCause());
+	}
+
+	@Test
+	public void closingASourceThatWasNeverOpenedTouchesNothing() {
+		IterableSQLDataSource source = new IterableSQLDataSource(connection, QUERY);
+
+		assertDoesNotThrow(source::close);
+
+		verifyNoInteractions(connection, statement, resultSet);
+	}
+
+	@Test
+	public void theColumnCountIsReadOnceForTheWholeResultSet() throws SQLException {
+		IterableSQLDataSource source = openedSource();
+		when(resultSet.next()).thenReturn(true, true, false);
+		when(resultSet.getString(anyInt())).thenReturn("value");
+
+		source.nextRow();
+		source.nextRow();
+		source.nextRow();
+
+		// Once at open(), and never again per row: some drivers make getMetaData() a
+		// round trip, which a row-at-a-time read would multiply by the row count.
+		verify(resultSet, times(1)).getMetaData();
+	}
+}


### PR DESCRIPTION
closeOpenResources() closed the result set first and the statement second, in
sequence, so a SQLException from resultSet.close() — a dropped connection, a
driver-side error — skipped statement.close() entirely. closeQueryResources()
nulls both fields in its finally either way, which leaves that statement, and
the server-side cursor it holds on a connection the caller owns and keeps
using, unreachable and impossible to close. reset() takes this path on every
pass, and the uniqueness check's subset search resets once per candidate
subset, so the leak is one statement per pass rather than one per source.

Close each of them for itself and report what failed afterwards: the result
set's failure is thrown with the statement's suppressed, so neither is lost
and the statement closes whatever the result set did.

While in the file: getNextFrom asked the result set for its metadata once per
row purely to read the column count, which some drivers make a round trip.
Read it once — at open() for the iterable source, before the loop in
readAll() for the in-memory one — and pass it in. The protected
getNextFrom(ResultSet) therefore takes the count as a second parameter now,
and columnCountOf(ResultSet) is protected beside it for the subclass that
reads a whole result set of its own.

The tests mock the driver, which is the only way to make a close() fail: they
pin that the statement still closes when the result set refuses, on close()
and on reset(), that both failures arrive as one exception with the other
suppressed, that a statement failure alone is reported unchanged, that a
source never opened touches nothing, and that the metadata is read once for
the whole result set rather than once per row.

Co-authored-by: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Uoc95pQDnCDrLQYJ5dz5NT