### PR TITLE
fix(data): report a ragged row instead of ArrayIndexOutOfBoundsException (#620)

### DIFF
--- a/.claude/skills/data-sources/SKILL.md
+++ b/.claude/skills/data-sources/SKILL.md
@@ -97,6 +97,14 @@ The checker consumes a `ColumnarDataSource`, asks whether the given columns form
 a key, and searches for a smaller one. `InMemory…` runs recursive passes over a
 single load; `NoMemory…` re-reads the source per pass for a tiny heap.
 
+A **row with fewer columns than the key reads** — a CSV line with a delimiter
+missing — fails with `RaggedRowException`, naming the data row's 1-based position
+(the header and any skipped comment line excluded), the arity the key needs and
+the one the row has. It replaces the `ArrayIndexOutOfBoundsException` the
+projection used to throw, which named neither the row nor the column. Columns the
+key does not read are never touched, so a short row only fails a key that reaches
+past its end.
+
 ## Data structures (`data.structure`)
 Open-addressing collections with double hashing, for when `HashMap`'s per-entry
 node allocation is what hurts:

--- a/README.md
+++ b/README.md
@@ -727,6 +727,8 @@ Notes:
 in memory checks are using in memory sources that load all the data once and run multiple recursive checks to find better options.
 Iterative (no memory) checks are keeping only one row at the time so they require very tiny heap size but for the recursive checks need to read the source many times. 
 
+A row holding fewer columns than the key reads — a CSV line with a delimiter missing — is reported as a fault in the data: `RaggedRowException` names the 1-based position of the row among the data rows (the header and any skipped comment line excluded), the arity the key needs and the arity the row has. Columns the key does not read are never touched, so a short row only fails a key that reaches past its end.
+
 ### Open-addressing map
 
 `OpenAddressingMap<K, V>` is a `java.util.Map` implementation that is **simpler

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/KeyFinder.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/KeyFinder.java
@@ -7,17 +7,37 @@ import java.util.Set;
 public class KeyFinder {
 
 	private final int[] indices;
+	private final int expectedColumns;
 	private final Set<Key> set = new HashSet<>();
+	private long rowNumber = 0;
 
 	public KeyFinder(int[] indices) {
 		this.indices = indices;
+		this.expectedColumns = Arrays.stream(indices).max().orElse(-1) + 1;
 	}
 
 	public boolean found(String[] row) {
-		return row != null && !set.add(key(row));
+		if (row == null) {
+			return false;
+		}
+		++rowNumber;
+		return !set.add(key(row));
 	}
 
 	protected Key key(String[] row) {
+		checkArity(row);
 		return new Key(Arrays.stream(indices).mapToObj(index -> row[index]).toArray(String[]::new));
+	}
+
+	/**
+	 * Refuses a row too short for the key before projecting it. The indices come from the
+	 * header, so a row that arrives with fewer columns than the file declares — a CSV line
+	 * with a delimiter missing — is data the caller has to fix, and it is reported as such
+	 * instead of reaching them as an {@code ArrayIndexOutOfBoundsException} naming nothing.
+	 */
+	private void checkArity(String[] row) {
+		if (row.length < expectedColumns) {
+			throw new RaggedRowException(rowNumber, expectedColumns, row.length, row);
+		}
 	}
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/uniqueness/RaggedRowException.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/uniqueness/RaggedRowException.java
@@ -1,0 +1,50 @@
+package io.github.adamw7.tools.data.uniqueness;
+
+import java.util.Arrays;
+
+/**
+ * A row that holds fewer columns than the key reads, raised instead of the
+ * {@code ArrayIndexOutOfBoundsException} the projection would otherwise fail with. The
+ * key's positions come from the header, and nothing makes a data row keep to that arity:
+ * a CSV line with a missing delimiter is split into a shorter array, and reading it is a
+ * fault in the data rather than in the check. The bare index-out-of-bounds message named
+ * neither the row nor the column, which left a caller reading somebody else's file with
+ * no way to find the offending line.
+ *
+ * <p>The row number counts the data rows handed to the check, starting at 1: the header
+ * and any line the source skips — a CSV comment — are not among them, so it is a position
+ * in the data rather than in the file.</p>
+ */
+public class RaggedRowException extends RuntimeException {
+
+	private final long rowNumber;
+	private final int expectedColumns;
+	private final int actualColumns;
+
+	public RaggedRowException(long rowNumber, int expectedColumns, int actualColumns, String[] row) {
+		super(message(rowNumber, expectedColumns, actualColumns, row));
+		this.rowNumber = rowNumber;
+		this.expectedColumns = expectedColumns;
+		this.actualColumns = actualColumns;
+	}
+
+	private static String message(long rowNumber, int expectedColumns, int actualColumns, String[] row) {
+		return "Data row " + rowNumber + " is ragged: the key reads at least " + expectedColumns
+				+ " columns but the row has " + actualColumns + ": " + Arrays.toString(row);
+	}
+
+	/** The 1-based position of the offending row among the data rows read so far. */
+	public long getRowNumber() {
+		return rowNumber;
+	}
+
+	/** The arity the key needs, one past the highest column index it reads. */
+	public int getExpectedColumns() {
+		return expectedColumns;
+	}
+
+	/** The arity the offending row actually has. */
+	public int getActualColumns() {
+		return actualColumns;
+	}
+}

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/KeyFinderTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/KeyFinderTest.java
@@ -1,6 +1,8 @@
 package io.github.adamw7.tools.data.uniqueness;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -82,5 +84,85 @@ public class KeyFinderTest {
 		Key key = finder.key(new String[] { "x", "y", "z" });
 
 		assertTrue(key.equals(new Key(new String[] { "z", "x" })));
+	}
+
+	/**
+	 * The indices come from the header, so a row that arrives shorter than the file
+	 * declares used to fail with a bare ArrayIndexOutOfBoundsException naming neither the
+	 * row nor the column.
+	 */
+	@Test
+	public void shortRowIsReportedAsRagged() {
+		KeyFinder finder = new KeyFinder(new int[] { 2 });
+
+		RaggedRowException thrown = assertThrows(RaggedRowException.class,
+				() -> finder.found(new String[] { "a", "b" }));
+
+		assertEquals("Data row 1 is ragged: the key reads at least 3 columns but the row has 2: [a, b]",
+				thrown.getMessage());
+	}
+
+	@Test
+	public void raggedRowIsReportedByItsPositionArityAndContent() {
+		KeyFinder finder = new KeyFinder(new int[] { 0, 3 });
+
+		RaggedRowException thrown = assertThrows(RaggedRowException.class,
+				() -> finder.found(new String[] { "a" }));
+
+		assertEquals(1, thrown.getRowNumber());
+		assertEquals(4, thrown.getExpectedColumns());
+		assertEquals(1, thrown.getActualColumns());
+	}
+
+	/** The highest index the key reads decides the arity, not the number of columns in it. */
+	@Test
+	public void arityIsTheHighestIndexTheKeyReads() {
+		KeyFinder finder = new KeyFinder(new int[] { 4 });
+
+		RaggedRowException thrown = assertThrows(RaggedRowException.class,
+				() -> finder.found(new String[] { "a", "b", "c", "d" }));
+
+		assertEquals(5, thrown.getExpectedColumns());
+	}
+
+	@Test
+	public void raggedRowIsNumberedAmongTheRowsRead() {
+		KeyFinder finder = new KeyFinder(new int[] { 1 });
+
+		finder.found(new String[] { "a", "b" });
+		finder.found(new String[] { "c", "d" });
+
+		RaggedRowException thrown = assertThrows(RaggedRowException.class,
+				() -> finder.found(new String[] { "e" }));
+
+		assertEquals(3, thrown.getRowNumber());
+	}
+
+	/** A row the source skipped is no row of the data, so it is not counted as one. */
+	@Test
+	public void skippedRowsAreNotNumbered() {
+		KeyFinder finder = new KeyFinder(new int[] { 1 });
+
+		finder.found(null);
+
+		RaggedRowException thrown = assertThrows(RaggedRowException.class,
+				() -> finder.found(new String[] { "a" }));
+
+		assertEquals(1, thrown.getRowNumber());
+	}
+
+	/** Only a row too short to project is a fault; trailing columns the key ignores are not. */
+	@Test
+	public void longerRowThanTheKeyReadsIsAccepted() {
+		KeyFinder finder = new KeyFinder(new int[] { 0 });
+
+		assertFalse(finder.found(new String[] { "a", "b", "c" }));
+	}
+
+	@Test
+	public void rowOfExactlyTheKeyArityIsAccepted() {
+		KeyFinder finder = new KeyFinder(new int[] { 2 });
+
+		assertFalse(finder.found(new String[] { "a", "b", "c" }));
 	}
 }

--- a/data/src/test/java/io/github/adamw7/tools/data/uniqueness/UniquenessCheckTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/uniqueness/UniquenessCheckTest.java
@@ -67,6 +67,37 @@ public class UniquenessCheckTest extends DBTest {
 		assertEquals(0, result.getBetterOptions().size());
 	}
 
+	static Stream<Arguments> raggedSources() {
+		String raggedFile = Utils.getFileName("ragged.csv");
+
+		return Stream.of(of(new NoMemoryUniquenessCheck(Utils.createDataSource(raggedFile, COLUMNS_ROW))),
+				of(new InMemoryUniquenessCheck(Utils.createInMemoryDataSource(raggedFile, COLUMNS_ROW))));
+	}
+
+	/**
+	 * A CSV line with a delimiter missing is split into an array shorter than the header,
+	 * and projecting the key out of it used to fail with a bare
+	 * "ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2", which named
+	 * neither the row nor the column. A ragged row is expected input for a library reading
+	 * somebody else's file, so it is reported as a fault in the data, positioned.
+	 */
+	@ParameterizedTest
+	@MethodSource("raggedSources")
+	void raggedRowNamesItsPositionAndArity(Uniqueness uniqueness) {
+		RaggedRowException thrown = assertThrows(RaggedRowException.class, () -> uniqueness.exec("city"),
+				"Expected exec method to throw, but it didn't");
+
+		assertEquals("Data row 2 is ragged: the key reads at least 3 columns but the row has 2: [2, Bob]",
+				thrown.getMessage());
+	}
+
+	/** A key read entirely out of the columns every row does have is unaffected by the short one. */
+	@ParameterizedTest
+	@MethodSource("raggedSources")
+	void raggedRowIsReadWhereverTheKeyFitsIt(Uniqueness uniqueness) {
+		assertTrue(uniqueness.exec("id").isUnique());
+	}
+
 	@ParameterizedTest
 	@MethodSource("happyPath")
 	void negativeWrongColumn(Uniqueness uniqueness) throws Exception {

--- a/data/src/test/resources/ragged.csv
+++ b/data/src/test/resources/ragged.csv
@@ -1,0 +1,4 @@
+id,name,city
+1,Ann,Warsaw
+2,Bob
+3,Cid,Krakow


### PR DESCRIPTION
KeyFinder projects the key out of a row by the indices the header gave it,
and nothing makes a data row keep to that arity: CSVDataSource.nextRow()
splits on the delimiter with a -1 limit, so a line with a delimiter missing
yields a shorter array and the projection failed with a bare
"ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2". That
message names neither the file, the row nor the column, and for a library
whose job is reading somebody else's CSV a ragged row is expected input, not
an internal error — the caller was left with no way to find the offending
line.

Check the row against the arity the key needs — one past the highest index it
reads, computed once in the constructor — before projecting it, and raise a
RaggedRowException naming the row's position, the arity needed, the arity
found and the row itself. The position counts the data rows handed to the
check, starting at 1, so the header and any line the source skips (a CSV
comment) are not among them; both check implementations feed the finder the
same rows, so the number means the same thing on either. Columns the key does
not read are still never touched, so a row with extra trailing fields, or one
short of columns the key ignores, passes as before.

The tests pin the message, the three reported numbers, the counting across
skipped and preceding rows, and the two accepted shapes, plus an end-to-end
pass over a fixture with one short line through both the in-memory and the
iterative check. README and the data-sources skill describe the new failure.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018LdukVkic6kmF68BERbSZZ