### PR TITLE
test(data): make the file-source tests Windows-neutral

### DIFF
--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/AbstractFileSourceTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/AbstractFileSourceTest.java
@@ -59,15 +59,19 @@ public class AbstractFileSourceTest {
 	@Test
 	public void csvSourceNamesTheFileItFailedToRead(@TempDir Path directory) throws IOException {
 		Path file = truncatedGzip(directory);
-		CSVDataSource source = new CSVDataSource(file.toString(), ",", 1, AllowedPaths.under(directory));
-		source.open();
+		// Closed even though the read failed: the failure leaves the descriptor open, and
+		// Windows refuses to delete a file some handle still holds, so an unclosed source
+		// fails @TempDir's cleanup rather than the assertions below.
+		try (CSVDataSource source = new CSVDataSource(file.toString(), ",", 1, AllowedPaths.under(directory))) {
+			source.open();
 
-		UncheckedIOException thrown = assertThrows(UncheckedIOException.class, () -> readAll(source));
+			UncheckedIOException thrown = assertThrows(UncheckedIOException.class, () -> readAll(source));
 
-		// A GZip member cut short ends with an unexpected EOF rather than a clean end of
-		// data; the message must name the file so the failure can be traced to it.
-		assertInstanceOf(EOFException.class, thrown.getCause());
-		assertTrue(thrown.getMessage().contains(file.toString()), thrown.getMessage());
+			// A GZip member cut short ends with an unexpected EOF rather than a clean end of
+			// data; the message must name the file so the failure can be traced to it.
+			assertInstanceOf(EOFException.class, thrown.getCause());
+			assertTrue(thrown.getMessage().contains(file.toString()), thrown.getMessage());
+		}
 	}
 
 	@Test

--- a/data/src/test/java/io/github/adamw7/tools/data/source/file/AllowedPathsTest.java
+++ b/data/src/test/java/io/github/adamw7/tools/data/source/file/AllowedPathsTest.java
@@ -71,7 +71,11 @@ public class AllowedPathsTest {
 
 		String validated = AllowedPaths.under(baseDir).validate(dotted.toString());
 
-		assertEquals(dotted.toRealPath().toString(), validated);
+		// Compared against the canonicalisation validate() documents -- absolute and
+		// normalised -- rather than the real path: on Windows the temporary directory is
+		// handed over in its short 8.3 form (RUNNER~1), which toRealPath() spells out and
+		// validate() leaves exactly as it was given.
+		assertEquals(dotted.toAbsolutePath().normalize().toString(), validated);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes the weekly [`maven-windows.yml` run](https://github.com/adamw7/tools/actions/runs/32607596688), where `tools.data` reported 1 failure and 1 error out of 669. Both are POSIX-only assumptions in the tests, which is why every Linux job stays green. The production classes are correct as written; only the tests change.

## `AbstractFileSourceTest.csvSourceNamesTheFileItFailedToRead`

```
org.junit.platform.commons.JUnitException: Failed to close extension context
Caused by: java.io.IOException: Failed to delete temp directory ... truncated.csv.gz
  Suppressed: java.nio.file.FileSystemException: ...\truncated.csv.gz:
      The process cannot access the file because it is being used by another process
```

The test builds a `CSVDataSource` over a truncated GZip member, asserts the read fails, and never closes it. The descriptor stays open: Linux unlinks an open file happily, Windows refuses, so `@TempDir` cleanup fails the test after its assertions have already passed. The source is now closed in a try-with-resources — `IterableDataSource extends Closeable`, and `AbstractFileSource#close` releases the handle whether or not `open()` succeeded.

## `AllowedPathsTest.acceptsFileNameStartingWithTwoDots`

```
expected: <C:\Users\runneradmin\AppData\Local\Temp\junit-...\..name.csv>
 but was: <C:\Users\RUNNER~1\AppData\Local\Temp\junit-...\..name.csv>
```

The test expected `dotted.toRealPath()`, but `AllowedPaths#validate` documents — and returns — `toAbsolutePath().normalize()`. The two agree everywhere except Windows, where `@TempDir` hands back the short 8.3 path that `toRealPath()` spells out. The assertion now compares against the canonicalisation `validate()` documents, the way `returnsCanonicalisedAbsolutePathWhenUnconfined` already does. The containment check was never at fault: `checkInsideBaseDir` resolves the real path before comparing, so validation itself passed.

## Verification

On JDK 25, `mvn -B test` in `data`: **Tests run: 669, Failures: 0, Errors: 0** — BUILD SUCCESS. The original red cannot be reproduced on Linux (both failures need Windows file-locking and 8.3 path semantics), so the pairing of cause to fix is read off the stack traces rather than observed failing-then-passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XmRt9ZYYtKg7S2Ebfvih6g)_