### PR TITLE
test(protogen): charge CodeTest's cold start to @BeforeAll, not a test

### DIFF
--- a/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/gen/CodeTest.java
+++ b/code/protogen-maven-plugin/src/test/java/io/github/adamw7/tools/code/gen/CodeTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.apache.maven.plugin.logging.Log;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -41,6 +42,27 @@ import com.google.protobuf.GeneratedMessage;
 public class CodeTest {
 
 	private static final String OUTPUT_PKG = "com/x/out";
+
+	private static Log log;
+
+	/**
+	 * Charges this class's one-time initialisation to a lifecycle method instead of
+	 * to whichever test Jupiter happens to run first. Three costs land on a first
+	 * caller and never again: Mockito generating and loading a proxy class,
+	 * protobuf bringing up its descriptor pool, and the generator loading the
+	 * classes that turn a descriptor into source. Together they are close to a
+	 * second on an idle machine, and they belong to no single test — CI charged all
+	 * of them to {@code refusesEditionsSyntax}, which then overran the 5-second
+	 * per-test deadline under the parallel build's contention while its siblings
+	 * ran in milliseconds. Running one full generation here pays all three against
+	 * the 10-second lifecycle-method deadline, the one meant to cover shared setup,
+	 * so each test then measures only the work it is asserting on.
+	 */
+	@BeforeAll
+	static void warmUpTheGeneratorAndItsDependencies(@TempDir Path warmUp) {
+		log = mock(Log.class);
+		generate(warmUp, Proto2Message.class);
+	}
 
 	/** Carries the syntax {@code Code} accepts today, so the accepting branch is asserted and not assumed. */
 	public abstract static class Proto2Message extends GeneratedMessage {
@@ -166,8 +188,8 @@ public class CodeTest {
 		assertFalse(Files.exists(nested), "the nested directory itself must go with its contents");
 	}
 
-	private void generate(Path generatedSources, Class<? extends GeneratedMessage> message) {
-		new Code(mock(Log.class), generatedSources.toString(), OUTPUT_PKG.replace('/', '.'))
+	private static void generate(Path generatedSources, Class<? extends GeneratedMessage> message) {
+		new Code(log, generatedSources.toString(), OUTPUT_PKG.replace('/', '.'))
 				.genBuilders(Set.of(message));
 	}
 


### PR DESCRIPTION
`CodeTest.refusesEditionsSyntax` failed CI with `Timeout ... timed out after
5 seconds`, and only on the push to main — the identical tree had passed as a
pull request run an hour earlier. Nothing about editions is slow: building
the synthetic editions descriptor and refusing it is ~30 ms of work.

What the test was actually paying for was the class's one-time initialisation,
charged to whichever method Jupiter runs first. Measured on an idle machine,
three costs land on a first caller and never again:

    Mockito's first mock(Log.class)   655 ms   (generates and loads a proxy)
    protobuf's first descriptor       149 ms   (brings up the descriptor pool)
    the generator's first generation  ~740 ms  (loads Clazz, TypeMappings, ...)

`refusesEditionsSyntax` ran first and took 0.982 s while its siblings took
0.003-0.026 s. That is only 5x under the 5-second per-test deadline, and the
deadline is wall-clock: under `-T1C` the runner builds four modules at once,
each running three test classes concurrently, so a 5x margin is not one.
The pull request run won the lottery; the push lost it.

Now a `@BeforeAll` creates the shared `Log` and runs one full generation into
its own `@TempDir`, paying all three costs against the 10-second
lifecycle-method deadline the root pom configures for exactly this — shared
setup. Every test then measures only what it asserts on. The 5-second guard
is untouched, so a test that starts doing real work still trips it.

Worst method in the class, before and after: 0.982 s -> 0.034 s.

Verified with the module suite (98 tests) and the full CI build,
`mvn -B -ntp package -DenforceClaudeMd`: BUILD SUCCESS, all 13 modules, 50 s
against the workflow's 120-second cap.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NaYufHxCGiTyjezSc2YMwf