### PR TITLE
fix(data): honour the Map contract in OpenAddressingMap (#622)

### DIFF
--- a/.claude/skills/data-sources/SKILL.md
+++ b/.claude/skills/data-sources/SKILL.md
@@ -100,7 +100,10 @@ single load; `NoMemory…` re-reads the source per pass for a tiny heap.
 ## Data structures (`data.structure`)
 Open-addressing collections with double hashing, for when `HashMap`'s per-entry
 node allocation is what hurts:
-- `OpenAddressingMap<K, V>` / `OpenAddressingSet<E>` — implement `Map` / `Set`.
+- `OpenAddressingMap<K, V>` / `OpenAddressingSet<E>` — extend `AbstractMap` /
+  `AbstractSet`, so `equals`/`hashCode`/`toString` are the contract's. A `null`
+  key or element is refused by `put`/`add` with a `NullPointerException` and
+  reported absent by the lookups; the view iterators are fail-fast.
 - `IntKeyOpenAddressingMap<V>` — primitive `int[]` keys, so lookups and inserts
   never box. It deliberately does **not** implement `Map` (that contract is
   defined over `Object` keys and would reintroduce the boxing it exists to

--- a/README.md
+++ b/README.md
@@ -762,13 +762,21 @@ How it works:
   `new OpenAddressingMap<>(size)` (minimum effective size is 3); a
   non-positive size is rejected with `IllegalArgumentException`.
 
+It extends `java.util.AbstractMap`, so `equals`, `hashCode` and `toString` are
+the ones `Map` specifies over the entry set — a map holding the same entries as a
+`HashMap` compares equal to it, and prints as `{a=1, b=2}`.
+
 Caveats:
 
-- **Null keys are not supported** — `put`/`get` with a `null` key throw
-  `IllegalArgumentException`.
-- **Null values are not distinguishable from absence**: `get` returns `null`
-  for a missing key and `containsKey` is defined as `get(key) != null`, so a key
-  mapped to a `null` value is reported as absent. Avoid storing `null` values.
+- **Null keys are not supported** — `put` rejects one with a
+  `NullPointerException`. As the `Map` contract requires of a map that cannot
+  hold such a key, `containsKey`/`get`/`remove` report it absent (`false`/`null`)
+  rather than throwing.
+- **Null values are stored faithfully** and reported by `containsKey`; only
+  `get` cannot tell a stored `null` from a missing key.
+- The iterators of `keySet`, `values` and `entrySet` are **fail-fast**: a
+  structural modification made through anything but the iterator's own `remove()`
+  makes the next `next()`/`remove()` throw `ConcurrentModificationException`.
 - It is **not thread-safe**; guard external synchronization if shared across
   threads.
 
@@ -788,8 +796,9 @@ set.contains("a");     // true
 set.remove("a");       // true
 ```
 
-It inherits the map's caveats: **null elements are not supported** (they are
-rejected with `IllegalArgumentException`) and it is **not thread-safe**. The
+It inherits the map's caveats: **null elements are not supported** (`add`
+rejects one with a `NullPointerException`, while `contains`/`remove` report it
+absent), its iterator is **fail-fast**, and it is **not thread-safe**. The
 initial capacity can be set via `new OpenAddressingSet<>(size)`.
 
 ### Primitive int-keyed map

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingMap.java
@@ -1,11 +1,14 @@
 package io.github.adamw7.tools.data.structure;
 
 import java.util.AbstractCollection;
+import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.Collection;
+import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -13,13 +16,42 @@ import io.github.adamw7.tools.data.structure.internal.DoubleHashing;
 import io.github.adamw7.tools.data.structure.internal.Primes;
 import io.github.adamw7.tools.data.structure.internal.Wrapper;
 
-public class OpenAddressingMap<K, V> implements Map<K, V> {
+/**
+ * A {@link Map} using open addressing with double hashing: entries live directly
+ * in one array, a removal leaves a tombstone behind, and the table grows while a
+ * slot is still free so every probe chain ends on an empty one.
+ *
+ * <p>It extends {@link AbstractMap}, so {@code equals}, {@code hashCode} and
+ * {@code toString} are the ones {@link Map} specifies over {@link #entrySet()} —
+ * a map holding the same entries as a {@link java.util.HashMap} compares equal
+ * to it.
+ *
+ * <p>{@code null} values are stored faithfully; {@code null} <em>keys</em> are
+ * not supported. Per the {@code Map} contract {@link #put} rejects one with a
+ * {@link NullPointerException}, while {@link #containsKey}, {@link #get} and
+ * {@link #remove} simply answer {@code false}/{@code null} for a key the map
+ * cannot hold.
+ *
+ * <p>The iterators of all three views are <em>fail-fast</em>: a structural
+ * modification made through anything but the iterator's own {@code remove()}
+ * makes the next {@code next()} or {@code remove()} throw
+ * {@link ConcurrentModificationException}. That is a best-effort check, so it
+ * must not be relied on for correctness. Not thread-safe.
+ */
+public class OpenAddressingMap<K, V> extends AbstractMap<K, V> {
 
 	static final int DEFAULT_SIZE = DoubleHashing.DEFAULT_SIZE;
 	int prime;
 
 	protected Wrapper<K, V>[] array;
 	protected int size;
+
+	/**
+	 * Counts the structural modifications — an insertion, a removal, a rehash or a
+	 * clear, but not the overwrite of an existing key — so the view iterators can
+	 * tell that the table changed underneath them.
+	 */
+	private int modCount;
 
 	public OpenAddressingMap(int size) {
 		initArray(size);
@@ -73,8 +105,15 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 	 * ends the search: {@link #put} always fills the first such slot, so the key
 	 * cannot lie beyond it. Tombstones ({@code removed}) are skipped rather than
 	 * treated as terminal, because live entries may sit past them.
+	 *
+	 * <p>A {@code null} key never reaches the probe: the map cannot hold one, so
+	 * it is absent by definition and the lookups built on this method answer
+	 * {@code false}/{@code null} instead of throwing, as {@link Map} requires.
 	 */
 	private Wrapper<K, V> find(Object key) {
+		if (key == null) {
+			return null;
+		}
 		DoubleHashing.Probe probe = probe(key);
 		for (int i = 0; i < array.length; ++i) {
 			Wrapper<K, V> wrapper = array[probe.slot(i)];
@@ -89,14 +128,12 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 	}
 
 	private DoubleHashing.Probe probe(Object key) {
-		if (key == null) {
-			throw new IllegalArgumentException("Key is null");
-		}
 		return DoubleHashing.sequence(key.hashCode(), prime, array.length);
 	}
 
 	@Override
 	public V put(K key, V value) {
+		Objects.requireNonNull(key, "Key is null");
 		checkIfResizeNeeded();
 		DoubleHashing.Probe probe = probe(key);
 		for (int i = 0; i < array.length; ++i) {
@@ -115,6 +152,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 	private V insert(int hash, K key, V value) {
 		array[hash] = new Wrapper<>(key, value);
 		size++;
+		modCount++;
 		return null;
 	}
 
@@ -130,7 +168,13 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 		}
 	}
 
+	/**
+	 * Rehashes into a larger table. It counts as a structural modification in its
+	 * own right, because it replaces the array an iterator is walking even when the
+	 * put that triggered it only overwrote an existing key.
+	 */
 	private void resize() {
+		modCount++;
 		Wrapper<K, V>[] old = array;
 		initArray(newSize());
 		size = 0;
@@ -149,6 +193,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 		}
 		wrapper.markRemoved();
 		size--;
+		modCount++;
 		return wrapper.getValue();
 	}
 
@@ -161,6 +206,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 	public void clear() {
 		initArray(size >= array.length ? newSize() : Math.max(size, 1));
 		size = 0;
+		modCount++;
 	}
 
 	private int newSize() {
@@ -235,16 +281,21 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 	 * view's element type. {@code remove()} retires the entry returned last, so
 	 * the views are writable and the bulk operations inherited from
 	 * {@code AbstractCollection} (removeAll, retainAll, removeIf) really mutate
-	 * the map instead of a throwaway copy.
+	 * the map instead of a throwaway copy. Any other structural modification made
+	 * while the walk is in progress is refused with a
+	 * {@link ConcurrentModificationException} rather than silently yielding
+	 * entries from a stale table.
 	 */
 	private final class LiveEntryIterator<T> implements Iterator<T> {
 
 		private final Function<Wrapper<K, V>, T> mapper;
 		private int nextIndex;
 		private Wrapper<K, V> lastReturned;
+		private int expectedModCount;
 
 		private LiveEntryIterator(Function<Wrapper<K, V>, T> mapper) {
 			this.mapper = mapper;
+			this.expectedModCount = modCount;
 			this.nextIndex = nextValidFrom(0);
 		}
 
@@ -255,6 +306,7 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 
 		@Override
 		public T next() {
+			checkForComodification();
 			if (!hasNext()) {
 				throw new NoSuchElementException();
 			}
@@ -268,9 +320,18 @@ public class OpenAddressingMap<K, V> implements Map<K, V> {
 			if (lastReturned == null) {
 				throw new IllegalStateException("next() has not been called since the last remove()");
 			}
+			checkForComodification();
 			lastReturned.markRemoved();
 			size--;
+			modCount++;
+			expectedModCount = modCount;
 			lastReturned = null;
+		}
+
+		private void checkForComodification() {
+			if (modCount != expectedModCount) {
+				throw new ConcurrentModificationException();
+			}
 		}
 
 		private int nextValidFrom(int index) {

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingSet.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingSet.java
@@ -11,9 +11,10 @@ import java.util.Set;
  * all of the open-addressing behaviour (double hashing, tombstone removal and
  * automatic resizing) is reused rather than re-implemented.
  *
- * <p>Like the underlying map this set does not support {@code null} elements
- * (they are rejected with {@link IllegalArgumentException}) and is not
- * thread-safe.
+ * <p>Like the underlying map this set does not support {@code null} elements:
+ * {@link #add} rejects one with a {@link NullPointerException}, while
+ * {@link #contains} and {@link #remove} answer {@code false} for an element the
+ * set cannot hold. Its iterator is fail-fast, and it is not thread-safe.
  */
 public class OpenAddressingSet<E> extends AbstractSet<E> implements Set<E> {
 

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/internal/Wrapper.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/internal/Wrapper.java
@@ -56,4 +56,10 @@ public class Wrapper<K, V> implements Entry<K, V>{
 		return Objects.hashCode(key) ^ Objects.hashCode(value);
 	}
 
+	/** The {@code key=value} form every {@link Entry} implementation prints. */
+	@Override
+	public String toString() {
+		return key + "=" + value;
+	}
+
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/MapTest.java
@@ -3,6 +3,7 @@ package io.github.adamw7.tools.data.structure;
 import static io.github.adamw7.tools.data.Utils.named;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -10,7 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 import java.util.Collection;
+import java.util.ConcurrentModificationException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -345,10 +348,23 @@ public class MapTest {
 	}
 
 	@Test
-	public void nullKey() {
-		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> new OpenAddressingMap<>(2).put(null, null), "Expected put method to throw, but it didn't");
+	public void nullKeyIsRejectedByPut() {
+		NullPointerException thrown = assertThrows(NullPointerException.class, () -> new OpenAddressingMap<>(2).put(null, null), "Expected put method to throw, but it didn't");
 
 		assertEquals("Key is null",thrown.getMessage());
+	}
+
+	@Test
+	public void nullKeyIsAbsentRatherThanAnErrorForLookups() {
+		// A map that cannot hold a null key must report it missing, not throw:
+		// Map.containsKey/get/remove specify that for the key types they reject.
+		Map<Integer, String> map = new OpenAddressingMap<>();
+		map.put(1, "A");
+
+		assertFalse(map.containsKey(null));
+		assertNull(map.get(null));
+		assertNull(map.remove(null));
+		assertEquals(1, map.size());
 	}
 	
 	@ParameterizedTest
@@ -502,5 +518,154 @@ public class MapTest {
 		map.clear();
 		assertEquals(0, map.size());
 		assertEquals(3, map.capacity());
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void equalsAndHashCodeAreDefinedByTheEntries(Map<Integer, String> map) {
+		map.put(1, "A");
+		map.put(2, "B");
+		Map<Integer, String> expected = Map.of(1, "A", 2, "B");
+
+		assertEquals(expected, map);
+		assertEquals(map, expected);
+		assertEquals(expected.hashCode(), map.hashCode());
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void equalsIgnoresRemovedEntries(Map<Integer, String> map) {
+		// The tombstone a removal leaves behind is not an entry, so it must not make
+		// the map differ from one that never held the key.
+		map.put(1, "A");
+		map.put(2, "B");
+		map.remove(1);
+
+		assertEquals(Map.of(2, "B"), map);
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void twoEmptyMapsAreEqual(Map<Integer, String> map) {
+		assertEquals(Map.of(), map);
+		assertEquals(map, Map.of());
+		assertEquals(Map.of().hashCode(), map.hashCode());
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void mapsWithDifferentEntriesAreNotEqual(Map<Integer, String> map) {
+		map.put(1, "A");
+
+		assertNotEquals(map, Map.of(1, "B"));
+		assertNotEquals(Map.of(1, "B"), map);
+		assertNotEquals(map, Map.of(2, "A"));
+		assertNotEquals(map, Map.of(1, "A", 2, "B"));
+		assertNotEquals(map, "not a map");
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void toStringListsTheEntries(Map<Integer, String> map) {
+		assertEquals("{}", map.toString());
+
+		map.put(1, "A");
+		assertEquals("{1=A}", map.toString());
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void anEntryPrintsAsKeyEqualsValue(Map<Integer, String> map) {
+		map.put(1, "A");
+
+		assertEquals("1=A", map.entrySet().iterator().next().toString());
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void iteratorFailsFastWhenAKeyIsAdded(Map<Integer, String> map) {
+		map.put(1, "A");
+		map.put(2, "B");
+		Iterator<Integer> iterator = map.keySet().iterator();
+		iterator.next();
+
+		map.put(3, "C");
+
+		assertThrows(ConcurrentModificationException.class, iterator::next);
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void iteratorFailsFastWhenAKeyIsRemoved(Map<Integer, String> map) {
+		map.put(1, "A");
+		map.put(2, "B");
+		Iterator<String> iterator = map.values().iterator();
+		iterator.next();
+
+		map.remove(1);
+
+		assertThrows(ConcurrentModificationException.class, iterator::next);
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void iteratorFailsFastAfterClear(Map<Integer, String> map) {
+		map.put(1, "A");
+		map.put(2, "B");
+		Iterator<Entry<Integer, String>> iterator = map.entrySet().iterator();
+		iterator.next();
+
+		map.clear();
+
+		assertThrows(ConcurrentModificationException.class, iterator::next);
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void iteratorRemoveFailsFastWhenTheMapChangedUnderneathIt(Map<Integer, String> map) {
+		map.put(1, "A");
+		map.put(2, "B");
+		Iterator<Integer> iterator = map.keySet().iterator();
+		iterator.next();
+
+		map.put(3, "C");
+
+		assertThrows(ConcurrentModificationException.class, iterator::remove);
+	}
+
+	@ParameterizedTest
+	@MethodSource("allImplementations")
+	public void iteratorOwnRemoveDoesNotFailFast(Map<Integer, String> map) {
+		for (int i = 0; i < 10; ++i) {
+			map.put(i, "v" + i);
+		}
+
+		Iterator<Integer> iterator = map.keySet().iterator();
+		while (iterator.hasNext()) {
+			if (iterator.next() % 2 == 0) {
+				iterator.remove();
+			}
+		}
+
+		assertEquals(5, map.size());
+		assertFalse(map.containsKey(0));
+		assertTrue(map.containsKey(1));
+	}
+
+	@Test
+	public void aGrowingPutFailsTheIteratorEvenWhenItOnlyOverwrites() {
+		// The rehash replaces the array the iterator walks, so it is a structural
+		// modification in its own right even though no entry was added.
+		OpenAddressingMap<Integer, String> map = new OpenAddressingMap<>(8);
+		for (int i = 0; i < 7; ++i) {
+			map.put(i, "v" + i);
+		}
+		Iterator<Integer> iterator = map.keySet().iterator();
+		iterator.next();
+
+		map.put(0, "overwritten"); // the table is one put away from growing
+
+		assertEquals(7, map.size());
+		assertThrows(ConcurrentModificationException.class, iterator::next);
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/OpenAddressingSetTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/OpenAddressingSetTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
+import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -180,6 +181,29 @@ public class OpenAddressingSetTest {
 
 	@Test
 	public void nullElementIsRejected() {
-		assertThrows(IllegalArgumentException.class, () -> new OpenAddressingSet<Integer>().add(null));
+		assertThrows(NullPointerException.class, () -> new OpenAddressingSet<Integer>().add(null));
+	}
+
+	@Test
+	public void nullElementIsAbsentRatherThanAnErrorForLookups() {
+		Set<Integer> set = new OpenAddressingSet<>();
+		set.add(1);
+
+		assertFalse(set.contains(null));
+		assertFalse(set.remove(null));
+		assertEquals(1, set.size());
+	}
+
+	@ParameterizedTest
+	@MethodSource("implementations")
+	public void iteratorFailsFastWhenTheSetChanges(Set<Integer> set) {
+		set.add(1);
+		set.add(2);
+		Iterator<Integer> iterator = set.iterator();
+		iterator.next();
+
+		set.add(3);
+
+		assertThrows(ConcurrentModificationException.class, iterator::next);
 	}
 }


### PR DESCRIPTION
The map implemented java.util.Map directly and never supplied the
behaviour AbstractMap would have given it, so it followed different
rules from the OpenAddressingSet built on top of it.

- Extend AbstractMap, so equals, hashCode and toString are the ones Map
  specifies over entrySet(): a map holding the same entries as a HashMap
  now compares equal to it instead of by identity, and prints its
  entries. Wrapper gains the key=value toString every Map.Entry prints.
- Handle a null key as the contract requires: put rejects one with a
  NullPointerException rather than an IllegalArgumentException, while
  containsKey, get and remove report it absent instead of throwing,
  since the map cannot hold such a key.
- Add a modCount so the view iterators are fail-fast. An insertion, a
  removal, a rehash or a clear now makes the next next()/remove() throw
  ConcurrentModificationException; the iterator's own remove() keeps
  working, so the write-through bulk operations are unaffected. The
  rehash counts on its own account, because it replaces the array the
  iterator walks even when the put that triggered it only overwrote.

The tests are parameterised against HashMap wherever the behaviour is
shared, so the JDK is the reference for all of it. README and the
data-sources skill drop the stale claim that a null value cannot be told
from absence, which the map already stores faithfully.