### PR TITLE
ci: skip pruning a package that is not in the registry

### DIFF
--- a/.github/workflows/packages-cleanup.yml
+++ b/.github/workflows/packages-cleanup.yml
@@ -114,7 +114,55 @@ jobs:
         package: ${{ fromJson(needs.discover.outputs.packages) }}
 
     steps:
+      - name: Look up ${{ matrix.package }} in the registry
+        id: lookup
+        # The poms name a module from the moment it joins the reactor, but its
+        # first version only reaches the registry when a release publishes it.
+        # Until then there is no such package, and the prune action stops with
+        # "Package not found" — a red run for a state that is entirely
+        # expected. `fail-fast: false` only keeps that from cancelling the
+        # other packages; the job itself still fails. So ask the registry
+        # first, and skip the prune when there is nothing there to prune.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          # Only the owner's own kind of route serves its packages: an
+          # organisation is not readable under /users, nor a user under /orgs.
+          # Probing both keeps this working whoever the repository moves to.
+          probe() {
+            curl -sS -o /dev/null -w '%{http_code}' \
+              -H 'Accept: application/vnd.github+json' \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/${1}/${OWNER}/packages/maven/${PACKAGE}"
+          }
+
+          status="$(probe users)"
+          if [ "${status}" = "404" ]; then
+            status="$(probe orgs)"
+          fi
+
+          case "${status}" in
+            200)
+              echo "published=true" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "published=false" >> "$GITHUB_OUTPUT"
+              # A warning rather than a notice: the same 404 answers both "this
+              # module has never been released" and "the token cannot see the
+              # package", and the second one means nothing is being pruned.
+              echo "::warning::${PACKAGE} is not in the registry, so there is nothing to prune. That is expected for a module that has never been released; if it has been released, then this token cannot see the package and its versions are going unpruned."
+              ;;
+            *)
+              echo "::error::Asking the registry about ${PACKAGE} returned HTTP ${status}. Refusing to read that as 'nothing to prune'."
+              exit 1
+              ;;
+          esac
+
       - name: Prune ${{ matrix.package }}
+        if: steps.lookup.outputs.published == 'true'
         # Maven packages inherit their permissions from this repository, so the
         # built-in token with `packages: write` is enough and no PAT secret is
         # needed. Only min-versions-to-keep is set: num-old-versions-to-delete


### PR DESCRIPTION
## Problem

The `prune` job of Packages Cleanup stops with:

```
##[error]get versions API failed. Package not found.
```

for any module the registry has never seen. The poms name a package from the moment a module joins the reactor, but its first version only arrives when a release publishes it.

The job already meant to tolerate this — `fail-fast: false` is there so one missing package does not stop the other eight — but that only keeps it from cancelling the others; the job itself still goes red, and the monthly sweep reports failure.

## Fix

Add a lookup step before the prune and guard the prune with `if: steps.lookup.outputs.published == 'true'`. It probes `/users/{owner}/packages/maven/{name}` and falls back to `/orgs/…`, since only the owner's own route serves its packages.

Status handling is deliberately not a blanket "ignore errors":

- **200** → prune as before.
- **404** → skip, with a `::warning::` rather than a notice. The same 404 also covers "the token cannot see this package", which would mean versions are quietly going unpruned — worth surfacing in the run summary.
- **anything else** (401/403/rate limit) → fail the job, rather than reading it as "nothing to prune" and silently defeating the sweep.

The `discover` job is untouched. The diff is purely additive: 48 lines in, 0 removed.

## Verification

This repository's copy of the workflow predates the variant in the other repos, so the change was applied to its own text rather than copied wholesale; the resulting file was checked byte for byte against the version built and validated locally.

The same change was tested end to end in `adamw7/translateai`, where the workflow was failing for exactly this reason: the prune job went from failing to green, with the lookup step succeeding and the prune step skipped. The step's script was also exercised against a stubbed `curl` across all four cases — user-owned 200, org-owned 200, 404/404, and 401 — each producing the right output and exit code.

The 200 path (package present → prune runs) has not been exercised live, since dispatching the workflow performs a real prune down to the floor of 3. It will first run on the next scheduled sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01293TNDFrUeSoeyNRDPjAcX

---
_Generated by [Claude Code](https://claude.ai/code/session_01293TNDFrUeSoeyNRDPjAcX)_