### PR TITLE
chore: drop dead pom entries, permissions and gitignore lines

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,8 +3,6 @@
     "allow": [
       "Bash(unzip -p *)",
       "Bash(unzip -l *)",
-      "Bash(mvn dependency:tree *)",
-      "Bash(mvn dependency:analyze *)",
       "Bash(mvn *)",
       "PowerShell(mvn *)",
       "Edit"

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
 target/
-pom.xml.tag
-pom.xml.releaseBackup
 pom.xml.versionsBackup
-pom.xml.next
-release.properties
-dependency-reduced-pom.xml
 .flattened-pom.xml
-buildNumber.properties
 .mvn/*
 !.mvn/maven.config
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1019,7 +1019,7 @@ ignored.
 `.claude/settings.json` carries two sections:
 
 - `permissions.allow` pre-approves the commands a session runs constantly — `mvn`
-  (and `PowerShell(mvn *)` for the Windows path), the
+  (and `PowerShell(mvn *)` for the Windows path), which already covers the
   `dependency:tree`/`dependency:analyze` reports, the `unzip -l`/`unzip -p`
   archive inspection, and `Edit`. Each entry must be a well-formed `Tool` or
   `Tool(specifier)` and must not also appear in `deny`.

--- a/pom.xml
+++ b/pom.xml
@@ -169,18 +169,6 @@
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.maven</groupId>
-				<artifactId>maven-model</artifactId>
-				<version>${maven.api.version}</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.maven</groupId>
-				<artifactId>maven-artifact</artifactId>
-				<version>${maven.api.version}</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
 				<groupId>org.apache.maven.plugin-tools</groupId>
 				<artifactId>maven-plugin-annotations</artifactId>
 				<version>4.0.0-beta-2</version>
@@ -228,12 +216,6 @@
 				<artifactId>grpc-inprocess</artifactId>
 				<version>${grpc.version}</version>
 				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>javax.annotation</groupId>
-				<artifactId>javax.annotation-api</artifactId>
-				<version>1.3.2</version>
-				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.jdt</groupId>
@@ -342,16 +324,6 @@
 							<phase>none</phase>
 						</execution>
 					</executions>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-release-plugin</artifactId>
-					<version>3.3.1</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-antrun-plugin</artifactId>
-					<version>3.2.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
An audit for removable weight found the codebase itself clean — no
unreferenced classes, unused imports, uncalled private methods, orphan
test resources or stale SpotBugs exclusions. What was left was
configuration nothing reaches:

- dependencyManagement: maven-model, maven-artifact and
  javax.annotation-api. No module declares them and nothing imports
  org.apache.maven.model, org.apache.maven.artifact or javax.annotation;
  the first two are Maven-3-era leftovers beside the live
  maven-plugin-api pin.
- pluginManagement: maven-release-plugin, which AGENTS.md already states
  is not how releases happen here (a revision edit instead), and
  maven-antrun-plugin, referenced nowhere and pinned to the same 3.2.0
  spring-boot-dependencies already inherits.
- permissions.allow: Bash(mvn dependency:tree *) and
  Bash(mvn dependency:analyze *), both subsumed by the Bash(mvn *) entry
  below them. AGENTS.md updated to match.
- .gitignore: the release-plugin backups (pom.xml.tag,
  pom.xml.releaseBackup, pom.xml.next, release.properties),
  dependency-reduced-pom.xml (no shade plugin) and buildNumber.properties
  (no buildnumber plugin). pom.xml.versionsBackup and .flattened-pom.xml
  stay — versions-maven-plugin and flatten-maven-plugin are both used.

Verified with mvn -B package (all 13 modules, tests green) and the
two-phase doc check, where all 22 enforcer rules still pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P7GBV56DfQvKJMTENf4DXZ