### PR TITLE
test(adopt): name the wrapper under test rather than the host's

### DIFF
--- a/adopt/src/test/java/io/github/adamw7/tools/adopt/step/StarterSkillsTest.java
+++ b/adopt/src/test/java/io/github/adamw7/tools/adopt/step/StarterSkillsTest.java
@@ -15,7 +15,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 class StarterSkillsTest {
 
-	private static final String WRAPPER = "mvnw";
+	private static final String POSIX_WRAPPER = "mvnw";
+	private static final String WINDOWS_WRAPPER = "mvnw.cmd";
 
 	@Test
 	void namesOneSkillDirectoryPerSkill(@TempDir Path checkout) {
@@ -111,11 +112,19 @@ class StarterSkillsTest {
 	 */
 	@Test
 	void theWrapperIsNamedRelativelyRatherThanByTheAdoptionHostsPath(@TempDir Path checkout) throws IOException {
-		Files.writeString(checkout.resolve(WRAPPER), "#!/bin/sh\n");
-		install(new MavenBuildSystem(), checkout);
-		String skill = read(checkout, StarterSkills.BUILD_SKILL);
-		assertTrue(skill.contains("./mvnw -q -N validate"), skill);
-		assertFalse(skill.contains(checkout.toAbsolutePath().toString()), skill);
+		assertTheWrapperIsNamedRelatively(checkout, POSIX_WRAPPER, false);
+	}
+
+	/**
+	 * The same, for the wrapper a Windows checkout is built with. Both platforms are
+	 * named by the test rather than read off the host: a Windows host looks for
+	 * {@value #WINDOWS_WRAPPER} and so found no wrapper to rewrite in a checkout given
+	 * only {@value #POSIX_WRAPPER}, leaving the skill naming a {@code mvn} off the
+	 * {@code PATH} and failing this assertion on Windows alone.
+	 */
+	@Test
+	void theWindowsWrapperIsNamedRelativelyToo(@TempDir Path checkout) throws IOException {
+		assertTheWrapperIsNamedRelatively(checkout, WINDOWS_WRAPPER, true);
 	}
 
 	/** A flag is not a path, and asking the filesystem to parse one is how Windows differs. */
@@ -242,6 +251,21 @@ class StarterSkillsTest {
 		public List<String> verifyCommand(Path repositoryDirectory) {
 			return List.of();
 		}
+	}
+
+	private void assertTheWrapperIsNamedRelatively(Path checkout, String wrapper, boolean windows)
+			throws IOException {
+		Files.writeString(checkout.resolve(wrapper), "#!/bin/sh\n");
+		install(maven(windows), checkout);
+		String skill = read(checkout, StarterSkills.BUILD_SKILL);
+		assertTrue(skill.contains("./" + wrapper + " -q -N validate"), skill);
+		assertFalse(skill.contains(checkout.toAbsolutePath().toString()), skill);
+	}
+
+	/** Maven looking for the named platform's wrapper rather than for the host's. */
+	private MavenBuildSystem maven(boolean windows) {
+		return new MavenBuildSystem(PomEnforcerInstaller.from(GuardOptions.defaults()),
+				new BuildWrapper(POSIX_WRAPPER, WINDOWS_WRAPPER, windows));
 	}
 
 	private void assertFrontMatterIsWellFormed(String skill, String name) {


### PR DESCRIPTION
The Windows CI run failed on
`StarterSkillsTest.theWrapperIsNamedRelativelyRatherThanByTheAdoptionHostsPath`,
and only there: the test wrote an `mvnw` into the checkout and asserted the
skill names it as `./mvnw`, but `BuildWrapper` looks for `mvnw.cmd` on a
Windows host. Finding no wrapper, `MavenBuildSystem.verifyCommand` answered
the fallback `mvn -q -N validate` off the PATH, there was no absolute path
to rewrite, and the assertion failed on the test's own assumption rather
than on the rewrite it exists to pin.

The platform is now named by the test, the way `BuildSystemsTest` already
names it, through the package-private `MavenBuildSystem(installer, wrapper)`
and `BuildWrapper(posix, windows, isWindows)` constructors. The existing case
pins the POSIX wrapper, and a new `theWindowsWrapperIsNamedRelativelyToo`
pins `mvnw.cmd` — so both wrapper names are exercised from either host
instead of only whichever one the host happens to use.

Production code is unchanged: preferring `mvnw.cmd` on Windows is correct.

Verified with `mvn test` in `adopt`: 922 tests, no failures.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014xYTmGxeSPJBNFjUAWTqKR