### PR TITLE
ci(renovate): stop the hourly limit starving grouped updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
     "before 06:00 on monday"
   ],
   "prConcurrentLimit": 5,
-  "prHourlyLimit": 2,
+  "prHourlyLimit": 0,
   "rebaseWhen": "conflicted",
   "vulnerabilityAlerts": {
     "enabled": false

--- a/docs/adr/0005-renovate-dependency-updates.md
+++ b/docs/adr/0005-renovate-dependency-updates.md
@@ -51,8 +51,15 @@ arrived ungrouped and unscheduled.
 The committed configuration extends `config:recommended` and adds only what this
 repository's shape calls for:
 
-- **`schedule` (Monday before 06:00 UTC) with concurrency limits** — batches the
-  noise the *Consequences* section anticipates into one weekly window.
+- **`schedule` (Monday before 06:00 UTC) with `prConcurrentLimit: 5`** — batches
+  the noise the *Consequences* section anticipates into one weekly window, capped
+  at five open pull requests. The hourly limit is deliberately off
+  (`prHourlyLimit: 0`): Renovate scans the repository about once a day, so only a
+  single scan falls inside the weekly window, and an hourly cap of two meant that
+  one scan opened two pull requests and rate-limited the rest until the *next*
+  week. A grouped update that keeps losing that race is never reviewed at all —
+  the GitHub Actions group sat rate-limited behind two Maven bumps — so the
+  concurrent limit alone now sets the ceiling.
 - **`vulnerabilityAlerts: { enabled: false }` and `osvVulnerabilityAlerts: false`**
   — the division of labour above, expressed as configuration rather than
   convention: Renovate declines security-driven bumps so Dependabot


### PR DESCRIPTION
Renovate scans this repository roughly once a day, so exactly one scan
falls inside the `before 06:00 on monday` window. With `prHourlyLimit: 2`
that single scan opened two pull requests and pushed everything else to
the dashboard's Rate-Limited section, where it waited a full week for a
window it would lose again.

Monday's run is the worked example: it opened #679 (mcp-bom 2.0.1) and
#680 (archunit-junit5 1.5.0), then rate-limited protobuf-java 4.36.0 and
the whole `github actions (major)` group — six action bumps that have now
been detected for days without ever reaching review.

Setting the hourly limit to 0 turns it off and leaves `prConcurrentLimit:
5` as the only ceiling, which is the limit that actually expresses the
intent: at most five Renovate pull requests open at a time.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019Dxj1Qk1NCR6egM1t9S3ar