### PR TITLE
fix(deps): pin embedded Tomcat to 11.0.25 for three critical CVEs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1298,6 +1298,11 @@ Skill: `maven-conventions`.
   `derby.version` and `log4j2.version` are Spring Boot's own property names on
   purpose — the BOM manages the rest of each family from them, so pinning only
   the artifacts declared here would leave the siblings on Boot's older version.
+- `tomcat.version` is the same mechanism used for a different reason: no module
+  declares a Tomcat artifact at all, but the embedded Tomcat the MCP servers'
+  web starter pulls in reaches the distribution's `lib/`, where `docker.yml`'s
+  Trivy scan sees it. Overriding Boot's property is how a Tomcat CVE gets fixed
+  ahead of the BOM; remove the override once Boot ships that version or later.
 - The root pom's parent is `spring-boot-starter-parent`, so its
   `<dependencyManagement>` and `<pluginManagement>` reach every module. Two of
   its entries are deliberately neutralised in the root pom rather than lived

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
 		<grpc.version>1.83.1</grpc.version>
 		<derby.version>10.17.1.0</derby.version>
 		<log4j2.version>2.26.1</log4j2.version>
+		<!-- Ahead of the Boot BOM's 11.0.24, which Trivy fails the Docker workflow on:
+		     CVE-2026-65182, CVE-2026-65905 and CVE-2026-68525 are all fixed in 11.0.25.
+		     Drop this once the BOM reaches that version or later. -->
+		<tomcat.version>11.0.25</tomcat.version>
 		<!-- Not maven.version: Maven exposes that as the running Maven's own version. -->
 		<maven.api.version>4.0.0-rc-5</maven.api.version>
 		<argLine/>


### PR DESCRIPTION
The weekly docker.yml run failed its Trivy scan: the distribution's
lib/tomcat-embed-core-11.0.24.jar carries CVE-2026-65182 (security
constraint bypass), CVE-2026-65905 (DIGEST authenticator replay) and
CVE-2026-68525 (FORM authentication bypass), all CRITICAL and all fixed
upstream in 11.0.25. The scan runs with ignore-unfixed and exit-code 1,
so a fixable critical fails the job by design — the fix is the upgrade,
not an exemption.

No module declares a Tomcat artifact; the embedded server arrives with
the web starter the MCP servers use and reaches the image through the
assembly's lib/. So the pin is an override of spring-boot-dependencies
4.1.1's own tomcat.version property, the mechanism derby.version and
log4j2.version already use here, which moves tomcat-embed-core, -el and
-websocket together rather than leaving the siblings behind.

Verified: mvn -B package builds all 13 modules green, the assembly's
lib/ now holds only 11.0.25 Tomcat jars, and the two-phase doc check
passes all 22 enforcer rules.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PYVe3va18vxtCTDquBNoZa