### PR TITLE
fix(data): reject n < 2 and stop Primes.isPrime overflowing (#624)

### DIFF
--- a/data/src/main/java/io/github/adamw7/tools/data/structure/internal/Primes.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/internal/Primes.java
@@ -5,10 +5,15 @@ public class Primes {
 	private Primes() {}
 	
 	public static boolean isPrime(int n) {
-		for (int i = 2; i * i <= n; i++)
+		if (n < 2) {
+			return false;
+		}
+
+		for (int i = 2; i <= n / i; i++) {
 			if (n % i == 0) {
 				return false;
 			}
+		}
 
 		return true;
 	}

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/PrimesTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/PrimesTest.java
@@ -1,6 +1,8 @@
 package io.github.adamw7.tools.data.structure;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.github.adamw7.tools.data.structure.internal.Primes;
 
@@ -16,7 +18,32 @@ public class PrimesTest {
 		assertTrue(Primes.isPrime(7907));
 		assertFalse(Primes.isPrime(7920));
 	}
-	
+
+	@ParameterizedTest
+	@ValueSource(ints = {2, 3, 5, 7, 13, 7907, 46337, 2147483647})
+	public void primesAreRecognised(int n) {
+		assertTrue(Primes.isPrime(n), n + " is prime");
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {4, 9, 25, 7920, 2147483645, 2147483646})
+	public void compositesAreRejected(int n) {
+		assertFalse(Primes.isPrime(n), n + " is composite");
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {1, 0, -1, -7, Integer.MIN_VALUE})
+	public void numbersBelowTwoAreNotPrime(int n) {
+		assertFalse(Primes.isPrime(n), n + " is smaller than 2, so it is not prime");
+	}
+
+	@Test
+	public void findsTheLargestPrimeBelowTheBound() {
+		assertEquals(2, Primes.findMaxSmallerThan(3));
+		assertEquals(3, Primes.findMaxSmallerThan(4));
+		assertEquals(7907, Primes.findMaxSmallerThan(7908));
+	}
+
 	@Test
 	public void negativeTooLowNumber() {
 		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> Primes.findMaxSmallerThan(2), "Expected findMaxSmallerThan method to throw, but it didn't");


### PR DESCRIPTION
`isPrime` fell through to `return true` for 1, 0 and negative numbers,
because the loop body never ran for them, and its `i * i <= n` guard
wrapped negative once `i` passed 46341, so the loop kept running long
past the square root for `n` near `Integer.MAX_VALUE`.

Return `false` below 2, and bound the loop with `i <= n / i`, which
cannot overflow. Cover both defects with parameterised cases: primes and
composites up to `Integer.MAX_VALUE`, and every shape of n below 2 down
to `Integer.MIN_VALUE`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016uekiPiaZoW2CuGCDorm1K