### PR TITLE
feat(adopt): create starter skills when adopting a repository

### DIFF
--- a/.claude/skills/adopt-pipeline/SKILL.md
+++ b/.claude/skills/adopt-pipeline/SKILL.md
@@ -30,16 +30,36 @@ module's rules are unusually strict because it shells out to `git`, `gh` and
    about to be wired in demands — `BuildSystem.requiredClaudeMdSections()`, so
    only the Maven path adds the format rule's Java/Maven headings — commit.
 7. `EnforcerStep` → `CommitStep` — wire the build-tool-aware guard in and commit.
-8. *(optional)* `AssetsStep` → `CommitStep` — starter config assets, on `--assets`.
+8. *(optional)* `AssetsStep` → `SkillsStep` → `CommitStep` — starter config assets
+   and the starter skills, on `--assets`, in one commit.
 9. `VerifyStep` — proves the guard passes on the generated file.
 10. `PushStep` → `PullRequestStep` — **omitted entirely on a dry run**, so the
     report says what a dry run really did rather than listing steps that
     pretended to run.
 
-The three build-system-aware steps (`BuildToolchainStep`, `EnforcerStep`,
-`VerifyStep`) share one `BuildSystems.defaults(...)` list, so the guard that is
-wired in is the guard that is verified with the tool that was probed
-(`MavenBuildSystem`, `GradleBuildSystem`, `FallbackBuildSystem`).
+The four build-system-aware steps (`BuildToolchainStep`, `EnforcerStep`,
+`SkillsStep`, `VerifyStep`) share one `BuildSystems.defaults(...)` list, so the
+guard that is wired in is the guard that is verified with the tool that was
+probed, and the one the starter skills describe (`MavenBuildSystem`,
+`GradleBuildSystem`, `FallbackBuildSystem`).
+
+## The starter skills
+`StarterSkills` writes `.claude/skills/build-and-test/SKILL.md` and
+`.claude/skills/claude-md/SKILL.md` from what the run established, never from
+anything guessed: `BuildSystem.buildDescription()` (overridden by the catch-all,
+which is not a build tool and must not claim to be), `requiredClaudeMdSections()`,
+and `verifyCommand(...)` — relativized, because that answers a checkout's wrapper
+by absolute path and committing it would put the adoption host's workspace path
+into somebody else's repository. What the adoption does not know is left as
+headings for the project to fill in. A skill whose name the checkout's own
+commands, sub-agents or skills already claim is not installed: `uniqueNames`
+fails a repository where two definitions answer to one name. Add a skill by
+naming it in `StarterSkills.NAMES` — `AdoptionAssets.WRITTEN_PATHS` derives its
+path from the name, so nothing else has to be told about it. Weigh that name
+against what repositories *ignore*, not only against what they name: the build
+skill is `build-and-test` because `build` is one of the most widely ignored words
+in a JVM `.gitignore`, and four of the seven foreign repositories excluded
+`.claude/skills/build/SKILL.md` on that rule alone.
 
 ## The step contract
 ```java
@@ -148,7 +168,8 @@ clone URL's credentials come back in the tool's own error text.
   branch — read from the remote, never guessed — is untouched, and the repository
   on GitHub is asked with `ls-remote` whether the adoption branch reached it (a
   local tracking ref is evidence about the clone; the claim is about somebody
-  else's repository). A second adoption changes nothing. It installs the starter assets too, so
+  else's repository). A second adoption changes nothing. It installs the starter
+  assets and skills too, so
   `AssetInstaller`'s "the project's own version wins" is checked against files
   somebody else wrote — `claude-code`'s own `.github/workflows/claude.yml` and
   `servers`' own `.mcp.json`, which no fixture can imitate. Its Maven guard is pinned to a released `--rule-version`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,9 @@ build tool → create a feature branch (the default branch is never written to) 
 mark the checkout trusted in `~/.claude.json` so the headless CLI is not blocked
 by the folder-trust prompt → `claude init` to generate `CLAUDE.md`, conform it
 (plus a companion `AGENTS.md`) and commit → wire a `CLAUDE.md` guard into the
-project's build and commit → optionally commit starter assets → verify the guard
-passes → push → open a pull request with `gh pr create`.
+project's build and commit → optionally install the starter assets and skills and
+commit them together → verify the guard passes → push → open a pull request with
+`gh pr create`.
 
 What is worth knowing before changing any of it:
 
@@ -208,6 +209,28 @@ What is worth knowing before changing any of it:
   `.claude/hooks/session-start.sh` stub, a starter `.mcp.json`, and a workflow
   answering `@claude` mentions — never overwriting a file the repository already
   has.
+- **`--assets` also creates the starter skills.** `SkillsStep` writes
+  `.claude/skills/build-and-test/SKILL.md` and `.claude/skills/claude-md/SKILL.md`
+  beside
+  the assets, into the same commit. It is its own step rather than two more
+  entries in `AdoptionAssets.DEFAULTS` because a skill's body depends on the
+  checkout's build system: it names the build the guard was wired into
+  (`BuildSystem.buildDescription()`, so the catch-all does not tell a project it
+  "is built with github-actions"), the headings that guard demands, and the
+  command `VerifyStep` runs — relativized, since `verifyCommand` answers a
+  checkout's wrapper by absolute path and committing that would put the adoption
+  host's workspace path into somebody else's repository. What the adoption does
+  not know — how the project builds, tests and lints — is left as headings for its
+  maintainers, the bargain the session-start hook stub already strikes. A skill
+  whose name the project's own commands, sub-agents or skills already claim is
+  not installed at all: the guard fails a repository where two definitions answer
+  to one name, and the name is the project's. The build skill is called
+  `build-and-test` for a related reason: a skill's name is a directory name, and
+  `build` is one of the most widely ignored words in a JVM project's `.gitignore`,
+  so four of the seven repositories `ForeignRepositoryAdoptionIT` adopts excluded
+  `.claude/skills/build/SKILL.md` and `CommitStep` rightly refused to commit
+  around it. Weigh a new skill's name against what a repository ignores, not only
+  against what it already names.
 - **Everything shells out through a `CommandRunner`**, so steps are unit-tested
   without spawning processes; `ProcessCommandRunner` bounds every command with a
   timeout, ten minutes by default and overridable with `--timeout <minutes>`
@@ -664,7 +687,9 @@ module's `*IT`s stay unrun until it gets its own copy. Run them with
   a `claude.yml` workflow of its own and `servers` an `.mcp.json` of its own, so
   the batch asserts each repository was given exactly the assets it lacked and
   that both of those files came through byte-identical to the blobs that were
-  cloned. A last test reads the one document the pipeline reshapes rather than
+  cloned. The starter skills land in the same run, and each is asserted to name
+  the guard its own checkout got and no other build system's — the one way a
+  generated file can be wrong on a repository nobody prepared. A last test reads the one document the pipeline reshapes rather than
   adds beside:
   `anthropic-quickstarts`' real `CLAUDE.md` is conformed and the real
   `claudeMdFormat` rule then accepts it, the foreign document having been

--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,29 @@ stub, a starter `.mcp.json`, and a GitHub Actions workflow answering `@claude`
 mentions. None of them ever overwrites a file the repository already carries, so
 the flag is safe on a project that has configured some of them already.
 
+The same flag creates two starter skills under `.claude/skills`, so an adopted
+repository carries its conventions where Claude Code loads them on demand rather
+than only in the file every session pays for:
+
+- **`build-and-test`** — what builds the project, and the command that runs the
+  guard the adoption just wired in, with headings left for the project's own
+  build, test and lint commands. Named that rather than `build` because a skill's
+  name is a directory name, and `build` is one of the most widely ignored words in
+  a JVM project's `.gitignore` — four of the seven real repositories the adoption
+  integration test adopts excluded `.claude/skills/build/SKILL.md` on that rule
+  alone.
+- **`claude-md`** — how to keep `CLAUDE.md` and `AGENTS.md` satisfying that
+  guard: which headings it demands, and the command to check them with before
+  pushing.
+
+Both are written from what the run established rather than from anything guessed
+about the project, so a Gradle checkout is told to run its Gradle task and is not
+sent appending the Maven rule's headings, and a repository with no build file at
+all is told where its guard actually lives instead of that it "is built with
+github-actions". A skill whose name the project's own commands, sub-agents or
+skills already claim is left out entirely — the guard fails a repository where
+two definitions answer to one name, and the name is the project's.
+
 The `claude-code-enforcer` version a Maven project's `pom.xml` is made to depend
 on defaults to the version of the `tools` build running the adoption;
 `--rule-version <version>` pins a different one. A `-SNAPSHOT` is refused either
@@ -1134,10 +1157,13 @@ The default pipeline runs these steps in order:
    `<rule/>`, turning a fourteen-line addition into a diff across the file.
 10. **`CommitStep`** — commits the build change (`Add claude-code-enforcer to the
    build`), reported as `commit:guard`.
-11. **`AssetsStep` → `CommitStep`** — *only on `--assets`* (`assets` on the MCP
-   tool): installs the starter configuration files described above and commits
-   them (`commit:assets`). Each asset is installed independently and never
-   overwrites an existing file, so the pair is idempotent.
+11. **`AssetsStep` → `SkillsStep` → `CommitStep`** — *only on `--assets`*
+   (`assets` on the MCP tool): installs the starter configuration files and the
+   starter skills described above, then commits them together (`commit:assets`),
+   so the run still leaves two commits. The skills are a step of their own
+   because their bodies name the detected build system and the command that runs
+   its guard, which the static asset list never sees. Each file is installed
+   independently and never overwrites an existing one, so the trio is idempotent.
 12. **`VerifyStep`** — runs the detected build system's verification (a
    non-recursive `mvn -N validate` for Maven, the `enforceClaudeMd` task for
    Gradle, the `.github/claude-md-guard.sh` script for the fallback) so the
@@ -1397,7 +1423,8 @@ clone from GitHub with the real `git` and answer that:
   script's own DSL, the commits carry only the paths the pipeline claims to write,
   the guard commit removes nothing the build file already declared, the starter
   assets the project already keeps at those paths come through byte-identical to
-  the blobs that were cloned, the default branch — read from the remote rather
+  the blobs that were cloned, each starter skill names the guard its own checkout
+  got and no other build system's, the default branch — read from the remote rather
   than guessed — is left as cloned, GitHub itself is asked with `ls-remote` and
   has no branch of the adoption's, and adopting the same batch a second time
   commits nothing.

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/GitHubRepoAdopter.java
@@ -21,6 +21,7 @@ import io.github.adamw7.tools.adopt.step.CommitStep;
 import io.github.adamw7.tools.adopt.step.EnforcerStep;
 import io.github.adamw7.tools.adopt.step.PullRequestStep;
 import io.github.adamw7.tools.adopt.step.PushStep;
+import io.github.adamw7.tools.adopt.step.SkillsStep;
 import io.github.adamw7.tools.adopt.step.ToolchainStep;
 import io.github.adamw7.tools.adopt.step.TrustStep;
 import io.github.adamw7.tools.adopt.step.VerifyStep;
@@ -40,8 +41,8 @@ import io.github.adamw7.tools.adopt.step.VerifyStep;
  * run returns an {@link AdoptionReport} of the steps completed and the pull request's
  * URL; a caller needing the report of a run that <em>fails</em> supplies its own to
  * {@link #adopt(AdoptionContext, AdoptionReport)}. What the default pipeline contains
- * is decided by {@link AdoptionOptions}: an {@link AssetsStep} on request, and a dry
- * run leaves out the two steps that write to GitHub.
+ * is decided by {@link AdoptionOptions}: an {@link AssetsStep} and a {@link SkillsStep}
+ * on request, and a dry run leaves out the two steps that write to GitHub.
  */
 public class GitHubRepoAdopter {
 
@@ -55,10 +56,10 @@ public class GitHubRepoAdopter {
 	static final String GUARD_COMMIT_MESSAGE = "Adopt Claude Code: add the CLAUDE.md guard";
 
 	/**
-	 * What the starter-assets commit says it did. It is named beside the guard's rather
-	 * than spelled out where the step is assembled, because a run leaves two commits in
-	 * somebody else's history and a test asking what each of them carried has to name
-	 * the one it means.
+	 * What the starter-assets commit says it did, the skills included. It is named beside
+	 * the guard's rather than spelled out where the step is assembled, because a run
+	 * leaves two commits in somebody else's history and a test asking what each of them
+	 * carried has to name the one it means.
 	 */
 	static final String ASSETS_COMMIT_MESSAGE = "Add Claude Code configuration assets";
 
@@ -108,7 +109,7 @@ public class GitHubRepoAdopter {
 		List<BuildSystem> buildSystems = BuildSystems.defaults(options.guard());
 		return Stream.of(
 				adoptionSteps(buildSystems, options),
-				assetSteps(options),
+				assetSteps(buildSystems, options),
 				List.<AdoptionStep>of(new VerifyStep(buildSystems)),
 				publicationSteps(options))
 				.flatMap(List::stream)
@@ -138,11 +139,18 @@ public class GitHubRepoAdopter {
 		return options.dryRun() ? ToolchainStep.forDryRun() : new ToolchainStep();
 	}
 
-	private static List<AdoptionStep> assetSteps(AdoptionOptions options) {
+	/**
+	 * The starter configuration is written by two steps and committed by one: the
+	 * assets that are the same everywhere, then the skills, whose bodies name the
+	 * build system the guard was wired into. One commit rather than two, so a run
+	 * still leaves exactly two commits in somebody else's history.
+	 */
+	private static List<AdoptionStep> assetSteps(List<BuildSystem> buildSystems, AdoptionOptions options) {
 		if (!options.includeAssets()) {
 			return List.of();
 		}
-		return List.of(new AssetsStep(), new CommitStep(ASSETS_COMMIT_MESSAGE, "assets"));
+		return List.of(new AssetsStep(), new SkillsStep(buildSystems),
+				new CommitStep(ASSETS_COMMIT_MESSAGE, "assets"));
 	}
 
 	/**

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/AdoptTool.java
@@ -100,7 +100,8 @@ public class AdoptTool implements McpTool {
 							Map.entry("draft", Map.of("type", "boolean",
 									"description", "open the pull request as a draft")),
 							Map.entry("assets", Map.of("type", "boolean",
-									"description", "also commit starter Claude Code configuration assets")),
+									"description",
+									"also commit starter Claude Code configuration assets and skills")),
 							Map.entry("rule_version", Map.of("type", "string",
 									"description", "released claude-code-enforcer version to wire into an adopted "
 											+ "Maven project; defaults to the version of this build")),

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/mcp/MCP_USAGE.md
@@ -73,7 +73,12 @@ This creates an executable JAR in `adopt/target/tools.adopt-{version}.jar`.
 - `draft` (boolean, optional): open the pull request as a draft
 - `assets` (boolean, optional): also commit starter Claude Code configuration
   assets (`AGENTS.md`, `.claude/settings.json`, a session-start hook,
-  `.mcp.json`, and an `@claude`-mention GitHub Actions workflow)
+  `.mcp.json`, an `@claude`-mention GitHub Actions workflow, and the
+  `.claude/skills/build-and-test` and `.claude/skills/claude-md` starter skills,
+  whose
+  bodies name the build system the guard was wired into and the command that
+  runs it). A skill whose name the project's own commands, sub-agents or skills
+  already claim is left out.
 - `rule_version` (string, optional): the released `claude-code-enforcer` version
   to wire into an adopted Maven project; defaults to the version of the `tools`
   build running the server, and a `-SNAPSHOT` is refused either way

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/AdoptionAssets.java
@@ -12,6 +12,11 @@ import java.util.stream.Stream;
  * {@code @claude} mentions. Every asset is a plain committed file, so the
  * configuration is shared with all contributors.
  *
+ * <p>The starter skills are written beside these by {@link SkillsStep} rather than
+ * listed here, their bodies depending on a build system this class never sees; only
+ * their paths are folded in below, so the adoption still accounts for every file it
+ * writes.
+ *
  * <p>Every repository-relative path the adoption writes is named here, including
  * the generated {@code CLAUDE.md} — not a starter asset, but keeping its name
  * beside the others stops the literal being spelled out in every step.
@@ -117,20 +122,22 @@ public final class AdoptionAssets {
 
 	/**
 	 * Every checkout-relative path an adoption may write or edit: the starter assets,
-	 * the generated {@code CLAUDE.md}, and whatever build file each supported build
-	 * system wires its guard into.
+	 * the starter skills, the generated {@code CLAUDE.md}, and whatever build file each
+	 * supported build system wires its guard into.
 	 *
 	 * <p>{@link CloneStep} reads this to tell the adoption's work from a contributor's,
 	 * and {@link CommitStep} refuses to commit while the checkout ignores one, so a
 	 * missing path is a file the adoption writes and cannot account for. Nothing is
-	 * added by hand for a new build system: the installers name their own paths and
-	 * each {@link BuildSystem} must answer {@link BuildSystem#writtenPaths()}.
+	 * added by hand for a new build system or a new skill: the installers name their own
+	 * paths, {@link StarterSkills} derives its paths from the skill names, and each
+	 * {@link BuildSystem} must answer {@link BuildSystem#writtenPaths()}.
 	 */
 	public static final List<String> WRITTEN_PATHS = writtenPaths();
 
 	private static List<String> writtenPaths() {
 		return Stream.of(
 				DEFAULTS.stream().map(AssetInstaller::relativePath),
+				StarterSkills.WRITTEN_PATHS.stream(),
 				Stream.of(CLAUDE_MD_FILE),
 				BuildSystems.DEFAULTS.stream().map(BuildSystem::writtenPaths).flatMap(List::stream))
 				.flatMap(paths -> paths)

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/BuildSystem.java
@@ -102,6 +102,20 @@ public interface BuildSystem {
 	}
 
 	/**
+	 * How a contributor reading the starter skills is told what builds this project,
+	 * named by the build system for the same reason {@link #toolAdvice()} is: the
+	 * answer is not the same for every one of them, and a sentence spelled out by
+	 * {@link StarterSkills} told a project with no build file at all that it "is built
+	 * with github-actions", which is neither its build tool nor true.
+	 *
+	 * @return the sentence, in prose rather than markup, so the skill that embeds it
+	 *         decides how it is presented
+	 */
+	default String buildDescription() {
+		return "This repository is built with " + name() + ".";
+	}
+
+	/**
 	 * What an operator whose {@link #toolProbe(Path)} could not be run has to do
 	 * about it, named by the build system rather than by {@link BuildToolchainStep}:
 	 * the remedy is not the same for every one of them, and a step that spelled out

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/FallbackBuildSystem.java
@@ -75,6 +75,17 @@ public class FallbackBuildSystem implements BuildSystem {
 		return Optional.of(SHELL_PROBE);
 	}
 
+	/**
+	 * This one matched because nothing else did, so there is no build tool to name: what
+	 * a contributor needs to know is where the guard actually lives.
+	 */
+	@Override
+	public String buildDescription() {
+		return "This repository ships no Maven or Gradle build file, so its CLAUDE.md guard is a GitHub"
+				+ " Actions workflow and the portable shell script that workflow runs, rather than a step"
+				+ " in a build.";
+	}
+
 	/** Nothing here is installable as "github-actions"; what is missing is a shell. */
 	@Override
 	public String toolAdvice() {

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/SkillsStep.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/SkillsStep.java
@@ -1,0 +1,54 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.command.CommandRunner;
+
+/**
+ * Writes the starter Claude Code skills (see {@link StarterSkills}) into the
+ * checkout, so an adopted repository carries the conventions the adoption
+ * established rather than only the document describing them. It runs beside
+ * {@link AssetsStep} under the same {@code --assets} switch and before the same
+ * commit, the skills being configuration assets like the rest.
+ *
+ * <p>Separate from {@link AssetsStep} because a skill's body depends on the
+ * checkout's build system — which guard was wired in, and what runs it — and
+ * {@link AbstractBuildSystemStep} is where that is detected once for every step
+ * that needs it. Folding the skills into the static asset list would instead have
+ * made the whole list conditional on a build system being detected at all.
+ *
+ * <p>Nothing is overwritten: {@link AssetInstaller} leaves an existing file alone and
+ * {@link StarterSkills} passes over a name the project's own definitions already
+ * claim, so the step is idempotent and safe to re-run.
+ */
+public class SkillsStep extends AbstractBuildSystemStep {
+
+	private static final Logger log = LogManager.getLogger(SkillsStep.class);
+
+	public SkillsStep() {
+	}
+
+	public SkillsStep(List<BuildSystem> buildSystems) {
+		super(buildSystems);
+	}
+
+	@Override
+	public String name() {
+		return "skills";
+	}
+
+	@Override
+	protected void onDetected(BuildSystem buildSystem, AdoptionContext context, CommandRunner runner) {
+		Path repositoryDirectory = context.repositoryDirectory();
+		long installed = StarterSkills.forCheckout(buildSystem, repositoryDirectory).stream()
+				.filter(installer -> installer.install(repositoryDirectory))
+				.count();
+		log.info("Installed {} starter skill(s) describing the {} build under {}/{}", installed,
+				buildSystem.name(), repositoryDirectory, StarterSkills.SKILLS_DIRECTORY);
+	}
+}

--- a/adopt/src/main/java/io/github/adamw7/tools/adopt/step/StarterSkills.java
+++ b/adopt/src/main/java/io/github/adamw7/tools/adopt/step/StarterSkills.java
@@ -1,0 +1,280 @@
+package io.github.adamw7.tools.adopt.step;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * The starter Claude Code skills a {@link SkillsStep} writes under
+ * {@value #SKILLS_DIRECTORY}, one directory each holding a {@code SKILL.md}. A
+ * skill is how Claude Code is told a convention once instead of being reminded of
+ * it every session, so an adopted repository that gets a {@code CLAUDE.md} and no
+ * skills is adopted only halfway.
+ *
+ * <p>Both skills are written from what the adoption itself established rather than
+ * from anything guessed about the project: the build system {@link EnforcerStep}
+ * wired the guard into, the sections that guard demands, and the very command
+ * {@link VerifyStep} runs. Everything the adoption does <em>not</em> know — how this
+ * project builds, tests and lints — is left as a heading for its maintainers to
+ * fill in, the same bargain {@code .claude/hooks/session-start.sh} strikes.
+ *
+ * <p>The bodies vary with the build system; the paths do not, which is what lets
+ * {@link AdoptionAssets#WRITTEN_PATHS} name them without a checkout in hand.
+ */
+public final class StarterSkills {
+
+	private static final Logger log = LogManager.getLogger(StarterSkills.class);
+
+	/** The directory Claude Code reads a project's skills from. */
+	static final String SKILLS_DIRECTORY = ".claude/skills";
+
+	/** The file inside a skill directory that carries the skill; the name Claude Code looks for. */
+	static final String SKILL_FILE = "SKILL.md";
+
+	/**
+	 * The other two directories a Claude Code definition is named by, read only to
+	 * find out which names are taken — the adoption installs nothing into either.
+	 */
+	static final String COMMANDS_DIRECTORY = ".claude/commands";
+	static final String AGENTS_DIRECTORY = ".claude/agents";
+
+	private static final String MARKDOWN_SUFFIX = ".md";
+
+	/**
+	 * Not {@code build}: a skill's name is a directory name, and {@code build} is one of
+	 * the most widely ignored words in a JVM project's {@code .gitignore}. Four of the
+	 * seven real repositories {@code ForeignRepositoryAdoptionIT} adopts excluded
+	 * {@code .claude/skills/build/SKILL.md} on that rule alone, and {@link CommitStep}
+	 * rightly refused to commit around it — an adoption lost to a word.
+	 */
+	static final String BUILD_SKILL = "build-and-test";
+	static final String CLAUDE_MD_SKILL = "claude-md";
+
+	/**
+	 * The skills installed, in the order they are written. A name is also the skill's
+	 * directory name and its {@code name:} front matter, which the guard's
+	 * {@code skillFilesExist} rule requires to be the same word.
+	 */
+	static final List<String> NAMES = List.of(BUILD_SKILL, CLAUDE_MD_SKILL);
+
+	/** Every checkout-relative path the starter skills occupy, whatever the build system. */
+	public static final List<String> WRITTEN_PATHS = NAMES.stream().map(StarterSkills::skillFile).toList();
+
+	private static final String BUILD_SKILL_TEMPLATE = """
+			---
+			name: build-and-test
+			description: Build, test and verify this repository, and run the CLAUDE.md guard wired into its build. Use when building the project, running its tests, or checking a change before pushing it.
+			---
+
+			# Build and test
+
+			%1$s
+
+			## Run the CLAUDE.md guard
+
+			Claude Code adoption wired a guard into the build and verified the generated
+			`CLAUDE.md` with this command, run from the repository root:
+
+			```sh
+			%2$s
+			```
+
+			Run it before pushing a change to `CLAUDE.md` or `AGENTS.md`: it is the same
+			check the build runs, so a failure here is a failure in CI.
+
+			## This project's own commands
+
+			The adoption knows the build, not this project's conventions. Fill these in so
+			an agent stops guessing at them:
+
+			- Build:
+			- Test:
+			- Lint or static analysis:
+			- Run locally:
+			""";
+
+	private static final String CLAUDE_MD_SKILL_TEMPLATE = """
+			---
+			name: claude-md
+			description: Keep CLAUDE.md and AGENTS.md satisfying the guard this repository's build runs. Use when editing either file, when adding a section to it, or when the guard fails the build.
+			---
+
+			# CLAUDE.md
+
+			`CLAUDE.md` carries this repository's agent instructions and is loaded into every
+			Claude Code session, so it is the file to put a convention in — and the file to
+			keep short. `AGENTS.md` beside it points back at `CLAUDE.md` for the agents that
+			follow the cross-tool convention; edit `CLAUDE.md` and leave `AGENTS.md`
+			pointing at it.
+
+			## What the guard demands
+
+			%1$s
+
+			## Check it before pushing
+
+			```sh
+			%2$s
+			```
+
+			A `CLAUDE.md` that fails this fails the build, so run it after editing either
+			file rather than finding out in CI.
+
+			## Adding to it
+
+			Put a new convention under the heading it belongs to. A section that grows past
+			a screen belongs in a skill of its own under `%3$s`, which is loaded
+			only when it is needed, rather than in the file every session pays for.
+			""";
+
+	private StarterSkills() {
+	}
+
+	/**
+	 * The installers for the checkout in hand: the skill bodies name the detected
+	 * build system and the command that runs its guard.
+	 *
+	 * @param buildSystem         the build system {@link EnforcerStep} wired the guard
+	 *                            into, so the skills describe the guard the repository
+	 *                            actually got
+	 * @param repositoryDirectory the checkout, needed because the guard command depends
+	 *                            on what it ships — a project carrying a build wrapper
+	 *                            is built with that wrapper
+	 */
+	public static List<AssetInstaller> forCheckout(BuildSystem buildSystem, Path repositoryDirectory) {
+		String guardCommand = guardCommand(buildSystem, repositoryDirectory);
+		Set<String> claimed = claimedNames(repositoryDirectory);
+		return List.of(
+				skill(BUILD_SKILL,
+						BUILD_SKILL_TEMPLATE.formatted(buildSystem.buildDescription(), guardCommand)),
+				skill(CLAUDE_MD_SKILL, CLAUDE_MD_SKILL_TEMPLATE.formatted(demands(buildSystem), guardCommand,
+						SKILLS_DIRECTORY)))
+				.stream()
+				.filter(installer -> isFree(installer, claimed))
+				.toList();
+	}
+
+	private static AssetInstaller skill(String name, String content) {
+		return new AssetInstaller(skillFile(name), content);
+	}
+
+	/**
+	 * Whether the checkout still has room for this skill's name. A name already worn by
+	 * one of the project's own commands, sub-agents or skills is left alone: the guard
+	 * the adoption is about to verify fails a repository where two definitions claim
+	 * one name, so installing over a taken name would break the very build the run
+	 * exists to leave green — and it is the project's name, not the adoption's.
+	 */
+	private static boolean isFree(AssetInstaller installer, Set<String> claimed) {
+		String name = nameOf(installer);
+		if (claimed.contains(name)) {
+			log.info("The project already has a Claude Code definition called {}; the starter skill is not"
+					+ " installed", name);
+			return false;
+		}
+		return true;
+	}
+
+	/** The skill's own name, read back from the path it installs to rather than passed twice. */
+	private static String nameOf(AssetInstaller installer) {
+		Path path = Path.of(installer.relativePath());
+		return path.getParent().getFileName().toString();
+	}
+
+	/**
+	 * Every name the checkout's Claude Code definitions already claim: a command's and
+	 * a sub-agent's is its {@code *.md} file name, a skill's is its directory name.
+	 * A directory the project does not carry claims nothing, which is the common case.
+	 */
+	static Set<String> claimedNames(Path repositoryDirectory) {
+		Set<String> names = new HashSet<>(markdownNames(repositoryDirectory.resolve(COMMANDS_DIRECTORY)));
+		names.addAll(markdownNames(repositoryDirectory.resolve(AGENTS_DIRECTORY)));
+		names.addAll(subdirectoryNames(repositoryDirectory.resolve(SKILLS_DIRECTORY)));
+		return names;
+	}
+
+	private static List<String> markdownNames(Path directory) {
+		return childrenOf(directory).stream()
+				.filter(File::isFile)
+				.map(File::getName)
+				.filter(name -> name.endsWith(MARKDOWN_SUFFIX))
+				.map(name -> name.substring(0, name.length() - MARKDOWN_SUFFIX.length()))
+				.toList();
+	}
+
+	private static List<String> subdirectoryNames(Path directory) {
+		return childrenOf(directory).stream().filter(File::isDirectory).map(File::getName).toList();
+	}
+
+	/** {@link File#listFiles()} answers {@code null} for a directory that is not there. */
+	private static List<File> childrenOf(Path directory) {
+		File[] children = directory.toFile().listFiles();
+		return children == null ? List.of() : List.of(children);
+	}
+
+	/** The checkout-relative path a named skill is written to. */
+	static String skillFile(String name) {
+		return SKILLS_DIRECTORY + "/" + name + "/" + SKILL_FILE;
+	}
+
+	/**
+	 * What the wired guard holds {@code CLAUDE.md} to, in the words of the build system
+	 * that wired it: a list of headings for the Maven rule that reads them, and the
+	 * presence-and-non-empty check for the guards that ask for no section in particular.
+	 * Listing the Maven headings in a Gradle project's skill would send a contributor
+	 * appending sections nothing checks.
+	 */
+	private static String demands(BuildSystem buildSystem) {
+		List<String> sections = buildSystem.requiredClaudeMdSections();
+		if (sections.isEmpty()) {
+			return "The guard asks for no section in particular: it fails the build when\n"
+					+ "`CLAUDE.md` is missing or empty.";
+		}
+		return "The guard fails the build unless `CLAUDE.md` declares every one of these\nheadings:\n\n"
+				+ sections.stream().map(section -> "- `" + section + "`").collect(Collectors.joining("\n"));
+	}
+
+	/**
+	 * The guard command as a contributor would type it, which is not always as the
+	 * adoption ran it: {@link BuildSystem#verifyCommand(Path)} answers a checkout's
+	 * wrapper by absolute path, because {@link ProcessBuilder} resolves a relative
+	 * program against the JVM's working directory rather than the command's. Writing
+	 * that verbatim would commit the adoption host's workspace path into somebody
+	 * else's repository, where it names a directory that never existed.
+	 *
+	 * @return the command, or a note in its place when the build system names none
+	 */
+	private static String guardCommand(BuildSystem buildSystem, Path repositoryDirectory) {
+		List<String> command = buildSystem.verifyCommand(repositoryDirectory);
+		if (command.isEmpty()) {
+			return "# This build system runs the guard as part of the build; it has no command of its own.";
+		}
+		return command.stream()
+				.map(word -> insideTheCheckout(word, repositoryDirectory))
+				.collect(Collectors.joining(" "));
+	}
+
+	/**
+	 * Rewrites a path inside the checkout as the relative one a contributor standing in
+	 * it would use. A word carrying no separator cannot be such a path, and is answered
+	 * without asking the filesystem to parse it — {@code -N} is a flag on every
+	 * platform, but {@link Path#of} rejects some perfectly ordinary argument text on
+	 * Windows.
+	 */
+	private static String insideTheCheckout(String word, Path repositoryDirectory) {
+		if (word.indexOf('/') < 0 && word.indexOf('\\') < 0) {
+			return word;
+		}
+		Path path = Path.of(word);
+		if (!path.isAbsolute() || !path.startsWith(repositoryDirectory.toAbsolutePath())) {
+			return word;
+		}
+		return "./" + repositoryDirectory.toAbsolutePath().relativize(path).toString().replace('\\', '/');
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/ForeignRepositoryAdoptionIT.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/ForeignRepositoryAdoptionIT.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -39,6 +40,8 @@ import io.github.adamw7.tools.adopt.step.ClaudeMdConformer;
 import io.github.adamw7.tools.adopt.step.CloneStep;
 import io.github.adamw7.tools.adopt.step.CommitStep;
 import io.github.adamw7.tools.adopt.step.EnforcerStep;
+import io.github.adamw7.tools.adopt.step.SkillsStep;
+import io.github.adamw7.tools.adopt.step.StarterSkills;
 import io.github.adamw7.tools.adopt.step.ToolchainStep;
 import io.github.adamw7.tools.enforcer.doc.ClaudeMdFormatRule;
 
@@ -67,7 +70,8 @@ import io.github.adamw7.tools.enforcer.doc.ClaudeMdFormatRule;
  * for, the commits carry only paths {@link AdoptionAssets#WRITTEN_PATHS} names,
  * nothing the project already declared is removed to make room for it, the starter
  * assets installed are the ones the repository was missing and the files it already
- * keeps at their paths are left exactly as they were cloned, the default branch — read
+ * keeps at their paths are left exactly as they were cloned, the starter skills name
+ * the guard that checkout's own build system got and no other, the default branch — read
  * from the remote rather than assumed — is where the clone left it, the repository on
  * GitHub is asked directly and has no branch of the adoption's, and adopting the same
  * repository a second time changes nothing.
@@ -210,13 +214,19 @@ class ForeignRepositoryAdoptionIT {
 
 	/** The steps this run is given, in order, as each reports itself to the report. */
 	private static final List<String> PIPELINE = List.of(
-			"toolchain", "clone", "branch", "enforcer", "commit:guard", "assets", "commit:assets");
+			"toolchain", "clone", "branch", "enforcer", "commit:guard", "assets", "skills", "commit:assets");
 
 	/** The checkout-relative paths {@link AssetsStep} installs, sorted as git reports them. */
 	private static final List<String> ASSET_PATHS = AdoptionAssets.DEFAULTS.stream()
 			.map(AssetInstaller::relativePath)
 			.sorted()
 			.toList();
+
+	/** The directory a skill's name is its own; see {@link #definitionNamesIn}. */
+	private static final String SKILLS_DIRECTORY = ".claude/skills/";
+
+	/** The two directories where the {@code *.md} file name is the definition's. */
+	private static final List<String> DEFINITION_DIRECTORIES = List.of(".claude/commands/", ".claude/agents/");
 
 	/**
 	 * Generous next to the second or two a clone of these repositories costs, and short
@@ -379,10 +389,36 @@ class ForeignRepositoryAdoptionIT {
 	void theStarterAssetsInstalledAreTheOnesTheRepositoryDidNotAlreadyHave() {
 		for (RealRepository repository : REPOSITORIES) {
 			List<String> alreadyThere = assetsAlreadyIn(repository);
-			List<String> missing = ASSET_PATHS.stream().filter(path -> !alreadyThere.contains(path)).toList();
-			assertEquals(missing, pathsIn(repository, GitHubRepoAdopter.ASSETS_COMMIT_MESSAGE),
+			List<String> expected = Stream.concat(
+					ASSET_PATHS.stream().filter(path -> !alreadyThere.contains(path)),
+					unclaimedSkillPathsIn(repository).stream())
+					.sorted()
+					.toList();
+			assertEquals(expected, pathsIn(repository, GitHubRepoAdopter.ASSETS_COMMIT_MESSAGE),
 					() -> "adopting " + repository + " did not install exactly the assets it was missing;"
 							+ " it already had " + alreadyThere);
+		}
+	}
+
+	/**
+	 * The starter skills describe the guard the checkout's own build system was given,
+	 * so the command each one tells a contributor to run has to be the command that
+	 * repository's guard is actually run with — a Gradle task in the Gradle projects, a
+	 * shell script in the ones with no build file. A skill naming the wrong tool would
+	 * be committed to somebody else's repository and read as an instruction.
+	 */
+	@Test
+	void theStarterSkillsNameTheGuardTheCheckoutActuallyGot() {
+		for (RealRepository repository : REPOSITORIES) {
+			unclaimedSkillPathsIn(repository).forEach(path -> {
+				String skill = readString(checkoutOf(repository).resolve(path));
+				assertTrue(skill.contains(guardCommandOf(repository)),
+						() -> "the skill at " + path + " in " + repository + " does not name the "
+								+ repository.buildSystem() + " guard the run wired in:\n" + skill);
+				otherGuardCommands(repository).forEach(other -> assertFalse(skill.contains(other),
+						() -> "the skill at " + path + " in " + repository + " names " + other
+								+ ", which is another build system's guard:\n" + skill));
+			});
 		}
 	}
 
@@ -509,6 +545,7 @@ class ForeignRepositoryAdoptionIT {
 				new EnforcerStep(BUILD_SYSTEMS),
 				new CommitStep(GitHubRepoAdopter.GUARD_COMMIT_MESSAGE, "guard"),
 				new AssetsStep(),
+				new SkillsStep(BUILD_SYSTEMS),
 				new CommitStep(GitHubRepoAdopter.ASSETS_COMMIT_MESSAGE, "assets"));
 		return new GitHubRepoAdopter(RUNNER, steps);
 	}
@@ -630,6 +667,79 @@ class ForeignRepositoryAdoptionIT {
 				.filter(line -> !line.isBlank())
 				.distinct()
 				.sorted()
+				.toList();
+	}
+
+	/**
+	 * The starter skills this repository had room for: one whose name the project's own
+	 * commands, sub-agents or skills already claim is not installed, the guard failing a
+	 * repository where two definitions answer to one name. Computed from what was
+	 * cloned rather than written out here, so the claim survives whatever these seven
+	 * repositories put under {@code .claude} next.
+	 */
+	private static List<String> unclaimedSkillPathsIn(RealRepository repository) {
+		Set<String> claimed = definitionNamesIn(repository);
+		return StarterSkills.WRITTEN_PATHS.stream()
+				.filter(path -> !claimed.contains(skillNameIn(path)))
+				.toList();
+	}
+
+	/**
+	 * Every Claude Code definition name the repository was cloned already carrying: a
+	 * command's and a sub-agent's is its {@code *.md} file name, a skill's is its
+	 * directory name. Read from the default branch's tree, which is the state the
+	 * adoption found rather than the one it left.
+	 */
+	private static Set<String> definitionNamesIn(RealRepository repository) {
+		Path checkout = checkoutOf(repository);
+		return git(checkout, "ls-tree", "-r", "--name-only", defaultBranchOf(checkout), "--", ".claude").lines()
+				.map(ForeignRepositoryAdoptionIT::definitionName)
+				.flatMap(Optional::stream)
+				.collect(Collectors.toSet());
+	}
+
+	/** @return the definition the tracked path names, or empty when it names none */
+	private static Optional<String> definitionName(String path) {
+		if (path.startsWith(SKILLS_DIRECTORY)) {
+			return Optional.of(skillNameIn(path));
+		}
+		return DEFINITION_DIRECTORIES.stream()
+				.filter(directory -> path.startsWith(directory) && path.endsWith(".md"))
+				.map(directory -> path.substring(directory.length(), path.length() - ".md".length()))
+				.filter(name -> !name.contains("/"))
+				.findFirst();
+	}
+
+	/** The skill directory's own name, the segment straight under {@link #SKILLS_DIRECTORY}. */
+	private static String skillNameIn(String path) {
+		String withinSkills = path.substring(SKILLS_DIRECTORY.length());
+		int end = withinSkills.indexOf('/');
+		return end < 0 ? withinSkills : withinSkills.substring(0, end);
+	}
+
+	/**
+	 * What the guard this repository's build system wires in is run with, taken as the
+	 * verify command's last word: the words before it are the build tool, which a
+	 * checkout shipping a wrapper answers as a path of the adoption host's rather than
+	 * as anything a skill may repeat.
+	 */
+	private static String guardCommandOf(RealRepository repository) {
+		Path checkout = checkoutOf(repository);
+		return BuildSystems.detect(BUILD_SYSTEMS, checkout).orElseThrow().verifyCommand(checkout).getLast();
+	}
+
+	/**
+	 * The same word for every build system this checkout is <em>not</em>. A skill that
+	 * merely mentioned a guard would pass on the positive assertion alone; only naming
+	 * the wrong one is the failure worth catching.
+	 */
+	private static List<String> otherGuardCommands(RealRepository repository) {
+		Path checkout = checkoutOf(repository);
+		String wired = guardCommandOf(repository);
+		return BUILD_SYSTEMS.stream()
+				.map(buildSystem -> buildSystem.verifyCommand(checkout).getLast())
+				.filter(command -> !command.equals(wired))
+				.distinct()
 				.toList();
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/GitHubRepoAdopterTest.java
@@ -151,11 +151,16 @@ class GitHubRepoAdopterTest {
 				stepNames(AdoptionOptions.defaults()));
 	}
 
+	/**
+	 * The skills are written beside the assets and committed with them: two steps
+	 * because a skill's body depends on the detected build system, one commit because a
+	 * run should still leave exactly two in somebody else's history.
+	 */
 	@Test
 	void defaultPipelineWithAssetsInstallsAndCommitsThemBeforeVerification() {
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
-				"commit:claude-md", "enforcer", "commit:guard", "assets", "commit:assets", "verify", "push",
-				"pull-request"),
+				"commit:claude-md", "enforcer", "commit:guard", "assets", "skills", "commit:assets", "verify",
+				"push", "pull-request"),
 				stepNames(withAssets()));
 	}
 
@@ -176,7 +181,7 @@ class GitHubRepoAdopterTest {
 		AdoptionOptions options = new AdoptionOptions(PullRequestOptions.defaults(), true, null, true, null,
 				AdoptionOptions.DEFAULT_RETRIES);
 		assertEquals(List.of("toolchain", "clone", "build-toolchain", "branch", "trust", "claude-init", "conform",
-				"commit:claude-md", "enforcer", "commit:guard", "assets", "commit:assets", "verify"),
+				"commit:claude-md", "enforcer", "commit:guard", "assets", "skills", "commit:assets", "verify"),
 				stepNames(options));
 	}
 

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetsStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/AssetsStepTest.java
@@ -109,16 +109,31 @@ class AssetsStepTest {
 	 * {@link CloneStep} tells the adoption's own uncommitted work apart from a
 	 * contributor's by this list, so a file the adoption writes but does not name here
 	 * would make a resumable checkout look like one carrying somebody else's work.
-	 * Every starter asset is folded in from {@link AdoptionAssets#DEFAULTS} itself; the
-	 * files written outside an installer are the ones worth pinning.
+	 * Every starter asset is folded in from {@link AdoptionAssets#DEFAULTS} itself and
+	 * every starter skill from {@link StarterSkills#WRITTEN_PATHS}; the files written
+	 * outside an installer are the ones worth pinning.
 	 */
 	@Test
 	void namesEveryFileTheAdoptionWrites() {
 		assertTrue(AdoptionAssets.WRITTEN_PATHS.containsAll(List.of(
 				"CLAUDE.md", "AGENTS.md", ".claude/settings.json", ".claude/hooks/session-start.sh",
 				".mcp.json", ".github/workflows/claude.yml", ".github/workflows/claude-md-guard.yml",
-				".github/claude-md-guard.sh", "pom.xml", "build.gradle", "build.gradle.kts")),
+				".github/claude-md-guard.sh", ".claude/skills/build-and-test/SKILL.md",
+				".claude/skills/claude-md/SKILL.md", "pom.xml", "build.gradle", "build.gradle.kts")),
 				AdoptionAssets.WRITTEN_PATHS.toString());
+	}
+
+	/**
+	 * The skills are written by {@link SkillsStep} beside this step, so a run that
+	 * installs the assets alone leaves the skills to it rather than writing a body no
+	 * build system has been detected for.
+	 */
+	@Test
+	void leavesTheStarterSkillsToTheStepThatKnowsTheBuildSystem(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		step.execute(context, new RecordingCommandRunner());
+		StarterSkills.WRITTEN_PATHS.forEach(
+				path -> assertTrue(Files.notExists(context.repositoryDirectory().resolve(path)), path));
 	}
 
 	/** A path named twice would report the same file twice in a refusal. */

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/BuildSystemsTest.java
@@ -245,6 +245,32 @@ class BuildSystemsTest {
 		assertTrue(new GradleBuildSystem().toolAdvice().contains("gradle"), "gradle should name itself");
 	}
 
+	@Test
+	void aBuildToolDescribesTheBuildByName() {
+		assertTrue(new MavenBuildSystem().buildDescription().contains("maven"), "maven should name itself");
+		assertTrue(new GradleBuildSystem().buildDescription().contains("gradle"), "gradle should name itself");
+	}
+
+	/**
+	 * The same mistake {@link #theFallbackAdvisesAboutAShellRatherThanAboutItself}
+	 * pins one method along: a repository the catch-all matched has no build tool, so a
+	 * starter skill telling its contributors it "is built with github-actions" would be
+	 * describing a build that does not exist.
+	 */
+	@Test
+	void theFallbackDescribesWhereItsGuardLivesRatherThanABuildTool() {
+		String description = new FallbackBuildSystem().buildDescription();
+		assertFalse(description.contains("built with github-actions"), description);
+		assertTrue(description.contains("GitHub Actions workflow"), description);
+	}
+
+	/** Every build system has to say what builds the project, the starter skills opening with it. */
+	@Test
+	void everyBuildSystemDescribesTheBuild() {
+		BuildSystems.DEFAULTS.forEach(buildSystem -> assertFalse(buildSystem.buildDescription().isBlank(),
+				buildSystem.name() + " must describe the build"));
+	}
+
 	/**
 	 * {@link BuildSystem#toolProbe(Path)} is the default a new build system inherits,
 	 * and it reads the first word of the verify command. One that names no command has

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/SkillsStepTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/SkillsStepTest.java
@@ -1,0 +1,92 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.adamw7.tools.adopt.AdoptionContext;
+import io.github.adamw7.tools.adopt.AdoptionContexts;
+import io.github.adamw7.tools.adopt.command.RecordingCommandRunner;
+
+class SkillsStepTest {
+
+	private final SkillsStep step = new SkillsStep();
+
+	@Test
+	void installsEveryStarterSkill(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		step.execute(context, new RecordingCommandRunner());
+		StarterSkills.WRITTEN_PATHS.forEach(
+				path -> assertTrue(Files.isRegularFile(context.repositoryDirectory().resolve(path)), path));
+	}
+
+	@Test
+	void runsNoExternalCommands(@TempDir Path workspace) throws IOException {
+		RecordingCommandRunner runner = new RecordingCommandRunner();
+		step.execute(AdoptionContexts.checkedOutIn(workspace), runner);
+		assertEquals(0, runner.count());
+	}
+
+	@Test
+	void isNamedSkills() {
+		assertEquals("skills", step.name());
+	}
+
+	/**
+	 * The step is separate from {@link AssetsStep} precisely because the skills
+	 * describe the guard the checkout's own build system got, so a Maven checkout and
+	 * a Gradle one must not be handed the same file.
+	 */
+	@Test
+	void describesTheGuardTheCheckoutsBuildSystemWired(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "build.gradle", "plugins { id 'java' }\n");
+		step.execute(context, new RecordingCommandRunner());
+		assertTrue(buildSkill(context).contains("enforceClaudeMd"), buildSkill(context));
+	}
+
+	@Test
+	void aMavenCheckoutIsToldToRunTheMavenGuard(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		AdoptionContexts.write(context, "pom.xml", "<project/>");
+		step.execute(context, new RecordingCommandRunner());
+		assertTrue(buildSkill(context).contains("mvn -q -N validate"), buildSkill(context));
+	}
+
+	@Test
+	void isIdempotentAcrossReRuns(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		step.execute(context, new RecordingCommandRunner());
+		Path skill = context.repositoryDirectory()
+				.resolve(StarterSkills.skillFile(StarterSkills.CLAUDE_MD_SKILL));
+		Files.writeString(skill, "customised\n");
+		step.execute(context, new RecordingCommandRunner());
+		assertEquals("customised\n", Files.readString(skill));
+	}
+
+	/**
+	 * A step configured with a build-system list that matches nothing is skipped with a
+	 * warning rather than failing the run, the same answer
+	 * {@link AbstractBuildSystemStep} gives every step that acts on a build system.
+	 * {@link BuildSystems#DEFAULTS} always matches, so this is reachable only from a
+	 * caller assembling its own list.
+	 */
+	@Test
+	void writesNothingWhenNoBuildSystemMatches(@TempDir Path workspace) throws IOException {
+		AdoptionContext context = AdoptionContexts.checkedOutIn(workspace);
+		new SkillsStep(List.of(new MavenBuildSystem())).execute(context, new RecordingCommandRunner());
+		assertTrue(Files.notExists(context.repositoryDirectory().resolve(".claude/skills")));
+	}
+
+	private String buildSkill(AdoptionContext context) throws IOException {
+		return Files.readString(context.repositoryDirectory()
+				.resolve(StarterSkills.skillFile(StarterSkills.BUILD_SKILL)));
+	}
+}

--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/StarterSkillsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/StarterSkillsTest.java
@@ -1,0 +1,285 @@
+package io.github.adamw7.tools.adopt.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class StarterSkillsTest {
+
+	private static final String WRAPPER = "mvnw";
+
+	@Test
+	void namesOneSkillDirectoryPerSkill(@TempDir Path checkout) {
+		assertEquals(List.of(".claude/skills/build-and-test/SKILL.md", ".claude/skills/claude-md/SKILL.md"),
+				installedPaths(new MavenBuildSystem(), checkout));
+	}
+
+	/**
+	 * The paths are what {@link AdoptionAssets#WRITTEN_PATHS} folds in without a
+	 * checkout in hand, so they must be the paths a run really writes rather than a
+	 * second list kept beside them.
+	 */
+	@Test
+	void writesTheVeryPathsItPublishes(@TempDir Path checkout) {
+		assertEquals(StarterSkills.WRITTEN_PATHS, installedPaths(new MavenBuildSystem(), checkout));
+	}
+
+	/** {@code skillFilesExist} fails a skill whose {@code name:} is not its directory name. */
+	@Test
+	void eachSkillNamesItselfAfterItsDirectory(@TempDir Path checkout) throws IOException {
+		install(new MavenBuildSystem(), checkout);
+		StarterSkills.NAMES.forEach(name -> assertTrue(read(checkout, name).contains("\nname: " + name + "\n"),
+				name));
+	}
+
+	@Test
+	void eachSkillOpensWithFrontMatterDeclaringANameAndADescription(@TempDir Path checkout) throws IOException {
+		install(new MavenBuildSystem(), checkout);
+		StarterSkills.NAMES.forEach(name -> assertFrontMatterIsWellFormed(read(checkout, name), name));
+	}
+
+	/** {@code uniqueDescriptions} fails a repository where two definitions describe themselves alike. */
+	@Test
+	void theSkillsDescribeThemselvesDifferently(@TempDir Path checkout) throws IOException {
+		install(new MavenBuildSystem(), checkout);
+		assertFalse(description(read(checkout, StarterSkills.BUILD_SKILL))
+				.equals(description(read(checkout, StarterSkills.CLAUDE_MD_SKILL))));
+	}
+
+	@Test
+	void aMavenSkillListsTheHeadingsTheWiredGuardDemands(@TempDir Path checkout) throws IOException {
+		install(new MavenBuildSystem(), checkout);
+		String skill = read(checkout, StarterSkills.CLAUDE_MD_SKILL);
+		ClaudeMdConformer.REQUIRED_SECTIONS.forEach(section -> assertTrue(skill.contains("`" + section + "`"),
+				section + " missing from: " + skill));
+	}
+
+	/**
+	 * The Gradle and workflow guards ask only that the document exist and carry
+	 * something, so listing the Maven rule's headings would send a contributor
+	 * appending sections nothing checks.
+	 */
+	@Test
+	void aGradleSkillListsNoHeadingItsGuardNeverReads(@TempDir Path checkout) throws IOException {
+		install(new GradleBuildSystem(), checkout);
+		String skill = read(checkout, StarterSkills.CLAUDE_MD_SKILL);
+		assertFalse(skill.contains("## Principles for Java Development"), skill);
+		assertTrue(skill.contains("no section in particular"), skill);
+	}
+
+	@Test
+	void eachSkillCarriesTheCommandThatRunsTheDetectedGuard(@TempDir Path checkout) throws IOException {
+		install(new GradleBuildSystem(), checkout);
+		StarterSkills.NAMES.forEach(name -> assertTrue(read(checkout, name).contains("gradle -q enforceClaudeMd"),
+				read(checkout, name)));
+	}
+
+	@Test
+	void theBuildSkillSaysWhatBuildsTheProject(@TempDir Path checkout) throws IOException {
+		install(new MavenBuildSystem(), checkout);
+		assertTrue(read(checkout, StarterSkills.BUILD_SKILL).contains("built with maven"),
+				read(checkout, StarterSkills.BUILD_SKILL));
+	}
+
+	/**
+	 * A checkout with no build file is adopted by the catch-all build system, which is
+	 * not a build tool: a skill claiming the project "is built with github-actions"
+	 * would be telling its contributors something untrue about their own repository.
+	 */
+	@Test
+	void theBuildSkillDoesNotCallTheCatchAllGuardABuildTool(@TempDir Path checkout) throws IOException {
+		install(new FallbackBuildSystem(), checkout);
+		String skill = read(checkout, StarterSkills.BUILD_SKILL);
+		assertFalse(skill.contains("built with github-actions"), skill);
+		assertTrue(skill.contains("no Maven or Gradle build file"), skill);
+	}
+
+	/**
+	 * {@link BuildSystem#verifyCommand(Path)} answers a checkout's wrapper by absolute
+	 * path, because a process is launched from the JVM's working directory rather than
+	 * the command's. Committing that verbatim would put the adoption host's workspace
+	 * path into somebody else's repository, naming a directory no contributor has.
+	 */
+	@Test
+	void theWrapperIsNamedRelativelyRatherThanByTheAdoptionHostsPath(@TempDir Path checkout) throws IOException {
+		Files.writeString(checkout.resolve(WRAPPER), "#!/bin/sh\n");
+		install(new MavenBuildSystem(), checkout);
+		String skill = read(checkout, StarterSkills.BUILD_SKILL);
+		assertTrue(skill.contains("./mvnw -q -N validate"), skill);
+		assertFalse(skill.contains(checkout.toAbsolutePath().toString()), skill);
+	}
+
+	/** A flag is not a path, and asking the filesystem to parse one is how Windows differs. */
+	@Test
+	void theGuardCommandsFlagsSurviveUnchanged(@TempDir Path checkout) throws IOException {
+		install(new MavenBuildSystem(), checkout);
+		assertTrue(read(checkout, StarterSkills.BUILD_SKILL).contains("mvn -q -N validate"),
+				read(checkout, StarterSkills.BUILD_SKILL));
+	}
+
+	@Test
+	void aProjectsOwnCommandOfTheSameNameKeepsIt(@TempDir Path checkout) throws IOException {
+		write(checkout, ".claude/commands/build-and-test.md", "# the project's own\n");
+		install(new MavenBuildSystem(), checkout);
+		assertTrue(Files.notExists(checkout.resolve(StarterSkills.skillFile(StarterSkills.BUILD_SKILL))));
+		assertTrue(Files.isRegularFile(checkout.resolve(StarterSkills.skillFile(StarterSkills.CLAUDE_MD_SKILL))));
+	}
+
+	@Test
+	void aProjectsOwnSubAgentOfTheSameNameKeepsIt(@TempDir Path checkout) throws IOException {
+		write(checkout, ".claude/agents/claude-md.md", "# the project's own\n");
+		install(new MavenBuildSystem(), checkout);
+		assertTrue(Files.notExists(checkout.resolve(StarterSkills.skillFile(StarterSkills.CLAUDE_MD_SKILL))));
+	}
+
+	/**
+	 * A skill directory the project already carries claims the name whether or not it
+	 * holds a {@code SKILL.md} yet, so the adoption never writes its own skill into a
+	 * directory somebody else made.
+	 */
+	@Test
+	void aProjectsOwnSkillDirectoryKeepsItsNameEvenWhileEmpty(@TempDir Path checkout) throws IOException {
+		Files.createDirectories(checkout.resolve(".claude/skills/build-and-test"));
+		install(new MavenBuildSystem(), checkout);
+		assertTrue(Files.notExists(checkout.resolve(StarterSkills.skillFile(StarterSkills.BUILD_SKILL))));
+	}
+
+	@Test
+	void aCheckoutWithNoClaudeDirectoryClaimsNothing(@TempDir Path checkout) {
+		assertEquals(Set.of(), StarterSkills.claimedNames(checkout));
+	}
+
+	@Test
+	void claimedNamesAreReadFromEveryDirectoryADefinitionIsNamedBy(@TempDir Path checkout) throws IOException {
+		write(checkout, ".claude/commands/review.md", "");
+		write(checkout, ".claude/agents/auditor.md", "");
+		Files.createDirectories(checkout.resolve(".claude/skills/deploy"));
+		assertEquals(Set.of("review", "auditor", "deploy"), StarterSkills.claimedNames(checkout));
+	}
+
+	/** Only Markdown names a command or a sub-agent; a README beside them names nothing. */
+	@Test
+	void aNonMarkdownFileClaimsNoName(@TempDir Path checkout) throws IOException {
+		write(checkout, ".claude/commands/notes.txt", "");
+		assertEquals(Set.of(), StarterSkills.claimedNames(checkout));
+	}
+
+	@Test
+	void reRunningInstallsNothingOverTheProjectsEdits(@TempDir Path checkout) throws IOException {
+		install(new MavenBuildSystem(), checkout);
+		Path skill = checkout.resolve(StarterSkills.skillFile(StarterSkills.BUILD_SKILL));
+		Files.writeString(skill, "customised\n");
+		install(new MavenBuildSystem(), checkout);
+		assertEquals("customised\n", Files.readString(skill));
+	}
+
+	/**
+	 * A build system may name no verification at all, and a skill telling a contributor
+	 * to run an empty command line would be worse than one telling them there is
+	 * nothing to run.
+	 */
+	@Test
+	void aBuildSystemWithNoVerificationIsSaidToHaveNone(@TempDir Path checkout) throws IOException {
+		install(new UnverifiedBuildSystem(), checkout);
+		String skill = read(checkout, StarterSkills.BUILD_SKILL);
+		assertTrue(skill.contains("no command of its own"), skill);
+		assertFalse(skill.contains("```sh\n```"), skill);
+	}
+
+	/**
+	 * A skill's name is a directory name, so it has to survive the checkout's ignore
+	 * rules as well as its other definitions: {@code build} is one of the most widely
+	 * ignored words in a JVM project's {@code .gitignore}, and naming a skill that lost
+	 * four of the seven repositories {@link
+	 * io.github.adamw7.tools.adopt.ForeignRepositoryAdoptionIT} adopts to
+	 * {@link CommitStep}'s refusal to commit a path the checkout excludes.
+	 */
+	@Test
+	void noSkillIsNamedAfterAWidelyIgnoredDirectory() {
+		List<String> ignored = List.of("build", "target", "out", "dist", "bin", "obj");
+		StarterSkills.NAMES.forEach(name -> assertFalse(ignored.contains(name),
+				() -> "a skill called " + name + " would be excluded by the ignore rules of most projects"));
+	}
+
+	/** A build system whose guard runs as part of the build and has no command to name. */
+	private static final class UnverifiedBuildSystem implements BuildSystem {
+
+		@Override
+		public String name() {
+			return "unverified";
+		}
+
+		@Override
+		public boolean matches(Path repositoryDirectory) {
+			return true;
+		}
+
+		@Override
+		public List<String> writtenPaths() {
+			return List.of();
+		}
+
+		@Override
+		public boolean install(Path repositoryDirectory) {
+			return false;
+		}
+
+		@Override
+		public boolean isGuardInstalled(Path repositoryDirectory) {
+			return true;
+		}
+
+		@Override
+		public List<String> verifyCommand(Path repositoryDirectory) {
+			return List.of();
+		}
+	}
+
+	private void assertFrontMatterIsWellFormed(String skill, String name) {
+		assertTrue(skill.startsWith("---\n"), name + " must open with front matter: " + skill);
+		assertTrue(skill.contains("\ndescription: "), name + " must declare a description: " + skill);
+		assertFalse(description(skill).isBlank(), name + " must describe itself: " + skill);
+	}
+
+	private String description(String skill) {
+		return skill.lines()
+				.filter(line -> line.startsWith("description: "))
+				.map(line -> line.substring("description: ".length()))
+				.findFirst()
+				.orElse("");
+	}
+
+	private List<String> installedPaths(BuildSystem buildSystem, Path checkout) {
+		return StarterSkills.forCheckout(buildSystem, checkout).stream()
+				.map(AssetInstaller::relativePath)
+				.toList();
+	}
+
+	private void install(BuildSystem buildSystem, Path checkout) {
+		StarterSkills.forCheckout(buildSystem, checkout).forEach(installer -> installer.install(checkout));
+	}
+
+	private String read(Path checkout, String skillName) {
+		Path skill = checkout.resolve(StarterSkills.skillFile(skillName));
+		try {
+			return Files.readString(skill);
+		} catch (IOException e) {
+			throw new IllegalStateException("Could not read " + skill, e);
+		}
+	}
+
+	private void write(Path checkout, String relativePath, String content) throws IOException {
+		Path file = checkout.resolve(relativePath);
+		Files.createDirectories(file.getParent());
+		Files.writeString(file, content);
+	}
+}

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -447,6 +447,7 @@ flowchart TB
             commit["<b>CommitStep</b><br/><i>runs after the conform,<br/>the guard, and the assets</i>"]
             enforcerStep["<b>EnforcerStep</b><br/><i>wires the guard in</i>"]
             assets["<b>AssetsStep</b><br/><i>optional starter config</i>"]
+            skills["<b>SkillsStep</b><br/><i>optional starter skills,<br/>written per build system</i>"]
             verify["<b>VerifyStep</b><br/><i>the guard passes on<br/>the generated file</i>"]
             publish["<b>PushStep +<br/>PullRequestStep</b><br/><i>omitted on a dry run</i>"]
         end
@@ -484,11 +485,13 @@ flowchart TB
     init --> commit
     commit --> enforcerStep
     enforcerStep --> assets
-    assets --> verify
+    assets --> skills
+    skills --> verify
     verify --> publish
 
     buildToolchain --> bs
     enforcerStep --> bs
+    skills --> bs
     verify --> bs
     bs --> installers
     installers -->|"edit pom.xml / build.gradle /<br/>.github workflow"| workspace
@@ -503,7 +506,7 @@ flowchart TB
     classDef comp fill:#85bbf0,stroke:#5d82a8,color:#08427b
     classDef ext fill:#999999,stroke:#6b6b6b,color:#fff
     class maintainer,agent person
-    class cliMain,mcpMain,adoptTool,options,batch,adopter,ctx,report,redaction,toolchain,clone,buildToolchain,branch,init,enforcerStep,assets,verify,publish,commit,bs,installers,runner comp
+    class cliMain,mcpMain,adoptTool,options,batch,adopter,ctx,report,redaction,toolchain,clone,buildToolchain,branch,init,enforcerStep,assets,skills,verify,publish,commit,bs,installers,runner comp
     class github,cli,workspace ext
     style adopt fill:#f2f7fc,stroke:#438dd5,color:#08427b
     style entryLayer fill:#eef4ec,stroke:#6b3fa0,color:#46296b
@@ -639,6 +642,7 @@ sequenceDiagram
         A->>R: commit "Adopt Claude Code: add the CLAUDE.md guard"
         opt --assets
             A->>W: assets — .claude/settings.json, hook, .mcp.json, workflow
+            A->>W: skills — .claude/skills/build-and-test, .claude/skills/claude-md
             A->>R: commit "Add Claude Code configuration assets"
         end
         A->>R: verify — the guard passes on the generated file


### PR DESCRIPTION
`--assets` now also writes two skills under `.claude/skills`, so an adopted
repository carries its conventions where Claude Code loads them on demand
rather than only in the file every session pays for:

- `build-and-test` — what builds the project and the command that runs the
  guard the adoption just wired in, with headings left for the project's own
  build, test and lint commands.
- `claude-md` — the headings that guard demands and how to check them before
  pushing.

`SkillsStep` is its own step, and a build-system-aware one, because a skill's
body depends on the checkout's build system; it runs beside `AssetsStep` and
into the same commit, so a run still leaves two commits in somebody else's
history. Both bodies come from what the run established — never from anything
guessed about the project — through the new `BuildSystem.buildDescription()`,
`requiredClaudeMdSections()` and `verifyCommand()`. The catch-all overrides the
first, so a repository with no build file is told where its guard lives instead
of that it "is built with github-actions", and the guard command is relativized,
since `verifyCommand` answers a checkout's wrapper by absolute path and
committing that would put the adoption host's workspace path into somebody
else's repository.

A skill whose name the project's own commands, sub-agents or skills already
claim is not installed at all: `uniqueNames` fails a repository where two
definitions answer to one name, and the name is the project's. The build skill
is `build-and-test` rather than `build` for a related reason found by
`ForeignRepositoryAdoptionIT` — a skill's name is a directory name, and `build`
is one of the most widely ignored words in a JVM `.gitignore`, so four of its
seven real repositories excluded `.claude/skills/build/SKILL.md` and
`CommitStep` rightly refused to commit around it.

`AdoptionAssets.WRITTEN_PATHS` derives the skill paths from the skill names, so
the adoption still accounts for every file it writes. The foreign-repository
integration test installs the skills too, and asserts each names the guard its
own checkout got and no other build system's.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018spWgNHkiZz99GrmvX96m9