### PR TITLE
fix(data): settle the null-row contract and stop widening readAll (#665)

### DIFF
--- a/.claude/skills/data-sources/SKILL.md
+++ b/.claude/skills/data-sources/SKILL.md
@@ -124,7 +124,13 @@ node allocation is what hurts:
 Implement `IterableDataSource` (five methods; `nextRows` is a default). If it can
 report its columns, also implement `ColumnarDataSource` so schema-dependent
 callers can use it. Add `readAll()` via `InMemoryDataSource` for an in-memory
-variant. Keep JDBC specifics in `source.db` (ArchUnit enforces this).
+variant — declare it `public` on that source itself and delegate to the
+`protected readAllRows()` on `AbstractFileSource`, rather than widening a
+`protected` base method, so `readAll()` stays off the surface of the
+forward-only sources. Return `null` from `nextRow()` for "no row" (an empty
+array is a real row) and keep `hasMoreData()` the thing that says whether the
+source is exhausted. Keep JDBC specifics in `source.db` (ArchUnit enforces
+this).
 
 ## References
 - `README.md` — *Data* (worked uniqueness example, source list, interfaces)

--- a/README.md
+++ b/README.md
@@ -714,6 +714,8 @@ public interface IterableDataSource extends AutoCloseable, Closeable {
 	public List<String[]> nextRows(int batchSize);
 }
 ```
+`nextRow()` answers `null` when a call produced no row, and `hasMoreData()` is what says which of the two reasons it was: the source is exhausted, or that particular line yielded nothing and a further call may still return a row (a CSV comment does this). `null` rather than an empty array because an empty array is a row these sources really produce — a blank CSV line splits to one empty column, and a query over no columns gives rows of exactly that shape.
+
 `nextRows(int batchSize)` lets callers decide how much data is pulled from the source at once instead of reading row by row. It is a default method built on `hasMoreData()`/`nextRow()`, so every source gets it for free; an empty list signals the source is exhausted. The SQL source additionally applies `batchSize` as the JDBC fetch size so the rows are fetched in a single round-trip.
 If you need an in memory source you need to implement one more method:
 ```java
@@ -721,6 +723,7 @@ public interface InMemoryDataSource extends IterableDataSource {
 	public List<String[]> readAll();
 }
 ```
+`readAll()` belongs to this interface alone, so a forward-only source never carries it: the file sources share the drain-the-whole-source machinery as a `protected readAllRows()` on their base class, and each in-memory source publishes it by writing `readAll()` itself.
 
 Notes:
 

--- a/data/spotbugs-exclude.xml
+++ b/data/spotbugs-exclude.xml
@@ -22,4 +22,33 @@
 		<Method name="readAll" />
 		<Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE" />
 	</Match>
+	<!--
+	  The forward-only read methods answer null for "no row", which is the published
+	  contract of IterableDataSource#nextRow rather than a missing empty array: an empty
+	  array is a row these sources really do produce (a blank CSV line, a query over no
+	  columns), so only null is free to mean the absence of one. hasMoreData() is what
+	  tells the two null meanings apart. Each method's javadoc says so; the detector is
+	  excluded for those methods alone, so a new null-returning array elsewhere in the
+	  module still fails.
+	-->
+	<Match>
+		<Class name="io.github.adamw7.tools.data.source.db.IterableSQLDataSource" />
+		<Method name="readRow" />
+		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
+	</Match>
+	<Match>
+		<Class name="io.github.adamw7.tools.data.source.file.AbstractInMemoryMapDataSource" />
+		<Method name="nextRow" />
+		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
+	</Match>
+	<Match>
+		<Class name="io.github.adamw7.tools.data.source.file.AbstractIterableJacksonDataSource" />
+		<Method name="consume" />
+		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
+	</Match>
+	<Match>
+		<Class name="io.github.adamw7.tools.data.source.file.CSVDataSource" />
+		<Method name="nextRow" />
+		<Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
+	</Match>
 </FindBugsFilter>

--- a/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/db/IterableSQLDataSource.java
@@ -147,6 +147,14 @@ public class IterableSQLDataSource implements ColumnarDataSource {
 		return Sql.answering(this::readRow);
 	}
 
+	/**
+	 * Advances the result set and reads the row it landed on, or {@code null} once it is
+	 * past the last one &mdash; the end-of-data answer
+	 * {@link io.github.adamw7.tools.data.source.interfaces.IterableDataSource#nextRow()}
+	 * defines, and the same value {@link #hasMoreData()} starts reporting from here. A
+	 * zero-length array is not free to mean it: a query selecting no columns produces
+	 * rows of exactly that shape.
+	 */
 	private String[] readRow() throws SQLException {
 		hasMoreData = resultSet.next();
 		return hasMoreData ? getNextFrom(resultSet, columnCount) : null;

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractFileSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractFileSource.java
@@ -148,7 +148,17 @@ public abstract class AbstractFileSource implements IterableDataSource {
 		return name.toString();
 	}
 	
-	protected List<String[]> readAll() {
+	/**
+	 * Opens this source and drains it into a list, skipping the rows {@link #nextRow()}
+	 * declines to produce. It is the shared machinery behind {@code readAll()} on the
+	 * in-memory sources built on this class, and deliberately not called that: only a
+	 * {@link io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource} publishes
+	 * a read-everything operation, and naming this one {@code readAll} would have every
+	 * forward-only source built here widen it to public just by implementing that
+	 * interface &mdash; putting the operation on the public surface of sources whose
+	 * whole point is that they do not offer it.
+	 */
+	protected List<String[]> readAllRows() {
 		open();
 		List<String[]> data = new ArrayList<>();
 		while (hasMoreData()) {

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryMapDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractInMemoryMapDataSource.java
@@ -49,6 +49,12 @@ public abstract class AbstractInMemoryMapDataSource extends AbstractFileSource i
 		opened = true;
 	}
 
+	/**
+	 * The next {@code {key, value}} pair, or {@code null} once the map is exhausted, as
+	 * {@link io.github.adamw7.tools.data.source.interfaces.IterableDataSource#nextRow()}
+	 * defines. Here the two answers line up exactly with {@link #hasMoreData()}: every
+	 * entry yields a row, so {@code null} only ever means the end.
+	 */
 	@Override
 	public String[] nextRow() {
 		checkIfOpen();

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractIterableJacksonDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/AbstractIterableJacksonDataSource.java
@@ -56,6 +56,13 @@ public abstract class AbstractIterableJacksonDataSource extends AbstractIterable
 		return row;
 	}
 
+	/**
+	 * Folds one token into the frame stack and returns the row it completed, or
+	 * {@code null} for the container tokens and field names that only move the stack on.
+	 * {@link #readNextRow()} pulls tokens until this answers with a row, so {@code null}
+	 * is "keep reading" &mdash; a zero-length array could not say that, since a row of no
+	 * columns is a value this method is entitled to build.
+	 */
 	private String[] consume(JsonToken token) throws IOException {
 		if (token == JsonToken.START_OBJECT) {
 			frames.push(Frame.object());

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/CSVDataSource.java
@@ -126,6 +126,14 @@ public class CSVDataSource extends AbstractFileSource implements ColumnarDataSou
 		return columnsRow != -1;
 	}
 
+	/**
+	 * The next row, or {@code null} for a line that produced none &mdash; a comment, or
+	 * the end of the file. The two are told apart by {@link #hasMoreData()}, which only
+	 * the second turns off, so a caller that stops at the first {@code null} stops at the
+	 * first comment instead of the end of the data. {@code null} rather than a zero-length
+	 * array because an empty array is a real row here: a blank line splits to one empty
+	 * column, and {@code ",,"} to three.
+	 */
 	@Override
 	public String[] nextRow() {
 		if (hasNextLine()) {

--- a/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryCSVDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/file/InMemoryCSVDataSource.java
@@ -33,9 +33,16 @@ public class InMemoryCSVDataSource extends CSVDataSource implements InMemoryData
 		super(fileName, delimiter, columnsRow, allowedPaths);
 	}
 
+	/**
+	 * Reads every row of the file at once, as
+	 * {@link io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource} promises.
+	 * The work is {@link #readAllRows()}, inherited from the file-source base class; this
+	 * method is what publishes it, so {@code readAll()} stays off the surface of the
+	 * forward-only {@link CSVDataSource} it extends.
+	 */
 	@Override
 	public List<String[]> readAll() {
-		return super.readAll();
+		return readAllRows();
 	}
 
 }

--- a/data/src/main/java/io/github/adamw7/tools/data/source/interfaces/IterableDataSource.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/source/interfaces/IterableDataSource.java
@@ -8,8 +8,27 @@ public interface IterableDataSource extends Closeable {
 
 	void open();
 
+	/**
+	 * The next row of this source, or {@code null} when there is none to hand back.
+	 *
+	 * <p>{@code null} is the contract here, not an oversight, and a zero-length array
+	 * would not replace it: the row a source produces may itself be empty &mdash; a blank
+	 * line in a CSV splits to one empty column, and a delimiter-only line to several
+	 * &mdash; so an empty array is a row, and only {@code null} can mean "no row". It
+	 * carries two meanings, told apart by {@link #hasMoreData()} rather than by the value:
+	 * the source is exhausted, or this particular input line produced nothing to emit and
+	 * a further call may still return a row (a CSV comment is the case that does this).
+	 * Callers that walk a source therefore pair this with {@link #hasMoreData()} and drop
+	 * the {@code null}s, as {@link #nextRows(int)} does.</p>
+	 *
+	 * @return the next row, or {@code null} if this call produced none
+	 */
 	String[] nextRow();
 
+	/**
+	 * Whether a further {@link #nextRow()} can still produce a row. A source that answers
+	 * {@code true} may still return {@code null} from the next call &mdash; see there.
+	 */
 	boolean hasMoreData();
 
 	void reset();

--- a/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingSet.java
+++ b/data/src/main/java/io/github/adamw7/tools/data/structure/OpenAddressingSet.java
@@ -16,7 +16,7 @@ import java.util.Set;
  * {@link #contains} and {@link #remove} answer {@code false} for an element the
  * set cannot hold. Its iterator is fail-fast, and it is not thread-safe.
  */
-public class OpenAddressingSet<E> extends AbstractSet<E> implements Set<E> {
+public class OpenAddressingSet<E> extends AbstractSet<E> {
 
 	private static final Object PRESENT = new Object();
 

--- a/data/src/test/java/io/github/adamw7/tools/data/source/db/SpotBugsExcludeFilterTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/db/SpotBugsExcludeFilterTest.java
@@ -25,14 +25,18 @@ import org.xml.sax.SAXException;
 /**
  * Pins the scope of the module's SpotBugs exclude filter. The two JDBC sources run the
  * caller's query on purpose, so {@code SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE} is
- * accepted there — but only there. A filter that grew a Match without a class, a method
- * or a pattern would silently stop the detector reporting a genuine concatenation
- * elsewhere in the module, which is what these assertions exist to catch.
+ * accepted there — but only there; the forward-only read methods answer {@code null} for
+ * "no row" on purpose, so {@code PZLA_PREFER_ZERO_LENGTH_ARRAYS} is accepted for those
+ * four methods — and only those. A filter that grew a Match without a class, a method or
+ * a pattern would silently stop either detector reporting a genuine finding elsewhere in
+ * the module, which is what these assertions exist to catch.
  */
 public class SpotBugsExcludeFilterTest {
 
 	private static final Path FILTER = Path.of("spotbugs-exclude.xml");
 	private static final String SQL_INJECTION = "SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE";
+	private static final String NULL_ARRAY = "PZLA_PREFER_ZERO_LENGTH_ARRAYS";
+	private static final String SOURCE_FILE_PACKAGE = "io.github.adamw7.tools.data.source.file.";
 
 	private static List<Element> matches;
 
@@ -69,11 +73,15 @@ public class SpotBugsExcludeFilterTest {
 	}
 
 	@Test
-	public void onlyTheTwoJdbcQueryExecutionsAreExcluded() {
+	public void onlyTheDecidedMethodsAreExcluded() {
 		List<String> excluded = matches.stream().map(SpotBugsExcludeFilterTest::describe).toList();
 		assertEquals(List.of(
 				IterableSQLDataSource.class.getName() + "#executeQuery:" + SQL_INJECTION,
-				InMemorySQLDataSource.class.getName() + "#readAll:" + SQL_INJECTION),
+				InMemorySQLDataSource.class.getName() + "#readAll:" + SQL_INJECTION,
+				IterableSQLDataSource.class.getName() + "#readRow:" + NULL_ARRAY,
+				SOURCE_FILE_PACKAGE + "AbstractInMemoryMapDataSource#nextRow:" + NULL_ARRAY,
+				SOURCE_FILE_PACKAGE + "AbstractIterableJacksonDataSource#consume:" + NULL_ARRAY,
+				SOURCE_FILE_PACKAGE + "CSVDataSource#nextRow:" + NULL_ARRAY),
 				excluded);
 	}
 

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/AbstractFileSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/AbstractFileSourceTest.java
@@ -1,6 +1,8 @@
 package io.github.adamw7.tools.data.source.file;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,6 +14,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,6 +26,7 @@ import java.util.zip.GZIPOutputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import io.github.adamw7.tools.data.source.interfaces.InMemoryDataSource;
 import io.github.adamw7.tools.data.uniqueness.NoMemoryUniquenessCheck;
 
 /**
@@ -32,7 +37,9 @@ import io.github.adamw7.tools.data.uniqueness.NoMemoryUniquenessCheck;
  * a corrupt GZip member or a disk error reads as a short but successful file. The same
  * corrupt GZip member is what leaks a descriptor when the wrapping fails before any
  * Scanner owns the opened file, which one test pins. The name a source answers for the
- * file it reads is pinned here too, that being the other thing every one of them shares.
+ * file it reads is pinned here too, that being the other thing every one of them shares,
+ * along with where the shared read-everything helper is allowed to show up: publicly on
+ * the in-memory sources that promise it, nowhere else.
  */
 public class AbstractFileSourceTest {
 
@@ -131,6 +138,34 @@ public class AbstractFileSourceTest {
 		IllegalStateException thrown = assertThrows(IllegalStateException.class, source::getFileName);
 
 		assertTrue(thrown.getMessage().contains("raw input stream"), thrown.getMessage());
+	}
+
+	@Test
+	public void theSharedReadEverythingHelperStaysProtected() throws NoSuchMethodException {
+		Method helper = AbstractFileSource.class.getDeclaredMethod("readAllRows");
+
+		// Named readAllRows rather than readAll so that implementing InMemoryDataSource
+		// never widens it: a subclass publishes the operation by writing readAll itself.
+		assertTrue(Modifier.isProtected(helper.getModifiers()), "readAllRows must stay protected");
+		assertFalse(Modifier.isPublic(helper.getModifiers()), "readAllRows must not be public");
+	}
+
+	@Test
+	public void onlyInMemorySourcesPublishReadAll() {
+		assertThrows(NoSuchMethodException.class, () -> CSVDataSource.class.getMethod("readAll"),
+				"readAll must stay off the surface of the forward-only CSV source");
+		assertThrows(NoSuchMethodException.class, () -> AbstractFileSource.class.getMethod("readAll"),
+				"readAll must stay off the surface of the file-source base class");
+
+		assertDeclaresPublicReadAll(InMemoryCSVDataSource.class);
+		assertDeclaresPublicReadAll(AbstractInMemoryMapDataSource.class);
+	}
+
+	private static void assertDeclaresPublicReadAll(Class<? extends InMemoryDataSource> source) {
+		Method readAll = assertDoesNotThrow(() -> source.getMethod("readAll"), source.getSimpleName());
+		assertTrue(Modifier.isPublic(readAll.getModifiers()), source.getSimpleName() + "#readAll must be public");
+		assertEquals(source, readAll.getDeclaringClass(),
+				source.getSimpleName() + " must declare readAll rather than inherit a widened one");
 	}
 
 	private static int readAll(CSVDataSource source) {

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/CSVDataSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/CSVDataSourceTest.java
@@ -3,7 +3,10 @@ package io.github.adamw7.tools.data.source.file;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 import java.io.ByteArrayInputStream;
@@ -279,6 +282,49 @@ public class CSVDataSourceTest {
 		IllegalStateException thrown = assertThrows(IllegalStateException.class, source::getColumnNames);
 		Utils.close(source);
 		assertEquals("Row 1 holds no header: the file ends before it, or it is a comment", thrown.getMessage());
+	}
+
+	@Test
+	public void aCommentRowIsNullWithoutEndingTheData() throws IOException {
+		try (InputStream stream = streamOf("id,name\n# skipped\n1,Adam\n")) {
+			CSVDataSource source = new CSVDataSource(stream, ",", COLUMNS_ROW);
+			source.open();
+
+			String[] comment = source.nextRow();
+
+			// null is "this line produced no row", not "the file is over": hasMoreData()
+			// is what tells the two apart, so a caller stopping at the first null would
+			// stop at the comment and never see the row behind it.
+			assertNull(comment);
+			assertTrue(source.hasMoreData());
+			assertArrayEquals(new String[] { "1", "Adam" }, source.nextRow());
+		}
+	}
+
+	@Test
+	public void anEmptyRowIsARowRatherThanTheEndOfTheData() throws IOException {
+		try (InputStream stream = streamOf("id,name\n\n1,Adam\n")) {
+			CSVDataSource source = new CSVDataSource(stream, ",", COLUMNS_ROW);
+			source.open();
+
+			// A blank line splits to one empty column, so a zero-length array could not
+			// stand in for null here: an empty array is already a value rows take.
+			assertArrayEquals(new String[] { "" }, source.nextRow());
+			assertTrue(source.hasMoreData());
+			assertArrayEquals(new String[] { "1", "Adam" }, source.nextRow());
+		}
+	}
+
+	@Test
+	public void nextRowIsNullAndHasMoreDataIsFalseOnceTheFileEnds() throws IOException {
+		try (InputStream stream = streamOf("id,name\n1,Adam\n")) {
+			CSVDataSource source = new CSVDataSource(stream, ",", COLUMNS_ROW);
+			source.open();
+			source.nextRow();
+
+			assertNull(source.nextRow());
+			assertFalse(source.hasMoreData());
+		}
 	}
 
 	@Test

--- a/data/src/test/java/io/github/adamw7/tools/data/structure/OpenAddressingSetTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/structure/OpenAddressingSetTest.java
@@ -2,6 +2,7 @@ package io.github.adamw7.tools.data.structure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
@@ -23,6 +24,14 @@ public class OpenAddressingSetTest {
 	static Stream<Arguments> implementations() {
 		return Stream.of(of(new HashSet<Integer>()), of(new OpenAddressingSet<Integer>()),
 				of(new OpenAddressingSet<Integer>(16)));
+	}
+
+	@Test
+	public void theSetIsStillASetWithoutDeclaringTheInterface() {
+		// AbstractSet already implements Set, so declaring it again here only added noise
+		// to the signature. Dropping it must not drop the type callers depend on.
+		assertInstanceOf(Set.class, new OpenAddressingSet<Integer>());
+		assertTrue(Set.class.isAssignableFrom(OpenAddressingSet.class));
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
SpotBugs reported seven priority-3 findings in `data`, of three unrelated
kinds. Each is decided here rather than silenced wholesale.

`PZLA_PREFER_ZERO_LENGTH_ARRAYS` (4) — the forward-only read methods answer
`null` for "no row". A zero-length array cannot replace it: an empty array is
a row these sources really produce (a blank CSV line splits to one empty
column, a query over no columns gives rows of that shape), so only `null` is
free to mean the absence of one. `null` also carries two meanings — the
source is exhausted, or this line yielded nothing and a further call may
still return a row — and `hasMoreData()` is what tells them apart, which is
why the lookahead in `AbstractIterableFileSource` is built on it. That is the
contract, so it is now stated on `IterableDataSource#nextRow` and on each of
the four methods, and the detector is excluded for those methods alone.

`IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY` (2) — `readAll()` was `protected`
on `AbstractFileSource` and widened to `public` by the two in-memory sources,
which had no choice: `InMemoryDataSource` declares it public. Making the base
method public instead would have put `readAll()` on the surface of every
forward-only source built there, undoing the split `ColumnarDataSource`
documents. The shared machinery is renamed `readAllRows()` and stays
`protected`; a source publishes the operation by writing `readAll()` itself.

`RI_REDUNDANT_INTERFACES` (1) — `OpenAddressingSet` declared `Set`, which
`AbstractSet` already implements. Dropped from the signature.

Tests pin what the change decided: that a CSV comment is `null` while
`hasMoreData()` stays true, that a blank line is a row rather than the end,
that `readAll()` is public only where `InMemoryDataSource` promises it, and
that the set is still a `Set`. Verified with the exclude filter emptied: the
four PZLA findings reappear (so each Match is load-bearing and exactly
scoped) while the IAOM and RI ones do not, being fixed in code.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015fYBan6n6D6oHWmpNJf6kh