### PR TITLE
test(markdown-common, adopt): meet the mutation floors the weekly run failed on

### DIFF
--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/CliArgumentsTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.github.adamw7.tools.adopt.command.ProcessCommandRunner;
+import io.github.adamw7.tools.adopt.step.GuardRules;
 import io.github.adamw7.tools.adopt.step.PullRequestOptions;
 import io.github.adamw7.tools.secret.Redaction;
 
@@ -603,6 +604,60 @@ class CliArgumentsTest {
 	void acceptsFreeFormProseThatLooksLikeAFlag() {
 		CliArguments cli = CliArguments.parse(new String[] { REPO_URL, "--body", "--wip: do not merge" });
 		assertEquals("--wip: do not merge", cli.pullRequestOptions().body());
+	}
+
+	@Test
+	void readsHowManyRepositoriesToAdoptAtOnce() {
+		assertEquals(4, CliArguments.parse(new String[] { REPO_URL, "--parallel", "4" }).parallelism());
+	}
+
+	@Test
+	void adoptsOneRepositoryAtATimeWhenNoCountIsNamed() {
+		assertEquals(BatchAdoption.SEQUENTIAL, CliArguments.parse(new String[] { REPO_URL }).parallelism());
+		assertEquals(BatchAdoption.SEQUENTIAL,
+				CliArguments.parse(new String[] { REPO_URL, "--parallel", "  " }).parallelism());
+	}
+
+	/**
+	 * Both ends of the bound are a count the batch may actually run at, so both are
+	 * accepted here and only what lies outside them is refused — while the operator is
+	 * still reading the command line, rather than at the first clone.
+	 */
+	@Test
+	void acceptsAParallelismAtEitherBound() {
+		assertEquals(BatchAdoption.SEQUENTIAL, parallelismOf(String.valueOf(BatchAdoption.SEQUENTIAL)));
+		assertEquals(BatchAdoption.MAX_PARALLELISM, parallelismOf(String.valueOf(BatchAdoption.MAX_PARALLELISM)));
+	}
+
+	@Test
+	void refusesAParallelismThatIsNotAWholeNumberWithinTheBounds() {
+		assertParallelismRefused("0");
+		assertParallelismRefused("-1");
+		assertParallelismRefused("many");
+		assertParallelismRefused(String.valueOf(BatchAdoption.MAX_PARALLELISM + 1));
+	}
+
+	@Test
+	void readsTheGuardRuleSetNamed() {
+		assertEquals(GuardRules.MINIMAL,
+				CliArguments.parse(new String[] { REPO_URL, "--rules", "minimal" }).adoptionOptions().guardRules());
+	}
+
+	/** A blank value is a rule set nobody named, which is the whole-project guard. */
+	@Test
+	void guardsTheWholeProjectWhenNoRuleSetIsNamed() {
+		assertEquals(GuardRules.PROJECT,
+				CliArguments.parse(new String[] { REPO_URL }).adoptionOptions().guardRules());
+		assertEquals(GuardRules.PROJECT,
+				CliArguments.parse(new String[] { REPO_URL, "--rules", "  " }).adoptionOptions().guardRules());
+	}
+
+	private static int parallelismOf(String count) {
+		return CliArguments.parse(new String[] { REPO_URL, "--parallel", count }).parallelism();
+	}
+
+	private void assertParallelismRefused(String count) {
+		assertFailure(IllegalArgumentException.class, () -> parallelismOf(count), "--parallel");
 	}
 
 	private void assertUsageFailure(String[] args) {

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GuardRulesTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/GuardRulesTest.java
@@ -1,0 +1,34 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static io.github.adamw7.tools.test.ExpectedFailures.assertFailure;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The rule set decides what somebody else's build comes to enforce, so a name that
+ * is not one of these is refused rather than read as the default: quietly widening
+ * or narrowing the guard is the failure worth spending a test on.
+ */
+class GuardRulesTest {
+
+	@Test
+	void namesTheRuleTheAdoptedPomConfigures() {
+		assertEquals("claudeMdFormat", GuardRules.MINIMAL.ruleName());
+		assertEquals("claudeCodeProject", GuardRules.PROJECT.ruleName());
+	}
+
+	/** The value is read as an operator wrote it: in any case, and with room around it. */
+	@Test
+	void readsARuleSetNamedInAnyCase() {
+		assertEquals(GuardRules.MINIMAL, GuardRules.of("minimal"));
+		assertEquals(GuardRules.PROJECT, GuardRules.of("  Project  "));
+	}
+
+	/** The refusal names what it accepts, so the operator can correct the command line from it. */
+	@Test
+	void refusesAnUnknownRuleSetNamingTheOnesItAccepts() {
+		assertFailure(IllegalArgumentException.class, () -> GuardRules.of("everything"),
+				"everything", "minimal", "project");
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstallerTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/WorkflowGuardInstallerTest.java
@@ -101,4 +101,39 @@ class WorkflowGuardInstallerTest {
 		assertTrue(installer.install(directory));
 		assertTrue(Files.isRegularFile(scriptFile));
 	}
+
+	/** The verification reads both files, because the workflow runs the script and either alone guards nothing. */
+	@Test
+	void readsACheckoutCarryingBothGuardFilesAsGuarded(@TempDir Path directory) {
+		installer.install(directory);
+
+		assertTrue(installer.isInstalled(directory));
+	}
+
+	@Test
+	void readsACheckoutCarryingNeitherGuardFileAsUnguarded(@TempDir Path directory) {
+		assertFalse(installer.isInstalled(directory));
+	}
+
+	@Test
+	void readsACheckoutThatLostTheGuardScriptAsUnguarded(@TempDir Path directory) throws IOException {
+		installer.install(directory);
+		Files.delete(directory.resolve(WorkflowGuardInstaller.SCRIPT_FILE));
+
+		assertFalse(installer.isInstalled(directory));
+	}
+
+	/**
+	 * A workflow the adoption did not write is kept but is unlikely to run the script,
+	 * so it does not stand in for the guard: the marker is what tells the two apart.
+	 */
+	@Test
+	void readsTheProjectsOwnWorkflowAsNoGuardOfTheAdoptionsOwn(@TempDir Path directory) throws IOException {
+		Path workflowFile = directory.resolve(WorkflowGuardInstaller.WORKFLOW_FILE);
+		Files.createDirectories(workflowFile.getParent());
+		Files.writeString(workflowFile, "name: my own guard\non: [push]\njobs: {}\n");
+		installer.install(directory);
+
+		assertFalse(installer.isInstalled(directory));
+	}
 }

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/LineTerminatorsTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/LineTerminatorsTest.java
@@ -1,0 +1,34 @@
+package io.github.adamw7.tools.markdown;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Text assembled in code is LF, so what a rewriter writes back has to be put on the
+ * terminator the file it is written into already uses. Both directions are pinned,
+ * because either one getting it wrong shows up the same way: a diff nobody wrote.
+ */
+class LineTerminatorsTest {
+
+	@Test
+	void writesCrlfIntoAFileThatAlreadyUsesIt() {
+		assertEquals("a\r\nb\r\n", LineTerminators.matching("a\nb\n", "first\r\nsecond\r\n"));
+	}
+
+	@Test
+	void leavesTextOnLfForAFileThatUsesLf() {
+		assertEquals("a\nb\n", LineTerminators.matching("a\r\nb\r\n", "first\nsecond\n"));
+	}
+
+	/** Text mixing terminators — a converted body beside a part carried over — converts once. */
+	@Test
+	void doesNotDoubleConvertTextThatAlreadyMixesTerminators() {
+		assertEquals("a\r\nb\r\n", LineTerminators.matching("a\r\nb\n", "sample\r\n"));
+	}
+
+	@Test
+	void normalizesEveryTerminatorToLf() {
+		assertEquals("a\nb\nc\n", LineTerminators.normalized("a\r\nb\rc\n"));
+	}
+}

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownConformerTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownConformerTest.java
@@ -108,4 +108,177 @@ class MarkdownConformerTest {
 
 		assertTrue(new MarkdownConformer(contract).conform("# X.md\n").contains("TBD."));
 	}
+
+	/** A title the document carries lower down is moved up rather than duplicated. */
+	@Test
+	void movesATitleTheDocumentCarriesLowerDownToTheFirstLine() {
+		MarkdownContract contract = MarkdownContract.titled("# AGENTS.md");
+
+		String conformed = new MarkdownConformer(contract).conform("Intro.\n\n# AGENTS.md\n\nBody.\n");
+
+		assertEquals("# AGENTS.md\n\nIntro.\n\nBody.\n", conformed);
+	}
+
+	/**
+	 * The blank line under a heading that is removed goes with it only where the line
+	 * above was blank too. Here it was not, so dropping it would have run the paragraph
+	 * above the title into the one below it.
+	 */
+	@Test
+	void keepsTheBlankBelowAMovedTitleWhenTheLineAboveItIsNotBlank() {
+		MarkdownContract contract = MarkdownContract.titled("# AGENTS.md");
+
+		String conformed = new MarkdownConformer(contract).conform("Intro.\n# AGENTS.md\n\nBody.\n");
+
+		assertEquals("# AGENTS.md\n\nIntro.\n\nBody.\n", conformed);
+	}
+
+	/**
+	 * A second title is a duplicate a check accepts, so nothing downstream would report
+	 * it and the reshape being idempotent means running it again never clears it.
+	 */
+	@Test
+	void removesASecondTitleFromADocumentThatAlreadyOpensWithOne() {
+		MarkdownContract contract = MarkdownContract.titled("# AGENTS.md");
+
+		String conformed = new MarkdownConformer(contract)
+				.conform("# AGENTS.md\n\nIntro.\n\n# AGENTS.md\n\nBody.\n");
+
+		assertEquals("# AGENTS.md\n\nIntro.\n\nBody.\n", conformed);
+	}
+
+	/** Renaming in place settles the section, so no second one is appended beside it. */
+	@Test
+	void renamesAHeadingCarryingExtraWordsWithoutAppendingASecondSection() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md").requiring(List.of("## Testing"));
+
+		String conformed = new MarkdownConformer(contract)
+				.conform("# X.md\n\n## Testing conventions\n\nHow we test.\n");
+
+		assertEquals("# X.md\n\n## Testing\n\nHow we test.\n", conformed);
+	}
+
+	/** Which case a near miss was typed in does not decide whether it is one. */
+	@Test
+	void renamesAHeadingThatDiffersFromTheRequiredOneOnlyInCase() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md").requiring(List.of("## Testing"));
+
+		String conformed = new MarkdownConformer(contract)
+				.conform("# X.md\n\n## testing\n\nHow we test.\n");
+
+		assertEquals("# X.md\n\n## Testing\n\nHow we test.\n", conformed);
+	}
+
+	/** The space a near match demands after the required wording keeps an unrelated heading its own. */
+	@Test
+	void leavesAHeadingThatMerelyBeginsWithTheRequiredWording() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md").requiring(List.of("## Maven"));
+
+		String conformed = new MarkdownConformer(contract).conform("# X.md\n\n## Mavenish\n\nProse.\n");
+
+		assertTrue(conformed.contains("## Mavenish\n\nProse."), conformed);
+		assertTrue(conformed.contains("## Maven\n\n" + MarkdownContract.DEFAULT_STUB_BODY), conformed);
+	}
+
+	/**
+	 * A heading that already is a required section is reserved, so the search for a near
+	 * match for another one cannot rename it and take its body with it.
+	 */
+	@Test
+	void doesNotRenameAHeadingThatIsItselfARequiredSection() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md")
+				.requiring(List.of("## Build", "## Build steps"));
+
+		String conformed = new MarkdownConformer(contract)
+				.conform("# X.md\n\n## Build steps\n\nHow to build.\n");
+
+		assertTrue(conformed.contains("## Build steps\n\nHow to build."), conformed);
+		assertTrue(conformed.contains("## Build\n\n" + MarkdownContract.DEFAULT_STUB_BODY), conformed);
+	}
+
+	/** A check fails an empty section as firmly as a missing one, so a bare heading is given a body. */
+	@Test
+	void stubsARequiredHeadingTheDocumentLeavesBare() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md").requiring(List.of("## Testing"));
+
+		String conformed = new MarkdownConformer(contract)
+				.conform("# X.md\n\n## Testing\n\n## Other\n\nx.\n");
+
+		assertEquals("# X.md\n\n## Testing\n\n" + MarkdownContract.DEFAULT_STUB_BODY
+				+ "\n\n## Other\n\nx.\n", conformed);
+	}
+
+	/** A section appended inside a fence the document left open is code, which a check reads as absent. */
+	@Test
+	void closesAnUnterminatedFenceSoAnAppendedSectionIsStructure() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md").requiring(List.of("## Testing"));
+
+		String conformed = new MarkdownConformer(contract).conform("# X.md\n\n```\ncode\n");
+
+		assertTrue(MarkdownDocument.parse(conformed).headings().contains("## Testing"), conformed);
+	}
+
+	/** The same for a comment the document left open: text appended inside one is inert. */
+	@Test
+	void closesAnUnterminatedCommentSoAnAppendedSectionIsStructure() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md").requiring(List.of("## Testing"));
+
+		String conformed = new MarkdownConformer(contract).conform("# X.md\n\n<!-- note\n");
+
+		assertTrue(MarkdownDocument.parse(conformed).headings().contains("## Testing"), conformed);
+	}
+
+	/** The reference is separated from the line below it, which here is prose. */
+	@Test
+	void separatesTheReferenceFromTheProseItIsInsertedAbove() {
+		MarkdownContract contract = MarkdownContract.titled("# CLAUDE.md").referencing("AGENTS.md");
+
+		String conformed = new MarkdownConformer(contract).conform("# CLAUDE.md\nProse.\n");
+
+		assertEquals("# CLAUDE.md\n\n" + contract.referenceLine() + "\n\nProse.\n", conformed);
+	}
+
+	/** A blank line already under the title is the separator, so a second one is not added. */
+	@Test
+	void leavesTheBlankAlreadyUnderTheTitleAsTheReferencesSeparator() {
+		MarkdownContract contract = MarkdownContract.titled("# CLAUDE.md").referencing("AGENTS.md");
+
+		String conformed = new MarkdownConformer(contract).conform("# CLAUDE.md\n\nProse.\n");
+
+		assertEquals("# CLAUDE.md\n\n" + contract.referenceLine() + "\n\nProse.\n", conformed);
+	}
+
+	/** A document that is nothing but its title has no line below it to read. */
+	@Test
+	void insertsTheReferenceIntoADocumentWithNothingBelowItsTitle() {
+		MarkdownContract contract = MarkdownContract.titled("# CLAUDE.md").referencing("AGENTS.md");
+
+		String conformed = new MarkdownConformer(contract).conform("# CLAUDE.md");
+
+		assertEquals("# CLAUDE.md\n\n" + contract.referenceLine() + "\n", conformed);
+	}
+
+	/**
+	 * A document nothing settles comes back as the last pass left it rather than looping.
+	 * An empty stub body never gives the section it is inserted under a body, so every
+	 * pass inserts another: the first appends both sections with a blank stub between
+	 * them, and each further pass the bound allows adds another pair of blank lines
+	 * there. Nine of them is that bound — one pass, then three more.
+	 */
+	@Test
+	void comesBackAsTheLastPassLeftItWhenNothingSettles() {
+		MarkdownContract contract = MarkdownContract.titled("# X.md")
+				.requiring(List.of("## A", "## B"))
+				.withStubBody("");
+
+		String conformed = new MarkdownConformer(contract).conform("# X.md\n");
+
+		assertEquals(9, blankLinesBetweenTheSections(conformed), conformed);
+	}
+
+	/** The blank lines between the two appended sections, less the newline ending the first heading. */
+	private static long blankLinesBetweenTheSections(String conformed) {
+		String between = conformed.substring(conformed.indexOf("## A"), conformed.indexOf("## B"));
+		return between.chars().filter(character -> character == '\n').count() - 1;
+	}
 }

--- a/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownDocumentTest.java
+++ b/markdown-common/src/test/java/io/github/adamw7/tools/markdown/MarkdownDocumentTest.java
@@ -1017,6 +1017,89 @@ class MarkdownDocumentTest {
 		assertEquals("-->", document.openCommentTerminator().orElseThrow());
 	}
 
+	/** The line as it was typed, indent and all: a caller that rewrites the document edits that. */
+	@Test
+	void readsALineWithoutTrimmingIt() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				    int x;
+				""");
+
+		assertEquals("    int x;", document.line(2));
+	}
+
+	@Test
+	void readsTheFirstNonBlankLineStrippedOfItsWhitespace() {
+		MarkdownDocument document = MarkdownDocument.parse("\n\n   # Title\n\nBody.\n");
+
+		assertEquals("# Title", document.firstNonBlankLine());
+	}
+
+	/**
+	 * A fence inside a comment is a sample the comment carries, so reading it leaves the
+	 * comment exactly as open as it was: the lines below the sample are commented out
+	 * too, up to the delimiter that closes it.
+	 */
+	@Test
+	void keepsACommentOpenAcrossAFencedBlockInsideIt() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				<!-- note
+
+				```
+				int x;
+				```
+
+				still commented
+				-->
+
+				## Section
+				""");
+
+		assertEquals(List.of(2, 3, 7, 8, 9), commentedLines(document));
+		assertEquals(Set.of("# Title", "## Section"), document.headings());
+	}
+
+	/**
+	 * A continuation indented exactly to the item's content keeps the list open, so the
+	 * four columns below it are still measured from the item rather than from the margin
+	 * and quote nothing.
+	 */
+	@Test
+	void aContinuationIndentedToTheItemsContentKeepsTheListOpen() {
+		MarkdownDocument document = MarkdownDocument.parse("""
+				# Title
+
+				- item
+				  continuation
+
+				    four columns in
+				""");
+
+		assertEquals(List.of(), codeLines(document));
+	}
+
+	/** A tab counts on to the next four-column stop, so a space and a tab reach the code indent. */
+	@Test
+	void readsASpaceAndATabAsFourColumns() {
+		MarkdownDocument document = MarkdownDocument.parse("# Title\n\n \tint x;\n");
+
+		assertEquals(List.of(2), codeLines(document));
+	}
+
+	/**
+	 * The same four columns inside a list item are the item's content rather than code,
+	 * which needs four past it — the tab stop is what keeps the two apart.
+	 */
+	@Test
+	void readsASpaceAndATabInsideAListItemAsThatItemsProse() {
+		MarkdownDocument document = MarkdownDocument.parse("# Title\n\n- item\n\n \tstill the item\n");
+
+		assertEquals(List.of(), codeLines(document));
+	}
+
 	private static String terminatorOf(String content) {
 		return MarkdownDocument.parse(content).openFenceTerminator().orElseThrow();
 	}


### PR DESCRIPTION
Fixes the [Mutation Testing run](https://github.com/adamw7/tools/actions/runs/32607423491), which failed with:

```
Failed to execute goal org.pitest:pitest-maven:1.25.9:mutationCoverage on project
tools.markdown-common: Mutation score of 82 is below threshold of 91
```

Nothing had regressed in the code. `MarkdownConformer` lives in `markdown-common` but its behaviour is tested from the `adopt` side, so the module's own suite covered the reshape only through a handful of end-to-end conforms: every decision inside it — which heading is a near miss, which blank line goes with a heading that is removed, how the settle loop ends — was free to change without a test saying so.

## Two failures, not one

The reactor stops at the module that fails, so `claude-code-enforcer`, `adopt`, `protogen-maven-plugin-test`, `grpc-example` and `assembly` were all SKIPPED. With the first floor met the run reaches `adopt`, which fails too, at 87 against a floor of 88 — a failure the weekly job had never got to see. Both are fixed here.

## markdown-common — 82% → 97% (floor 91)

Tests written to the decisions PIT found unwatched, each stating the reading it pins:

- **the title** — one carried lower down is moved rather than copied, a second is removed, and the blank line under a removed heading goes with it only where the line above was blank too;
- **the near match** — renamed in place with its body, in another case as readily as with extra words, never onto a heading that is already a required section of its own, and never onto one that merely begins with the wording;
- **the insertions** — a bare heading is stubbed beneath itself, the reference takes the blank line already under the title rather than adding a second, and a document that is nothing but its title has no line below it to read;
- **the blocks** — a fence or a comment the document left open is closed before anything is appended, so the appended section is structure a check can see;
- **the loop** — a document nothing settles comes back as the last pass left it.

`MarkdownDocument` gains the readings PIT found unwatched — a raw line, the first non-blank one, a comment held open across a fenced sample inside it, a list kept open by a continuation indented exactly to its content, and a tab counting on to the next four-column stop both at the margin and inside a list item. `LineTerminators`, until now exercised only from `adopt`, gets both directions of its conversion.

The nine survivors left are boundary mutants on an index the title always occupies and on calls the settle loop makes twice over — equivalent under the loop rather than gaps.

## adopt — 87% → 90% (floor 88)

Three gaps that share a shape: a value an operator types, or a file a checkout may or may not carry, read by a method no test asks anything of.

- **`GuardRules`** had no test at all, though what it returns decides how much of somebody else's build the installed guard enforces. `of` now answers in any case and with room around the name, and refuses an unknown one naming what it accepts.
- **`--parallel`** was parsed and bounded but never exercised, so neither end of the bound was pinned. Both ends are now accepted and everything outside them refused — zero, a negative, a word, one past the maximum — beside the default that adopts one repository at a time. `--rules` is read the same way, blank included.
- **`WorkflowGuardInstaller.isInstalled`** is what a verification asks, and nothing called it. A checkout carrying both guard files reads as guarded, one carrying neither or having lost the script does not, and the project's own workflow at the guard's path does not stand in for the adoption's — the marker is what tells the two apart.

## Verification

`mvn -B install -Ppitest` over the whole reactor: all 13 modules SUCCESS, `markdown-common` at 97% and `adopt` at 90%. Tests only — no production code and no threshold was changed, so both floors still guard exactly what they did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jbmrw5FtTYTmWyvQ37uZXb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jbmrw5FtTYTmWyvQ37uZXb)_